### PR TITLE
ACCUMULO-4334 Correct JMX Ingest rate

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -3832,11 +3832,11 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
   @Override
   public long getIngest() {
     if (this.isEnabled()) {
-      long result = 0;
+      double result = 0;
       for (Tablet tablet : Collections.unmodifiableCollection(onlineTablets.values())) {
-        result += tablet.getNumEntriesInMemory();
+        result += tablet.ingestRate();
       }
-      return result;
+      return (long) result;
     }
     return 0;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -3830,13 +3830,13 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
   }
 
   @Override
-  public long getIngest() {
+  public double getIngest() {
     if (this.isEnabled()) {
       double result = 0;
       for (Tablet tablet : Collections.unmodifiableCollection(onlineTablets.values())) {
         result += tablet.ingestRate();
       }
-      return (long) result;
+      return result;
     }
     return 0;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMBean.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMBean.java
@@ -38,7 +38,7 @@ public interface TabletServerMBean {
 
   long getQueries();
 
-  long getIngest();
+  double getIngest();
 
   long getTotalMinorCompactions();
 


### PR DESCRIPTION
It's mostly a one-line fix. I would like to change the interface `TabletServerMBean.getIngest()` to return double instead of long. I didn't do it here because I don't know if it would break binary compatibility.  The current method is pretty much good enough.