### PR TITLE
ACCUMULO-3681 modified log statements that take format string (slf4j) from using arbitrary strings as first argument.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
@@ -92,13 +92,13 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
           return;
         }
       } catch (IsolationException | ScanTimedOutException | AccumuloException | AccumuloSecurityException | TableDeletedException | TableOfflineException e) {
-        log.trace(e.getMessage(), e);
+        log.trace("{}", e.getMessage(), e);
         synchQ.add(e);
       } catch (TableNotFoundException e) {
-        log.warn(e.getMessage(), e);
+        log.warn("{}", e.getMessage(), e);
         synchQ.add(e);
       } catch (Exception e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         synchQ.add(e);
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
@@ -526,9 +526,9 @@ public class TabletServerBatchWriter {
     this.lastUnknownError = t;
     this.notifyAll();
     if (t instanceof TableDeletedException || t instanceof TableOfflineException || t instanceof TimedOutException)
-      log.debug(msg, t); // this is not unknown
+      log.debug("{}", msg, t); // this is not unknown
     else
-      log.error(msg, t);
+      log.error("{}", msg, t);
   }
 
   private void checkForFailures() throws MutationsRejectedException {
@@ -837,7 +837,7 @@ public class TabletServerBatchWriter {
           }
         } catch (IOException e) {
           if (log.isTraceEnabled())
-            log.trace("failed to send mutations to " + location + " : " + e.getMessage());
+            log.trace("failed to send mutations to {} : {}", location, e.getMessage());
 
           HashSet<String> tables = new HashSet<String>();
           for (KeyExtent ke : mutationBatch.keySet())

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
@@ -334,7 +334,7 @@ class ConfigurationDocGen {
         try {
           data.close();
         } catch (IOException ex) {
-          log.error(ex.getMessage(), ex);
+          log.error("{}", ex.getMessage(), ex);
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -683,9 +683,9 @@ public enum Property {
         if (annotationType.isInstance(a))
           return true;
     } catch (SecurityException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     } catch (NoSuchFieldException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     }
     return false;
   }

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -240,7 +240,7 @@ public class BloomFilterLayer {
             if (!closed)
               LOG.warn("Can't open BloomFilter", ioe);
             else
-              LOG.debug("Can't open BloomFilter, file closed : " + ioe.getMessage());
+              LOG.debug("Can't open BloomFilter, file closed : {}", ioe.getMessage());
 
             bloomFilter = null;
           } catch (ClassNotFoundException e) {

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/CachingHDFSSecretKeyEncryptionStrategy.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/CachingHDFSSecretKeyEncryptionStrategy.java
@@ -50,7 +50,7 @@ public class CachingHDFSSecretKeyEncryptionStrategy implements SecretKeyEncrypti
       secretKeyCache.ensureSecretKeyCacheInitialized(context);
       doKeyEncryptionOperation(Cipher.WRAP_MODE, context);
     } catch (IOException e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       throw new RuntimeException(e);
     }
     return context;
@@ -62,7 +62,7 @@ public class CachingHDFSSecretKeyEncryptionStrategy implements SecretKeyEncrypti
       secretKeyCache.ensureSecretKeyCacheInitialized(context);
       doKeyEncryptionOperation(Cipher.UNWRAP_MODE, context);
     } catch (IOException e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       throw new RuntimeException(e);
     }
     return context;
@@ -74,7 +74,7 @@ public class CachingHDFSSecretKeyEncryptionStrategy implements SecretKeyEncrypti
     try {
       cipher.init(encryptionMode, new SecretKeySpec(secretKeyCache.getKeyEncryptionKey(), params.getAlgorithmName()));
     } catch (InvalidKeyException e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       throw new RuntimeException(e);
     }
 
@@ -83,10 +83,10 @@ public class CachingHDFSSecretKeyEncryptionStrategy implements SecretKeyEncrypti
         Key plaintextKey = cipher.unwrap(params.getEncryptedKey(), params.getAlgorithmName(), Cipher.SECRET_KEY);
         params.setPlaintextKey(plaintextKey.getEncoded());
       } catch (InvalidKeyException e) {
-        log.error(e.getMessage(),e);
+        log.error("{}", e.getMessage(),e);
         throw new RuntimeException(e);
       } catch (NoSuchAlgorithmException e) {
-        log.error(e.getMessage(),e);
+        log.error("{}", e.getMessage(),e);
         throw new RuntimeException(e);
       }
     } else {
@@ -96,10 +96,10 @@ public class CachingHDFSSecretKeyEncryptionStrategy implements SecretKeyEncrypti
         params.setEncryptedKey(encryptedSecretKey);
         params.setOpaqueKeyEncryptionKeyID(secretKeyCache.getPathToKeyName());
       } catch (InvalidKeyException e) {
-        log.error(e.getMessage(),e);
+        log.error("{}", e.getMessage(),e);
         throw new RuntimeException(e);
       } catch (IllegalBlockSizeException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         throw new RuntimeException(e);
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/NonCachingSecretKeyEncryptionStrategy.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/NonCachingSecretKeyEncryptionStrategy.java
@@ -83,7 +83,7 @@ public class NonCachingSecretKeyEncryptionStrategy implements SecretKeyEncryptio
       try {
         cipher.init(encryptionMode, new SecretKeySpec(keyEncryptionKey, params.getAlgorithmName()));
       } catch (InvalidKeyException e) {
-        log.error(e.getMessage(),e);
+        log.error("{}", e.getMessage(),e);
         throw new RuntimeException(e);
       }
 
@@ -92,10 +92,10 @@ public class NonCachingSecretKeyEncryptionStrategy implements SecretKeyEncryptio
           Key plaintextKey = cipher.unwrap(params.getEncryptedKey(), params.getAlgorithmName(), Cipher.SECRET_KEY);
           params.setPlaintextKey(plaintextKey.getEncoded());
         } catch (InvalidKeyException e) {
-          log.error(e.getMessage(),e);
+          log.error("{}", e.getMessage(),e);
           throw new RuntimeException(e);
         } catch (NoSuchAlgorithmException e) {
-          log.error(e.getMessage(),e);
+          log.error("{}", e.getMessage(),e);
           throw new RuntimeException(e);
         }
       } else {
@@ -105,10 +105,10 @@ public class NonCachingSecretKeyEncryptionStrategy implements SecretKeyEncryptio
           params.setEncryptedKey(encryptedSecretKey);
           params.setOpaqueKeyEncryptionKeyID(pathToKeyName);
         } catch (InvalidKeyException e) {
-          log.error(e.getMessage(),e);
+          log.error("{}", e.getMessage(),e);
           throw new RuntimeException(e);
         } catch (IllegalBlockSizeException e) {
-          log.error(e.getMessage(),e);
+          log.error("{}", e.getMessage(),e);
           throw new RuntimeException(e);
         }
 
