### PR TITLE
ACCUMULO-4065 Create a separate connection cache for oneway Thrift ca…

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
@@ -233,7 +233,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
 
         TInfo tinfo = Tracer.traceInfo();
         try {
-          client = getClient(sid.location);
+          client = getClient(sid.location, true);
           client.closeConditionalUpdate(tinfo, sid.sessionID);
         } catch (Exception e) {} finally {
           ThriftUtil.returnClient((TServiceClient) client);
@@ -541,12 +541,12 @@ class ConditionalWriterImpl implements ConditionalWriter {
     return activeSessions;
   }
 
-  private TabletClientService.Iface getClient(String location) throws TTransportException {
+  private TabletClientService.Iface getClient(String location, boolean oneway) throws TTransportException {
     TabletClientService.Iface client;
     if (timeout < ServerConfigurationUtil.getConfiguration(instance).getTimeInMillis(Property.GENERAL_RPC_TIMEOUT))
-      client = ThriftUtil.getTServerClient(location, ServerConfigurationUtil.getConfiguration(instance), timeout);
+      client = ThriftUtil.getTServerClient(location, ServerConfigurationUtil.getConfiguration(instance), timeout, oneway);
     else
-      client = ThriftUtil.getTServerClient(location, ServerConfigurationUtil.getConfiguration(instance));
+      client = ThriftUtil.getTServerClient(location, ServerConfigurationUtil.getConfiguration(instance), oneway);
     return client;
   }
 
@@ -567,7 +567,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
       convertMutations(mutations, cmidToCm, cmid, tmutations, compressedIters);
 
       // getClient() call must come after converMutations in case it throws a TException
-      client = getClient(location);
+      client = getClient(location, false);
 
       List<TCMResult> tresults = null;
       while (tresults == null) {
@@ -698,7 +698,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     TInfo tinfo = Tracer.traceInfo();
 
     try {
-      client = getClient(location);
+      client = getClient(location, false);
       client.invalidateConditionalUpdate(tinfo, sessionId);
     } finally {
       ThriftUtil.returnClient((TServiceClient) client);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
@@ -69,7 +69,7 @@ public class ConnectorImpl extends Connector {
           if (!iface.authenticate(Tracer.traceInfo(), credentials.toThrift(instance)))
             throw new AccumuloSecurityException("Authentication failed, access denied", SecurityErrorCode.BAD_CREDENTIALS);
         }
-      });
+      }, false);
     }
 
     this.tableops = new TableOperationsImpl(instance, credentials);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/InstanceOperationsImpl.java
@@ -76,7 +76,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
       public void execute(MasterClientService.Client client) throws Exception {
         client.setSystemProperty(Tracer.traceInfo(), credentials.toThrift(instance), property, value);
       }
-    });
+    }, false);
   }
 
   @Override
@@ -87,7 +87,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
       public void execute(MasterClientService.Client client) throws Exception {
         client.removeSystemProperty(Tracer.traceInfo(), credentials.toThrift(instance), property);
       }
-    });
+    }, false);
   }
 
   @Override
@@ -97,7 +97,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
       public Map<String,String> execute(ClientService.Client client) throws Exception {
         return client.getConfiguration(Tracer.traceInfo(), credentials.toThrift(instance), ConfigurationType.CURRENT);
       }
-    });
+    }, false);
   }
 
   @Override
@@ -107,7 +107,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
       public Map<String,String> execute(ClientService.Client client) throws Exception {
         return client.getConfiguration(Tracer.traceInfo(), credentials.toThrift(instance), ConfigurationType.SITE);
       }
-    });
+    }, false);
   }
 
   @Override
