### PR TITLE
ACCUMULO-4121 - netbeans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/assemble/.gitignore
+++ b/assemble/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/assemble/.gitignore
+++ b/assemble/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -171,6 +171,9 @@
             <excludes>
               <exclude>bin-LICENSE</exclude>
               <exclude>bin-NOTICE</exclude>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -27,3 +27,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -24,3 +24,6 @@
 /.idea
 /*.iml
 /bin/
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,6 +173,9 @@
               <exclude>src/test/resources/accumulo.jceks</exclude>
               <exclude>src/test/resources/empty.jceks</exclude>
               <exclude>src/test/resources/passwords.jceks</exclude>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/examples/simple/.gitignore
+++ b/examples/simple/.gitignore
@@ -27,3 +27,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/examples/simple/.gitignore
+++ b/examples/simple/.gitignore
@@ -24,3 +24,6 @@
 /.idea
 /*.iml
 /bin/
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/examples/simple/pom.xml
+++ b/examples/simple/pom.xml
@@ -95,6 +95,9 @@
           <configuration>
             <excludes>
               <exclude>src/main/resources/META-INF/services/org.apache.accumulo.core.util.shell.ShellExtension</exclude>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/fate/.gitignore
+++ b/fate/.gitignore
@@ -27,3 +27,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/fate/.gitignore
+++ b/fate/.gitignore
@@ -24,3 +24,6 @@
 /.idea
 /*.iml
 /bin/
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/maven-plugin/.gitignore
+++ b/maven-plugin/.gitignore
@@ -27,3 +27,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/maven-plugin/.gitignore
+++ b/maven-plugin/.gitignore
@@ -24,3 +24,6 @@
 /.idea
 /*.iml
 /target/
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/minicluster/.gitignore
+++ b/minicluster/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/minicluster/.gitignore
+++ b/minicluster/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/pom.xml
+++ b/pom.xml
@@ -738,6 +738,18 @@
           <artifactId>maven-plugin-plugin</artifactId>
           <version>3.4</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <version>0.10</version>
+          <configuration>
+            <excludes>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/proxy/.gitignore
+++ b/proxy/.gitignore
@@ -23,6 +23,9 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml
 
 # python ignores
 *.pyc

--- a/proxy/.gitignore
+++ b/proxy/.gitignore
@@ -29,3 +29,4 @@
 
 # python ignores
 *.pyc
+

--- a/server/base/.gitignore
+++ b/server/base/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/base/.gitignore
+++ b/server/base/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/gc/.gitignore
+++ b/server/gc/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/gc/.gitignore
+++ b/server/gc/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/master/.gitignore
+++ b/server/master/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/master/.gitignore
+++ b/server/master/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/monitor/.gitignore
+++ b/server/monitor/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/monitor/.gitignore
+++ b/server/monitor/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -134,6 +134,9 @@
           <configuration>
             <excludes>
               <exclude>src/main/resources/web/flot/**/*.js</exclude>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/server/native/.gitignore
+++ b/server/native/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/native/.gitignore
+++ b/server/native/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/tracer/.gitignore
+++ b/server/tracer/.gitignore
@@ -27,3 +27,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/tracer/.gitignore
+++ b/server/tracer/.gitignore
@@ -24,3 +24,6 @@
 /.idea
 /*.iml
 /target/
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/tserver/.gitignore
+++ b/server/tserver/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/server/tserver/.gitignore
+++ b/server/tserver/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -117,6 +117,9 @@
             <excludes>
               <exclude>src/test/resources/*.walog</exclude>
               <exclude>src/test/resources/walog-from-14/*</exclude>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/start/.gitignore
+++ b/start/.gitignore
@@ -23,3 +23,6 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml

--- a/start/.gitignore
+++ b/start/.gitignore
@@ -26,3 +26,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -23,6 +23,9 @@
 /.pydevproject
 /.idea
 /*.iml
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml
 
 # python ignores
 *.pyc

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -29,3 +29,4 @@
 
 # python ignores
 *.pyc
+

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -183,6 +183,9 @@
             <excludes>
               <exclude>system/bench/lib/*splits</exclude>
               <exclude>system/continuous/*.txt</exclude>
+              <exclude>nbproject/**</exclude>
+              <exclude>nb-configuration.xml</exclude>
+              <exclude>nbactions.xml</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/trace/.gitignore
+++ b/trace/.gitignore
@@ -27,3 +27,4 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+

--- a/trace/.gitignore
+++ b/trace/.gitignore
@@ -24,3 +24,6 @@
 /.idea
 /*.iml
 /bin/
+/nbproject/
+/nbactions.xml
+/nb-configuration.xml


### PR DESCRIPTION
Added typical files for a maven project to all .gitignores

Also excluded those files in the rat plugin section of the pom.xml files.  Not
excluded by default, see
http://creadur.apache.org/rat/apache-rat-plugin/check-mojo.html#useDefaultExcludes