### PR TITLE
ACCUMULO-4145 Eliminate Text wrapping of tableIDs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveCompactionImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveCompactionImpl.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.data.impl.TabletIdImpl;
 import org.apache.accumulo.core.data.thrift.IterInfo;
+import org.apache.hadoop.io.Text;
 
 /**
  *
@@ -52,7 +53,7 @@ public class ActiveCompactionImpl extends ActiveCompaction {
   @Deprecated
   public org.apache.accumulo.core.data.KeyExtent getExtent() {
     KeyExtent ke = new KeyExtent(tac.getExtent());
-    org.apache.accumulo.core.data.KeyExtent oke = new org.apache.accumulo.core.data.KeyExtent(ke.getTableId(), ke.getEndRow(), ke.getPrevEndRow());
+    org.apache.accumulo.core.data.KeyExtent oke = new org.apache.accumulo.core.data.KeyExtent(new Text(ke.getTableId()), ke.getEndRow(), ke.getPrevEndRow());
     return oke;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveScanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveScanImpl.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.data.impl.TabletIdImpl;
 import org.apache.accumulo.core.data.thrift.IterInfo;
 import org.apache.accumulo.core.data.thrift.TColumn;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.hadoop.io.Text;
 
 /**
  * A class that contains information about an ActiveScan
@@ -121,7 +122,7 @@ public class ActiveScanImpl extends ActiveScan {
   @Override
   @Deprecated
   public org.apache.accumulo.core.data.KeyExtent getExtent() {
-    return new org.apache.accumulo.core.data.KeyExtent(extent.getTableId(), extent.getEndRow(), extent.getPrevEndRow());
+    return new org.apache.accumulo.core.data.KeyExtent(new Text(extent.getTableId()), extent.getEndRow(), extent.getPrevEndRow());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
@@ -388,7 +388,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     this.auths = config.getAuthorizations();
     this.ve = new VisibilityEvaluator(config.getAuthorizations());
     this.threadPool = new ScheduledThreadPoolExecutor(config.getMaxWriteThreads(), new NamingThreadFactory(this.getClass().getSimpleName()));
-    this.locator = TabletLocator.getLocator(context, new Text(tableId));
+    this.locator = TabletLocator.getLocator(context, tableId);
     this.serverQueues = new HashMap<String,ServerQueue>();
     this.tableId = tableId;
     this.timeout = config.getTimeout(TimeUnit.MILLISECONDS);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -221,7 +221,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       else
         startRow = new Text();
 
-      nextRange = new Range(new KeyExtent(new Text(tableId), startRow, null).getMetadataEntry(), true, null, false);
+      nextRange = new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
     } else {
 
       if (currentExtent.getEndRow() == null) {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationOperationsImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client.impl;
 
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
@@ -50,8 +51,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 
 public class ReplicationOperationsImpl implements ReplicationOperations {
   private static final Logger log = LoggerFactory.getLogger(ReplicationOperationsImpl.class);
@@ -168,7 +167,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
     try {
       Text buffer = new Text();
       for (Entry<Key,Value> entry : metaBs) {
-        ReplicationSection.getTableId(entry.getKey(), buffer);
+        ReplicationSection.getTableId(entry.getKey());
         if (buffer.equals(tableId)) {
           ReplicationSection.getFile(entry.getKey(), buffer);
           wals.add(buffer.toString());

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerImpl.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.hadoop.io.Text;
 
 /**
  * provides scanner functionality
@@ -47,7 +46,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
 
   private final ClientContext context;
   private Authorizations authorizations;
-  private Text table;
+  private String table;
 
   private int size;
 
@@ -60,7 +59,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
     checkArgument(table != null, "table is null");
     checkArgument(authorizations != null, "authorizations is null");
     this.context = context;
-    this.table = new Text(table);
+    this.table = table;
     this.range = new Range((Key) null, (Key) null);
     this.authorizations = authorizations;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.NamingThreadFactory;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,6 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
   private static final Logger log = LoggerFactory.getLogger(ScannerIterator.class);
 
   // scanner options
-  private Text tableId;
   private int timeOut;
 
   // scanner state
@@ -106,9 +104,8 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
 
   }
 
-  ScannerIterator(ClientContext context, Text table, Authorizations authorizations, Range range, int size, int timeOut, ScannerOptions options,
+  ScannerIterator(ClientContext context, String tableId, Authorizations authorizations, Range range, int size, int timeOut, ScannerOptions options,
       boolean isolated, long readaheadThreshold) {
-    this.tableId = new Text(table);
     this.timeOut = timeOut;
     this.readaheadThreshold = readaheadThreshold;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -442,7 +442,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   private void addSplits(String tableName, SortedSet<Text> partitionKeys, String tableId) throws AccumuloException, AccumuloSecurityException,
       TableNotFoundException, AccumuloServerException {
-    TabletLocator tabLocator = TabletLocator.getLocator(context, new Text(tableId));
+    TabletLocator tabLocator = TabletLocator.getLocator(context, tableId);
 
     for (Text split : partitionKeys) {
       boolean successful = false;
@@ -984,7 +984,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     Random random = new Random();
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<String,Map<KeyExtent,List<Range>>>();
     String tableId = Tables.getTableId(context.getInstance(), tableName);
-    TabletLocator tl = TabletLocator.getLocator(context, new Text(tableId));
+    TabletLocator tl = TabletLocator.getLocator(context, tableId);
     // its possible that the cache could contain complete, but old information about a tables tablets... so clear it
     tl.invalidateCache();
     while (!tl.binRanges(context, Collections.singletonList(range), binnedRanges).isEmpty()) {
@@ -1106,9 +1106,9 @@ public class TableOperationsImpl extends TableOperationsHelper {
         }
       }
 
-      Range range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, null).toMetadataRange();
       if (startRow == null || lastRow == null)
-        range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+        range = new KeyExtent(tableId, null, null).toMetadataRange();
       else
         range = new Range(startRow, lastRow);
 
@@ -1264,7 +1264,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
   @Override
   public void clearLocatorCache(String tableName) throws TableNotFoundException {
     checkArgument(tableName != null, "tableName is null");
-    TabletLocator tabLocator = TabletLocator.getLocator(context, new Text(Tables.getTableId(context.getInstance(), tableName)));
+    TabletLocator tabLocator = TabletLocator.getLocator(context, Tables.getTableId(context.getInstance(), tableName));
     tabLocator.invalidateCache();
   }
 
@@ -1590,7 +1590,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     requireNonNull(ranges, "ranges must be non null");
 
     String tableId = Tables.getTableId(context.getInstance(), tableName);
-    TabletLocator locator = TabletLocator.getLocator(context, new Text(tableId));
+    TabletLocator locator = TabletLocator.getLocator(context, tableId);
 
     List<Range> rangeList = null;
     if (ranges instanceof List) {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocator.java
@@ -65,9 +65,9 @@ public abstract class TabletLocator {
 
   private static class LocatorKey {
     String instanceId;
-    Text tableName;
+    String tableName;
 
-    LocatorKey(String instanceId, Text table) {
+    LocatorKey(String instanceId, String table) {
       this.instanceId = instanceId;
       this.tableName = table;
     }
@@ -96,19 +96,19 @@ public abstract class TabletLocator {
     locators.clear();
   }
 
-  public static synchronized TabletLocator getLocator(ClientContext context, Text tableId) {
+  public static synchronized TabletLocator getLocator(ClientContext context, String tableId) {
     Instance instance = context.getInstance();
     LocatorKey key = new LocatorKey(instance.getInstanceID(), tableId);
     TabletLocator tl = locators.get(key);
     if (tl == null) {
       MetadataLocationObtainer mlo = new MetadataLocationObtainer();
 
-      if (tableId.toString().equals(RootTable.ID)) {
+      if (RootTable.ID.equals(tableId)) {
         tl = new RootTabletLocator(new ZookeeperLockChecker(instance));
-      } else if (tableId.toString().equals(MetadataTable.ID)) {
-        tl = new TabletLocatorImpl(new Text(MetadataTable.ID), getLocator(context, new Text(RootTable.ID)), mlo, new ZookeeperLockChecker(instance));
+      } else if (MetadataTable.ID.equals(tableId)) {
+        tl = new TabletLocatorImpl(MetadataTable.ID, getLocator(context, RootTable.ID), mlo, new ZookeeperLockChecker(instance));
       } else {
-        tl = new TabletLocatorImpl(tableId, getLocator(context, new Text(MetadataTable.ID)), mlo, new ZookeeperLockChecker(instance));
+        tl = new TabletLocatorImpl(tableId, getLocator(context, MetadataTable.ID), mlo, new ZookeeperLockChecker(instance));
       }
       locators.put(key, tl);
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocatorImpl.java
@@ -88,7 +88,7 @@ public class TabletLocatorImpl extends TabletLocator {
 
   static final EndRowComparator endRowComparator = new EndRowComparator();
 
-  protected Text tableId;
+  protected String tableId;
   protected TabletLocator parent;
   protected TreeMap<Text,TabletLocation> metaCache = new TreeMap<Text,TabletLocation>(endRowComparator);
   protected TabletLocationObtainer locationObtainer;
@@ -152,8 +152,8 @@ public class TabletLocatorImpl extends TabletLocator {
     }
   }
 
-  public TabletLocatorImpl(Text table, TabletLocator parent, TabletLocationObtainer tlo, TabletServerLockChecker tslc) {
-    this.tableId = table;
+  public TabletLocatorImpl(String tableId, TabletLocator parent, TabletLocationObtainer tlo, TabletServerLockChecker tslc) {
+    this.tableId = tableId;
     this.parent = parent;
     this.locationObtainer = tlo;
     this.lockChecker = tslc;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
@@ -65,7 +65,6 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.OpTimer;
-import org.apache.hadoop.io.Text;
 import org.apache.htrace.wrappers.TraceRunnable;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
@@ -120,7 +119,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     this.options = new ScannerOptions(scannerOptions);
     resultsQueue = new ArrayBlockingQueue<List<Entry<Key,Value>>>(numThreads);
 
-    this.locator = new TimeoutTabletLocator(TabletLocator.getLocator(context, new Text(table)), timeout);
+    this.locator = new TimeoutTabletLocator(TabletLocator.getLocator(context, table), timeout);
 
     timeoutTrackers = Collections.synchronizedMap(new HashMap<String,TabletServerBatchReaderIterator.TimeoutTracker>());
     timedoutServers = Collections.synchronizedSet(new HashSet<String>());

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -136,7 +136,7 @@ public class ThriftScanner {
   public static class ScanState {
 
     boolean isolated;
-    Text tableId;
+    String tableId;
     Text startRow;
     boolean skipStartRow;
     long readaheadThreshold;
@@ -163,7 +163,7 @@ public class ThriftScanner {
 
     SamplerConfiguration samplerConfig;
 
-    public ScanState(ClientContext context, Text tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns, int size,
+    public ScanState(ClientContext context, String tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns, int size,
         List<IterInfo> serverSideIteratorList, Map<String,Map<String,String>> serverSideIteratorOptions, boolean isolated, long readaheadThreshold,
         SamplerConfiguration samplerConfig, long batchTimeOut, String classLoaderContext) {
       this.context = context;
@@ -442,7 +442,7 @@ public class ThriftScanner {
           client.closeScan(tinfo, is.scanID);
 
       } else {
-        // log.debug("Calling continue scan : "+scanState.range+"  loc = "+loc);
+        // log.debug("Calling continue scan : "+scanState.range+" loc = "+loc);
         String msg = "Continuing scan tserver=" + loc.tablet_location + " scanid=" + scanState.scanID;
         Thread.currentThread().setName(msg);
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.concurrent.TimeUnit;
@@ -41,24 +42,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.net.HostAndPort;
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 
 public class Writer {
 
   private static final Logger log = LoggerFactory.getLogger(Writer.class);
 
   private ClientContext context;
-  private Text table;
+  private String table;
 
-  public Writer(ClientContext context, Text table) {
+  public Writer(ClientContext context, String table) {
     checkArgument(context != null, "context is null");
     checkArgument(table != null, "table is null");
     this.context = context;
     this.table = table;
-  }
-
-  public Writer(ClientContext context, String table) {
-    this(context, new Text(table));
   }
 
   private static void updateServer(ClientContext context, Mutation m, KeyExtent extent, HostAndPort server) throws TException, NotServingTabletException,

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
@@ -683,7 +683,7 @@ public class InputConfigurator extends ConfiguratorBase {
     ClientConfiguration clientConf = getClientConfiguration(implementingClass, conf);
     ClientContext context = new ClientContext(instance,
         new Credentials(getPrincipal(implementingClass, conf), getAuthenticationToken(implementingClass, conf)), clientConf);
-    return TabletLocator.getLocator(context, new Text(tableId));
+    return TabletLocator.getLocator(context, tableId);
   }
 
   /**
@@ -869,7 +869,7 @@ public class InputConfigurator extends ConfiguratorBase {
       else
         startRow = new Text();
 
-      Range metadataRange = new Range(new KeyExtent(new Text(tableId), startRow, null).getMetadataEntry(), true, null, false);
+      Range metadataRange = new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
       Scanner scanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
       MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       scanner.fetchColumnFamily(MetadataSchema.TabletsSection.LastLocationColumnFamily.NAME);

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
@@ -57,7 +57,7 @@ public class MockTabletLocator extends TabletLocator {
   @Override
   public List<Range> binRanges(ClientContext context, List<Range> ranges, Map<String,Map<KeyExtent,List<Range>>> binnedRanges) throws AccumuloException,
       AccumuloSecurityException, TableNotFoundException {
-    binnedRanges.put("", Collections.singletonMap(new KeyExtent(new Text(), null, null), ranges));
+    binnedRanges.put("", Collections.singletonMap(new KeyExtent("", null, null), ranges));
     return Collections.emptyList();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyExtent.java
@@ -51,11 +51,11 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public KeyExtent(Text table, Text endRow, Text prevEndRow) {
-    this.wrapped = new org.apache.accumulo.core.data.impl.KeyExtent(table, endRow, prevEndRow);
+    this.wrapped = new org.apache.accumulo.core.data.impl.KeyExtent(table.toString(), endRow, prevEndRow);
   }
 
   public KeyExtent(KeyExtent extent) {
-    this.wrapped = new org.apache.accumulo.core.data.impl.KeyExtent(extent.getTableId(), extent.getEndRow(), extent.getPrevEndRow());
+    this.wrapped = new org.apache.accumulo.core.data.impl.KeyExtent(extent.getTableId().toString(), extent.getEndRow(), extent.getPrevEndRow());
   }
 
   public KeyExtent(TKeyExtent tke) {
@@ -78,11 +78,11 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public void setTableId(Text tId) {
-    wrapped.setTableId(tId);
+    wrapped.setTableId(tId.toString());
   }
 
   public Text getTableId() {
-    return wrapped.getTableId();
+    return new Text(wrapped.getTableId());
   }
 
   public void setEndRow(Text endRow) {
@@ -189,7 +189,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   private static KeyExtent wrap(org.apache.accumulo.core.data.impl.KeyExtent ke) {
-    return new KeyExtent(ke.getTableId(), ke.getEndRow(), ke.getPrevEndRow());
+    return new KeyExtent(new Text(ke.getTableId()), ke.getEndRow(), ke.getPrevEndRow());
   }
 
   private static SortedSet<KeyExtent> wrap(Collection<org.apache.accumulo.core.data.impl.KeyExtent> unwrapped) {
@@ -202,7 +202,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public static Text getMetadataEntry(Text tableId, Text endRow) {
-    return MetadataSchema.TabletsSection.getRow(tableId, endRow);
+    return MetadataSchema.TabletsSection.getRow(tableId.toString(), endRow);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/impl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/impl/KeyExtent.java
@@ -16,12 +16,15 @@
  */
 package org.apache.accumulo.core.data.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,25 +58,24 @@ import org.apache.hadoop.io.WritableComparable;
 
 public class KeyExtent implements WritableComparable<KeyExtent> {
 
-  private static final WeakHashMap<Text,WeakReference<Text>> tableIds = new WeakHashMap<Text,WeakReference<Text>>();
+  private static final WeakHashMap<String,WeakReference<String>> tableIds = new WeakHashMap<>();
 
-  private static Text dedupeTableId(Text tableId) {
+  private static String dedupeTableId(String tableId) {
     synchronized (tableIds) {
-      WeakReference<Text> etir = tableIds.get(tableId);
+      WeakReference<String> etir = tableIds.get(tableId);
       if (etir != null) {
-        Text eti = etir.get();
+        String eti = etir.get();
         if (eti != null) {
           return eti;
         }
       }
 
-      tableId = new Text(tableId);
-      tableIds.put(tableId, new WeakReference<Text>(tableId));
+      tableIds.put(tableId, new WeakReference<>(tableId));
       return tableId;
     }
   }
 
-  private Text textTableId;
+  private String textTableId;
   private Text textEndRow;
   private Text textPrevEndRow;
 
@@ -95,12 +97,12 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    *
    */
   public KeyExtent() {
-    this.setTableId(new Text());
+    this.setTableId("");
     this.setEndRow(new Text(), false, false);
     this.setPrevEndRow(new Text(), false, false);
   }
 
-  public KeyExtent(Text table, Text endRow, Text prevEndRow) {
+  public KeyExtent(String table, Text endRow, Text prevEndRow) {
     this.setTableId(table);
     this.setEndRow(endRow, false, true);
     this.setPrevEndRow(prevEndRow, false, true);
@@ -118,7 +120,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public KeyExtent(TKeyExtent tke) {
-    this.setTableId(new Text(ByteBufferUtil.toBytes(tke.table)));
+    this.setTableId(dedupeTableId(new String(ByteBufferUtil.toBytes(tke.table), UTF_8)));
     this.setEndRow(tke.endRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.endRow)), false, false);
     this.setPrevEndRow(tke.prevEndRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.prevEndRow)), false, false);
 
@@ -133,7 +135,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     return getMetadataEntry(getTableId(), getEndRow());
   }
 