@@ -159,7 +159,7 @@ public class NonCachingSecretKeyEncryptionStrategy implements SecretKeyEncryptio
       doKeyEncryptionOperation(Cipher.WRAP_MODE, params, fullPath, pathToKey, fs);
 
     } catch (IOException e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       throw new RuntimeException(e);
     }
 
@@ -183,7 +183,7 @@ public class NonCachingSecretKeyEncryptionStrategy implements SecretKeyEncryptio
       doKeyEncryptionOperation(Cipher.UNWRAP_MODE, params, pathToKeyName, pathToKey, fs);
 
     } catch (IOException e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       throw new RuntimeException(e);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/trace/DistributedTrace.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/DistributedTrace.java
@@ -198,7 +198,7 @@ public class DistributedTrace {
       try {
         rcvr.close();
       } catch (IOException e) {
-        log.warn("Unable to close SpanReceiver correctly: " + e.getMessage(), e);
+        log.warn("Unable to close SpanReceiver correctly: {}", e.getMessage(), e);
       }
     }
     receivers.clear();

--- a/core/src/main/java/org/apache/accumulo/core/util/CleanUp.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CleanUp.java
@@ -55,7 +55,7 @@ public class CleanUp {
           try {
             Thread.sleep(100);
           } catch (InterruptedException e) {
-            log.error(e.getMessage(), e);
+            log.error("{}", e.getMessage(), e);
           }
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/util/UtilWaitThread.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/UtilWaitThread.java
@@ -27,7 +27,7 @@ public class UtilWaitThread {
     try {
       Thread.sleep(millis);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/aggregation/NumSummationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/aggregation/NumSummationTest.java
@@ -74,7 +74,7 @@ public class NumSummationTest {
       la = NumArraySummation.bytesToLongArray(nas.aggregate().get());
       assertTrue(la.length == 0);
     } catch (Exception e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       assertTrue(false);
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
@@ -91,7 +91,7 @@ public class VersioningIteratorTest {
     } catch (IOException e) {
       assertFalse(true);
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       assertFalse(true);
     }
   }
@@ -127,7 +127,7 @@ public class VersioningIteratorTest {
     } catch (IOException e) {
       assertFalse(true);
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       assertFalse(true);
     }
   }
@@ -176,7 +176,7 @@ public class VersioningIteratorTest {
     } catch (IOException e) {
       assertFalse(true);
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       assertFalse(true);
     }
   }
@@ -204,7 +204,7 @@ public class VersioningIteratorTest {
       } catch (IOException e) {
         assertFalse(true);
       } catch (Exception e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         assertFalse(true);
       }
     }

--- a/examples/simple/src/test/java/org/apache/accumulo/examples/simple/filedata/ChunkInputStreamTest.java
+++ b/examples/simple/src/test/java/org/apache/accumulo/examples/simple/filedata/ChunkInputStreamTest.java
@@ -285,7 +285,7 @@ public class ChunkInputStreamTest extends TestCase {
       assertEquals(0, cis.read(b));
       fail();
     } catch (IOException e) {
-      log.debug("EXCEPTION " + e.getMessage());
+      log.debug("EXCEPTION {}", e.getMessage());
       // expected, ignore
     }
   }
@@ -295,7 +295,7 @@ public class ChunkInputStreamTest extends TestCase {
       cis.close();
       fail();
     } catch (IOException e) {
-      log.debug("EXCEPTION " + e.getMessage());
+      log.debug("EXCEPTION {}", e.getMessage());
       // expected, ignore
     }
   }

--- a/fate/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -111,7 +111,7 @@ public class AdminUtil<T> {
             tables.add(lda[0].charAt(0) + ":" + id);
 
           } catch (Exception e) {
-            log.error(e.getMessage(),e);
+            log.error("{}", e.getMessage(),e);
           }
           pos++;
         }

