### PR TITLE
ACCUMULO-4144 Add copyright/license info to manual

### DIFF
--- a/docs/src/main/latex/accumulo_user_manual/accumulo_user_manual.tex
+++ b/docs/src/main/latex/accumulo_user_manual/accumulo_user_manual.tex
@@ -48,6 +48,24 @@ Version 1.6}
 \begin{document}
 \frontmatter
 \maketitle
+\null\vfill
+\noindent
+Copyright \copyright 2011-2016 The Apache Software Foundation\\
+\\
+Licensed to the Apache Software Foundation (ASF) under one or more\\
+contributor license agreements. See the NOTICE file distributed with\\
+this work for additional information regarding copyright ownership.\\
+The ASF licenses this file to You under the Apache License, Version 2.0\\
+(the "License"); you may not use this file except in compliance with\\
+the License. You may obtain a copy of the License at\\
+\\
+    http://www.apache.org/licenses/LICENSE-2.0\\
+\\
+Unless required by applicable law or agreed to in writing, software\\
+distributed under the License is distributed on an "AS IS" BASIS,\\
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\
+See the License for the specific language governing permissions and\\
+limitations under the License.
 \tableofcontents
 \mainmatter
 \include{chapters/introduction}


### PR DESCRIPTION
This is a best effort to pass scrutiny. Personally, I find this confusing... references to software guarantees which don't apply to docs, confusing reference to "using this file", etc. Additional clarification was requested in LEGAL-235, but this is an attempt to make progress in the interim.