@@ -133,7 +133,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
   public List<ActiveScan> getActiveScans(String tserver) throws AccumuloException, AccumuloSecurityException {
     Client client = null;
     try {
-      client = ThriftUtil.getTServerClient(tserver, ServerConfigurationUtil.getConfiguration(instance));
+      client = ThriftUtil.getTServerClient(tserver, ServerConfigurationUtil.getConfiguration(instance), false);
 
       List<ActiveScan> as = new ArrayList<ActiveScan>();
       for (org.apache.accumulo.core.tabletserver.thrift.ActiveScan activeScan : client.getActiveScans(Tracer.traceInfo(), credentials.toThrift(instance))) {
@@ -163,14 +163,14 @@ public class InstanceOperationsImpl implements InstanceOperations {
       public Boolean execute(ClientService.Client client) throws Exception {
         return client.checkClass(Tracer.traceInfo(), credentials.toThrift(instance), className, asTypeName);
       }
-    });
+    }, false);
   }
 
   @Override
   public List<ActiveCompaction> getActiveCompactions(String tserver) throws AccumuloException, AccumuloSecurityException {
     Client client = null;
     try {
-      client = ThriftUtil.getTServerClient(tserver, ServerConfigurationUtil.getConfiguration(instance));
+      client = ThriftUtil.getTServerClient(tserver, ServerConfigurationUtil.getConfiguration(instance), false);
 
       List<ActiveCompaction> as = new ArrayList<ActiveCompaction>();
       for (org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction activeCompaction : client.getActiveCompactions(Tracer.traceInfo(),

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
@@ -143,7 +143,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
       public void execute(MasterClientService.Client client) throws Exception {
         client.setNamespaceProperty(Tracer.traceInfo(), credentials.toThrift(instance), namespace, property, value);
       }
-    });
+    }, false);
   }
 
   @Override
@@ -155,7 +155,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
       public void execute(MasterClientService.Client client) throws Exception {
         client.removeNamespaceProperty(Tracer.traceInfo(), credentials.toThrift(instance), namespace, property);
       }
-    });
+    }, false);
   }
 
   @Override
@@ -167,7 +167,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
         public Map<String,String> execute(ClientService.Client client) throws Exception {
           return client.getNamespaceConfiguration(Tracer.traceInfo(), credentials.toThrift(instance), namespace);
         }
-      }).entrySet();
+      }, false).entrySet();
     } catch (ThriftTableOperationException e) {
       switch (e.getType()) {
         case NAMESPACE_NOTFOUND:
@@ -200,7 +200,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
         public Boolean execute(ClientService.Client client) throws Exception {
           return client.checkNamespaceClass(Tracer.traceInfo(), credentials.toThrift(instance), namespace, className, asTypeName);
         }
-      });
+      }, false);
     } catch (ThriftTableOperationException e) {
       switch (e.getType()) {
         case NAMESPACE_NOTFOUND:

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/SecurityOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/SecurityOperationsImpl.java
@@ -44,9 +44,9 @@ public class SecurityOperationsImpl implements SecurityOperations {
   private Instance instance;
   private Credentials credentials;
 
-  private void execute(ClientExec<ClientService.Client> exec) throws AccumuloException, AccumuloSecurityException {
+  private void execute(ClientExec<ClientService.Client> exec, boolean oneway) throws AccumuloException, AccumuloSecurityException {
     try {
-      ServerClient.executeRaw(instance, exec);
+      ServerClient.executeRaw(instance, exec, oneway);
     } catch (ThriftTableOperationException ttoe) {
       // recast missing table
       if (ttoe.getType() == TableOperationExceptionType.NOTFOUND)
@@ -64,9 +64,9 @@ public class SecurityOperationsImpl implements SecurityOperations {
     }
   }
 
-  private <T> T execute(ClientExecReturn<T,ClientService.Client> exec) throws AccumuloException, AccumuloSecurityException {
+  private <T> T execute(ClientExecReturn<T,ClientService.Client> exec, boolean oneway) throws AccumuloException, AccumuloSecurityException {
     try {
-      return ServerClient.executeRaw(instance, exec);
+      return ServerClient.executeRaw(instance, exec, oneway);
     } catch (ThriftTableOperationException ttoe) {
       // recast missing table
       if (ttoe.getType() == TableOperationExceptionType.NOTFOUND)
@@ -105,7 +105,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.createLocalUser(Tracer.traceInfo(), credentials.toThrift(instance), principal, ByteBuffer.wrap(password.getPassword()));
       }
-    });
+    }, false);
   }
 
   @Deprecated
@@ -122,7 +122,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.dropLocalUser(Tracer.traceInfo(), credentials.toThrift(instance), principal);
       }
-    });
+    }, false);
   }
 
   @Deprecated