--- a/fate/src/main/java/org/apache/accumulo/fate/util/LoggingRunnable.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/util/LoggingRunnable.java
@@ -35,7 +35,7 @@ public class LoggingRunnable implements Runnable {
       runnable.run();
     } catch (Throwable t) {
       try {
-        log.error("Thread \"" + Thread.currentThread().getName() + "\" died " + t.getMessage(), t);
+        log.error("Thread \"{}\" died {}", Thread.currentThread().getName(), t.getMessage(), t);
       } catch (Throwable t2) {
         // maybe the logging system is screwed up OR there is a bug in the exception, like t.getMessage() throws a NPE
         System.err.println("ERROR " + new Date() + " Failed to log message about thread death " + t2.getMessage());

--- a/fate/src/main/java/org/apache/accumulo/fate/util/UtilWaitThread.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/util/UtilWaitThread.java
@@ -27,7 +27,7 @@ public class UtilWaitThread {
     try {
       Thread.sleep(millis);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     }
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -343,7 +343,7 @@ public class BulkImporter {
         mapFileSizes.put(path, fs.getContentSummary(path).getLength());
       }
     } catch (IOException e) {
-      log.error("Failed to get map files in for " + paths + ": " + e.getMessage(), e);
+      log.error("Failed to get map files in for {}: {}", paths, e.getMessage(), e);
       throw new RuntimeException(e);
     }
 
@@ -370,7 +370,7 @@ public class BulkImporter {
           try {
             estimatedSizes = FileUtil.estimateSizes(acuConf, entry.getKey(), mapFileSizes.get(entry.getKey()), extentsOf(entry.getValue()), conf, vm);
           } catch (IOException e) {
-            log.warn("Failed to estimate map file sizes " + e.getMessage());
+            log.warn("Failed to estimate map file sizes {}", e.getMessage());
           }
 
           if (estimatedSizes == null) {
@@ -462,7 +462,7 @@ public class BulkImporter {
           }
         }
 
-        log.info("Could not assign " + mapFiles.size() + " map files to tablet " + ke + " because : " + message + ".  Will retry ...");
+        log.info("Could not assign {} map files to tablet {} because : {} .  Will retry ...", mapFiles.size(), ke, message);
       }
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -259,7 +259,7 @@ public class MetadataConstraints implements Constraint {
           try {
             lockHeld = ZooLock.isLockHeld(zooCache, new ZooUtil.LockID(zooRoot, lockId));
           } catch (Exception e) {
-            log.debug("Failed to verify lock was held " + lockId + " " + e.getMessage());
+            log.debug("Failed to verify lock was held {} {}", lockId, e.getMessage());
           }
 
           if (!lockHeld) {
@@ -271,10 +271,10 @@ public class MetadataConstraints implements Constraint {
     }
 
     if (violations != null) {
-      log.debug("violating metadata mutation : " + new String(mutation.getRow(), UTF_8));
+      log.debug("violating metadata mutation : {}", new String(mutation.getRow(), UTF_8));
       for (ColumnUpdate update : mutation.getUpdates()) {
-        log.debug(" update: " + new String(update.getColumnFamily(), UTF_8) + ":" + new String(update.getColumnQualifier(), UTF_8) + " value "
-            + (update.isDeleted() ? "[delete]" : new String(update.getValue(), UTF_8)));
+        log.debug(" update: {}:{} value {}", new String(update.getColumnFamily(), UTF_8), new String(update.getColumnQualifier(), UTF_8),
+            (update.isDeleted() ? "[delete]" : new String(update.getValue(), UTF_8)));
       }
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilter.java
@@ -62,7 +62,7 @@ public class MetadataBulkLoadFilter extends Filter {
           }
         } catch (Exception e) {
           status = Status.ACTIVE;
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
 
         bulkTxStatusCache.put(txid, status);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
@@ -265,7 +265,7 @@ public class LiveTServerSet implements Watcher {
       if (!doomed.isEmpty() || !updates.isEmpty())
         this.cback.update(this, doomed, updates);
     } catch (Exception ex) {
-      log.error(ex.getMessage(), ex);
+      log.error("{}", ex.getMessage(), ex);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/DeadServerList.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/DeadServerList.java
@@ -67,7 +67,7 @@ public class DeadServerList {
         }
       }
     } catch (Exception ex) {
-      log.error(ex.getMessage(), ex);
+      log.error("{}", ex.getMessage(), ex);
     }
     return result;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/monitor/LogService.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/monitor/LogService.java
@@ -77,7 +77,7 @@ public class LogService extends org.apache.log4j.AppenderSkeleton {
           t.start();
         }
       } catch (IOException io) {
-        log.error(io.getMessage(), io);
+        log.error("{}", io.getMessage(), io);
       }
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -112,7 +112,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
     try {
       reportExecutor.execute(new LoggingRunnable(log, r));
     } catch (RejectedExecutionException ree) {
-      log.error("Failed to report problem " + pr.getTableName() + " " + pr.getProblemType() + " " + pr.getResource() + "  " + ree.getMessage());
+      log.error("Failed to report problem {} {} {} {}", pr.getTableName(), pr.getProblemType(), pr.getResource(), ree.getMessage());
     }
 
   }
@@ -139,7 +139,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
             pr.removeFromMetadataTable(context);
           }
         } catch (Exception e) {
-          log.error("Failed to delete problem report " + pr.getTableName() + " " + pr.getProblemType() + " " + pr.getResource(), e);
+          log.error("Failed to delete problem report {} {} {}", pr.getTableName(), pr.getProblemType(), pr.getResource(), e);
         }
       }
     };
