### PR TITLE
ACCUMULO-4155 Limit javadoc:aggregate to public API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1510,5 +1510,31 @@
         </pluginManagement>
       </build>
     </profile>
+    <profile>
+      <id>aggregate-javadocs</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <configuration>
+                <sourceFileIncludes>
+                  <sourceFileInclude>**/org/apache/accumulo/core/client/**/*.java</sourceFileInclude>
+                  <sourceFileInclude>**/org/apache/accumulo/core/data/**/*.java</sourceFileInclude>
+                  <sourceFileInclude>**/org/apache/accumulo/core/security/**/*.java</sourceFileInclude>
+                  <sourceFileInclude>**/org/apache/accumulo/minicluster/**/*.java</sourceFileInclude>
+                </sourceFileIncludes>
+                <sourceFileExcludes>
+                  <sourceFileExclude>**/crypto/**/*.java</sourceFileExclude>
+                  <sourceFileExclude>**/impl/**/*.java</sourceFileExclude>
+                  <sourceFileExclude>**/thrift/**/*.java</sourceFileExclude>
+                </sourceFileExcludes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This PR is a preview for review. If acceptable, I'll backport this fix to the 1.6 and 1.7 branches, and update the website with the smaller document set for the latest releases.