### PR TITLE
ACCUMULO-3102 Increase timeout for SplitRecoveryIT test on multinode

### DIFF
--- a/test/src/test/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -69,7 +69,7 @@ public class SplitRecoveryIT extends ConfigurableMacIT {
   
   @Override
   protected int defaultTimeoutSeconds() {
-    return 30;
+    return 60;
   }
   
   private KeyExtent nke(String table, String endRow, String prevEndRow) {


### PR DESCRIPTION
SplitRecoveryIT test fails on multinode cluster due to insufficient timeout. It passes when defaultTimeoutSeconds is increased from 30 to 60.