@@ -140,7 +140,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public Boolean execute(ClientService.Client client) throws Exception {
         return client.authenticateUser(Tracer.traceInfo(), credentials.toThrift(instance), toAuth.toThrift(instance));
       }
-    });
+    }, false);
   }
 
   @Override
@@ -158,7 +158,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.changeLocalUserPassword(Tracer.traceInfo(), credentials.toThrift(instance), principal, ByteBuffer.wrap(token.getPassword()));
       }
-    });
+    }, false);
     if (this.credentials.getPrincipal().equals(principal)) {
       this.credentials = toChange;
     }
@@ -173,7 +173,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
         client.changeAuthorizations(Tracer.traceInfo(), credentials.toThrift(instance), principal,
             ByteBufferUtil.toByteBuffers(authorizations.getAuthorizations()));
       }
-    });
+    }, false);
   }
 
   @Override
@@ -184,7 +184,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public Authorizations execute(ClientService.Client client) throws Exception {
         return new Authorizations(client.getUserAuthorizations(Tracer.traceInfo(), credentials.toThrift(instance), principal));
       }
-    });
+    }, false);
   }
 
   @Override
@@ -195,7 +195,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public Boolean execute(ClientService.Client client) throws Exception {
         return client.hasSystemPermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, perm.getId());
       }
-    });
+    }, false);
   }
 
   @Override
@@ -207,7 +207,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
         public Boolean execute(ClientService.Client client) throws Exception {
           return client.hasTablePermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, table, perm.getId());
         }
-      });
+      }, false);
     } catch (AccumuloSecurityException e) {
       if (e.getSecurityErrorCode() == org.apache.accumulo.core.client.security.SecurityErrorCode.NAMESPACE_DOESNT_EXIST)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST, e);
@@ -225,7 +225,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public Boolean execute(ClientService.Client client) throws Exception {
         return client.hasNamespacePermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, namespace, permission.getId());
       }
-    });
+    }, false);
   }
 
   @Override
@@ -236,7 +236,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.grantSystemPermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, permission.getId());
       }
-    });
+    }, false);
   }
 
   @Override
@@ -249,7 +249,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
         public void execute(ClientService.Client client) throws Exception {
           client.grantTablePermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, table, permission.getId());
         }
-      });
+      }, false);
     } catch (AccumuloSecurityException e) {
       if (e.getSecurityErrorCode() == org.apache.accumulo.core.client.security.SecurityErrorCode.NAMESPACE_DOESNT_EXIST)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST, e);
@@ -267,7 +267,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.grantNamespacePermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, namespace, permission.getId());
       }
-    });
+    }, false);
   }
 
   @Override
@@ -278,7 +278,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.revokeSystemPermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, permission.getId());
       }
-    });
+    }, false);
   }
 
   @Override
@@ -291,7 +291,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
         public void execute(ClientService.Client client) throws Exception {
           client.revokeTablePermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, table, permission.getId());
         }
-      });
+      }, false);
     } catch (AccumuloSecurityException e) {
       if (e.getSecurityErrorCode() == org.apache.accumulo.core.client.security.SecurityErrorCode.NAMESPACE_DOESNT_EXIST)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST, e);
@@ -309,7 +309,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public void execute(ClientService.Client client) throws Exception {
         client.revokeNamespacePermission(Tracer.traceInfo(), credentials.toThrift(instance), principal, namespace, permission.getId());
       }
-    });
+    }, false);
   }
 
   @Deprecated
@@ -325,7 +325,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       public Set<String> execute(ClientService.Client client) throws Exception {
         return client.listLocalUsers(Tracer.traceInfo(), credentials.toThrift(instance));
       }