@@ -147,7 +147,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
     try {
       reportExecutor.execute(new LoggingRunnable(log, r));
     } catch (RejectedExecutionException ree) {
-      log.error("Failed to delete problem report " + pr.getTableName() + " " + pr.getProblemType() + " " + pr.getResource() + "  " + ree.getMessage());
+      log.error("Failed to delete problem report {} {} {} {}", pr.getTableName(), pr.getProblemType(), pr.getResource(), ree.getMessage());
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/RpcWrapper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/RpcWrapper.java
@@ -47,11 +47,11 @@ public class RpcWrapper {
           return super.invoke(obj, method, args);
         } catch (RuntimeException e) {
           String msg = e.getMessage();
-          log.error(msg, e);
+          log.error("{}", msg, e);
           throw new TException(msg);
         } catch (Error e) {
           String msg = e.getMessage();
-          log.error(msg, e);
+          log.error("{}", msg, e);
           throw new TException(msg);
         }
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TNonblockingServerSocket.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TNonblockingServerSocket.java
@@ -140,7 +140,7 @@ public class TNonblockingServerSocket extends TNonblockingServerTransport {
       try {
         serverSocket_.close();
       } catch (IOException iox) {
-        log.warn("WARNING: Could not close server socket: " + iox.getMessage());
+        log.warn("WARNING: Could not close server socket: {}", iox.getMessage());
       }
       serverSocket_ = null;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
@@ -79,13 +79,13 @@ public final class ZKAuthenticator implements Authenticator {
         constructUser(principal, ZKSecurityTool.createPass(token));
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (AccumuloException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -121,10 +121,10 @@ public final class ZKAuthenticator implements Authenticator {
         throw new AccumuloSecurityException(principal, SecurityErrorCode.USER_EXISTS, e);
       throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (AccumuloException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(principal, SecurityErrorCode.DEFAULT_SECURITY_ERROR, e);
     }
   }
@@ -137,13 +137,13 @@ public final class ZKAuthenticator implements Authenticator {
         ZooReaderWriter.getInstance().recursiveDelete(ZKUserPath + "/" + user, NodeMissingPolicy.FAIL);
       }
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (KeeperException e) {
       if (e.code().equals(KeeperException.Code.NONODE)) {
         throw new AccumuloSecurityException(user, SecurityErrorCode.USER_DOESNT_EXIST, e);
       }
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     }
   }
@@ -161,13 +161,13 @@ public final class ZKAuthenticator implements Authenticator {
               NodeExistsPolicy.OVERWRITE);
         }
       } catch (KeeperException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
       } catch (InterruptedException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         throw new RuntimeException(e);
       } catch (AccumuloException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         throw new AccumuloSecurityException(principal, SecurityErrorCode.DEFAULT_SECURITY_ERROR, e);
       }
     } else

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
@@ -102,10 +102,10 @@ public class ZKAuthorizor implements Authorizor {
       initUser(rootuser);
       zoo.putPersistentData(ZKUserPath + "/" + rootuser + ZKUserAuths, ZKSecurityTool.convertAuthorizations(Authorizations.EMPTY), NodeExistsPolicy.FAIL);
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -116,10 +116,10 @@ public class ZKAuthorizor implements Authorizor {
     try {
       zoo.putPersistentData(ZKUserPath + "/" + user, new byte[0], NodeExistsPolicy.SKIP);
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -133,10 +133,10 @@ public class ZKAuthorizor implements Authorizor {
         zooCache.clear(ZKUserPath + "/" + user);
       }
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       if (e.code().equals(KeeperException.Code.NONODE))
         throw new AccumuloSecurityException(user, SecurityErrorCode.USER_DOESNT_EXIST, e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
@@ -153,10 +153,10 @@ public class ZKAuthorizor implements Authorizor {
             NodeExistsPolicy.OVERWRITE);
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -196,10 +196,10 @@ public class ZKPermHandler implements PermissionHandler {
         }
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -222,10 +222,10 @@ public class ZKPermHandler implements PermissionHandler {
         }
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -248,10 +248,10 @@ public class ZKPermHandler implements PermissionHandler {
         }
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -275,10 +275,10 @@ public class ZKPermHandler implements PermissionHandler {
         }
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -303,10 +303,10 @@ public class ZKPermHandler implements PermissionHandler {
               NodeExistsPolicy.OVERWRITE);
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -331,10 +331,10 @@ public class ZKPermHandler implements PermissionHandler {
               NodeExistsPolicy.OVERWRITE);
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -349,10 +349,10 @@ public class ZKPermHandler implements PermissionHandler {
           zoo.recursiveDelete(ZKUserPath + "/" + user + ZKUserTablePerms + "/" + table, NodeMissingPolicy.SKIP);
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException("unknownUser", SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -367,10 +367,10 @@ public class ZKPermHandler implements PermissionHandler {
           zoo.recursiveDelete(ZKUserPath + "/" + user + ZKUserNamespacePerms + "/" + namespace, NodeMissingPolicy.SKIP);
       }
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException("unknownUser", SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -404,10 +404,10 @@ public class ZKPermHandler implements PermissionHandler {
       for (Entry<String,Set<NamespacePermission>> entry : namespacePerms.entrySet())
         createNamespacePerm(rootuser, entry.getKey(), entry.getValue());
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -420,10 +420,10 @@ public class ZKPermHandler implements PermissionHandler {
       zoo.putPersistentData(ZKUserPath + "/" + user + ZKUserTablePerms, new byte[0], NodeExistsPolicy.SKIP);
       zoo.putPersistentData(ZKUserPath + "/" + user + ZKUserNamespacePerms, new byte[0], NodeExistsPolicy.SKIP);
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     }
   }
@@ -461,10 +461,10 @@ public class ZKPermHandler implements PermissionHandler {
         zooCache.clear(ZKUserPath + "/" + user);
       }
     } catch (InterruptedException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e);
     } catch (KeeperException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       if (e.code().equals(KeeperException.Code.NONODE))
         throw new AccumuloSecurityException(user, SecurityErrorCode.USER_DOESNT_EXIST, e);
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -111,7 +111,7 @@ class ZKSecurityTool {
       for (SystemPermission sp : systempermissions)
         out.writeByte(sp.getId());
     } catch (IOException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e); // this is impossible with ByteArrayOutputStream; crash hard if this happens
     }
     return bytes.toByteArray();
@@ -138,7 +138,7 @@ class ZKSecurityTool {
       for (TablePermission tp : tablepermissions)
         out.writeByte(tp.getId());
     } catch (IOException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e); // this is impossible with ByteArrayOutputStream; crash hard if this happens
     }
     return bytes.toByteArray();
@@ -158,7 +158,7 @@ class ZKSecurityTool {
       for (NamespacePermission tnp : namespacepermissions)
         out.writeByte(tnp.getId());
     } catch (IOException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw new RuntimeException(e); // this is impossible with ByteArrayOutputStream; crash hard if this happens
     }
     return bytes.toByteArray();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -254,13 +254,13 @@ public class Admin implements KeywordExecutable {
       if (rc != 0)
         System.exit(rc);
     } catch (AccumuloException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       System.exit(1);
     } catch (AccumuloSecurityException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       System.exit(2);
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       System.exit(3);
     }
   }
@@ -316,7 +316,7 @@ public class Admin implements KeywordExecutable {
             }
           }
         } catch (Exception e) {
-          log.warn("Failed to intiate flush " + e.getMessage());
+          log.warn("Failed to intiate flush {}", e.getMessage());
         }
       }
     };

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -165,7 +165,7 @@ public class FileUtil {
           if (reader != null)
             reader.close();
         } catch (IOException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
 
         for (SortedKeyValueIterator<Key,Value> r : iters)
@@ -174,13 +174,13 @@ public class FileUtil {
               ((FileSKVIterator) r).close();
           } catch (IOException e) {
             // continue closing
-            log.error(e.getMessage(), e);
+            log.error("{}", e.getMessage(), e);
           }
 
         try {
           writer.close();
         } catch (IOException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
           throw e;
         }
       }
@@ -374,7 +374,7 @@ public class FileUtil {
           r.close();
       } catch (IOException e) {
         // okay, try to close the rest anyway
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
     }
 
@@ -420,7 +420,7 @@ public class FileUtil {
           if (reader != null)
             reader.close();
         } catch (IOException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
       }
 
@@ -495,7 +495,7 @@ public class FileUtil {
           if (reader != null)
             reader.close();
         } catch (IOException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
       }
     }
