### PR TITLE
ACCUMULO-3509: Allow cleanup state to be kept to avoid blocking tserv…

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -276,6 +276,7 @@ public enum Property {
   TSERV_MEM_MGMT("tserver.memory.manager", "org.apache.accumulo.server.tabletserver.LargestFirstMemoryManager", PropertyType.CLASSNAME,
       "An implementation of MemoryManger that accumulo will use."),
   TSERV_SESSION_MAXIDLE("tserver.session.idle.max", "1m", PropertyType.TIMEDURATION, "maximum idle time for a session"),
+  TSERV_UPDATE_SESSION_MAXIDLE("tserver.session.update.idle.max", "1m", PropertyType.TIMEDURATION, "maximum idle time for an update session"),
   TSERV_READ_AHEAD_MAXCONCURRENT("tserver.readahead.concurrent.max", "16", PropertyType.COUNT,
       "The maximum number of concurrent read ahead that will execute. This effectively"
           + " limits the number of long running scans that can run concurrently per tserver."),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ConditionalSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ConditionalSession.java
@@ -40,7 +40,8 @@ public class ConditionalSession extends Session {
   }
 
   @Override
-  public void cleanup() {
+  public boolean cleanup() {
     interruptFlag.set(true);
+    return true;
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/MultiScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/MultiScanSession.java
@@ -63,8 +63,9 @@ public class MultiScanSession extends Session {
   }
 
   @Override
-  public void cleanup() {
+  public boolean cleanup() {
     if (lookupTask != null)
       lookupTask.cancel(true);
+    return true;
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -60,14 +60,17 @@ public class ScanSession extends Session {
     this.context = context;
   }
 
+  @SuppressWarnings("finally")
   @Override
-  public void cleanup() {
+  public boolean cleanup() {
     try {
       if (nextBatchTask != null)
         nextBatchTask.cancel(true);
     } finally {
       if (scanner != null)
-        scanner.close();
+        return scanner.close();
+      else
+        return true;
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/Session.java
@@ -39,5 +39,7 @@ public class Session {
     return credentials;
   }
 
-  public void cleanup() {}
+  public boolean cleanup() {
+    return true;
+  }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.ActiveScan;
+import org.apache.accumulo.core.client.admin.InstanceOperations;
+import org.apache.accumulo.core.client.impl.Tables;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verify that we have resolved blocking issue by ensuring that we have not lost scan sessions which we know to currently be running
+ */
+public class SessionBlockVerifyIT extends AccumuloClusterHarness {
+  private static final Logger log = LoggerFactory.getLogger(SessionBlockVerifyIT.class);
+
+  @Override
+  public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    Map<String,String> siteConfig = cfg.getSiteConfig();
+    cfg.setNumTservers(1);
+    port = ThreadLocalRandom.current().nextInt(9997, 55333);
+    siteConfig.put(Property.TSERV_CLIENTPORT.getKey(), String.valueOf(port));
+    siteConfig.put(Property.TSERV_SESSION_MAXIDLE.getKey(), "1s");
+    siteConfig.put(Property.TSERV_READ_AHEAD_MAXCONCURRENT.getKey(), "11");
+    cfg.setSiteConfig(siteConfig);
+  }
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 60;
+  }
+
+  private String sessionIdle = null;
+  private int port;
+
+  @Before
+  public void reduceSessionIdle() throws Exception {
+
+    InstanceOperations ops = getConnector().instanceOperations();
+    sessionIdle = ops.getSystemConfiguration().get(Property.TSERV_SESSION_MAXIDLE.getKey());
+    ops.setProperty(Property.TSERV_SESSION_MAXIDLE.getKey(), "1s");
+    log.info("Waiting for existing session idle time to expire");
+    Thread.sleep(AccumuloConfiguration.getTimeInMillis(sessionIdle));
+    log.info("Finished waiting");
+  }
+
+  ExecutorService service = Executors.newFixedThreadPool(10);
+
+  @Test
+  public void run() throws Exception {
+    Connector c = getConnector();
+    String tableName = getUniqueNames(1)[0];
+    c.tableOperations().create(tableName);
+
+    BatchWriter bw = c.createBatchWriter(tableName, new BatchWriterConfig());
+
+    for (int i = 0; i < 1000; i++) {
+      Mutation m = new Mutation(new Text(String.format("%08d", i)));
+      for (int j = 0; j < 3; j++)
+        m.put(new Text("cf1"), new Text("cq" + j), new Value((i + "_" + j).getBytes(UTF_8)));
+
+      bw.addMutation(m);
+    }
+
+    bw.close();
+
+    Scanner scanner = c.createScanner(tableName, new Authorizations());
+    scanner.setRange(new Range(String.format("%08d", 0), String.format("%08d", 1000)));
+    scanner.setBatchTimeout(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+
+    // test by making a slow iterator and then a couple of fast ones.
+    // when then checking we shouldn't have any running except the slow iterator
+    IteratorSetting setting = new IteratorSetting(21, SlowButBusyIterator.class);
+    SlowButBusyIterator.setMaxCount(setting, Long.MAX_VALUE);
+    SlowButBusyIterator.setNumberLoops(setting, Long.MAX_VALUE);
+    scanner.addScanIterator(setting);
+
+    final Iterator<Entry<Key,Value>> slow = scanner.iterator();
+
+    final List<Future<Boolean>> callables = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Future<Boolean> callable = service.submit(new Callable<Boolean>() {
+        public Boolean call() {
+          while (slow.hasNext()) {
+
+            slow.next();
+          }
+          return slow.hasNext();
+        }
+      });
+      callables.add(callable);
+    }
+
+    Thread.sleep(10000);
+    log.info("Starting");
+    // let's add more for good measure.
+    for (int i = 0; i < 2; i++) {
+      Scanner scanner2 = c.createScanner(tableName, new Authorizations());
+
+      scanner2.setRange(new Range(String.format("%08d", 0), String.format("%08d", 1000)));
+
+      scanner2.setBatchSize(1);
+      Iterator<Entry<Key,Value>> iter = scanner2.iterator();
+      sinkKeyValues(iter);
+
+    }
+    boolean foundScan = false;
+    String tableId = Tables.getTableId(c.getInstance(), tableName);
+    int sessionsFound = 0;
+    while (!foundScan) {
+      for (int i = 0; i < 10; i++) {
+        List<ActiveScan> scans = null;
+        try {
+          scans = c.instanceOperations().getActiveScans("localhost:" + (port + i));
+        } catch (Exception e) {
+          continue;
+        }
+
+        for (ActiveScan scan : scans) {
+          // foundScan = true;
+          if (tableId.toString().equals(scan.getTablet().getTableId().toString())) {
+            foundScan = true;
+          }
+
+          if (foundScan && scan.getSsiList().size() > 0) {
+            assertEquals("Not the expected iterator", 1, scan.getSsiList().size());
+            assertTrue("Not the expected iterator", scan.getSsiList().iterator().next().contains("SlowButBusyIterator"));
+
+          }
+          sessionsFound++;
+        }
+
+        if (scans.size() > 0)
+          break;
+
+      }
+      if (foundScan)
+        break;
+    }
+
+    assertEquals("Must have ten sessions to ensure 3509 is resolved", 10, sessionsFound);
+
+    service.shutdown();
+  }
+
+  private void sinkKeyValues(Iterator<Entry<Key,Value>> iter) throws Exception {
+    while (iter.hasNext()) {
+
+      iter.next();
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/SlowButBusyIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SlowButBusyIterator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.WrappingIterator;
+
+public class SlowButBusyIterator extends WrappingIterator {
+
+  static private final String MAX_COUNT = "maxcounter";
+  static private final String LOOPS = "loops";
+
+  private long maxCount = 0;
+  private long maxLoops = 1;
+
+  public static void setMaxCount(IteratorSetting is, long millis) {
+    is.addOption(MAX_COUNT, Long.toString(millis));
+  }
+
+  public static void setNumberLoops(IteratorSetting is, long t) {
+    is.addOption(LOOPS, Long.toString(t));
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void sleepByCounting(long count, long loops) {
+    long countr = 0;
+    Random rand = new Random();
+    for (long i = 0; i < loops; i++) {
+      for (long j = 0; j < count; j++) {
+        countr *= rand.nextInt();
+        countr += rand.nextInt();
+      }
+    }
+    countr = 0;
+  }
+
+  @Override
+  public void next() throws IOException {
+    sleepByCounting(maxCount, maxLoops);
+    super.next();
+  }
+
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+    sleepByCounting(maxCount, maxLoops);
+    super.seek(range, columnFamilies, inclusive);
+  }
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+    super.init(source, options, env);
+    if (options.containsKey(MAX_COUNT))
+      maxCount = Long.parseLong(options.get(MAX_COUNT));
+
+    if (options.containsKey(LOOPS))
+      maxLoops = Long.parseLong(options.get(LOOPS));
+  }
+
+}


### PR DESCRIPTION
…er session sweep

By enabling state ( true/false) from the cleanup method, the change will avoid blocking
on a scan session being swept. if the session cleanup blocks because a ScanSession is
still being read, we may block until the ScanBatch returns for that ScanSession.

The change uses a simple semaphore ( purely because I like the word ) to attempt acquisition.
If that fails, we return false from the cleanup and reintroduce that Session back into
the queue to clean up.

Added unit test that in the error condition will show the missing scan sessions ( which are missing due to the cleanup being blocked)