-    });
+    }, false);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -229,7 +229,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     while (true) {
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(instance);
+        client = MasterClient.getConnectionWithRetry(instance, false);
         return client.beginFateOperation(Tracer.traceInfo(), credentials.toThrift(instance));
       } catch (TTransportException tte) {
         log.debug("Failed to call beginFateOperation(), retrying ... ", tte);
@@ -246,7 +246,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     while (true) {
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(instance);
+        client = MasterClient.getConnectionWithRetry(instance, false);
         client.executeFateOperation(Tracer.traceInfo(), credentials.toThrift(instance), opid, op, args, opts, autoCleanUp);
         break;
       } catch (TTransportException tte) {
@@ -262,7 +262,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     while (true) {
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(instance);
+        client = MasterClient.getConnectionWithRetry(instance, false);
         return client.waitForFateOperation(Tracer.traceInfo(), credentials.toThrift(instance), opid);
       } catch (TTransportException tte) {
         log.debug("Failed to call waitForFateOperation(), retrying ... ", tte);
@@ -277,7 +277,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     while (true) {
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(instance);
+        client = MasterClient.getConnectionWithRetry(instance, false);
         client.finishFateOperation(Tracer.traceInfo(), credentials.toThrift(instance), opid);
         break;
       } catch (TTransportException tte) {
@@ -480,7 +480,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         }
 
         try {
-          TabletClientService.Client client = ThriftUtil.getTServerClient(tl.tablet_location, ServerConfigurationUtil.getConfiguration(instance));
+          TabletClientService.Client client = ThriftUtil.getTServerClient(tl.tablet_location, ServerConfigurationUtil.getConfiguration(instance), false);
           try {
             OpTimer opTimer = null;
             if (log.isTraceEnabled())
@@ -833,7 +833,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       while (true) {
         MasterClientService.Iface client = null;
         try {
-          client = MasterClient.getConnectionWithRetry(instance);
+          client = MasterClient.getConnectionWithRetry(instance, false);
           flushID = client.initiateFlush(Tracer.traceInfo(), credentials.toThrift(instance), tableId);
           break;
         } catch (TTransportException tte) {
@@ -847,7 +847,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       while (true) {
         MasterClientService.Iface client = null;
         try {
-          client = MasterClient.getConnectionWithRetry(instance);
+          client = MasterClient.getConnectionWithRetry(instance, false);
           client.waitForFlush(Tracer.traceInfo(), credentials.toThrift(instance), tableId, TextUtil.getByteBuffer(start), TextUtil.getByteBuffer(end), flushID,
               wait ? Long.MAX_VALUE : 1);
           break;
@@ -901,7 +901,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         public void execute(MasterClientService.Client client) throws Exception {
           client.setTableProperty(Tracer.traceInfo(), credentials.toThrift(instance), tableName, property, value);
         }
-      });
+      }, false);
     } catch (TableNotFoundException e) {
       throw new AccumuloException(e);
     }
@@ -928,7 +928,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         public void execute(MasterClientService.Client client) throws Exception {
           client.removeTableProperty(Tracer.traceInfo(), credentials.toThrift(instance), tableName, property);
         }
-      });
+      }, false);
     } catch (TableNotFoundException e) {
       throw new AccumuloException(e);
     }
@@ -952,7 +952,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         public Map<String,String> execute(ClientService.Client client) throws Exception {
           return client.getTableConfiguration(Tracer.traceInfo(), credentials.toThrift(instance), tableName);
         }
