### PR TITLE
ACCUMULO-2493: Deprecated BinaryFormatter in favor of DefaultFormatter

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/format/BinaryFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/BinaryFormatter.java
@@ -17,67 +17,50 @@
 package org.apache.accumulo.core.util.format;
 
 import java.util.Map.Entry;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.hadoop.io.Text;
 
+/**
+ * @deprecated Use {@link DefaultFormatter} providing showLength and printTimestamps via {@link FormatterConfig}.
+ */
+@Deprecated
 public class BinaryFormatter extends DefaultFormatter {
-  private static int showLength;
-
+  // this class can probably be replaced by DefaultFormatter since DefaultFormatter has the max length stuff
   @Override
   public String next() {
     checkState(true);
-    return formatEntry(getScannerIterator().next(), isDoTimestamps());
+    return formatEntry(getScannerIterator().next(), config.willPrintTimestamps(), config.getShownLength());
   }
 
-  // this should be replaced with something like Record.toString();
-  // it would be great if we were able to combine code with DefaultFormatter.formatEntry, but that currently does not respect the showLength option.
-  public static String formatEntry(Entry<Key,Value> entry, boolean showTimestamps) {
+  public static String formatEntry(Entry<Key,Value> entry, boolean printTimestamps, int shownLength) {
     StringBuilder sb = new StringBuilder();
 
     Key key = entry.getKey();
 
     // append row
-    appendText(sb, key.getRow()).append(" ");
+    appendText(sb, key.getRow(), shownLength).append(" ");
 
     // append column family
-    appendText(sb, key.getColumnFamily()).append(":");
+    appendText(sb, key.getColumnFamily(), shownLength).append(":");
 
     // append column qualifier
-    appendText(sb, key.getColumnQualifier()).append(" ");
+    appendText(sb, key.getColumnQualifier(), shownLength).append(" ");
 
     // append visibility expression
     sb.append(new ColumnVisibility(key.getColumnVisibility()));
 
     // append timestamp
-    if (showTimestamps)
+    if (printTimestamps)
       sb.append(" ").append(entry.getKey().getTimestamp());
 
     // append value
     Value value = entry.getValue();
     if (value != null && value.getSize() > 0) {
       sb.append("\t");
-      appendValue(sb, value);
+      appendValue(sb, value, shownLength);
     }
     return sb.toString();
   }
 
-  public static StringBuilder appendText(StringBuilder sb, Text t) {
-    return appendBytes(sb, t.getBytes(), 0, t.getLength());
-  }
-
-  static StringBuilder appendValue(StringBuilder sb, Value value) {
-    return appendBytes(sb, value.get(), 0, value.get().length);
-  }
-
-  static StringBuilder appendBytes(StringBuilder sb, byte ba[], int offset, int len) {
-    int length = Math.min(len, showLength);
-    return DefaultFormatter.appendBytes(sb, ba, offset, length);
-  }
-
-  public static void getlength(int length) {
-    showLength = length;
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/format/DateFormatSupplier.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/DateFormatSupplier.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.util.format;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+import com.google.common.base.Supplier;
+
+/**
+ * DateFormatSupplier is a {@code ThreadLocal<DateFormat>} that will set the correct TimeZone when the object is retrieved by {@link #get()}.
+ *
+ * This exists as a way to get around thread safety issues in {@link DateFormat}. This class also contains helper methods that create some useful
+ * DateFormatSuppliers.
+ *
+ * Instances of DateFormatSuppliers can be shared, but note that a DateFormat generated from it will be shared by all classes within a Thread.
+ *
+ * In general, the state of a retrieved DateFormat should not be changed, unless it makes sense to only perform a state change within that Thread.
+ */
+public abstract class DateFormatSupplier extends ThreadLocal<DateFormat> implements Supplier<DateFormat> {
+  private TimeZone timeZone;
+
+  public DateFormatSupplier() {
+    timeZone = TimeZone.getDefault();
+  }
+
+  public DateFormatSupplier(TimeZone timeZone) {
+    this.timeZone = timeZone;
+  }
+
+  public TimeZone getTimeZone() {
+    return timeZone;
+  }
+
+  public void setTimeZone(TimeZone timeZone) {
+    this.timeZone = timeZone;
+  }
+
+  /** Always sets the TimeZone, which is a fast operation */
+  @Override
+  public DateFormat get() {
+    final DateFormat df = super.get();
+    df.setTimeZone(timeZone);
+    return df;
+  }
+
+  public static final String HUMAN_READABLE_FORMAT = "yyyy/MM/dd HH:mm:ss.SSS";
+
+  /**
+   * Create a Supplier for {@link FormatterConfig.DefaultDateFormat}s
+   */
+  public static DateFormatSupplier createDefaultFormatSupplier() {
+    return new DateFormatSupplier() {
+      @Override
+      protected DateFormat initialValue() {
+        return new FormatterConfig.DefaultDateFormat();
+      }
+    };
+  }
+
+  /** Create a generator for SimpleDateFormats accepting a dateFormat */
+  public static DateFormatSupplier createSimpleFormatSupplier(final String dateFormat) {
+    return new DateFormatSupplier() {
+      @Override
+      protected SimpleDateFormat initialValue() {
+        return new SimpleDateFormat(dateFormat);
+      }
+    };
+  }
+
+  /** Create a generator for SimpleDateFormats accepting a dateFormat */
+  public static DateFormatSupplier createSimpleFormatSupplier(final String dateFormat, final TimeZone timeZone) {
+    return new DateFormatSupplier(timeZone) {
+      @Override
+      protected SimpleDateFormat initialValue() {
+        return new SimpleDateFormat(dateFormat);
+      }
+    };
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/util/format/DateStringFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/DateStringFormatter.java
@@ -16,31 +16,44 @@
  */
 package org.apache.accumulo.core.util.format;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Map.Entry;
 import java.util.TimeZone;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
+/**
+ * This class is <strong>not</strong> recommended because {@link #initialize(Iterable, FormatterConfig)} replaces parameters in {@link FormatterConfig}, which
+ * could surprise users.
+ *
+ * This class can be replaced by {@link DefaultFormatter} where FormatterConfig is initialized with a DateFormat set to {@link #DATE_FORMAT}. See
+ * {@link DateFormatSupplier#createSimpleFormatSupplier(String, java.util.TimeZone)}.
+ *
+ * <pre>
+ * final DateFormatSupplier dfSupplier = DateFormatSupplier.createSimpleFormatSupplier(DateFormatSupplier.HUMAN_READABLE_FORMAT, TimeZone.getTimeZone(&quot;UTC&quot;));
+ * final FormatterConfig config = new FormatterConfig().setPrintTimestamps(true).setDateFormatSupplier(dfSupplier);
+ * </pre>
+ */
 public class DateStringFormatter implements Formatter {
-  private boolean printTimestamps = false;
-  private DefaultFormatter defaultFormatter = new DefaultFormatter();
 
-  public static final String DATE_FORMAT = "yyyy/MM/dd HH:mm:ss.SSS";
-  // SimpleDataFormat is not thread safe
-  private static final ThreadLocal<DateFormat> formatter = new ThreadLocal<DateFormat>() {
-    @Override
-    protected SimpleDateFormat initialValue() {
-      return new SimpleDateFormat(DATE_FORMAT);
-    }
-  };
+  private DefaultFormatter defaultFormatter;
+  private TimeZone timeZone;
+
+  public static final String DATE_FORMAT = DateFormatSupplier.HUMAN_READABLE_FORMAT;
+
+  public DateStringFormatter() {
+    this(TimeZone.getDefault());
+  }
+
+  public DateStringFormatter(TimeZone timeZone) {
+    this.defaultFormatter = new DefaultFormatter();
+    this.timeZone = timeZone;
+  }
 
   @Override
-  public void initialize(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps) {
-    this.printTimestamps = printTimestamps;
-    defaultFormatter.initialize(scanner, printTimestamps);
+  public void initialize(Iterable<Entry<Key,Value>> scanner, FormatterConfig config) {
+    FormatterConfig newConfig = new FormatterConfig(config);
+    newConfig.setDateFormatSupplier(DateFormatSupplier.createSimpleFormatSupplier(DATE_FORMAT, timeZone));
+    defaultFormatter.initialize(scanner, newConfig);
   }
 
   @Override
@@ -50,13 +63,7 @@ public class DateStringFormatter implements Formatter {
 
   @Override
   public String next() {
-    DateFormat timestampformat = null;
-
-    if (printTimestamps) {
-      timestampformat = formatter.get();
-    }
-
-    return defaultFormatter.next(timestampformat);
+    return defaultFormatter.next();
   }
 
   @Override
@@ -64,7 +71,4 @@ public class DateStringFormatter implements Formatter {
     defaultFormatter.remove();
   }
 
-  public void setTimeZone(TimeZone zone) {
-    formatter.get().setTimeZone(zone);
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/format/Formatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/Formatter.java
@@ -23,5 +23,5 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
 public interface Formatter extends Iterator<String> {
-  void initialize(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps);
+  void initialize(Iterable<Entry<Key,Value>> scanner, FormatterConfig config);
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/format/FormatterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/FormatterConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.util.format;
+
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+
+/**
+ * Holds configuration settings for a {@link Formatter}
+ */
+public class FormatterConfig {
+
+  private boolean printTimestamps;
+  private int shownLength;
+  private Supplier<DateFormat> dateFormatSupplier;
+
+  /** Formats with milliseconds since epoch */
+  public static class DefaultDateFormat extends SimpleDateFormat {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
+      toAppendTo.append(Long.toString(date.getTime()));
+      return toAppendTo;
+    }
+
+    @Override
+    public Date parse(String source, ParsePosition pos) {
+      return new Date(Long.parseLong(source));
+    }
+  }
+
+  public FormatterConfig() {
+    this.setPrintTimestamps(false);
+    this.doNotLimitShowLength();
+    this.dateFormatSupplier = DateFormatSupplier.createDefaultFormatSupplier();
+  }
+
+  /**
+   * Copies most fields, but still points to other.dateFormatSupplier.
+   */
+  public FormatterConfig(FormatterConfig other) {
+    this.printTimestamps = other.printTimestamps;
+    this.shownLength = other.shownLength;
+    this.dateFormatSupplier = other.dateFormatSupplier;
+  }
+
+  public boolean willPrintTimestamps() {
+    return printTimestamps;
+  }
+
+  public FormatterConfig setPrintTimestamps(boolean printTimestamps) {
+    this.printTimestamps = printTimestamps;
+    return this;
+  }
+
+  public int getShownLength() {
+    return shownLength;
+  }
+
+  public boolean willLimitShowLength() {
+    return this.shownLength != Integer.MAX_VALUE;
+  }
+
+  /**
+   * If given a negative number, throws an {@link IllegalArgumentException}
+   *
+   * @param shownLength
+   *          maximum length of formatted output
+   * @return {@code this} to allow chaining of set methods
+   */
+  public FormatterConfig setShownLength(int shownLength) {
+    Preconditions.checkArgument(shownLength >= 0, "Shown length cannot be negative");
+    this.shownLength = shownLength;
+    return this;
+  }
+
+  public FormatterConfig doNotLimitShowLength() {
+    this.shownLength = Integer.MAX_VALUE;
+    return this;
+  }
+
+  public Supplier<DateFormat> getDateFormatSupplier() {
+    return dateFormatSupplier;
+  }
+
+  /**
+   * this.dateFormatSupplier points to dateFormatSupplier, so it is recommended that you create a new {@code Supplier} when calling this function if your
+   * {@code Supplier} maintains some kind of state (see {@link DateFormatSupplier}.
+   */
+  public FormatterConfig setDateFormatSupplier(Supplier<DateFormat> dateFormatSupplier) {
+    this.dateFormatSupplier = dateFormatSupplier;
+    return this;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/util/format/FormatterFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/FormatterFactory.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class FormatterFactory {
   private static final Logger log = LoggerFactory.getLogger(FormatterFactory.class);
 
-  public static Formatter getFormatter(Class<? extends Formatter> formatterClass, Iterable<Entry<Key,Value>> scanner, boolean printTimestamps) {
+  public static Formatter getFormatter(Class<? extends Formatter> formatterClass, Iterable<Entry<Key,Value>> scanner, FormatterConfig config) {
     Formatter formatter = null;
     try {
       formatter = formatterClass.newInstance();
@@ -34,12 +34,12 @@ public class FormatterFactory {
       log.warn("Unable to instantiate formatter. Using default formatter.", e);
       formatter = new DefaultFormatter();
     }
-    formatter.initialize(scanner, printTimestamps);
+    formatter.initialize(scanner, config);
     return formatter;
   }
 
-  public static Formatter getDefaultFormatter(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps) {
-    return getFormatter(DefaultFormatter.class, scanner, printTimestamps);
+  public static Formatter getDefaultFormatter(Iterable<Entry<Key,Value>> scanner, FormatterConfig config) {
+    return getFormatter(DefaultFormatter.class, scanner, config);
   }
 
   private FormatterFactory() {

--- a/core/src/main/java/org/apache/accumulo/core/util/format/HexFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/HexFormatter.java
@@ -31,7 +31,7 @@ public class HexFormatter implements Formatter, ScanInterpreter {
 
   private char chars[] = new char[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
   private Iterator<Entry<Key,Value>> iter;
-  private boolean printTimestamps;
+  private FormatterConfig config;
 
   private void toHex(StringBuilder sb, byte[] bin) {
 
@@ -88,7 +88,7 @@ public class HexFormatter implements Formatter, ScanInterpreter {
     sb.append(" [");
     sb.append(entry.getKey().getColumnVisibilityData().toString());
     sb.append("] ");
-    if (printTimestamps) {
+    if (config.willPrintTimestamps()) {
       sb.append(Long.toString(entry.getKey().getTimestamp()));
       sb.append("  ");
     }
@@ -103,9 +103,9 @@ public class HexFormatter implements Formatter, ScanInterpreter {
   }
 
   @Override
-  public void initialize(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps) {
+  public void initialize(Iterable<Entry<Key,Value>> scanner, FormatterConfig config) {
     this.iter = scanner.iterator();
-    this.printTimestamps = printTimestamps;
+    this.config = new FormatterConfig(config);
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/util/format/DateFormatSupplierTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/DateFormatSupplierTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.util.format;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import org.junit.Test;
+
+public class DateFormatSupplierTest {
+
+  /** Asserts two supplier instance create independent objects */
+  private void assertSuppliersIndependent(ThreadLocal<DateFormat> supplierA, ThreadLocal<DateFormat> supplierB) {
+    DateFormat getA1 = supplierA.get();
+    DateFormat getA2 = supplierA.get();
+    assertSame(getA1, getA2);
+
+    DateFormat getB1 = supplierB.get();
+    DateFormat getB2 = supplierB.get();
+
+    assertSame(getB1, getB2);
+    assertNotSame(getA1, getB1);
+  }
+
+  @Test
+  public void testCreateDefaultFormatSupplier() throws Exception {
+    ThreadLocal<DateFormat> supplierA = DateFormatSupplier.createDefaultFormatSupplier();
+    ThreadLocal<DateFormat> supplierB = DateFormatSupplier.createDefaultFormatSupplier();
+    assertSuppliersIndependent(supplierA, supplierB);
+  }
+
+  @Test
+  public void testCreateSimpleFormatSupplier() throws Exception {
+    final String format = DateFormatSupplier.HUMAN_READABLE_FORMAT;
+    DateFormatSupplier supplierA = DateFormatSupplier.createSimpleFormatSupplier(format);
+    DateFormatSupplier supplierB = DateFormatSupplier.createSimpleFormatSupplier(format);
+    assertSuppliersIndependent(supplierA, supplierB);
+
+    // since dfA and dfB come from different suppliers, altering the TimeZone on one does not affect the other
+    supplierA.setTimeZone(TimeZone.getTimeZone("UTC"));
+    final DateFormat dfA = supplierA.get();
+
+    supplierB.setTimeZone(TimeZone.getTimeZone("EST"));
+    final DateFormat dfB = supplierB.get();
+
+    final String resultA = dfA.format(new Date(0));
+    assertEquals("1970/01/01 00:00:00.000", resultA);
+
+    final String resultB = dfB.format(new Date(0));
+    assertEquals("1969/12/31 19:00:00.000", resultB);
+
+    assertTrue(!resultA.equals(resultB));
+
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/util/format/DateStringFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/DateStringFormatterTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.TreeMap;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.junit.Before;
@@ -40,13 +39,30 @@ public class DateStringFormatterTest {
     data.put(new Key("", "", "", 0), new Value());
   }
 
-  @Test
-  public void testTimestamps() {
-    formatter.initialize(data.entrySet(), true);
-    formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+  private void testFormatterIgnoresConfig(FormatterConfig config, DateStringFormatter formatter) {
+    // ignores config's DateFormatSupplier and substitutes its own
+    formatter.initialize(data.entrySet(), config);
 
     assertTrue(formatter.hasNext());
-    assertTrue(formatter.next().endsWith("1970/01/01 00:00:00.000"));
+    final String next = formatter.next();
+    assertTrue(next, next.endsWith("1970/01/01 00:00:00.000"));
+  }
+
+  @Test
+  public void testTimestamps() {
+    final TimeZone utc = TimeZone.getTimeZone("UTC");
+    final TimeZone est = TimeZone.getTimeZone("EST");
+    final FormatterConfig config = new FormatterConfig().setPrintTimestamps(true);
+    DateStringFormatter formatter;
+
+    formatter = new DateStringFormatter(utc);
+    testFormatterIgnoresConfig(config, formatter);
+
+    // even though config says to use EST and only print year, the Formatter will override these
+    formatter = new DateStringFormatter(utc);
+    DateFormatSupplier dfSupplier = DateFormatSupplier.createSimpleFormatSupplier("YYYY", est);
+    config.setDateFormatSupplier(dfSupplier);
+    testFormatterIgnoresConfig(config, formatter);
   }
 
   @Test
@@ -55,7 +71,7 @@ public class DateStringFormatterTest {
 
     assertEquals(2, data.size());
 
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     assertEquals(formatter.next(), formatter.next());
   }

--- a/core/src/test/java/org/apache/accumulo/core/util/format/FormatterConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/FormatterConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.util.format;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.text.DateFormat;
+import org.junit.Test;
+
+public class FormatterConfigTest {
+
+  @Test
+  public void testConstructor() {
+    FormatterConfig config = new FormatterConfig();
+    assertEquals(false, config.willLimitShowLength());
+    assertEquals(false, config.willPrintTimestamps());
+  }
+
+  @Test
+  public void testSetShownLength() throws Exception {
+    FormatterConfig config = new FormatterConfig();
+    try {
+      config.setShownLength(-1);
+      fail("Should throw on negative length.");
+    } catch (IllegalArgumentException e) {}
+
+    config.setShownLength(0);
+    assertEquals(0, config.getShownLength());
+    assertEquals(true, config.willLimitShowLength());
+
+    config.setShownLength(1);
+    assertEquals(1, config.getShownLength());
+    assertEquals(true, config.willLimitShowLength());
+  }
+
+  @Test
+  public void testDoNotLimitShowLength() {
+    FormatterConfig config = new FormatterConfig();
+    assertEquals(false, config.willLimitShowLength());
+
+    config.setShownLength(1);
+    assertEquals(true, config.willLimitShowLength());
+
+    config.doNotLimitShowLength();
+    assertEquals(false, config.willLimitShowLength());
+  }
+
+  @Test
+  public void testGetDateFormat() {
+    FormatterConfig config1 = new FormatterConfig();
+    DateFormat df1 = config1.getDateFormatSupplier().get();
+
+    FormatterConfig config2 = new FormatterConfig();
+    assertNotSame(df1, config2.getDateFormatSupplier().get());
+
+    config2.setDateFormatSupplier(config1.getDateFormatSupplier());
+    assertSame(df1, config2.getDateFormatSupplier().get());
+
+    // even though copying, it can't copy the Generator, so will pull out the same DateFormat
+    FormatterConfig configCopy = new FormatterConfig(config1);
+    assertSame(df1, configCopy.getDateFormatSupplier().get());
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/util/format/FormatterFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/FormatterFactoryTest.java
@@ -37,8 +37,9 @@ public class FormatterFactoryTest {
 
   @Test
   public void testGetDefaultFormatter() {
-    Formatter defaultFormatter = FormatterFactory.getDefaultFormatter(scanner, true);
-    Formatter bogusFormatter = FormatterFactory.getFormatter(Formatter.class, scanner, true);
+    final FormatterConfig timestampConfig = new FormatterConfig().setPrintTimestamps(true);
+    Formatter defaultFormatter = FormatterFactory.getDefaultFormatter(scanner, timestampConfig);
+    Formatter bogusFormatter = FormatterFactory.getFormatter(Formatter.class, scanner, timestampConfig);
     assertEquals(defaultFormatter.getClass(), bogusFormatter.getClass());
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/util/format/HexFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/HexFormatterTest.java
@@ -42,7 +42,7 @@ public class HexFormatterTest {
   @Test
   public void testInitialize() {
     data.put(new Key(), new Value());
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     assertTrue(formatter.hasNext());
     assertEquals("  " + "  " + " [" + "] ", formatter.next());
@@ -59,7 +59,7 @@ public class HexFormatterTest {
     Text bytes = new Text(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     data.put(new Key(bytes), new Value());
 
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     String row = formatter.next().split(" ")[0];
     assertEquals("0001-0203-0405-0607-0809-0a0b-0c0d-0e0f", row);
@@ -80,7 +80,7 @@ public class HexFormatterTest {
   public void testTimestamps() {
     long now = System.currentTimeMillis();
     data.put(new Key("", "", "", now), new Value());
-    formatter.initialize(data.entrySet(), true);
+    formatter.initialize(data.entrySet(), new FormatterConfig().setPrintTimestamps(true));
     String entry = formatter.next().split("\\s+")[2];
     assertEquals(now, Long.parseLong(entry));
   }

--- a/core/src/test/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatterTest.java
@@ -47,7 +47,7 @@ public class ShardedTableDistributionFormatterTest {
   public void testInitialize() {
     data.put(new Key(), new Value());
     data.put(new Key("r", "~tab"), new Value());
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     assertTrue(formatter.hasNext());
     formatter.next();
@@ -60,7 +60,7 @@ public class ShardedTableDistributionFormatterTest {
     data.put(new Key("t;19700101", "~tab", "loc", 0), new Value("srv1".getBytes(UTF_8)));
     data.put(new Key("t;19700101", "~tab", "loc", 1), new Value("srv2".getBytes(UTF_8)));
 
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     String[] resultLines = formatter.next().split("\n");
     List<String> results = Arrays.asList(resultLines).subList(2, 4);

--- a/core/src/test/java/org/apache/accumulo/core/util/format/StatisticsDisplayFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/StatisticsDisplayFormatterTest.java
@@ -42,7 +42,7 @@ public class StatisticsDisplayFormatterTest {
   @Test
   public void testInitialize() {
     data.put(new Key(), new Value());
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     assertTrue(formatter.hasNext());
   }
@@ -51,7 +51,7 @@ public class StatisticsDisplayFormatterTest {
   public void testAggregate() {
     data.put(new Key("", "", "", 1), new Value());
     data.put(new Key("", "", "", 2), new Value());
-    formatter.initialize(data.entrySet(), false);
+    formatter.initialize(data.entrySet(), new FormatterConfig());
 
     String[] output = formatter.next().split("\n");
     assertTrue(output[2].endsWith(": 1"));

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/StatusFormatter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/StatusFormatter.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Set;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
@@ -32,8 +31,8 @@ import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.core.replication.ReplicationSchema.WorkSection;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.util.format.DefaultFormatter;
-import org.apache.accumulo.core.util.format.DefaultFormatter.DefaultDateFormat;
 import org.apache.accumulo.core.util.format.Formatter;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
@@ -52,20 +51,13 @@ public class StatusFormatter implements Formatter {
       WorkSection.NAME, OrderSection.NAME));
 
   private Iterator<Entry<Key,Value>> iterator;
-  private boolean printTimestamps;
+  private FormatterConfig config;
 
   /* so a new date object doesn't get created for every record in the scan result */
   private static ThreadLocal<Date> tmpDate = new ThreadLocal<Date>() {
     @Override
     protected Date initialValue() {
       return new Date();
-    }
-  };
-
-  private static final ThreadLocal<DateFormat> formatter = new ThreadLocal<DateFormat>() {
-    @Override
-    protected DateFormat initialValue() {
-      return new DefaultDateFormat();
     }
   };
 
@@ -77,7 +69,7 @@ public class StatusFormatter implements Formatter {
   @Override
   public String next() {
     Entry<Key,Value> entry = iterator.next();
-    DateFormat timestampFormat = printTimestamps ? formatter.get() : null;
+    DateFormat timestampFormat = config.willPrintTimestamps() ? config.getDateFormatSupplier().get() : null;
 
     // If we expected this to be a protobuf, try to parse it, adding a message when it fails to parse
     if (REPLICATION_COLFAMS.contains(entry.getKey().getColumnFamily())) {
@@ -157,9 +149,9 @@ public class StatusFormatter implements Formatter {
   }
 
   @Override
-  public void initialize(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps) {
+  public void initialize(Iterable<Entry<Key,Value>> scanner, FormatterConfig config) {
     this.iterator = scanner.iterator();
-    this.printTimestamps = printTimestamps;
+    this.config = new FormatterConfig(config);
   }
 
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -67,9 +67,9 @@ import org.apache.accumulo.core.data.thrift.TConstraintViolationSummary;
 import org.apache.accumulo.core.tabletserver.thrift.ConstraintViolationException;
 import org.apache.accumulo.core.trace.DistributedTrace;
 import org.apache.accumulo.core.util.BadArgumentException;
-import org.apache.accumulo.core.util.format.BinaryFormatter;
 import org.apache.accumulo.core.util.format.DefaultFormatter;
 import org.apache.accumulo.core.util.format.Formatter;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.core.util.format.FormatterFactory;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
@@ -204,7 +204,6 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   protected ConsoleReader reader;
   private AuthenticationToken token;
   private final Class<? extends Formatter> defaultFormatterClass = DefaultFormatter.class;
-  private final Class<? extends Formatter> binaryFormatterClass = BinaryFormatter.class;
   public Map<String,List<IteratorSetting>> scanIteratorOptions = new HashMap<String,List<IteratorSetting>>();
   public Map<String,List<IteratorSetting>> iteratorProfiles = new HashMap<String,List<IteratorSetting>>();
 
@@ -1088,22 +1087,14 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     }
   }
 
-  public final void printRecords(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps, boolean paginate, Class<? extends Formatter> formatterClass,
+  public final void printRecords(Iterable<Entry<Key,Value>> scanner, FormatterConfig config, boolean paginate, Class<? extends Formatter> formatterClass,
       PrintLine outFile) throws IOException {
-    printLines(FormatterFactory.getFormatter(formatterClass, scanner, printTimestamps), paginate, outFile);
+    printLines(FormatterFactory.getFormatter(formatterClass, scanner, config), paginate, outFile);
   }
 
-  public final void printRecords(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps, boolean paginate, Class<? extends Formatter> formatterClass)
+  public final void printRecords(Iterable<Entry<Key,Value>> scanner, FormatterConfig config, boolean paginate, Class<? extends Formatter> formatterClass)
       throws IOException {
-    printLines(FormatterFactory.getFormatter(formatterClass, scanner, printTimestamps), paginate);
-  }
-
-  public final void printBinaryRecords(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps, boolean paginate, PrintLine outFile) throws IOException {
-    printLines(FormatterFactory.getFormatter(binaryFormatterClass, scanner, printTimestamps), paginate, outFile);
-  }
-
-  public final void printBinaryRecords(Iterable<Entry<Key,Value>> scanner, boolean printTimestamps, boolean paginate) throws IOException {
-    printLines(FormatterFactory.getFormatter(binaryFormatterClass, scanner, printTimestamps), paginate);
+    printLines(FormatterFactory.getFormatter(formatterClass, scanner, config), paginate);
   }
 
   public static String repeat(String s, int c) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.iterators.SortedKeyIterator;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.core.util.interpret.ScanInterpreter;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.format.DeleterFormatter;
@@ -61,7 +62,9 @@ public class DeleteManyCommand extends ScanCommand {
     // output / delete the records
     final BatchWriter writer = shellState.getConnector()
         .createBatchWriter(tableName, new BatchWriterConfig().setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS));
-    shellState.printLines(new DeleterFormatter(writer, scanner, cl.hasOption(timestampOpt.getOpt()), shellState, cl.hasOption(forceOpt.getOpt())), false);
+    FormatterConfig config = new FormatterConfig();
+    config.setPrintTimestamps(cl.hasOption(timestampOpt.getOpt()));
+    shellState.printLines(new DeleterFormatter(writer, scanner, config, shellState, cl.hasOption(forceOpt.getOpt())), false);
 
     return 0;
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Base64;
 import org.apache.accumulo.core.util.TextUtil;
-import org.apache.accumulo.core.util.format.BinaryFormatter;
+import org.apache.accumulo.core.util.format.DefaultFormatter;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.accumulo.shell.Shell.PrintFile;
@@ -102,8 +102,8 @@ public class GetSplitsCommand extends Command {
     if (text == null) {
       return null;
     }
-    BinaryFormatter.getlength(text.getLength());
-    return encode ? Base64.encodeBase64String(TextUtil.getBytes(text)) : BinaryFormatter.appendText(new StringBuilder(), text).toString();
+    final int length = text.getLength();
+    return encode ? Base64.encodeBase64String(TextUtil.getBytes(text)) : DefaultFormatter.appendText(new StringBuilder(), text, length).toString();
   }
 
   private static String obscuredTabletName(final KeyExtent extent) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
@@ -19,12 +19,12 @@ package org.apache.accumulo.shell.commands;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.format.Formatter;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.core.util.interpret.ScanInterpreter;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.PrintFile;
@@ -69,7 +69,9 @@ public class GrepCommand extends ScanCommand {
       fetchColumns(cl, scanner, interpeter);
 
       // output the records
-      printRecords(cl, shellState, scanner, formatter, printFile);
+      final FormatterConfig config = new FormatterConfig();
+      config.setPrintTimestamps(cl.hasOption(timestampOpt.getOpt()));
+      printRecords(cl, shellState, config, scanner, formatter, printFile);
     } finally {
       scanner.close();
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/format/DeleterFormatter.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/format/DeleterFormatter.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.shell.format;
 
 import java.io.IOException;
 import java.util.Map.Entry;
-
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.data.ConstraintViolationSummary;
@@ -27,7 +26,9 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.util.format.DefaultFormatter;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.shell.Shell;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,15 +37,13 @@ public class DeleterFormatter extends DefaultFormatter {
   private static final Logger log = LoggerFactory.getLogger(DeleterFormatter.class);
   private BatchWriter writer;
   private Shell shellState;
-  private boolean printTimestamps;
   private boolean force;
   private boolean more;
 
-  public DeleterFormatter(BatchWriter writer, Iterable<Entry<Key,Value>> scanner, boolean printTimestamps, Shell shellState, boolean force) {
-    super.initialize(scanner, printTimestamps);
+  public DeleterFormatter(BatchWriter writer, Iterable<Entry<Key,Value>> scanner, FormatterConfig config, Shell shellState, boolean force) {
+    super.initialize(scanner, config);
     this.writer = writer;
     this.shellState = shellState;
-    this.printTimestamps = printTimestamps;
     this.force = force;
     this.more = true;
   }
@@ -73,7 +72,7 @@ public class DeleterFormatter extends DefaultFormatter {
     Entry<Key,Value> next = getScannerIterator().next();
     Key key = next.getKey();
     Mutation m = new Mutation(key.getRow());
-    String entryStr = formatEntry(next, printTimestamps);
+    String entryStr = formatEntry(next, isDoTimestamps());
     boolean delete = force;
     try {
       if (!force) {

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellTest.java
@@ -33,8 +33,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
-import jline.console.ConsoleReader;
-
 import org.apache.accumulo.core.util.format.DateStringFormatter;
 import org.apache.log4j.Level;
 import org.junit.After;
@@ -42,6 +40,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jline.console.ConsoleReader;
 
 public class ShellTest {
   private static final Logger log = LoggerFactory.getLogger(ShellTest.class);
@@ -177,6 +177,8 @@ public class ShellTest {
     exec("createtable test", true);
     exec("addsplits 1 \\x80", true);
     exec("getsplits", true, "1\n\\x80");
+    exec("getsplits -m 1", true, "1");
+    exec("getsplits -b64", true, "MQ==\ngA==");
     exec("deletetable test -f", true, "Table: [test] has been deleted");
   }
 
@@ -202,6 +204,37 @@ public class ShellTest {
     exec("scan -e \\x8f", true, "\\x90 \\xA0:\\xB0 []    \\xC0", false);
     exec("delete \\x90 \\xa0 \\xb0", true);
     exec("scan", true, "\\x90 \\xA0:\\xB0 []    \\xC0", false);
+    exec("deletetable test -f", true, "Table: [test] has been deleted");
+  }
+
+  @Test
+  public void deleteManyTest() throws IOException {
+    exec("deletemany", false, "java.lang.IllegalStateException: Not in a table context");
+    exec("createtable test", true);
+    exec("deletemany", true, "\n");
+
+    exec("insert 0 0 0 0 -ts 0");
+    exec("insert 0 0 0 0 -l 0 -ts 0");
+    exec("insert 1 1 1 1 -ts 1");
+    exec("insert 2 2 2 2 -ts 2");
+
+    // prompts for delete, and rejects by default
+    exec("deletemany", true, "[SKIPPED] 0 0:0 []");
+    exec("deletemany -r 0", true, "[SKIPPED] 0 0:0 []");
+    exec("deletemany -r 0 -f", true, "[DELETED] 0 0:0 []");
+
+    // with auths, can delete the other record
+    exec("setauths -s 0");
+    exec("deletemany -r 0 -f", true, "[DELETED] 0 0:0 [0]");
+
+    // delete will show the timestamp
+    exec("deletemany -r 1 -f -st", true, "[DELETED] 1 1:1 [] 1");
+
+    // DeleteManyCommand has its own Formatter (DeleterFormatter), so it does not honor the -fm flag
+    exec("deletemany -r 2 -f -st -fm org.apache.accumulo.core.util.format.DateStringFormatter", true,
+            "[DELETED] 2 2:2 [] 2");
+
+    exec("setauths -c ", true);
     exec("deletetable test -f", true, "Table: [test] has been deleted");
   }
 
@@ -254,13 +287,69 @@ public class ShellTest {
   }
 
   @Test
+  public void scanTimestampTest() throws IOException {
+    Shell.log.debug("Starting scanTimestamp test ------------------------");
+    exec("createtable test", true);
+    exec("insert r f q v -ts 0", true);
+    exec("scan -st", true, "r f:q [] 0    v");
+    exec("scan -st -f 0", true, " : [] 0   ");
+    exec("deletemany -f", true);
+    exec("deletetable test -f", true, "Table: [test] has been deleted");
+  }
+
+  @Test
+  public void scanFewTest() throws IOException {
+    Shell.log.debug("Starting scanFew test ------------------------");
+    exec("createtable test", true);
+    // historically, showing few did not pertain to ColVis or Timestamp
+    exec("insert 1 123 123456 -l '12345678' -ts 123456789 1234567890", true);
+    exec("setauths -s 12345678", true);
+    String expected = "1 123:123456 [12345678] 123456789    1234567890";
+    String expectedFew = "1 123:12345 [12345678] 123456789    12345";
+    exec("scan -st", true, expected);
+    exec("scan -st -f 5", true, expectedFew);
+    // also prove that BinaryFormatter behaves same as the default
+    exec("scan -st -fm org.apache.accumulo.core.util.format.BinaryFormatter", true, expected);
+    exec("scan -st -f 5 -fm org.apache.accumulo.core.util.format.BinaryFormatter", true, expectedFew);
+    exec("setauths -c", true);
+    exec("deletetable test -f", true, "Table: [test] has been deleted");
+  }
+
+  @Test
   public void scanDateStringFormatterTest() throws IOException {
     Shell.log.debug("Starting scan dateStringFormatter test --------------------------");
     exec("createtable t", true);
     exec("insert r f q v -ts 0", true);
     DateFormat dateFormat = new SimpleDateFormat(DateStringFormatter.DATE_FORMAT);
     String expected = String.format("r f:q [] %s    v", dateFormat.format(new Date(0)));
+    // historically, showing few did not pertain to ColVis or Timestamp
+    String expectedFew = expected;
+    String expectedNoTimestamp = String.format("r f:q []    v");
     exec("scan -fm org.apache.accumulo.core.util.format.DateStringFormatter -st", true, expected);
+    exec("scan -fm org.apache.accumulo.core.util.format.DateStringFormatter -st -f 1000", true, expected);
+    exec("scan -fm org.apache.accumulo.core.util.format.DateStringFormatter -st -f 5", true, expectedFew);
+    exec("scan -fm org.apache.accumulo.core.util.format.DateStringFormatter", true, expectedNoTimestamp);
+    exec("deletetable t -f", true, "Table: [t] has been deleted");
+  }
+
+  @Test
+  public void grepTest() throws IOException {
+    Shell.log.debug("Starting grep test --------------------------");
+    exec("grep", false, "java.lang.IllegalStateException: Not in a table context");
+    exec("createtable t", true);
+    exec("setauths -s vis", true);
+    exec("insert r f q v -ts 0 -l vis", true);
+
+    String expected = "r f:q [vis]    v";
+    String expectedTimestamp = "r f:q [vis] 0    v";
+    exec("grep", false, "No terms specified");
+    exec("grep non_matching_string", true, "");
+    // historically, showing few did not pertain to ColVis or Timestamp
+    exec("grep r", true, expected);
+    exec("grep r -f 1", true, expected);
+    exec("grep r -st", true, expectedTimestamp);
+    exec("grep r -st -f 1", true, expectedTimestamp);
+    exec("setauths -c", true);
     exec("deletetable t -f", true, "Table: [t] has been deleted");
   }
 

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/FormatterCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/FormatterCommandTest.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.util.format.Formatter;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.mock.MockShell;
 import org.apache.log4j.Level;
@@ -134,7 +135,7 @@ public class FormatterCommandTest {
    */
   public static class HexFormatter implements Formatter {
     private Iterator<Entry<Key,Value>> iter = null;
-    private boolean printTs = false;
+    private FormatterConfig config;
 
     private final static String tab = "\t";
     private final static String newline = "\n";
@@ -153,7 +154,7 @@ public class FormatterCommandTest {
       String key;
 
       // Observe the timestamps
-      if (printTs) {
+      if (config.willPrintTimestamps()) {
         key = entry.getKey().toString();
       } else {
         key = entry.getKey().toStringNoTime();
@@ -181,9 +182,9 @@ public class FormatterCommandTest {
     public void remove() {}
 
     @Override
-    public void initialize(final Iterable<Entry<Key,Value>> scanner, final boolean printTimestamps) {
+    public void initialize(final Iterable<Entry<Key,Value>> scanner, final FormatterConfig config) {
       this.iter = scanner.iterator();
-      this.printTs = printTimestamps;
+      this.config = new FormatterConfig(config);
     }
   }
 

--- a/shell/src/test/java/org/apache/accumulo/shell/format/DeleterFormatterTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/format/DeleterFormatterTest.java
@@ -34,16 +34,16 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
-
-import jline.UnsupportedTerminal;
-import jline.console.ConsoleReader;
-
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.util.format.FormatterConfig;
 import org.apache.accumulo.shell.Shell;
+
+import jline.UnsupportedTerminal;
+import jline.console.ConsoleReader;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,13 +99,13 @@ public class DeleterFormatterTest {
 
   @Test
   public void testEmpty() {
-    formatter = new DeleterFormatter(writer, Collections.<Key,Value> emptyMap().entrySet(), true, shellState, true);
+    formatter = new DeleterFormatter(writer, Collections.<Key,Value> emptyMap().entrySet(), new FormatterConfig().setPrintTimestamps(true), shellState, true);
     assertFalse(formatter.hasNext());
   }
 
   @Test
   public void testSingle() throws IOException {
-    formatter = new DeleterFormatter(writer, data.entrySet(), true, shellState, true);
+    formatter = new DeleterFormatter(writer, data.entrySet(), new FormatterConfig().setPrintTimestamps(true), shellState, true);
 
     assertTrue(formatter.hasNext());
     assertNull(formatter.next());
@@ -117,7 +117,7 @@ public class DeleterFormatterTest {
   public void testNo() throws IOException {
     input.set("no\n");
     data.put(new Key("z"), new Value("v2".getBytes(UTF_8)));
-    formatter = new DeleterFormatter(writer, data.entrySet(), true, shellState, false);
+    formatter = new DeleterFormatter(writer, data.entrySet(), new FormatterConfig().setPrintTimestamps(true), shellState, false);
 
     assertTrue(formatter.hasNext());
     assertNull(formatter.next());
@@ -131,7 +131,7 @@ public class DeleterFormatterTest {
   public void testNoConfirmation() throws IOException {
     input.set("");
     data.put(new Key("z"), new Value("v2".getBytes(UTF_8)));
-    formatter = new DeleterFormatter(writer, data.entrySet(), true, shellState, false);
+    formatter = new DeleterFormatter(writer, data.entrySet(), new FormatterConfig().setPrintTimestamps(true), shellState, false);
 
     assertTrue(formatter.hasNext());
     assertNull(formatter.next());
@@ -145,7 +145,7 @@ public class DeleterFormatterTest {
   public void testYes() throws IOException {
     input.set("y\nyes\n");
     data.put(new Key("z"), new Value("v2".getBytes(UTF_8)));
-    formatter = new DeleterFormatter(writer, data.entrySet(), true, shellState, false);
+    formatter = new DeleterFormatter(writer, data.entrySet(), new FormatterConfig().setPrintTimestamps(true), shellState, false);
 
     assertTrue(formatter.hasNext());
     assertNull(formatter.next());
@@ -158,7 +158,7 @@ public class DeleterFormatterTest {
 
   @Test
   public void testMutationException() {
-    formatter = new DeleterFormatter(exceptionWriter, data.entrySet(), true, shellState, true);
+    formatter = new DeleterFormatter(exceptionWriter, data.entrySet(), new FormatterConfig().setPrintTimestamps(true), shellState, true);
 
     assertTrue(formatter.hasNext());
     assertNull(formatter.next());


### PR DESCRIPTION
with FormatterConfig.

* New class FormatterConfig handles configuration of Formatter objects
* FormatterConfig is taken by Formatter.initialize, which broke the
interface for many classes throughout the non-public API
* Added DateFormatSupplier to let Formatters use DateFormat in a
Thread-safe way
* Removed code from ScanCommand and Shell tied to BinaryFormatter to use
properly configured DefaultFormatter instead
* Fixed bug where `scan -f [num] -fm [class]` would ignore Formatter
class used in `-fm` and be overridden with BinaryFormatter