### PR TITLE
ACCUMULO-4328: Run multiple tablet servers per host

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -110,7 +110,7 @@ fi
 case "$1" in
 master)  export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_MASTER_OPTS}" ;;
 gc)      export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_GC_OPTS}" ;;
-tserver) export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_TSERVER_OPTS}" ;;
+tserver*) export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_TSERVER_OPTS}" ;;
 monitor) export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_MONITOR_OPTS}" ;;
 *)       export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_OTHER_OPTS}" ;;
 esac
@@ -158,10 +158,23 @@ fi
 # Export the variables just in case they are not exported
 # This makes them available to java
 export JAVA_HOME HADOOP_PREFIX ZOOKEEPER_HOME LD_LIBRARY_PATH DYLD_LIBRARY_PATH
+
+# Strip the instance from $1
+APP=$1
+INSTANCE="1"
+if [[ "$1" =~ .*-.* ]]; then
+  APP=`echo $1 | cut -d"-" -f1`
+  INSTANCE=`echo $1 | cut -d"-" -f2`
+
+  #Rewrite the input arguments
+  set -- "$APP" "${@:2}"
+fi
+
 #
 # app isn't used anywhere, but it makes the process easier to spot when ps/top/snmp truncate the command line
 JAVA="${JAVA_HOME}/bin/java"
-exec $JAVA "-Dapp=$1" \
+exec $JAVA "-Dapp=$APP" \
+   "-Dinstance=$INSTANCE" \
    $ACCUMULO_OPTS \
    -classpath "${CLASSPATH}" \
    -XX:OnOutOfMemoryError="${ACCUMULO_KILL_CMD:-kill -9 %p}" \

--- a/assemble/bin/config-server.sh
+++ b/assemble/bin/config-server.sh
@@ -1,0 +1,82 @@
+#! /usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Guarantees that Accumulo and its environment variables are set for start
+# and stop scripts.  Should always be run after config.sh.
+#
+# Parameters checked by script
+#  ACCUMULO_VERIFY_ONLY set to skip actions that would alter the local filesystem
+#
+# Values set by script that can be user provided.  If not provided script attempts to infer.
+#  MONITOR            Machine to run monitor daemon on. Used by start-here.sh script
+#
+# Iff ACCUMULO_VERIFY_ONLY is not set, this script will
+#   * Check for standalone mode (lack of masters and slaves files)
+#     - Do appropriate set up
+#   * Ensure the presense of local role files (masters, slaves, gc, tracers)
+#
+# Values always set by script.
+#  SSH                Default ssh parameters used to start daemons
+#
+
+unset MASTER1
+if [[ -f "$ACCUMULO_CONF_DIR/masters" ]]; then
+  MASTER1=$(egrep -v '(^#|^\s*$)' "$ACCUMULO_CONF_DIR/masters" | head -1)
+fi
+
+if [[ -z "${MONITOR}" ]] ; then
+  MONITOR=$MASTER1
+  if [[ -f "$ACCUMULO_CONF_DIR/monitor" ]]; then
+      MONITOR=$(egrep -v '(^#|^\s*$)' "$ACCUMULO_CONF_DIR/monitor" | head -1)
+  fi
+  if [[ -z "${MONITOR}" ]] ; then
+    echo "Could not infer a Monitor role. You need to either define the MONITOR env variable, define \"${ACCUMULO_CONF_DIR}/monitor\", or make sure \"${ACCUMULO_CONF_DIR}/masters\" is non-empty."
+    exit 1
+  fi
+fi
+if [[ ! -f "$ACCUMULO_CONF_DIR/tracers" && -z "${ACCUMULO_VERIFY_ONLY}" ]]; then
+  if [[ -z "${MASTER1}" ]] ; then
+    echo "Could not find a master node to use as a default for the tracer role. Either set up \"${ACCUMULO_CONF_DIR}/tracers\" or make sure \"${ACCUMULO_CONF_DIR}/masters\" is non-empty."
+    exit 1
+  else
+    echo "$MASTER1" > "$ACCUMULO_CONF_DIR/tracers"
+  fi
+
+fi
+
+if [[ ! -f "$ACCUMULO_CONF_DIR/gc" && -z "${ACCUMULO_VERIFY_ONLY}" ]]; then
+  if [[ -z "${MASTER1}" ]] ; then
+    echo "Could not infer a GC role. You need to either set up \"${ACCUMULO_CONF_DIR}/gc\" or make sure \"${ACCUMULO_CONF_DIR}/masters\" is non-empty."
+    exit 1
+  else
+    echo "$MASTER1" > "$ACCUMULO_CONF_DIR/gc"
+  fi
+fi
+
+SSH='ssh -qnf -o ConnectTimeout=2'
+
+# ACCUMULO-1985 provide a way to use the scripts and still bind to all network interfaces
+export ACCUMULO_MONITOR_BIND_ALL=${ACCUMULO_MONITOR_BIND_ALL:-"false"}
+
+if [[ -z "${ACCUMULO_PID_DIR}" ]]; then
+  export ACCUMULO_PID_DIR="${ACCUMULO_HOME}/run"
+fi
+[[ -z ${ACCUMULO_VERIFY_ONLY} ]] && mkdir -p "${ACCUMULO_PID_DIR}" 2>/dev/null
+
+if [[ -z "${ACCUMULO_IDENT_STRING}" ]]; then
+  export ACCUMULO_IDENT_STRING="$USER"
+fi

