### PR TITLE
ACCUMULO-4143 Make protective copy of migrations

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/CurrentState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/CurrentState.java
@@ -29,5 +29,5 @@ public interface CurrentState {
 
   Collection<MergeInfo> merges();
 
-  Collection<KeyExtent> migrations();
+  Set<KeyExtent> migrations();
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -902,11 +902,7 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
 
     private long balanceTablets() {
       List<TabletMigration> migrationsOut = new ArrayList<TabletMigration>();
-      Set<KeyExtent> migrationsCopy = new HashSet<KeyExtent>();
-      synchronized (migrations) {
-        migrationsCopy.addAll(migrations.keySet());
-      }
-      long wait = tabletBalancer.balance(Collections.unmodifiableSortedMap(tserverStatus), Collections.unmodifiableSet(migrationsCopy), migrationsOut);
+      long wait = tabletBalancer.balance(Collections.unmodifiableSortedMap(tserverStatus), Collections.unmodifiableSet(migrations()), migrationsOut);
 
       for (TabletMigration m : TabletBalancer.checkMigrationSanity(tserverStatus.keySet(), migrationsOut)) {
         if (migrations.containsKey(m.tablet)) {
@@ -1336,7 +1332,11 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
   }
 
   @Override
-  public Collection<KeyExtent> migrations() {
-    return migrations.keySet();
+  public Set<KeyExtent> migrations() {
+    Set<KeyExtent> migrationsCopy = new HashSet<KeyExtent>();
+    synchronized (migrations) {
+      migrationsCopy.addAll(migrations.keySet());
+    }
+    return migrationsCopy;
   }
 }

--- a/server/master/src/test/java/org/apache/accumulo/master/TestMergeState.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/TestMergeState.java
@@ -82,8 +82,8 @@ public class TestMergeState {
     }
 
     @Override
-    public Collection<KeyExtent> migrations() {
-      return Collections.emptyList();
+    public Set<KeyExtent> migrations() {
+      return Collections.emptySet();
     }
   }
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -172,8 +172,8 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterIT {
     }
 
     @Override
-    public Collection<KeyExtent> migrations() {
-      return Collections.emptyList();
+    public Set<KeyExtent> migrations() {
+      return Collections.emptySet();
     }
   }
 


### PR DESCRIPTION
Makes a protective copy of the master's migrations, when requested, to prevent
ConcurrentModificationExceptions when the requestor iterates over the set at the
same time the master is updating it.