### PR TITLE
Multiple code improvements - squid:CommentedOutCodeLine, squid:MissingDeprecatedCheck, squid:S1165, squid:S1854

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -86,7 +86,6 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
           lastRow = row;
           rowIter = buffer.iterator();
-          // System.out.println("lastRow <- "+lastRow + " "+buffer);
           return;
         } catch (IsolationException ie) {
           Range seekRange = null;
@@ -102,7 +101,6 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
             if (!range.afterEndKey(startKey)) {
               seekRange = new Range(startKey, true, range.getEndKey(), range.isEndKeyInclusive());
             }
-            // System.out.println(seekRange);
           }
 
           if (seekRange == null) {
@@ -129,7 +127,6 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
         setOptions((ScannerOptions) scanner, opts);
 
         return scanner.iterator();
-        // return new FaultyIterator(scanner.iterator());
       }
     }
 
@@ -238,6 +235,9 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
     return new RowBufferingIterator(scanner, this, range, timeOut, batchSize, readaheadThreshold, bufferFactory);
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   @Override
   public void setTimeOut(int timeOut) {
@@ -247,6 +247,9 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
       setTimeout(timeOut, TimeUnit.SECONDS);
   }
 
+  /**
+   * @deprecated
+   */
   @Deprecated
   @Override
   public int getTimeOut() {

--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -41,10 +41,10 @@ import com.google.common.collect.Collections2;
 public class MutationsRejectedException extends AccumuloException {
   private static final long serialVersionUID = 1L;
 
-  private List<ConstraintViolationSummary> cvsl;
+  private final List<ConstraintViolationSummary> cvsl;
   private Map<TabletId,Set<SecurityErrorCode>> af;
   private Collection<String> es;
-  private int unknownErrors;
+  private final int unknownErrors;
 
   private static <K,V,L> Map<L,V> transformKeys(Map<K,V> map, Function<K,L> keyFunction) {
     HashMap<L,V> ret = new HashMap<L,V>();

--- a/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotEmptyException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotEmptyException.java
@@ -25,7 +25,7 @@ public class NamespaceNotEmptyException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
-  private String namespace;
+  private final String namespace;
 
   /**
    * @param namespaceId

--- a/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotFoundException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/NamespaceNotFoundException.java
@@ -28,7 +28,7 @@ public class NamespaceNotFoundException extends Exception {
    */
   private static final long serialVersionUID = 1L;
 
-  private String namespace;
+  private final String namespace;
 
   /**
    * @param namespaceId

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -211,7 +211,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
 
   private void nextTablet() throws TableNotFoundException, AccumuloException, IOException {
 
-    Range nextRange = null;
+    Range nextRange;
 
     if (currentExtent == null) {
       Text startRow;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
@@ -163,7 +163,6 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
       List<KeyValue> currentBatch = (List<KeyValue>) obj;
 
       if (currentBatch.size() == 0) {
-        currentBatch = null;
         finished = true;
         return false;
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
squid:S1165 - Exception classes should be immutable.
squid:S1854 - Dead stores should be removed.
This pull request removes technical debt of 115 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1165
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
George Kankava