-      }).entrySet();
+      }, false).entrySet();
     } catch (ThriftTableOperationException e) {
       switch (e.getType()) {
         case NOTFOUND:
@@ -1554,7 +1554,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         public Boolean execute(ClientService.Client client) throws Exception {
           return client.checkTableClass(Tracer.traceInfo(), credentials.toThrift(instance), tableName, className, asTypeName);
         }
-      });
+      }, false);
     } catch (ThriftTableOperationException e) {
       switch (e.getType()) {
         case NOTFOUND:

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
@@ -645,9 +645,9 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     try {
       TabletClientService.Client client;
       if (timeoutTracker.getTimeOut() < conf.getTimeInMillis(Property.GENERAL_RPC_TIMEOUT))
-        client = ThriftUtil.getTServerClient(server, conf, timeoutTracker.getTimeOut());
+        client = ThriftUtil.getTServerClient(server, conf, timeoutTracker.getTimeOut(), false);
       else
-        client = ThriftUtil.getTServerClient(server, conf);
+        client = ThriftUtil.getTServerClient(server, conf, false);
 
       try {
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
@@ -65,7 +65,7 @@ public class Writer {
 
     TabletClientService.Iface client = null;
     try {
-      client = ThriftUtil.getTServerClient(server, configuration);
+      client = ThriftUtil.getTServerClient(server, configuration, false);
       client.update(Tracer.traceInfo(), ai.toThrift(instance), extent.toThrift(), m.toThrift());
       return;
     } catch (ThriftSecurityException e) {

--- a/core/src/main/thrift/master.thrift
+++ b/core/src/main/thrift/master.thrift
@@ -166,6 +166,7 @@ service MasterClientService extends FateService {
   MasterMonitorInfo getMasterStats(2:trace.TInfo tinfo, 1:security.TCredentials credentials) throws (1:client.ThriftSecurityException sec)
 
   // tablet server reporting
+  // Important: all of these reports to the Master are assumed to be oneway in the TabletServer's reporting code.
   oneway void reportSplitExtent(4:trace.TInfo tinfo, 1:security.TCredentials credentials, 2:string serverName, 3:TabletSplit split)
   oneway void reportTabletStatus(5:trace.TInfo tinfo, 1:security.TCredentials credentials, 2:string serverName, 3:TabletLoadState status, 4:data.TKeyExtent tablet)
 

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
@@ -761,7 +761,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     MasterMonitorInfo stats = null;
     try {
       Instance instance = new ZooKeeperInstance(getClientConfig());
-      client = MasterClient.getConnectionWithRetry(instance);
+      client = MasterClient.getConnectionWithRetry(instance, false);
       stats = client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get(instance).toThrift(instance));
     } catch (ThriftSecurityException exception) {
       throw new AccumuloSecurityException(exception);

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -593,7 +593,7 @@ public class BulkImporter {
       throws AccumuloException, AccumuloSecurityException {
     try {
       long timeInMillis = ServerConfiguration.getSystemConfiguration(instance).getTimeInMillis(Property.TSERV_BULK_TIMEOUT);
-      TabletClientService.Iface client = ThriftUtil.getTServerClient(location, ServerConfiguration.getSystemConfiguration(instance), timeInMillis);
+      TabletClientService.Iface client = ThriftUtil.getTServerClient(location, ServerConfiguration.getSystemConfiguration(instance), timeInMillis, false);
       try {
         HashMap<KeyExtent,Map<String,org.apache.accumulo.core.data.thrift.MapFileInfo>> files = new HashMap<KeyExtent,Map<String,org.apache.accumulo.core.data.thrift.MapFileInfo>>();
         for (Entry<KeyExtent,List<PathSize>> entry : assignmentsPerTablet.entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
@@ -98,7 +98,7 @@ public class LiveTServerSet implements Watcher {
           transport.close();
         }
       } else {
-        TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+        TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
         try {
           loadTablet(client, lock, extent);
         } finally {
@@ -108,7 +108,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void unloadTablet(ZooLock lock, KeyExtent extent, boolean save) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
       try {
         client.unloadTablet(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock), extent.toThrift(), save);
       } finally {
@@ -133,7 +133,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void halt(ZooLock lock) throws TException, ThriftSecurityException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, false);
       try {
         client.halt(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock));
       } finally {
@@ -142,7 +142,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void fastHalt(ZooLock lock) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
       try {
         client.fastHalt(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock));
       } finally {
@@ -151,7 +151,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void flush(ZooLock lock, String tableId, byte[] startRow, byte[] endRow) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
       try {
         client.flush(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock), tableId,
             startRow == null ? null : ByteBuffer.wrap(startRow), endRow == null ? null : ByteBuffer.wrap(endRow));
@@ -161,7 +161,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void chop(ZooLock lock, KeyExtent extent) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
       try {
         client.chop(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock), extent.toThrift());
       } finally {
@@ -170,7 +170,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void splitTablet(ZooLock lock, KeyExtent extent, Text splitPoint) throws TException, ThriftSecurityException, NotServingTabletException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, false);
       try {
         client.splitTablet(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), extent.toThrift(),
             ByteBuffer.wrap(splitPoint.getBytes(), 0, splitPoint.getLength()));
@@ -180,7 +180,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void flushTablet(ZooLock lock, KeyExtent extent) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
       try {
         client.flushTablet(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock), extent.toThrift());
       } finally {
@@ -189,7 +189,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public void compact(ZooLock lock, String tableId, byte[] startRow, byte[] endRow) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
       try {
         client.compact(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), lockString(lock), tableId,
             startRow == null ? null : ByteBuffer.wrap(startRow), endRow == null ? null : ByteBuffer.wrap(endRow));
@@ -199,7 +199,7 @@ public class LiveTServerSet implements Watcher {
     }
 
     public boolean isActive(long tid) throws TException {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, false);
       try {
         return client.isActive(Tracer.traceInfo(), tid);
       } finally {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
@@ -183,7 +183,7 @@ public abstract class TabletBalancer {
    */
   public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, String tableId) throws ThriftSecurityException, TException {
     log.debug("Scanning tablet server " + tserver + " for table " + tableId);
-    Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), tserver.getLocation(), configuration.getConfiguration());
+    Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), tserver.getLocation(), configuration.getConfiguration(), false);
     try {
       List<TabletStats> onlineTabletsForTable = client.getTabletStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(configuration.getInstance()),
           tableId);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -323,7 +323,7 @@ public class Admin {
       public void execute(MasterClientService.Client client) throws Exception {
         client.shutdown(Tracer.traceInfo(), credentials.toThrift(instance), tabletServersToo);
       }
-    });
+    }, false);
   }
 
   private static void stopTabletServer(final Instance instance, final Credentials creds, List<String> servers, final boolean force) throws AccumuloException,
@@ -341,7 +341,7 @@ public class Admin {
         public void execute(MasterClientService.Client client) throws Exception {
           client.shutdownTabletServer(Tracer.traceInfo(), creds.toThrift(instance), finalServer, force);
         }
-      });
+      }, false);
     }
   }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -206,7 +206,7 @@ public class GarbageCollectWriteAheadLogs {
         } else {
           Client tserver = null;
           try {
-            tserver = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
+            tserver = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf, true);
             tserver.removeLogs(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), paths2strings(entry.getValue()));
             log.debug("deleted " + entry.getValue() + " from " + entry.getKey());
             status.currentLog.deleted += entry.getValue().size();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/BulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/BulkImport.java