--- a/assemble/bin/start-all.sh
+++ b/assemble/bin/start-all.sh
@@ -67,8 +67,8 @@ for master in `egrep -v '(^#|^\s*$)' "$ACCUMULO_CONF_DIR/masters"`; do
    ${bin}/start-server.sh $master master
 done
 
-for gc in `egrep -v '(^#|^\s*$)' "$ACCUMULO_CONF_DIR/gc"`; do
-   ${bin}/start-server.sh $gc gc "garbage collector"
+for gc in $(egrep -v '(^#|^\s*$)' "$ACCUMULO_CONF_DIR/gc"); do
+   ${bin}/start-server.sh $gc gc
 done
 
 for tracer in `egrep -v '(^#|^\s*$)' "$ACCUMULO_CONF_DIR/tracers"`; do

--- a/assemble/bin/start-daemon.sh
+++ b/assemble/bin/start-daemon.sh
@@ -60,27 +60,63 @@ if [[ ${SERVICE} == "monitor" && ${ACCUMULO_MONITOR_BIND_ALL} == "true" ]]; then
    ADDRESS="0.0.0.0"
 fi
 
-# Check the pid file to figure out if its already running.
-PID_FILE="${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${SERVICE}.pid"
-if [ -f ${PID_FILE} ]; then
-   PID=`cat ${PID_FILE}`
-   if kill -0 $PID 2>/dev/null; then
-      # Starting an already-started service shouldn't be an error per LSB
-      echo "$HOST : $SERVICE already running (${PID})"
-      exit 0
-   fi
-else
-   echo "Starting $SERVICE on $HOST"
-fi
-
 COMMAND="${bin}/accumulo"
-if [ "${ACCUMULO_WATCHER}" = "true" ]; then
-   COMMAND="${bin}/accumulo_watcher.sh ${LOGHOST}"
-fi
 