@@ -542,7 +542,7 @@ public class FileUtil {
           index.close();
       } catch (IOException e) {
         // continue with next file
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
@@ -221,7 +221,7 @@ public class ListInstances {
 
   private static void handleException(Exception e, boolean printErrors) {
     if (printErrors) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     }
 
     errors++;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -189,9 +189,9 @@ public class MasterMetadataUtil {
       try {
         return new TServerInstance(address, zooLock.getSessionId());
       } catch (KeeperException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       } catch (InterruptedException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
       UtilWaitThread.sleep(1000);
     }
@@ -280,9 +280,9 @@ public class MasterMetadataUtil {
           }
           break;
         } catch (KeeperException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         } catch (InterruptedException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
         UtilWaitThread.sleep(1000);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -153,15 +153,15 @@ public class MetadataTableUtil {
         t.update(m);
         return;
       } catch (AccumuloException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       } catch (AccumuloSecurityException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       } catch (ConstraintViolationException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         // retrying when a CVE occurs is probably futile and can cause problems, see ACCUMULO-3096
         throw new RuntimeException(e);
       } catch (TableNotFoundException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
       UtilWaitThread.sleep(1000);
     }
@@ -465,11 +465,11 @@ public class MetadataTableUtil {
           }
           break;
         } catch (KeeperException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         } catch (InterruptedException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         } catch (IOException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
         UtilWaitThread.sleep(1000);
       }
@@ -680,7 +680,7 @@ public class MetadataTableUtil {
             }
             break;
           } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            log.error("{}", e.getMessage(), e);
           }
           UtilWaitThread.sleep(1000);
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
@@ -104,7 +104,7 @@ public class RandomWriter {
       bw.addMutations(new RandomMutationGenerator(opts.count));
       bw.close();
     } catch (Exception e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw e;
     }
     long stop = System.currentTimeMillis();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
@@ -67,7 +67,7 @@ public class RandomizeVolumes {
       int status = randomize(c, opts.getTableName());
       System.exit(status);
     } catch (Exception ex) {
-      log.error(ex.getMessage(), ex);
+      log.error("{}", ex.getMessage(), ex);
       System.exit(4);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -101,7 +101,7 @@ public class ZooZap {
           }
         }
       } catch (Exception e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
     }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
@@ -83,7 +83,7 @@ public class ZKAuthenticatorTest extends TestCase {
       storedBytes = ZKSecurityTool.createPass(rawPass);
       assertTrue(ZKSecurityTool.checkPass(rawPass, storedBytes));
     } catch (AccumuloException e) {
-      log.error(e.getMessage(),e);
+      log.error("{}", e.getMessage(),e);
       assertTrue(false);
     }
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -415,7 +415,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
                 putMarkerDeleteMutation(delete, finalWriter);
               }
             } catch (Exception e) {
-              log.error(e.getMessage(), e);
+              log.error("{}", e.getMessage(), e);
             }
 
           }
@@ -430,7 +430,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
       try {
         while (!deleteThreadPool.awaitTermination(1000, TimeUnit.MILLISECONDS)) {}
       } catch (InterruptedException e1) {
-        log.error(e1.getMessage(), e1);
+        log.error("{}", e1.getMessage(), e1);
       }
 
       if (writer != null) {
@@ -513,7 +513,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     try {
       getZooLock(startStatsService());
     } catch (Exception ex) {
-      log.error(ex.getMessage(), ex);
+      log.error("{}", ex.getMessage(), ex);
       System.exit(1);
     }
 
@@ -522,7 +522,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
       log.debug("Sleeping for " + delay + " milliseconds before beginning garbage collection cycles");
       Thread.sleep(delay);
     } catch (InterruptedException e) {
-      log.warn(e.getMessage(), e);
+      log.warn("{}", e.getMessage(), e);
       return;
     }
 
@@ -551,7 +551,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
         status.current = new GcCycleStats();
 
       } catch (Exception e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
 
       tStop = System.currentTimeMillis();
@@ -576,7 +576,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
         log.info("Beginning garbage collection of write-ahead logs");
         walogCollector.collect(status);
       } catch (Exception e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       } finally {
         waLogs.stop();
       }
@@ -588,7 +588,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
         connector.tableOperations().compact(MetadataTable.NAME, null, null, true, true);
         connector.tableOperations().compact(RootTable.NAME, null, null, true, true);
       } catch (Exception e) {
-        log.warn(e.getMessage(), e);
+        log.warn("{}", e.getMessage(), e);
       }
 
       Trace.off();
@@ -597,7 +597,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
         log.debug("Sleeping for " + gcDelay + " milliseconds");
         Thread.sleep(gcDelay);
       } catch (InterruptedException e) {
-        log.warn(e.getMessage(), e);
+        log.warn("{}", e.getMessage(), e);
         return;
       }
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1003,7 +1003,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
           if (connection != null)
             connection.fastHalt(masterLock);
         } catch (TException e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
         }
         tserverSet.remove(instance);
       }

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -129,7 +129,7 @@ class MasterClientServiceHandler extends FateServiceHandler implements MasterCli
     } catch (NoNodeException nne) {
       throw new ThriftTableOperationException(tableId, null, TableOperation.FLUSH, TableOperationExceptionType.NOTFOUND, null);
     } catch (Exception e) {
-      Master.log.warn(e.getMessage(), e);
+      Master.log.warn("{}", e.getMessage(), e);
       throw new ThriftTableOperationException(tableId, null, TableOperation.FLUSH, TableOperationExceptionType.OTHER, null);
     }
     return Long.parseLong(new String(fid));
