### PR TITLE
ACCUMULO-2944 Fixes harded coded Sun JVM in config and env

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -163,7 +163,6 @@ exec $JAVA "-Dapp=$1" \
    -classpath "${CLASSPATH}" \
    -XX:OnOutOfMemoryError="${ACCUMULO_KILL_CMD:-kill -9 %p}" \
    -XX:-OmitStackTraceInFastThrow \
-   -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl \
    -Dorg.apache.accumulo.core.home.dir="${ACCUMULO_HOME}" \
    -Dhadoop.home.dir="${HADOOP_PREFIX}" \
    -Dzookeeper.home.dir="${ZOOKEEPER_HOME}" \

--- a/assemble/conf/templates/accumulo-env.sh
+++ b/assemble/conf/templates/accumulo-env.sh
@@ -51,10 +51,11 @@ test -z "$ACCUMULO_TSERVER_OPTS" && export ACCUMULO_TSERVER_OPTS="${POLICY} ${tS
 test -z "$ACCUMULO_MASTER_OPTS"  && export ACCUMULO_MASTER_OPTS="${POLICY} ${masterHigh_masterLow}"
 test -z "$ACCUMULO_MONITOR_OPTS" && export ACCUMULO_MONITOR_OPTS="${POLICY} ${monitorHigh_monitorLow}"
 test -z "$ACCUMULO_GC_OPTS"      && export ACCUMULO_GC_OPTS="${gcHigh_gcLow}"
-test -z "$ACCUMULO_GENERAL_OPTS" && export ACCUMULO_GENERAL_OPTS="-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -Djava.net.preferIPv4Stack=true"
+test -z "$ACCUMULO_GENERAL_OPTS" && export ACCUMULO_GENERAL_OPTS="${gcPolicy} -Djava.net.preferIPv4Stack=true ${jaxpDocBuilderFactory} ${randomNumGeneratorProviderOverride}"
 test -z "$ACCUMULO_OTHER_OPTS"   && export ACCUMULO_OTHER_OPTS="${otherHigh_otherLow}"
 # what do when the JVM runs out of heap memory
 export ACCUMULO_KILL_CMD='kill -9 %p'
+export GC_POLICY_ARGS="${gcPolicy}"
 
 ### Optionally look for hadoop and accumulo native libraries for your
 ### platform in additional directories. (Use DYLD_LIBRARY_PATH on Mac OS X.)

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
@@ -259,7 +259,14 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     for (Entry<String,String> sysProp : config.getSystemProperties().entrySet()) {
       argList.add(String.format("-D%s=%s", sysProp.getKey(), sysProp.getValue()));
     }
-    argList.addAll(Arrays.asList("-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=75", "-Dapple.awt.UIElement=true", Main.class.getName(), className));
+    
+    String gcPolicyArgs = System.getenv("GC_POLICY_ARGS");
+    if (gcPolicyArgs == null) {
+      gcPolicyArgs = "-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75";
+    }
+    String[] gcPolicyArgsArr = gcPolicyArgs.split("\\s+");
+    argList.addAll(Arrays.asList(gcPolicyArgsArr));
+    argList.addAll(Arrays.asList("-Dapple.awt.UIElement=true", Main.class.getName(), className));
     argList.addAll(Arrays.asList(args));
 
     ProcessBuilder builder = new ProcessBuilder(argList);


### PR DESCRIPTION
ACCUMULO-2944 add support for multiple java vendors in conf & scripts

Support for multiple java vendors is added by getting the
bootstrap_config.sh to generate correct configuration depending on 
specified java vendor. Following details depend on Java vendor
- GC settings
- Exclude/Include JAXP implementation
- Default NRG provider

A new question is being asked in the bootstrap_config.sh for Java 
vendor. This is then used to set GC settings, exclude/include JAXP 
implementation in ACCUMULO_OPTS. Also, default NRG provider is being 
injected as system property on command line since IBM JVM does not 
have SUN registered as default provider.