-# Fork the process, store the pid
-nohup ${NUMA_CMD} "$COMMAND" "${SERVICE}" --address "${ADDRESS}" >"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out" 2>"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err" < /dev/null &
-echo $! > ${PID_FILE}
+if [[ "$SERVICE" != "tserver" || $NUM_TSERVERS -eq 1 ]]; then
+   # Check the pid file to figure out if its already running.
+   PID_FILE="${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${SERVICE}.pid"
+   if [ -f ${PID_FILE} ]; then
+      PID=`cat ${PID_FILE}`
+      if kill -0 $PID 2>/dev/null; then
+         # Starting an already-started service shouldn't be an error per LSB
+         echo "$HOST : $SERVICE already running (${PID})"
+         exit 0
+      fi
+   fi
+   echo "Starting $SERVICE on $HOST"
+
+   # Fork the process, store the pid
+   nohup ${NUMA_CMD} "$COMMAND" "${SERVICE}" --address "${ADDRESS}" >"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out" 2>"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err" < /dev/null &
+   echo $! > ${PID_FILE}
+
+else
+
+  S="$SERVICE"
+  for (( t=1; t<=$NUM_TSERVERS; t++)); do
+
+     SERVICE="$S-$t"
+
+     # Check the pid file to figure out if its already running.
+     PID_FILE="${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${SERVICE}.pid"
+     if [ -f ${PID_FILE} ]; then
+        PID=`cat ${PID_FILE}`
+        if kill -0 $PID 2>/dev/null; then
+           # Starting an already-started service shouldn't be an error per LSB
+           echo "$HOST : $SERVICE already running (${PID})"
+           exit 0
+        fi
+     fi
+     echo "Starting $SERVICE on $HOST"
+
+      ACCUMULO_NUMACTL_OPTIONS=${ACCUMULO_NUMACTL_OPTIONS:-"--interleave=all"}
+      ACCUMULO_NUMACTL_OPTIONS=${TSERVER_NUMA_OPTIONS[$t]:-$ACCUMULO_NUMACTL_OPTIONS}
+      if [[ "$ACCUMULO_ENABLE_NUMACTL" == "true" ]]; then
+         NUMA=`which numactl 2>/dev/null`
+         NUMACTL_EXISTS=$?
+         if [[ ( ${NUMACTL_EXISTS} -eq 0 ) ]]; then
+             export NUMA_CMD="${NUMA} ${ACCUMULO_NUMACTL_OPTIONS}"
+         else
+             export NUMA_CMD=""
+         fi
+      fi
+
+      # Fork the process, store the pid
+      nohup ${NUMA_CMD} "$COMMAND" "${SERVICE}" --address "${ADDRESS}" >"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out" 2>"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err" < /dev/null &
+      echo $! > ${PID_FILE}
+
+  done
+
+fi
 
 # Check the max open files limit and selectively warn
 MAX_FILES_OPEN=$(ulimit -n)