-  public static Text getMetadataEntry(Text tableId, Text endRow) {
+  public static Text getMetadataEntry(String tableId, Text endRow) {
     return MetadataSchema.TabletsSection.getRow(tableId, endRow);
   }
 
@@ -164,7 +166,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    * Sets the extents table id
    *
    */
-  public void setTableId(Text tId) {
+  public void setTableId(String tId) {
 
     if (tId == null)
       throw new IllegalArgumentException("null table name not allowed");
@@ -178,7 +180,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    * Returns the extent's table id
    *
    */
-  public Text getTableId() {
+  public String getTableId() {
     return textTableId;
   }
 
@@ -246,7 +248,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   public void readFields(DataInput in) throws IOException {
     Text tid = new Text();
     tid.readFields(in);
-    setTableId(tid);
+    setTableId(tid.toString());
     boolean hasRow = in.readBoolean();
     if (hasRow) {
       Text er = new Text();
@@ -270,7 +272,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
 
   @Override
   public void write(DataOutput out) throws IOException {
-    getTableId().write(out);
+    new Text(getTableId()).write(out);
     if (getEndRow() != null) {
       out.writeBoolean(true);
       getEndRow().write(out);
@@ -526,14 +528,12 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
         throw new IllegalArgumentException("< must come at end of Metadata row  " + flattenedExtent);
       }
 
-      Text tableId = new Text();
-      tableId.set(flattenedExtent.getBytes(), 0, flattenedExtent.getLength() - 1);
+      String tableId = new String(flattenedExtent.getBytes(), 0, flattenedExtent.getLength() - 1, UTF_8);
       this.setTableId(tableId);
       this.setEndRow(null, false, false);
     } else {
 
-      Text tableId = new Text();
-      tableId.set(flattenedExtent.getBytes(), 0, semiPos);
+      String tableId = new String(flattenedExtent.getBytes(), 0, semiPos, UTF_8);
 
       Text endRow = new Text();
       endRow.set(flattenedExtent.getBytes(), semiPos + 1, flattenedExtent.getLength() - (semiPos + 1));
@@ -547,7 +547,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   public static byte[] tableOfMetadataRow(Text row) {
     KeyExtent ke = new KeyExtent();
     ke.decodeMetadataRow(row);
-    return TextUtil.getBytes(ke.getTableId());
+    return ke.getTableId().getBytes(UTF_8);
   }
 
   public boolean contains(final ByteSequence bsrow) {
@@ -738,8 +738,8 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   }
 
   public TKeyExtent toThrift() {
-    return new TKeyExtent(TextUtil.getByteBuffer(textTableId), textEndRow == null ? null : TextUtil.getByteBuffer(textEndRow), textPrevEndRow == null ? null
-        : TextUtil.getByteBuffer(textPrevEndRow));
+    return new TKeyExtent(ByteBuffer.wrap(textTableId.getBytes(UTF_8)), textEndRow == null ? null : TextUtil.getByteBuffer(textEndRow),
+        textPrevEndRow == null ? null : TextUtil.getByteBuffer(textPrevEndRow));
   }
 
   public boolean isPreviousExtent(KeyExtent prevExtent) {

--- a/core/src/main/java/org/apache/accumulo/core/data/impl/TabletIdImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/impl/TabletIdImpl.java
@@ -53,7 +53,7 @@ public class TabletIdImpl implements TabletId {
 
   @Deprecated
   public TabletIdImpl(org.apache.accumulo.core.data.KeyExtent ke) {
-    this.ke = new KeyExtent(ke.getTableId(), ke.getEndRow(), ke.getPrevEndRow());
+    this.ke = new KeyExtent(ke.getTableId().toString(), ke.getEndRow(), ke.getPrevEndRow());
   }
 
   public TabletIdImpl(KeyExtent ke) {
@@ -67,7 +67,7 @@ public class TabletIdImpl implements TabletId {
 
   @Override
   public Text getTableId() {
-    return ke.getTableId();
+    return new Text(ke.getTableId());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.core.metadata;
 
 import org.apache.accumulo.core.client.impl.Namespaces;
 import org.apache.accumulo.core.data.impl.KeyExtent;
-import org.apache.hadoop.io.Text;
 
 /**
  *
@@ -44,7 +43,7 @@ public class RootTable {
   public static final String ZROOT_TABLET_CURRENT_LOGS = ZROOT_TABLET + "/current_logs";
   public static final String ZROOT_TABLET_PATH = ZROOT_TABLET + "/dir";
 
-  public static final KeyExtent EXTENT = new KeyExtent(new Text(ID), null, null);
-  public static final KeyExtent OLD_EXTENT = new KeyExtent(new Text(MetadataTable.ID), KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), null), null);
+  public static final KeyExtent EXTENT = new KeyExtent(ID, null, null);
+  public static final KeyExtent OLD_EXTENT = new KeyExtent(MetadataTable.ID, KeyExtent.getMetadataEntry(MetadataTable.ID, null), null);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -49,7 +49,7 @@ public class MetadataSchema {
       return new Range(new Key(tableId + ';'), true, new Key(tableId + '<').followingKey(PartialKey.ROW), false);
     }
 
-    public static Text getRow(Text tableId, Text endRow) {
+    public static Text getRow(String tableId, Text endRow) {
       Text entry = new Text(tableId);
 
       if (endRow == null) {
@@ -247,18 +247,14 @@ public class MetadataSchema {
     }
 
     /**
-     * Extract the table ID from the colfam into the given {@link Text}
+     * Extract the table ID from the colfam
      *
      * @param k
      *          Key to extract from
-     * @param buff
-     *          Text to place table ID into
      */
-    public static void getTableId(Key k, Text buff) {
+    public static String getTableId(Key k) {
       requireNonNull(k);
-      requireNonNull(buff);
-
-      k.getColumnQualifier(buff);
+      return k.getColumnQualifier().toString();
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationSchema.java
@@ -141,8 +141,8 @@ public class ReplicationSchema {
       scanner.fetchColumnFamily(NAME);
     }
 
-    public static Mutation add(Mutation m, Text tableId, Value v) {
-      m.put(NAME, tableId, v);
+    public static Mutation add(Mutation m, String tableId, Value v) {
+      m.put(NAME, new Text(tableId), v);
       return m;
     }
   }
@@ -234,8 +234,8 @@ public class ReplicationSchema {
      *          Serialized Status msg
      * @return The original Mutation
      */
-    public static Mutation add(Mutation m, Text tableId, Value v) {
-      m.put(NAME, tableId, v);
+    public static Mutation add(Mutation m, String tableId, Value v) {
+      m.put(NAME, new Text(tableId), v);
       return m;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -212,7 +212,7 @@ public class Merge {
     } catch (Exception e) {
       throw new MergeException(e);
     }
-    scanner.setRange(new KeyExtent(new Text(tableId), end, start).toMetadataRange());
+    scanner.setRange(new KeyExtent(tableId, end, start).toMetadataRange());
     scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
     final Iterator<Entry<Key,Value>> iterator = scanner.iterator();

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
@@ -27,7 +27,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
@@ -45,7 +44,7 @@ public class TableOperationsImplTest {
     Connector connector = EasyMock.createMock(Connector.class);
     Scanner scanner = EasyMock.createMock(Scanner.class);
 
-    Range range = new KeyExtent(new Text("1"), null, null).toMetadataRange();
+    Range range = new KeyExtent("1", null, null).toMetadataRange();
 
     String user = "root";
     PasswordToken token = new PasswordToken("password");

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
@@ -63,10 +63,10 @@ import org.junit.Test;
 public class TabletLocatorImplTest {
 
   private static final KeyExtent RTE = RootTable.EXTENT;
-  private static final KeyExtent MTE = new KeyExtent(new Text(MetadataTable.ID), null, RTE.getEndRow());
+  private static final KeyExtent MTE = new KeyExtent(MetadataTable.ID, null, RTE.getEndRow());
 
   static KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(new Text(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(t, er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   static Range nr(String k1, boolean si, String k2, boolean ei) {
@@ -143,8 +143,8 @@ public class TabletLocatorImplTest {
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
 
     RootTabletLocator rtl = new TestRootTabletLocator();
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Text(table), rootTabletCache, ttlo, tslc);
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(table, rootTabletCache, ttlo, tslc);
 
     setLocation(tservers, rootTabLoc, RTE, MTE, metaTabLoc);
 
@@ -692,8 +692,8 @@ public class TabletLocatorImplTest {
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
 
     RootTabletLocator rtl = new TestRootTabletLocator();
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Text("tab1"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl("tab1", rootTabletCache, ttlo, new YesLockChecker());
 
     locateTabletTest(tab1TabletCache, "r1", null, null);
 
@@ -770,8 +770,8 @@ public class TabletLocatorImplTest {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver3");
 
     // simulate the metadata table splitting
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), tab1e21.getMetadataEntry(), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), null, tab1e21.getMetadataEntry());
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, tab1e21.getMetadataEntry(), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, tab1e21.getMetadataEntry());
 
     setLocation(tservers, "tserver4", RTE, mte1, "tserver5");
     setLocation(tservers, "tserver4", RTE, mte2, "tserver6");
@@ -809,8 +809,8 @@ public class TabletLocatorImplTest {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver9");
 
     // simulate a hole in the metadata, caused by a partial split
-    KeyExtent mte11 = new KeyExtent(new Text(MetadataTable.ID), tab1e1.getMetadataEntry(), RTE.getEndRow());
-    KeyExtent mte12 = new KeyExtent(new Text(MetadataTable.ID), tab1e21.getMetadataEntry(), tab1e1.getMetadataEntry());
+    KeyExtent mte11 = new KeyExtent(MetadataTable.ID, tab1e1.getMetadataEntry(), RTE.getEndRow());
+    KeyExtent mte12 = new KeyExtent(MetadataTable.ID, tab1e21.getMetadataEntry(), tab1e1.getMetadataEntry());
     deleteServer(tservers, "tserver10");
     setLocation(tservers, "tserver4", RTE, mte12, "tserver10");
     setLocation(tservers, "tserver10", mte12, tab1e21, "tserver12");
@@ -1228,22 +1228,22 @@ public class TabletLocatorImplTest {
   @Test
   public void testBug1() throws Exception {
     // a bug that occurred while running continuous ingest
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), new Text("0;0bc"), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), null, new Text("0;0bc"));
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("0;0bc"), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, new Text("0;0bc"));
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
 
     RootTabletLocator rtl = new TestRootTabletLocator();
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Text("0"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("0", rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
 
     // create two tablets that straddle a metadata split point
-    KeyExtent ke1 = new KeyExtent(new Text("0"), new Text("0bbf20e"), null);
-    KeyExtent ke2 = new KeyExtent(new Text("0"), new Text("0bc0756"), new Text("0bbf20e"));
+    KeyExtent ke1 = new KeyExtent("0", new Text("0bbf20e"), null);
+    KeyExtent ke2 = new KeyExtent("0", new Text("0bc0756"), new Text("0bbf20e"));
 
     setLocation(tservers, "tserver2", mte1, ke1, "tserver4");
     setLocation(tservers, "tserver3", mte2, ke2, "tserver5");
@@ -1255,15 +1255,15 @@ public class TabletLocatorImplTest {
   @Test
   public void testBug2() throws Exception {
     // a bug that occurred while running a functional test
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), new Text("~"), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), null, new Text("~"));
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("~"), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, new Text("~"));
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
 
     RootTabletLocator rtl = new TestRootTabletLocator();
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Text("0"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("0", rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
@@ -1280,21 +1280,21 @@ public class TabletLocatorImplTest {
   // this test reproduces a problem where empty metadata tablets, that were created by user tablets being merged away, caused locating tablets to fail
   @Test
   public void testBug3() throws Exception {
-    KeyExtent mte1 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;c"), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;f"), new Text("1;c"));
-    KeyExtent mte3 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;j"), new Text("1;f"));
-    KeyExtent mte4 = new KeyExtent(new Text(MetadataTable.ID), new Text("1;r"), new Text("1;j"));
-    KeyExtent mte5 = new KeyExtent(new Text(MetadataTable.ID), null, new Text("1;r"));
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("1;c"), RTE.getEndRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, new Text("1;f"), new Text("1;c"));
+    KeyExtent mte3 = new KeyExtent(MetadataTable.ID, new Text("1;j"), new Text("1;f"));
+    KeyExtent mte4 = new KeyExtent(MetadataTable.ID, new Text("1;r"), new Text("1;j"));
+    KeyExtent mte5 = new KeyExtent(MetadataTable.ID, null, new Text("1;r"));
 
-    KeyExtent ke1 = new KeyExtent(new Text("1"), null, null);
+    KeyExtent ke1 = new KeyExtent("1", null, null);
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
 
     RootTabletLocator rtl = new TestRootTabletLocator();
 
-    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(new Text(MetadataTable.ID), rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Text("1"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("1", rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 
 public class KeyExtentTest {
   KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(new Text(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(t, er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   KeyExtent ke;
@@ -62,7 +62,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertEquals(new Text("bar"), ke.getEndRow());
-    assertEquals(new Text("foo"), ke.getTableId());
+    assertEquals("foo", ke.getTableId());
     assertNull(ke.getPrevEndRow());
 
     flattenedExtent = new Text("foo<");
@@ -70,7 +70,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertNull(ke.getEndRow());
-    assertEquals(new Text("foo"), ke.getTableId());
+    assertEquals("foo", ke.getTableId());
     assertNull(ke.getPrevEndRow());
 
     flattenedExtent = new Text("foo;bar;");
@@ -78,7 +78,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertEquals(new Text("bar;"), ke.getEndRow());
-    assertEquals(new Text("foo"), ke.getTableId());
+    assertEquals("foo", ke.getTableId());
     assertNull(ke.getPrevEndRow());
 
   }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -191,31 +191,30 @@ public class RangeTest extends TestCase {
 
   public void testMergeOverlapping22() {
 
-    Range ke1 = new KeyExtent(new Text("tab1"), new Text("Bank"), null).toMetadataRange();
-    Range ke2 = new KeyExtent(new Text("tab1"), new Text("Fails"), new Text("Bank")).toMetadataRange();
-    Range ke3 = new KeyExtent(new Text("tab1"), new Text("Sam"), new Text("Fails")).toMetadataRange();
-    Range ke4 = new KeyExtent(new Text("tab1"), new Text("bails"), new Text("Sam")).toMetadataRange();
-    Range ke5 = new KeyExtent(new Text("tab1"), null, new Text("bails")).toMetadataRange();
+    Range ke1 = new KeyExtent("tab1", new Text("Bank"), null).toMetadataRange();
+    Range ke2 = new KeyExtent("tab1", new Text("Fails"), new Text("Bank")).toMetadataRange();
+    Range ke3 = new KeyExtent("tab1", new Text("Sam"), new Text("Fails")).toMetadataRange();
+    Range ke4 = new KeyExtent("tab1", new Text("bails"), new Text("Sam")).toMetadataRange();
+    Range ke5 = new KeyExtent("tab1", null, new Text("bails")).toMetadataRange();
 
     List<Range> rl = nrl(ke1, ke2, ke3, ke4, ke5);
-    List<Range> expected = nrl(new KeyExtent(new Text("tab1"), null, null).toMetadataRange());
+    List<Range> expected = nrl(new KeyExtent("tab1", null, null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke1, ke2, ke4, ke5);
-    expected = nrl(new KeyExtent(new Text("tab1"), new Text("Fails"), null).toMetadataRange(),
-        new KeyExtent(new Text("tab1"), null, new Text("Sam")).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", new Text("Fails"), null).toMetadataRange(), new KeyExtent("tab1", null, new Text("Sam")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke2, ke3, ke4, ke5);
-    expected = nrl(new KeyExtent(new Text("tab1"), null, new Text("Bank")).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", null, new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke1, ke2, ke3, ke4);
-    expected = nrl(new KeyExtent(new Text("tab1"), new Text("bails"), null).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", new Text("bails"), null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = nrl(ke2, ke3, ke4);
-    expected = nrl(new KeyExtent(new Text("tab1"), new Text("bails"), new Text("Bank")).toMetadataRange());
+    expected = nrl(new KeyExtent("tab1", new Text("bails"), new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -2132,7 +2132,7 @@ public class RFileTest {
 
     // mfw.startDefaultLocalityGroup();
 
-    Text tableExtent = new Text(KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), MetadataSchema.TabletsSection.getRange().getEndKey().getRow()));
+    Text tableExtent = new Text(KeyExtent.getMetadataEntry(MetadataTable.ID, MetadataSchema.TabletsSection.getRange().getEndKey().getRow()));
 
     // table tablet's directory
     Key tableDirKey = new Key(tableExtent, TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
@@ -2150,7 +2150,7 @@ public class RFileTest {
     mfw.append(tablePrevRowKey, KeyExtent.encodePrevEndRow(null));
 
     // ----------] default tablet info
-    Text defaultExtent = new Text(KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), null));
+    Text defaultExtent = new Text(KeyExtent.getMetadataEntry(MetadataTable.ID, null));
 
     // default's directory
     Key defaultDirKey = new Key(defaultExtent, TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.system.MultiIteratorTest;
 import org.apache.accumulo.core.iterators.user.AgeOffFilter;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -139,7 +138,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -171,7 +170,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -207,7 +206,7 @@ public class IteratorUtilTest {
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".addIter", "2," + AddingIter.class.getName());
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".sqIter", "1," + SquaringIter.class.getName());
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -243,7 +242,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -279,7 +278,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Text("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
-
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -33,6 +31,8 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class MultiIteratorTest extends TestCase {
 
@@ -344,7 +344,7 @@ public class MultiIteratorTest extends TestCase {
     List<SortedKeyValueIterator<Key,Value>> skvil = new ArrayList<SortedKeyValueIterator<Key,Value>>(1);
     skvil.add(new SortedMapIterator(tm1));
 
-    KeyExtent extent = new KeyExtent(new Text("tablename"), nr(1), nr(0));
+    KeyExtent extent = new KeyExtent("tablename", nr(1), nr(0));
     MultiIterator mi = new MultiIterator(skvil, extent);
 
     Range r1 = new Range((Text) null, (Text) null);

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtilTest.java
@@ -46,39 +46,39 @@ public class ReplicationConfigurationUtilTest {
 
   @Test
   public void rootTableExtent() {
-    KeyExtent extent = new KeyExtent(new Text(RootTable.ID), null, null);
+    KeyExtent extent = new KeyExtent(RootTable.ID, null, null);
     Assert.assertFalse("The root table should never be replicated", ReplicationConfigurationUtil.isEnabled(extent, conf));
   }
 
   @Test
   public void metadataTableExtent() {
-    KeyExtent extent = new KeyExtent(new Text(MetadataTable.ID), null, null);
+    KeyExtent extent = new KeyExtent(MetadataTable.ID, null, null);
     Assert.assertFalse("The metadata table should never be replicated", ReplicationConfigurationUtil.isEnabled(extent, conf));
   }
 
   @Test
   public void rootTableExtentEmptyConf() {
-    KeyExtent extent = new KeyExtent(new Text(RootTable.ID), null, null);
+    KeyExtent extent = new KeyExtent(RootTable.ID, null, null);
     Assert.assertFalse("The root table should never be replicated",
         ReplicationConfigurationUtil.isEnabled(extent, new ConfigurationCopy(new HashMap<String,String>())));
   }
 
   @Test
   public void metadataTableExtentEmptyConf() {
-    KeyExtent extent = new KeyExtent(new Text(MetadataTable.ID), null, null);
+    KeyExtent extent = new KeyExtent(MetadataTable.ID, null, null);
     Assert.assertFalse("The metadata table should never be replicated",
         ReplicationConfigurationUtil.isEnabled(extent, new ConfigurationCopy(new HashMap<String,String>())));
   }
 
   @Test
   public void regularTable() {
-    KeyExtent extent = new KeyExtent(new Text("1"), new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent("1", new Text("b"), new Text("a"));
     Assert.assertTrue("Table should be replicated", ReplicationConfigurationUtil.isEnabled(extent, conf));
   }
 
   @Test
   public void regularNonEnabledTable() {
-    KeyExtent extent = new KeyExtent(new Text("1"), new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent("1", new Text("b"), new Text("a"));
     Assert.assertFalse("Table should not be replicated", ReplicationConfigurationUtil.isEnabled(extent, new ConfigurationCopy(new HashMap<String,String>())));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -43,7 +43,7 @@ public class MergeTest {
           end = null;
         else
           end = new Text(String.format("%05d", tablets.size()));
-        KeyExtent extent = new KeyExtent(new Text("table"), end, start);
+        KeyExtent extent = new KeyExtent("table", end, start);
         start = end;
         tablets.add(new Size(extent, size));
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -129,7 +129,7 @@ public class BulkImporter {
     final Map<Path,List<KeyExtent>> completeFailures = Collections.synchronizedSortedMap(new TreeMap<Path,List<KeyExtent>>());
 
     ClientService.Client client = null;
-    final TabletLocator locator = TabletLocator.getLocator(context, new Text(tableId));
+    final TabletLocator locator = TabletLocator.getLocator(context, tableId);
 
     try {
       final Map<Path,List<TabletLocation>> assignments = Collections.synchronizedSortedMap(new TreeMap<Path,List<TabletLocation>>());

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -477,7 +477,7 @@ public class Initialize implements KeywordExecutable {
 
   private static void createEntriesForTablet(TreeMap<Key,Value> map, Tablet tablet) {
     Value EMPTY_SIZE = new DataFileValue(0, 0).encodeAsValue();
-    Text extent = new Text(KeyExtent.getMetadataEntry(new Text(tablet.tableId), tablet.endRow));
+    Text extent = new Text(KeyExtent.getMetadataEntry(tablet.tableId, tablet.endRow));
     addEntry(map, extent, DIRECTORY_COLUMN, new Value(tablet.dir.getBytes(UTF_8)));
     addEntry(map, extent, TIME_COLUMN, new Value((TabletTime.LOGICAL_TIME_ID + "0").getBytes(UTF_8)));
     addEntry(map, extent, PREV_ROW_COLUMN, KeyExtent.encodePrevEndRow(tablet.prevEndRow));

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.core.util.Base64;
 import org.apache.accumulo.server.master.state.TabletLocationState.BadLocationStateException;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
 
   private Set<TServerInstance> current;
   private Set<String> onlineTables;
-  private Map<Text,MergeInfo> merges;
+  private Map<String,MergeInfo> merges;
   private boolean debug = false;
   private Set<KeyExtent> migrations;
   private MasterState masterState = MasterState.NORMAL;
@@ -133,11 +132,11 @@ public class TabletStateChangeIterator extends SkippingIterator {
     return result;
   }
 
-  private Map<Text,MergeInfo> parseMerges(String merges) {
+  private Map<String,MergeInfo> parseMerges(String merges) {
     if (merges == null)
       return null;
     try {
-      Map<Text,MergeInfo> result = new HashMap<Text,MergeInfo>();
+      Map<String,MergeInfo> result = new HashMap<String,MergeInfo>();
       DataInputBuffer buffer = new DataInputBuffer();
       byte[] data = Base64.decodeBase64(merges.getBytes(UTF_8));
       buffer.reset(data, data.length);

--- a/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.server.conf.ServerConfiguration;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +51,7 @@ public class LargestFirstMemoryManager implements MemoryManager {
   // The fraction of memory that needs to be used before we begin flushing.
   private double compactionThreshold;
   private long maxObserved;
-  private final HashMap<Text,Long> mincIdleThresholds = new HashMap<Text,Long>();
+  private final HashMap<String,Long> mincIdleThresholds = new HashMap<String,Long>();
   private ServerConfiguration config = null;
 
   private static class TabletInfo {
@@ -140,9 +139,9 @@ public class LargestFirstMemoryManager implements MemoryManager {
   }
 
   protected long getMinCIdleThreshold(KeyExtent extent) {
-    Text tableId = extent.getTableId();
+    String tableId = extent.getTableId();
     if (!mincIdleThresholds.containsKey(tableId))
-      mincIdleThresholds.put(tableId, config.getTableConfiguration(tableId.toString()).getTimeInMillis(Property.TABLE_MINC_COMPACT_IDLETIME));
+      mincIdleThresholds.put(tableId, config.getTableConfiguration(tableId).getTimeInMillis(Property.TABLE_MINC_COMPACT_IDLETIME));
     return mincIdleThresholds.get(tableId);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.master.state.TabletState;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.tables.TableManager;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +100,7 @@ public class FindOfflineTablets {
     Range range = MetadataSchema.TabletsSection.getRange();
     if (tableName != null) {
       String tableId = Tables.getTableId(context.getInstance(), tableName);
-      range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+      range = new KeyExtent(tableId, null, null).toMetadataRange();
     }
 
     MetaDataTableScanner metaScanner = new MetaDataTableScanner(context, range, MetadataTable.NAME);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -136,12 +136,12 @@ public class MasterMetadataUtil {
 
     Text metadataPrevEndRow = KeyExtent.decodePrevEndRow(prevEndRowIBW);
 
-    Text table = (new KeyExtent(metadataEntry, (Text) null)).getTableId();
+    String table = (new KeyExtent(metadataEntry, (Text) null)).getTableId();
 
     return fixSplit(context, table, metadataEntry, metadataPrevEndRow, oper, splitRatio, tserver, time.toString(), initFlushID, initCompactID, lock);
   }
 
-  private static KeyExtent fixSplit(ClientContext context, Text table, Text metadataEntry, Text metadataPrevEndRow, Value oper, double splitRatio,
+  private static KeyExtent fixSplit(ClientContext context, String table, Text metadataEntry, Text metadataPrevEndRow, Value oper, double splitRatio,
       TServerInstance tserver, String time, long initFlushID, long initCompactID, ZooLock lock) throws AccumuloException, IOException {
     if (metadataPrevEndRow == null)
       // something is wrong, this should not happen... if a tablet is split, it will always have a

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -352,7 +352,7 @@ public class MetadataTableUtil {
   }
 
   public static void addDeleteEntry(AccumuloServerContext context, String tableId, String path) throws IOException {
-    update(context, createDeleteMutation(tableId, path), new KeyExtent(new Text(tableId), null, null));
+    update(context, createDeleteMutation(tableId, path), new KeyExtent(tableId, null, null));
   }
 
   public static Mutation createDeleteMutation(String tableId, String pathToRemove) throws IOException {
@@ -371,7 +371,7 @@ public class MetadataTableUtil {
     update(context, zooLock, m, extent);
   }
 
-  public static void splitDatafiles(Text table, Text midRow, double splitRatio, Map<FileRef,FileUtil.FileInfo> firstAndLastRows,
+  public static void splitDatafiles(String tableId, Text midRow, double splitRatio, Map<FileRef,FileUtil.FileInfo> firstAndLastRows,
       SortedMap<FileRef,DataFileValue> datafiles, SortedMap<FileRef,DataFileValue> lowDatafileSizes, SortedMap<FileRef,DataFileValue> highDatafileSizes,
       List<FileRef> highDatafilesToRemove) {
 
@@ -416,13 +416,12 @@ public class MetadataTableUtil {
 
   public static void deleteTable(String tableId, boolean insertDeletes, ClientContext context, ZooLock lock) throws AccumuloException, IOException {
     Scanner ms = new ScannerImpl(context, MetadataTable.ID, Authorizations.EMPTY);
-    Text tableIdText = new Text(tableId);
     BatchWriter bw = new BatchWriterImpl(context, MetadataTable.ID, new BatchWriterConfig().setMaxMemory(1000000).setMaxLatency(120000l, TimeUnit.MILLISECONDS)
         .setMaxWriteThreads(2));
 
     // scan metadata for our table and delete everything we find
     Mutation m = null;
-    ms.setRange(new KeyExtent(tableIdText, null, null).toMetadataRange());
+    ms.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
     // insert deletes before deleting data from metadata... this makes the code fault tolerant
     if (insertDeletes) {
@@ -612,7 +611,7 @@ public class MetadataTableUtil {
 
     LogEntryIterator(ClientContext context) throws IOException, KeeperException, InterruptedException {
       zookeeperEntries = getLogEntries(context, RootTable.EXTENT).iterator();
-      rootTableEntries = getLogEntries(context, new KeyExtent(new Text(MetadataTable.ID), null, null)).iterator();
+      rootTableEntries = getLogEntries(context, new KeyExtent(MetadataTable.ID, null, null)).iterator();
       try {
         Scanner scanner = context.getConnector().createScanner(MetadataTable.NAME, Authorizations.EMPTY);
         log.info("Setting range to " + MetadataSchema.TabletsSection.getRange());
@@ -688,7 +687,7 @@ public class MetadataTableUtil {
   private static Mutation createCloneMutation(String srcTableId, String tableId, Map<Key,Value> tablet) {
 
     KeyExtent ke = new KeyExtent(tablet.keySet().iterator().next().getRow(), (Text) null);
-    Mutation m = new Mutation(KeyExtent.getMetadataEntry(new Text(tableId), ke.getEndRow()));
+    Mutation m = new Mutation(KeyExtent.getMetadataEntry(tableId, ke.getEndRow()));
 
     for (Entry<Key,Value> entry : tablet.entrySet()) {
       if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
@@ -709,7 +708,7 @@ public class MetadataTableUtil {
 
   private static Scanner createCloneScanner(String tableName, String tableId, Connector conn) throws TableNotFoundException {
     Scanner mscanner = new IsolatedScanner(conn.createScanner(tableName, Authorizations.EMPTY));
-    mscanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
     mscanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     mscanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
     mscanner.fetchColumnFamily(TabletsSection.LastLocationColumnFamily.NAME);
@@ -726,7 +725,7 @@ public class MetadataTableUtil {
     if (srcTableId.equals(MetadataTable.ID))
       ti = new TabletIterator(createCloneScanner(tableName, srcTableId, conn), new Range(), true, true);
     else
-      ti = new TabletIterator(createCloneScanner(tableName, srcTableId, conn), new KeyExtent(new Text(srcTableId), null, null).toMetadataRange(), true, true);
+      ti = new TabletIterator(createCloneScanner(tableName, srcTableId, conn), new KeyExtent(srcTableId, null, null).toMetadataRange(), true, true);
 
     if (!ti.hasNext())
       throw new RuntimeException(" table deleted during clone?  srcTableId = " + srcTableId);
@@ -738,16 +737,16 @@ public class MetadataTableUtil {
   }
 
   private static int compareEndRows(Text endRow1, Text endRow2) {
-    return new KeyExtent(new Text("0"), endRow1, null).compareTo(new KeyExtent(new Text("0"), endRow2, null));
+    return new KeyExtent("0", endRow1, null).compareTo(new KeyExtent("0", endRow2, null));
   }
 
   @VisibleForTesting
   public static int checkClone(String tableName, String srcTableId, String tableId, Connector conn, BatchWriter bw) throws TableNotFoundException,
       MutationsRejectedException {
-    TabletIterator srcIter = new TabletIterator(createCloneScanner(tableName, srcTableId, conn),
-        new KeyExtent(new Text(srcTableId), null, null).toMetadataRange(), true, true);
-    TabletIterator cloneIter = new TabletIterator(createCloneScanner(tableName, tableId, conn), new KeyExtent(new Text(tableId), null, null).toMetadataRange(),
-        true, true);
+    TabletIterator srcIter = new TabletIterator(createCloneScanner(tableName, srcTableId, conn), new KeyExtent(srcTableId, null, null).toMetadataRange(), true,
+        true);
+    TabletIterator cloneIter = new TabletIterator(createCloneScanner(tableName, tableId, conn), new KeyExtent(tableId, null, null).toMetadataRange(), true,
+        true);
 
     if (!cloneIter.hasNext() || !srcIter.hasNext())
       throw new RuntimeException(" table deleted during clone?  srcTableId = " + srcTableId + " tableId=" + tableId);
@@ -863,7 +862,7 @@ public class MetadataTableUtil {
 
     // delete the clone markers and create directory entries
     Scanner mscanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    mscanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
     mscanner.fetchColumnFamily(ClonedColumnFamily.NAME);
 
     int dirCount = 0;
@@ -891,7 +890,7 @@ public class MetadataTableUtil {
 
   public static void removeBulkLoadEntries(Connector conn, String tableId, long tid) throws Exception {
     Scanner mscanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-    mscanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
     mscanner.fetchColumnFamily(TabletsSection.BulkFileColumnFamily.NAME);
     BatchWriter bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     for (Entry<Key,Value> entry : mscanner) {
@@ -951,7 +950,7 @@ public class MetadataTableUtil {
 
     // new KeyExtent is only added to force update to write to the metadata table, not the root table
     // because bulk loads aren't supported to the metadata table
-    update(context, m, new KeyExtent(new Text("anythingNotMetadata"), null, null));
+    update(context, m, new KeyExtent("anythingNotMetadata", null, null));
   }
 
   public static void removeBulkLoadInProgressFlag(AccumuloServerContext context, String path) {
@@ -961,7 +960,7 @@ public class MetadataTableUtil {
 
     // new KeyExtent is only added to force update to write to the metadata table, not the root table
     // because bulk loads aren't supported to the metadata table
-    update(context, m, new KeyExtent(new Text("anythingNotMetadata"), null, null));
+    update(context, m, new KeyExtent("anythingNotMetadata", null, null));
   }
 
   /**
@@ -971,7 +970,7 @@ public class MetadataTableUtil {
     String dir = VolumeManagerImpl.get().choose(Optional.of(ReplicationTable.ID), ServerConstants.getBaseUris()) + Constants.HDFS_TABLES_DIR + Path.SEPARATOR
         + ReplicationTable.ID + Constants.DEFAULT_TABLET_LOCATION;
 
-    Mutation m = new Mutation(new Text(KeyExtent.getMetadataEntry(new Text(ReplicationTable.ID), null)));
+    Mutation m = new Mutation(new Text(KeyExtent.getMetadataEntry(ReplicationTable.ID, null)));
     m.put(DIRECTORY_COLUMN.getColumnFamily(), DIRECTORY_COLUMN.getColumnQualifier(), 0, new Value(dir.getBytes(UTF_8)));
     m.put(TIME_COLUMN.getColumnFamily(), TIME_COLUMN.getColumnQualifier(), 0, new Value((TabletTime.LOGICAL_TIME_ID + "0").getBytes(UTF_8)));
     m.put(PREV_ROW_COLUMN.getColumnFamily(), PREV_ROW_COLUMN.getColumnQualifier(), 0, KeyExtent.encodePrevEndRow(null));
@@ -1000,7 +999,7 @@ public class MetadataTableUtil {
 
   public static void moveMetaDeleteMarkersFrom14(ClientContext context) {
     // new KeyExtent is only added to force update to write to the metadata table, not the root table
-    KeyExtent notMetadata = new KeyExtent(new Text("anythingNotMetadata"), null, null);
+    KeyExtent notMetadata = new KeyExtent("anythingNotMetadata", null, null);
 
     // move delete markers from the normal delete keyspace to the root tablet delete keyspace if the files are for the !METADATA table
     Scanner scanner = new ScannerImpl(context, MetadataTable.ID, Authorizations.EMPTY);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -51,7 +51,6 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.commons.collections.map.LRUMap;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
 
@@ -199,7 +198,7 @@ public class RemoveEntriesForMissingFiles {
       return checkTable(context, RootTable.NAME, MetadataSchema.TabletsSection.getRange(), fix);
     } else {
       String tableId = Tables.getTableId(context.getInstance(), tableName);
-      Range range = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, null).toMetadataRange();
       return checkTable(context, MetadataTable.NAME, range, fix);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.server.util;
 
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -51,8 +53,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 
 /**
  * provides a reference to the replication table for updates by tablet servers
@@ -194,7 +194,7 @@ public class ReplicationTableUtil {
 
   private static Mutation createUpdateMutation(Text row, Value v, KeyExtent extent) {
     Mutation m = new Mutation(row);
-    m.put(MetadataSchema.ReplicationSection.COLF, extent.getTableId(), v);
+    m.put(MetadataSchema.ReplicationSection.COLF, new Text(extent.getTableId()), v);
     return m;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,7 +177,7 @@ public class TableDiskUsage {
         throw new RuntimeException(e);
       }
       mdScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      mdScanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+      mdScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
       if (!mdScanner.iterator().hasNext()) {
         emptyTableIds.add(tableId);

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -52,7 +52,8 @@ import org.junit.Test;
 public class BulkImporterTest {
 
   static final SortedSet<KeyExtent> fakeMetaData = new TreeSet<KeyExtent>();
-  static final Text tableId = new Text("1");
+  static final String tableId = "1";
+
   static {
     fakeMetaData.add(new KeyExtent(tableId, new Text("a"), null));
     for (String part : new String[] {"b", "bm", "c", "cm", "d", "dm", "e", "em", "f", "g", "h", "i", "j", "k", "l"}) {
@@ -161,19 +162,19 @@ public class BulkImporterTest {
     // a correct startRow so that findOverlappingTablets works as intended.
 
     // 1;2;1
-    KeyExtent extent = new KeyExtent(new Text("1"), new Text("2"), new Text("1"));
+    KeyExtent extent = new KeyExtent("1", new Text("2"), new Text("1"));
     Assert.assertEquals(new Text("1\0"), BulkImporter.getStartRowForExtent(extent));
 
     // 1;2<
-    extent = new KeyExtent(new Text("1"), new Text("2"), null);
+    extent = new KeyExtent("1", new Text("2"), null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1<<
-    extent = new KeyExtent(new Text("1"), null, null);
+    extent = new KeyExtent("1", null, null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1;8;7777777
-    extent = new KeyExtent(new Text("1"), new Text("8"), new Text("7777777"));
+    extent = new KeyExtent("1", new Text("8"), new Text("7777777"));
     Assert.assertEquals(new Text("7777777\0"), BulkImporter.getStartRowForExtent(extent));
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -154,7 +154,7 @@ public class ChaoticLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(new Text(table), toText(end), toText(prev));
+    return new KeyExtent(table, toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -169,7 +169,7 @@ public class DefaultLoadBalancerTest {
   public void testUnevenAssignment() {
     for (char c : "abcdefghijklmnopqrstuvwxyz".toCharArray()) {
       String cString = Character.toString(c);
-      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", (int) c);
+      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", c);
       String fakeInstance = cString;
       TServerInstance tsi = new TServerInstance(fakeAddress, fakeInstance);
       FakeTServer fakeTServer = new FakeTServer();
@@ -210,7 +210,7 @@ public class DefaultLoadBalancerTest {
     // make 26 servers
     for (char c : "abcdefghijklmnopqrstuvwxyz".toCharArray()) {
       String cString = Character.toString(c);
-      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", (int) c);
+      HostAndPort fakeAddress = HostAndPort.fromParts("127.0.0.1", c);
       String fakeInstance = cString;
       TServerInstance tsi = new TServerInstance(fakeAddress, fakeInstance);
       FakeTServer fakeTServer = new FakeTServer();
@@ -279,7 +279,7 @@ public class DefaultLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(new Text(table), toText(end), toText(prev));
+    return new KeyExtent(table, toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -67,7 +67,7 @@ public class GroupBalancerTest {
 
     public void addTablet(String er, String location) {
       TServerInstance tsi = new TServerInstance(location, 6);
-      tabletLocs.put(new KeyExtent(new Text("b"), er == null ? null : new Text(er), null), new TServerInstance(location, 6));
+      tabletLocs.put(new KeyExtent("b", er == null ? null : new Text(er), null), new TServerInstance(location, 6));
       tservers.add(tsi);
     }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -82,8 +82,8 @@ public class TableLoadBalancerTest {
     // generate some fake tablets
     for (int i = 0; i < tableInfo.tableMap.get(tableId).onlineTablets; i++) {
       TabletStats stats = new TabletStats();
-      stats.extent = new KeyExtent(new Text(tableId), new Text(tserver.host() + String.format("%03d", i + 1)), new Text(tserver.host()
-          + String.format("%03d", i))).toThrift();
+      stats.extent = new KeyExtent(tableId, new Text(tserver.host() + String.format("%03d", i + 1)), new Text(tserver.host() + String.format("%03d", i)))
+          .toThrift();
       result.add(stats);
     }
     return result;

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
@@ -68,7 +68,7 @@ public class MergeInfoTest {
 
   @Test
   public void testSerialization() throws Exception {
-    Text table = new Text("table");
+    String table = "table";
     Text endRow = new Text("end");
     Text prevEndRow = new Text("begin");
     keyExtent = new KeyExtent(table, endRow, prevEndRow);
@@ -88,10 +88,10 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_DifferentTables() {
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table2"));
+    expect(keyExtent2.getTableId()).andReturn("table2");
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.needsToBeChopped(keyExtent2));
@@ -99,9 +99,9 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_NotDelete() {
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent2.getTableId()).andReturn("table1");
     replay(keyExtent2);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(true);
     replay(keyExtent);
@@ -125,11 +125,11 @@ public class MergeInfoTest {
   }
 
   private void testNeedsToBeChopped_Delete(String prevEndRow, boolean expected) {
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent2.getTableId()).andReturn("table1");
     expect(keyExtent2.getPrevEndRow()).andReturn(prevEndRow != null ? new Text(prevEndRow) : null);
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -150,9 +150,9 @@ public class MergeInfoTest {
   public void testOverlaps_DoesNotNeedChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table2"));
+    expect(keyExtent2.getTableId()).andReturn("table2");
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.overlaps(keyExtent2));
@@ -162,10 +162,10 @@ public class MergeInfoTest {
   public void testOverlaps_NeedsChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent.getTableId()).andReturn("table1");
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(new Text("table1"));
+    expect(keyExtent2.getTableId()).andReturn("table1");
     expect(keyExtent2.getPrevEndRow()).andReturn(new Text("prev"));
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -187,7 +187,7 @@ public class MergeInfoTest {
   }
 
   private static KeyExtent ke(String tableId, String endRow, String prevEndRow) {
-    return new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(tableId, endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
@@ -91,7 +91,7 @@ public class ReplicationTableUtilTest {
     String myFile = "file:////home/user/accumulo/wal/server+port/" + uuid;
 
     long createdTime = System.currentTimeMillis();
-    ReplicationTableUtil.updateFiles(context, new KeyExtent(new Text("1"), null, null), myFile, StatusUtil.fileCreated(createdTime));
+    ReplicationTableUtil.updateFiles(context, new KeyExtent("1", null, null), myFile, StatusUtil.fileCreated(createdTime));
 
     verify(writer);
 
@@ -116,7 +116,7 @@ public class ReplicationTableUtilTest {
     String file = "file:///accumulo/wal/127.0.0.1+9997" + UUID.randomUUID();
     Path filePath = new Path(file);
     Text row = new Text(filePath.toString());
-    KeyExtent extent = new KeyExtent(new Text("1"), new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent("1", new Text("b"), new Text("a"));
 
     Mutation m = ReplicationTableUtil.createUpdateMutation(filePath, ProtobufUtil.toValue(stat), extent);
 
@@ -125,7 +125,7 @@ public class ReplicationTableUtilTest {
     ColumnUpdate col = m.getUpdates().get(0);
 
     Assert.assertEquals(MetadataSchema.ReplicationSection.COLF, new Text(col.getColumnFamily()));
-    Assert.assertEquals(extent.getTableId(), new Text(col.getColumnQualifier()));
+    Assert.assertEquals(extent.getTableId(), new Text(col.getColumnQualifier()).toString());
     Assert.assertEquals(0, col.getColumnVisibility().length);
     Assert.assertArrayEquals(stat.toByteArray(), col.getValue());
   }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -92,7 +92,7 @@ public class GarbageCollectionTest {
     }
 
     public Key newFileReferenceKey(String tableId, String endRow, String file) {
-      String row = new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.DataFileColumnFamily.NAME.toString();
       String cq = file;
       Key key = new Key(row, cf, cq);
@@ -110,7 +110,7 @@ public class GarbageCollectionTest {
     }
 
     Key newDirReferenceKey(String tableId, String endRow) {
-      String row = new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily().toString();
       String cq = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier().toString();
       Key key = new Key(row, cf, cq);

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -177,7 +177,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
           scanner.setRange(MetadataSchema.TabletsSection.getRange());
         } else {
           scanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-          Range range = new KeyExtent(new Text(tableId), null, ByteBufferUtil.toText(startRow)).toMetadataRange();
+          Range range = new KeyExtent(tableId, null, ByteBufferUtil.toText(startRow)).toMetadataRange();
           scanner.setRange(range.clip(MetadataSchema.TabletsSection.getRange()));
         }
         TabletsSection.ServerColumnFamily.FLUSH_COLUMN.fetch(scanner);

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -111,7 +111,7 @@ class TabletGroupWatcher extends Daemon {
     this.dependentWatcher = dependentWatcher;
   }
 
-  Map<Text,TableCounts> getStats() {
+  Map<String,TableCounts> getStats() {
     return stats.getLast();
   }
 
@@ -120,7 +120,7 @@ class TabletGroupWatcher extends Daemon {
     return masterState;
   }
 
-  TableCounts getStats(Text tableId) {
+  TableCounts getStats(String tableId) {
     return stats.getLast(tableId);
   }
 
@@ -142,8 +142,8 @@ class TabletGroupWatcher extends Daemon {
       int unloaded = 0;
       ClosableIterator<TabletLocationState> iter = null;
       try {
-        Map<Text,MergeStats> mergeStatsCache = new HashMap<Text,MergeStats>();
-        Map<Text,MergeStats> currentMerges = new HashMap<Text,MergeStats>();
+        Map<String,MergeStats> mergeStatsCache = new HashMap<String,MergeStats>();
+        Map<String,MergeStats> currentMerges = new HashMap<String,MergeStats>();
         for (MergeInfo merge : master.merges()) {
           if (merge.getExtent() != null) {
             currentMerges.put(merge.getExtent().getTableId(), new MergeStats(merge));
@@ -200,7 +200,7 @@ class TabletGroupWatcher extends Daemon {
             unloaded = 0;
             eventListener.waitForEvents(Master.TIME_TO_WAIT_BETWEEN_SCANS);
           }
-          Text tableId = tls.extent.getTableId();
+          String tableId = tls.extent.getTableId();
           MergeStats mergeStats = mergeStatsCache.get(tableId);
           if (mergeStats == null) {
             mergeStats = currentMerges.get(tableId);
@@ -478,7 +478,7 @@ class TabletGroupWatcher extends Daemon {
     }
   }
 
-  private void updateMergeState(Map<Text,MergeStats> mergeStatsCache) {
+  private void updateMergeState(Map<String,MergeStats> mergeStatsCache) {
     for (MergeStats stats : mergeStatsCache.values()) {
       try {
         MergeState update = stats.nextMergeState(this.master.getConnector(), this.master);

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/FinishedWorkUpdater.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/FinishedWorkUpdater.java
@@ -145,10 +145,10 @@ public class FinishedWorkUpdater implements Runnable {
           Value serializedUpdatedStatus = ProtobufUtil.toValue(updatedStatus);
 
           // Pull the sourceTableId into a Text
-          buffer.set(entry.getKey());
+          String srcTableId = entry.getKey();
 
           // Make the mutation
-          StatusSection.add(replMutation, buffer, serializedUpdatedStatus);
+          StatusSection.add(replMutation, srcTableId, serializedUpdatedStatus);
 
           log.debug("Updating replication status entry for {} with {}", serializedRow.getKey().getRow(), ProtobufUtil.toString(updatedStatus));
 

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/StatusMaker.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/StatusMaker.java
@@ -90,7 +90,7 @@ public class StatusMaker {
       s.fetchColumnFamily(ReplicationSection.COLF);
       s.setRange(ReplicationSection.getRange());
 
-      Text file = new Text(), tableId = new Text();
+      Text file = new Text();
       for (Entry<Key,Value> entry : s) {
         // Get a writer to the replication table
         if (null == replicationWriter) {
@@ -106,7 +106,7 @@ public class StatusMaker {
         }
         // Extract the useful bits from the status key
         MetadataSchema.ReplicationSection.getFile(entry.getKey(), file);
-        MetadataSchema.ReplicationSection.getTableId(entry.getKey(), tableId);
+        String tableId = MetadataSchema.ReplicationSection.getTableId(entry.getKey());
 
         Status status;
         try {
@@ -158,10 +158,10 @@ public class StatusMaker {
   /**
    * Create a status record in the replication table
    */
-  protected boolean addStatusRecord(Text file, Text tableId, Value v) {
+  protected boolean addStatusRecord(Text file, String tableId, Value v) {
     try {
       Mutation m = new Mutation(file);
-      m.put(StatusSection.NAME, tableId, v);
+      m.put(StatusSection.NAME, new Text(tableId), v);
 
       try {
         replicationWriter.addMutation(m);
@@ -194,7 +194,7 @@ public class StatusMaker {
    * @param value
    *          Serialized version of the Status msg
    */
-  protected boolean addOrderRecord(Text file, Text tableId, Status stat, Value value) {
+  protected boolean addOrderRecord(Text file, String tableId, Status stat, Value value) {
     try {
       if (!stat.hasCreatedTime()) {
         log.error("Status record ({}) for {} in table {} was written to metadata table which lacked createdTime", ProtobufUtil.toString(stat), file, tableId);

--- a/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
@@ -185,7 +185,7 @@ public class MergeStats {
     if (start == null) {
       start = new Text();
     }
-    Text tableId = extent.getTableId();
+    String tableId = extent.getTableId();
     Text first = KeyExtent.getMetadataEntry(tableId, start);
     Range range = new Range(first, false, null, true);
     scanner.setRange(range.clip(MetadataSchema.TabletsSection.getRange()));

--- a/server/master/src/main/java/org/apache/accumulo/master/state/TableStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/TableStats.java
@@ -21,21 +21,20 @@ import java.util.Map;
 
 import org.apache.accumulo.core.master.thrift.MasterState;
 import org.apache.accumulo.server.master.state.TabletState;
-import org.apache.hadoop.io.Text;
 
 public class TableStats {
-  private Map<Text,TableCounts> last = new HashMap<Text,TableCounts>();
-  private Map<Text,TableCounts> next;
+  private Map<String,TableCounts> last = new HashMap<String,TableCounts>();
+  private Map<String,TableCounts> next;
   private long startScan = 0;
   private long endScan = 0;
   private MasterState state;
 
   public synchronized void begin() {
-    next = new HashMap<Text,TableCounts>();
+    next = new HashMap<String,TableCounts>();
     startScan = System.currentTimeMillis();
   }
 
-  public synchronized void update(Text tableId, TabletState state) {
+  public synchronized void update(String tableId, TabletState state) {
     TableCounts counts = next.get(tableId);
     if (counts == null) {
       counts = new TableCounts();
@@ -51,7 +50,7 @@ public class TableStats {
     this.state = state;
   }
 
-  public synchronized Map<Text,TableCounts> getLast() {
+  public synchronized Map<String,TableCounts> getLast() {
     return last;
   }
 
@@ -59,7 +58,7 @@ public class TableStats {
     return state;
   }
 
-  public synchronized TableCounts getLast(Text tableId) {
+  public synchronized TableCounts getLast(String tableId) {
     TableCounts result = last.get(tableId);
     if (result == null)
       return new TableCounts();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
@@ -52,7 +52,6 @@ import org.apache.accumulo.server.tables.TableManager;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +89,7 @@ class CleanUp extends MasterRepo {
     }
 
     boolean done = true;
-    Range tableRange = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+    Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();
     Scanner scanner = master.getConnector().createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetaDataTableScanner.configureScanner(scanner, master);
     scanner.setRange(tableRange);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CompactionDriver.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CompactionDriver.java
@@ -90,7 +90,7 @@ class CompactionDriver extends MasterRepo {
       scanner.setRange(MetadataSchema.TabletsSection.getRange());
     } else {
       scanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-      Range range = new KeyExtent(new Text(tableId), null, startRow == null ? null : new Text(startRow)).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, startRow == null ? null : new Text(startRow)).toMetadataRange();
       scanner.setRange(range);
     }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CopyFailed.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CopyFailed.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.server.master.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,7 +112,7 @@ class CopyFailed extends MasterRepo {
     // determine which failed files were loaded
     Connector conn = master.getConnector();
     Scanner mscanner = new IsolatedScanner(conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
-    mscanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
     mscanner.fetchColumnFamily(TabletsSection.BulkFileColumnFamily.NAME);
 
     for (Entry<Key,Value> entry : mscanner) {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadata.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadata.java
@@ -20,7 +20,6 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.util.MetadataTableUtil;
-import org.apache.hadoop.io.Text;
 
 class PopulateMetadata extends MasterRepo {
 
@@ -39,7 +38,7 @@ class PopulateMetadata extends MasterRepo {
 
   @Override
   public Repo<Master> call(long tid, Master environment) throws Exception {
-    KeyExtent extent = new KeyExtent(new Text(tableInfo.tableId), null, null);
+    KeyExtent extent = new KeyExtent(tableInfo.tableId, null, null);
     MetadataTableUtil.addTablet(extent, tableInfo.dir, environment, tableInfo.timeType, environment.getMasterLock());
 
     return new FinishCreateTable(tableInfo);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadataTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadataTable.java
@@ -125,7 +125,7 @@ class PopulateMetadataTable extends MasterRepo {
             val.readFields(in);
 
             Text endRow = new KeyExtent(key.getRow(), (Text) null).getEndRow();
-            Text metadataRow = new KeyExtent(new Text(tableInfo.tableId), endRow, null).getMetadataEntry();
+            Text metadataRow = new KeyExtent(tableInfo.tableId, endRow, null).getMetadataEntry();
 
             Text cq;
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOp.java
@@ -77,7 +77,7 @@ public class TableRangeOp extends MasterRepo {
     MergeInfo info = env.getMergeInfo(tableIdText);
 
     if (info.getState() == MergeState.NONE) {
-      KeyExtent range = new KeyExtent(tableIdText, end, start);
+      KeyExtent range = new KeyExtent(tableId, end, start);
       env.setMergeState(new MergeInfo(range, op), MergeState.STARTED);
     }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/WriteExportFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/WriteExportFiles.java
@@ -59,7 +59,6 @@ import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 
 class WriteExportFiles extends MasterRepo {
 
@@ -93,7 +92,7 @@ class WriteExportFiles extends MasterRepo {
     checkOffline(conn);
 
     Scanner metaScanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    metaScanner.setRange(new KeyExtent(new Text(tableInfo.tableID), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableInfo.tableID, null, null).toMetadataRange());
 
     // scan for locations
     metaScanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
@@ -209,7 +208,7 @@ class WriteExportFiles extends MasterRepo {
     metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);
     TabletsSection.ServerColumnFamily.TIME_COLUMN.fetch(metaScanner);
-    metaScanner.setRange(new KeyExtent(new Text(tableID), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableID, null, null).toMetadataRange());
 
     for (Entry<Key,Value> entry : metaScanner) {
       entry.getKey().write(dataOut);

--- a/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.master.state.TabletLocationState.BadLocationStateException;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -191,7 +190,7 @@ public class RootTabletStateStoreTest {
     }
     assertEquals(count, 1);
 
-    KeyExtent notRoot = new KeyExtent(new Text("0"), null, null);
+    KeyExtent notRoot = new KeyExtent("0", null, null);
     try {
       tstore.setLocations(Collections.singletonList(new Assignment(notRoot, server)));
       Assert.fail("should not get here");

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TablesServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TablesServlet.java
@@ -150,8 +150,8 @@ public class TablesServlet extends BasicServlet {
       locs.add(instance.getRootTabletLocation());
     } else {
       String systemTableName = MetadataTable.ID.equals(tableId) ? RootTable.NAME : MetadataTable.NAME;
-      MetaDataTableScanner scanner = new MetaDataTableScanner(Monitor.getContext(), new Range(KeyExtent.getMetadataEntry(new Text(tableId), new Text()),
-          KeyExtent.getMetadataEntry(new Text(tableId), null)), systemTableName);
+      MetaDataTableScanner scanner = new MetaDataTableScanner(Monitor.getContext(), new Range(KeyExtent.getMetadataEntry(tableId, new Text()),
+          KeyExtent.getMetadataEntry(tableId, null)), systemTableName);
 
       while (scanner.hasNext()) {
         TabletLocationState state = scanner.next();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1301,7 +1301,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         }
       }
 
-      Text tid = new Text(cs.tableId);
+      String tid = cs.tableId;
       long opid = writeTracker.startWrite(TabletType.type(new KeyExtent(tid, null, null)));
 
       try {
@@ -1395,7 +1395,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         onlineTabletsCopy = new TreeMap<KeyExtent,Tablet>(onlineTablets);
       }
       List<TabletStats> result = new ArrayList<TabletStats>();
-      Text text = new Text(tableId);
+      String text = tableId;
       KeyExtent start = new KeyExtent(text, new Text(), null);
       for (Entry<KeyExtent,Tablet> entry : onlineTabletsCopy.tailMap(start).entrySet()) {
         KeyExtent ke = entry.getKey();
@@ -1570,7 +1570,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
       ArrayList<Tablet> tabletsToFlush = new ArrayList<Tablet>();
 
-      KeyExtent ke = new KeyExtent(new Text(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(tableId, ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       synchronized (onlineTablets) {
         for (Tablet tablet : onlineTablets.values())
@@ -1688,7 +1688,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         throw new RuntimeException(e);
       }
 
-      KeyExtent ke = new KeyExtent(new Text(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(tableId, ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       ArrayList<Tablet> tabletsToCompact = new ArrayList<Tablet>();
       synchronized (onlineTablets) {
@@ -2759,7 +2759,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
           extents = new ArrayList<KeyExtent>(onlineTablets.keySet());
         }
 
-        Set<Text> tables = new HashSet<Text>();
+        Set<String> tables = new HashSet<String>();
 
         for (KeyExtent keyExtent : extents) {
           tables.add(keyExtent.getTableId());
@@ -2767,7 +2767,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
         HashSet<String> contexts = new HashSet<String>();
 
-        for (Text tableid : tables) {
+        for (String tableid : tables) {
           String context = getTableConfiguration(new KeyExtent(tableid, null, null)).get(Property.TABLE_CLASSPATH);
           if (!context.equals("")) {
             contexts.add(context);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
@@ -56,15 +56,6 @@ public class MajorCompactionRequest implements Cloneable {
     this.files = mcr.files;
   }
 
-  /**
-   * @return org.apache.accumulo.core.data.KeyExtent
-   * @deprecated since 1.7. Use {@link #getTabletId()} instead.
-   */
-  @Deprecated
-  public org.apache.accumulo.core.data.KeyExtent getExtent() {
-    return new org.apache.accumulo.core.data.KeyExtent(extent.getTableId(), extent.getEndRow(), extent.getPrevEndRow());
-  }
-
   public TabletId getTabletId() {
     return new TabletIdImpl(extent);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -84,7 +84,7 @@ public class LogReader {
       row = new Text(opts.row);
     if (opts.extent != null) {
       String sa[] = opts.extent.split(";");
-      ke = new KeyExtent(new Text(sa[0]), new Text(sa[1]), new Text(sa[2]));
+      ke = new KeyExtent(sa[0], new Text(sa[1]), new Text(sa[2]));
     }
     if (opts.regexp != null) {
       Pattern pattern = Pattern.compile(opts.regexp);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
@@ -24,7 +24,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.tserver.TabletServerResourceManager.AssignmentWatcher;
-import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +49,7 @@ public class AssignmentWatcherTest {
     RunnableStartedAt run = new RunnableStartedAt(task, System.currentTimeMillis());
     EasyMock.expect(conf.getTimeInMillis(Property.TSERV_ASSIGNMENT_DURATION_WARNING)).andReturn(0l);
 
-    assignments.put(new KeyExtent(new Text("1"), null, null), run);
+    assignments.put(new KeyExtent("1", null, null), run);
 
     EasyMock.expect(task.getException()).andReturn(new Exception("Assignment warning happened"));
     EasyMock.expect(timer.schedule(watcher, 5000l)).andReturn(null);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -70,7 +70,7 @@ public class CheckTabletMetadataTest {
   @Test
   public void testBadTabletMetadata() throws Exception {
 
-    KeyExtent ke = new KeyExtent(new Text("1"), null, null);
+    KeyExtent ke = new KeyExtent("1", null, null);
 
     TreeMap<Key,Value> tabletMeta = new TreeMap<Key,Value>();
 
@@ -89,9 +89,9 @@ public class CheckTabletMetadataTest {
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 4));
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 5));
 
-    assertFail(tabletMeta, new KeyExtent(new Text("1"), null, new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent("1", null, new Text("m")), tsi);
 
-    assertFail(tabletMeta, new KeyExtent(new Text("1"), new Text("r"), new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent("1", new Text("r"), new Text("m")), tsi);
 
     assertFail(tabletMeta, ke, tsi, nk("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/LargestFirstMemoryManagerTest.java
@@ -214,7 +214,7 @@ public class LargestFirstMemoryManagerTest {
     mgr.init(config);
     MemoryManagementActions result;
     // one tablet is really big and the other is for a nonexistent table
-    KeyExtent extent = new KeyExtent(new Text("2"), new Text("j"), null);
+    KeyExtent extent = new KeyExtent("2", new Text("j"), null);
     result = mgr.getMemoryManagementActions(tablets(t(extent, ZERO, ONE_GIG, 0), t(k("j"), ZERO, ONE_GIG, 0)));
     assertEquals(1, result.tabletsToMinorCompact.size());
     assertEquals(extent, result.tabletsToMinorCompact.get(0));
@@ -256,7 +256,7 @@ public class LargestFirstMemoryManagerTest {
   }
 
   private static KeyExtent k(String endRow) {
-    return new KeyExtent(new Text("1"), new Text(endRow), null);
+    return new KeyExtent("1", new Text(endRow), null);
   }
 
   private static class TestTabletState implements TabletState {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -60,6 +60,7 @@ public class DefaultCompactionStrategyTest {
   }
 
   static final Map<String,Pair<Key,Key>> fakeFiles = new HashMap<String,Pair<Key,Key>>();
+
   static {
     fakeFiles.put("file1", keys("b", "m"));
     fakeFiles.put("file2", keys("n", "z"));
@@ -157,7 +158,7 @@ public class DefaultCompactionStrategyTest {
   }
 
   private MajorCompactionRequest createRequest(MajorCompactionReason reason, Object... objs) throws IOException {
-    return createRequest(new KeyExtent(new Text("0"), null, null), reason, objs);
+    return createRequest(new KeyExtent("0", null, null), reason, objs);
   }
 
   private MajorCompactionRequest createRequest(KeyExtent extent, MajorCompactionReason reason, Object... objs) throws IOException {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.server.fs.FileRef;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public class SizeLimitCompactionStrategyTest {
 
     slcs.init(opts);
 
-    KeyExtent ke = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke = new KeyExtent("0", null, null);
     MajorCompactionRequest mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, AccumuloConfiguration.getDefaultConfiguration());
 
     mcr.setFiles(nfl("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G"));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.server.fs.FileRef;
 import org.apache.accumulo.tserver.compaction.CompactionPlan;
 import org.apache.accumulo.tserver.compaction.MajorCompactionReason;
 import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,7 +37,7 @@ public class ConfigurableCompactionStrategyTest {
 
   @Test
   public void testOutputOptions() throws Exception {
-    MajorCompactionRequest mcr = new MajorCompactionRequest(new KeyExtent(new Text("1"), null, null), MajorCompactionReason.USER, null, null);
+    MajorCompactionRequest mcr = new MajorCompactionRequest(new KeyExtent("1", null, null), MajorCompactionReason.USER, null, null);
 
     Map<FileRef,DataFileValue> files = new HashMap<>();
     files.put(new FileRef("hdfs://nn1/accumulo/tables/1/t-009/F00001.rf"), new DataFileValue(50000, 400));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEntryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEntryTest.java
@@ -29,7 +29,7 @@ public class LogEntryTest {
 
   @Test
   public void test() throws Exception {
-    KeyExtent extent = new KeyExtent(new Text("1"), null, new Text(""));
+    KeyExtent extent = new KeyExtent("1", null, new Text(""));
     long ts = 12345678L;
     String server = "localhost:1234";
     String filename = "default/foo";

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -56,7 +56,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class SortedLogRecoveryTest {
 
-  static final KeyExtent extent = new KeyExtent(new Text("table"), null, null);
+  static final KeyExtent extent = new KeyExtent("table", null, null);
   static final Text cf = new Text("cf");
   static final Text cq = new Text("cq");
   static final Value value = new Value("value".getBytes());

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -80,7 +80,7 @@ public class LogFileTest {
     assertEquals(key.seq, 3);
     assertEquals(key.tid, 4);
     assertEquals(key.filename, "some file");
-    KeyExtent tablet = new KeyExtent(new Text("table"), new Text("bbbb"), new Text("aaaa"));
+    KeyExtent tablet = new KeyExtent("table", new Text("bbbb"), new Text("aaaa"));
     readWrite(DEFINE_TABLET, 5, 6, null, tablet, null, key, value);
     assertEquals(key.event, DEFINE_TABLET);
     assertEquals(key.seq, 5);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
@@ -77,7 +77,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("1"), null, null);
+    key.tablet = new KeyExtent("1", null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -92,7 +92,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("2"), null, null);
+    key.tablet = new KeyExtent("2", null, null);
     key.tid = 2;
     value.mutations = Collections.emptyList();
 
@@ -123,7 +123,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("1"), null, null);
+    key.tablet = new KeyExtent("1", null, null);
     key.tid = 3;
     value.mutations = Collections.emptyList();
 
@@ -183,7 +183,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("1"), null, null);
+    key.tablet = new KeyExtent("1", null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -198,7 +198,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("2"), null, null);
+    key.tablet = new KeyExtent("2", null, null);
     key.tid = 2;
     value.mutations = Collections.emptyList();
 
@@ -229,7 +229,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("1"), null, null);
+    key.tablet = new KeyExtent("1", null, null);
     key.tid = 3;
     value.mutations = Collections.emptyList();
 
@@ -380,7 +380,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text("1"), null, null);
+    key.tablet = new KeyExtent("1", null, null);
     key.tid = 1;
 
     key.write(dos);

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -48,7 +48,7 @@ public class CloneIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    KeyExtent ke = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke = new KeyExtent("0", null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -78,7 +78,7 @@ public class CloneIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    KeyExtent ke = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke = new KeyExtent("0", null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -111,7 +111,7 @@ public class CloneIT extends AccumuloClusterHarness {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -152,7 +152,7 @@ public class CloneIT extends AccumuloClusterHarness {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -202,7 +202,7 @@ public class CloneIT extends AccumuloClusterHarness {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -221,7 +221,7 @@ public class CloneIT extends AccumuloClusterHarness {
   }
 
   private static Mutation deleteTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(new Text(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(tid, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = new Mutation(ke.getMetadataEntry());
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
     TabletsSection.ServerColumnFamily.TIME_COLUMN.putDelete(mut);
@@ -232,7 +232,7 @@ public class CloneIT extends AccumuloClusterHarness {
   }
 
   private static Mutation createTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(new Text(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(tid, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -272,7 +272,7 @@ public class CloneIT extends AccumuloClusterHarness {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 
@@ -337,7 +337,7 @@ public class CloneIT extends AccumuloClusterHarness {
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<String>();
 

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -70,7 +70,7 @@ public class LocatorIT extends AccumuloClusterHarness {
   }
 
   private static TabletId newTabletId(String tableId, String endRow, String prevRow) {
-    return new TabletIdImpl(new KeyExtent(new Text(tableId), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow)));
+    return new TabletIdImpl(new KeyExtent(tableId, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow)));
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
@@ -109,7 +109,7 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
       for (TabletLocationState tls : store) {
         if (tls != null && tls.current != null) {
           states.add(tls.current);
-        } else if (tls != null && tls.extent.equals(new KeyExtent(new Text(ReplicationTable.ID), null, null))) {
+        } else if (tls != null && tls.extent.equals(new KeyExtent(ReplicationTable.ID, null, null))) {
           replStates.add(tls.current);
         } else {
           allAssigned = false;
@@ -139,7 +139,7 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
     waitForCleanStore(store);
     // now jam up the metadata table
     bw = c.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
-    assignment = new Mutation(new KeyExtent(new Text(MetadataTable.ID), null, null).getMetadataEntry());
+    assignment = new Mutation(new KeyExtent(MetadataTable.ID, null, null).getMetadataEntry());
     moved.current.putLocation(assignment);
     bw.addMutation(assignment);
     bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -27,7 +27,6 @@ import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.tabletserver.thrift.ConstraintViolationException;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.util.MetadataTableUtil;
-import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class MetaConstraintRetryIT extends AccumuloClusterHarness {
@@ -46,7 +45,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
     Credentials credentials = new Credentials(getAdminPrincipal(), getAdminToken());
     ClientContext context = new ClientContext(getConnector().getInstance(), credentials, cluster.getClientConfig());
     Writer w = new Writer(context, MetadataTable.ID);
-    KeyExtent extent = new KeyExtent(new Text("5"), null, null);
+    KeyExtent extent = new KeyExtent("5", null, null);
 
     Mutation m = new Mutation(extent.getMetadataEntry());
     // unknown columns should cause contraint violation

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -127,14 +127,14 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
     String tableId = conn.tableOperations().tableIdMap().get(tableName);
     Assert.assertNotNull("Table ID was null", tableId);
 
-    LogEntry logEntry = new LogEntry(new KeyExtent(new Text(tableId), null, null), 0, "127.0.0.1:12345", emptyWalog.toURI().toString());
+    LogEntry logEntry = new LogEntry(new KeyExtent(tableId, null, null), 0, "127.0.0.1:12345", emptyWalog.toURI().toString());
 
     log.info("Taking {} offline", tableName);
     conn.tableOperations().offline(tableName, true);
 
     log.info("{} is offline", tableName);
 
-    Text row = MetadataSchema.TabletsSection.getRow(new Text(tableId), null);
+    Text row = MetadataSchema.TabletsSection.getRow(tableId, null);
     Mutation m = new Mutation(row);
     m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 
@@ -189,7 +189,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
     log.info("{} is offline", tableName);
 
-    Text row = MetadataSchema.TabletsSection.getRow(new Text(tableId), null);
+    Text row = MetadataSchema.TabletsSection.getRow(tableId, null);
     Mutation m = new Mutation(row);
     m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 

--- a/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
@@ -104,7 +104,7 @@ public class QueryMetadataTable {
     Connector connector = opts.getConnector();
     Scanner scanner = connector.createScanner(MetadataTable.NAME, opts.auths);
     scanner.setBatchSize(scanOpts.scanBatchSize);
-    Text mdrow = new Text(KeyExtent.getMetadataEntry(new Text(MetadataTable.ID), null));
+    Text mdrow = new Text(KeyExtent.getMetadataEntry(MetadataTable.ID, null));
 
     HashSet<Text> rowSet = new HashSet<Text>();
 

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -88,7 +88,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
       connector.securityOperations().grantTablePermission(getAdminPrincipal(), MetadataTable.NAME, TablePermission.WRITE);
       String tableId = connector.tableOperations().tableIdMap().get(tableName);
 
-      KeyExtent extent = new KeyExtent(new Text(tableId), null, new Text("b"));
+      KeyExtent extent = new KeyExtent(tableId, null, new Text("b"));
       Mutation m = extent.getPrevRowUpdateMutation();
 
       TabletsSection.TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m, new Value(Double.toString(0.5).getBytes()));
@@ -104,7 +104,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
         scanner.setRange(extent.toMetadataRange());
         scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
 
-        KeyExtent extent2 = new KeyExtent(new Text(tableId), new Text("b"), null);
+        KeyExtent extent2 = new KeyExtent(tableId, new Text("b"), null);
         m = extent2.getPrevRowUpdateMutation();
         TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("/t2".getBytes()));
         TabletsSection.ServerColumnFamily.TIME_COLUMN.put(m, new Value("M0".getBytes()));

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -228,7 +228,7 @@ public class VolumeIT extends ConfigurableMacBase {
 
     Scanner metaScanner = connector.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
-    metaScanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
     BatchWriter mbw = connector.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
 
@@ -405,7 +405,7 @@ public class VolumeIT extends ConfigurableMacBase {
     Scanner metaScanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(metaScanner);
     metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
-    metaScanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
     int counts[] = new int[paths.length];
 

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -63,7 +63,7 @@ public class WrongTabletTest {
 
       Mutation mutation = new Mutation(new Text("row_0003750001"));
       mutation.putDelete(new Text("colf"), new Text("colq"));
-      client.update(Tracer.traceInfo(), context.rpcCreds(), new KeyExtent(new Text("!!"), null, new Text("row_0003750000")).toThrift(), mutation.toThrift(),
+      client.update(Tracer.traceInfo(), context.rpcCreds(), new KeyExtent("!!", null, new Text("row_0003750000")).toThrift(), mutation.toThrift(),
           TDurability.DEFAULT);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousStatsCollector.java
+++ b/test/src/main/java/org/apache/accumulo/test/continuous/ContinuousStatsCollector.java
@@ -52,7 +52,6 @@ import org.apache.accumulo.server.util.TableInfoUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.ClusterStatus;
 import org.apache.hadoop.mapred.JobClient;
 import org.slf4j.Logger;
@@ -99,7 +98,7 @@ public class ContinuousStatsCollector {
       scanner.setBatchSize(scanBatchSize);
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       scanner.addScanIterator(new IteratorSetting(1000, "cfc", ColumnFamilyCounter.class.getName()));
-      scanner.setRange(new KeyExtent(new Text(tableId), null, null).toMetadataRange());
+      scanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
       Stat s = new Stat();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.io.Text;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -177,8 +178,8 @@ public class CompactionIT extends AccumuloClusterHarness {
 
   private int countFiles(Connector c) throws Exception {
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    s.fetchColumnFamily(MetadataSchema.TabletsSection.TabletColumnFamily.NAME);
-    s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+    s.fetchColumnFamily(new Text(MetadataSchema.TabletsSection.TabletColumnFamily.NAME));
+    s.fetchColumnFamily(new Text(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME));
     return Iterators.size(s.iterator());
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.master.state.MetaDataTableScanner;
 import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class MasterAssignmentIT extends AccumuloClusterHarness {
@@ -92,7 +91,7 @@ public class MasterAssignmentIT extends AccumuloClusterHarness {
   private TabletLocationState getTabletLocationState(Connector c, String tableId) throws FileNotFoundException, ConfigurationException {
     Credentials creds = new Credentials(getAdminPrincipal(), getAdminToken());
     ClientContext context = new ClientContext(c.getInstance(), creds, getCluster().getClientConfig());
-    MetaDataTableScanner s = new MetaDataTableScanner(context, new Range(KeyExtent.getMetadataEntry(new Text(tableId), null)));
+    MetaDataTableScanner s = new MetaDataTableScanner(context, new Range(KeyExtent.getMetadataEntry(tableId, null)));
     TabletLocationState tlState = s.next();
     s.close();
     return tlState;

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
@@ -218,7 +218,7 @@ public class MergeIT extends AccumuloClusterHarness {
     protected void resetScanner() {
       try {
         Scanner ds = conn.createScanner(metadataTableName, Authorizations.EMPTY);
-        Text tablet = new KeyExtent(new Text("0"), new Text("m"), null).getMetadataEntry();
+        Text tablet = new KeyExtent("0", new Text("m"), null).getMetadataEntry();
         ds.setRange(new Range(tablet, true, tablet, true));
 
         Mutation m = new Mutation(tablet);
@@ -249,11 +249,11 @@ public class MergeIT extends AccumuloClusterHarness {
     String metadataTableName = getUniqueNames(1)[0];
     getConnector().tableOperations().create(metadataTableName);
 
-    KeyExtent ke1 = new KeyExtent(new Text("0"), new Text("m"), null);
+    KeyExtent ke1 = new KeyExtent("0", new Text("m"), null);
     Mutation mut1 = ke1.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut1, new Value("/d1".getBytes()));
 
-    KeyExtent ke2 = new KeyExtent(new Text("0"), null, null);
+    KeyExtent ke2 = new KeyExtent("0", null, null);
     Mutation mut2 = ke2.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut2, new Value("/d2".getBytes()));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -49,7 +49,6 @@ import org.apache.accumulo.server.util.CheckForMetadataProblems;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.Text;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -150,7 +149,7 @@ public class SplitIT extends AccumuloClusterHarness {
     }
     String id = c.tableOperations().tableIdMap().get(table);
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    KeyExtent extent = new KeyExtent(new Text(id), null, null);
+    KeyExtent extent = new KeyExtent(id, null, null);
     s.setRange(extent.toMetadataRange());
     MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
     int count = 0;

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -77,7 +77,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   private KeyExtent nke(String table, String endRow, String prevEndRow) {
-    return new KeyExtent(new Text(table), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(table, endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   private void run() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.VerifyIngest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Test;
@@ -85,7 +84,7 @@ public class TableIT extends AccumuloClusterHarness {
     VerifyIngest.verifyIngest(c, vopts, new ScannerOpts());
     String id = to.tableIdMap().get(tableName);
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    s.setRange(new KeyExtent(new Text(id), null, null).toMetadataRange());
+    s.setRange(new KeyExtent(id, null, null).toMetadataRange());
     s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
     assertTrue(Iterators.size(s.iterator()) > 0);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -108,7 +108,7 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterBase {
       @Override
       public Collection<MergeInfo> merges() {
         String tableIdToModify = getConnector().tableOperations().tableIdMap().get(t3);
-        return Collections.singletonList(new MergeInfo(new KeyExtent(new Text(tableIdToModify), null, null), MergeInfo.Operation.MERGE));
+        return Collections.singletonList(new MergeInfo(new KeyExtent(tableIdToModify, null, null), MergeInfo.Operation.MERGE));
       }
     };
     assertEquals("Should have 2 tablets that need to be chopped or unassigned", 1, findTabletsNeedingAttention(cloned, state));
@@ -125,7 +125,7 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterBase {
 
   private void addDuplicateLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
     String tableIdToModify = getConnector().tableOperations().tableIdMap().get(tableNameToModify);
-    Mutation m = new Mutation(new KeyExtent(new Text(tableIdToModify), null, null).getMetadataEntry());
+    Mutation m = new Mutation(new KeyExtent(tableIdToModify, null, null).getMetadataEntry());
     m.put(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME, new Text("1234567"), new Value("fake:9005".getBytes(UTF_8)));
     BatchWriter bw = getConnector().createBatchWriter(table, null);
     bw.addMutation(m);
@@ -135,7 +135,7 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterBase {
   private void reassignLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
     String tableIdToModify = getConnector().tableOperations().tableIdMap().get(tableNameToModify);
     Scanner scanner = getConnector().createScanner(table, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Text(tableIdToModify), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(tableIdToModify, null, null).toMetadataRange());
     scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
     Entry<Key,Value> entry = scanner.iterator().next();
     Mutation m = new Mutation(entry.getKey().getRow());
@@ -150,7 +150,7 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterBase {
   private void removeLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
     String tableIdToModify = getConnector().tableOperations().tableIdMap().get(tableNameToModify);
     BatchDeleter deleter = getConnector().createBatchDeleter(table, Authorizations.EMPTY, 1, new BatchWriterConfig());
-    deleter.setRanges(Collections.singleton(new KeyExtent(new Text(tableIdToModify), null, null).toMetadataRange()));
+    deleter.setRanges(Collections.singleton(new KeyExtent(tableIdToModify, null, null).toMetadataRange()));
     deleter.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
     deleter.delete();
     deleter.close();

--- a/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
@@ -169,7 +169,7 @@ public class CloseWriteAheadLogReferencesIT extends ConfigurableMacBase {
     Set<String> wals = Collections.singleton(file);
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
     Mutation m = new Mutation(file);
-    StatusSection.add(m, new Text("1"), ProtobufUtil.toValue(StatusUtil.ingestedUntil(1000)));
+    StatusSection.add(m, "1", ProtobufUtil.toValue(StatusUtil.ingestedUntil(1000)));
     bw.addMutation(m);
     bw.close();
 

--- a/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
@@ -113,7 +113,7 @@ public class MergeStateIT extends ConfigurableMacBase {
     // Create a fake METADATA table with these splits
     String splits[] = {"a", "e", "j", "o", "t", "z"};
     // create metadata for a table "t" with the splits above
-    Text tableId = new Text("t");
+    String tableId = "t";
     Text pr = null;
     for (String s : splits) {
       Text split = new Text(s);

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
@@ -77,7 +77,7 @@ public class MetadataBatchScanTest {
       splits.add((r.nextLong() & 0x7fffffffffffffffl) % 1000000000000l);
     }
 
-    Text tid = new Text("8");
+    String tid = "8";
     Text per = null;
 
     ArrayList<KeyExtent> extents = new ArrayList<KeyExtent>();

--- a/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
@@ -73,7 +73,6 @@ import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftServerType;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher;
-import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 
 import com.beust.jcommander.Parameter;
@@ -267,7 +266,7 @@ public class NullTserver {
     String tableId = Tables.getTableId(zki, opts.tableName);
 
     // read the locations for the table
-    Range tableRange = new KeyExtent(new Text(tableId), null, null).toMetadataRange();
+    Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();
     MetaDataTableScanner s = new MetaDataTableScanner(context, tableRange);
     long randomSessionID = opts.port;
     TServerInstance instance = new TServerInstance(addr, randomSessionID);

--- a/test/src/main/java/org/apache/accumulo/test/replication/RemoveCompleteReplicationRecordsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/RemoveCompleteReplicationRecordsIT.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.master.replication.RemoveCompleteReplicationRecords;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
-import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -84,7 +83,7 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     for (int i = 0; i < numRecords; i++) {
       String file = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
       Mutation m = new Mutation(file);
-      StatusSection.add(m, new Text(Integer.toString(i)), StatusUtil.openWithUnknownLengthValue());
+      StatusSection.add(m, Integer.toString(i), StatusUtil.openWithUnknownLengthValue());
       bw.addMutation(m);
     }
 
@@ -117,7 +116,7 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     for (int i = 0; i < numRecords; i++) {
       String file = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
       Mutation m = new Mutation(file);
-      StatusSection.add(m, new Text(Integer.toString(i)), ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build()));
+      StatusSection.add(m, Integer.toString(i), ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build()));
       bw.addMutation(m);
     }
 
@@ -154,21 +153,21 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     for (int i = 0; i < numRecords; i++) {
       String file = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
       Mutation m = new Mutation(file);
-      StatusSection.add(m, new Text(Integer.toString(i)), ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build()));
+      StatusSection.add(m, Integer.toString(i), ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build()));
       replBw.addMutation(m);
     }
 
     // Add two records that we can delete
     String fileToRemove = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
     Mutation m = new Mutation(fileToRemove);
-    StatusSection.add(m, new Text("5"), ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
+    StatusSection.add(m, "5", ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
     replBw.addMutation(m);
 
     numRecords++;
 
     fileToRemove = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
     m = new Mutation(fileToRemove);
-    StatusSection.add(m, new Text("6"), ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
+    StatusSection.add(m, "6", ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
     replBw.addMutation(m);
 
     numRecords++;
@@ -209,10 +208,10 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
       String file = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
       Mutation m = new Mutation(file);
       Value v = ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build());
-      StatusSection.add(m, new Text(Integer.toString(i)), v);
+      StatusSection.add(m, Integer.toString(i), v);
       replBw.addMutation(m);
       m = OrderSection.createMutation(file, time);
-      OrderSection.add(m, new Text(Integer.toString(i)), v);
+      OrderSection.add(m, Integer.toString(i), v);
       replBw.addMutation(m);
     }
 
@@ -227,12 +226,12 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     Mutation m = new Mutation(fileToRemove);
     ReplicationTarget target = new ReplicationTarget("peer1", "5", "5");
     Value value = ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(true).setCreatedTime(time).build());
-    StatusSection.add(m, new Text("5"), value);
+    StatusSection.add(m, "5", value);
     WorkSection.add(m, target.toText(), value);
     replBw.addMutation(m);
 
     m = OrderSection.createMutation(fileToRemove, time);
-    OrderSection.add(m, new Text("5"), value);
+    OrderSection.add(m, "5", value);
     replBw.addMutation(m);
     time++;
 
@@ -243,12 +242,12 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     m = new Mutation(fileToRemove);
     value = ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(true).setCreatedTime(time).build());
     target = new ReplicationTarget("peer1", "6", "6");
-    StatusSection.add(m, new Text("6"), value);
+    StatusSection.add(m, "6", value);
     WorkSection.add(m, target.toText(), value);
     replBw.addMutation(m);
 
     m = OrderSection.createMutation(fileToRemove, time);
-    OrderSection.add(m, new Text("6"), value);
+    OrderSection.add(m, "6", value);
     replBw.addMutation(m);
     time++;
 
@@ -297,7 +296,7 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     for (int i = 0; i < numRecords; i++) {
       String file = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
       Mutation m = new Mutation(file);
-      StatusSection.add(m, new Text(Integer.toString(i)), ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build()));
+      StatusSection.add(m, Integer.toString(i), ProtobufUtil.toValue(builder.setBegin(1000 * (i + 1)).build()));
       replBw.addMutation(m);
     }
 
@@ -306,7 +305,7 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     Mutation m = new Mutation(fileToRemove);
     ReplicationTarget target = new ReplicationTarget("peer1", "5", "5");
     Value value = ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(true).build());
-    StatusSection.add(m, new Text("5"), value);
+    StatusSection.add(m, "5", value);
     WorkSection.add(m, target.toText(), value);
     target = new ReplicationTarget("peer2", "5", "5");
     WorkSection.add(m, target.toText(), value);

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
@@ -113,7 +113,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   @Test
   public void waitsUntilEntriesAreReplicated() throws Exception {
     conn.tableOperations().create("foo");
-    Text tableId = new Text(conn.tableOperations().tableIdMap().get("foo"));
+    String tableId = conn.tableOperations().tableIdMap().get("foo");
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID(), file2 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -132,12 +132,12 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
 
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.put(ReplicationSection.COLF, tableId, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId), ProtobufUtil.toValue(stat));
 
     bw.addMutation(m);
 
     m = new Mutation(ReplicationSection.getRowPrefix() + file2);
-    m.put(ReplicationSection.COLF, tableId, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId), ProtobufUtil.toValue(stat));
 
     bw.close();
 
@@ -164,14 +164,14 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
 
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.putDelete(ReplicationSection.COLF, tableId);
+    m.putDelete(ReplicationSection.COLF, new Text(tableId));
     bw.addMutation(m);
     bw.flush();
 
     Assert.assertFalse(done.get());
 
     m = new Mutation(ReplicationSection.getRowPrefix() + file2);
-    m.putDelete(ReplicationSection.COLF, tableId);
+    m.putDelete(ReplicationSection.COLF, new Text(tableId));
     bw.addMutation(m);
     bw.flush();
     bw.close();
@@ -182,14 +182,14 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     // Remove the replication entries too
     bw = ReplicationTable.getBatchWriter(conn);
     m = new Mutation(file1);
-    m.putDelete(StatusSection.NAME, tableId);
+    m.putDelete(StatusSection.NAME, new Text(tableId));
     bw.addMutation(m);
     bw.flush();
 
     Assert.assertFalse(done.get());
 
     m = new Mutation(file2);
-    m.putDelete(StatusSection.NAME, tableId);
+    m.putDelete(StatusSection.NAME, new Text(tableId));
     bw.addMutation(m);
     bw.flush();
 
@@ -209,8 +209,8 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     conn.tableOperations().create("foo");
     conn.tableOperations().create("bar");
 
-    Text tableId1 = new Text(conn.tableOperations().tableIdMap().get("foo"));
-    Text tableId2 = new Text(conn.tableOperations().tableIdMap().get("bar"));
+    String tableId1 = conn.tableOperations().tableIdMap().get("foo");
+    String tableId2 = conn.tableOperations().tableIdMap().get("bar");
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID(), file2 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -229,12 +229,12 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
 
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.put(ReplicationSection.COLF, tableId1, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId1), ProtobufUtil.toValue(stat));
 
     bw.addMutation(m);
 
     m = new Mutation(ReplicationSection.getRowPrefix() + file2);
-    m.put(ReplicationSection.COLF, tableId2, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId2), ProtobufUtil.toValue(stat));
 
     bw.close();
 
@@ -263,7 +263,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
 
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.putDelete(ReplicationSection.COLF, tableId1);
+    m.putDelete(ReplicationSection.COLF, new Text(tableId1));
     bw.addMutation(m);
     bw.flush();
 
@@ -273,7 +273,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     // Remove the replication entries too
     bw = ReplicationTable.getBatchWriter(conn);
     m = new Mutation(file1);
-    m.putDelete(StatusSection.NAME, tableId1);
+    m.putDelete(StatusSection.NAME, new Text(tableId1));
     bw.addMutation(m);
     bw.flush();
 
@@ -292,7 +292,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   public void inprogressReplicationRecordsBlockExecution() throws Exception {
     conn.tableOperations().create("foo");
 
-    Text tableId1 = new Text(conn.tableOperations().tableIdMap().get("foo"));
+    String tableId1 = conn.tableOperations().tableIdMap().get("foo");
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -304,11 +304,11 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     bw.addMutation(m);
     bw.close();
 
-    LogEntry logEntry = new LogEntry(new KeyExtent(new Text(tableId1), null, null), System.currentTimeMillis(), "tserver", file1);
+    LogEntry logEntry = new LogEntry(new KeyExtent(tableId1, null, null), System.currentTimeMillis(), "tserver", file1);
 
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.put(ReplicationSection.COLF, tableId1, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId1), ProtobufUtil.toValue(stat));
     bw.addMutation(m);
 
     m = new Mutation(logEntry.getRow());
@@ -341,7 +341,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     Status newStatus = Status.newBuilder().setBegin(1000).setEnd(2000).setInfiniteEnd(false).setClosed(true).build();
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.put(ReplicationSection.COLF, tableId1, ProtobufUtil.toValue(newStatus));
+    m.put(ReplicationSection.COLF, new Text(tableId1), ProtobufUtil.toValue(newStatus));
     bw.addMutation(m);
     bw.flush();
 
@@ -351,7 +351,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     // Remove the replication entries too
     bw = ReplicationTable.getBatchWriter(conn);
     m = new Mutation(file1);
-    m.put(StatusSection.NAME, tableId1, ProtobufUtil.toValue(newStatus));
+    m.put(StatusSection.NAME, new Text(tableId1), ProtobufUtil.toValue(newStatus));
     bw.addMutation(m);
     bw.flush();
 
@@ -370,7 +370,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   public void laterCreatedLogsDontBlockExecution() throws Exception {
     conn.tableOperations().create("foo");
 
-    Text tableId1 = new Text(conn.tableOperations().tableIdMap().get("foo"));
+    String tableId1 = conn.tableOperations().tableIdMap().get("foo");
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -383,7 +383,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
 
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.put(ReplicationSection.COLF, tableId1, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId1), ProtobufUtil.toValue(stat));
     bw.addMutation(m);
 
     bw.close();
@@ -417,10 +417,10 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     // Write another file, but also delete the old files
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + "/accumulo/wals/tserver+port/" + UUID.randomUUID());
-    m.put(ReplicationSection.COLF, tableId1, ProtobufUtil.toValue(stat));
+    m.put(ReplicationSection.COLF, new Text(tableId1), ProtobufUtil.toValue(stat));
     bw.addMutation(m);
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);
-    m.putDelete(ReplicationSection.COLF, tableId1);
+    m.putDelete(ReplicationSection.COLF, new Text(tableId1));
     bw.addMutation(m);
     bw.close();
 
@@ -431,7 +431,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
 
     bw = ReplicationTable.getBatchWriter(conn);
     m = new Mutation(file1);
-    m.putDelete(StatusSection.NAME, tableId1);
+    m.putDelete(StatusSection.NAME, new Text(tableId1));
     bw.addMutation(m);
     bw.close();
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/SequentialWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/SequentialWorkAssignerIT.java
@@ -126,11 +126,11 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file1, stat1.getCreatedTime());
-    OrderSection.add(m, new Text(target.getSourceTableId()), ProtobufUtil.toValue(stat1));
+    OrderSection.add(m, target.getSourceTableId(), ProtobufUtil.toValue(stat1));
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file2, stat2.getCreatedTime());
-    OrderSection.add(m, new Text(target.getSourceTableId()), ProtobufUtil.toValue(stat2));
+    OrderSection.add(m, target.getSourceTableId(), ProtobufUtil.toValue(stat2));
     bw.addMutation(m);
 
     bw.close();
@@ -188,11 +188,11 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file1, stat1.getCreatedTime());
-    OrderSection.add(m, new Text(target1.getSourceTableId()), ProtobufUtil.toValue(stat1));
+    OrderSection.add(m, target1.getSourceTableId(), ProtobufUtil.toValue(stat1));
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file2, stat2.getCreatedTime());
-    OrderSection.add(m, new Text(target2.getSourceTableId()), ProtobufUtil.toValue(stat2));
+    OrderSection.add(m, target2.getSourceTableId(), ProtobufUtil.toValue(stat2));
     bw.addMutation(m);
 
     bw.close();
@@ -257,11 +257,11 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file1, stat1.getCreatedTime());
-    OrderSection.add(m, new Text(target1.getSourceTableId()), ProtobufUtil.toValue(stat1));
+    OrderSection.add(m, target1.getSourceTableId(), ProtobufUtil.toValue(stat1));
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file2, stat2.getCreatedTime());
-    OrderSection.add(m, new Text(target2.getSourceTableId()), ProtobufUtil.toValue(stat2));
+    OrderSection.add(m, target2.getSourceTableId(), ProtobufUtil.toValue(stat2));
     bw.addMutation(m);
 
     bw.close();
@@ -325,11 +325,11 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file1, stat1.getCreatedTime());
-    OrderSection.add(m, new Text(target.getSourceTableId()), ProtobufUtil.toValue(stat1));
+    OrderSection.add(m, target.getSourceTableId(), ProtobufUtil.toValue(stat1));
     bw.addMutation(m);
 
     m = OrderSection.createMutation(file2, stat2.getCreatedTime());
-    OrderSection.add(m, new Text(target.getSourceTableId()), ProtobufUtil.toValue(stat2));
+    OrderSection.add(m, target.getSourceTableId(), ProtobufUtil.toValue(stat2));
     bw.addMutation(m);
 
     bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
@@ -41,7 +41,6 @@ import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.server.util.ReplicationTableUtil;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -90,7 +89,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
     long createTime = System.currentTimeMillis();
     try {
       Mutation m = new Mutation("file:/accumulo/wal/HW10447.local+56808/93cdc17e-7521-44fa-87b5-37f45bcb92d3");
-      StatusSection.add(m, new Text("1"), StatusUtil.fileCreatedValue(createTime));
+      StatusSection.add(m, "1", StatusUtil.fileCreatedValue(createTime));
       bw.addMutation(m);
     } finally {
       bw.close();
@@ -103,7 +102,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
     bw = ReplicationTable.getBatchWriter(conn);
     try {
       Mutation m = new Mutation("file:/accumulo/wal/HW10447.local+56808/93cdc17e-7521-44fa-87b5-37f45bcb92d3");
-      StatusSection.add(m, new Text("1"), ProtobufUtil.toValue(StatusUtil.replicated(Long.MAX_VALUE)));
+      StatusSection.add(m, "1", ProtobufUtil.toValue(StatusUtil.replicated(Long.MAX_VALUE)));
       bw.addMutation(m);
     } finally {
       bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
@@ -138,14 +138,14 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
     WorkSection.add(m, serializedTarget1, ProtobufUtil.toValue(status1));
     bw.addMutation(m);
     m = OrderSection.createMutation(file1, status1.getCreatedTime());
-    OrderSection.add(m, new Text(target1.getSourceTableId()), ProtobufUtil.toValue(status1));
+    OrderSection.add(m, target1.getSourceTableId(), ProtobufUtil.toValue(status1));
     bw.addMutation(m);
 
     m = new Mutation(file2);
     WorkSection.add(m, serializedTarget2, ProtobufUtil.toValue(status2));
     bw.addMutation(m);
     m = OrderSection.createMutation(file2, status2.getCreatedTime());
-    OrderSection.add(m, new Text(target2.getSourceTableId()), ProtobufUtil.toValue(status2));
+    OrderSection.add(m, target2.getSourceTableId(), ProtobufUtil.toValue(status2));
     bw.addMutation(m);
 
     bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
@@ -113,7 +113,7 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     value.write(out);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Text(Integer.toString(fakeTableId)), null, null);
+    key.tablet = new KeyExtent(Integer.toString(fakeTableId), null, null);
     key.seq = 1l;
     key.tid = 1;
 
@@ -169,7 +169,7 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
 
     // Add our fake WAL to the log column for this table
     String walUri = tserverWal.toURI().toString();
-    KeyExtent extent = new KeyExtent(new Text(tableId), null, null);
+    KeyExtent extent = new KeyExtent(tableId, null, null);
     bw = conn.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(extent.getMetadataEntry());
     m.put(MetadataSchema.TabletsSection.LogColumnFamily.NAME, new Text("localhost:12345/" + walUri), new Value((walUri + "|1").getBytes(UTF_8)));


### PR DESCRIPTION
* Best attempt to eliminate text wrapping of tableIDs on master branch.
* Some ByteBuffer wrapping still occurs due to thrift using bytes to transfer tableId instead of string.
* Some Text wrapping is needed for:
 - preserving existing KeyExtent serialization
 - putting tableIDs in replication-related table entries
 - avoiding public API changes to deprecated KeyExtent.

All unit tests pass, and -Psunny ITs, as well as checkstyle, findbugs, and modernizer
This replaces #70