### PR TITLE
ACCUMULO-3900 Fix Lexicoder precondition check and bad test.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/AbstractEncoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/AbstractEncoder.java
@@ -51,7 +51,7 @@ public abstract class AbstractEncoder<T> implements Encoder<T> {
     Preconditions.checkNotNull(b, "cannot decode null byte array");
     Preconditions.checkArgument(offset >= 0, "offset %s cannot be negative", offset);
     Preconditions.checkArgument(len >= 0, "length %s cannot be negative", len);
-    Preconditions.checkArgument(offset + len < b.length, "offset + length %s exceeds byte array length %s", (offset + len), b.length);
+    Preconditions.checkArgument(offset + len <= b.length, "offset + length %s exceeds byte array length %s", (offset + len), b.length);
 
     return decodeUnchecked(b, offset, len);
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/impl/AbstractLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/impl/AbstractLexicoderTest.java
@@ -78,11 +78,6 @@ public abstract class AbstractLexicoderTest extends LexicoderTest {
     } catch (IllegalArgumentException e) {}
 
     try {
-      lexicoder.decode(encoded, encoded.length, 0);
-      fail("Should throw on offset==length.");
-    } catch (IllegalArgumentException e) {}
-
-    try {
       lexicoder.decode(encoded, 0, -1);
       fail("Should throw on negative length.");
     } catch (IllegalArgumentException e) {}


### PR DESCRIPTION

This should do it.  `offset + len == b.length` should be allowed, even when `len ==0`.