### PR TITLE
ACCUMULO-3970

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -512,9 +512,9 @@ public enum Property {
   @Experimental
   TABLE_VOLUME_CHOOSER("table.volume.chooser", "org.apache.accumulo.server.fs.RandomVolumeChooser", PropertyType.CLASSNAME,
       "The class that will be used to select which volume will be used to create new files for this table."),
-    @Experimental
-    TABLE_VTI_CLASS("table.vti.class", null, PropertyType.CLASSNAME, "The class that will be used to transform key-value pairs"
-            + " to different visibilities at scan-time.\nThe class must be a subclass of VisibilityTransformingIterator"),
+  @Experimental
+  TABLE_VTI_CLASS("table.vti.class", null, PropertyType.CLASSNAME, "The class that will be used to transform key-value pairs"
+      + " to different visibilities at scan-time.\nThe class must be a subclass of VisibilityTransformingIterator"),
 
   // VFS ClassLoader properties
   VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY(AccumuloVFSClassLoader.VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY, "", PropertyType.STRING,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -512,6 +512,9 @@ public enum Property {
   @Experimental
   TABLE_VOLUME_CHOOSER("table.volume.chooser", "org.apache.accumulo.server.fs.RandomVolumeChooser", PropertyType.CLASSNAME,
       "The class that will be used to select which volume will be used to create new files for this table."),
+    @Experimental
+    TABLE_VTI_CLASS("table.vti.class", null, PropertyType.CLASSNAME, "The class that will be used to transform key-value pairs"
+            + " to different visibilities at scan-time.\nThe class must be a subclass of VisibilityTransformingIterator"),
 
   // VFS ClassLoader properties
   VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY(AccumuloVFSClassLoader.VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY, "", PropertyType.STRING,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -513,7 +513,7 @@ public enum Property {
   TABLE_VOLUME_CHOOSER("table.volume.chooser", "org.apache.accumulo.server.fs.RandomVolumeChooser", PropertyType.CLASSNAME,
       "The class that will be used to select which volume will be used to create new files for this table."),
   @Experimental
-  TABLE_VTI_CLASS("table.vti.class", null, PropertyType.CLASSNAME, "The class that will be used to transform key-value pairs"
+  TABLE_VTI_CLASS("table.vti.class", "", PropertyType.STRING, "The class that will be used to transform key-value pairs"
       + " to different visibilities at scan-time.\nThe class must be a subclass of VisibilityTransformingIterator"),
 
   // VFS ClassLoader properties

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityTransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityTransformingIterator.java
@@ -1,0 +1,140 @@
+package org.apache.accumulo.core.iterators.system;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public abstract class VisibilityTransformingIterator implements SortedKeyValueIterator<Key,Value> {
+
+    private SortedKeyValueIterator<Key, Value> source;
+
+    private SortedMap<Key,Value> vtiKvPairs = new TreeMap<>();
+
+    private final Text rowHolder = new Text();
+    private final Text cfHolder = new Text();
+    private final Text cqHolder = new Text();
+
+    @Override
+    public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env) throws IOException {
+        this.source = source;
+    }
+
+    @Override
+    public boolean hasTop() {
+        return !vtiKvPairs.isEmpty() || source.hasTop();
+    }
+
+    @Override
+    public void next() throws IOException {
+        vtiKvPairs = vtiKvPairs.tailMap(vtiKvPairs.firstKey());
+        if (vtiKvPairs.isEmpty()) {
+            source.next();
+            transformSource();
+        }
+    }
+
+    private void transformSource() {
+        Key topKey = source.getTopKey();
+        Value topVal = source.getTopValue();
+        vtiKvPairs.put(topKey, topVal);
+        for (Map.Entry<ColumnVisibility, Value> transformed: transformVisibility(topKey, topVal)) {
+            vtiKvPairs.put(replaceVisibility(topKey, transformed.getKey()), transformed.getValue());
+        }
+    }
+
+    private Key replaceVisibility(Key key, ColumnVisibility newVis) {
+        return new Key(key.getRow(rowHolder), key.getColumnFamily(cfHolder), key.getColumnQualifier(cqHolder), newVis, key.getTimestamp());
+    }
+
+    public static ColumnVisibility replaceTerm(ColumnVisibility vis, String oldTerm, String newTerm) {
+        newTerm = ColumnVisibility.quote(newTerm);
+        ByteSequence oldTermBs = new ArrayByteSequence(oldTerm.getBytes());
+        ColumnVisibility.Node root = vis.getParseTree();
+        byte[] expression = vis.getExpression();
+        StringBuilder out = new StringBuilder();
+        stringify(newTerm, oldTermBs, root, expression, out);
+        return new ColumnVisibility(out.toString());
+    }
+
+    private static void stringify(String newTerm, ByteSequence oldTermBs, ColumnVisibility.Node root, byte[] expression, StringBuilder out) {
+        if (root.getType() == ColumnVisibility.NodeType.TERM) {
+            ByteSequence termBs = root.getTerm(expression);
+            if (termBs.compareTo(oldTermBs) == 0) {
+                out.append(newTerm);
+            } else {
+                out.append(termBs);
+            }
+        } else {
+            String sep = "";
+            for (ColumnVisibility.Node c : root.getChildren()) {
+                out.append(sep);
+                boolean parens = (c.getType() != ColumnVisibility.NodeType.TERM && root.getType() != c.getType());
+                if (parens)
+                    out.append("(");
+                stringify(newTerm, oldTermBs, c, expression, out);
+                if (parens)
+                    out.append(")");
+                sep = root.getType() == ColumnVisibility.NodeType.AND ? "&" : "|";
+            }
+        }
+    }
+
+    protected abstract Iterable<Map.Entry<ColumnVisibility, Value>> transformVisibility(Key key, Value value);
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        Range adjusted = range;
+        if (!range.isInfiniteStartKey()) {
+            // The start key of the range might be a transformed key, that is, it might not be present in the source
+            // iterator. Seek to the specified (row, cf, cq) and start transforming from there, throwing out anything
+            // prior to the specified start key. Complicated a little bit by the fact that visibility sorts before
+            // timestamp -- we might have to throw out a bunch of different versions of the key before we start
+            // producing useful data.
+            Key startKey = range.getStartKey();
+            startKey = new Key(startKey.getRow(rowHolder), startKey.getColumnFamily(cfHolder),
+                    startKey.getColumnQualifier(cqHolder));
+            adjusted = new Range(startKey, range.getEndKey());
+        }
+        source.seek(adjusted, columnFamilies, inclusive);
+        transformSource();
+        if (!adjusted.equals(range)) {
+            while (getTopKey().compareTo(range.getStartKey()) < 0) {
+                next();
+            }
+        }
+    }
+
+    @Override
+    public Key getTopKey() {
+        return vtiKvPairs.firstKey();
+    }
+
+    @Override
+    public Value getTopValue() {
+        return vtiKvPairs.get(vtiKvPairs.firstKey());
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key, Value> deepCopy(IteratorEnvironment env) {
+        VisibilityTransformingIterator vtiIter;
+        try {
+            vtiIter = getClass().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Subclasses of VisibilityTransformingIterator must define a no-arg constructor", e);
+        }
+        vtiIter.source = source.deepCopy(env);
+        return vtiIter;
+    }
+}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityTransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityTransformingIterator.java
@@ -1,140 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.core.iterators.system;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 
 public abstract class VisibilityTransformingIterator implements SortedKeyValueIterator<Key,Value> {
 
-    private SortedKeyValueIterator<Key, Value> source;
+  private static final Logger logger = LoggerFactory.getLogger(VisibilityTransformingIterator.class);
 
-    private SortedMap<Key,Value> vtiKvPairs = new TreeMap<>();
+  private SortedKeyValueIterator<Key,Value> source;
+  private LinkedList<Map.Entry<Key,Value>> sourceKvPairs = new LinkedList<>();
+  private NavigableMap<Key,Value> vtiKvPairs = new TreeMap<>();
 
-    private final Text rowHolder = new Text();
-    private final Text cfHolder = new Text();
-    private final Text cqHolder = new Text();
+  private Map.Entry<Key,Value> topEntry;
+  private Range seekRange;
 
-    @Override
-    public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options, IteratorEnvironment env) throws IOException {
-        this.source = source;
+  private final Text rowHolder = new Text();
+  private final Text cfHolder = new Text();
+  private final Text cqHolder = new Text();
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+    this.source = source;
+  }
+
+  @Override
+  public boolean hasTop() {
+    return topEntry != null;
+  }
+
+  @Override
+  public Key getTopKey() {
+    return topEntry.getKey();
+  }
+
+  @Override
+  public Value getTopValue() {
+    return topEntry.getValue();
+  }
+
+  @Override
+  public void next() throws IOException {
+    if (sourceKvPairs.isEmpty() && vtiKvPairs.isEmpty()) {
+      consumeSource();
     }
+    setTop();
+  }
 
-    @Override
-    public boolean hasTop() {
-        return !vtiKvPairs.isEmpty() || source.hasTop();
+  private void consumeSource() throws IOException {
+    if (!source.hasTop()) {
+      return;
     }
-
-    @Override
-    public void next() throws IOException {
-        vtiKvPairs = vtiKvPairs.tailMap(vtiKvPairs.firstKey());
-        if (vtiKvPairs.isEmpty()) {
-            source.next();
-            transformSource();
+    Key sourceTop = source.getTopKey();
+    Key nextKey = sourceTop.followingKey(PartialKey.ROW_COLFAM_COLQUAL);
+    while (source.hasTop() && source.getTopKey().compareTo(nextKey) < 0 && seekRange.contains(source.getTopKey())) {
+      sourceKvPairs.add(new AbstractMap.SimpleImmutableEntry<>(source.getTopKey(), source.getTopValue()));
+      source.next();
+    }
+    for (Map.Entry<Key,Value> sourceKv : sourceKvPairs) {
+      Key sourceKey = sourceKv.getKey();
+      for (Map.Entry<ColumnVisibility,Value> transformed : transformVisibility(sourceKey, sourceKv.getValue())) {
+        Key transformedKey = replaceVisibility(sourceKey, transformed.getKey());
+        if (seekRange.contains(transformedKey)) {
+          vtiKvPairs.put(transformedKey, transformed.getValue());
         }
+      }
     }
+    setTop();
+  }
 
-    private void transformSource() {
-        Key topKey = source.getTopKey();
-        Value topVal = source.getTopValue();
-        vtiKvPairs.put(topKey, topVal);
-        for (Map.Entry<ColumnVisibility, Value> transformed: transformVisibility(topKey, topVal)) {
-            vtiKvPairs.put(replaceVisibility(topKey, transformed.getKey()), transformed.getValue());
-        }
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+    seekRange = range;
+    Range adjusted = range;
+    if (!range.isInfiniteStartKey()) {
+      // The start key of the range might be a transformed key, that is, it might not be present in the source
+      // iterator. Seek to the specified (row, cf, cq) and start transforming from there, throwing out anything
+      // prior to the specified start key. Complicated a little bit by the fact that visibility sorts before
+      // timestamp -- we might have to throw out a bunch of different versions of the key before we start
+      // producing useful data.
+      Key startKey = range.getStartKey();
+      startKey = new Key(startKey.getRow(rowHolder), startKey.getColumnFamily(cfHolder), startKey.getColumnQualifier(cqHolder));
+      adjusted = new Range(startKey, range.getEndKey());
     }
-
-    private Key replaceVisibility(Key key, ColumnVisibility newVis) {
-        return new Key(key.getRow(rowHolder), key.getColumnFamily(cfHolder), key.getColumnQualifier(cqHolder), newVis, key.getTimestamp());
+    source.seek(adjusted, columnFamilies, inclusive);
+    consumeSource();
+    if (!adjusted.equals(range)) {
+      while (getTopKey().compareTo(range.getStartKey()) < 0) {
+        next();
+      }
     }
+  }
 
-    public static ColumnVisibility replaceTerm(ColumnVisibility vis, String oldTerm, String newTerm) {
-        newTerm = ColumnVisibility.quote(newTerm);
-        ByteSequence oldTermBs = new ArrayByteSequence(oldTerm.getBytes());
-        ColumnVisibility.Node root = vis.getParseTree();
-        byte[] expression = vis.getExpression();
-        StringBuilder out = new StringBuilder();
-        stringify(newTerm, oldTermBs, root, expression, out);
-        return new ColumnVisibility(out.toString());
+  private void setTop() {
+    topEntry = null;
+    if (vtiKvPairs.isEmpty() && sourceKvPairs.isEmpty()) {
+      // exhausted.
+      return;
     }
-
-    private static void stringify(String newTerm, ByteSequence oldTermBs, ColumnVisibility.Node root, byte[] expression, StringBuilder out) {
-        if (root.getType() == ColumnVisibility.NodeType.TERM) {
-            ByteSequence termBs = root.getTerm(expression);
-            if (termBs.compareTo(oldTermBs) == 0) {
-                out.append(newTerm);
-            } else {
-                out.append(termBs);
-            }
-        } else {
-            String sep = "";
-            for (ColumnVisibility.Node c : root.getChildren()) {
-                out.append(sep);
-                boolean parens = (c.getType() != ColumnVisibility.NodeType.TERM && root.getType() != c.getType());
-                if (parens)
-                    out.append("(");
-                stringify(newTerm, oldTermBs, c, expression, out);
-                if (parens)
-                    out.append(")");
-                sep = root.getType() == ColumnVisibility.NodeType.AND ? "&" : "|";
-            }
-        }
+    if (vtiKvPairs.isEmpty()) {
+      topEntry = sourceKvPairs.removeFirst();
+    } else if (sourceKvPairs.isEmpty()) {
+      topEntry = vtiKvPairs.pollFirstEntry();
+    } else {
+      Map.Entry<Key,Value> sourceTop = sourceKvPairs.getFirst();
+      Map.Entry<Key,Value> vtiTop = vtiKvPairs.firstEntry();
+      int cmp = sourceTop.getKey().compareTo(vtiTop.getKey());
+      if (cmp < 0) {
+        topEntry = sourceKvPairs.removeFirst();
+      } else if (cmp > 0) {
+        topEntry = vtiKvPairs.pollFirstEntry();
+      } else {
+        logger.info("Transform key " + vtiTop.getKey() + " also exists in source");
+        topEntry = sourceKvPairs.removeFirst();
+        vtiKvPairs.pollFirstEntry();
+      }
     }
+  }
 
-    protected abstract Iterable<Map.Entry<ColumnVisibility, Value>> transformVisibility(Key key, Value value);
+  private Key replaceVisibility(Key key, ColumnVisibility newVis) {
+    return new Key(key.getRow(rowHolder), key.getColumnFamily(cfHolder), key.getColumnQualifier(cqHolder), newVis, key.getTimestamp());
+  }
 
-    @Override
-    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
-        Range adjusted = range;
-        if (!range.isInfiniteStartKey()) {
-            // The start key of the range might be a transformed key, that is, it might not be present in the source
-            // iterator. Seek to the specified (row, cf, cq) and start transforming from there, throwing out anything
-            // prior to the specified start key. Complicated a little bit by the fact that visibility sorts before
-            // timestamp -- we might have to throw out a bunch of different versions of the key before we start
-            // producing useful data.
-            Key startKey = range.getStartKey();
-            startKey = new Key(startKey.getRow(rowHolder), startKey.getColumnFamily(cfHolder),
-                    startKey.getColumnQualifier(cqHolder));
-            adjusted = new Range(startKey, range.getEndKey());
-        }
-        source.seek(adjusted, columnFamilies, inclusive);
-        transformSource();
-        if (!adjusted.equals(range)) {
-            while (getTopKey().compareTo(range.getStartKey()) < 0) {
-                next();
-            }
-        }
+  public static ColumnVisibility replaceTerm(ColumnVisibility vis, String oldTerm, String newTerm) {
+    newTerm = ColumnVisibility.quote(newTerm);
+    ByteSequence oldTermBs = new ArrayByteSequence(oldTerm.getBytes());
+    ColumnVisibility.Node root = vis.getParseTree();
+    byte[] expression = vis.getExpression();
+    StringBuilder out = new StringBuilder();
+    stringify(newTerm, oldTermBs, root, expression, out);
+    return new ColumnVisibility(out.toString());
+  }
+
+  private static void stringify(String newTerm, ByteSequence oldTermBs, ColumnVisibility.Node root, byte[] expression, StringBuilder out) {
+    if (root.getType() == ColumnVisibility.NodeType.TERM) {
+      ByteSequence termBs = root.getTerm(expression);
+      if (termBs.compareTo(oldTermBs) == 0) {
+        out.append(newTerm);
+      } else {
+        out.append(termBs);
+      }
+    } else {
+      String sep = "";
+      for (ColumnVisibility.Node c : root.getChildren()) {
+        out.append(sep);
+        boolean parens = (c.getType() != ColumnVisibility.NodeType.TERM && root.getType() != c.getType());
+        if (parens)
+          out.append("(");
+        stringify(newTerm, oldTermBs, c, expression, out);
+        if (parens)
+          out.append(")");
+        sep = root.getType() == ColumnVisibility.NodeType.AND ? "&" : "|";
+      }
     }
+  }
 
-    @Override
-    public Key getTopKey() {
-        return vtiKvPairs.firstKey();
-    }
+  protected abstract Collection<? extends Map.Entry<ColumnVisibility,Value>> transformVisibility(Key key, Value value);
 
-    @Override
-    public Value getTopValue() {
-        return vtiKvPairs.get(vtiKvPairs.firstKey());
+  @Override
+  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    VisibilityTransformingIterator vtiIter;
+    try {
+      vtiIter = getClass().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException("Subclasses of VisibilityTransformingIterator must define a no-arg constructor", e);
     }
-
-    @Override
-    public SortedKeyValueIterator<Key, Value> deepCopy(IteratorEnvironment env) {
-        VisibilityTransformingIterator vtiIter;
-        try {
-            vtiIter = getClass().newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException("Subclasses of VisibilityTransformingIterator must define a no-arg constructor", e);
-        }
-        vtiIter.source = source.deepCopy(env);
-        return vtiIter;
-    }
+    vtiIter.source = source.deepCopy(env);
+    return vtiIter;
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityTransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityTransformingIterator.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -173,20 +173,19 @@ class ScanDataSource implements DataSource {
 
     ColumnQualifierFilter colFilter = new ColumnQualifierFilter(cfsi, options.getColumnSet());
 
-    SortedKeyValueIterator visParent = insertVTI(colFilter, iterEnv);
+    SortedKeyValueIterator<Key, Value> visParent = insertVTI(colFilter, iterEnv);
     VisibilityFilter visFilter = new VisibilityFilter(visParent, options.getAuthorizations(), options.getDefaultLabels());
 
     return iterEnv.getTopLevelIterator(IteratorUtil.loadIterators(IteratorScope.scan, visFilter, tablet.getExtent(), tablet.getTableConfiguration(),
         options.getSsiList(), options.getSsio(), iterEnv));
   }
 
-  private SortedKeyValueIterator<Key, Value> insertVTI(final SortedKeyValueIterator<Key, Value> parent,
-                                                       IteratorEnvironment iterEnv) throws IOException {
+  private SortedKeyValueIterator<Key,Value> insertVTI(final SortedKeyValueIterator<Key,Value> parent, IteratorEnvironment iterEnv) throws IOException {
     String vtiClass = tablet.getTableConfiguration().get(Property.TABLE_VTI_CLASS);
     if (vtiClass != null) {
       try {
         VisibilityTransformingIterator vtiIter = (VisibilityTransformingIterator) Class.forName(vtiClass).newInstance();
-        vtiIter.init(parent, Collections.<String, String>emptyMap(), iterEnv);
+        vtiIter.init(parent, Collections.<String,String> emptyMap(), iterEnv);
         return vtiIter;
       } catch (Exception e) {
         throw new IOException("Unable to create VisibilityTransformingIterator " + vtiClass, e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+//import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;
@@ -173,7 +174,7 @@ class ScanDataSource implements DataSource {
 
     ColumnQualifierFilter colFilter = new ColumnQualifierFilter(cfsi, options.getColumnSet());
 
-    SortedKeyValueIterator<Key, Value> visParent = insertVTI(colFilter, iterEnv);
+    SortedKeyValueIterator<Key,Value> visParent = insertVTI(colFilter, iterEnv);
     VisibilityFilter visFilter = new VisibilityFilter(visParent, options.getAuthorizations(), options.getDefaultLabels());
 
     return iterEnv.getTopLevelIterator(IteratorUtil.loadIterators(IteratorScope.scan, visFilter, tablet.getExtent(), tablet.getTableConfiguration(),
@@ -182,7 +183,7 @@ class ScanDataSource implements DataSource {
 
   private SortedKeyValueIterator<Key,Value> insertVTI(final SortedKeyValueIterator<Key,Value> parent, IteratorEnvironment iterEnv) throws IOException {
     String vtiClass = tablet.getTableConfiguration().get(Property.TABLE_VTI_CLASS);
-    if (vtiClass != null) {
+    if (vtiClass != null && vtiClass.length() > 0) {
       try {
         VisibilityTransformingIterator vtiIter = (VisibilityTransformingIterator) Class.forName(vtiClass).newInstance();
         vtiIter.init(parent, Collections.<String,String> emptyMap(), iterEnv);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-//import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;

--- a/test/src/test/java/org/apache/accumulo/test/vti/VisibilityTransformingIteratorTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/vti/VisibilityTransformingIteratorTest.java
@@ -1,0 +1,130 @@
+package org.apache.accumulo.test.vti;
+
+import com.google.common.collect.Lists;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.system.VisibilityTransformingIterator;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.accumulo.minicluster.MiniAccumuloConfig;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VisibilityTransformingIteratorTest {
+
+    private static final String VTI_TABLE = "vti";
+    private static final ColumnVisibility RAW_VIS = new ColumnVisibility("raw");
+
+    private static MiniAccumuloCluster mac;
+    private static Connector rootConn;
+
+    @BeforeClass
+    public static void setupMAC() throws Exception {
+        Path macPath = Files.createTempDirectory("mac");
+        System.out.println("MAC running at " + macPath);
+        MiniAccumuloConfig macCfg = new MiniAccumuloConfig(macPath.toFile(), "password");
+        macCfg.setNumTservers(1);
+        mac = new MiniAccumuloCluster(macCfg);
+        mac.start();
+        rootConn = mac.getConnector("root", "password");
+        rootConn.tableOperations().create(VTI_TABLE);
+        rootConn.tableOperations().setProperty("vti", Property.TABLE_VTI_CLASS.getKey(),
+                HashingIterator.class.getName());
+        rootConn.securityOperations().createLocalUser("hash_user", new PasswordToken("hash_user"));
+        rootConn.securityOperations().createLocalUser("raw_user", new PasswordToken("raw_user"));
+        rootConn.securityOperations().createLocalUser("all_user", new PasswordToken("all_user"));
+        rootConn.securityOperations().changeUserAuthorizations("hash_user", new Authorizations("hash"));
+        rootConn.securityOperations().changeUserAuthorizations("raw_user", new Authorizations("raw"));
+        rootConn.securityOperations().changeUserAuthorizations("all_user", new Authorizations("hash", "raw"));
+    }
+
+    @Test
+    public void testVti() throws Exception {
+        BatchWriter bw = rootConn.createBatchWriter(VTI_TABLE, new BatchWriterConfig());
+        Mutation m = new Mutation("r0");
+        m.put("cf0", "cq0", RAW_VIS, new Value("some bytes".getBytes()));
+        bw.addMutation(m);
+        bw.flush();
+
+        Scanner rawScan = mac.getConnector("all_user", "all_user")
+                .createScanner(VTI_TABLE, new Authorizations("hash", "raw"));
+        rawScan.setRange(new Range());
+        List<Map.Entry<Key,Value>> allKvs = Lists.newArrayList(rawScan);
+        assertTrue("All scan must have 2 kv pairs", allKvs.size() == 2);
+        assertTrue("First value must be hashed", HashingIterator.isHashedValue(allKvs.get(0).getValue()));
+        assertFalse("Second value must not be hashed", HashingIterator.isHashedValue(allKvs.get(1).getValue()));
+        assertTrue("Hashed value must have hashed visibility", HashingIterator.isHashedVisibility(allKvs.get(0).getKey()));
+        assertTrue("Raw value must have raw visibility", RAW_VIS.equals(allKvs.get(1).getKey().getColumnVisibilityParsed()));
+    }
+
+    @Before
+    public void clearVtiTable() throws Exception {
+        rootConn.tableOperations().deleteRows(VTI_TABLE, null, null);
+    }
+
+    @AfterClass
+    public static void tearDownMAC() throws Exception {
+        mac.stop();
+    }
+
+    static class HashingIterator extends VisibilityTransformingIterator {
+
+        private static final String VIS_HASHED = "hashed";
+
+        private static final byte[] HDR = "sha1:".getBytes();
+        private static final HashFunction SHA1 = Hashing.sha1();
+
+        private final byte[] out = new byte[HDR.length + SHA1.bits() / 8];
+
+        public HashingIterator() {
+            System.arraycopy(HDR, 0, out, 0, HDR.length);
+        }
+
+        @Override
+        protected Iterable<Map.Entry<ColumnVisibility, Value>> transformVisibility(Key key, Value value) {
+            byte[] hash = SHA1.hashBytes(value.get()).asBytes();
+            System.arraycopy(hash, 0, out, HDR.length, hash.length);
+            return Collections.singletonMap(
+                    replaceTerm(key.getColumnVisibilityParsed(), "raw", VIS_HASHED), new Value(out)
+            ).entrySet();
+        }
+
+        static boolean isHashedValue(Value v) {
+            byte[] b = v.get();
+            for (int i = 0; i < HDR.length; i++) {
+                if (b[i] != HDR[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static boolean isHashedVisibility(Key k) {
+            return VIS_HASHED.equals(k.getColumnVisibility().toString());
+        }
+    }
+
+}

--- a/test/src/test/java/org/apache/accumulo/test/vti/VisibilityTransformingIteratorTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/vti/VisibilityTransformingIteratorTest.java
@@ -24,7 +24,6 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -33,7 +32,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.system.VisibilityTransformingIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.MiniAccumuloConfig;
 import org.junit.AfterClass;
@@ -73,7 +71,7 @@ public class VisibilityTransformingIteratorTest {
     rootConn = mac.getConnector("root", "password");
     rootConn.tableOperations().create(VTI_TABLE);
     rootConn.tableOperations().setProperty("vti", Property.TABLE_VTI_CLASS.getKey(), HashingIterator.class.getName());
-    rootConn.securityOperations().changeUserAuthorizations("root",ALL_AUTHS);
+    rootConn.securityOperations().changeUserAuthorizations("root", ALL_AUTHS);
   }
 
   @Test

--- a/test/src/test/java/org/apache/accumulo/test/vti/VisibilityTransformingIteratorTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/vti/VisibilityTransformingIteratorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.test.vti;
 
 import com.google.common.collect.Lists;
@@ -17,6 +33,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.system.VisibilityTransformingIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.MiniAccumuloConfig;
 import org.junit.AfterClass;
@@ -26,6 +43,8 @@ import org.junit.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -35,96 +54,98 @@ import static org.junit.Assert.assertTrue;
 
 public class VisibilityTransformingIteratorTest {
 
-    private static final String VTI_TABLE = "vti";
-    private static final ColumnVisibility RAW_VIS = new ColumnVisibility("raw");
+  private static final String VTI_TABLE = "vti";
+  private static final ColumnVisibility RAW_VIS = new ColumnVisibility("raw");
+  private static final Authorizations ALL_AUTHS = new Authorizations(HashingIterator.VIS_HASHED, "raw");
+  private static final Authorizations HASHED_AUTHS = new Authorizations(HashingIterator.VIS_HASHED);
 
-    private static MiniAccumuloCluster mac;
-    private static Connector rootConn;
+  private static MiniAccumuloCluster mac;
+  private static Connector rootConn;
 
-    @BeforeClass
-    public static void setupMAC() throws Exception {
-        Path macPath = Files.createTempDirectory("mac");
-        System.out.println("MAC running at " + macPath);
-        MiniAccumuloConfig macCfg = new MiniAccumuloConfig(macPath.toFile(), "password");
-        macCfg.setNumTservers(1);
-        mac = new MiniAccumuloCluster(macCfg);
-        mac.start();
-        rootConn = mac.getConnector("root", "password");
-        rootConn.tableOperations().create(VTI_TABLE);
-        rootConn.tableOperations().setProperty("vti", Property.TABLE_VTI_CLASS.getKey(),
-                HashingIterator.class.getName());
-        rootConn.securityOperations().createLocalUser("hash_user", new PasswordToken("hash_user"));
-        rootConn.securityOperations().createLocalUser("raw_user", new PasswordToken("raw_user"));
-        rootConn.securityOperations().createLocalUser("all_user", new PasswordToken("all_user"));
-        rootConn.securityOperations().changeUserAuthorizations("hash_user", new Authorizations("hash"));
-        rootConn.securityOperations().changeUserAuthorizations("raw_user", new Authorizations("raw"));
-        rootConn.securityOperations().changeUserAuthorizations("all_user", new Authorizations("hash", "raw"));
+  @BeforeClass
+  public static void setupMAC() throws Exception {
+    Path macPath = Files.createTempDirectory("mac");
+    System.out.println("MAC running at " + macPath);
+    MiniAccumuloConfig macCfg = new MiniAccumuloConfig(macPath.toFile(), "password");
+    macCfg.setNumTservers(1);
+    mac = new MiniAccumuloCluster(macCfg);
+    mac.start();
+    rootConn = mac.getConnector("root", "password");
+    rootConn.tableOperations().create(VTI_TABLE);
+    rootConn.tableOperations().setProperty("vti", Property.TABLE_VTI_CLASS.getKey(), HashingIterator.class.getName());
+    rootConn.securityOperations().changeUserAuthorizations("root",ALL_AUTHS);
+  }
+
+  @Test
+  public void testVti() throws Exception {
+    BatchWriter bw = rootConn.createBatchWriter(VTI_TABLE, new BatchWriterConfig());
+    Mutation m = new Mutation("r0");
+    m.put("cf0", "cq0", RAW_VIS, new Value("some bytes".getBytes()));
+    bw.addMutation(m);
+    bw.flush();
+
+    Scanner rawScan = rootConn.createScanner(VTI_TABLE, ALL_AUTHS);
+    rawScan.setRange(new Range());
+    List<Map.Entry<Key,Value>> allKvs = Lists.newArrayList(rawScan);
+    assertTrue("All scan must have 2 kv pairs", allKvs.size() == 2);
+    assertTrue("First value must be hashed", HashingIterator.isHashedValue(allKvs.get(0).getValue()));
+    assertFalse("Second value must not be hashed", HashingIterator.isHashedValue(allKvs.get(1).getValue()));
+    assertTrue("Hashed key must have hashed visibility", HashingIterator.isHashedVisibility(allKvs.get(0).getKey()));
+    assertTrue("Raw key must have raw visibility", RAW_VIS.equals(allKvs.get(1).getKey().getColumnVisibilityParsed()));
+    rawScan.close();
+
+    rawScan = rootConn.createScanner(VTI_TABLE, HASHED_AUTHS);
+    rawScan.setRange(new Range());
+    allKvs = Lists.newArrayList(rawScan);
+    assertTrue("Hashed scan must have 1 kv pairs", allKvs.size() == 1);
+    assertTrue("First value must be hashed", HashingIterator.isHashedValue(allKvs.get(0).getValue()));
+    assertTrue("Hashed key must have hashed visibility", HashingIterator.isHashedVisibility(allKvs.get(0).getKey()));
+    rawScan.close();
+  }
+
+  @Before
+  public void clearVtiTable() throws Exception {
+    rootConn.tableOperations().deleteRows(VTI_TABLE, null, null);
+  }
+
+  @AfterClass
+  public static void tearDownMAC() throws Exception {
+    mac.stop();
+  }
+
+  public static class HashingIterator extends VisibilityTransformingIterator {
+
+    private static final String VIS_HASHED = "hashed";
+
+    private static final byte[] HDR = "sha1:".getBytes();
+    private static final HashFunction SHA1 = Hashing.sha1();
+
+    private final byte[] out = new byte[HDR.length + SHA1.bits() / 8];
+
+    public HashingIterator() {
+      System.arraycopy(HDR, 0, out, 0, HDR.length);
     }
 
-    @Test
-    public void testVti() throws Exception {
-        BatchWriter bw = rootConn.createBatchWriter(VTI_TABLE, new BatchWriterConfig());
-        Mutation m = new Mutation("r0");
-        m.put("cf0", "cq0", RAW_VIS, new Value("some bytes".getBytes()));
-        bw.addMutation(m);
-        bw.flush();
-
-        Scanner rawScan = mac.getConnector("all_user", "all_user")
-                .createScanner(VTI_TABLE, new Authorizations("hash", "raw"));
-        rawScan.setRange(new Range());
-        List<Map.Entry<Key,Value>> allKvs = Lists.newArrayList(rawScan);
-        assertTrue("All scan must have 2 kv pairs", allKvs.size() == 2);
-        assertTrue("First value must be hashed", HashingIterator.isHashedValue(allKvs.get(0).getValue()));
-        assertFalse("Second value must not be hashed", HashingIterator.isHashedValue(allKvs.get(1).getValue()));
-        assertTrue("Hashed value must have hashed visibility", HashingIterator.isHashedVisibility(allKvs.get(0).getKey()));
-        assertTrue("Raw value must have raw visibility", RAW_VIS.equals(allKvs.get(1).getKey().getColumnVisibilityParsed()));
+    @Override
+    protected Collection<? extends Map.Entry<ColumnVisibility,Value>> transformVisibility(Key key, Value value) {
+      byte[] hash = SHA1.hashBytes(value.get()).asBytes();
+      System.arraycopy(hash, 0, out, HDR.length, hash.length);
+      return Collections.singletonList(new AbstractMap.SimpleImmutableEntry<>(replaceTerm(key.getColumnVisibilityParsed(), "raw", VIS_HASHED), new Value(out)));
     }
 
-    @Before
-    public void clearVtiTable() throws Exception {
-        rootConn.tableOperations().deleteRows(VTI_TABLE, null, null);
-    }
-
-    @AfterClass
-    public static void tearDownMAC() throws Exception {
-        mac.stop();
-    }
-
-    static class HashingIterator extends VisibilityTransformingIterator {
-
-        private static final String VIS_HASHED = "hashed";
-
-        private static final byte[] HDR = "sha1:".getBytes();
-        private static final HashFunction SHA1 = Hashing.sha1();
-
-        private final byte[] out = new byte[HDR.length + SHA1.bits() / 8];
-
-        public HashingIterator() {
-            System.arraycopy(HDR, 0, out, 0, HDR.length);
+    static boolean isHashedValue(Value v) {
+      byte[] b = v.get();
+      for (int i = 0; i < HDR.length; i++) {
+        if (b[i] != HDR[i]) {
+          return false;
         }
-
-        @Override
-        protected Iterable<Map.Entry<ColumnVisibility, Value>> transformVisibility(Key key, Value value) {
-            byte[] hash = SHA1.hashBytes(value.get()).asBytes();
-            System.arraycopy(hash, 0, out, HDR.length, hash.length);
-            return Collections.singletonMap(
-                    replaceTerm(key.getColumnVisibilityParsed(), "raw", VIS_HASHED), new Value(out)
-            ).entrySet();
-        }
-
-        static boolean isHashedValue(Value v) {
-            byte[] b = v.get();
-            for (int i = 0; i < HDR.length; i++) {
-                if (b[i] != HDR[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        static boolean isHashedVisibility(Key k) {
-            return VIS_HASHED.equals(k.getColumnVisibility().toString());
-        }
+      }
+      return true;
     }
+
+    static boolean isHashedVisibility(Key k) {
+      return VIS_HASHED.equals(k.getColumnVisibility().toString());
+    }
+  }
 
 }


### PR DESCRIPTION
Here's a sketch of what I'm thinking for ACCUMULO-3970. It's by no means ready to be merged, I just want to send the PR as a starting point for a discussion.

The idea is to define a new type of iterator, a VisibilityTransformingIterator, which can be set on a table. The iterator is only active in scan scope and is applied before the scan authorizations. Concrete subclasses of the VisibilityTransformingIterator receive individual key-value pairs that are present in the table and, for each pair, produce zero or more extra representations of that value. How these extra representations are produced will probably be driven by how an organization wants to anonymize or de-identify its data.
