### PR TITLE
ACCUMULO-4157 Bug fix for removing WALs to quickly

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -305,6 +305,8 @@ public enum Property {
   GC_DELETE_THREADS("gc.threads.delete", "16", PropertyType.COUNT, "The number of threads used to delete files"),
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN, "Do not use the Trash, even if it is configured"),
   GC_FILE_ARCHIVE("gc.file.archive", "false", PropertyType.BOOLEAN, "Archive any files/directories instead of moving to the HDFS trash or deleting"),
+  GC_WAL_DEAD_SERVER_WAIT("gc.wal.dead.server.wait", "1h", PropertyType.TIMEDURATION,
+      "Time to wait after a tserver is first seen as dead before removing associated WAL files"),
 
   // properties that are specific to the monitor server behavior
   MONITOR_PREFIX("monitor.", null, PropertyType.PREFIX, "Properties in this category affect the behavior of the monitor web server."),

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -147,4 +147,9 @@ public class PropertyTest {
       }
     }
   }
+
+  @Test
+  public void testGCDeadServerWaitSecond() {
+    assertEquals("1h", Property.GC_WAL_DEAD_SERVER_WAIT.getDefaultValue());
+  }
 }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -260,7 +260,6 @@ public class GarbageCollectWriteAheadLogs {
    * @param status
    *          GCStatus object
    */
-  @VisibleForTesting
   void removeWALFile(Entry<String,ArrayList<Path>> entry, AccumuloConfiguration conf, final GCStatus status) {
     HostAndPort address = AddressUtil.parseAddress(entry.getKey(), false);
     if (!holdsLock(address)) {
@@ -292,7 +291,7 @@ public class GarbageCollectWriteAheadLogs {
     try {
       tserver = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, conf);
       tserver.removeLogs(Tracer.traceInfo(), SystemCredentials.get().toThrift(instance), paths2strings(entry.getValue()));
-      log.debug("asking tserver to delete " + entry.getValue() + " from " + entry.getKey());
+      log.debug("asked tserver to delete " + entry.getValue() + " from " + entry.getKey());
       status.currentLog.deleted += entry.getValue().size();
     } catch (TException e) {
       log.warn("Error talking to " + address + ": " + e);
@@ -565,7 +564,7 @@ public class GarbageCollectWriteAheadLogs {
    * @param address
    *          HostAndPort of dead tserver
    * @param wait
-   *          long value of elapsed time to wait
+   *          long value of elapsed millis to wait
    * @return boolean whether enough time elapsed since the server was first seen as dead.
    */
   @VisibleForTesting
@@ -574,7 +573,7 @@ public class GarbageCollectWriteAheadLogs {
     Long firstSeen = firstSeenDead.get(address);
     if (firstSeen != null) {
       long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - firstSeen);
-      log.trace("Elapsed seconds since " + address + " first seen dead: " + elapsedTime);
+      log.trace("Elapsed milliseconds since " + address + " first seen dead: " + elapsedTime);
       return elapsedTime > wait;
     } else {
       log.trace("Adding server to firstSeenDead map " + address);

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -16,26 +16,49 @@
  */
 package org.apache.accumulo.gc;
 
-import static org.easymock.EasyMock.createMock;
+import com.google.common.net.HostAndPort;
+
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.gc.thrift.GCStatus;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import org.apache.accumulo.core.client.mock.MockInstance;
+import org.apache.accumulo.core.gc.thrift.GcCycleStats;
+import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.zookeeper.KeeperException;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static java.lang.Thread.sleep;
+
+import java.io.FileOutputStream;
+import org.apache.commons.io.FileUtils;
 
 public class GarbageCollectWriteAheadLogsTest {
   private static final long BLOCK_SIZE = 64000000L;
@@ -233,5 +256,289 @@ public class GarbageCollectWriteAheadLogsTest {
     assertFalse(GarbageCollectWriteAheadLogs.isUUID("foo"));
     assertFalse(GarbageCollectWriteAheadLogs.isUUID("0" + UUID.randomUUID().toString()));
     assertFalse(GarbageCollectWriteAheadLogs.isUUID(null));
+  }
+
+  @Test
+  public void testTimeToDeleteTrue() throws InterruptedException {
+    gcwal.clearFirstSeenDead();
+    HostAndPort address = HostAndPort.fromString("tserver1:9998");
+    long wait = AccumuloConfiguration.getTimeInMillis("1s");
+    gcwal.timeToDelete(address, wait); // to store first seen dead
+    sleep(wait * 2);
+    assertTrue(gcwal.timeToDelete(address, wait));
+  }
+
+  @Test
+  public void testTimeToDeleteFalse() {
+    HostAndPort address = HostAndPort.fromString("tserver1:9998");
+    long wait = AccumuloConfiguration.getTimeInMillis("1h");
+    long t1, t2;
+    boolean ttd;
+    do {
+      t1 = System.nanoTime();
+      gcwal.clearFirstSeenDead();
+      gcwal.timeToDelete(address, wait);
+      ttd = gcwal.timeToDelete(address, wait);
+      t2 = System.nanoTime();
+    } while (t2 - t1 > (wait / 2) * 1000000); // as long as it took less than half of the configured wait
+
+    assertFalse(gcwal.timeToDelete(address, wait));
+  }
+
+  @Test
+  public void testTimeToDeleteWithNullAddress() {
+    assertFalse(gcwal.timeToDelete(null, 123l));
+  }
+
+  /**
+   * Wrapper class with some helper methods
+   * <p>
+   * Just a wrapper around a LinkedHashMap that store method name and argument information. Also includes some convenience methods to make usage cleaner.
+   */
+  class MethodCalls {
+
+    private LinkedHashMap<String,List<Object>> mapWrapper;
+
+    public MethodCalls() {
+      mapWrapper = new LinkedHashMap<String,List<Object>>();
+    }
+
+    public void put(String methodName, Object... args) {
+      mapWrapper.put(methodName, Arrays.asList(args));
+    }
+
+    public int size() {
+      return mapWrapper.size();
+    }
+
+    public boolean hasOneEntry() {
+      return size() == 1;
+    }
+
+    public Map.Entry<String,List<Object>> getFirstEntry() {
+      return mapWrapper.entrySet().iterator().next();
+    }
+
+    public String getFirstEntryMethod() {
+      return getFirstEntry().getKey();
+    }
+
+    public List<Object> getFirstEntryArgs() {
+      return getFirstEntry().getValue();
+    }
+
+    public Object getFirstEntryArg(int number) {
+      return getFirstEntryArgs().get(number);
+    }
+  }
+
+  /**
+   * Partial mock of the GarbageCollectWriteAheadLogs for testing the removeFile method
+   * <p>
+   * There is a map named methodCalls that can be used to assert parameters on methods called inside the removeFile method
+   */
+  class GCWALPartialMock extends GarbageCollectWriteAheadLogs {
+
+    private boolean holdsLockBool = false;
+
+    public GCWALPartialMock(Instance i, VolumeManager vm, boolean useTrash, boolean holdLock) throws IOException {
+      super(i, vm, useTrash);
+      this.holdsLockBool = holdLock;
+    }
+
+    public MethodCalls methodCalls = new MethodCalls();
+
+    @Override
+    boolean holdsLock(HostAndPort addr) {
+      return holdsLockBool;
+    }
+
+    @Override
+    void removeWALfromDownTserver(HostAndPort address, AccumuloConfiguration conf, Entry<String,ArrayList<Path>> entry, final GCStatus status) {
+      methodCalls.put("removeWALFromDownTserver", address, conf, entry, status);
+    }
+
+    @Override
+    void askTserverToRemoveWAL(HostAndPort address, AccumuloConfiguration conf, Entry<String,ArrayList<Path>> entry, final GCStatus status) {
+      methodCalls.put("askTserverToRemoveWAL", address, conf, entry, status);
+    }
+
+    @Override
+    void removeOldStyleWAL(Entry<String,ArrayList<Path>> entry, final GCStatus status) {
+      methodCalls.put("removeOldStyleWAL", entry, status);
+    }
+
+    @Override
+    void removeSortedWAL(Path swalog) {
+      methodCalls.put("removeSortedWAL", swalog);
+    }
+  }
+
+  private GCWALPartialMock getGCWALForRemoveFileTest(GCStatus s, final boolean locked) throws IOException {
+    return new GCWALPartialMock(new MockInstance("accumulo"), VolumeManagerImpl.get(), false, locked);
+  }
+
+  private Map<String,Path> getEmptyMap() {
+    return new HashMap<String,Path>();
+  }
+
+  private Map<String,ArrayList<Path>> getServerToFileMap1(String key, Path singlePath) {
+    Map<String,ArrayList<Path>> serverToFileMap = new HashMap<String,ArrayList<Path>>();
+    serverToFileMap.put(key, new ArrayList<Path>(Arrays.asList(singlePath)));
+    return serverToFileMap;
+  }
+
+  @Test
+  public void testRemoveFilesWithOldStyle() throws IOException {
+    GCStatus status = new GCStatus();
+    GarbageCollectWriteAheadLogs realGCWAL = getGCWALForRemoveFileTest(status, true);
+    Path p1 = new Path("hdfs://localhost:9000/accumulo/wal/tserver1+9997/" + UUID.randomUUID().toString());
+    Map<String,ArrayList<Path>> serverToFileMap = getServerToFileMap1("", p1);
+
+    realGCWAL.removeFiles(getEmptyMap(), serverToFileMap, getEmptyMap(), status);
+
+    MethodCalls calls = ((GCWALPartialMock) realGCWAL).methodCalls;
+    assertEquals("Only one method should have been called", 1, calls.size());
+    assertEquals("Method should be removeOldStyleWAL", "removeOldStyleWAL", calls.getFirstEntryMethod());
+    Entry<String,ArrayList<Path>> firstServerToFileMap = serverToFileMap.entrySet().iterator().next();
+    assertEquals("First param should be empty", firstServerToFileMap, calls.getFirstEntryArg(0));
+    assertEquals("Second param should be the status", status, calls.getFirstEntryArg(1));
+  }
+
+  @Test
+  public void testRemoveFilesWithDeadTservers() throws IOException {
+    GCStatus status = new GCStatus();
+    GarbageCollectWriteAheadLogs realGCWAL = getGCWALForRemoveFileTest(status, false);
+    String server = "tserver1+9997";
+    Path p1 = new Path("hdfs://localhost:9000/accumulo/wal/" + server + "/" + UUID.randomUUID().toString());
+    Map<String,ArrayList<Path>> serverToFileMap = getServerToFileMap1(server, p1);
+
+    realGCWAL.removeFiles(getEmptyMap(), serverToFileMap, getEmptyMap(), status);
+
+    MethodCalls calls = ((GCWALPartialMock) realGCWAL).methodCalls;
+    assertEquals("Only one method should have been called", 1, calls.size());
+    assertEquals("Method should be removeWALfromDownTserver", "removeWALFromDownTserver", calls.getFirstEntryMethod());
+    assertEquals("First param should be address", HostAndPort.fromString(server.replaceAll("[+]", ":")), calls.getFirstEntryArg(0));
+    assertTrue("Second param should be an AccumuloConfiguration", calls.getFirstEntryArg(1) instanceof AccumuloConfiguration);
+    Entry<String,ArrayList<Path>> firstServerToFileMap = serverToFileMap.entrySet().iterator().next();
+    assertEquals("Third param should be the entry", firstServerToFileMap, calls.getFirstEntryArg(2));
+    assertEquals("Forth param should be the status", status, calls.getFirstEntryArg(3));
+  }
+
+  @Test
+  public void testRemoveFilesWithLiveTservers() throws IOException {
+    GCStatus status = new GCStatus();
+    GarbageCollectWriteAheadLogs realGCWAL = getGCWALForRemoveFileTest(status, true);
+    String server = "tserver1+9997";
+    Path p1 = new Path("hdfs://localhost:9000/accumulo/wal/" + server + "/" + UUID.randomUUID().toString());
+    Map<String,ArrayList<Path>> serverToFileMap = getServerToFileMap1(server, p1);
+
+    realGCWAL.removeFiles(getEmptyMap(), serverToFileMap, getEmptyMap(), status);
+
+    MethodCalls calls = ((GCWALPartialMock) realGCWAL).methodCalls;
+    assertEquals("Only one method should have been called", 1, calls.size());
+    assertEquals("Method should be askTserverToRemoveWAL", "askTserverToRemoveWAL", calls.getFirstEntryMethod());
+    assertEquals("First param should be address", HostAndPort.fromString(server.replaceAll("[+]", ":")), calls.getFirstEntryArg(0));
+    assertTrue("Second param should be an AccumuloConfiguration", calls.getFirstEntryArg(1) instanceof AccumuloConfiguration);
+    Entry<String,ArrayList<Path>> firstServerToFileMap = serverToFileMap.entrySet().iterator().next();
+    assertEquals("Third param should be the entry", firstServerToFileMap, calls.getFirstEntryArg(2));
+    assertEquals("Forth param should be the status", status, calls.getFirstEntryArg(3));
+  }
+
+  @Test
+  public void testRemoveFilesRemovesSortedWALs() throws IOException {
+    GCStatus status = new GCStatus();
+    GarbageCollectWriteAheadLogs realGCWAL = getGCWALForRemoveFileTest(status, true);
+    Map<String,ArrayList<Path>> serverToFileMap = new HashMap<String,ArrayList<Path>>();
+    Map<String,Path> sortedWALogs = new HashMap<String,Path>();
+    Path p1 = new Path("hdfs://localhost:9000/accumulo/wal/tserver1+9997/" + UUID.randomUUID().toString());
+    sortedWALogs.put("junk", p1); // TODO: see if this key is actually used here, maybe can be removed
+
+    realGCWAL.removeFiles(getEmptyMap(), serverToFileMap, sortedWALogs, status);
+    MethodCalls calls = ((GCWALPartialMock) realGCWAL).methodCalls;
+    assertEquals("Only one method should have been called", 1, calls.size());
+    assertEquals("Method should be removeSortedWAL", "removeSortedWAL", calls.getFirstEntryMethod());
+    assertEquals("First param should be the Path", p1, calls.getFirstEntryArg(0));
+
+  }
+
+  static String GCWAL_DEAD_DIR = "gcwal-collect-deadtserver";
+  static String GCWAL_DEAD_TSERVER = "tserver1";
+  static String GCWAL_DEAD_TSERVER_PORT = "9995";
+  static String GCWAL_DEAD_TSERVER_COLLECT_FILE = UUID.randomUUID().toString();
+
+  class GCWALDeadTserverCollectMock extends GarbageCollectWriteAheadLogs {
+
+    public GCWALDeadTserverCollectMock(Instance i, VolumeManager vm, boolean useTrash) throws IOException {
+      super(i, vm, useTrash);
+    }
+
+    @Override
+    boolean holdsLock(HostAndPort addr) {
+      // tries use zookeeper
+      return false;
+    }
+
+    @Override
+    Map<String,Path> getSortedWALogs() {
+      return new HashMap<String,Path>();
+    }
+
+    @Override
+    int scanServers(Map<Path,String> fileToServerMap, Map<String,Path> nameToFileMap) throws Exception {
+      String sep = File.separator;
+      Path p = new Path(System.getProperty("java.io.tmpdir") + sep + GCWAL_DEAD_DIR + sep + GCWAL_DEAD_TSERVER + "+" + GCWAL_DEAD_TSERVER_PORT + sep
+          + GCWAL_DEAD_TSERVER_COLLECT_FILE);
+      fileToServerMap.put(p, GCWAL_DEAD_TSERVER + ":" + GCWAL_DEAD_TSERVER_PORT);
+      nameToFileMap.put(GCWAL_DEAD_TSERVER_COLLECT_FILE, p);
+      return 1;
+    }
+
+    @Override
+    int removeMetadataEntries(Map<String,Path> nameToFileMap, Map<String,Path> sortedWALogs, GCStatus status) throws IOException, KeeperException,
+        InterruptedException {
+      return 0;
+    }
+
+    long getGCWALDeadServerWaitTime(AccumuloConfiguration conf) {
+      // tries to use zookeeper
+      return 1000l;
+    }
+  }
+
+  @Test
+  public void testCollectWithDeadTserver() throws IOException, InterruptedException {
+    Instance i = new MockInstance();
+    File walDir = new File(System.getProperty("java.io.tmpdir") + File.separator + GCWAL_DEAD_DIR);
+    File walFileDir = new File(walDir + File.separator + GCWAL_DEAD_TSERVER + "+" + GCWAL_DEAD_TSERVER_PORT);
+    File walFile = new File(walFileDir + File.separator + GCWAL_DEAD_TSERVER_COLLECT_FILE);
+    if (!walFileDir.exists()) {
+      walFileDir.mkdirs();
+      new FileOutputStream(walFile).close();
+    }
+
+    try {
+      VolumeManager vm = VolumeManagerImpl.getLocal(walDir.toString());
+      GarbageCollectWriteAheadLogs gcwal2 = new GCWALDeadTserverCollectMock(i, vm, false);
+      GCStatus status = new GCStatus(new GcCycleStats(), new GcCycleStats(), new GcCycleStats(), new GcCycleStats());
+
+      gcwal2.collect(status);
+
+      assertTrue("File should not be deleted", walFile.exists());
+      assertEquals("Should have one candidate", 1, status.lastLog.getCandidates());
+      assertEquals("Should not have deleted that file", 0, status.lastLog.getDeleted());
+
+      sleep(2000);
+      gcwal2.collect(status);
+
+      assertFalse("File should be gone", walFile.exists());
+      assertEquals("Should have one candidate", 1, status.lastLog.getCandidates());
+      assertEquals("Should have deleted that file", 1, status.lastLog.getDeleted());
+
+    } finally {
+      if (walDir.exists()) {
+        FileUtils.deleteDirectory(walDir);
+      }
+    }
   }
 }


### PR DESCRIPTION
Keep track of first time a tserver is seen down and only remove WALs for that server if past configurated threshhold

Much work left to be done here, but trying to keep the changes to the GarbageCollectWriteAheadLogs class small to get the bug fixed.  I'll create another ticket to refactor and cleanup.

Includes an end to end test calling the collect method simulating a dead tserver.