--- a/assemble/bin/start-daemon.sh
+++ b/assemble/bin/start-daemon.sh
@@ -1,0 +1,94 @@
+#! /usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start: Resolve Script Directory
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -h "$SOURCE" ]]; do # resolve $SOURCE until the file is no longer a symlink
+   bin="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+   SOURCE="$(readlink "$SOURCE")"
+   [[ $SOURCE != /* ]] && SOURCE="$bin/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+bin="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+script=$( basename "$SOURCE" )
+# Stop: Resolve Script Directory
+
+usage="Usage: start-daemon.sh <host> <service>"
+
+if [[ $# -ne 2 ]]; then
+  echo $usage
+  exit 2
+fi
+
+. "$bin"/config.sh
+. "$bin"/config-server.sh
+
+HOST="$1"
+ADDRESS=$HOST
+host "$1" >/dev/null 2>&1
+if [[ $? != 0 ]]; then
+   LOGHOST=$HOST
+else
+   LOGHOST=$(host "$HOST" | head -1 | cut -d' ' -f1)
+fi
+SERVICE=$2
+
+SLAVES=$(wc -l < "${ACCUMULO_CONF_DIR}/slaves")
+
+# When the hostname provided is the alias/shortname, try to use the FQDN to make
+# sure we send the right address to the Accumulo process.
+if [[ "$HOST" = "$(hostname -s)" ]]; then
+   HOST="$(hostname -f)"
+   ADDRESS="$HOST"
+fi
+
+# ACCUMULO-1985 Allow monitor to bind on all interfaces
+if [[ ${SERVICE} == "monitor" && ${ACCUMULO_MONITOR_BIND_ALL} == "true" ]]; then
+   ADDRESS="0.0.0.0"
+fi
+
+# Check the pid file to figure out if its already running.
+PID_FILE="${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${SERVICE}.pid"
+if [ -f ${PID_FILE} ]; then
+   PID=`cat ${PID_FILE}`
+   if kill -0 $PID 2>/dev/null; then
+      # Starting an already-started service shouldn't be an error per LSB
+      echo "$HOST : $SERVICE already running (${PID})"
+      exit 0
+   fi
+else
+   echo "Starting $SERVICE on $HOST"
+fi
+
+COMMAND="${bin}/accumulo"
+if [ "${ACCUMULO_WATCHER}" = "true" ]; then
+   COMMAND="${bin}/accumulo_watcher.sh ${LOGHOST}"
+fi
+
+# Fork the process, store the pid
+nohup ${NUMA_CMD} "$COMMAND" "${SERVICE}" --address "${ADDRESS}" >"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out" 2>"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err" < /dev/null &
+echo $! > ${PID_FILE}
+
+# Check the max open files limit and selectively warn
+MAX_FILES_OPEN=$(ulimit -n)
+
+if [[ -n $MAX_FILES_OPEN && -n $SLAVES ]] ; then
+   MAX_FILES_RECOMMENDED=${MAX_FILES_RECOMMENDED:-32768}
+   if (( SLAVES > 10 )) && (( MAX_FILES_OPEN < MAX_FILES_RECOMMENDED ))
+   then
+      echo "WARN : Max open files on $HOST is $MAX_FILES_OPEN, recommend $MAX_FILES_RECOMMENDED" >&2
+   fi
+fi

--- a/assemble/bin/start-here.sh
+++ b/assemble/bin/start-here.sh
@@ -42,8 +42,8 @@ fi
 
 HOSTS="$(hostname -a 2> /dev/null) $(hostname) localhost 127.0.0.1 $ip"
 for host in $HOSTS; do
-   if grep -q "^${host}\$" $ACCUMULO_CONF_DIR/slaves; then
-      ${bin}/start-server.sh $host tserver "tablet server"
+   if grep -q "^${host}\$" "$ACCUMULO_CONF_DIR/slaves"; then
+      "${bin}/start-server.sh" "$host" tserver
       break
    fi
 done
@@ -57,8 +57,8 @@ for host in $HOSTS; do
 done
 
 for host in $HOSTS; do
-   if grep -q "^${host}\$" $ACCUMULO_CONF_DIR/gc; then
-      ${bin}/start-server.sh $host gc "garbage collector"
+   if grep -q "^${host}\$" "$ACCUMULO_CONF_DIR/gc"; then
+      "${bin}/start-server.sh" "$host" gc
       break
    fi
 done

--- a/assemble/bin/start-server.sh
+++ b/assemble/bin/start-server.sh
@@ -26,69 +26,31 @@ bin="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 script=$( basename "$SOURCE" )
 # Stop: Resolve Script Directory
 
+# Really, we still support the third <long_name> argument, but let's not tell people that..
+usage="Usage: start-server.sh <host> <service>"
+
+# Support the 3-arg invocation for backwards-compat
+if [[ $# -ne 2 ]] && [[ $# -ne 3 ]]; then
+  echo $usage
+  exit 2
+fi
+
 . "$bin"/config.sh
 
 HOST="$1"
-host "$1" >/dev/null 2>/dev/null
-if [ $? -ne 0 ]; then
-   LOGHOST="$1"
-else
-   LOGHOST=$(host "$1" | head -1 | cut -d' ' -f1)
-fi
-ADDRESS="$1"
 SERVICE="$2"
-LONGNAME="$3"
-if [ -z "$LONGNAME" ]; then
-   LONGNAME="$2"
-fi
-SLAVES=$( wc -l < ${ACCUMULO_CONF_DIR}/slaves )
 
 IFCONFIG=/sbin/ifconfig
-if [ ! -x $IFCONFIG ]; then
-   IFCONFIG='/bin/netstat -ie'
+[[ ! -x $IFCONFIG ]] && IFCONFIG='/bin/netstat -ie'
+
+IP=$($IFCONFIG 2>/dev/null| grep "inet[^6]" | awk '{print $2}' | sed 's/addr://' | grep -v 0.0.0.0 | grep -v 127.0.0.1 | head -n 1)
+if [[ $? != 0 ]] ; then
+   IP=$(python -c 'import socket as s; print s.gethostbyname(s.getfqdn())')
 fi
 
-ip=$($IFCONFIG 2>/dev/null| grep inet[^6] | awk '{print $2}' | sed 's/addr://' | grep -v 0.0.0.0 | grep -v 127.0.0.1 | head -n 1)
-if [ $? != 0 ]
-then
-   ip=$(python -c 'import socket as s; print s.gethostbyname(s.getfqdn())')
-fi
-
-# When the hostname provided is the alias/shortname, try to use the FQDN to make
-# sure we send the right address to the Accumulo process.
-if [ "$HOST" = "`hostname -s`" ]; then
-    HOST="`hostname -f`"
-    ADDRESS="$HOST"
-fi
-
-# ACCUMULO-1985 Allow monitor to bind on all interfaces
-if [ ${SERVICE} == "monitor" -a ${ACCUMULO_MONITOR_BIND_ALL} == "true" ]; then
-    ADDRESS="0.0.0.0"
-fi
-
-if [ "$HOST" = "localhost" -o "$HOST" = "`hostname -f`" -o "$HOST" = "$ip" ]; then
-   PID=$(ps -ef | egrep ${ACCUMULO_HOME}/.*/accumulo.*.jar | grep "Main $SERVICE" | grep -v grep | awk {'print $2'} | head -1)
+if [[ $HOST == "localhost" || $HOST == $(hostname -f) || $HOST == $(hostname -s) || $HOST == $IP ]]; then
+   "$bin/start-daemon.sh" "$HOST" "$SERVICE"
 else
-   PID=$($SSH $HOST ps -ef | egrep ${ACCUMULO_HOME}/.*/accumulo.*.jar | grep "Main $SERVICE" | grep -v grep | awk {'print $2'} | head -1)
-fi
-
-if [ -z "$PID" ]; then
-   echo "Starting $LONGNAME on $HOST"
-   if [ "$HOST" = "localhost" -o "$HOST" = "`hostname -f`" -o "$HOST" = "$ip" ]; then
-      nohup ${NUMA_CMD} ${bin}/accumulo ${SERVICE} --address ${ADDRESS} >${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out 2>${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err & 
-      MAX_FILES_OPEN=$(ulimit -n)
-   else
-      $SSH $HOST "bash -c 'exec nohup ${NUMA_CMD} ${bin}/accumulo ${SERVICE} --address ${ADDRESS} >${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out 2>${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err' &"
-      MAX_FILES_OPEN=$($SSH $HOST "/usr/bin/env bash -c 'ulimit -n'") 
-   fi
-
-   if [ -n "$MAX_FILES_OPEN" ] && [ -n "$SLAVES" ] ; then
-      MAX_FILES_RECOMMENDED=${MAX_FILES_RECOMMENDED:-32768}
-      if (( SLAVES > 10 )) && (( MAX_FILES_OPEN < MAX_FILES_RECOMMENDED ))
-      then
-         echo "WARN : Max open files on $HOST is $MAX_FILES_OPEN, recommend $MAX_FILES_RECOMMENDED" >&2
-      fi
-   fi
-else
-   echo "$HOST : $LONGNAME already running (${PID})"
+   # Ensure that the provided configuration directory is sent with the command
+   echo $($SSH $HOST "bash -c 'ACCUMULO_CONF_DIR=${ACCUMULO_CONF_DIR} $bin/start-daemon.sh \"$HOST\" \"$SERVICE\"'")
 fi

--- a/assemble/bin/start-server.sh
+++ b/assemble/bin/start-server.sh
@@ -36,6 +36,7 @@ if [[ $# -ne 2 ]] && [[ $# -ne 3 ]]; then
 fi
 
 . "$bin"/config.sh
+. "$bin"/config-server.sh
 
 HOST="$1"
 SERVICE="$2"

--- a/assemble/bin/stop-here.sh
+++ b/assemble/bin/stop-here.sh
@@ -42,7 +42,7 @@ fi
 if egrep -q localhost\|127.0.0.1 $ACCUMULO_CONF_DIR/slaves; then
    $bin/accumulo admin stop localhost
 else
-   for host in "$(hostname -a 2> /dev/null) $(hostname)"; do
+   for host in "$(hostname -a 2> /dev/null)" "$(hostname)"; do
       if grep -q ${host} $ACCUMULO_CONF_DIR/slaves; then
          ${bin}/accumulo admin stop $host
       fi
@@ -51,10 +51,6 @@ fi
 
 for signal in TERM KILL; do
    for svc in tserver gc master monitor tracer; do
-      PID=$(ps -ef | egrep ${ACCUMULO} | grep "Main $svc" | grep -v grep | grep -v stop-here.sh | awk '{print $2}' | head -1)
-      if [ ! -z $PID ]; then
-         echo "Stopping ${svc} on ${HOSTNAME} with signal ${signal}"
-         kill -s ${signal} ${PID}
-      fi
+      $ACCUMULO_HOME/bin/stop-server.sh $HOSTNAME "$ACCUMULO_HOME/lib/accumulo-start.jar" $svc $signal
    done
 done

--- a/assemble/bin/stop-server.sh
+++ b/assemble/bin/stop-server.sh
@@ -26,6 +26,7 @@ bin="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # Stop: Resolve Script Directory
 
 . "$bin"/config.sh
+. "$bin"/config-server.sh
 
 HOST=$1
 
@@ -41,16 +42,17 @@ then
 fi
 
 # only stop if there's not one already running
-if [ "$HOST" = "localhost" -o "$HOST" = "`hostname -s`" -o "$HOST" = "`hostname -f`" -o "$HOST" = "$ip" ]; then
-   PID=$(ps -ef | grep "$ACCUMULO_HOME" | egrep ${2} | grep "Main ${3}" | grep -v grep | grep -v ssh | grep -v stop-server.sh | awk {'print $2'} | head -1)
-   if [ ! -z $PID ]; then
-      echo "Stopping ${3} on $1";
-      kill -s ${4} ${PID} 2>/dev/null
+PID_FILE="${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${3}.pid"
+if [[ $HOST == localhost || $HOST = "$(hostname -s)" || $HOST = "$(hostname -f)" || $HOST = "$IP" ]] ; then
+   if [ -f ${PID_FILE} ]; then
+      echo "Stopping $3 on $1";
+      kill -s "$4" `cat ${PID_FILE}` 2>/dev/null
+      rm -f ${PID_FILE} 2>/dev/null
    fi;
 else
-   PID=$(ssh -q -o 'ConnectTimeout 8' $1 "ps -ef | grep \"$ACCUMULO_HOME\" |  egrep '${2}' | grep 'Main ${3}' | grep -v grep | grep -v ssh | grep -v stop-server.sh" | awk {'print $2'} | head -1)
-   if [ ! -z $PID ]; then
-      echo "Stopping ${3} on $1";
-      ssh -q -o 'ConnectTimeout 8' $1 "kill -s ${4} ${PID} 2>/dev/null"
-   fi;
+   PID=$(ssh -q -o 'ConnectTimeout 8' "$1" cat "${PID_FILE}" 2>/dev/null)
+   if [[ ! -z $PID ]]; then
+      echo "Stopping $3 on $1";
+      ssh -q -o 'ConnectTimeout 8' "$1" "kill -s $4 $PID 2>/dev/null; rm -f ${PID_FILE} 2>/dev/null"
+   fi
 fi

--- a/assemble/bin/stop-server.sh
+++ b/assemble/bin/stop-server.sh
@@ -42,17 +42,20 @@ then
 fi
 
 # only stop if there's not one already running
-PID_FILE="${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${3}.pid"
 if [[ $HOST == localhost || $HOST = "$(hostname -s)" || $HOST = "$(hostname -f)" || $HOST = "$IP" ]] ; then
-   if [ -f ${PID_FILE} ]; then
-      echo "Stopping $3 on $1";
-      kill -s "$4" `cat ${PID_FILE}` 2>/dev/null
-      rm -f ${PID_FILE} 2>/dev/null
-   fi;
+   for PID_FILE in ${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${3}*.pid; do
+      if [ -f ${PID_FILE} ]; then
+         echo "Stopping $3 on $1";
+         kill -s "$4" `cat ${PID_FILE}` 2>/dev/null
+         rm -f ${PID_FILE} 2>/dev/null
+      fi;
+   done
 else
-   PID=$(ssh -q -o 'ConnectTimeout 8' "$1" cat "${PID_FILE}" 2>/dev/null)
-   if [[ ! -z $PID ]]; then
-      echo "Stopping $3 on $1";
-      ssh -q -o 'ConnectTimeout 8' "$1" "kill -s $4 $PID 2>/dev/null; rm -f ${PID_FILE} 2>/dev/null"
-   fi
+   for PID_FILE in $(ssh -q -o 'ConnectTimeout 8' "$1" ls "${ACCUMULO_PID_DIR}/accumulo-${ACCUMULO_IDENT_STRING}-${3}*.pid" 2>/dev/null); do
+      PID=$(ssh -q -o 'ConnectTimeout 8' "$1" cat "${PID_FILE}" 2>/dev/null)
+      if [[ ! -z $PID ]]; then
+         echo "Stopping $3 on $1";
+         ssh -q -o 'ConnectTimeout 8' "$1" "kill -s $4 $PID 2>/dev/null; rm -f ${PID_FILE} 2>/dev/null"
+      fi
+   done
 fi

--- a/assemble/bin/tup.sh
+++ b/assemble/bin/tup.sh
@@ -34,9 +34,8 @@ echo -n "Starting tablet servers ..."
 count=1
 for server in `egrep -v '(^#|^\s*$)' "${SLAVES}"`; do
    echo -n "."
-   ${bin}/start-server.sh $server tserver "tablet server" &
-   let count++
-   if [ $(( ${count} % 72 )) -eq 0 ] ;
+   ${bin}/start-server.sh $server tserver &
+   if (( ++count % 72 == 0 )) ;
    then
       echo
       wait

--- a/assemble/conf/templates/accumulo-env.sh
+++ b/assemble/conf/templates/accumulo-env.sh
@@ -53,6 +53,7 @@ test -z "$ACCUMULO_MONITOR_OPTS" && export ACCUMULO_MONITOR_OPTS="${POLICY} ${mo
 test -z "$ACCUMULO_GC_OPTS"      && export ACCUMULO_GC_OPTS="${gcHigh_gcLow}"
 test -z "$ACCUMULO_GENERAL_OPTS" && export ACCUMULO_GENERAL_OPTS="-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -Djava.net.preferIPv4Stack=true -XX:+CMSClassUnloadingEnabled"
 test -z "$ACCUMULO_OTHER_OPTS"   && export ACCUMULO_OTHER_OPTS="${otherHigh_otherLow}"
+test -z "${ACCUMULO_PID_DIR}"    && export ACCUMULO_PID_DIR="${ACCUMULO_HOME}/run"
 # what do when the JVM runs out of heap memory
 export ACCUMULO_KILL_CMD='kill -9 %p'
 

--- a/assemble/conf/templates/accumulo-env.sh
+++ b/assemble/conf/templates/accumulo-env.sh
@@ -65,3 +65,11 @@ export ACCUMULO_KILL_CMD='kill -9 %p'
 
 # Should the monitor bind to all network interfaces -- default: false
 # export ACCUMULO_MONITOR_BIND_ALL="true"
+
+export NUM_TSERVERS=1
+
+### Example for configuring multiple tservers per host
+### export NUM_TSERVERS=2
+### declare -a TSERVER_NUMA_OPTIONS
+### TSERVER_NUMA_OPTIONS[1]="--cpunodebind 0"
+### TSERVER_NUMA_OPTIONS[2]="--cpunodebind 1"

--- a/assemble/conf/templates/generic_logger.xml
+++ b/assemble/conf/templates/generic_logger.xml
@@ -25,7 +25,7 @@
      <param name="MaxBackupIndex" value="10"/>
      <param name="Threshold"      value="DEBUG"/>
      <layout class="org.apache.log4j.PatternLayout">
-       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %m%n"/>
+       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] [pid:%6X{pid}] %-5p: %m%n"/>
      </layout>
   </appender>
 
@@ -36,7 +36,7 @@
      <param name="MaxBackupIndex" value="10"/>
      <param name="Threshold"      value="INFO"/>
      <layout class="org.apache.log4j.PatternLayout">
-       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %m%n"/>
+       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] [pid:%6X{pid}] %-5p: %m%n"/>
      </layout>
   </appender>
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -229,6 +229,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
+import org.apache.log4j.MDC;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.TServiceClient;
@@ -3736,6 +3737,12 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
 
   public static void main(String[] args) throws IOException {
     try {
+      String pid = ManagementFactory.getRuntimeMXBean().getName();
+      int idx = pid.indexOf("@");
+      if (-1 != idx) {
+        pid = pid.substring(0, idx);
+      }
+      MDC.put("pid", pid);
       SecurityUtil.serverLogin(ServerConfiguration.getSiteConfiguration());
       ServerOpts opts = new ServerOpts();
       final String app = "tserver";


### PR DESCRIPTION
Backport of ACCUMULO-925 to enable pid support.
Modification to TabletServer.java to put the pid into the MDC
Modification to generic_logger to put the pid of the process into the log
Modification to environment to be able to define NUM_TSERVERS per host
Modification to environment to be able to define NUMA parameters per tserver per host
Modification to start/stop scripts to handle multiple tservers per host

To be able to run multiple tservers per host, tserver.port.client must be zero in accumulo-site.xml