### PR TITLE
ACCUMULO-4191 Tracing on client can sometimes lose "sendMutations" events.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
@@ -733,7 +733,7 @@ public class TabletServerBatchWriter {
     void queueMutations(final MutationSet mutationsToSend) throws InterruptedException {
       if (null == mutationsToSend)
         return;
-      binningThreadPool.execute(new Runnable() {
+      binningThreadPool.execute(Trace.wrap(new Runnable() {
 
         @Override
         public void run() {
@@ -746,7 +746,7 @@ public class TabletServerBatchWriter {
             }
           }
         }
-      });
+      }));
     }
 
     private void addMutations(MutationSet mutationsToSend) {


### PR DESCRIPTION
Wrapped a `Runnable` with `Trace.wrap(...)` in `TabletServerBatchWriter`.  This should allow proper tracing propagation across the binning thread pool, and consequently prevent loss of "sendMutation" events.