### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:S1197, squid:S1192, squid:S2131

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -39,6 +39,14 @@ import com.google.common.collect.Collections2;
  *
  */
 public class MutationsRejectedException extends AccumuloException {
+  private static final String EXCEPTIONS = " # exceptions ";
+
+  private static final String SERVER_ERRORS = "  # server errors ";
+
+  private static final String SECURITY_CODES = "  security codes: ";
+
+  private static final String CONSTRAINT_VIOLATIONS = "# constraint violations : ";
+
   private static final long serialVersionUID = 1L;
 
   private List<ConstraintViolationSummary> cvsl;
@@ -70,8 +78,8 @@ public class MutationsRejectedException extends AccumuloException {
   @Deprecated
   public MutationsRejectedException(List<ConstraintViolationSummary> cvsList, HashMap<org.apache.accumulo.core.data.KeyExtent,Set<SecurityErrorCode>> hashMap,
       Collection<String> serverSideErrors, int unknownErrors, Throwable cause) {
-    super("# constraint violations : " + cvsList.size() + "  security codes: " + hashMap.values() + "  # server errors " + serverSideErrors.size()
-        + " # exceptions " + unknownErrors, cause);
+    super(CONSTRAINT_VIOLATIONS + cvsList.size() + SECURITY_CODES + hashMap.values() + SERVER_ERRORS + serverSideErrors.size()
+        + EXCEPTIONS + unknownErrors, cause);
     this.cvsl = cvsList;
     this.af = transformKeys(hashMap, TabletIdImpl.KE_2_TID_OLD);
     this.es = serverSideErrors;
@@ -93,8 +101,8 @@ public class MutationsRejectedException extends AccumuloException {
   @Deprecated
   public MutationsRejectedException(Instance instance, List<ConstraintViolationSummary> cvsList,
       HashMap<org.apache.accumulo.core.data.KeyExtent,Set<SecurityErrorCode>> hashMap, Collection<String> serverSideErrors, int unknownErrors, Throwable cause) {
-    super("# constraint violations : " + cvsList.size() + "  security codes: " + format(transformKeys(hashMap, TabletIdImpl.KE_2_TID_OLD), instance)
-        + "  # server errors " + serverSideErrors.size() + " # exceptions " + unknownErrors, cause);
+    super(CONSTRAINT_VIOLATIONS + cvsList.size() + SECURITY_CODES + format(transformKeys(hashMap, TabletIdImpl.KE_2_TID_OLD), instance)
+        + SERVER_ERRORS + serverSideErrors.size() + EXCEPTIONS + unknownErrors, cause);
     this.cvsl = cvsList;
     this.af = transformKeys(hashMap, TabletIdImpl.KE_2_TID_OLD);
     this.es = serverSideErrors;
@@ -116,8 +124,8 @@ public class MutationsRejectedException extends AccumuloException {
    */
   public MutationsRejectedException(Instance instance, List<ConstraintViolationSummary> cvsList, Map<TabletId,Set<SecurityErrorCode>> hashMap,
       Collection<String> serverSideErrors, int unknownErrors, Throwable cause) {
-    super("# constraint violations : " + cvsList.size() + "  security codes: " + format(hashMap, instance) + "  # server errors " + serverSideErrors.size()
-        + " # exceptions " + unknownErrors, cause);
+    super(CONSTRAINT_VIOLATIONS + cvsList.size() + SECURITY_CODES + format(hashMap, instance) + SERVER_ERRORS + serverSideErrors.size()
+        + EXCEPTIONS + unknownErrors, cause);
     this.cvsl = cvsList;
     this.af = hashMap;
     this.es = serverSideErrors;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsHelper.java
@@ -92,7 +92,7 @@ public abstract class NamespaceOperationsHelper implements NamespaceOperations {
     String opt = root + ".opt.";
     for (Entry<String,String> property : this.getProperties(namespace)) {
       if (property.getKey().equals(root)) {
-        String parts[] = property.getValue().split(",");
+        String[] parts = property.getValue().split(",");
         if (parts.length != 2) {
           throw new AccumuloException("Bad value for iterator setting: " + property.getValue());
         }
@@ -147,7 +147,7 @@ public abstract class NamespaceOperationsHelper implements NamespaceOperations {
             optionConflicts.put(property.getKey(), property.getValue());
           if (property.getKey().contains(".opt."))
             continue;
-          String parts[] = property.getValue().split(",");
+          String[] parts = property.getValue().split(",");
           if (parts.length != 2)
             throw new AccumuloException("Bad value for existing iterator setting: " + property.getKey() + "=" + property.getValue());
           try {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -1078,7 +1078,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     Path failPath = checkPath(failureDir, "Bulk", "failure");
 
     List<ByteBuffer> args = Arrays.asList(ByteBuffer.wrap(tableName.getBytes(UTF_8)), ByteBuffer.wrap(dirPath.toString().getBytes(UTF_8)),
-        ByteBuffer.wrap(failPath.toString().getBytes(UTF_8)), ByteBuffer.wrap((setTime + "").getBytes(UTF_8)));
+        ByteBuffer.wrap(failPath.toString().getBytes(UTF_8)), ByteBuffer.wrap((Boolean.toString(setTime)).getBytes(UTF_8)));
     Map<String,String> opts = new HashMap<String,String>();
 
     try {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/thrift/ThriftSecurityException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/thrift/ThriftSecurityException.java
@@ -255,6 +255,8 @@ public class ThriftSecurityException extends TException implements org.apache.th
       }
       break;
 
+    default:
+        break;
     }
   }
 
@@ -266,6 +268,8 @@ public class ThriftSecurityException extends TException implements org.apache.th
     case CODE:
       return getCode();
 
+    default:
+        break;
     }
     throw new IllegalStateException();
   }
@@ -281,6 +285,8 @@ public class ThriftSecurityException extends TException implements org.apache.th
       return isSetUser();
     case CODE:
       return isSetCode();
+    default:
+      break;
     }
     throw new IllegalStateException();
   }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -170,7 +170,7 @@ public class CachableBlockFile {
 
       @Override
       public String getInfo() {
-        return "" + blockIndex;
+        return Integer.toString(blockIndex);
       }
 
     }
@@ -194,7 +194,7 @@ public class CachableBlockFile {
 
       @Override
       public String getInfo() {
-        return "" + offset + "," + compressedSize + "," + rawSize;
+        return offset + "," + compressedSize + "," + rawSize;
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -668,7 +668,7 @@ abstract public class TransformingIterator extends WrappingIterator implements O
    *          size in bytes
    */
   public static void setMaxBufferSize(IteratorSetting config, long maxBufferSize) {
-    config.addOption(MAX_BUFFER_SIZE_OPT, maxBufferSize + "");
+    config.addOption(MAX_BUFFER_SIZE_OPT, Long.toString(maxBufferSize));
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
@@ -71,8 +71,8 @@ public class DataFileValue {
 
   public String encodeAsString() {
     if (time >= 0)
-      return ("" + size + "," + numEntries + "," + time);
-    return ("" + size + "," + numEntries);
+      return (size + "," + numEntries + "," + time);
+    return (size + "," + numEntries);
   }
 
   public Value encodeAsValue() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1192 - String literals should not be duplicated.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
This pull request removes technical debit of 80 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
George Kankava