@@ -241,10 +241,10 @@ class MasterClientServiceHandler extends FateServiceHandler implements MasterCli
       } catch (TabletDeletedException tde) {
         Master.log.debug("Failed to scan " + MetadataTable.NAME + " table to wait for flush " + tableId, tde);
       } catch (AccumuloSecurityException e) {
-        Master.log.warn(e.getMessage(), e);
+        Master.log.warn("{}", e.getMessage(), e);
         throw new ThriftSecurityException();
       } catch (TableNotFoundException e) {
-        Master.log.error(e.getMessage(), e);
+        Master.log.error("{}", e.getMessage(), e);
         throw new ThriftTableOperationException();
       }
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
@@ -71,7 +71,7 @@ public class RecoveryManager {
       List<String> workIDs = new DistributedWorkQueue(ZooUtil.getRoot(master.getInstance()) + Constants.ZRECOVERY, aconf).getWorkQueued();
       sortsQueued.addAll(workIDs);
     } catch (Exception e) {
-      log.warn(e.getMessage(), e);
+      log.warn("{}", e.getMessage(), e);
     }
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
@@ -196,7 +196,7 @@ public class MergeStats {
       try {
         tls = MetaDataTableScanner.createTabletLocationState(entry.getKey(), entry.getValue());
       } catch (BadLocationStateException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         return false;
       }
       log.debug("consistency check: " + tls + " walogs " + tls.walogs.size());

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/BulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/BulkImport.java
@@ -273,7 +273,7 @@ public class BulkImport extends MasterRepo {
               fs.rename(fileStatus.getPath(), newPath);
               log.debug("Moved " + fileStatus.getPath() + " to " + newPath);
             } catch (IOException E1) {
-              log.error("Could not move: " + fileStatus.getPath().toString() + " " + E1.getMessage());
+              log.error("Could not move: {} {}", fileStatus.getPath().toString(), E1.getMessage());
             }
 
           } catch (Exception ex) {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
@@ -198,7 +198,7 @@ class ClonePermissions extends MasterRepo {
         AuditedSecurityOperation.getInstance(environment).grantTablePermission(environment.rpcCreds(), cloneInfo.user, cloneInfo.tableId, permission,
             cloneInfo.namespaceId);
       } catch (ThriftSecurityException e) {
-        LoggerFactory.getLogger(FinishCloneTable.class).error(e.getMessage(), e);
+        LoggerFactory.getLogger(FinishCloneTable.class).error("{}", e.getMessage(), e);
         throw e;
       }
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
@@ -146,7 +146,7 @@ class SetupNamespacePermissions extends MasterRepo {
       try {
         security.grantNamespacePermission(env.rpcCreds(), namespaceInfo.user, namespaceInfo.namespaceId, permission);
       } catch (ThriftSecurityException e) {
-        LoggerFactory.getLogger(FinishCreateNamespace.class).error(e.getMessage(), e);
+        LoggerFactory.getLogger(FinishCreateNamespace.class).error("{}", e.getMessage(), e);
         throw e;
       }
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
@@ -256,7 +256,7 @@ class SetupPermissions extends MasterRepo {
         try {
           security.grantTablePermission(env.rpcCreds(), tableInfo.user, tableInfo.tableId, permission, tableInfo.namespaceId);
         } catch (ThriftSecurityException e) {
-          LoggerFactory.getLogger(FinishCreateTable.class).error(e.getMessage(), e);
+          LoggerFactory.getLogger(FinishCreateTable.class).error("{}", e.getMessage(), e);
           throw e;
         }
       }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteNamespace.java
@@ -58,7 +58,7 @@ class NamespaceCleanUp extends MasterRepo {
     try {
       AuditedSecurityOperation.getInstance(master).deleteNamespace(master.rpcCreds(), namespaceId);
     } catch (ThriftSecurityException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     }
 
     Utils.unreserveNamespace(namespaceId, id, true);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteTable.java
@@ -207,7 +207,7 @@ class CleanUp extends MasterRepo {
     try {
       AuditedSecurityOperation.getInstance(master).deleteTable(master.rpcCreds(), tableId, namespaceId);
     } catch (ThriftSecurityException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
     }
 
     Utils.unreserveTable(tableId, tid, true);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
@@ -169,7 +169,7 @@ class MoveExportedFiles extends MasterRepo {
 
       return new FinishImportTable(tableInfo);
     } catch (IOException ioe) {
-      log.warn(ioe.getMessage(), ioe);
+      log.warn("{}", ioe.getMessage(), ioe);
       throw new ThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
           "Error renaming files " + ioe.getMessage());
     }
@@ -303,7 +303,7 @@ class PopulateMetadataTable extends MasterRepo {
 
       return new MoveExportedFiles(tableInfo);
     } catch (IOException ioe) {
-      log.warn(ioe.getMessage(), ioe);
+      log.warn("{}", ioe.getMessage(), ioe);
       throw new ThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
           "Error reading " + path + " " + ioe.getMessage());
     } finally {
@@ -397,7 +397,7 @@ class MapImportFileNames extends MasterRepo {
 
       return new PopulateMetadataTable(tableInfo);
     } catch (IOException ioe) {
-      log.warn(ioe.getMessage(), ioe);
+      log.warn("{}", ioe.getMessage(), ioe);
       throw new ThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
           "Error writing mapping file " + path + " " + ioe.getMessage());
     } finally {
@@ -538,7 +538,7 @@ class ImportSetupPermissions extends MasterRepo {
       try {
         security.grantTablePermission(env.rpcCreds(), tableInfo.user, tableInfo.tableId, permission, tableInfo.namespaceId);
       } catch (ThriftSecurityException e) {
-        LoggerFactory.getLogger(ImportSetupPermissions.class).error(e.getMessage(), e);
+        LoggerFactory.getLogger(ImportSetupPermissions.class).error("{}", e.getMessage(), e);
         throw e;
       }
     }
@@ -617,7 +617,7 @@ public class ImportTable extends MasterRepo {
         }
       }
     } catch (IOException ioe) {
-      log.warn(ioe.getMessage(), ioe);
+      log.warn("{}", ioe.getMessage(), ioe);
       throw new ThriftTableOperationException(null, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
           "Failed to read export metadata " + ioe.getMessage());
     }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -495,7 +495,7 @@ public class Monitor {
           try {
             Monitor.fetchData();
           } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            log.warn("{}", e.getMessage(), e);
           }
 
           UtilWaitThread.sleep(333);
@@ -511,7 +511,7 @@ public class Monitor {
           try {
             Monitor.fetchScans();
           } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            log.warn("{}", e.getMessage(), e);
           }
           UtilWaitThread.sleep(5000);
         }

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/SendSpansViaThrift.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/SendSpansViaThrift.java
@@ -63,7 +63,7 @@ public class SendSpansViaThrift extends AsyncSpanReceiver<String,Client> {
       TProtocol prot = new TBinaryProtocol(transport);
       return new Client(prot);
     } catch (Exception ex) {
-      log.error(ex.getMessage(), ex);
+      log.error("{}", ex.getMessage(), ex);
       return null;
     }
   }

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -360,7 +360,7 @@ public class TraceServer implements Watcher {
         if (ZooReaderWriter.getInstance().exists(event.getPath(), this))
           return;
       } catch (Exception ex) {
-        log.error(ex.getMessage(), ex);
+        log.error("{}", ex.getMessage(), ex);
       }
       log.warn("Trace server unable to reset watch on zookeeper registration");
       server.stop();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -237,7 +237,7 @@ public class FileManager {
       try {
         reader.close();
       } catch (Exception e) {
-        log.error("Failed to close file " + e.getMessage(), e);
+        log.error("Failed to close file {}", e.getMessage(), e);
       }
     }
   }
