### PR TITLE
ACCUMULO-3101 Increase timeout for some of ExamplesIT tests on multinode

### DIFF
--- a/test/src/test/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -69,7 +69,7 @@ public class SplitRecoveryIT extends ConfigurableMacIT {
   
   @Override
   protected int defaultTimeoutSeconds() {
-    return 30;
+    return 60;
   }
   
   private KeyExtent nke(String table, String endRow, String prevEndRow) {


### PR DESCRIPTION
Timeout for ExamplesIT-testReadWriteAndDelete and testScansWithInterference need to be increased for multinode cluster
