### PR TITLE
ACCUMULO-2942 Fixes ShardedTableDistributionFormatterTest on all JVMs

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatterTest.java
@@ -19,12 +19,16 @@ package org.apache.accumulo.core.util.format;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,9 +62,29 @@ public class ShardedTableDistributionFormatterTest {
 
     formatter.initialize(data.entrySet(), false);
 
-    String[] result = formatter.next().split("\n");
-    assertTrue(result[2].endsWith("\t1"));
-    assertTrue(result[3].endsWith("\t2"));
+    String[] resultLines = formatter.next().split("\n");
+    List<String> results = Arrays.asList(resultLines).subList(2, 4);
+
+    assertTrue(CollectionUtils.exists(results, new AggregateReportChecker("NULL", 1)));
+    assertTrue(CollectionUtils.exists(results, new AggregateReportChecker("19700101", 2)));
+
     assertFalse(formatter.hasNext());
+  }
+
+  private static class AggregateReportChecker implements Predicate {
+    private String day;
+    private int count;
+
+    AggregateReportChecker(String day, int count) {
+      this.day = day;
+      this.count = count;
+    }
+
+    @Override
+    public boolean evaluate(Object arg) {
+      String resLine = (String) arg;
+      return resLine.startsWith(this.day) && resLine.endsWith("" + this.count);
+    }
+
   }
 }


### PR DESCRIPTION
ACCUMULO-2942 Fixes ShardedTableDistributionFormatterTest on all JVMs

ShardedTableDistributionFormatterTest.testAggregate() was failing due
to inconsistency in order to stats that were returned in the getStats()
method. This is due to the fact that the structure that holds the stats is
a HashMap.

The test was changed so that it does not assert that elements exists
at certain location in results, but rather it now checks that elements
exist in the list. The test was also slightly broadened so that it
checks that tuples of (day, count) exist in list.