@@ -327,7 +327,7 @@ public class FileManager {
           if (!tablet.isMeta()) {
             filePermits.release(1);
           }
-          log.warn("Failed to open file " + file + " " + e.getMessage() + " continuing...");
+          log.warn("Failed to open file {} {}  continuing...", file, e.getMessage());
         } else {
           // close whatever files were opened
           closeReaders(reservedFiles);
@@ -336,7 +336,7 @@ public class FileManager {
             filePermits.release(files.size());
           }
 
-          log.error("Failed to open file " + file + " " + e.getMessage());
+          log.error("Failed to open file {} {}", file, e.getMessage());
           throw new IOException("Failed to open " + file, e);
         }
       }
@@ -365,7 +365,7 @@ public class FileManager {
         try {
           reader.closeDeepCopies();
         } catch (IOException e) {
-          log.warn(e.getMessage(), e);
+          log.warn("{}", e.getMessage(), e);
           sawIOException = true;
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -647,7 +647,7 @@ public class InMemoryMap {
             if (mds.reader != null)
               mds.reader.close();
           } catch (IOException e) {
-            log.warn(e.getMessage(), e);
+            log.warn("{}", e.getMessage(), e);
           }
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -423,7 +423,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
           try {
             importTablet.importMapFiles(tid, fileRefMap, setTime);
           } catch (IOException ioe) {
-            log.info("files " + fileMap.keySet() + " not imported to " + new KeyExtent(tke) + ": " + ioe.getMessage());
+            log.info("files {} not imported to {}: {}", fileMap.keySet(), new KeyExtent(tke), ioe.getMessage());
             failures.add(tke);
           }
         }
@@ -1563,7 +1563,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
             flushID = tablet.getFlushID();
           } catch (NoNodeException e) {
             // table was probably deleted
-            log.info("Asked to flush table that has no flush id " + ke + " " + e.getMessage());
+            log.info("Asked to flush table that has no flush id {} {}", ke, e.getMessage());
             return;
           }
         }
@@ -1586,7 +1586,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         try {
           tablet.flush(tablet.getFlushID());
         } catch (NoNodeException nne) {
-          log.info("Asked to flush tablet that has no flush id " + new KeyExtent(textent) + " " + nne.getMessage());
+          log.info("Asked to flush tablet that has no flush id {} {}", new KeyExtent(textent), nne.getMessage());
         }
       }
     }
@@ -1681,7 +1681,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
           try {
             compactionInfo = tablet.getCompactionID();
           } catch (NoNodeException e) {
-            log.info("Asked to compact table with no compaction id " + ke + " " + e.getMessage());
+            log.info("Asked to compact table with no compaction id {} {}", ke, e.getMessage());
             return;
           }
         tablet.compactAll(compactionInfo.getFirst(), compactionInfo.getSecond());
@@ -1904,10 +1904,10 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       }
     } catch (IOException e) {
       statsKeeper.updateTime(Operation.SPLIT, 0, 0, true);
-      log.error("split failed: " + e.getMessage() + " for tablet " + tablet.getExtent(), e);
+      log.error("split failed: {} for tablet {}", e.getMessage(), tablet.getExtent(), e);
     } catch (Exception e) {
       statsKeeper.updateTime(Operation.SPLIT, 0, 0, true);
-      log.error("Unknown error on split: " + e, e);
+      log.error("Unknown error on split: {}", e, e);
     }
   }
 
@@ -2009,9 +2009,9 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       } catch (Throwable e) {
 
         if ((t.isClosing() || t.isClosed()) && e instanceof IllegalStateException) {
-          log.debug("Failed to unload tablet " + extent + "... it was alread closing or closed : " + e.getMessage());
+          log.debug("Failed to unload tablet {} ... it was alread closing or closed : {}", extent, e.getMessage());
         } else {
-          log.error("Failed to close tablet " + extent + "... Aborting migration", e);
+          log.error("Failed to close tablet {}... Aborting migration", extent, e);
           enqueueMasterMessage(new TabletStatusMessage(TabletLoadState.UNLOAD_ERROR, extent));
         }
         return;
@@ -2183,9 +2183,12 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         tablet = null; // release this reference
         successful = true;
       } catch (Throwable e) {
-        log.warn("exception trying to assign tablet " + extent + " " + locationToOpen, e);
-        if (e.getMessage() != null)
-          log.warn(e.getMessage());
+        log.warn("exception trying to assign tablet {} {}", extent, locationToOpen, e);
+
+        if (e.getMessage() != null) {
+          log.warn("{}", e.getMessage());
+        }
+
         String table = extent.getTableId().toString();
         ProblemReports.getInstance(TabletServer.this).report(new ProblemReport(table, TABLET_LOAD, extent.getUUID().toString(), getClientAddressString(), e));
       } finally {
@@ -2580,7 +2583,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       log.debug("Closing filesystem");
       fs.close();
     } catch (IOException e) {
-      log.warn("Failed to close filesystem : " + e.getMessage(), e);
+      log.warn("Failed to close filesystem : {}", e.getMessage(), e);
     }
 
     gcLogger.logGCInfo(getConfiguration());
@@ -2816,7 +2819,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         try {
           AccumuloVFSClassLoader.getContextManager().removeUnusedContexts(contexts);
         } catch (IOException e) {
-          log.warn(e.getMessage(), e);
+          log.warn("{}", e.getMessage(), e);
         }
       }
     };

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -409,7 +409,7 @@ public class TabletServerResourceManager {
           mma = memoryManager.getMemoryManagementActions(tabletStates);
 
         } catch (Throwable t) {
-          log.error("Memory manager failed " + t.getMessage(), t);
+          log.error("Memory manager failed {}", t.getMessage(), t);
         }
 
         try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/WriteTracker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/WriteTracker.java
@@ -78,7 +78,7 @@ class WriteTracker {
       try {
         this.wait();
       } catch (InterruptedException e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
       }
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
@@ -102,7 +102,7 @@ public class ConstraintChecker {
 
       return currentLoader != loader;
     } catch (Exception e) {
-      log.debug("Failed to check " + e.getMessage());
+      log.debug("Failed to check {}", e.getMessage());
       return true;
     }
   }
