### PR TITLE
ACCUMULO-1755: Modified TSBW so that all client threads will not bloc…

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
@@ -716,14 +716,13 @@ public class TabletServerBatchWriter {
       if (null == mutationsToSend)
         return;
       binningThreadPool.execute(new Runnable() {
-        final MutationSet m = mutationsToSend;
 
         @Override
         public void run() {
-          if (null != m) {
+          if (null != mutationsToSend) {
             try {
-              log.trace("{} - binning {} mutations", Thread.currentThread().getName(), m.size());
-              addMutations(m);
+              log.trace("{} - binning {} mutations", Thread.currentThread().getName(), mutationsToSend.size());
+              addMutations(mutationsToSend);
             } catch (Exception e) {
               updateUnknownErrors("Error processing mutation set", e);
             }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
@@ -33,7 +33,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedTransferQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -640,7 +639,7 @@ public class TabletServerBatchWriter {
     private static final int MUTATION_BATCH_SIZE = 1 << 17;
     private final ExecutorService sendThreadPool;
     private final LinkedTransferQueue<Runnable> queue = new LinkedTransferQueue<>();
-    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 10L, TimeUnit.SECONDS, queue);
+    private final SimpleThreadPool executor = new SimpleThreadPool(1, "BinMutations", queue);
     private final Map<String,TabletServerMutations<Mutation>> serversMutations;
     private final Set<String> queued;
     private final Map<String,TabletLocator> locators;

--- a/core/src/main/java/org/apache/accumulo/core/util/SimpleThreadPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/SimpleThreadPool.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.util;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +28,11 @@ public class SimpleThreadPool extends ThreadPoolExecutor {
 
   public SimpleThreadPool(int max, final String name) {
     super(max, max, 4l, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(), new NamingThreadFactory(name));
+    allowCoreThreadTimeOut(true);
+  }
+
+  public SimpleThreadPool(int max, final String name, BlockingQueue<Runnable> queue) {
+    super(max, max, 4l, TimeUnit.SECONDS, queue, new NamingThreadFactory(name));
     allowCoreThreadTimeOut(true);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -16,11 +16,20 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -31,21 +40,27 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.TabletServerBatchWriter;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.hadoop.io.Text;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Iterators;
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 
 public class BatchWriterFlushIT extends AccumuloClusterHarness {
 
   private static final int NUM_TO_FLUSH = 100000;
+  private static final int NUM_THREADS = 3;
 
   @Override
   protected int defaultTimeoutSeconds() {
@@ -62,7 +77,6 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
     c.tableOperations().create(bwlt);
     runFlushTest(bwft);
     runLatencyTest(bwlt);
-
   }
 
   private void runLatencyTest(String tableName) throws Exception {
@@ -163,6 +177,110 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
     if (!caught) {
       throw new Exception("Adding to closed batch writer did not fail");
     }
+  }
+
+  @Test
+  public void runMultiThreadedBinningTest() throws Exception {
+    Connector c = getConnector();
+    String[] tableNames = getUniqueNames(1);
+    String tableName = tableNames[0];
+    c.tableOperations().create(tableName);
+    for (int x = 0; x < NUM_THREADS; x++) {
+      c.tableOperations().addSplits(tableName, new TreeSet<Text>(Collections.singleton(new Text(Integer.toString(x * NUM_TO_FLUSH)))));
+    }
+    c.instanceOperations().waitForBalance();
+
+    //Logger.getLogger(TabletServerBatchWriter.class).setLevel(Level.TRACE);
+    final List<Set<Mutation>> allMuts = new LinkedList<>();
+    final ConcurrentSkipListSet<Mutation> data = new ConcurrentSkipListSet<>(new Comparator<Mutation>() {
+      @Override
+      public int compare(Mutation o1, Mutation o2) {
+        CompareToBuilder compare = new CompareToBuilder();
+        compare.append(o1.getRow().toString(), o2.getRow().toString());
+        compare.append(o1.getUpdates().size(), o2.getUpdates().size());
+        if (o1.getUpdates().size() == o2.getUpdates().size()) {
+          for (int x = 0; x < o1.getUpdates().size(); x++) {
+            compare.append(o1.getUpdates().get(x).toString(), o2.getUpdates().get(x).toString());
+          }
+        }
+        return compare.toComparison();
+      }
+    });
+    SimpleThreadPool createThreads = new SimpleThreadPool(NUM_THREADS, "CreateThreads");
+    createThreads.allowCoreThreadTimeOut(false);
+    createThreads.prestartAllCoreThreads();
+    for (int i = 0; i < NUM_THREADS; i++) {
+      final int thread = i;
+      createThreads.execute(new Runnable() {
+        @Override
+        public void run() {
+          for (int j = 0; j < NUM_TO_FLUSH; j++) {
+            int row = thread * NUM_TO_FLUSH + j;
+
+            Mutation m = new Mutation(new Text(String.format("%10d", row)));
+            m.put(new Text("cf" + thread), new Text("cq"), new Value(("" + row).getBytes()));
+            data.add(m);
+          }
+        }
+      });
+    }
+    createThreads.shutdown();
+    createThreads.awaitTermination(3, TimeUnit.MINUTES);
+    Assert.assertEquals(NUM_THREADS * NUM_TO_FLUSH, data.size());
+    List<Mutation> shuffled = new LinkedList<>(data);
+    Collections.shuffle(shuffled);
+    for (int n = 0; n < (NUM_THREADS * NUM_TO_FLUSH); n += NUM_TO_FLUSH) {
+      System.out.println("subList: " + (n) + " to " + (n + NUM_TO_FLUSH));
+      Set<Mutation> muts = new HashSet<>(shuffled.subList(n, n + NUM_TO_FLUSH));
+      allMuts.add(muts);
+    }
+
+    SimpleThreadPool threads = new SimpleThreadPool(NUM_THREADS, "ClientThreads");
+    threads.allowCoreThreadTimeOut(false);
+    threads.prestartAllCoreThreads();
+
+    BatchWriterConfig cfg = new BatchWriterConfig();
+    cfg.setMaxLatency(10, TimeUnit.SECONDS);
+    cfg.setMaxMemory(1 * 1024 * 1024);
+    cfg.setMaxWriteThreads(NUM_THREADS);
+    final BatchWriter bw = getConnector().createBatchWriter(tableName, cfg);
+
+    for (int k = 0; k < NUM_THREADS; k++) {
+      final int idx = k;
+      threads.execute(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            bw.addMutations(allMuts.get(idx));
+            bw.flush();
+          } catch (MutationsRejectedException e) {
+            Assert.fail("Error adding mutations to batch writer");
+          }
+        }
+      });
+    }
+    threads.shutdown();
+    threads.awaitTermination(3, TimeUnit.MINUTES);
+    bw.close();
+    Scanner scanner = getConnector().createScanner(tableName, Authorizations.EMPTY);
+    for (Entry<Key,Value> e : scanner) {
+      Mutation m = new Mutation(e.getKey().getRow());
+      m.put(e.getKey().getColumnFamily(), e.getKey().getColumnQualifier(), e.getValue());
+      boolean found = false;
+      for (int l = 0; l < NUM_THREADS; l++) {
+        if (allMuts.get(l).contains(m)) {
+          found = true;
+          allMuts.get(l).remove(m);
+          break;
+        }
+      }
+      Assert.assertTrue("Mutation not found: " + m.toString(), found);
+    }
+
+    for (int m = 0; m < NUM_THREADS; m++) {
+      Assert.assertEquals(0, allMuts.get(m).size());
+    }
+
   }
 
   private void verifyEntry(int row, Entry<Key,Value> entry) throws Exception {


### PR DESCRIPTION
I ditched review board and went back to the drawing board.

Before this change all client threads that were adding mutations to a BatchWriter would block
when the mutations needed to be written to the tablet servers. This change gives each client
thread their own MutationWriter object using a ThreadLocal. With this change only one client
should block on adding the mutations to the sendThreadPool object, and allows the other client
threads to push mutations onto a new MutationSet.