### PR TITLE
ACCUMULO-4145 Eliminate Text wrapping of tableIDs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
@@ -379,7 +379,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     this.auths = config.getAuthorizations();
     this.ve = new VisibilityEvaluator(config.getAuthorizations());
     this.threadPool = new ScheduledThreadPoolExecutor(config.getMaxWriteThreads(), new NamingThreadFactory(this.getClass().getSimpleName()));
-    this.locator = TabletLocator.getLocator(instance, new Text(tableId));
+    this.locator = TabletLocator.getLocator(instance, tableId);
     this.serverQueues = new HashMap<String,ServerQueue>();
     this.tableId = tableId;
     this.timeout = config.getTimeout(TimeUnit.MILLISECONDS);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineScanner.java
@@ -181,7 +181,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       else
         startRow = new Text();
 
-      nextRange = new Range(new KeyExtent(new Text(tableId), startRow, null).getMetadataEntry(), true, null, false);
+      nextRange = new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
     } else {
 
       if (currentExtent.getEndRow() == null) {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerImpl.java
@@ -29,7 +29,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.Credentials;
 import org.apache.accumulo.core.util.ArgumentChecker;
-import org.apache.hadoop.io.Text;
 
 /**
  * provides scanner functionality
@@ -49,7 +48,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   private Instance instance;
   private Credentials credentials;
   private Authorizations authorizations;
-  private Text table;
+  private String table;
 
   private int size;
 
@@ -61,7 +60,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
     ArgumentChecker.notNull(instance, credentials, table, authorizations);
     this.instance = instance;
     this.credentials = credentials;
-    this.table = new Text(table);
+    this.table = table;
     this.range = new Range((Key) null, (Key) null);
     this.authorizations = authorizations;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.Credentials;
 import org.apache.accumulo.core.util.NamingThreadFactory;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 public class ScannerIterator implements Iterator<Entry<Key,Value>> {
@@ -50,7 +49,6 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
   private static final Logger log = Logger.getLogger(ScannerIterator.class);
 
   // scanner options
-  private Text tableId;
   private int timeOut;
 
   // scanner state
@@ -123,15 +121,14 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
 
   }
 
-  ScannerIterator(Instance instance, Credentials credentials, Text table, Authorizations authorizations, Range range, int size, int timeOut,
+  ScannerIterator(Instance instance, Credentials credentials, String tableId, Authorizations authorizations, Range range, int size, int timeOut,
       ScannerOptions options, boolean isolated) {
-    this(instance, credentials, table, authorizations, range, size, timeOut, options, isolated, Constants.SCANNER_DEFAULT_READAHEAD_THRESHOLD);
+    this(instance, credentials, tableId, authorizations, range, size, timeOut, options, isolated, Constants.SCANNER_DEFAULT_READAHEAD_THRESHOLD);
   }
 
-  ScannerIterator(Instance instance, Credentials credentials, Text table, Authorizations authorizations, Range range, int size, int timeOut,
+  ScannerIterator(Instance instance, Credentials credentials, String tableId, Authorizations authorizations, Range range, int size, int timeOut,
       ScannerOptions options, boolean isolated, long readaheadThreshold) {
     this.instance = instance;
-    this.tableId = new Text(table);
     this.timeOut = timeOut;
     this.credentials = credentials;
     this.readaheadThreshold = readaheadThreshold;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -455,7 +455,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   private void addSplits(String tableName, SortedSet<Text> partitionKeys, String tableId) throws AccumuloException, AccumuloSecurityException,
       TableNotFoundException, AccumuloServerException {
-    TabletLocator tabLocator = TabletLocator.getLocator(instance, new Text(tableId));
+    TabletLocator tabLocator = TabletLocator.getLocator(instance, tableId);
 
     for (Text split : partitionKeys) {
       boolean successful = false;
@@ -1087,7 +1087,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     Random random = new Random();
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<String,Map<KeyExtent,List<Range>>>();
     String tableId = Tables.getTableId(instance, tableName);
-    TabletLocator tl = TabletLocator.getLocator(instance, new Text(tableId));
+    TabletLocator tl = TabletLocator.getLocator(instance, tableId);
     // its possible that the cache could contain complete, but old information about a tables tablets... so clear it
     tl.invalidateCache();
     while (!tl.binRanges(credentials, Collections.singletonList(range), binnedRanges).isEmpty()) {
@@ -1205,9 +1205,9 @@ public class TableOperationsImpl extends TableOperationsHelper {
         }
       }
 
-      Range range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, null).toMetadataRange();
       if (startRow == null || lastRow == null)
-        range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+        range = new KeyExtent(tableId, null, null).toMetadataRange();
       else
         range = new Range(startRow, lastRow);
 
@@ -1391,7 +1391,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
   @Override
   public void clearLocatorCache(String tableName) throws TableNotFoundException {
     ArgumentChecker.notNull(tableName);
-    TabletLocator tabLocator = TabletLocator.getLocator(instance, new Text(Tables.getTableId(instance, tableName)));
+    TabletLocator tabLocator = TabletLocator.getLocator(instance, Tables.getTableId(instance, tableName));
     tabLocator.invalidateCache();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocator.java
@@ -65,9 +65,9 @@ public abstract class TabletLocator {
 
   private static class LocatorKey {
     String instanceId;
-    Text tableName;
+    String tableName;
 
-    LocatorKey(String instanceId, Text table) {
+    LocatorKey(String instanceId, String table) {
       this.instanceId = instanceId;
       this.tableName = table;
     }
@@ -96,19 +96,19 @@ public abstract class TabletLocator {
     locators.clear();
   }
 
-  public static synchronized TabletLocator getLocator(Instance instance, Text tableId) {
+  public static synchronized TabletLocator getLocator(Instance instance, String tableId) {
 
     LocatorKey key = new LocatorKey(instance.getInstanceID(), tableId);
     TabletLocator tl = locators.get(key);
     if (tl == null) {
       MetadataLocationObtainer mlo = new MetadataLocationObtainer(instance);
 
-      if (tableId.toString().equals(RootTable.ID)) {
+      if (tableId.equals(RootTable.ID)) {
         tl = new RootTabletLocator(instance, new ZookeeperLockChecker(instance));
-      } else if (tableId.toString().equals(MetadataTable.ID)) {
-        tl = new TabletLocatorImpl(new Text(MetadataTable.ID), getLocator(instance, new Text(RootTable.ID)), mlo, new ZookeeperLockChecker(instance));
+      } else if (tableId.equals(MetadataTable.ID)) {
+        tl = new TabletLocatorImpl(MetadataTable.ID, getLocator(instance, RootTable.ID), mlo, new ZookeeperLockChecker(instance));
       } else {
-        tl = new TabletLocatorImpl(tableId, getLocator(instance, new Text(MetadataTable.ID)), mlo, new ZookeeperLockChecker(instance));
+        tl = new TabletLocatorImpl(tableId, getLocator(instance, MetadataTable.ID), mlo, new ZookeeperLockChecker(instance));
       }
       locators.put(key, tl);
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocatorImpl.java
@@ -86,7 +86,7 @@ public class TabletLocatorImpl extends TabletLocator {
 
   static final EndRowComparator endRowComparator = new EndRowComparator();
 
-  protected Text tableId;
+  protected String tableId;
   protected TabletLocator parent;
   protected TreeMap<Text,TabletLocation> metaCache = new TreeMap<Text,TabletLocation>(endRowComparator);
   protected TabletLocationObtainer locationObtainer;
@@ -150,8 +150,8 @@ public class TabletLocatorImpl extends TabletLocator {
     }
   }
 
-  public TabletLocatorImpl(Text table, TabletLocator parent, TabletLocationObtainer tlo, TabletServerLockChecker tslc) {
-    this.tableId = table;
+  public TabletLocatorImpl(String tableId, TabletLocator parent, TabletLocationObtainer tlo, TabletServerLockChecker tslc) {
+    this.tableId = tableId;
     this.parent = parent;
     this.locationObtainer = tlo;
     this.lockChecker = tslc;
@@ -465,7 +465,7 @@ public class TabletLocatorImpl extends TabletLocator {
         // try the next tablet, the current tablet does not have any tablets that overlap the row
         Text er = ptl.tablet_extent.getEndRow();
         if (er != null && er.compareTo(lastTabletRow) < 0) {
-          // System.out.println("er "+er+"  ltr "+lastTabletRow);
+          // System.out.println("er "+er+" ltr "+lastTabletRow);
           ptl = parent.locateTablet(credentials, er, true, retry);
           if (ptl != null)
             locations = locationObtainer.lookupTablet(credentials, ptl, metadataRow, lastTabletRow, parent);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
@@ -64,7 +64,6 @@ import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.core.util.ThriftUtil;
 import org.apache.accumulo.trace.instrument.TraceRunnable;
 import org.apache.accumulo.trace.instrument.Tracer;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TApplicationException;
@@ -143,7 +142,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     this.options = new ScannerOptions(scannerOptions);
     resultsQueue = new ArrayBlockingQueue<List<Entry<Key,Value>>>(numThreads);
 
-    this.locator = new TimeoutTabletLocator(TabletLocator.getLocator(instance, new Text(table)), timeout);
+    this.locator = new TimeoutTabletLocator(TabletLocator.getLocator(instance, table), timeout);
 
     timeoutTrackers = Collections.synchronizedMap(new HashMap<String,TabletServerBatchReaderIterator.TimeoutTracker>());
     timedoutServers = Collections.synchronizedSet(new HashSet<String>());

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -129,7 +129,7 @@ public class ThriftScanner {
   public static class ScanState {
 
     boolean isolated;
-    Text tableId;
+    String tableId;
     Text startRow;
     boolean skipStartRow;
     long readaheadThreshold;
@@ -152,13 +152,13 @@ public class ThriftScanner {
 
     Map<String,Map<String,String>> serverSideIteratorOptions;
 
-    public ScanState(Instance instance, Credentials credentials, Text tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns,
+    public ScanState(Instance instance, Credentials credentials, String tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns,
         int size, List<IterInfo> serverSideIteratorList, Map<String,Map<String,String>> serverSideIteratorOptions, boolean isolated) {
       this(instance, credentials, tableId, authorizations, range, fetchedColumns, size, serverSideIteratorList, serverSideIteratorOptions, isolated,
           Constants.SCANNER_DEFAULT_READAHEAD_THRESHOLD);
     }
 
-    public ScanState(Instance instance, Credentials credentials, Text tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns,
+    public ScanState(Instance instance, Credentials credentials, String tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns,
         int size, List<IterInfo> serverSideIteratorList, Map<String,Map<String,String>> serverSideIteratorOptions, boolean isolated, long readaheadThreshold) {
       this.instance = instance;
       this.credentials = credentials;
@@ -414,7 +414,7 @@ public class ThriftScanner {
           client.closeScan(tinfo, is.scanID);
 
       } else {
-        // log.debug("Calling continue scan : "+scanState.range+"  loc = "+loc);
+        // log.debug("Calling continue scan : "+scanState.range+" loc = "+loc);
         String msg = "Continuing scan tserver=" + loc.tablet_location + " scanid=" + scanState.scanID;
         Thread.currentThread().setName(msg);
         opTimer.start(msg);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
@@ -46,17 +46,13 @@ public class Writer {
 
   private Instance instance;
   private Credentials credentials;
-  private Text table;
+  private String table;
 
-  public Writer(Instance instance, Credentials credentials, Text table) {
+  public Writer(Instance instance, Credentials credentials, String table) {
     ArgumentChecker.notNull(instance, credentials, table);
     this.instance = instance;
     this.credentials = credentials;
     this.table = table;
-  }
-
-  public Writer(Instance instance, Credentials credentials, String table) {
-    this(instance, credentials, new Text(table));
   }
 
   private static void updateServer(Instance instance, Mutation m, KeyExtent extent, String server, Credentials ai, AccumuloConfiguration configuration)

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
@@ -608,7 +608,7 @@ public class InputConfigurator extends ConfiguratorBase {
     if ("MockInstance".equals(instanceType))
       return new MockTabletLocator();
     Instance instance = getInstance(implementingClass, conf);
-    return TabletLocator.getLocator(instance, new Text(tableId));
+    return TabletLocator.getLocator(instance, tableId);
   }
 
   // InputFormat doesn't have the equivalent of OutputFormat's checkOutputSpecs(JobContext job)
@@ -722,7 +722,7 @@ public class InputConfigurator extends ConfiguratorBase {
       else
         startRow = new Text();
 
-      Range metadataRange = new Range(new KeyExtent(new Text(tableId), startRow, null).getMetadataEntry(), true, null, false);
+      Range metadataRange = new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
       Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
       MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       scanner.fetchColumnFamily(MetadataSchema.TabletsSection.LastLocationColumnFamily.NAME);

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
@@ -52,7 +52,7 @@ public class MockTabletLocator extends TabletLocator {
   @Override
   public List<Range> binRanges(Credentials credentials, List<Range> ranges, Map<String,Map<KeyExtent,List<Range>>> binnedRanges) throws AccumuloException,
       AccumuloSecurityException, TableNotFoundException {
-    binnedRanges.put("", Collections.singletonMap(new KeyExtent(new Text(), null, null), ranges));
+    binnedRanges.put("", Collections.singletonMap(new KeyExtent("", null, null), ranges));
     return Collections.emptyList();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyExtent.java
@@ -16,11 +16,7 @@
  */
 package org.apache.accumulo.core.data;
 
-/**
- * keeps track of information needed to identify a tablet
- * apparently, we only need the endKey and not the start as well
- *
- */
+import static com.google.common.base.Charsets.UTF_8;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -28,6 +24,7 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -50,27 +47,30 @@ import org.apache.hadoop.io.BinaryComparable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 
+/**
+ * keeps track of information needed to identify a tablet apparently, we only need the endKey and not the start as well
+ *
+ */
 public class KeyExtent implements WritableComparable<KeyExtent> {
 
-  private static final WeakHashMap<Text,WeakReference<Text>> tableIds = new WeakHashMap<Text,WeakReference<Text>>();
+  private static final WeakHashMap<String,WeakReference<String>> tableIds = new WeakHashMap<String,WeakReference<String>>();
 
-  private static Text dedupeTableId(Text tableId) {
+  private static String dedupeTableId(String tableId) {
     synchronized (tableIds) {
-      WeakReference<Text> etir = tableIds.get(tableId);
+      WeakReference<String> etir = tableIds.get(tableId);
       if (etir != null) {
-        Text eti = etir.get();
+        String eti = etir.get();
         if (eti != null) {
           return eti;
         }
       }
 
-      tableId = new Text(tableId);
-      tableIds.put(tableId, new WeakReference<Text>(tableId));
+      tableIds.put(tableId, new WeakReference<String>(tableId));
       return tableId;
     }
   }
 
-  private Text textTableId;
+  private String tableId;
   private Text textEndRow;
   private Text textPrevEndRow;
 
@@ -92,13 +92,13 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    *
    */
   public KeyExtent() {
-    this.setTableId(new Text());
+    this.setTableId("");
     this.setEndRow(new Text(), false, false);
     this.setPrevEndRow(new Text(), false, false);
   }
 
-  public KeyExtent(Text table, Text endRow, Text prevEndRow) {
-    this.setTableId(table);
+  public KeyExtent(String tableId, Text endRow, Text prevEndRow) {
+    this.setTableId(tableId);
     this.setEndRow(endRow, false, true);
     this.setPrevEndRow(prevEndRow, false, true);
 
@@ -107,7 +107,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
 
   public KeyExtent(KeyExtent extent) {
     // extent has already deduped table id, so there is no need to do it again
-    this.textTableId = extent.textTableId;
+    this.tableId = extent.tableId;
     this.setEndRow(extent.getEndRow(), false, true);
     this.setPrevEndRow(extent.getPrevEndRow(), false, true);
 
@@ -115,7 +115,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public KeyExtent(TKeyExtent tke) {
-    this.setTableId(new Text(ByteBufferUtil.toBytes(tke.table)));
+    this.setTableId(new String(ByteBufferUtil.toBytes(tke.table), UTF_8));
     this.setEndRow(tke.endRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.endRow)), false, false);
     this.setPrevEndRow(tke.prevEndRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.prevEndRow)), false, false);
 
@@ -130,7 +130,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     return getMetadataEntry(getTableId(), getEndRow());
   }
 
-  public static Text getMetadataEntry(Text tableId, Text endRow) {
+  public static Text getMetadataEntry(String tableId, Text endRow) {
     return MetadataSchema.TabletsSection.getRow(tableId, endRow);
   }
 
@@ -161,12 +161,12 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    * Sets the extents table id
    *
    */
-  public void setTableId(Text tId) {
+  public void setTableId(String tId) {
 
     if (tId == null)
       throw new IllegalArgumentException("null table name not allowed");
 
-    this.textTableId = dedupeTableId(tId);
+    this.tableId = dedupeTableId(tId);
 
     hashCode = 0;
   }
@@ -175,8 +175,8 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    * Returns the extent's table id
    *
    */
-  public Text getTableId() {
-    return textTableId;
+  public String getTableId() {
+    return tableId;
   }
 
   private void setEndRow(Text endRow, boolean check, boolean copy) {
@@ -245,9 +245,10 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    */
   @Override
   public void readFields(DataInput in) throws IOException {
+    // in.readUTF() would be better, but retrieving as a Text preserves backwards-compatibility
     Text tid = new Text();
     tid.readFields(in);
-    setTableId(tid);
+    setTableId(tid.toString());
     boolean hasRow = in.readBoolean();
     if (hasRow) {
       Text er = new Text();
@@ -275,7 +276,8 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    */
   @Override
   public void write(DataOutput out) throws IOException {
-    getTableId().write(out);
+    // out.writeUTF() would be better, but writing as Text preserves backwards-compatibility
+    new Text(getTableId()).write(out);
     if (getEndRow() != null) {
       out.writeBoolean(true);
       getEndRow().write(out);
@@ -462,14 +464,14 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     if (!(o instanceof KeyExtent))
       return false;
     KeyExtent oke = (KeyExtent) o;
-    return textTableId.equals(oke.textTableId) && equals(textEndRow, oke.textEndRow) && equals(textPrevEndRow, oke.textPrevEndRow);
+    return tableId.equals(oke.tableId) && equals(textEndRow, oke.textEndRow) && equals(textPrevEndRow, oke.textPrevEndRow);
   }
 
   @Override
   public String toString() {
     String endRowString;
     String prevEndRowString;
-    String tableIdString = getTableId().toString().replaceAll(";", "\\\\;").replaceAll("\\\\", "\\\\\\\\");
+    String tableIdString = getTableId();
 
     if (getEndRow() == null)
       endRowString = "<";
@@ -535,14 +537,12 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
         throw new IllegalArgumentException("< must come at end of Metadata row  " + flattenedExtent);
       }
 
-      Text tableId = new Text();
-      tableId.set(flattenedExtent.getBytes(), 0, flattenedExtent.getLength() - 1);
+      String tableId = new String(flattenedExtent.getBytes(), 0, flattenedExtent.getLength() - 1, UTF_8);
       this.setTableId(tableId);
       this.setEndRow(null, false, false);
     } else {
 
-      Text tableId = new Text();
-      tableId.set(flattenedExtent.getBytes(), 0, semiPos);
+      String tableId = new String(flattenedExtent.getBytes(), 0, semiPos, UTF_8);
 
       Text endRow = new Text();
       endRow.set(flattenedExtent.getBytes(), semiPos + 1, flattenedExtent.getLength() - (semiPos + 1));
@@ -556,7 +556,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   public static byte[] tableOfMetadataRow(Text row) {
     KeyExtent ke = new KeyExtent();
     ke.decodeMetadataRow(row);
-    return TextUtil.getBytes(ke.getTableId());
+    return ke.getTableId().getBytes(UTF_8);
   }
 
   public boolean contains(final ByteSequence bsrow) {
@@ -747,8 +747,8 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public TKeyExtent toThrift() {
-    return new TKeyExtent(TextUtil.getByteBuffer(textTableId), textEndRow == null ? null : TextUtil.getByteBuffer(textEndRow), textPrevEndRow == null ? null
-        : TextUtil.getByteBuffer(textPrevEndRow));
+    return new TKeyExtent(ByteBuffer.wrap(tableId.getBytes(UTF_8)), textEndRow == null ? null : TextUtil.getByteBuffer(textEndRow),
+        textPrevEndRow == null ? null : TextUtil.getByteBuffer(textPrevEndRow));
   }
 
   public boolean isPreviousExtent(KeyExtent prevExtent) {
@@ -768,10 +768,10 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public boolean isMeta() {
-    return getTableId().toString().equals(MetadataTable.ID) || isRootTablet();
+    return getTableId().equals(MetadataTable.ID) || isRootTablet();
   }
 
   public boolean isRootTablet() {
-    return getTableId().toString().equals(RootTable.ID);
+    return getTableId().equals(RootTable.ID);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.core.metadata;
 
 import org.apache.accumulo.core.client.impl.Namespaces;
 import org.apache.accumulo.core.data.KeyExtent;
-import org.apache.hadoop.io.Text;
 
 /**
  *
@@ -43,7 +42,7 @@ public class RootTable {
   public static final String ZROOT_TABLET_WALOGS = ZROOT_TABLET + "/walogs";
   public static final String ZROOT_TABLET_PATH = ZROOT_TABLET + "/dir";
 
-  public static final KeyExtent EXTENT = new KeyExtent(new Text(ID), null, null);
-  public static final KeyExtent OLD_EXTENT = new KeyExtent(new Text(MetadataTable.ID), KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), null), null);
+  public static final KeyExtent EXTENT = new KeyExtent(ID, null, null);
+  public static final KeyExtent OLD_EXTENT = new KeyExtent(MetadataTable.ID, KeyExtent.getMetadataEntry(MetadataTable.ID, null), null);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -54,7 +54,7 @@ public class MetadataSchema {
       return new Range(new Key(tableId + ';'), true, new Key(tableId + '<').followingKey(PartialKey.ROW), false);
     }
 
-    public static Text getRow(Text tableId, Text endRow) {
+    public static Text getRow(String tableId, Text endRow) {
       Text entry = new Text(tableId);
 
       if (endRow == null) {

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -218,7 +218,7 @@ public class Merge {
     } catch (Exception e) {
       throw new MergeException(e);
     }
-    scanner.setRange(new KeyExtent(new Text(tableId), end, start).toMetadataRange());
+    scanner.setRange(new KeyExtent(tableId, end, start).toMetadataRange());
     scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
     final Iterator<Entry<Key,Value>> iterator = scanner.iterator();

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
@@ -27,7 +27,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.Credentials;
-import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class TableOperationsImplTest {
     Connector connector = EasyMock.createMock(Connector.class);
     Scanner scanner = EasyMock.createMock(Scanner.class);
 
-    Range range = new KeyExtent(new Text("1"), null, null).toMetadataRange();
+    Range range = new KeyExtent("1", null, null).toMetadataRange();
 
     String user = "root";
     PasswordToken token = new PasswordToken("password");

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
@@ -29,8 +29,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
-
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -55,14 +53,16 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.security.Credentials;
 import org.apache.hadoop.io.Text;
 
+import junit.framework.TestCase;
+
 public class TabletLocatorImplTest extends TestCase {
 
   private static final KeyExtent RTE = RootTable.EXTENT;
-  private static final KeyExtent MTE = new KeyExtent(new Text(MetadataTable.ID), null, RTE.getEndRow());
+  private static final KeyExtent MTE = new KeyExtent(MetadataTable.ID, null, RTE.getEndRow());
   private static Credentials credentials = null;
 
   static KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(new Text(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(t, er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   static Range nr(String k1, boolean si, String k2, boolean ei) {
@@ -140,8 +140,8 @@ public class TabletLocatorImplTest extends TestCase {
     TestInstance testInstance = new TestInstance("instance1", "tserver1");
 
     RootTabletLocator rtl = new TestRootTabletLocator(testInstance);
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Text(table), rootTabletCache, ttlo, tslc);
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(table, rootTabletCache, ttlo, tslc);
 
     setLocation(tservers, rootTabLoc, RTE, MTE, metaTabLoc);
 
@@ -684,8 +684,8 @@ public class TabletLocatorImplTest extends TestCase {
     TestInstance testInstance = new TestInstance("instance1", "tserver1");
 
     RootTabletLocator rtl = new TestRootTabletLocator(testInstance);
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Text("tab1"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl("tab1", rootTabletCache, ttlo, new YesLockChecker());
 
     locateTabletTest(tab1TabletCache, "r1", null, null, credentials);
 
@@ -762,8 +762,8 @@ public class TabletLocatorImplTest extends TestCase {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver3", credentials);
 
     // simulate the metadata table splitting
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), tab1e21.getMetadataEntry(), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), null, tab1e21.getMetadataEntry());
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, tab1e21.getMetadataEntry(), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, tab1e21.getMetadataEntry());
 
     setLocation(tservers, "tserver4", RTE, mte1, "tserver5");
     setLocation(tservers, "tserver4", RTE, mte2, "tserver6");
@@ -801,8 +801,8 @@ public class TabletLocatorImplTest extends TestCase {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver9", credentials);
 
     // simulate a hole in the metadata, caused by a partial split
-    KeyExtent mte11 = new KeyExtent(new Text(MetadataTable.ID), tab1e1.getMetadataEntry(), RTE.getEndRow());
-    KeyExtent mte12 = new KeyExtent(new Text(MetadataTable.ID), tab1e21.getMetadataEntry(), tab1e1.getMetadataEntry());
+    KeyExtent mte11 = new KeyExtent(MetadataTable.ID, tab1e1.getMetadataEntry(), RTE.getEndRow());
+    KeyExtent mte12 = new KeyExtent(MetadataTable.ID, tab1e21.getMetadataEntry(), tab1e1.getMetadataEntry());
     deleteServer(tservers, "tserver10");
     setLocation(tservers, "tserver4", RTE, mte12, "tserver10");
     setLocation(tservers, "tserver10", mte12, tab1e21, "tserver12");
@@ -1208,23 +1208,23 @@ public class TabletLocatorImplTest extends TestCase {
 
   public void testBug1() throws Exception {
     // a bug that occurred while running continuous ingest
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), new Text("0;0bc"), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), null, new Text("0;0bc"));
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("0;0bc"), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, new Text("0;0bc"));
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
     TestInstance testInstance = new TestInstance("instance1", "tserver1");
 
     RootTabletLocator rtl = new TestRootTabletLocator(testInstance);
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Text("0"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("0", rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
 
     // create two tablets that straddle a metadata split point
-    KeyExtent ke1 = new KeyExtent(new Text("0"), new Text("0bbf20e"), null);
-    KeyExtent ke2 = new KeyExtent(new Text("0"), new Text("0bc0756"), new Text("0bbf20e"));
+    KeyExtent ke1 = new KeyExtent("0", new Text("0bbf20e"), null);
+    KeyExtent ke2 = new KeyExtent("0", new Text("0bc0756"), new Text("0bbf20e"));
 
     setLocation(tservers, "tserver2", mte1, ke1, "tserver4");
     setLocation(tservers, "tserver3", mte2, ke2, "tserver5");
@@ -1235,16 +1235,16 @@ public class TabletLocatorImplTest extends TestCase {
 
   public void testBug2() throws Exception {
     // a bug that occurred while running a functional test
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), new Text("~"), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), null, new Text("~"));
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("~"), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, new Text("~"));
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
     TestInstance testInstance = new TestInstance("instance1", "tserver1");
 
     RootTabletLocator rtl = new TestRootTabletLocator(testInstance);
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Text("0"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("0", rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
@@ -1260,13 +1260,13 @@ public class TabletLocatorImplTest extends TestCase {
 
   // this test reproduces a problem where empty metadata tablets, that were created by user tablets being merged away, caused locating tablets to fail
   public void testBug3() throws Exception {
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;c"), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;f"), new Text("1;c"));
-    KeyExtent mte3 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;j"), new Text("1;f"));
-    KeyExtent mte4 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;r"), new Text("1;j"));
-    KeyExtent mte5 = new KeyExtent(new Text(MetadataTable.ID), null, new Text("1;r"));
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("1;c"), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, new Text("1;f"), new Text("1;c"));
+    KeyExtent mte3 = new KeyExtent(MetadataTable.ID, new Text("1;j"), new Text("1;f"));
+    KeyExtent mte4 = new KeyExtent(MetadataTable.ID, new Text("1;r"), new Text("1;j"));
+    KeyExtent mte5 = new KeyExtent(MetadataTable.ID, null, new Text("1;r"));
 
-    KeyExtent ke1 = new KeyExtent(new Text("1"), null, null);
+    KeyExtent ke1 = new KeyExtent("1", null, null);
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
@@ -1274,8 +1274,8 @@ public class TabletLocatorImplTest extends TestCase {
 
     RootTabletLocator rtl = new TestRootTabletLocator(testInstance);
 
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Text("1"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("1", rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 
 public class KeyExtentTest {
   KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(new Text(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(t, er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   KeyExtent ke;
@@ -61,7 +61,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertEquals(new Text("bar"), ke.getEndRow());
-    assertEquals(new Text("foo"), ke.getTableId());
+    assertEquals("foo", ke.getTableId());
     assertNull(ke.getPrevEndRow());
 
     flattenedExtent = new Text("foo<");
@@ -69,7 +69,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertNull(ke.getEndRow());
-    assertEquals(new Text("foo"), ke.getTableId());
+    assertEquals("foo", ke.getTableId());
     assertNull(ke.getPrevEndRow());
 
     flattenedExtent = new Text("foo;bar;");
@@ -77,7 +77,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertEquals(new Text("bar;"), ke.getEndRow());
-    assertEquals(new Text("foo"), ke.getTableId());
+    assertEquals("foo", ke.getTableId());
     assertNull(ke.getPrevEndRow());
 
   }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -25,10 +25,10 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.accumulo.core.data.thrift.TRange;
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class RangeTest extends TestCase {
   private Range nr(String k1, String k2) {
@@ -190,31 +190,30 @@ public class RangeTest extends TestCase {
 
   public void testMergeOverlapping22() {
 
-    Range ke1 = new KeyExtent(new Text("tab1"), new Text("Bank"), null).toMetadataRange();
-    Range ke2 = new KeyExtent(new Text("tab1"), new Text("Fails"), new Text("Bank")).toMetadataRange();
-    Range ke3 = new KeyExtent(new Text("tab1"), new Text("Sam"), new Text("Fails")).toMetadataRange();
-    Range ke4 = new KeyExtent(new Text("tab1"), new Text("bails"), new Text("Sam")).toMetadataRange();
-    Range ke5 = new KeyExtent(new Text("tab1"), null, new Text("bails")).toMetadataRange();
+    Range ke1 = new KeyExtent("tab1", new Text("Bank"), null).toMetadataRange();
+    Range ke2 = new KeyExtent("tab1", new Text("Fails"), new Text("Bank")).toMetadataRange();
+    Range ke3 = new KeyExtent("tab1", new Text("Sam"), new Text("Fails")).toMetadataRange();
+    Range ke4 = new KeyExtent("tab1", new Text("bails"), new Text("Sam")).toMetadataRange();
+    Range ke5 = new KeyExtent("tab1", null, new Text("bails")).toMetadataRange();
 
     List<Range> rl = nrl(ke1, ke2, ke3, ke4, ke5);
-    List<Range> expected = nrl(new KeyExtent(new Text("tab1"), null, null).toMetadataRange());
+    List<Range> expected = nrl(new KeyExtent("tab1", null, null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke1, ke2, ke4, ke5);
-    expected = nrl(new KeyExtent(new Text("tab1"), new Text("Fails"), null).toMetadataRange(),
-        new KeyExtent(new Text("tab1"), null, new Text("Sam")).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", new Text("Fails"), null).toMetadataRange(), new KeyExtent("tab1", null, new Text("Sam")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke2, ke3, ke4, ke5);
-    expected = nrl(new KeyExtent(new Text("tab1"), null, new Text("Bank")).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", null, new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke1, ke2, ke3, ke4);
-    expected = nrl(new KeyExtent(new Text("tab1"), new Text("bails"), null).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", new Text("bails"), null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke2, ke3, ke4);
-    expected = nrl(new KeyExtent(new Text("tab1"), new Text("bails"), new Text("Bank")).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", new Text("bails"), new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -1793,7 +1793,7 @@ public class RFileTest {
 
     // mfw.startDefaultLocalityGroup();
 
-    Text tableExtent = new Text(KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), MetadataSchema.TabletsSection.getRange().getEndKey().getRow()));
+    Text tableExtent = new Text(KeyExtent.getMetadataEntry(MetadataTable.ID, MetadataSchema.TabletsSection.getRange().getEndKey().getRow()));
 
     // table tablet's directory
     Key tableDirKey = new Key(tableExtent, TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
@@ -1811,7 +1811,7 @@ public class RFileTest {
     mfw.append(tablePrevRowKey, KeyExtent.encodePrevEndRow(null));
 
     // ----------] default tablet info
-    Text defaultExtent = new Text(KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), null));
+    Text defaultExtent = new Text(KeyExtent.getMetadataEntry(MetadataTable.ID, null));
 
     // default's directory
     Key defaultDirKey = new Key(defaultExtent, TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.system.MultiIteratorTest;
 import org.apache.accumulo.core.iterators.user.AgeOffFilter;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,26 +51,32 @@ public class IteratorUtilTest {
 
     protected SortedKeyValueIterator<Key,Value> source;
 
+    @Override
     public WrappedIter deepCopy(IteratorEnvironment env) {
       throw new UnsupportedOperationException();
     }
 
+    @Override
     public Key getTopKey() {
       return source.getTopKey();
     }
 
+    @Override
     public Value getTopValue() {
       return source.getTopValue();
     }
 
+    @Override
     public boolean hasTop() {
       return source.hasTop();
     }
 
+    @Override
     public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
       this.source = source;
     }
 
+    @Override
     public void next() throws IOException {
       source.next();
     }
@@ -86,6 +91,7 @@ public class IteratorUtilTest {
 
     int amount = 1;
 
+    @Override
     public Value getTopValue() {
       Value val = super.getTopValue();
 
@@ -94,6 +100,7 @@ public class IteratorUtilTest {
       return new Value(((orig + amount) + "").getBytes());
     }
 
+    @Override
     public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
       super.init(source, options, env);
 
@@ -106,6 +113,7 @@ public class IteratorUtilTest {
   }
 
   static class SquaringIter extends WrappedIter {
+    @Override
     public Value getTopValue() {
       Value val = super.getTopValue();
 
@@ -130,7 +138,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -162,7 +170,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -198,7 +206,7 @@ public class IteratorUtilTest {
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".addIter", "2," + AddingIter.class.getName());
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".sqIter", "1," + SquaringIter.class.getName());
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -234,7 +242,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -270,7 +278,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
-
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.KeyExtent;
@@ -33,6 +31,8 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class MultiIteratorTest extends TestCase {
 
@@ -344,7 +344,7 @@ public class MultiIteratorTest extends TestCase {
     List<SortedKeyValueIterator<Key,Value>> skvil = new ArrayList<SortedKeyValueIterator<Key,Value>>(1);
     skvil.add(new SortedMapIterator(tm1));
 
-    KeyExtent extent = new KeyExtent(new Text("tablename"), nr(1), nr(0));
+    KeyExtent extent = new KeyExtent("tablename", nr(1), nr(0));
     MultiIterator mi = new MultiIterator(skvil, extent);
 
     Range r1 = new Range((Text) null, (Text) null);

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -43,7 +43,7 @@ public class MergeTest {
           end = null;
         else
           end = new Text(String.format("%05d", tablets.size()));
-        KeyExtent extent = new KeyExtent(new Text("table"), end, start);
+        KeyExtent extent = new KeyExtent("table", end, start);
         start = end;
         tablets.add(new Size(extent, size));
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -131,7 +131,7 @@ public class BulkImporter {
     final Map<Path,List<KeyExtent>> completeFailures = Collections.synchronizedSortedMap(new TreeMap<Path,List<KeyExtent>>());
 
     ClientService.Client client = null;
-    final TabletLocator locator = TabletLocator.getLocator(instance, new Text(tableId));
+    final TabletLocator locator = TabletLocator.getLocator(instance, tableId);
 
     try {
       final Map<Path,List<TabletLocation>> assignments = Collections.synchronizedSortedMap(new TreeMap<Path,List<TabletLocation>>());

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.TIME_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
@@ -29,7 +30,6 @@ import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.UUID;
 
-import jline.console.ConsoleReader;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -82,6 +82,8 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
 
 import com.beust.jcommander.Parameter;
+
+import jline.console.ConsoleReader;
 
 /**
  * This class is used to setup the directory structure and the root tablet to get an instance started
@@ -344,7 +346,7 @@ public class Initialize {
 
   private static void createEntriesForTablet(FileSKVWriter writer, String tableId, String tabletDir, Text tabletPrevEndRow, Text tabletEndRow)
       throws IOException {
-    Text extent = new Text(KeyExtent.getMetadataEntry(new Text(tableId), tabletEndRow));
+    Text extent = new Text(KeyExtent.getMetadataEntry(tableId, tabletEndRow));
     addEntry(writer, extent, DIRECTORY_COLUMN, new Value(tabletDir.getBytes(UTF_8)));
     addEntry(writer, extent, TIME_COLUMN, new Value((TabletTime.LOGICAL_TIME_ID + "0").getBytes(UTF_8)));
     addEntry(writer, extent, PREV_ROW_COLUMN, KeyExtent.encodePrevEndRow(tabletPrevEndRow));

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.core.util.StringUtil;
 import org.apache.accumulo.server.master.state.TabletLocationState.BadLocationStateException;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 public class TabletStateChangeIterator extends SkippingIterator {
@@ -56,7 +55,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
 
   Set<TServerInstance> current;
   Set<String> onlineTables;
-  Map<Text,MergeInfo> merges;
+  Map<String,MergeInfo> merges;
   boolean debug = false;
   Set<KeyExtent> migrations;
 
@@ -116,11 +115,11 @@ public class TabletStateChangeIterator extends SkippingIterator {
     return result;
   }
 
-  private Map<Text,MergeInfo> parseMerges(String merges) {
+  private Map<String,MergeInfo> parseMerges(String merges) {
     if (merges == null)
       return null;
     try {
-      Map<Text,MergeInfo> result = new HashMap<Text,MergeInfo>();
+      Map<String,MergeInfo> result = new HashMap<String,MergeInfo>();
       DataInputBuffer buffer = new DataInputBuffer();
       byte[] data = Base64.decodeBase64(merges.getBytes(UTF_8));
       buffer.reset(data, data.length);

--- a/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.KeyExtent;
 import org.apache.accumulo.server.conf.ServerConfiguration;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 /**
@@ -49,7 +48,7 @@ public class LargestFirstMemoryManager implements MemoryManager {
   // The fraction of memory that needs to be used before we begin flushing.
   private double compactionThreshold;
   private long maxObserved;
-  private final HashMap<Text,Long> mincIdleThresholds = new HashMap<Text,Long>();
+  private final HashMap<String,Long> mincIdleThresholds = new HashMap<String,Long>();
   private ServerConfiguration config = null;
 
   private static class TabletInfo {
@@ -137,9 +136,9 @@ public class LargestFirstMemoryManager implements MemoryManager {
   }
 
   private long getMinCIdleThreshold(KeyExtent extent) {
-    Text tableId = extent.getTableId();
+    String tableId = extent.getTableId();
     if (!mincIdleThresholds.containsKey(tableId))
-      mincIdleThresholds.put(tableId, config.getTableConfiguration(tableId.toString()).getTimeInMillis(Property.TABLE_MINC_COMPACT_IDLETIME));
+      mincIdleThresholds.put(tableId, config.getTableConfiguration(tableId).getTimeInMillis(Property.TABLE_MINC_COMPACT_IDLETIME));
     return mincIdleThresholds.get(tableId);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -43,7 +43,6 @@ import org.apache.accumulo.server.master.state.TabletState;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.security.SystemCredentials;
 import org.apache.accumulo.server.tables.TableManager;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 public class FindOfflineTablets {
@@ -103,7 +102,7 @@ public class FindOfflineTablets {
     Range range = MetadataSchema.TabletsSection.getRange();
     if (tableName != null) {
       String tableId = Tables.getTableId(instance, tableName);
-      range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+      range = new KeyExtent(tableId, null, null).toMetadataRange();
     }
 
     MetaDataTableScanner metaScanner = new MetaDataTableScanner(instance, creds, range, MetadataTable.NAME);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -129,12 +129,12 @@ public class MasterMetadataUtil {
 
     Text metadataPrevEndRow = KeyExtent.decodePrevEndRow(prevEndRowIBW);
 
-    Text table = (new KeyExtent(metadataEntry, (Text) null)).getTableId();
+    String table = (new KeyExtent(metadataEntry, (Text) null)).getTableId();
 
     return fixSplit(table, metadataEntry, metadataPrevEndRow, oper, splitRatio, tserver, credentials, time.toString(), initFlushID, initCompactID, lock);
   }
 
-  private static KeyExtent fixSplit(Text table, Text metadataEntry, Text metadataPrevEndRow, Value oper, double splitRatio, TServerInstance tserver,
+  private static KeyExtent fixSplit(String table, Text metadataEntry, Text metadataPrevEndRow, Value oper, double splitRatio, TServerInstance tserver,
       Credentials credentials, String time, long initFlushID, long initCompactID, ZooLock lock) throws AccumuloException, IOException {
     if (metadataPrevEndRow == null)
       // something is wrong, this should not happen... if a tablet is split, it will always have a

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.commons.collections.map.LRUMap;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
 
@@ -198,7 +197,7 @@ public class RemoveEntriesForMissingFiles {
       return checkTable(instance, principal, token, RootTable.NAME, MetadataSchema.TabletsSection.getRange(), fix);
     } else {
       String tableId = Tables.getTableId(instance, tableName);
-      Range range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, null).toMetadataRange();
       return checkTable(instance, principal, token, MetadataTable.NAME, range, fix);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -49,7 +49,6 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 import com.beust.jcommander.Parameter;
@@ -177,7 +176,7 @@ public class TableDiskUsage {
         throw new RuntimeException(e);
       }
       mdScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      mdScanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+      mdScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
       if (!mdScanner.iterator().hasNext()) {
         emptyTableIds.add(tableId);

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -50,7 +50,8 @@ import org.junit.Test;
 public class BulkImporterTest {
 
   static final SortedSet<KeyExtent> fakeMetaData = new TreeSet<KeyExtent>();
-  static final Text tableId = new Text("1");
+  static final String tableId = "1";
+
   static {
     fakeMetaData.add(new KeyExtent(tableId, new Text("a"), null));
     for (String part : new String[] {"b", "bm", "c", "cm", "d", "dm", "e", "em", "f", "g", "h", "i", "j", "k", "l"}) {
@@ -158,19 +159,19 @@ public class BulkImporterTest {
     // a correct startRow so that findOverlappingTablets works as intended.
 
     // 1;2;1
-    KeyExtent extent = new KeyExtent(new Text("1"), new Text("2"), new Text("1"));
+    KeyExtent extent = new KeyExtent("1", new Text("2"), new Text("1"));
     Assert.assertEquals(new Text("1\0"), BulkImporter.getStartRowForExtent(extent));
 
     // 1;2<
-    extent = new KeyExtent(new Text("1"), new Text("2"), null);
+    extent = new KeyExtent("1", new Text("2"), null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1<<
-    extent = new KeyExtent(new Text("1"), null, null);
+    extent = new KeyExtent("1", null, null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1;8;7777777
-    extent = new KeyExtent(new Text("1"), new Text("8"), new Text("7777777"));
+    extent = new KeyExtent("1", new Text("8"), new Text("7777777"));
     Assert.assertEquals(new Text("7777777\0"), BulkImporter.getStartRowForExtent(extent));
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -154,7 +154,7 @@ public class ChaoticLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(new Text(table), toText(end), toText(prev));
+    return new KeyExtent(table, toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -169,7 +169,7 @@ public class DefaultLoadBalancerTest {
   public void testUnevenAssignment() {
     for (char c : "abcdefghijklmnopqrstuvwxyz".toCharArray()) {
       String cString = Character.toString(c);
-      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", (int) c);
+      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", c);
       String fakeInstance = cString;
       TServerInstance tsi = new TServerInstance(fakeAddress, fakeInstance);
       FakeTServer fakeTServer = new FakeTServer();
@@ -210,7 +210,7 @@ public class DefaultLoadBalancerTest {
     // make 26 servers
     for (char c : "abcdefghijklmnopqrstuvwxyz".toCharArray()) {
       String cString = Character.toString(c);
-      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", (int) c);
+      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", c);
       String fakeInstance = cString;
       TServerInstance tsi = new TServerInstance(fakeAddress, fakeInstance);
       FakeTServer fakeTServer = new FakeTServer();
@@ -279,7 +279,7 @@ public class DefaultLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(new Text(table), toText(end), toText(prev));
+    return new KeyExtent(table, toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -77,8 +77,8 @@ public class TableLoadBalancerTest {
     // generate some fake tablets
     for (int i = 0; i < tableInfo.tableMap.get(tableId).onlineTablets; i++) {
       TabletStats stats = new TabletStats();
-      stats.extent = new KeyExtent(new Text(tableId), new Text(tserver.host() + String.format("%03d", i + 1)), new Text(tserver.host()
-          + String.format("%03d", i))).toThrift();
+      stats.extent = new KeyExtent(tableId, new Text(tserver.host() + String.format("%03d", i + 1)), new Text(tserver.host() + String.format("%03d", i)))
+          .toThrift();
       result.add(stats);
     }
     return result;

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
@@ -65,7 +65,7 @@ public class MergeInfoTest {
 
   @Test
   public void testSerialization() throws Exception {
-    Text table = new Text("table");
+    String table = "table";
     Text endRow = new Text("end");
     Text prevEndRow = new Text("begin");
     keyExtent = new KeyExtent(table, endRow, prevEndRow);
@@ -85,10 +85,10 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_DifferentTables() {
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table2"));
+    expect(keyExtent2.getTableId()).andReturn("table2");
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.needsToBeChopped(keyExtent2));
@@ -96,9 +96,9 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_NotDelete() {
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent2.getTableId()).andReturn("table1");
     replay(keyExtent2);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(true);
     replay(keyExtent);
@@ -122,11 +122,11 @@ public class MergeInfoTest {
   }
 
   private void testNeedsToBeChopped_Delete(String prevEndRow, boolean expected) {
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent2.getTableId()).andReturn("table1");
     expect(keyExtent2.getPrevEndRow()).andReturn(prevEndRow != null ? new Text(prevEndRow) : null);
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -147,9 +147,9 @@ public class MergeInfoTest {
   public void testOverlaps_DoesNotNeedChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table2"));
+    expect(keyExtent2.getTableId()).andReturn("table2");
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.overlaps(keyExtent2));
@@ -159,10 +159,10 @@ public class MergeInfoTest {
   public void testOverlaps_NeedsChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent2.getTableId()).andReturn("table1");
     expect(keyExtent2.getPrevEndRow()).andReturn(new Text("prev"));
     expectLastCall().anyTimes();
     replay(keyExtent2);

--- a/server/base/src/test/java/org/apache/accumulo/server/util/CloneTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/CloneTest.java
@@ -47,7 +47,7 @@ public class CloneTest {
     MockInstance mi = new MockInstance();
     Connector conn = mi.getConnector("", new PasswordToken(""));
 
-    KeyExtent ke = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke = new KeyExtent("0", null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -76,7 +76,7 @@ public class CloneTest {
     MockInstance mi = new MockInstance();
     Connector conn = mi.getConnector("", new PasswordToken(""));
 
-    KeyExtent ke = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke = new KeyExtent("0", null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -109,7 +109,7 @@ public class CloneTest {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -149,7 +149,7 @@ public class CloneTest {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -198,7 +198,7 @@ public class CloneTest {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -217,7 +217,7 @@ public class CloneTest {
   }
 
   private static Mutation deleteTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(new Text(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(tid, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = new Mutation(ke.getMetadataEntry());
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
     TabletsSection.ServerColumnFamily.TIME_COLUMN.putDelete(mut);
@@ -228,7 +228,7 @@ public class CloneTest {
   }
 
   private static Mutation createTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(new Text(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(tid, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -267,7 +267,7 @@ public class CloneTest {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -332,7 +332,7 @@ public class CloneTest {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TabletIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TabletIteratorTest.java
@@ -18,8 +18,6 @@ package org.apache.accumulo.server.util;
 
 import java.util.Map.Entry;
 
-import junit.framework.TestCase;
-
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
@@ -38,6 +36,8 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.util.TabletIterator.TabletDeletedException;
 import org.apache.hadoop.io.Text;
 
+import junit.framework.TestCase;
+
 public class TabletIteratorTest extends TestCase {
 
   class TestTabletIterator extends TabletIterator {
@@ -53,7 +53,7 @@ public class TabletIteratorTest extends TestCase {
     protected void resetScanner() {
       try {
         Scanner ds = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-        Text tablet = new KeyExtent(new Text("0"), new Text("m"), null).getMetadataEntry();
+        Text tablet = new KeyExtent("0", new Text("m"), null).getMetadataEntry();
         ds.setRange(new Range(tablet, true, tablet, true));
 
         Mutation m = new Mutation(tablet);
@@ -82,11 +82,11 @@ public class TabletIteratorTest extends TestCase {
     MockInstance mi = new MockInstance();
     Connector conn = mi.getConnector("", new PasswordToken(""));
 
-    KeyExtent ke1 = new KeyExtent(new Text("0"), new Text("m"), null);
+    KeyExtent ke1 = new KeyExtent("0", new Text("m"), null);
     Mutation mut1 = ke1.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut1, new Value("/d1".getBytes()));
 
-    KeyExtent ke2 = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke2 = new KeyExtent("0", null, null);
     Mutation mut2 = ke2.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut2, new Value("/d2".getBytes()));
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -87,7 +87,7 @@ public class GarbageCollectionTest {
     }
 
     public Key newFileReferenceKey(String tableId, String endRow, String file) {
-      String row = new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.DataFileColumnFamily.NAME.toString();
       String cq = file;
       Key key = new Key(row, cf, cq);
@@ -105,7 +105,7 @@ public class GarbageCollectionTest {
     }
 
     Key newDirReferenceKey(String tableId, String endRow) {
-      String row = new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily().toString();
       String cq = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier().toString();
       Key key = new Key(row, cf, cq);

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -164,7 +164,7 @@ class MasterClientServiceHandler extends FateServiceHandler implements MasterCli
           scanner.setRange(MetadataSchema.TabletsSection.getRange());
         } else {
           scanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-          scanner.setRange(new KeyExtent(new Text(tableId), null, ByteBufferUtil.toText(startRow)).toMetadataRange());
+          scanner.setRange(new KeyExtent(tableId, null, ByteBufferUtil.toText(startRow)).toMetadataRange());
         }
         TabletsSection.ServerColumnFamily.FLUSH_COLUMN.fetch(scanner);
         TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(scanner);

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -104,11 +104,11 @@ class TabletGroupWatcher extends Daemon {
     this.dependentWatcher = dependentWatcher;
   }
 
-  Map<Text,TableCounts> getStats() {
+  Map<String,TableCounts> getStats() {
     return stats.getLast();
   }
 
-  TableCounts getStats(Text tableId) {
+  TableCounts getStats(String tableId) {
     return stats.getLast(tableId);
   }
 
@@ -127,8 +127,8 @@ class TabletGroupWatcher extends Daemon {
       int unloaded = 0;
       ClosableIterator<TabletLocationState> iter = null;
       try {
-        Map<Text,MergeStats> mergeStatsCache = new HashMap<Text,MergeStats>();
-        Map<Text,MergeStats> currentMerges = new HashMap<Text,MergeStats>();
+        Map<String,MergeStats> mergeStatsCache = new HashMap<String,MergeStats>();
+        Map<String,MergeStats> currentMerges = new HashMap<String,MergeStats>();
         for (MergeInfo merge : master.merges()) {
           if (merge.getExtent() != null) {
             currentMerges.put(merge.getExtent().getTableId(), new MergeStats(merge));
@@ -182,7 +182,7 @@ class TabletGroupWatcher extends Daemon {
             unloaded = 0;
             eventListener.waitForEvents(Master.TIME_TO_WAIT_BETWEEN_SCANS);
           }
-          Text tableId = tls.extent.getTableId();
+          String tableId = tls.extent.getTableId();
           MergeStats mergeStats = mergeStatsCache.get(tableId);
           if (mergeStats == null) {
             mergeStats = currentMerges.get(tableId);
@@ -450,7 +450,7 @@ class TabletGroupWatcher extends Daemon {
     }
   }
 
-  private void updateMergeState(Map<Text,MergeStats> mergeStatsCache) {
+  private void updateMergeState(Map<String,MergeStats> mergeStatsCache) {
     for (MergeStats stats : mergeStatsCache.values()) {
       try {
         MergeState update = stats.nextMergeState(this.master.getConnector(), this.master);

--- a/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
@@ -183,7 +183,7 @@ public class MergeStats {
     if (start == null) {
       start = new Text();
     }
-    Text tableId = extent.getTableId();
+    String tableId = extent.getTableId();
     Text first = KeyExtent.getMetadataEntry(tableId, start);
     Range range = new Range(first, false, null, true);
     scanner.setRange(range);

--- a/server/master/src/main/java/org/apache/accumulo/master/state/TableStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/TableStats.java
@@ -20,20 +20,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.accumulo.server.master.state.TabletState;
-import org.apache.hadoop.io.Text;
 
 public class TableStats {
-  private Map<Text,TableCounts> last = new HashMap<Text,TableCounts>();
-  private Map<Text,TableCounts> next;
+  private Map<String,TableCounts> last = new HashMap<String,TableCounts>();
+  private Map<String,TableCounts> next;
   private long startScan = 0;
   private long endScan = 0;
 
   public synchronized void begin() {
-    next = new HashMap<Text,TableCounts>();
+    next = new HashMap<String,TableCounts>();
     startScan = System.currentTimeMillis();
   }
 
-  public synchronized void update(Text tableId, TabletState state) {
+  public synchronized void update(String tableId, TabletState state) {
     TableCounts counts = next.get(tableId);
     if (counts == null) {
       counts = new TableCounts();
@@ -48,11 +47,11 @@ public class TableStats {
     endScan = System.currentTimeMillis();
   }
 
-  public synchronized Map<Text,TableCounts> getLast() {
+  public synchronized Map<String,TableCounts> getLast() {
     return last;
   }
 
-  public synchronized TableCounts getLast(Text tableId) {
+  public synchronized TableCounts getLast(String tableId) {
     TableCounts result = last.get(tableId);
     if (result == null)
       return new TableCounts();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/BulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/BulkImport.java
@@ -82,7 +82,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.MapFile;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 
@@ -414,7 +413,7 @@ class CopyFailed extends MasterRepo {
     // determine which failed files were loaded
     Connector conn = master.getConnector();
     Scanner mscanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-    mscanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
     mscanner.fetchColumnFamily(TabletsSection.BulkFileColumnFamily.NAME);
 
     for (Entry<Key,Value> entry : mscanner) {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CompactRange.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CompactRange.java
@@ -108,7 +108,7 @@ class CompactionDriver extends MasterRepo {
       scanner.setRange(MetadataSchema.TabletsSection.getRange());
     } else {
       scanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-      Range range = new KeyExtent(new Text(tableId), null, startRow == null ? null : new Text(startRow)).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, startRow == null ? null : new Text(startRow)).toMetadataRange();
       scanner.setRange(range);
     }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.server.tablets.TabletTime;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.util.TablePropUtil;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 class TableInfo implements Serializable {
@@ -116,7 +115,7 @@ class PopulateMetadata extends MasterRepo {
 
   @Override
   public Repo<Master> call(long tid, Master environment) throws Exception {
-    KeyExtent extent = new KeyExtent(new Text(tableInfo.tableId), null, null);
+    KeyExtent extent = new KeyExtent(tableInfo.tableId, null, null);
     MetadataTableUtil.addTablet(extent, tableInfo.dir, SystemCredentials.get(), tableInfo.timeType, environment.getMasterLock());
 
     return new FinishCreateTable(tableInfo);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteTable.java
@@ -57,7 +57,6 @@ import org.apache.accumulo.server.tables.TableManager;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
 class CleanUp extends MasterRepo {
@@ -96,7 +95,7 @@ class CleanUp extends MasterRepo {
     }
 
     boolean done = true;
-    Range tableRange = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+    Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();
     Scanner scanner = master.getConnector().createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetaDataTableScanner.configureScanner(scanner, master);
     scanner.setRange(tableRange);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportTable.java
@@ -62,7 +62,6 @@ import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 
 class ExportInfo implements Serializable {
 
@@ -106,7 +105,7 @@ class WriteExportFiles extends MasterRepo {
     checkOffline(conn);
 
     Scanner metaScanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    metaScanner.setRange(new KeyExtent(new Text(tableInfo.tableID), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableInfo.tableID, null, null).toMetadataRange());
 
     // scan for locations
     metaScanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
@@ -224,7 +223,7 @@ class WriteExportFiles extends MasterRepo {
     metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);
     TabletsSection.ServerColumnFamily.TIME_COLUMN.fetch(metaScanner);
-    metaScanner.setRange(new KeyExtent(new Text(tableID), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableID, null, null).toMetadataRange());
 
     for (Entry<Key,Value> entry : metaScanner) {
       entry.getKey().write(dataOut);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
@@ -245,7 +245,7 @@ class PopulateMetadataTable extends MasterRepo {
             val.readFields(in);
 
             Text endRow = new KeyExtent(key.getRow(), (Text) null).getEndRow();
-            Text metadataRow = new KeyExtent(new Text(tableInfo.tableId), endRow, null).getMetadataEntry();
+            Text metadataRow = new KeyExtent(tableInfo.tableId, endRow, null).getMetadataEntry();
 
             Text cq;
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOp.java
@@ -125,7 +125,7 @@ public class TableRangeOp extends MasterRepo {
     MergeInfo info = env.getMergeInfo(tableIdText);
 
     if (info.getState() == MergeState.NONE) {
-      KeyExtent range = new KeyExtent(tableIdText, end, start);
+      KeyExtent range = new KeyExtent(tableId, end, start);
       env.setMergeState(new MergeInfo(range, op), MergeState.STARTED);
     }
 

--- a/server/master/src/test/java/org/apache/accumulo/master/TestMergeState.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/TestMergeState.java
@@ -102,7 +102,7 @@ public class TestMergeState {
     // Create a fake METADATA table with these splits
     String splits[] = {"a", "e", "j", "o", "t", "z"};
     // create metadata for a table "t" with the splits above
-    Text tableId = new Text("t");
+    String tableId = "t";
     Text pr = null;
     for (String s : splits) {
       Text split = new Text(s);

--- a/server/master/src/test/java/org/apache/accumulo/master/state/MergeInfoTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/state/MergeInfoTest.java
@@ -41,7 +41,7 @@ public class MergeInfoTest {
   }
 
   KeyExtent ke(String tableId, String endRow, String prevEndRow) {
-    return new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(tableId, endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   @Test

--- a/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.master.state.TabletLocationState.BadLocationStateException;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -191,7 +190,7 @@ public class RootTabletStateStoreTest {
     }
     assertEquals(count, 1);
 
-    KeyExtent notRoot = new KeyExtent(new Text("0"), null, null);
+    KeyExtent notRoot = new KeyExtent("0", null, null);
     try {
       tstore.setLocations(Collections.singletonList(new Assignment(notRoot, server)));
       Assert.fail("should not get here");

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TablesServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TablesServlet.java
@@ -152,8 +152,8 @@ public class TablesServlet extends BasicServlet {
       locs.add(instance.getRootTabletLocation());
     } else {
       String systemTableName = MetadataTable.ID.equals(tableId) ? RootTable.NAME : MetadataTable.NAME;
-      MetaDataTableScanner scanner = new MetaDataTableScanner(instance, SystemCredentials.get(), new Range(KeyExtent.getMetadataEntry(new Text(tableId),
-          new Text()), KeyExtent.getMetadataEntry(new Text(tableId), null)), systemTableName);
+      MetaDataTableScanner scanner = new MetaDataTableScanner(instance, SystemCredentials.get(), new Range(KeyExtent.getMetadataEntry(tableId, new Text()),
+          KeyExtent.getMetadataEntry(tableId, null)), systemTableName);
 
       while (scanner.hasNext()) {
         TabletLocationState state = scanner.next();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2147,7 +2147,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
         }
       }
 
-      Text tid = new Text(cs.tableId);
+      String tid = cs.tableId;
       long opid = writeTracker.startWrite(TabletType.type(new KeyExtent(tid, null, null)));
 
       try {
@@ -2241,7 +2241,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
         onlineTabletsCopy = new TreeMap<KeyExtent,Tablet>(onlineTablets);
       }
       List<TabletStats> result = new ArrayList<TabletStats>();
-      Text text = new Text(tableId);
+      String text = tableId;
       KeyExtent start = new KeyExtent(text, new Text(), null);
       for (Entry<KeyExtent,Tablet> entry : onlineTabletsCopy.tailMap(start).entrySet()) {
         KeyExtent ke = entry.getKey();
@@ -2417,7 +2417,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
 
       ArrayList<Tablet> tabletsToFlush = new ArrayList<Tablet>();
 
-      KeyExtent ke = new KeyExtent(new Text(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(tableId, ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       synchronized (onlineTablets) {
         for (Tablet tablet : onlineTablets.values())
@@ -2535,7 +2535,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
         throw new RuntimeException(e);
       }
 
-      KeyExtent ke = new KeyExtent(new Text(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(tableId, ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       ArrayList<Tablet> tabletsToCompact = new ArrayList<Tablet>();
       synchronized (onlineTablets) {
@@ -3594,7 +3594,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
           extents = new ArrayList<KeyExtent>(onlineTablets.keySet());
         }
 
-        Set<Text> tables = new HashSet<Text>();
+        Set<String> tables = new HashSet<String>();
 
         for (KeyExtent keyExtent : extents) {
           tables.add(keyExtent.getTableId());
@@ -3602,7 +3602,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
 
         HashSet<String> contexts = new HashSet<String>();
 
-        for (Text tableid : tables) {
+        for (String tableid : tables) {
           String context = getTableConfiguration(new KeyExtent(tableid, null, null)).get(Property.TABLE_CLASSPATH);
           if (!context.equals("")) {
             contexts.add(context);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -83,7 +83,7 @@ public class LogReader {
       row = new Text(opts.row);
     if (opts.extent != null) {
       String sa[] = opts.extent.split(";");
-      ke = new KeyExtent(new Text(sa[0]), new Text(sa[1]), new Text(sa[2]));
+      ke = new KeyExtent(sa[0], new Text(sa[1]), new Text(sa[2]));
     }
     if (opts.regexp != null) {
       Pattern pattern = Pattern.compile(opts.regexp);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
@@ -24,7 +24,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.KeyExtent;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.tserver.TabletServerResourceManager.AssignmentWatcher;
-import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +49,7 @@ public class AssignmentWatcherTest {
     RunnableStartedAt run = new RunnableStartedAt(task, System.currentTimeMillis());
     EasyMock.expect(conf.getTimeInMillis(Property.TSERV_ASSIGNMENT_DURATION_WARNING)).andReturn(0l);
 
-    assignments.put(new KeyExtent(new Text("1"), null, null), run);
+    assignments.put(new KeyExtent("1", null, null), run);
 
     EasyMock.expect(task.getException()).andReturn(new Exception("Assignment warning happened"));
     timer.schedule(watcher, 5000l);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -70,7 +70,7 @@ public class CheckTabletMetadataTest {
   @Test
   public void testBadTabletMetadata() throws Exception {
 
-    KeyExtent ke = new KeyExtent(new Text("1"), null, null);
+    KeyExtent ke = new KeyExtent("1", null, null);
 
     TreeMap<Key,Value> tabletMeta = new TreeMap<Key,Value>();
 
@@ -89,9 +89,9 @@ public class CheckTabletMetadataTest {
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 4));
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 5));
 
-    assertFail(tabletMeta, new KeyExtent(new Text("1"), null, new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent("1", null, new Text("m")), tsi);
 
-    assertFail(tabletMeta, new KeyExtent(new Text("1"), new Text("r"), new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent("1", new Text("r"), new Text("m")), tsi);
 
     assertFail(tabletMeta, ke, tsi, nk("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -59,6 +59,7 @@ public class DefaultCompactionStrategyTest {
   }
 
   static final Map<String,Pair<Key,Key>> fakeFiles = new HashMap<String,Pair<Key,Key>>();
+
   static {
     fakeFiles.put("file1", keys("b", "m"));
     fakeFiles.put("file2", keys("n", "z"));
@@ -151,7 +152,7 @@ public class DefaultCompactionStrategyTest {
   }
 
   private MajorCompactionRequest createRequest(MajorCompactionReason reason, Object... objs) throws IOException {
-    return createRequest(new KeyExtent(new Text("0"), null, null), reason, objs);
+    return createRequest(new KeyExtent("0", null, null), reason, objs);
   }
 
   private MajorCompactionRequest createRequest(KeyExtent extent, MajorCompactionReason reason, Object... objs) throws IOException {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.server.fs.FileRef;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public class SizeLimitCompactionStrategyTest {
 
     slcs.init(opts);
 
-    KeyExtent ke = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke = new KeyExtent("0", null, null);
     MajorCompactionRequest mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, AccumuloConfiguration.getDefaultConfiguration());
 
     mcr.setFiles(nfl("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G"));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -55,7 +55,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class SortedLogRecoveryTest {
 
-  static final KeyExtent extent = new KeyExtent(new Text("table"), null, null);
+  static final KeyExtent extent = new KeyExtent("table", null, null);
   static final Text cf = new Text("cf");
   static final Text cq = new Text("cq");
   static final Value value = new Value("value".getBytes());

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -80,7 +80,7 @@ public class LogFileTest {
     assertEquals(key.seq, 3);
     assertEquals(key.tid, 4);
     assertEquals(key.filename, "some file");
-    KeyExtent tablet = new KeyExtent(new Text("table"), new Text("bbbb"), new Text("aaaa"));
+    KeyExtent tablet = new KeyExtent("table", new Text("bbbb"), new Text("aaaa"));
     readWrite(DEFINE_TABLET, 5, 6, null, tablet, null, key, value);
     assertEquals(key.event, DEFINE_TABLET);
     assertEquals(key.seq, 5);

--- a/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
@@ -101,7 +101,7 @@ public class QueryMetadataTable {
     Connector connector = opts.getConnector();
     Scanner scanner = connector.createScanner(MetadataTable.NAME, opts.auths);
     scanner.setBatchSize(scanOpts.scanBatchSize);
-    Text mdrow = new Text(KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), null));
+    Text mdrow = new Text(KeyExtent.getMetadataEntry(MetadataTable.ID, null));
 
     HashSet<Text> rowSet = new HashSet<Text>();
 

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -45,8 +45,8 @@ public class WrongTabletTest {
 
       Mutation mutation = new Mutation(new Text("row_0003750001"));
       mutation.putDelete(new Text("colf"), new Text("colq"));
-      client.update(Tracer.traceInfo(), new Credentials(opts.principal, opts.getToken()).toThrift(opts.getInstance()), new KeyExtent(new Text("!!"), null,
-          new Text("row_0003750000")).toThrift(), mutation.toThrift());
+      client.update(Tracer.traceInfo(), new Credentials(opts.principal, opts.getToken()).toThrift(opts.getInstance()), new KeyExtent("!!", null, new Text(
+          "row_0003750000")).toThrift(), mutation.toThrift());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousStatsCollector.java
+++ b/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousStatsCollector.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.trace.instrument.Tracer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.ClusterStatus;
 import org.apache.hadoop.mapred.JobClient;
 
@@ -94,7 +93,7 @@ public class ContinuousStatsCollector {
       scanner.setBatchSize(scanBatchSize);
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       scanner.addScanIterator(new IteratorSetting(1000, "cfc", ColumnFamilyCounter.class.getName()));
-      scanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+      scanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
       Stat s = new Stat();
 

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
@@ -71,7 +71,7 @@ public class MetadataBatchScanTest {
       splits.add((r.nextLong() & 0x7fffffffffffffffl) % 1000000000000l);
     }
 
-    Text tid = new Text("8");
+    String tid = "8";
     Text per = null;
 
     ArrayList<KeyExtent> extents = new ArrayList<KeyExtent>();

--- a/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
@@ -70,7 +70,6 @@ import org.apache.accumulo.server.security.SystemCredentials;
 import org.apache.accumulo.server.util.TServerUtils;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher;
 import org.apache.accumulo.trace.thrift.TInfo;
-import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 
 import com.beust.jcommander.Parameter;
@@ -253,7 +252,7 @@ public class NullTserver {
     String tableId = Tables.getTableId(zki, opts.tableName);
 
     // read the locations for the table
-    Range tableRange = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+    Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();
     MetaDataTableScanner s = new MetaDataTableScanner(zki, SystemCredentials.get(), tableRange);
     long randomSessionID = opts.port;
     TServerInstance instance = new TServerInstance(addr, randomSessionID);

--- a/test/src/test/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
@@ -131,7 +131,7 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacIT {
     waitForCleanStore(store);
     // now jam up the metadata table
     bw = c.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
-    assignment = new Mutation(new KeyExtent(new Text(MetadataTable.ID), null, null).getMetadataEntry());
+    assignment = new Mutation(new KeyExtent(MetadataTable.ID, null, null).getMetadataEntry());
     assignment.put(CurrentLocationColumnFamily.NAME, moved.current.asColumnQualifier(), moved.current.asMutationValue());
     bw.addMutation(assignment);
     bw.close();

--- a/test/src/test/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.tabletserver.thrift.ConstraintViolationException;
 import org.apache.accumulo.harness.AccumuloClusterIT;
 import org.apache.accumulo.server.util.MetadataTableUtil;
-import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class MetaConstraintRetryIT extends AccumuloClusterIT {
@@ -44,7 +43,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterIT {
 
     Credentials credentials = new Credentials(getPrincipal(), getToken());
     Writer w = new Writer(super.getConnector().getInstance(), credentials, MetadataTable.ID);
-    KeyExtent extent = new KeyExtent(new Text("5"), null, null);
+    KeyExtent extent = new KeyExtent("5", null, null);
 
     Mutation m = new Mutation(extent.getMetadataEntry());
     // unknown columns should cause contraint violation

--- a/test/src/test/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -136,7 +136,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacIT {
 
     log.info("{} is offline", tableName);
 
-    Text row = MetadataSchema.TabletsSection.getRow(new Text(tableId), null);
+    Text row = MetadataSchema.TabletsSection.getRow(tableId, null);
     Mutation m = new Mutation(row);
     m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 
@@ -195,7 +195,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacIT {
 
     log.info("{} is offline", tableName);
 
-    Text row = MetadataSchema.TabletsSection.getRow(new Text(tableId), null);
+    Text row = MetadataSchema.TabletsSection.getRow(tableId, null);
     Mutation m = new Mutation(row);
     m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 

--- a/test/src/test/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -86,7 +86,7 @@ public class SplitRecoveryIT extends AccumuloClusterIT {
       connector.securityOperations().grantTablePermission("root", MetadataTable.NAME, TablePermission.WRITE);
       String tableId = connector.tableOperations().tableIdMap().get(tableName);
 
-      KeyExtent extent = new KeyExtent(new Text(tableId), null, new Text("b"));
+      KeyExtent extent = new KeyExtent(tableId, null, new Text("b"));
       Mutation m = extent.getPrevRowUpdateMutation();
 
       TabletsSection.TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m, new Value(Double.toString(0.5).getBytes()));
@@ -102,7 +102,7 @@ public class SplitRecoveryIT extends AccumuloClusterIT {
         scanner.setRange(extent.toMetadataRange());
         scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
 
-        KeyExtent extent2 = new KeyExtent(new Text(tableId), new Text("b"), null);
+        KeyExtent extent2 = new KeyExtent(tableId, new Text("b"), null);
         m = extent2.getPrevRowUpdateMutation();
         TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("/t2".getBytes()));
         TabletsSection.ServerColumnFamily.TIME_COLUMN.put(m, new Value("M0".getBytes()));

--- a/test/src/test/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/VolumeIT.java
@@ -224,7 +224,7 @@ public class VolumeIT extends ConfigurableMacIT {
 
     Scanner metaScanner = connector.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
-    metaScanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
     BatchWriter mbw = connector.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
 
@@ -402,7 +402,7 @@ public class VolumeIT extends ConfigurableMacIT {
     Scanner metaScanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(metaScanner);
     metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
-    metaScanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
     int counts[] = new int[paths.length];
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterIT;
 import org.apache.accumulo.server.master.state.MetaDataTableScanner;
 import org.apache.accumulo.server.master.state.TabletLocationState;
-import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class MasterAssignmentIT extends AccumuloClusterIT {
@@ -87,7 +86,7 @@ public class MasterAssignmentIT extends AccumuloClusterIT {
 
   private TabletLocationState getTabletLocationState(Connector c, String tableId) {
     Credentials creds = new Credentials(getPrincipal(), getToken());
-    MetaDataTableScanner s = new MetaDataTableScanner(c.getInstance(), creds, new Range(KeyExtent.getMetadataEntry(new Text(tableId), null)));
+    MetaDataTableScanner s = new MetaDataTableScanner(c.getInstance(), creds, new Range(KeyExtent.getMetadataEntry(tableId, null)));
     TabletLocationState tlState = s.next();
     s.close();
     return tlState;

--- a/test/src/test/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -46,7 +46,6 @@ import org.apache.accumulo.server.util.CheckForMetadataProblems;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.Text;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -140,7 +139,7 @@ public class SplitIT extends AccumuloClusterIT {
     }
     String id = c.tableOperations().tableIdMap().get(table);
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    KeyExtent extent = new KeyExtent(new Text(id), null, null);
+    KeyExtent extent = new KeyExtent(id, null, null);
     s.setRange(extent.toMetadataRange());
     MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
     int count = 0;

--- a/test/src/test/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -74,7 +74,7 @@ public class SplitRecoveryIT extends ConfigurableMacIT {
   }
 
   private KeyExtent nke(String table, String endRow, String prevEndRow) {
-    return new KeyExtent(new Text(table), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(table, endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   private void run() throws Exception {

--- a/test/src/test/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/TableIT.java
@@ -39,7 +39,6 @@ import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Test;
@@ -72,7 +71,7 @@ public class TableIT extends AccumuloClusterIT {
     VerifyIngest.verifyIngest(c, vopts, new ScannerOpts());
     String id = to.tableIdMap().get(tableName);
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    s.setRange(new KeyExtent(new Text(id), null, null).toMetadataRange());
+    s.setRange(new KeyExtent(id, null, null).toMetadataRange());
     s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
     assertTrue(FunctionalTestUtils.count(s) > 0);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -51,7 +51,6 @@ import org.apache.accumulo.server.master.state.MetaDataTableScanner;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletStateChangeIterator;
 import org.apache.accumulo.server.zookeeper.ZooLock;
-import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 import com.google.common.base.Predicate;
@@ -101,7 +100,7 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterIT {
   private void removeLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
     String tableIdToModify = getConnector().tableOperations().tableIdMap().get(tableNameToModify);
     BatchDeleter deleter = getConnector().createBatchDeleter(table, Authorizations.EMPTY, 1, new BatchWriterConfig());
-    deleter.setRanges(Collections.singleton(new KeyExtent(new Text(tableIdToModify), null, null).toMetadataRange()));
+    deleter.setRanges(Collections.singleton(new KeyExtent(tableIdToModify, null, null).toMetadataRange()));
     deleter.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
     deleter.delete();
     deleter.close();


### PR DESCRIPTION
Best effort attempt to eliminate Text wrapping of tableIDs for 1.6 branch, to example the extent of the changes.
Preserves KeyExtent caching with WeakHashMap (might not be needed, or possibly could be replaced with String.intern()).
Preserves Text serialization/deserialization of tableIDs in KeyExtent serialization/deserialization (needed for backwards compatibility and KeyExtents serialized in WALs).