### PR TITLE
ACCUMULO-4195 Added generalized configuration objects for RFile interaction

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -345,7 +345,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     // TODO need to close files - ACCUMULO-1303
     for (String file : absFiles) {
       FileSystem fs = VolumeConfiguration.getVolume(file, conf, config).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader(file, false, fs, conf, null, acuTableConf, null, null);
+      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(file, fs, conf).withTableConfiguration(acuTableConf).execute();
       if (scannerSamplerConfigImpl != null) {
         reader = reader.getSample(scannerSamplerConfigImpl);
         if (reader == null)

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -345,7 +345,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     // TODO need to close files - ACCUMULO-1303
     for (String file : absFiles) {
       FileSystem fs = VolumeConfiguration.getVolume(file, conf, config).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(file, fs, conf).withTableConfiguration(acuTableConf).execute();
+      FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder().forFile(file, fs, conf).withTableConfiguration(acuTableConf).build();
       if (scannerSamplerConfigImpl != null) {
         reader = reader.getSample(scannerSamplerConfigImpl);
         if (reader == null)

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
@@ -186,7 +186,8 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
         }
 
         if (out == null) {
-          out = FileOperations.getInstance().openWriter().ofFile(file.toString(), file.getFileSystem(conf), conf).withTableConfiguration(acuConf).execute();
+          out = FileOperations.getInstance().newWriterBuilder().forFile(file.toString(), file.getFileSystem(conf), conf).withTableConfiguration(acuConf)
+              .build();
           out.startDefaultLocalityGroup();
         }
         out.append(key, value);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
@@ -186,7 +186,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
         }
 
         if (out == null) {
-          out = FileOperations.getInstance().openWriter(file.toString(), file.getFileSystem(conf), conf, null, acuConf);
+          out = FileOperations.getInstance().openWriter().ofFile(file.toString(), file.getFileSystem(conf), conf).withTableConfiguration(acuConf).execute();
           out.startDefaultLocalityGroup();
         }
         out.append(key, value);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
@@ -184,7 +184,8 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
         }
 
         if (out == null) {
-          out = FileOperations.getInstance().openWriter().ofFile(file.toString(), file.getFileSystem(conf), conf).withTableConfiguration(acuConf).execute();
+          out = FileOperations.getInstance().newWriterBuilder().forFile(file.toString(), file.getFileSystem(conf), conf).withTableConfiguration(acuConf)
+              .build();
           out.startDefaultLocalityGroup();
         }
         out.append(key, value);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
@@ -184,7 +184,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
         }
 
         if (out == null) {
-          out = FileOperations.getInstance().openWriter(file.toString(), file.getFileSystem(conf), conf, null, acuConf);
+          out = FileOperations.getInstance().openWriter().ofFile(file.toString(), file.getFileSystem(conf), conf).withTableConfiguration(acuConf).execute();
           out.startDefaultLocalityGroup();
         }
         out.append(key, value);

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
@@ -16,7 +16,6 @@
  */
 package org.apache.accumulo.core.client.mock;
 
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -67,6 +66,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * @deprecated since 1.8.0; use MiniAccumuloCluster or a standard mock framework instead.
@@ -289,8 +289,8 @@ class MockTableOperations extends TableOperationsHelper {
      */
     for (FileStatus importStatus : fs.listStatus(importPath)) {
       try {
-        FileSKVIterator importIterator = FileOperations.getInstance().openReader(importStatus.getPath().toString(), true, fs, fs.getConf(), null,
-            AccumuloConfiguration.getDefaultConfiguration());
+        FileSKVIterator importIterator = FileOperations.getInstance().openReader().ofFile(importStatus.getPath().toString(), fs, fs.getConf())
+            .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).seekToBeginning().execute();
         while (importIterator.hasTop()) {
           Key key = importIterator.getTopKey();
           Value value = importIterator.getTopValue();

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
@@ -16,7 +16,6 @@
  */
 package org.apache.accumulo.core.client.mock;
 
-
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
@@ -288,8 +288,8 @@ class MockTableOperations extends TableOperationsHelper {
      */
     for (FileStatus importStatus : fs.listStatus(importPath)) {
       try {
-        FileSKVIterator importIterator = FileOperations.getInstance().openReader().ofFile(importStatus.getPath().toString(), fs, fs.getConf())
-            .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).seekToBeginning().execute();
+        FileSKVIterator importIterator = FileOperations.getInstance().newReaderBuilder().forFile(importStatus.getPath().toString(), fs, fs.getConf())
+            .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).seekToBeginning().build();
         while (importIterator.hasTop()) {
           Key key = importIterator.getTopKey();
           Value value = importIterator.getTopValue();

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -458,7 +458,7 @@ public class BloomFilterLayer {
 
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = "/tmp/test." + suffix;
-    FileSKVWriter bmfw = FileOperations.getInstance().openWriter().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
+    FileSKVWriter bmfw = FileOperations.getInstance().newWriterBuilder().forFile(fname, fs, conf).withTableConfiguration(acuconf).build();
 
     long t1 = System.currentTimeMillis();
 
@@ -477,7 +477,7 @@ public class BloomFilterLayer {
     bmfw.close();
 
     t1 = System.currentTimeMillis();
-    FileSKVIterator bmfr = FileOperations.getInstance().openReader().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
+    FileSKVIterator bmfr = FileOperations.getInstance().newReaderBuilder().forFile(fname, fs, conf).withTableConfiguration(acuconf).build();
     t2 = System.currentTimeMillis();
     out.println("Opened " + fname + " in " + (t2 - t1));
 

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -458,7 +458,7 @@ public class BloomFilterLayer {
 
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = "/tmp/test." + suffix;
-    FileSKVWriter bmfw = FileOperations.getInstance().openWriter(fname, fs, conf, null, acuconf);
+    FileSKVWriter bmfw = FileOperations.getInstance().openWriter().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
 
     long t1 = System.currentTimeMillis();
 
@@ -477,7 +477,7 @@ public class BloomFilterLayer {
     bmfw.close();
 
     t1 = System.currentTimeMillis();
-    FileSKVIterator bmfr = FileOperations.getInstance().openReader(fname, false, fs, conf, null, acuconf);
+    FileSKVIterator bmfr = FileOperations.getInstance().openReader().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
     t2 = System.currentTimeMillis();
     out.println("Opened " + fname + " in " + (t2 - t1));
 

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -72,11 +72,11 @@ public abstract class FileOperations {
    * Syntax:
    *
    * <pre>
-   * long size = fileOperations.getFileSize().ofFile(filename, fileSystem, fsConfiguration).withTableConfiguration(tableConf).execute();
+   * long size = fileOperations.getFileSize().forFile(filename, fileSystem, fsConfiguration).withTableConfiguration(tableConf).execute();
    * </pre>
    */
   @SuppressWarnings("unchecked")
-  public NeedsFile<NeedsTableConfiguration<GetFileSizeOperationBuilder>> getFileSize() {
+  public NeedsFile<GetFileSizeOperationBuilder> getFileSize() {
     return (NeedsFile) new GetFileSizeOperation();
   }
 
@@ -85,16 +85,16 @@ public abstract class FileOperations {
    * Syntax:
    *
    * <pre>
-   * FileSKVWriter writer = fileOperations.openWriter()
-   *     .ofFile(...)
+   * FileSKVWriter writer = fileOperations.newWriterBuilder()
+   *     .forFile(...)
    *     .withTableConfiguration(...)
    *     .withRateLimiter(...) // optional
    *     .withCompression(...) // optional
-   *     .execute();
+   *     .build();
    * </pre>
    */
   @SuppressWarnings("unchecked")
-  public NeedsFile<NeedsTableConfiguration<OpenWriterOperationBuilder>> openWriter() {
+  public NeedsFile<OpenWriterOperationBuilder> newWriterBuilder() {
     return (NeedsFile) new OpenWriterOperation();
   }
 
@@ -103,16 +103,16 @@ public abstract class FileOperations {
    * Syntax:
    *
    * <pre>
-   * FileSKVIterator iterator = fileOperations.openIndex()
-   *     .ofFile(...)
+   * FileSKVIterator iterator = fileOperations.newIndexReaderBuilder()
+   *     .forFile(...)
    *     .withTableConfiguration(...)
    *     .withRateLimiter(...) // optional
    *     .withBlockCache(...) // optional
-   *     .execute();
+   *     .build();
    * </pre>
    */
   @SuppressWarnings("unchecked")
-  public NeedsFile<NeedsTableConfiguration<OpenIndexOperationBuilder>> openIndex() {
+  public NeedsFile<OpenIndexOperationBuilder> newIndexReaderBuilder() {
     return (NeedsFile) new OpenIndexOperation();
   }
 
@@ -123,17 +123,17 @@ public abstract class FileOperations {
    * Syntax:
    *
    * <pre>
-   * FileSKVIterator scanner = fileOperations.openScanReader()
-   *     .ofFile(...)
-   *     .overRange(...)
+   * FileSKVIterator scanner = fileOperations.newScanReaderBuilder()
+   *     .forFile(...)
    *     .withTableConfiguration(...)
+   *     .overRange(...)
    *     .withRateLimiter(...) // optional
    *     .withBlockCache(...) // optional
-   *     .execute();
+   *     .build();
    * </pre>
    */
   @SuppressWarnings("unchecked")
-  public NeedsFile<NeedsRange<NeedsTableConfiguration<OpenScanReaderOperationBuilder>>> openScanReader() {
+  public NeedsFile<NeedsRange<OpenScanReaderOperationBuilder>> newScanReaderBuilder() {
     return (NeedsFile) new OpenScanReaderOperation();
   }
 
@@ -143,17 +143,17 @@ public abstract class FileOperations {
    * Syntax:
    *
    * <pre>
-   * FileSKVIterator scanner = fileOperations.openReader()
-   *     .ofFile(...)
+   * FileSKVIterator scanner = fileOperations.newReaderBuilder()
+   *     .forFile(...)
    *     .withTableConfiguration(...)
    *     .withRateLimiter(...) // optional
    *     .withBlockCache(...) // optional
    *     .seekToBeginning(...) // optional
-   *     .execute();
+   *     .build();
    * </pre>
    */
   @SuppressWarnings("unchecked")
-  public NeedsFile<NeedsTableConfiguration<OpenReaderOperationBuilder>> openReader() {
+  public NeedsFile<OpenReaderOperationBuilder> newReaderBuilder() {
     return (NeedsFile) new OpenReaderOperation();
   }
 
@@ -185,7 +185,7 @@ public abstract class FileOperations {
 
     /** Specify the file this operation should apply to. */
     @SuppressWarnings("unchecked")
-    public SubclassType ofFile(String filename, FileSystem fs, Configuration fsConf) {
+    public SubclassType forFile(String filename, FileSystem fs, Configuration fsConf) {
       this.filename = filename;
       this.fs = fs;
       this.fsConf = fsConf;
@@ -194,7 +194,7 @@ public abstract class FileOperations {
 
     /** Specify the file this operation should apply to. */
     @SuppressWarnings("unchecked")
-    public SubclassType ofFile(String filename) {
+    public SubclassType forFile(String filename) {
       this.filename = filename;
       return (SubclassType) this;
     }
@@ -294,7 +294,7 @@ public abstract class FileOperations {
       return compression;
     }
 
-    public FileSKVWriter execute() throws IOException {
+    public FileSKVWriter build() throws IOException {
       validate();
       return openWriter(this);
     }
@@ -306,7 +306,7 @@ public abstract class FileOperations {
     public OpenWriterOperationBuilder withCompression(String compression);
 
     /** Construct the writer. */
-    public FileSKVWriter execute() throws IOException;
+    public FileSKVWriter build() throws IOException;
   }
 
   /**
@@ -363,7 +363,7 @@ public abstract class FileOperations {
    * Operation object for opening an index.
    */
   protected class OpenIndexOperation extends FileReaderOperation<OpenIndexOperation> implements OpenIndexOperationBuilder {
-    public FileSKVIterator execute() throws IOException {
+    public FileSKVIterator build() throws IOException {
       validate();
       return openIndex(this);
     }
@@ -372,7 +372,7 @@ public abstract class FileOperations {
   /** Builder interface parallel to {@link OpenIndexOperation}. */
   public static interface OpenIndexOperationBuilder extends FileReaderOperationBuilder<OpenIndexOperationBuilder> {
     /** Construct the reader. */
-    public FileSKVIterator execute() throws IOException;
+    public FileSKVIterator build() throws IOException;
   }
 
   /** Operation object for opening a scan reader. */
@@ -411,7 +411,7 @@ public abstract class FileOperations {
     }
 
     /** Execute the operation, constructing a scan iterator. */
-    public FileSKVIterator execute() throws IOException {
+    public FileSKVIterator build() throws IOException {
       validate();
       return openScanReader(this);
     }
@@ -421,7 +421,7 @@ public abstract class FileOperations {
   public static interface OpenScanReaderOperationBuilder extends FileReaderOperationBuilder<OpenScanReaderOperationBuilder>,
       NeedsRange<OpenScanReaderOperationBuilder> {
     /** Execute the operation, constructing a scan iterator. */
-    public FileSKVIterator execute() throws IOException;
+    public FileSKVIterator build() throws IOException;
   }
 
   /** Operation object for opening a full reader. */
@@ -446,7 +446,7 @@ public abstract class FileOperations {
     }
 
     /** Execute the operation, constructing the specified file reader. */
-    public FileSKVIterator execute() throws IOException {
+    public FileSKVIterator build() throws IOException {
       validate();
       return openReader(this);
     }
@@ -463,18 +463,18 @@ public abstract class FileOperations {
     public OpenReaderOperationBuilder seekToBeginning(boolean seekToBeginning);
 
     /** Execute the operation, constructing the specified file reader. */
-    public FileSKVIterator execute() throws IOException;
+    public FileSKVIterator build() throws IOException;
   }
 
   /**
-   * Type wrapper to ensure that {@code ofFile(...)} is called before other methods.
+   * Type wrapper to ensure that {@code forFile(...)} is called before other methods.
    */
   public static interface NeedsFile<ReturnType> {
     /** Specify the file this operation should apply to. */
-    public ReturnType ofFile(String filename, FileSystem fs, Configuration fsConf);
+    public NeedsTableConfiguration<ReturnType> forFile(String filename, FileSystem fs, Configuration fsConf);
 
     /** Specify the file this operation should apply to. */
-    public NeedsFileSystem<ReturnType> ofFile(String filename);
+    public NeedsFileSystem<ReturnType> forFile(String filename);
   }
 
   /**
@@ -482,7 +482,7 @@ public abstract class FileOperations {
    */
   public static interface NeedsFileSystem<ReturnType> {
     /** Specify the {@link FileSystem} that this operation operates on, along with an alternate configuration. */
-    public ReturnType inFileSystem(FileSystem fs, Configuration fsConf);
+    public NeedsTableConfiguration<ReturnType> inFileSystem(FileSystem fs, Configuration fsConf);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -48,38 +48,295 @@ public abstract class FileOperations {
     return new DispatchingFileFactory();
   }
 
+  //
+  // Abstract methods (to be implemented by subclasses)
+  //
+
+  protected abstract long getFileSize(GetFileSizeOperation options) throws IOException;
+
+  protected abstract FileSKVWriter openWriter(OpenWriterOperation options) throws IOException;
+
+  protected abstract FileSKVIterator openIndex(OpenIndexOperation options) throws IOException;
+
+  protected abstract FileSKVIterator openScanReader(OpenScanReaderOperation options) throws IOException;
+
+  protected abstract FileSKVIterator openReader(OpenReaderOperation options) throws IOException;
+
+  //
+  // File operations
+  //
+
   /**
-   * Open a reader that will not be seeked giving an initial seek location. This is useful for file operations that only need to scan data within a range and do
-   * not need to seek. Therefore file metadata such as indexes does not need to be kept in memory while the file is scanned. Also seek optimizations like bloom
-   * filters do not need to be loaded.
+   * Construct an operation object allowing one to query the size of a file. <br>
+   * Syntax:
    *
+   * <pre>
+   * long size = fileOperations.getFileSize().ofFile(filename, fileSystem, fsConfiguration).withTableConfiguration(tableConf).execute();
+   * </pre>
    */
-
-  public abstract FileSKVIterator openReader(String file, Range range, Set<ByteSequence> columnFamilies, boolean inclusive, FileSystem fs, Configuration conf,
-      RateLimiter readLimiter, AccumuloConfiguration tableConf) throws IOException;
-
-  public abstract FileSKVIterator openReader(String file, Range range, Set<ByteSequence> columnFamilies, boolean inclusive, FileSystem fs, Configuration conf,
-      RateLimiter readLimiter, AccumuloConfiguration tableConf, BlockCache dataCache, BlockCache indexCache) throws IOException;
+  public GetFileSizeOperation getFileSize() {
+    return new GetFileSizeOperation();
+  }
 
   /**
-   * Open a reader that fully support seeking and also enable any optimizations related to seeking, like bloom filters.
+   * Construct an operation object allowing one to create a writer for a file. <br>
+   * Syntax:
    *
+   * <pre>
+   * FileSKVWriter writer = fileOperations.openWriter()
+   *     .ofFile(...)
+   *     .withTableConfiguration(...)
+   *     .withRateLimiter(...) // optional
+   *     .withCompression(...) // optional
+   *     .execute();
+   * </pre>
    */
+  public OpenWriterOperation openWriter() {
+    return new OpenWriterOperation();
+  }
 
-  public abstract FileSKVIterator openReader(String file, boolean seekToBeginning, FileSystem fs, Configuration conf, RateLimiter readLimiter,
-      AccumuloConfiguration acuconf) throws IOException;
+  /**
+   * Construct an operation object allowing one to create an index iterator for a file. <br>
+   * Syntax:
+   *
+   * <pre>
+   * FileSKVIterator iterator = fileOperations.openIndex()
+   *     .ofFile(...)
+   *     .withTableConfiguration(...)
+   *     .withRateLimiter(...) // optional
+   *     .withBlockCache(...) // optional
+   *     .execute();
+   * </pre>
+   */
+  public OpenIndexOperation openIndex() {
+    return new OpenIndexOperation();
+  }
 
-  public abstract FileSKVIterator openReader(String file, boolean seekToBeginning, FileSystem fs, Configuration conf, RateLimiter readLimiter,
-      AccumuloConfiguration acuconf, BlockCache dataCache, BlockCache indexCache) throws IOException;
+  /**
+   * Construct an operation object allowing one to create a "scan" reader for a file. Scan readers do not have any optimizations for seeking beyond their
+   * initial position. This is useful for file operations that only need to scan data within a range and do not need to seek. Therefore file metadata such as
+   * indexes does not need to be kept in memory while the file is scanned. Also seek optimizations like bloom filters do not need to be loaded. <br>
+   * Syntax:
+   *
+   * <pre>
+   * FileSKVIterator scanner = fileOperations.openScanReader()
+   *     .ofFile(...)
+   *     .overRange(...)
+   *     .withTableConfiguration(...)
+   *     .withRateLimiter(...) // optional
+   *     .withBlockCache(...) // optional
+   *     .execute();
+   * </pre>
+   */
+  public OpenScanReaderOperation openScanReader() {
+    return new OpenScanReaderOperation();
+  }
 
-  public abstract FileSKVWriter openWriter(String file, FileSystem fs, Configuration conf, RateLimiter writeLimiter, AccumuloConfiguration acuconf)
-      throws IOException;
+  /**
+   * Construct an operation object allowing one to create a reader for a file. A reader constructed in this manner fully supports seeking, and also enables any
+   * optimizations related to seeking (e.g. Bloom filters). <br>
+   * Syntax:
+   *
+   * <pre>
+   * FileSKVIterator scanner = fileOperations.openReader()
+   *     .ofFile(...)
+   *     .withTableConfiguration(...)
+   *     .withRateLimiter(...) // optional
+   *     .withBlockCache(...) // optional
+   *     .seekToBeginning(...) // optional
+   *     .execute();
+   * </pre>
+   */
+  public OpenReaderOperation openReader() {
+    return new OpenReaderOperation();
+  }
 
-  public abstract FileSKVIterator openIndex(String file, FileSystem fs, Configuration conf, AccumuloConfiguration acuconf) throws IOException;
+  //
+  // Operation objects.
+  //
 
-  public abstract FileSKVIterator openIndex(String file, FileSystem fs, Configuration conf, AccumuloConfiguration acuconf, BlockCache dCache, BlockCache iCache)
-      throws IOException;
+  /**
+   * Options common to all FileOperations.
+   */
+  protected static class FileAccessOperation<SubclassType extends FileAccessOperation<SubclassType>> {
+    private AccumuloConfiguration tableConfiguration;
 
-  public abstract long getFileSize(String file, FileSystem fs, Configuration conf, AccumuloConfiguration acuconf) throws IOException;
+    private String filename;
+    private FileSystem fs;
+    private Configuration fsConf;
 
+    /** Specify the table configuration defining access to this file. */
+    @SuppressWarnings("unchecked")
+    public SubclassType withTableConfiguration(AccumuloConfiguration tableConfiguration) {
+      this.tableConfiguration = tableConfiguration;
+      return (SubclassType) this;
+    }
+
+    /** Specify the file this operation should apply to. */
+    @SuppressWarnings("unchecked")
+    public SubclassType ofFile(String filename, FileSystem fs, Configuration fsConf) {
+      this.filename = filename;
+      this.fs = fs;
+      this.fsConf = fsConf;
+      return (SubclassType) this;
+    }
+
+    public String getFilename() {
+      return filename;
+    }
+
+    public FileSystem getFileSystem() {
+      return fs;
+    }
+
+    public Configuration getConfiguration() {
+      return fsConf;
+    }
+
+    public AccumuloConfiguration getTableConfiguration() {
+      return tableConfiguration;
+    }
+  }
+
+  /**
+   * Operation object for performing {@code getFileSize()} operations.
+   */
+  public class GetFileSizeOperation extends FileAccessOperation<GetFileSizeOperation> {
+    /** Return the size of the file. */
+    public long execute() throws IOException {
+      return getFileSize(this);
+    }
+  }
+
+  /**
+   * Options common to all {@code FileOperations} which perform reading or writing.
+   */
+  protected static class FileIOOperation<SubclassType extends FileIOOperation<SubclassType>> extends FileAccessOperation<SubclassType> {
+    private RateLimiter rateLimiter;
+
+    /** Specify a rate limiter for this operation. */
+    @SuppressWarnings("unchecked")
+    public SubclassType withRateLimiter(RateLimiter rateLimiter) {
+      this.rateLimiter = rateLimiter;
+      return (SubclassType) this;
+    }
+
+    public RateLimiter getRateLimiter() {
+      return rateLimiter;
+    }
+  }
+
+  /**
+   * Operation object for constructing a writer.
+   */
+  public class OpenWriterOperation extends FileIOOperation<OpenWriterOperation> {
+    private String compression;
+
+    /** Set the compression type. */
+    public OpenWriterOperation withCompression(String compression) {
+      this.compression = compression;
+      return this;
+    }
+
+    public String getCompression() {
+      return compression;
+    }
+
+    /** Construct the writer. */
+    public FileSKVWriter execute() throws IOException {
+      return openWriter(this);
+    }
+  }
+
+  /**
+   * Options common to all {@code FileOperations} which perform reads.
+   */
+  protected static class FileReaderOperation<SubclassType extends FileReaderOperation<SubclassType>> extends FileIOOperation<SubclassType> {
+    private BlockCache dataCache;
+    private BlockCache indexCache;
+
+    /** Set the block cache pair to be used to optimize reads within the constructed reader. */
+    @SuppressWarnings("unchecked")
+    public SubclassType withBlockCache(BlockCache dataCache, BlockCache indexCache) {
+      this.dataCache = dataCache;
+      this.indexCache = indexCache;
+      return (SubclassType) this;
+    }
+
+    public BlockCache getDataCache() {
+      return dataCache;
+    }
+
+    public BlockCache getIndexCache() {
+      return indexCache;
+    }
+  }
+
+  /**
+   * Operation object for opening an index.
+   */
+  public class OpenIndexOperation extends FileReaderOperation<OpenIndexOperation> {
+    public FileSKVIterator execute() throws IOException {
+      return openIndex(this);
+    }
+  }
+
+  /** Operation object for opening a scan reader. */
+  public class OpenScanReaderOperation extends FileReaderOperation<OpenScanReaderOperation> {
+    private Range range;
+    private Set<ByteSequence> columnFamilies;
+    private boolean inclusive;
+
+    /** Set the range over which the constructed iterator will search. */
+    public OpenScanReaderOperation overRange(Range range, Set<ByteSequence> columnFamilies, boolean inclusive) {
+      this.range = range;
+      this.columnFamilies = columnFamilies;
+      this.inclusive = inclusive;
+      return this;
+    }
+
+    public Range getRange() {
+      return range;
+    }
+
+    public Set<ByteSequence> getColumnFamilies() {
+      return columnFamilies;
+    }
+
+    public boolean isRangeInclusive() {
+      return inclusive;
+    }
+
+    /** Execute the operation, constructing a scan iterator. */
+    public FileSKVIterator execute() throws IOException {
+      return openScanReader(this);
+    }
+  }
+
+  /** Operation object for opening a full reader. */
+  public class OpenReaderOperation extends FileReaderOperation<OpenReaderOperation> {
+    private boolean seekToBeginning = false;
+
+    /**
+     * Seek the constructed iterator to the beginning of its domain before returning. Equivalent to {@code seekToBeginning(true)}.
+     */
+    public OpenReaderOperation seekToBeginning() {
+      return seekToBeginning(true);
+    }
+
+    /** If true, seek the constructed iterator to the beginning of its domain before returning. */
+    public OpenReaderOperation seekToBeginning(boolean seekToBeginning) {
+      this.seekToBeginning = seekToBeginning;
+      return this;
+    }
+
+    /** Execute the operation, constructing the specified file reader. */
+    public FileSKVIterator execute() throws IOException {
+      return openReader(this);
+    }
+
+    public boolean isSeekToBeginning() {
+      return seekToBeginning;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -77,8 +77,8 @@ public class CreateEmpty {
     for (String arg : opts.files) {
       Path path = new Path(arg);
       log.info("Writing to file '" + path + "'");
-      FileSKVWriter writer = (new RFileOperations()).openWriter().ofFile(arg, path.getFileSystem(conf), conf)
-          .withTableConfiguration(DefaultConfiguration.getDefaultConfiguration()).withCompression(opts.codec).execute();
+      FileSKVWriter writer = (new RFileOperations()).newWriterBuilder().forFile(arg, path.getFileSystem(conf), conf)
+          .withTableConfiguration(DefaultConfiguration.getDefaultConfiguration()).withCompression(opts.codec).build();
       writer.close();
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -77,8 +77,8 @@ public class CreateEmpty {
     for (String arg : opts.files) {
       Path path = new Path(arg);
       log.info("Writing to file '" + path + "'");
-      FileSKVWriter writer = (new RFileOperations()).openWriter(arg, path.getFileSystem(conf), conf, null, DefaultConfiguration.getDefaultConfiguration(),
-          opts.codec);
+      FileSKVWriter writer = (new RFileOperations()).openWriter().ofFile(arg, path.getFileSystem(conf), conf)
+          .withTableConfiguration(DefaultConfiguration.getDefaultConfiguration()).withCompression(opts.codec).execute();
       writer.close();
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/mock/MockTableOperationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/mock/MockTableOperationsTest.java
@@ -225,8 +225,8 @@ public class MockTableOperationsTest {
     fs.delete(tempFile, true);
     fs.mkdirs(failures);
     fs.mkdirs(tempFile.getParent());
-    FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(tempFile.toString(), fs, defaultConf)
-        .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+    FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder().forFile(tempFile.toString(), fs, defaultConf)
+        .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
     writer.startDefaultLocalityGroup();
     List<Pair<Key,Value>> keyVals = new ArrayList<Pair<Key,Value>>();
     for (int i = 0; i < 5; i++) {

--- a/core/src/test/java/org/apache/accumulo/core/client/mock/MockTableOperationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/mock/MockTableOperationsTest.java
@@ -225,7 +225,8 @@ public class MockTableOperationsTest {
     fs.delete(tempFile, true);
     fs.mkdirs(failures);
     fs.mkdirs(tempFile.getParent());
-    FileSKVWriter writer = FileOperations.getInstance().openWriter(tempFile.toString(), fs, defaultConf, null, AccumuloConfiguration.getDefaultConfiguration());
+    FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(tempFile.toString(), fs, defaultConf)
+        .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
     writer.startDefaultLocalityGroup();
     List<Pair<Key,Value>> keyVals = new ArrayList<Pair<Key,Value>>();
     for (int i = 0; i < 5; i++) {

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -80,7 +80,7 @@ public class BloomFilterLayerLookupTest {
     // get output file name
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = new File(tempDir.getRoot(), testName + "." + suffix).getAbsolutePath();
-    FileSKVWriter bmfw = FileOperations.getInstance().openWriter().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
+    FileSKVWriter bmfw = FileOperations.getInstance().newWriterBuilder().forFile(fname, fs, conf).withTableConfiguration(acuconf).build();
 
     // write data to file
     long t1 = System.currentTimeMillis();
@@ -96,7 +96,7 @@ public class BloomFilterLayerLookupTest {
     bmfw.close();
 
     t1 = System.currentTimeMillis();
-    FileSKVIterator bmfr = FileOperations.getInstance().openReader().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
+    FileSKVIterator bmfr = FileOperations.getInstance().newReaderBuilder().forFile(fname, fs, conf).withTableConfiguration(acuconf).build();
     t2 = System.currentTimeMillis();
     LOG.debug("Opened " + fname + " in " + (t2 - t1));
 

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -80,7 +80,7 @@ public class BloomFilterLayerLookupTest {
     // get output file name
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = new File(tempDir.getRoot(), testName + "." + suffix).getAbsolutePath();
-    FileSKVWriter bmfw = FileOperations.getInstance().openWriter(fname, fs, conf, null, acuconf);
+    FileSKVWriter bmfw = FileOperations.getInstance().openWriter().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
 
     // write data to file
     long t1 = System.currentTimeMillis();
@@ -96,7 +96,7 @@ public class BloomFilterLayerLookupTest {
     bmfw.close();
 
     t1 = System.currentTimeMillis();
-    FileSKVIterator bmfr = FileOperations.getInstance().openReader(fname, false, fs, conf, null, acuconf);
+    FileSKVIterator bmfr = FileOperations.getInstance().openReader().ofFile(fname, fs, conf).withTableConfiguration(acuconf).execute();
     t2 = System.currentTimeMillis();
     LOG.debug("Opened " + fname + " in " + (t2 - t1));
 

--- a/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
@@ -51,7 +51,7 @@ public class FileOperationsTest {
       Configuration conf = new Configuration();
       FileSystem fs = FileSystem.getLocal(conf);
       AccumuloConfiguration acuconf = AccumuloConfiguration.getDefaultConfiguration();
-      writer = fileOperations.openWriter().ofFile(filename, fs, conf).withTableConfiguration(acuconf).execute();
+      writer = fileOperations.newWriterBuilder().forFile(filename, fs, conf).withTableConfiguration(acuconf).build();
       writer.close();
     } catch (Exception ex) {
       caughtException = true;

--- a/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
@@ -51,7 +51,7 @@ public class FileOperationsTest {
       Configuration conf = new Configuration();
       FileSystem fs = FileSystem.getLocal(conf);
       AccumuloConfiguration acuconf = AccumuloConfiguration.getDefaultConfiguration();
-      writer = fileOperations.openWriter(filename, fs, conf, null, acuconf);
+      writer = fileOperations.openWriter().ofFile(filename, fs, conf).withTableConfiguration(acuconf).execute();
       writer.close();
     } catch (Exception ex) {
       caughtException = true;

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -642,8 +642,8 @@ public class BulkImporter {
     String filename = file.toString();
     // log.debug(filename + " finding overlapping tablets " + startRow + " -> " + endRow);
     FileSystem fs = vm.getVolumeByPath(file).getFileSystem();
-    FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(filename, fs, fs.getConf()).withTableConfiguration(context.getConfiguration())
-        .seekToBeginning().execute();
+    FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder().forFile(filename, fs, fs.getConf())
+        .withTableConfiguration(context.getConfiguration()).seekToBeginning().build();
     try {
       Text row = startRow;
       if (row == null)

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -642,7 +642,8 @@ public class BulkImporter {
     String filename = file.toString();
     // log.debug(filename + " finding overlapping tablets " + startRow + " -> " + endRow);
     FileSystem fs = vm.getVolumeByPath(file).getFileSystem();
-    FileSKVIterator reader = FileOperations.getInstance().openReader(filename, true, fs, fs.getConf(), null, context.getConfiguration());
+    FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(filename, fs, fs.getConf()).withTableConfiguration(context.getConfiguration())
+        .seekToBeginning().execute();
     try {
       Text row = startRow;
       if (row == null)

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -465,7 +465,8 @@ public class Initialize implements KeywordExecutable {
       createEntriesForTablet(sorted, tablet);
     }
     FileSystem fs = volmanager.getVolumeByPath(new Path(fileName)).getFileSystem();
-    FileSKVWriter tabletWriter = FileOperations.getInstance().openWriter(fileName, fs, fs.getConf(), null, AccumuloConfiguration.getDefaultConfiguration());
+    FileSKVWriter tabletWriter = FileOperations.getInstance().openWriter().ofFile(fileName, fs, fs.getConf())
+        .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
     tabletWriter.startDefaultLocalityGroup();
 
     for (Entry<Key,Value> entry : sorted.entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -465,8 +465,8 @@ public class Initialize implements KeywordExecutable {
       createEntriesForTablet(sorted, tablet);
     }
     FileSystem fs = volmanager.getVolumeByPath(new Path(fileName)).getFileSystem();
-    FileSKVWriter tabletWriter = FileOperations.getInstance().openWriter().ofFile(fileName, fs, fs.getConf())
-        .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+    FileSKVWriter tabletWriter = FileOperations.getInstance().newWriterBuilder().forFile(fileName, fs, fs.getConf())
+        .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
     tabletWriter.startDefaultLocalityGroup();
 
     for (Entry<Key,Value> entry : sorted.entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -132,7 +132,7 @@ public class FileUtil {
 
       outFiles.add(newMapFile);
       FileSystem ns = fs.getVolumeByPath(new Path(newMapFile)).getFileSystem();
-      FileSKVWriter writer = new RFileOperations().openWriter().ofFile(newMapFile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
+      FileSKVWriter writer = new RFileOperations().newWriterBuilder().forFile(newMapFile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).build();
       writer.startDefaultLocalityGroup();
       List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<SortedKeyValueIterator<Key,Value>>(inFiles.size());
 
@@ -140,7 +140,7 @@ public class FileUtil {
       try {
         for (String s : inFiles) {
           ns = fs.getVolumeByPath(new Path(s)).getFileSystem();
-          reader = FileOperations.getInstance().openIndex().ofFile(s, ns, ns.getConf()).withTableConfiguration(acuConf).execute();
+          reader = FileOperations.getInstance().newIndexReaderBuilder().forFile(s, ns, ns.getConf()).withTableConfiguration(acuConf).build();
           iters.add(reader);
         }
 
@@ -401,10 +401,10 @@ public class FileUtil {
       FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
       try {
         if (useIndex)
-          reader = FileOperations.getInstance().openIndex().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
+          reader = FileOperations.getInstance().newIndexReaderBuilder().forFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).build();
         else
-          reader = FileOperations.getInstance().openScanReader().ofFile(path.toString(), ns, ns.getConf())
-              .overRange(new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false).withTableConfiguration(acuConf).execute();
+          reader = FileOperations.getInstance().newScanReaderBuilder().forFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf)
+              .overRange(new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false).build();
 
         while (reader.hasTop()) {
           Key key = reader.getTopKey();
@@ -425,10 +425,10 @@ public class FileUtil {
       }
 
       if (useIndex)
-        readers.add(FileOperations.getInstance().openIndex().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute());
+        readers.add(FileOperations.getInstance().newIndexReaderBuilder().forFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).build());
       else
-        readers.add(FileOperations.getInstance().openScanReader().ofFile(path.toString(), ns, ns.getConf())
-            .overRange(new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false).withTableConfiguration(acuConf).execute());
+        readers.add(FileOperations.getInstance().newScanReaderBuilder().forFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf)
+            .overRange(new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false).build());
 
     }
     return numKeys;
@@ -445,7 +445,7 @@ public class FileUtil {
       FileSKVIterator reader = null;
       FileSystem ns = fs.getVolumeByPath(mapfile.path()).getFileSystem();
       try {
-        reader = FileOperations.getInstance().openReader().ofFile(mapfile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
+        reader = FileOperations.getInstance().newReaderBuilder().forFile(mapfile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).build();
 
         Key firstKey = reader.getFirstKey();
         if (firstKey != null) {
@@ -479,8 +479,8 @@ public class FileUtil {
     for (FileRef ref : mapFiles) {
       Path path = ref.path();
       FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf)
-          .seekToBeginning().execute();
+      FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder().forFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf)
+          .seekToBeginning().build();
 
       try {
         if (!reader.hasTop())
@@ -523,7 +523,8 @@ public class FileUtil {
 
     Text row = new Text();
     FileSystem ns = fs.getVolumeByPath(mapFile).getFileSystem();
-    FileSKVIterator index = FileOperations.getInstance().openIndex().ofFile(mapFile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
+    FileSKVIterator index = FileOperations.getInstance().newIndexReaderBuilder().forFile(mapFile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf)
+        .build();
 
     try {
       while (index.hasTop()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -132,7 +132,7 @@ public class FileUtil {
 
       outFiles.add(newMapFile);
       FileSystem ns = fs.getVolumeByPath(new Path(newMapFile)).getFileSystem();
-      FileSKVWriter writer = new RFileOperations().openWriter(newMapFile.toString(), ns, ns.getConf(), null, acuConf);
+      FileSKVWriter writer = new RFileOperations().openWriter().ofFile(newMapFile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
       writer.startDefaultLocalityGroup();
       List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<SortedKeyValueIterator<Key,Value>>(inFiles.size());
 
@@ -140,7 +140,7 @@ public class FileUtil {
       try {
         for (String s : inFiles) {
           ns = fs.getVolumeByPath(new Path(s)).getFileSystem();
-          reader = FileOperations.getInstance().openIndex(s, ns, ns.getConf(), acuConf);
+          reader = FileOperations.getInstance().openIndex().ofFile(s, ns, ns.getConf()).withTableConfiguration(acuConf).execute();
           iters.add(reader);
         }
 
@@ -401,10 +401,10 @@ public class FileUtil {
       FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
       try {
         if (useIndex)
-          reader = FileOperations.getInstance().openIndex(path.toString(), ns, ns.getConf(), acuConf);
+          reader = FileOperations.getInstance().openIndex().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
         else
-          reader = FileOperations.getInstance().openReader(path.toString(), new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false,
-              ns, ns.getConf(), null, acuConf);
+          reader = FileOperations.getInstance().openScanReader().ofFile(path.toString(), ns, ns.getConf())
+              .overRange(new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false).withTableConfiguration(acuConf).execute();
 
         while (reader.hasTop()) {
           Key key = reader.getTopKey();
@@ -425,10 +425,10 @@ public class FileUtil {
       }
 
       if (useIndex)
-        readers.add(FileOperations.getInstance().openIndex(path.toString(), ns, ns.getConf(), acuConf));
+        readers.add(FileOperations.getInstance().openIndex().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute());
       else
-        readers.add(FileOperations.getInstance().openReader(path.toString(), new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false,
-            ns, ns.getConf(), null, acuConf));
+        readers.add(FileOperations.getInstance().openScanReader().ofFile(path.toString(), ns, ns.getConf())
+            .overRange(new Range(prevEndRow, false, null, true), LocalityGroupUtil.EMPTY_CF_SET, false).withTableConfiguration(acuConf).execute());
 
     }
     return numKeys;
@@ -445,7 +445,7 @@ public class FileUtil {
       FileSKVIterator reader = null;
       FileSystem ns = fs.getVolumeByPath(mapfile.path()).getFileSystem();
       try {
-        reader = FileOperations.getInstance().openReader(mapfile.toString(), false, ns, ns.getConf(), null, acuConf);
+        reader = FileOperations.getInstance().openReader().ofFile(mapfile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
 
         Key firstKey = reader.getFirstKey();
         if (firstKey != null) {
@@ -479,7 +479,8 @@ public class FileUtil {
     for (FileRef ref : mapFiles) {
       Path path = ref.path();
       FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader(path.toString(), true, ns, ns.getConf(), null, acuConf);
+      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(acuConf)
+          .seekToBeginning().execute();
 
       try {
         if (!reader.hasTop())
@@ -522,7 +523,7 @@ public class FileUtil {
 
     Text row = new Text();
     FileSystem ns = fs.getVolumeByPath(mapFile).getFileSystem();
-    FileSKVIterator index = FileOperations.getInstance().openIndex(mapFile.toString(), ns, ns.getConf(), acuConf);
+    FileSKVIterator index = FileOperations.getInstance().openIndex().ofFile(mapFile.toString(), ns, ns.getConf()).withTableConfiguration(acuConf).execute();
 
     try {
       while (index.hasTop()) {

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -113,8 +113,8 @@ public class BulkImporterTest {
     EasyMock.replay(context);
     String file = "target/testFile.rf";
     fs.delete(new Path(file), true);
-    FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(file, fs, fs.getConf()).withTableConfiguration(context.getConfiguration())
-        .execute();
+    FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder().forFile(file, fs, fs.getConf()).withTableConfiguration(context.getConfiguration())
+        .build();
     writer.startDefaultLocalityGroup();
     Value empty = new Value(new byte[] {});
     writer.append(new Key("a", "cf", "cq"), empty);

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -113,7 +113,8 @@ public class BulkImporterTest {
     EasyMock.replay(context);
     String file = "target/testFile.rf";
     fs.delete(new Path(file), true);
-    FileSKVWriter writer = FileOperations.getInstance().openWriter(file, fs, fs.getConf(), null, context.getConfiguration());
+    FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(file, fs, fs.getConf()).withTableConfiguration(context.getConfiguration())
+        .execute();
     writer.startDefaultLocalityGroup();
     Value empty = new Value(new byte[] {});
     writer.append(new Key("a", "cf", "cq"), empty);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -316,8 +316,8 @@ public class FileManager {
         Path path = new Path(file);
         FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
         // log.debug("Opening "+file + " path " + path);
-        FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(path.toString(), ns, ns.getConf())
-            .withTableConfiguration(context.getServerConfigurationFactory().getTableConfiguration(tablet)).withBlockCache(dataCache, indexCache).execute();
+        FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder().forFile(path.toString(), ns, ns.getConf())
+            .withTableConfiguration(context.getServerConfigurationFactory().getTableConfiguration(tablet)).withBlockCache(dataCache, indexCache).build();
         reservedFiles.add(reader);
         readersReserved.put(reader, file);
       } catch (Exception e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -316,8 +316,8 @@ public class FileManager {
         Path path = new Path(file);
         FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
         // log.debug("Opening "+file + " path " + path);
-        FileSKVIterator reader = FileOperations.getInstance().openReader(path.toString(), false, ns, ns.getConf(), null,
-            context.getServerConfigurationFactory().getTableConfiguration(tablet), dataCache, indexCache);
+        FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(path.toString(), ns, ns.getConf())
+            .withTableConfiguration(context.getServerConfigurationFactory().getTableConfiguration(tablet)).withBlockCache(dataCache, indexCache).execute();
         reservedFiles.add(reader);
         readersReserved.put(reader, file);
       } catch (Exception e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -632,7 +632,8 @@ public class InMemoryMap {
         Configuration conf = CachedConfiguration.getInstance();
         FileSystem fs = FileSystem.getLocal(conf);
 
-        reader = new RFileOperations().openReader(memDumpFile, true, fs, conf, null, SiteConfiguration.getInstance());
+        reader = new RFileOperations().openReader().ofFile(memDumpFile, fs, conf).withTableConfiguration(SiteConfiguration.getInstance()).seekToBeginning()
+            .execute();
         if (iflag != null)
           reader.setInterruptFlag(iflag);
 
@@ -804,7 +805,7 @@ public class InMemoryMap {
           siteConf = createSampleConfig(siteConf);
         }
 
-        FileSKVWriter out = new RFileOperations().openWriter(tmpFile, fs, newConf, null, siteConf);
+        FileSKVWriter out = new RFileOperations().openWriter().ofFile(tmpFile, fs, newConf).withTableConfiguration(siteConf).execute();
 
         InterruptibleIterator iter = map.skvIterator(null);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -632,8 +632,8 @@ public class InMemoryMap {
         Configuration conf = CachedConfiguration.getInstance();
         FileSystem fs = FileSystem.getLocal(conf);
 
-        reader = new RFileOperations().openReader().ofFile(memDumpFile, fs, conf).withTableConfiguration(SiteConfiguration.getInstance()).seekToBeginning()
-            .execute();
+        reader = new RFileOperations().newReaderBuilder().forFile(memDumpFile, fs, conf).withTableConfiguration(SiteConfiguration.getInstance())
+            .seekToBeginning().build();
         if (iflag != null)
           reader.setInterruptFlag(iflag);
 
@@ -805,7 +805,7 @@ public class InMemoryMap {
           siteConf = createSampleConfig(siteConf);
         }
 
-        FileSKVWriter out = new RFileOperations().openWriter().ofFile(tmpFile, fs, newConf).withTableConfiguration(siteConf).execute();
+        FileSKVWriter out = new RFileOperations().newWriterBuilder().forFile(tmpFile, fs, newConf).withTableConfiguration(siteConf).build();
 
         InterruptibleIterator iter = map.skvIterator(null);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
@@ -77,8 +77,8 @@ public class MajorCompactionRequest implements Cloneable {
     // @TODO ensure these files are always closed?
     FileOperations fileFactory = FileOperations.getInstance();
     FileSystem ns = volumeManager.getVolumeByPath(ref.path()).getFileSystem();
-    FileSKVIterator openReader = fileFactory.openReader().ofFile(ref.path().toString(), ns, ns.getConf()).withTableConfiguration(tableConfig).seekToBeginning()
-        .execute();
+    FileSKVIterator openReader = fileFactory.newReaderBuilder().forFile(ref.path().toString(), ns, ns.getConf()).withTableConfiguration(tableConfig)
+        .seekToBeginning().build();
     return openReader;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
@@ -77,7 +77,8 @@ public class MajorCompactionRequest implements Cloneable {
     // @TODO ensure these files are always closed?
     FileOperations fileFactory = FileOperations.getInstance();
     FileSystem ns = volumeManager.getVolumeByPath(ref.path()).getFileSystem();
-    FileSKVIterator openReader = fileFactory.openReader(ref.path().toString(), true, ns, ns.getConf(), null, tableConfig);
+    FileSKVIterator openReader = fileFactory.openReader().ofFile(ref.path().toString(), ns, ns.getConf()).withTableConfiguration(tableConfig).seekToBeginning()
+        .execute();
     return openReader;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -197,7 +197,8 @@ public class Compactor implements Callable<CompactionStats> {
     try {
       FileOperations fileFactory = FileOperations.getInstance();
       FileSystem ns = this.fs.getVolumeByPath(outputFilePath).getFileSystem();
-      mfw = fileFactory.openWriter(outputFilePathName, ns, ns.getConf(), env.getWriteLimiter(), acuTableConf);
+      mfw = fileFactory.openWriter().ofFile(outputFilePathName, ns, ns.getConf()).withTableConfiguration(acuTableConf).withRateLimiter(env.getWriteLimiter())
+          .execute();
 
       Map<String,Set<ByteSequence>> lGroups;
       try {
@@ -285,7 +286,8 @@ public class Compactor implements Callable<CompactionStats> {
         FileSystem fs = this.fs.getVolumeByPath(mapFile.path()).getFileSystem();
         FileSKVIterator reader;
 
-        reader = fileFactory.openReader(mapFile.path().toString(), false, fs, fs.getConf(), env.getReadLimiter(), acuTableConf);
+        reader = fileFactory.openReader().ofFile(mapFile.path().toString(), fs, fs.getConf()).withTableConfiguration(acuTableConf)
+            .withRateLimiter(env.getReadLimiter()).execute();
 
         readers.add(reader);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -197,8 +197,8 @@ public class Compactor implements Callable<CompactionStats> {
     try {
       FileOperations fileFactory = FileOperations.getInstance();
       FileSystem ns = this.fs.getVolumeByPath(outputFilePath).getFileSystem();
-      mfw = fileFactory.openWriter().ofFile(outputFilePathName, ns, ns.getConf()).withTableConfiguration(acuTableConf).withRateLimiter(env.getWriteLimiter())
-          .execute();
+      mfw = fileFactory.newWriterBuilder().forFile(outputFilePathName, ns, ns.getConf()).withTableConfiguration(acuTableConf)
+          .withRateLimiter(env.getWriteLimiter()).build();
 
       Map<String,Set<ByteSequence>> lGroups;
       try {
@@ -286,8 +286,8 @@ public class Compactor implements Callable<CompactionStats> {
         FileSystem fs = this.fs.getVolumeByPath(mapFile.path()).getFileSystem();
         FileSKVIterator reader;
 
-        reader = fileFactory.openReader().ofFile(mapFile.path().toString(), fs, fs.getConf()).withTableConfiguration(acuTableConf)
-            .withRateLimiter(env.getReadLimiter()).execute();
+        reader = fileFactory.newReaderBuilder().forFile(mapFile.path().toString(), fs, fs.getConf()).withTableConfiguration(acuTableConf)
+            .withRateLimiter(env.getReadLimiter()).build();
 
         readers.add(reader);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1584,7 +1584,8 @@ public class Tablet implements TabletCommitter {
     for (Entry<FileRef,DataFileValue> entry : allFiles.entrySet()) {
       FileRef file = entry.getKey();
       FileSystem ns = fs.getVolumeByPath(file.path()).getFileSystem();
-      FileSKVIterator openReader = fileFactory.openReader(file.path().toString(), true, ns, ns.getConf(), null, this.getTableConfiguration());
+      FileSKVIterator openReader = fileFactory.openReader().ofFile(file.path().toString(), ns, ns.getConf())
+          .withTableConfiguration(this.getTableConfiguration()).seekToBeginning().execute();
       try {
         Key first = openReader.getFirstKey();
         Key last = openReader.getLastKey();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1584,8 +1584,8 @@ public class Tablet implements TabletCommitter {
     for (Entry<FileRef,DataFileValue> entry : allFiles.entrySet()) {
       FileRef file = entry.getKey();
       FileSystem ns = fs.getVolumeByPath(file.path()).getFileSystem();
-      FileSKVIterator openReader = fileFactory.openReader().ofFile(file.path().toString(), ns, ns.getConf())
-          .withTableConfiguration(this.getTableConfiguration()).seekToBeginning().execute();
+      FileSKVIterator openReader = fileFactory.newReaderBuilder().forFile(file.path().toString(), ns, ns.getConf())
+          .withTableConfiguration(this.getTableConfiguration()).seekToBeginning().build();
       try {
         Key first = openReader.getFirstKey();
         Key last = openReader.getLastKey();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -149,8 +149,8 @@ public class TabletData {
       dataFiles.put(ref, dfv);
 
       FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(conf)
-          .seekToBeginning().execute();
+      FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder().forFile(path.toString(), ns, ns.getConf()).withTableConfiguration(conf)
+          .seekToBeginning().build();
       long maxTime = -1;
       try {
         while (reader.hasTop()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -149,7 +149,8 @@ public class TabletData {
       dataFiles.put(ref, dfv);
 
       FileSystem ns = fs.getVolumeByPath(path).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader(path.toString(), true, ns, ns.getConf(), null, conf);
+      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(path.toString(), ns, ns.getConf()).withTableConfiguration(conf)
+          .seekToBeginning().execute();
       long maxTime = -1;
       try {
         while (reader.hasTop()) {

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
@@ -98,8 +98,9 @@ public class BulkImportMonitoringIT extends ConfigurableMacBase {
           fs.mkdirs(bulkFailures);
           fs.mkdirs(files);
           for (int i = 0; i < 10; i++) {
-            FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
-                .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+            FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
+                .forFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
+                .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
             writer.startDefaultLocalityGroup();
             for (int j = 0x100; j < 0xfff; j += 3) {
               writer.append(new Key(Integer.toHexString(j)), new Value(new byte[0]));

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
@@ -98,8 +98,8 @@ public class BulkImportMonitoringIT extends ConfigurableMacBase {
           fs.mkdirs(bulkFailures);
           fs.mkdirs(files);
           for (int i = 0; i < 10; i++) {
-            FileSKVWriter writer = FileOperations.getInstance().openWriter(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf(), null,
-                AccumuloConfiguration.getDefaultConfiguration());
+            FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
+                .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
             writer.startDefaultLocalityGroup();
             for (int j = 0x100; j < 0xfff; j += 3) {
               writer.append(new Key(Integer.toHexString(j)), new Value(new byte[0]));

--- a/test/src/main/java/org/apache/accumulo/test/CreateRandomRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/CreateRandomRFile.java
@@ -69,7 +69,7 @@ public class CreateRandomRFile {
     FileSKVWriter mfw;
     try {
       FileSystem fs = FileSystem.get(conf);
-      mfw = new RFileOperations().openWriter().ofFile(file, fs, conf).withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+      mfw = new RFileOperations().newWriterBuilder().forFile(file, fs, conf).withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/CreateRandomRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/CreateRandomRFile.java
@@ -69,7 +69,7 @@ public class CreateRandomRFile {
     FileSKVWriter mfw;
     try {
       FileSystem fs = FileSystem.get(conf);
-      mfw = new RFileOperations().openWriter(file, fs, conf, null, AccumuloConfiguration.getDefaultConfiguration());
+      mfw = new RFileOperations().openWriter().ofFile(file, fs, conf).withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
@@ -58,7 +58,8 @@ public class GenerateSequentialRFile implements Runnable {
       final Configuration conf = new Configuration();
       Path p = new Path(opts.filePath);
       final FileSystem fs = p.getFileSystem(conf);
-      FileSKVWriter writer = FileOperations.getInstance().openWriter(opts.filePath, fs, conf, null, DefaultConfiguration.getInstance());
+      FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(opts.filePath, fs, conf)
+          .withTableConfiguration(DefaultConfiguration.getInstance()).execute();
 
       writer.startDefaultLocalityGroup();
 

--- a/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
@@ -58,8 +58,8 @@ public class GenerateSequentialRFile implements Runnable {
       final Configuration conf = new Configuration();
       Path p = new Path(opts.filePath);
       final FileSystem fs = p.getFileSystem(conf);
-      FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(opts.filePath, fs, conf)
-          .withTableConfiguration(DefaultConfiguration.getInstance()).execute();
+      FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder().forFile(opts.filePath, fs, conf)
+          .withTableConfiguration(DefaultConfiguration.getInstance()).build();
 
       writer.startDefaultLocalityGroup();
 

--- a/test/src/main/java/org/apache/accumulo/test/GetFileInfoBulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetFileInfoBulkIT.java
@@ -123,8 +123,9 @@ public class GetFileInfoBulkIT extends ConfigurableMacBase {
           fs.mkdirs(bulkFailures);
           fs.mkdirs(files);
           for (int i = 0; i < 100; i++) {
-            FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
-                .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+            FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
+                .forFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
+                .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
             writer.startDefaultLocalityGroup();
             for (int j = 0x100; j < 0xfff; j += 3) {
               writer.append(new Key(Integer.toHexString(j)), new Value(new byte[0]));

--- a/test/src/main/java/org/apache/accumulo/test/GetFileInfoBulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetFileInfoBulkIT.java
@@ -123,8 +123,8 @@ public class GetFileInfoBulkIT extends ConfigurableMacBase {
           fs.mkdirs(bulkFailures);
           fs.mkdirs(files);
           for (int i = 0; i < 100; i++) {
-            FileSKVWriter writer = FileOperations.getInstance().openWriter(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf(), null,
-                AccumuloConfiguration.getDefaultConfiguration());
+            FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
+                .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
             writer.startDefaultLocalityGroup();
             for (int j = 0x100; j < 0xfff; j += 3) {
               writer.append(new Key(Integer.toHexString(j)), new Value(new byte[0]));

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1338,9 +1338,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
     assertTrue(errorsDir.mkdir());
     fs.mkdirs(new Path(errorsDir.toString()));
     AccumuloConfiguration aconf = AccumuloConfiguration.getDefaultConfiguration();
-    FileSKVWriter evenWriter = FileOperations.getInstance().openWriter().ofFile(even, fs, conf).withTableConfiguration(aconf).execute();
+    FileSKVWriter evenWriter = FileOperations.getInstance().newWriterBuilder().forFile(even, fs, conf).withTableConfiguration(aconf).build();
     evenWriter.startDefaultLocalityGroup();
-    FileSKVWriter oddWriter = FileOperations.getInstance().openWriter().ofFile(odd, fs, conf).withTableConfiguration(aconf).execute();
+    FileSKVWriter oddWriter = FileOperations.getInstance().newWriterBuilder().forFile(odd, fs, conf).withTableConfiguration(aconf).build();
     oddWriter.startDefaultLocalityGroup();
     long timestamp = System.currentTimeMillis();
     Text cf = new Text("cf");

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1338,9 +1338,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
     assertTrue(errorsDir.mkdir());
     fs.mkdirs(new Path(errorsDir.toString()));
     AccumuloConfiguration aconf = AccumuloConfiguration.getDefaultConfiguration();
-    FileSKVWriter evenWriter = FileOperations.getInstance().openWriter(even, fs, conf, null, aconf);
+    FileSKVWriter evenWriter = FileOperations.getInstance().openWriter().ofFile(even, fs, conf).withTableConfiguration(aconf).execute();
     evenWriter.startDefaultLocalityGroup();
-    FileSKVWriter oddWriter = FileOperations.getInstance().openWriter(odd, fs, conf, null, aconf);
+    FileSKVWriter oddWriter = FileOperations.getInstance().openWriter().ofFile(odd, fs, conf).withTableConfiguration(aconf).execute();
     oddWriter.startDefaultLocalityGroup();
     long timestamp = System.currentTimeMillis();
     Text cf = new Text("cf");

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -218,8 +218,8 @@ public class TestIngest {
 
     if (opts.outputFile != null) {
       Configuration conf = CachedConfiguration.getInstance();
-      writer = FileOperations.getInstance()
-          .openWriter(opts.outputFile + "." + RFile.EXTENSION, fs, conf, null, AccumuloConfiguration.getDefaultConfiguration());
+      writer = FileOperations.getInstance().openWriter().ofFile(opts.outputFile + "." + RFile.EXTENSION, fs, conf)
+          .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
       writer.startDefaultLocalityGroup();
     } else {
       bw = connector.createBatchWriter(opts.getTableName(), bwOpts.getBatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -218,8 +218,8 @@ public class TestIngest {
 
     if (opts.outputFile != null) {
       Configuration conf = CachedConfiguration.getInstance();
-      writer = FileOperations.getInstance().openWriter().ofFile(opts.outputFile + "." + RFile.EXTENSION, fs, conf)
-          .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+      writer = FileOperations.getInstance().newWriterBuilder().forFile(opts.outputFile + "." + RFile.EXTENSION, fs, conf)
+          .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
       writer.startDefaultLocalityGroup();
     } else {
       bw = connector.createBatchWriter(opts.getTableName(), bwOpts.getBatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
@@ -74,17 +74,17 @@ public class BulkFileIT extends AccumuloClusterHarness {
 
     fs.delete(new Path(dir), true);
 
-    FileSKVWriter writer1 = FileOperations.getInstance().openWriter(dir + "/f1." + RFile.EXTENSION, fs, conf, null, aconf);
+    FileSKVWriter writer1 = FileOperations.getInstance().openWriter().ofFile(dir + "/f1." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf).execute();
     writer1.startDefaultLocalityGroup();
     writeData(writer1, 0, 333);
     writer1.close();
 
-    FileSKVWriter writer2 = FileOperations.getInstance().openWriter(dir + "/f2." + RFile.EXTENSION, fs, conf, null, aconf);
+    FileSKVWriter writer2 = FileOperations.getInstance().openWriter().ofFile(dir + "/f2." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf).execute();
     writer2.startDefaultLocalityGroup();
     writeData(writer2, 334, 999);
     writer2.close();
 
-    FileSKVWriter writer3 = FileOperations.getInstance().openWriter(dir + "/f3." + RFile.EXTENSION, fs, conf, null, aconf);
+    FileSKVWriter writer3 = FileOperations.getInstance().openWriter().ofFile(dir + "/f3." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf).execute();
     writer3.startDefaultLocalityGroup();
     writeData(writer3, 1000, 1999);
     writer3.close();

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
@@ -74,17 +74,20 @@ public class BulkFileIT extends AccumuloClusterHarness {
 
     fs.delete(new Path(dir), true);
 
-    FileSKVWriter writer1 = FileOperations.getInstance().openWriter().ofFile(dir + "/f1." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf).execute();
+    FileSKVWriter writer1 = FileOperations.getInstance().newWriterBuilder().forFile(dir + "/f1." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf)
+        .build();
     writer1.startDefaultLocalityGroup();
     writeData(writer1, 0, 333);
     writer1.close();
 
-    FileSKVWriter writer2 = FileOperations.getInstance().openWriter().ofFile(dir + "/f2." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf).execute();
+    FileSKVWriter writer2 = FileOperations.getInstance().newWriterBuilder().forFile(dir + "/f2." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf)
+        .build();
     writer2.startDefaultLocalityGroup();
     writeData(writer2, 334, 999);
     writer2.close();
 
-    FileSKVWriter writer3 = FileOperations.getInstance().openWriter().ofFile(dir + "/f3." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf).execute();
+    FileSKVWriter writer3 = FileOperations.getInstance().newWriterBuilder().forFile(dir + "/f3." + RFile.EXTENSION, fs, conf).withTableConfiguration(aconf)
+        .build();
     writer3.startDefaultLocalityGroup();
     writeData(writer3, 1000, 1999);
     writer3.close();

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
@@ -193,8 +193,8 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
       Configuration conf = CachedConfiguration.getInstance();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
-      FileSKVIterator sample = RFileOperations.getInstance().openReader().ofFile(files[0].toString(), FileSystem.get(conf), conf)
-          .withTableConfiguration(acuconf).execute().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
+      FileSKVIterator sample = RFileOperations.getInstance().newReaderBuilder().forFile(files[0].toString(), FileSystem.get(conf), conf)
+          .withTableConfiguration(acuconf).build().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);
     } else {
       assertEquals(0, files.length);

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
@@ -193,8 +193,8 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
       Configuration conf = CachedConfiguration.getInstance();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
-      FileSKVIterator sample = RFileOperations.getInstance().openReader(files[0].toString(), false, FileSystem.get(conf), conf, null, acuconf)
-          .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
+      FileSKVIterator sample = RFileOperations.getInstance().openReader().ofFile(files[0].toString(), FileSystem.get(conf), conf)
+          .withTableConfiguration(acuconf).execute().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);
     } else {
       assertEquals(0, files.length);

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
@@ -205,8 +205,8 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
       Configuration conf = CachedConfiguration.getInstance();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
-      FileSKVIterator sample = RFileOperations.getInstance().openReader(files[0].toString(), false, FileSystem.get(conf), conf, null, acuconf)
-          .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
+      FileSKVIterator sample = RFileOperations.getInstance().openReader().ofFile(files[0].toString(), FileSystem.get(conf), conf)
+          .withTableConfiguration(acuconf).execute().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);
     } else {
       assertEquals(0, files.length);

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
@@ -205,8 +205,8 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
       Configuration conf = CachedConfiguration.getInstance();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
-      FileSKVIterator sample = RFileOperations.getInstance().openReader().ofFile(files[0].toString(), FileSystem.get(conf), conf)
-          .withTableConfiguration(acuconf).execute().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
+      FileSKVIterator sample = RFileOperations.getInstance().newReaderBuilder().forFile(files[0].toString(), FileSystem.get(conf), conf)
+          .withTableConfiguration(acuconf).build().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);
     } else {
       assertEquals(0, files.length);

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/FastBulkImportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/FastBulkImportIT.java
@@ -90,8 +90,8 @@ public class FastBulkImportIT extends ConfigurableMacBase {
     fs.mkdirs(bulkFailures);
     fs.mkdirs(files);
     for (int i = 0; i < 100; i++) {
-      FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
-          .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+      FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder().forFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
+          .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
       writer.startDefaultLocalityGroup();
       for (int j = 0x100; j < 0xfff; j += 3) {
         writer.append(new Key(Integer.toHexString(j)), new Value(new byte[0]));

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/FastBulkImportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/FastBulkImportIT.java
@@ -90,8 +90,8 @@ public class FastBulkImportIT extends ConfigurableMacBase {
     fs.mkdirs(bulkFailures);
     fs.mkdirs(files);
     for (int i = 0; i < 100; i++) {
-      FileSKVWriter writer = FileOperations.getInstance().openWriter(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf(), null,
-          AccumuloConfiguration.getDefaultConfiguration());
+      FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(files.toString() + "/bulk_" + i + "." + RFile.EXTENSION, fs, fs.getConf())
+          .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
       writer.startDefaultLocalityGroup();
       for (int j = 0x100; j < 0xfff; j += 3) {
         writer.append(new Key(Integer.toHexString(j)), new Value(new byte[0]));

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -447,8 +447,8 @@ public class CollectTabletStats {
 
     for (FileRef file : files) {
       FileSystem ns = fs.getVolumeByPath(file.path()).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(file.path().toString(), ns, ns.getConf()).withTableConfiguration(aconf)
-          .execute();
+      FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder().forFile(file.path().toString(), ns, ns.getConf()).withTableConfiguration(aconf)
+          .build();
       Range range = new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true);
       reader.seek(range, columnSet, columnSet.size() == 0 ? false : true);
       while (reader.hasTop() && !range.afterEndKey(reader.getTopKey())) {
@@ -478,8 +478,8 @@ public class CollectTabletStats {
 
     for (FileRef file : files) {
       FileSystem ns = fs.getVolumeByPath(file.path()).getFileSystem();
-      readers.add(FileOperations.getInstance().openReader().ofFile(file.path().toString(), ns, ns.getConf()).withTableConfiguration(aconf.getConfiguration())
-          .execute());
+      readers.add(FileOperations.getInstance().newReaderBuilder().forFile(file.path().toString(), ns, ns.getConf())
+          .withTableConfiguration(aconf.getConfiguration()).build());
     }
 
     List<IterInfo> emptyIterinfo = Collections.emptyList();

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -447,7 +447,8 @@ public class CollectTabletStats {
 
     for (FileRef file : files) {
       FileSystem ns = fs.getVolumeByPath(file.path()).getFileSystem();
-      FileSKVIterator reader = FileOperations.getInstance().openReader(file.path().toString(), false, ns, ns.getConf(), null, aconf);
+      FileSKVIterator reader = FileOperations.getInstance().openReader().ofFile(file.path().toString(), ns, ns.getConf()).withTableConfiguration(aconf)
+          .execute();
       Range range = new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true);
       reader.seek(range, columnSet, columnSet.size() == 0 ? false : true);
       while (reader.hasTop() && !range.afterEndKey(reader.getTopKey())) {
@@ -477,7 +478,8 @@ public class CollectTabletStats {
 
     for (FileRef file : files) {
       FileSystem ns = fs.getVolumeByPath(file.path()).getFileSystem();
-      readers.add(FileOperations.getInstance().openReader(file.path().toString(), false, ns, ns.getConf(), null, aconf.getConfiguration()));
+      readers.add(FileOperations.getInstance().openReader().ofFile(file.path().toString(), ns, ns.getConf()).withTableConfiguration(aconf.getConfiguration())
+          .execute());
     }
 
     List<IterInfo> emptyIterinfo = Collections.emptyList();

--- a/test/src/main/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
@@ -2077,7 +2077,8 @@ public abstract class SimpleProxyBase extends SharedMiniClusterBase {
 
     // Write an RFile
     String filename = dir + "/bulk/import/rfile.rf";
-    FileSKVWriter writer = FileOperations.getInstance().openWriter(filename, fs, fs.getConf(), null, DefaultConfiguration.getInstance());
+    FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(filename, fs, fs.getConf())
+        .withTableConfiguration(DefaultConfiguration.getInstance()).execute();
     writer.startDefaultLocalityGroup();
     writer.append(new org.apache.accumulo.core.data.Key(new Text("a"), new Text("b"), new Text("c")), new Value("value".getBytes(UTF_8)));
     writer.close();

--- a/test/src/main/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
@@ -2077,8 +2077,8 @@ public abstract class SimpleProxyBase extends SharedMiniClusterBase {
 
     // Write an RFile
     String filename = dir + "/bulk/import/rfile.rf";
-    FileSKVWriter writer = FileOperations.getInstance().openWriter().ofFile(filename, fs, fs.getConf())
-        .withTableConfiguration(DefaultConfiguration.getInstance()).execute();
+    FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder().forFile(filename, fs, fs.getConf())
+        .withTableConfiguration(DefaultConfiguration.getInstance()).build();
     writer.startDefaultLocalityGroup();
     writer.append(new org.apache.accumulo.core.data.Key(new Text("a"), new Text("b"), new Text("c")), new Value("value".getBytes(UTF_8)));
     writer.close();

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/bulk/BulkPlusOne.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/bulk/BulkPlusOne.java
@@ -83,7 +83,7 @@ public class BulkPlusOne extends BulkImportTest {
 
     for (int i = 0; i < parts; i++) {
       String fileName = dir + "/" + String.format("part_%d.", i) + RFile.EXTENSION;
-      FileSKVWriter f = FileOperations.getInstance().openWriter(fileName, fs, fs.getConf(), null, defaultConfiguration);
+      FileSKVWriter f = FileOperations.getInstance().openWriter().ofFile(fileName, fs, fs.getConf()).withTableConfiguration(defaultConfiguration).execute();
       f.startDefaultLocalityGroup();
       int start = rows.get(i);
       int end = rows.get(i + 1);

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/bulk/BulkPlusOne.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/bulk/BulkPlusOne.java
@@ -83,7 +83,8 @@ public class BulkPlusOne extends BulkImportTest {
 
     for (int i = 0; i < parts; i++) {
       String fileName = dir + "/" + String.format("part_%d.", i) + RFile.EXTENSION;
-      FileSKVWriter f = FileOperations.getInstance().openWriter().ofFile(fileName, fs, fs.getConf()).withTableConfiguration(defaultConfiguration).execute();
+      FileSKVWriter f = FileOperations.getInstance().newWriterBuilder().forFile(fileName, fs, fs.getConf()).withTableConfiguration(defaultConfiguration)
+          .build();
       f.startDefaultLocalityGroup();
       int start = rows.get(i);
       int end = rows.get(i + 1);

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/security/TableOp.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/security/TableOp.java
@@ -203,8 +203,8 @@ public class TableOp extends Test {
         Path dir = new Path("/tmp", "bulk_" + UUID.randomUUID().toString());
         Path fail = new Path(dir.toString() + "_fail");
         FileSystem fs = WalkingSecurity.get(state, env).getFs();
-        FileSKVWriter f = FileOperations.getInstance().openWriter().ofFile(dir + "/securityBulk." + RFile.EXTENSION, fs, fs.getConf())
-            .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
+        FileSKVWriter f = FileOperations.getInstance().newWriterBuilder().forFile(dir + "/securityBulk." + RFile.EXTENSION, fs, fs.getConf())
+            .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).build();
         f.startDefaultLocalityGroup();
         fs.mkdirs(fail);
         for (Key k : keys)

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/security/TableOp.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/security/TableOp.java
@@ -203,8 +203,8 @@ public class TableOp extends Test {
         Path dir = new Path("/tmp", "bulk_" + UUID.randomUUID().toString());
         Path fail = new Path(dir.toString() + "_fail");
         FileSystem fs = WalkingSecurity.get(state, env).getFs();
-        FileSKVWriter f = FileOperations.getInstance().openWriter(dir + "/securityBulk." + RFile.EXTENSION, fs, fs.getConf(), null,
-            AccumuloConfiguration.getDefaultConfiguration());
+        FileSKVWriter f = FileOperations.getInstance().openWriter().ofFile(dir + "/securityBulk." + RFile.EXTENSION, fs, fs.getConf())
+            .withTableConfiguration(AccumuloConfiguration.getDefaultConfiguration()).execute();
         f.startDefaultLocalityGroup();
         fs.mkdirs(fail);
         for (Key k : keys)


### PR DESCRIPTION
Implemented a builder/fluent style of syntax, where each operation creates an operation object with both some methods for setting
parameters and an execute() method to actually invoke the operation.

I'm not really sure if this is in line with the improvement the reporter suggests.  It does however address the only goal I can identify with that request: it should be possible to extend the interface `FileOperations` in a manner such as was done for ACCUMULO-4187 without requiring significant changes to unrelated code.

Also, the automatic formatter hates me, and completely undid most of my eye-pleasing formatting.