### PR TITLE
ACCUMULO-4065 Work around TExceptions being written back to clients i…

### DIFF
--- a/proxy/src/main/java/org/apache/accumulo/proxy/Proxy.java
+++ b/proxy/src/main/java/org/apache/accumulo/proxy/Proxy.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.proxy.thrift.AccumuloProxy;
 import org.apache.accumulo.server.util.RpcWrapper;
 import org.apache.log4j.Logger;
+import org.apache.thrift.TBaseProcessor;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
@@ -135,7 +136,8 @@ public class Proxy {
     @SuppressWarnings("unchecked")
     Constructor<? extends TProcessor> proxyProcConstructor = (Constructor<? extends TProcessor>) proxyProcClass.getConstructor(proxyIfaceClass);
 
-    final TProcessor processor = proxyProcConstructor.newInstance(RpcWrapper.service(impl));
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    final TProcessor processor = proxyProcConstructor.newInstance(RpcWrapper.service(impl, ((TBaseProcessor) proxyProcConstructor.newInstance(impl)).getProcessMapView()));
 
     THsHaServer.Args args = new THsHaServer.Args(socket);
     args.processor(processor);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -702,7 +702,7 @@ public class SimpleGarbageCollector implements Iface {
   }
 
   private HostAndPort startStatsService() throws UnknownHostException {
-    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(this));
+    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(this, new Processor<Iface>(this).getProcessMapView()));
     int port = config.getPort(Property.GC_PORT);
     long maxMessageSize = config.getMemoryInBytes(Property.GENERAL_MAX_MESSAGE_SIZE);
     HostAndPort result = HostAndPort.fromParts(opts.getAddress(), port);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1032,7 +1032,8 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
       throw new IOException(e);
     }
 
-    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(new MasterClientServiceHandler(this)));
+    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(new MasterClientServiceHandler(this),
+        new Processor<Iface>(new MasterClientServiceHandler(this)).getProcessMapView()));
     ServerAddress sa = TServerUtils.startServer(getSystemConfiguration(), hostname, Property.MASTER_CLIENTPORT, processor, "Master",
         "Master Client Service Handler", null, Property.MASTER_MINTHREADS, Property.MASTER_THREADCHECK, Property.GENERAL_MAX_MESSAGE_SIZE);
     clientService = sa.server;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -230,6 +230,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
+import org.apache.thrift.ProcessFunction;
+import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.TServiceClient;
@@ -3159,7 +3161,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
 
   private HostAndPort startTabletClientService() throws UnknownHostException {
     // start listening for client connection last
-    Iface tch = RpcWrapper.service(new ThriftClientHandler());
+    ThriftClientHandler handler = new ThriftClientHandler();
+    Iface tch = RpcWrapper.service(handler, new Processor<Iface>(handler).getProcessMapView());
     Processor<Iface> processor = new Processor<Iface>(tch);
     HostAndPort address = startServer(getSystemConfiguration(), clientAddress.getHostText(), Property.TSERV_CLIENTPORT, processor, "Thrift Client Server");
     log.info("address = " + address);


### PR DESCRIPTION
…n oneway methods.

In talking to @keith-turner on the previous pull request, we came to the conclusion that the real issue was that when a TException is thrown on by the (server-side) Processor on a oneway method, a message is written back to the client. This message is left on the wire, and will mess up other calls which expect their message to be on the wire (this was what the first pull request realized and tried to work around).

I noticed that RpcWrapper is actually rethrowing RTEs and Errors as TExceptions, in an attempt to work around some change in logic from 0.6.0 and 0.9.0. Since clients will never know that an Exception was thrown as a result of some invocation of a oneway Thrift call, we want to avoid wrapping and rethrowing any RTE/Error in the oneway call's path.

These changes alter `RpcWrapper` so that it does not wrap and rethrow RTEs and Errors when thrown from a oneway method invocation.

I verified that the patch works with some logging (thus removed), as well as hacking together a call to `TabletClientService.fastHalt` and verifying that no data is sent back to the client.