### PR TITLE
ACCUMULO-3645 Run iterators at major compaction on empty tablets

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/EverythingCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/EverythingCompactionStrategy.java
@@ -27,7 +27,7 @@ public class EverythingCompactionStrategy extends CompactionStrategy {
 
   @Override
   public boolean shouldCompact(MajorCompactionRequest request) throws IOException {
-    return request.getFiles().size() > 0;
+      return true; // ACCUMULO-3645 compact for empty files too
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1863,21 +1863,26 @@ public class Tablet implements TabletCommitter {
 
       if (inputFiles.isEmpty()) {
         if (reason == MajorCompactionReason.USER) {
-          // no work to do
-          lastCompactID = compactionId.getFirst();
-          updateCompactionID = true;
+          if (compactionId.getSecond().getIterators().isEmpty()) {
+            log.debug("No-op major compaction by USER on 0 input files because no iterators present.");
+            lastCompactID = compactionId.getFirst();
+            updateCompactionID = true;
+          } else {
+            log.debug("Major compaction by USER on 0 input files with iterators.");
+            filesToCompact = new HashMap<>();
+          }
         } else {
           return majCStats;
         }
       } else {
         // If no original files will exist at the end of the compaction, we do not have to propogate deletes
-        Set<FileRef> droppedFiles = new HashSet<FileRef>();
+        Set<FileRef> droppedFiles = new HashSet<>();
         droppedFiles.addAll(inputFiles);
         if (plan != null)
           droppedFiles.addAll(plan.deleteFiles);
         propogateDeletes = !(droppedFiles.equals(allFiles.keySet()));
         log.debug("Major compaction plan: " + plan + " propogate deletes : " + propogateDeletes);
-        filesToCompact = new HashMap<FileRef,DataFileValue>(allFiles);
+        filesToCompact = new HashMap<>(allFiles);
         filesToCompact.keySet().retainAll(inputFiles);
 
         getDatafileManager().reserveMajorCompactingFiles(filesToCompact.keySet());
@@ -1916,6 +1921,7 @@ public class Tablet implements TabletCommitter {
             // compaction was canceled
             return majCStats;
           }
+          compactionIterators = compactionId.getSecond().getIterators();
 
           synchronized (this) {
             if (lastCompactID >= compactionId.getFirst())
@@ -1924,12 +1930,11 @@ public class Tablet implements TabletCommitter {
           }
         }
 
-        compactionIterators = compactionId.getSecond().getIterators();
       }
 
       // need to handle case where only one file is being major compacted
-      while (filesToCompact.size() > 0) {
-
+      // ACCUMULO-3645 run loop at least once, even if filesToCompact.isEmpty()
+      do {
         int numToCompact = maxFilesToCompact;
 
         if (filesToCompact.size() > maxFilesToCompact && filesToCompact.size() < 2 * maxFilesToCompact) {
@@ -1995,7 +2000,7 @@ public class Tablet implements TabletCommitter {
           span.stop();
         }
 
-      }
+      } while (filesToCompact.size() > 0);
       return majCStats;
     } finally {
       synchronized (Tablet.this) {
@@ -2024,6 +2029,13 @@ public class Tablet implements TabletCommitter {
 
   private Set<FileRef> removeSmallest(Map<FileRef,DataFileValue> filesToCompact, int maxFilesToCompact) {
     // ensure this method works properly when multiple files have the same size
+
+    // short-circuit; also handles zero files case
+    if (filesToCompact.size() <= maxFilesToCompact) {
+      Set<FileRef> smallestFiles = new HashSet<FileRef>(filesToCompact.keySet());
+      filesToCompact.clear();
+      return smallestFiles;
+    }
 
     PriorityQueue<Pair<FileRef,Long>> fileHeap = new PriorityQueue<Pair<FileRef,Long>>(filesToCompact.size(), new Comparator<Pair<FileRef,Long>>() {
       @Override
@@ -2565,29 +2577,22 @@ public class Tablet implements TabletCommitter {
       if (isClosing() || isClosed() || majorCompactionQueued.contains(MajorCompactionReason.USER) || isMajorCompactionRunning())
         return;
 
-      if (getDatafileManager().getDatafileSizes().size() == 0) {
-        // no files, so jsut update the metadata table
-        majorCompactionState = CompactionState.IN_PROGRESS;
-        updateMetadata = true;
-        lastCompactID = compactionId;
-      } else {
-        CompactionStrategyConfig strategyConfig = compactionConfig.getCompactionStrategy();
-        CompactionStrategy strategy = createCompactionStrategy(strategyConfig);
+      CompactionStrategyConfig strategyConfig = compactionConfig.getCompactionStrategy();
+      CompactionStrategy strategy = createCompactionStrategy(strategyConfig);
 
-        MajorCompactionRequest request = new MajorCompactionRequest(extent, MajorCompactionReason.USER, getTabletServer().getFileSystem(), tableConfiguration);
-        request.setFiles(getDatafileManager().getDatafileSizes());
+      MajorCompactionRequest request = new MajorCompactionRequest(extent, MajorCompactionReason.USER, getTabletServer().getFileSystem(), tableConfiguration);
+      request.setFiles(getDatafileManager().getDatafileSizes());
 
-        try {
-          if (strategy.shouldCompact(request)) {
-            initiateMajorCompaction(MajorCompactionReason.USER);
-          } else {
-            majorCompactionState = CompactionState.IN_PROGRESS;
-            updateMetadata = true;
-            lastCompactID = compactionId;
-          }
-        } catch (IOException e) {
-          throw new RuntimeException(e);
+      try {
+        if (strategy.shouldCompact(request)) {
+          initiateMajorCompaction(MajorCompactionReason.USER);
+        } else {
+          majorCompactionState = CompactionState.IN_PROGRESS;
+          updateMetadata = true;
+          lastCompactID = compactionId;
         }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/HardListIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/HardListIterator.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.util.PeekingIterator;
+import org.apache.hadoop.io.Text;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * A wrapper making a list of hardcoded data into a SKVI. For testing.
+ */
+public class HardListIterator implements SortedKeyValueIterator<Key,Value> {
+  private static final Logger log = Logger.getLogger(HardListIterator.class);
+  public final static SortedMap<Key,Value> allEntriesToInject;
+  static {
+    SortedMap<Key,Value> t = new TreeMap<>();
+    t.put(new Key(new Text("a1"), new Text("colF3"), new Text("colQ3"), System.currentTimeMillis()), new Value("1".getBytes()));
+    t.put(new Key(new Text("c1"), new Text("colF3"), new Text("colQ3"), System.currentTimeMillis()), new Value("1".getBytes()));
+    t.put(new Key(new Text("m1"), new Text("colF3"), new Text("colQ3"), System.currentTimeMillis()), new Value("1".getBytes()));
+    allEntriesToInject = Collections.unmodifiableSortedMap(t); // for safety
+  }
+
+  private PeekingIterator<Map.Entry<Key,Value>> inner;
+  private Range seekRng;
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+    if (source != null)
+      log.info("HardListIterator ignores/replaces parent source passed in init(): " + source);
+
+    IteratorUtil.IteratorScope scope = env.getIteratorScope();
+    log.debug(this.getClass() + ": init on scope " + scope + (scope == IteratorUtil.IteratorScope.majc ? " fullScan=" + env.isFullMajorCompaction() : ""));
+
+    // define behavior before seek as seek to start at negative infinity
+    inner = new PeekingIterator<>(allEntriesToInject.entrySet().iterator());
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    HardListIterator newInstance;
+    try {
+      newInstance = HardListIterator.class.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    newInstance.inner = new PeekingIterator<>(allEntriesToInject.tailMap(inner.peek().getKey()).entrySet().iterator());
+
+    return newInstance;
+  }
+
+  @Override
+  public boolean hasTop() {
+    if (!inner.hasNext())
+      return false;
+    Key k = inner.peek().getKey();
+    return seekRng.contains(k); // do not return entries past the seek() range
+  }
+
+  @Override
+  public void next() throws IOException {
+    inner.next();
+  }
+
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+    seekRng = range;
+    // seek to first entry inside range
+    if (range.isInfiniteStartKey())
+      inner = new PeekingIterator<>(allEntriesToInject.entrySet().iterator());
+    else if (range.isStartKeyInclusive())
+      inner = new PeekingIterator<>(allEntriesToInject.tailMap(range.getStartKey()).entrySet().iterator());
+    else
+      inner = new PeekingIterator<>(allEntriesToInject.tailMap(range.getStartKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME)).entrySet()
+          .iterator());
+  }
+
+  @Override
+  public Key getTopKey() {
+    return hasTop() ? inner.peek().getKey() : null;
+  }
+
+  @Override
+  public Value getTopValue() {
+    return hasTop() ? inner.peek().getValue() : null;
+  }
+}


### PR DESCRIPTION
Putting this out for review to see if I am on the right track; I don't expect it to be perfect on the first shot.  I'd like to redo this for 1.6.3 if it looks good.  Open to suggestions on design and on testing compacting empty tablets.

Removed/modified lines in Tablet that stop construction of the SKVI stack when a tablet has no data.
Includes an iterator that generates data, for testing purposes. Includes one integration test. Not sure about MiniAccumulo.