### PR TITLE
Multiple code improvements - squid:S1118, squid:S1155, squid:ClassVariableVisibilityCheck, squid:MissingDeprecatedCheck, squid:S1186

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -130,4 +130,6 @@ public class Constants {
   public static final String HDFS_TABLES_DIR = "/tables";
 
   public static final int DEFAULT_VISIBILITY_CACHE_SIZE = 1000;
+  
+  private Constants() {}
 }

--- a/core/src/main/java/org/apache/accumulo/core/bloomfilter/DynamicBloomFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/bloomfilter/DynamicBloomFilter.java
@@ -97,7 +97,7 @@ public class DynamicBloomFilter extends Filter {
   /**
    * Zero-args constructor for the serialization.
    */
-  public DynamicBloomFilter() {}
+  public DynamicBloomFilter() {/**default constructor*/}
 
   /**
    * Constructor.

--- a/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
@@ -82,10 +82,18 @@ public class ClientOpts extends Help {
   }
 
   public static class Password {
-    public byte[] value;
+    private byte[] value;
 
     public Password(String dfault) {
       value = dfault.getBytes(UTF_8);
+    }
+
+    public void setValue(byte[] value) {
+        this.value = value;
+    }
+
+    public byte[] getValue() {
+        return this.value;
     }
 
     @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -176,7 +176,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
 
     @Override
     public void seek(final Range range, final Collection<ByteSequence> columnFamilies, final boolean inclusive) throws IOException {
-      if (!inclusive && columnFamilies.size() > 0) {
+      if (!inclusive && !columnFamilies.isEmpty()) {
         throw new IllegalArgumentException();
       }
       scanner.setRange(range);
@@ -284,6 +284,9 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
     return smi.scanner.getAuthorizations();
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   @Override
   public void setTimeOut(int timeOut) {
@@ -293,6 +296,9 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
       setTimeout(timeOut, TimeUnit.SECONDS);
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   @Override
   public int getTimeOut() {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
@@ -279,7 +279,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
         }
       }
 
-      if (mutations2.size() > 0)
+      if (!mutations2.isEmpty())
         failedMutations.addAll(mutations2);
 
     } else {
@@ -311,7 +311,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
       binnedMutations.clear();
     }
 
-    if (failures.size() > 0)
+    if (!failures.isEmpty())
       queueRetry(failures, null);
 
     for (Entry<String,TabletServerMutations<QCMutation>> entry : binnedMutations.entrySet()) {
@@ -344,7 +344,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     // in bigger batches and less RPC overhead
 
     synchronized (serverQueue) {
-      if (serverQueue.queue.size() > 0)
+      if (!serverQueue.queue.isEmpty())
         threadPool.execute(new LoggingRunnable(log, Trace.wrap(task)));
       else
         serverQueue.taskQueued = false;
@@ -358,7 +358,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     ArrayList<TabletServerMutations<QCMutation>> mutations = new ArrayList<TabletLocator.TabletServerMutations<QCMutation>>();
     queue.drainTo(mutations);
 
-    if (mutations.size() == 0)
+    if (mutations.isEmpty())
       return null;
 
     if (mutations.size() == 1) {
@@ -401,7 +401,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
       public void run() {
         List<QCMutation> mutations = new ArrayList<QCMutation>();
         failedMutations.drainTo(mutations);
-        if (mutations.size() > 0)
+        if (!mutations.isEmpty())
           queue(mutations);
       }
     };
@@ -426,7 +426,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
       ConditionalMutation mut = mutations.next();
       count++;
 
-      if (mut.getConditions().size() == 0)
+      if (mut.getConditions().isEmpty())
         throw new IllegalArgumentException("ConditionalMutation had no conditions " + new String(mut.getRow(), UTF_8));
 
       for (Condition cond : mut.getConditions()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
squid:S1186 - Methods should not be empty.
This pull request removes technical debt of 69 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1186
Please let me know if you have any questions.
George Kankava