### PR TITLE
ACCUMULO-4032 Monitor ignores the hostname supplied in cmdline.

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -484,8 +484,6 @@ public class Monitor {
     server.start();
 
     try {
-      hostname = InetAddress.getLocalHost().getHostName();
-
       log.debug("Using " + hostname + " to advertise monitor location in ZooKeeper");
 
       String monitorAddress = HostAndPort.fromParts(hostname, server.getPort()).toString();


### PR DESCRIPTION
Monitor should not overwrite the hostname supplied in command line argument `-a` with an autodetected hostname.