### PR TITLE
libaccumulo.so from java.library.path

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -78,6 +78,7 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
       String errMsg = "Tried and failed to load native map library from " + ldLibraryPath;
       try {
         System.loadLibrary("accumulo");
+        loadedNativeLibraries.set(true);
         log.info("Loaded native map shared library from " + ldLibraryPath);
       } catch (Exception e) {
         log.error(errMsg, e);


### PR DESCRIPTION
if libaccumulo.so was loaded from java.library.path, NativeMap.isLoaded() returns false, and native lib is not used