### PR TITLE
ACCUMULO-3840 deprecated OpTimer and replaced usages with EventTimer …

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/OpTimer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/OpTimer.java
@@ -16,37 +16,126 @@
  */
 package org.apache.accumulo.core.util;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+/**
+ * Provides a stop watch for timing a single type of event. This code is based on the org.apache.hadoop.util.StopWatch available in hadoop 2.7.0
+ */
+public class OpTimer implements Closeable {
 
-public class OpTimer {
-  private Logger log;
-  private Level level;
-  private long t1;
-  private long opid;
-  private static AtomicLong nextOpid = new AtomicLong();
+  private boolean isStarted;
+  private long startNanos;
+  private long currentElapsedNanos;
 
-  public OpTimer(Logger log, Level level) {
-    this.log = log;
-    this.level = level;
+  /**
+   * Create an OpTimer instance. The timer is not running.
+   */
+  public OpTimer() {}
+
+  /**
+   * Returns timer running state
+   *
+   * @return true if timer is running
+   */
+  public boolean isRunning() {
+    return isStarted;
   }
 
-  public OpTimer start(String msg) {
-    opid = nextOpid.getAndIncrement();
-    if (log.isEnabledFor(level))
-      log.log(level, "tid=" + Thread.currentThread().getId() + " oid=" + opid + "  " + msg);
-    t1 = System.currentTimeMillis();
+  /**
+   * Start the timer instance.
+   *
+   * @return this instance for fluent chaining.
+   * @throws IllegalStateException
+   *           if start is called on running instance.
+   */
+  public OpTimer start() throws IllegalStateException {
+    if (isStarted) {
+      throw new IllegalStateException("OpTimer is already running");
+    }
+    isStarted = true;
+    startNanos = System.nanoTime();
     return this;
   }
 
-  public void stop(String msg) {
-    if (log.isEnabledFor(level)) {
-      long t2 = System.currentTimeMillis();
-      String duration = String.format("%.3f secs", (t2 - t1) / 1000.0);
-      msg = msg.replace("%DURATION%", duration);
-      log.log(level, "tid=" + Thread.currentThread().getId() + " oid=" + opid + "  " + msg);
+  /**
+   * Stop the timer instance.
+   *
+   * @return this instance for fluent chaining.
+   * @throws IllegalStateException
+   *           if stop is called on instance that is not running.
+   */
+  public OpTimer stop() throws IllegalStateException {
+    if (!isStarted) {
+      throw new IllegalStateException("OpTimer is already stopped");
+    }
+    long now = System.nanoTime();
+    isStarted = false;
+    currentElapsedNanos += now - startNanos;
+    return this;
+  }
+
+  /**
+   * Stops timer instance and current elapsed time to 0.
+   *
+   * @return this instance for fluent chaining
+   */
+  public OpTimer reset() {
+    currentElapsedNanos = 0;
+    isStarted = false;
+    return this;
+  }
+
+  /**
+   * Converts current timer value to specific unit. The conversion to courser granularities truncate with loss of precision.
+   *
+   * @param timeUnit
+   *          the time unit that will converted to.
+   * @return truncated time in unit of specified time unit.
+   */
+  public long now(TimeUnit timeUnit) {
+    return timeUnit.convert(now(), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Returns the current elapsed time scaled to the provided time unit. This method does not truncate like {@link #now(TimeUnit)} but returns the value as a
+   * double. </p> Note: this method is not included in the hadoop 2.7 org.apache.hadoop.util.StopWatch class. If that class is adopted, then provisions will be
+   * required to replace this method.
+   *
+   * @param timeUnit
+   *          the time unit to scale the elapsed time to.
+   * @return the elapsed time of this instance scaled to the provided time unit.
+   */
+  public double scale(TimeUnit timeUnit) {
+    return (double) now() / TimeUnit.NANOSECONDS.convert(1L, timeUnit);
+  }
+
+  /**
+   * Returns current timer elapsed time as nanoseconds.
+   *
+   * @return elapsed time in nanoseconds.
+   */
+  public long now() {
+    return isStarted ? System.nanoTime() - startNanos + currentElapsedNanos : currentElapsedNanos;
+  }
+
+  /**
+   * Return the current elapsed time in nanoseconds as a string.
+   *
+   * @return timer elapsed time as nanoseconds.
+   */
+  @Override
+  public String toString() {
+    return String.valueOf(now());
+  }
+
+  /**
+   * If the timer is running, stop it. This method can be called even if the timer is not running.
+   */
+  @Override
+  public void close() {
+    if (isStarted) {
+      stop();
     }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/OpTimerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/OpTimerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.util;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exercise basic timer (org.apache.hadoop.util.StopWatch) functionality. Current usage requires ability to reset timer.
+ */
+public class OpTimerTest {
+
+  private static Logger log = LoggerFactory.getLogger(OpTimerTest.class);
+
+  /**
+   * Validate reset functionality
+   */
+  @Test
+  public void verifyReset() {
+
+    OpTimer timer = new OpTimer().start();
+
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    timer.stop();
+
+    long tValue = timer.now();
+
+    log.debug("Time value before reset {}", String.format("%.3f ms", timer.scale(TimeUnit.MILLISECONDS)));
+
+    timer.reset().start();
+
+    try {
+      Thread.sleep(1);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    timer.stop();
+
+    assertTrue(timer.now() > 0);
+
+    assertTrue(tValue > timer.now());
+
+    timer.reset();
+
+    log.debug("Time value after reset {}", String.format("%.3f ms", timer.scale(TimeUnit.MILLISECONDS)));
+
+    assertEquals(0, timer.now());
+
+  }
+
+  /**
+   * Verify that IllegalStateException is thrown when calling stop when timer has not been started.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void verifyExceptionCallingStopWhenNotStarted() {
+
+    OpTimer timer = new OpTimer();
+
+    assertFalse(timer.isRunning());
+
+    // should throw exception - not running
+    timer.stop();
+  }
+
+  /**
+   * Verify that IllegalStateException is thrown when calling start on running timer.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void verifyExceptionCallingStartWhenRunning() {
+
+    OpTimer timer = new OpTimer().start();
+
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    assertTrue(timer.isRunning());
+
+    // should throw exception - already running
+    timer.start();
+  }
+
+  /**
+   * Verify that IllegalStateException is thrown when calling stop when not running.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void verifyExceptionCallingStopWhenNotRunning() {
+
+    OpTimer timer = new OpTimer().start();
+
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    assertTrue(timer.isRunning());
+
+    timer.stop();
+
+    assertFalse(timer.isRunning());
+
+    // should throw exception
+    timer.stop();
+  }
+
+  /**
+   * Validate that start / stop accumulates time.
+   */
+  @Test
+  public void verifyElapsed() {
+
+    OpTimer timer = new OpTimer().start();
+
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    timer.stop();
+
+    long tValue = timer.now();
+
+    log.debug("Time value after first stop {}", String.format("%.3f ms", timer.scale(TimeUnit.MILLISECONDS)));
+
+    timer.start();
+
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    timer.stop();
+
+    log.debug("Time value after second stop {}", String.format("%.3f ms", timer.scale(TimeUnit.MILLISECONDS)));
+
+    assertTrue(tValue < timer.now());
+
+  }
+
+  /**
+   * Validate that scale returns correct values.
+   */
+  @Test
+  public void scale() {
+    OpTimer timer = new OpTimer().start();
+
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException ex) {
+      log.info("sleep sleep interrupted");
+      Thread.currentThread().interrupt();
+    }
+
+    timer.stop();
+
+    long tValue = timer.now();
+
+    double millis = timer.scale(TimeUnit.MILLISECONDS);
+
+    assertEquals(tValue / 1000000.0, timer.scale(TimeUnit.MILLISECONDS), 0.00000001);
+
+    assertEquals(tValue / 1000000000.0, timer.scale(TimeUnit.SECONDS), 0.00000001);
+
+  }
+}


### PR DESCRIPTION
Added EventTimer class (based on hadoop 2.7 org.apache.hadoop.util.StopWatch) to remove direct log4j dependencies inherent in OpTimer. Added scale method to provide conversion without truncation that is not in StopWatch.

These changes include suggestions from Josh and have been looked at a few times.

This is being done as part of the log4j dependency removal and contains modification to some log statements to remove string concatenation.

Also available on review board at https://reviews.apache.org/r/36186/