@@ -553,7 +553,7 @@ class LoadFiles extends MasterRepo {
               // serving the metadata tablets
               long timeInMillis = master.getConfiguration().getConfiguration().getTimeInMillis(Property.MASTER_BULK_TIMEOUT);
               server = servers[random.nextInt(servers.length)].getLocation().toString();
-              client = ThriftUtil.getTServerClient(server, master.getConfiguration().getConfiguration(), timeInMillis);
+              client = ThriftUtil.getTServerClient(server, master.getConfiguration().getConfiguration(), timeInMillis, false);
               List<String> attempt = Collections.singletonList(file);
               log.debug("Asking " + server + " to bulk import " + file);
               List<String> fail = client.bulkImportFiles(Tracer.traceInfo(), SystemCredentials.get().toThrift(master.getInstance()), tid, tableId, attempt,

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -275,7 +275,7 @@ public class Monitor {
       while (retry) {
         MasterClientService.Iface client = null;
         try {
-          client = MasterClient.getConnection(HdfsZooInstance.getInstance());
+          client = MasterClient.getConnection(HdfsZooInstance.getInstance(), false);
           if (client != null) {
             mmi = client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(HdfsZooInstance.getInstance()));
             retry = false;
@@ -408,7 +408,7 @@ public class Monitor {
       if (locks != null && locks.size() > 0) {
         Collections.sort(locks);
         address = new ServerServices(new String(zk.getData(path + "/" + locks.get(0), null), UTF_8)).getAddress(Service.GC_CLIENT);
-        GCMonitorService.Client client = ThriftUtil.getClient(new GCMonitorService.Client.Factory(), address, config.getConfiguration());
+        GCMonitorService.Client client = ThriftUtil.getClient(new GCMonitorService.Client.Factory(), address, config.getConfiguration(), false);
         try {
           result = client.getStatus(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance));
         } finally {
@@ -560,7 +560,7 @@ public class Monitor {
       return;
     Connector c = instance.getConnector(SystemCredentials.get().getPrincipal(), SystemCredentials.get().getToken());
     for (String server : c.instanceOperations().getTabletServers()) {
-      Client tserver = ThriftUtil.getTServerClient(server, Monitor.getSystemConfiguration());
+      Client tserver = ThriftUtil.getTServerClient(server, Monitor.getSystemConfiguration(), false);
       try {
         List<ActiveScan> scans = tserver.getActiveScans(null, SystemCredentials.get().toThrift(instance));
         synchronized (allScans) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TServersServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TServersServlet.java
@@ -124,7 +124,7 @@ public class TServersServlet extends BasicServlet {
     TabletStats historical = new TabletStats(null, new ActionStats(), new ActionStats(), new ActionStats(), 0, 0, 0, 0);
     List<TabletStats> tsStats = new ArrayList<TabletStats>();
     try {
-      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, Monitor.getSystemConfiguration());
+      TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, Monitor.getSystemConfiguration(), false);
       try {
         for (String tableId : Monitor.getMmi().tableMap.keySet()) {
           tsStats.addAll(client.getTabletStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(Monitor.getInstance()), tableId));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -3138,13 +3138,13 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
   }
 
   // Connect to the master for posting asynchronous results
-  private MasterClientService.Client masterConnection(String address) {
+  private MasterClientService.Client masterConnection(String address, boolean oneway) {
     try {
       if (address == null) {
         return null;
       }
       MasterClientService.Client client = ThriftUtil.getClient(new MasterClientService.Client.Factory(), address, Property.GENERAL_RPC_TIMEOUT,
-          getSystemConfiguration());
+          getSystemConfiguration(), oneway);
       // log.info("Listener API to master has been opened");
       return client;
     } catch (Exception e) {
@@ -3280,7 +3280,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
           // have a message to send to the master, so grab a
           // connection
           masterHost = getMasterAddress();
-          iface = masterConnection(masterHost);
+          // All MasterMessages reports are oneway -- this relies on that.
+          iface = masterConnection(masterHost, true);
           TServiceClient client = iface;
 
           // if while loop does not execute at all and mm != null,

--- a/test/src/main/java/org/apache/accumulo/test/GetMasterStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetMasterStats.java
@@ -39,7 +39,7 @@ public class GetMasterStats {
     MasterMonitorInfo stats = null;
     try {
       Instance instance = HdfsZooInstance.getInstance();
-      client = MasterClient.getConnectionWithRetry(instance);
+      client = MasterClient.getConnectionWithRetry(instance, false);
       stats = client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance));
     } finally {
       if (client != null)

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -41,7 +41,7 @@ public class WrongTabletTest {
 
     ServerConfiguration conf = new ServerConfiguration(opts.getInstance());
     try {
-      TabletClientService.Iface client = ThriftUtil.getTServerClient(opts.location, conf.getConfiguration());
+      TabletClientService.Iface client = ThriftUtil.getTServerClient(opts.location, conf.getConfiguration(), false);
 
       Mutation mutation = new Mutation(new Text("row_0003750001"));
       mutation.putDelete(new Text("colf"), new Text("colq"));

--- a/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousStatsCollector.java
+++ b/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousStatsCollector.java
@@ -133,7 +133,7 @@ public class ContinuousStatsCollector {
 
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(opts.getInstance());
+        client = MasterClient.getConnectionWithRetry(opts.getInstance(), false);
         MasterMonitorInfo stats = client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(opts.getInstance()));
 
         TableInfo all = new TableInfo();

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/concurrent/Shutdown.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/concurrent/Shutdown.java
@@ -44,7 +44,7 @@ public class Shutdown extends Test {
     while (true) {
       try {
         Instance instance = HdfsZooInstance.getInstance();
-        Client client = MasterClient.getConnection(instance);
+        Client client = MasterClient.getConnection(instance, false);
         client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance));
       } catch (Exception e) {
         // assume this is due to server shutdown

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/concurrent/StartAll.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/concurrent/StartAll.java
@@ -42,7 +42,7 @@ public class StartAll extends Test {
     while (true) {
       try {
         Instance instance = HdfsZooInstance.getInstance();
-        Client client = MasterClient.getConnection(instance);
+        Client client = MasterClient.getConnection(instance, false);
         MasterMonitorInfo masterStats = client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance));
         if (!masterStats.tServerInfo.isEmpty())
           break;

--- a/test/src/test/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
@@ -82,7 +82,7 @@ public class DetectDeadTabletServersIT extends ConfigurableMacIT {
     Credentials creds = new Credentials("root", new PasswordToken(ROOT_PASSWORD));
     MasterClientService.Iface client = null;
     try {
-      client = MasterClient.getConnectionWithRetry(c.getInstance());
+      client = MasterClient.getConnectionWithRetry(c.getInstance(), false);
       log.info("Fetching master stats");
       return client.getMasterStats(Tracer.traceInfo(), creds.toThrift(c.getInstance()));
     } finally {

--- a/test/src/test/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/BalanceAfterCommsFailureIT.java
@@ -104,7 +104,7 @@ public class BalanceAfterCommsFailureIT extends ConfigurableMacIT {
     for (int i = 0; unassignedTablets > 0 && i < 10; i++) {
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(c.getInstance());
+        client = MasterClient.getConnectionWithRetry(c.getInstance(), false);
         stats = client.getMasterStats(Tracer.traceInfo(), creds.toThrift(c.getInstance()));
       } finally {
         if (client != null)

--- a/test/src/test/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -142,7 +142,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterIT {
       MasterMonitorInfo stats = null;
       try {
         Instance instance = new ZooKeeperInstance(cluster.getClientConfig());
-        client = MasterClient.getConnectionWithRetry(instance);
+        client = MasterClient.getConnectionWithRetry(instance, false);
         stats = client.getMasterStats(Tracer.traceInfo(), SystemCredentials.get(instance).toThrift(instance));
       } catch (ThriftSecurityException exception) {
         throw new AccumuloSecurityException(exception);

--- a/test/src/test/java/org/apache/accumulo/test/functional/DynamicThreadPoolsIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/DynamicThreadPoolsIT.java
@@ -94,7 +94,7 @@ public class DynamicThreadPoolsIT extends AccumuloClusterIT {
       MasterClientService.Iface client = null;
       MasterMonitorInfo stats = null;
       try {
-        client = MasterClient.getConnectionWithRetry(c.getInstance());
+        client = MasterClient.getConnectionWithRetry(c.getInstance(), false);
         stats = client.getMasterStats(Tracer.traceInfo(), creds.toThrift(c.getInstance()));
       } finally {
         if (client != null)

--- a/test/src/test/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
@@ -125,7 +125,7 @@ public class MetadataMaxFilesIT extends AccumuloClusterIT {
         Credentials creds = new Credentials(getPrincipal(), getToken());
         Client client = null;
         try {
-          client = MasterClient.getConnectionWithRetry(c.getInstance());
+          client = MasterClient.getConnectionWithRetry(c.getInstance(), false);
           stats = client.getMasterStats(Tracer.traceInfo(), creds.toThrift(c.getInstance()));
         } finally {
           if (client != null)

--- a/test/src/test/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
@@ -83,7 +83,7 @@ public class SimpleBalancerFairnessIT extends ConfigurableMacIT {
     for (int i = 0; unassignedTablets > 0 && i < 10; i++) {
       MasterClientService.Iface client = null;
       try {
-        client = MasterClient.getConnectionWithRetry(c.getInstance());
+        client = MasterClient.getConnectionWithRetry(c.getInstance(), false);
         stats = client.getMasterStats(Tracer.traceInfo(), creds.toThrift(c.getInstance()));
       } finally {
         if (client != null)


### PR DESCRIPTION
…lls.

Oneway Thrift calls return to the caller before the response from a server
is received. Even though all oneway calls are void methods, there is still
an implicit response sent by the server so that the client knows when
the RPC has completed. Because of this potential delay, a connection that
is re-used by a non-oneway call could see the response from the oneway
call, not its own (void or typed response message). We must separate
connections to ensure that this is avoided.