@@ -138,7 +138,7 @@ public class ConstraintChecker {
           }
         }
       } catch (Throwable throwable) {
-        log.warn("CONSTRAINT FAILED : " + throwable.getMessage(), throwable);
+        log.warn("CONSTRAINT FAILED : {}", throwable.getMessage(), throwable);
 
         // constraint failed in some way, do not allow mutation to pass
         short vcode;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -234,10 +234,10 @@ public class Compactor implements Callable<CompactionStats> {
       majCStats.setFileSize(fileFactory.getFileSize(outputFile.path().toString(), ns, ns.getConf(), acuTableConf));
       return majCStats;
     } catch (IOException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw e;
     } catch (RuntimeException e) {
-      log.error(e.getMessage(), e);
+      log.error("{}", e.getMessage(), e);
       throw e;
     } finally {
       Thread.currentThread().setName(oldThreadName);
@@ -258,9 +258,9 @@ public class Compactor implements Callable<CompactionStats> {
           }
         }
       } catch (IOException e) {
-        log.warn(e.getMessage(), e);
+        log.warn("{}", e.getMessage(), e);
       } catch (RuntimeException exception) {
-        log.warn(exception.getMessage(), exception);
+        log.warn("{}", exception.getMessage(), exception);
       }
     }
   }
@@ -292,7 +292,7 @@ public class Compactor implements Callable<CompactionStats> {
 
         ProblemReports.getInstance(context).report(new ProblemReport(extent.getTableId().toString(), ProblemType.FILE_READ, mapFile.path().toString(), e));
 
-        log.warn("Some problem opening map file " + mapFile + " " + e.getMessage(), e);
+        log.warn("Some problem opening map file {} {}", mapFile, e.getMessage(), e);
         // failed to open some map file... close the ones that were opened
         for (FileSKVIterator reader : readers) {
           try {
@@ -369,7 +369,7 @@ public class Compactor implements Callable<CompactionStats> {
             try {
               mfw.close();
             } catch (IOException e) {
-              log.error(e.getMessage(), e);
+              log.error("{}", e.getMessage(), e);
             }
             fs.deleteRecursively(outputFile.path());
           } catch (Exception e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -72,7 +72,7 @@ class MinorCompactionTask implements Runnable {
           tablet.getTabletServer().minorCompactionStarted(commitSession, commitSession.getWALogSeq() + 1, newMapfileLocation.path().toString());
           break;
         } catch (IOException e) {
-          log.warn("Failed to write to write ahead log " + e.getMessage(), e);
+          log.warn("Failed to write to write ahead log {}", e.getMessage(), e);
         }
       }
       span.stop();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -105,13 +105,13 @@ public class MinorCompactor extends Compactor {
 
           return ret;
         } catch (IOException e) {
-          log.warn("MinC failed (" + e.getMessage() + ") to create " + getOutputFile() + " retrying ...");
+          log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(),getOutputFile());
           ProblemReports.getInstance(tabletServer).report(new ProblemReport(getExtent().getTableId().toString(), ProblemType.FILE_WRITE, getOutputFile(), e));
           reportedProblem = true;
         } catch (RuntimeException e) {
           // if this is coming from a user iterator, it is possible that the user could change the iterator config and that the
           // minor compaction would succeed
-          log.warn("MinC failed (" + e.getMessage() + ") to create " + getOutputFile() + " retrying ...", e);
+          log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), getOutputFile(), e);
           ProblemReports.getInstance(tabletServer).report(new ProblemReport(getExtent().getTableId().toString(), ProblemType.FILE_WRITE, getOutputFile(), e));
           reportedProblem = true;
         } catch (CompactionCanceledException e) {
@@ -131,7 +131,7 @@ public class MinorCompactor extends Compactor {
             getFileSystem().deleteRecursively(new Path(getOutputFile()));
           }
         } catch (IOException e) {
-          log.warn("Failed to delete failed MinC file " + getOutputFile() + " " + e.getMessage());
+          log.warn("Failed to delete failed MinC file {} {}", getOutputFile(), e.getMessage());
         }
 
         if (isTableDeleting())

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -137,7 +137,7 @@ class TabletMemory implements Closeable {
       try {
         tablet.wait(50);
       } catch (InterruptedException e) {
-        log.warn(e.getMessage(), e);
+        log.warn("{}", e.getMessage(), e);
       }
     }
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ShellPluginConfigurationCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ShellPluginConfigurationCommand.java
@@ -113,16 +113,16 @@ public abstract class ShellPluginConfigurationCommand extends Command {
           CommandLine cl = new BasicParser().parse(o, args);
           pluginClazz = shellState.getClassLoader(cl, shellState).loadClass(ent.getValue()).asSubclass(clazz);
         } catch (ClassNotFoundException e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Class not found" + e.getMessage());
+          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Class not found {}", e.getMessage());
           return null;
         } catch (ParseException e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Error parsing table: " + Arrays.toString(args) + e.getMessage());
+          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Error parsing table: {} {}", Arrays.toString(args), e.getMessage());
           return null;
         } catch (TableNotFoundException e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Table not found: " + tableName + e.getMessage());
+          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Table not found: {} {}", tableName, e.getMessage());
           return null;
         } catch (Exception e) {
-          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Error: " + e.getMessage());
+          LoggerFactory.getLogger(ShellPluginConfigurationCommand.class).error("Error: {}", e.getMessage());
           return null;
         }
 

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoader.java
@@ -88,11 +88,11 @@ public class AccumuloReloadingVFSClassLoader implements FileListener, ReloadingC
           updateClassloader(files, cl);
           return;
         } catch (Exception e) {
-          log.error(e.getMessage(), e);
+          log.error("{}", e.getMessage(), e);
           try {
             Thread.sleep(DEFAULT_TIMEOUT);
           } catch (InterruptedException ie) {
-            log.error(e.getMessage(), ie);
+            log.error("{}", e.getMessage(), ie);
           }
         }
       }

--- a/test/src/test/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -974,7 +974,7 @@ public class ConditionalWriterIT extends AccumuloClusterIT {
         }
 
       } catch (Exception e) {
-        log.error(e.getMessage(), e);
+        log.error("{}", e.getMessage(), e);
         failed.set(true);
       }
     }

--- a/test/src/test/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -66,7 +66,7 @@ public class MetaGetsReadersIT extends ConfigurableMacIT {
             }
           }
         } catch (Exception ex) {
-          log.trace(ex.getMessage(), ex);
+          log.trace("{}", ex.getMessage(), ex);
           stop.set(true);
         }
       }

--- a/test/src/test/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -125,7 +125,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacIT {
           }
           System.out.println("Restarted " + i + " times");
         } catch (Exception ex) {
-          log.error(ex.getMessage(), ex);
+          log.error("{}", ex.getMessage(), ex);
         }
       }
     };


### PR DESCRIPTION
This should complete ACCUMULO-3681.  Additional clean-up is still required for logging statements that are using log4j.
