### PR TITLE
ACCUMULO-2826 Allow single CF for IntersectingIterator

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/IntersectingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/IntersectingIterator.java
@@ -444,8 +444,8 @@ public class IntersectingIterator implements SortedKeyValueIterator<Key,Value> {
     Text[] terms = decodeColumns(options.get(columnFamiliesOptionName));
     boolean[] notFlag = decodeBooleans(options.get(notFlagOptionName));
     
-    if (terms.length < 2) {
-      throw new IllegalArgumentException("IntersectionIterator requires two or more columns families");
+    if (terms.length < 1) {
+      throw new IllegalArgumentException("IntersectionIterator requires one or more columns families");
     }
     
     // Scan the not flags.
@@ -533,8 +533,8 @@ public class IntersectingIterator implements SortedKeyValueIterator<Key,Value> {
    * Encode the columns to be used when iterating.
    */
   public static void setColumnFamilies(IteratorSetting cfg, Text[] columns) {
-    if (columns.length < 2)
-      throw new IllegalArgumentException("Must supply at least two terms to intersect");
+    if (columns.length < 1)
+      throw new IllegalArgumentException("Must supply at least one term to intersect");
     cfg.addOption(IntersectingIterator.columnFamiliesOptionName, IntersectingIterator.encodeColumns(columns));
   }
   
@@ -542,8 +542,8 @@ public class IntersectingIterator implements SortedKeyValueIterator<Key,Value> {
    * Encode columns and NOT flags indicating which columns should be negated (docIDs will be excluded if matching negated columns, instead of included).
    */
   public static void setColumnFamilies(IteratorSetting cfg, Text[] columns, boolean[] notFlags) {
-    if (columns.length < 2)
-      throw new IllegalArgumentException("Must supply at least two terms to intersect");
+    if (columns.length < 1)
+      throw new IllegalArgumentException("Must supply at least one terms to intersect");
     if (columns.length != notFlags.length)
       throw new IllegalArgumentException("columns and notFlags arrays must be the same length");
     setColumnFamilies(cfg, columns);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
@@ -270,6 +270,33 @@ public class IntersectingIteratorTest extends TestCase {
     cleanup();
   }
   
+  public void test6() throws IOException {
+    columnFamilies = new Text[1];
+    columnFamilies[0] = new Text("C");
+    otherColumnFamilies = new Text[4];
+    otherColumnFamilies[0] = new Text("A");
+    otherColumnFamilies[1] = new Text("B");
+    otherColumnFamilies[2] = new Text("D");
+    otherColumnFamilies[3] = new Text("F");
+    
+    float hitRatio = 0.5f;
+    SortedKeyValueIterator<Key,Value> source = createIteratorStack(hitRatio, NUM_ROWS, NUM_DOCIDS, columnFamilies, otherColumnFamilies, docs);
+    IteratorSetting is = new IteratorSetting(1, IntersectingIterator.class);
+    IntersectingIterator.setColumnFamilies(is, columnFamilies);
+    IntersectingIterator iter = new IntersectingIterator();
+    iter.init(source, is.getOptions(), env);
+    iter.seek(new Range(), EMPTY_COL_FAMS, false);
+    int hitCount = 0;
+    while (iter.hasTop()) {
+      hitCount++;
+      Key k = iter.getTopKey();
+      assertTrue(docs.contains(k.getColumnQualifier()));
+      iter.next();
+    }
+    assertTrue(hitCount == docs.size());
+    cleanup();
+  }
+  
   public void testWithBatchScanner() throws Exception {
     Value empty = new Value(new byte[] {});
     MockInstance inst = new MockInstance("mockabye");


### PR DESCRIPTION
The iterator functions properly, as-is, when given only a single column family 'term'. As such, that functionality should not be artificially prevented.
