### PR TITLE
ACCUMULO-4348 Deprecate KerberosToken constructor with side effects

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/KerberosToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/KerberosToken.java
@@ -59,6 +59,20 @@ public class KerberosToken implements AuthenticationToken {
   }
 
   /**
+   * Creates a Kerberos token for the specified principal using the provided keytab. The principal and keytab combination are verified by attempting a log in.
+   * <p>
+   * This constructor does not have any side effects.
+   *
+   * @param principal
+   *          The Kerberos principal
+   * @param keytab
+   *          A keytab file containing the principal's credentials.
+   */
+  public KerberosToken(String principal, File keytab) throws IOException {
+    this(principal, keytab, false);
+  }
+
+  /**
    * Creates a token and logs in via {@link UserGroupInformation} using the provided principal and keytab. A key for the principal must exist in the keytab,
    * otherwise login will fail.
    *
@@ -68,7 +82,9 @@ public class KerberosToken implements AuthenticationToken {
    *          A keytab file
    * @param replaceCurrentUser
    *          Should the current Hadoop user be replaced with this user
+   * @deprecated since 1.8.0, @see #KerberosToken(String, File)
    */
+  @Deprecated
   public KerberosToken(String principal, File keytab, boolean replaceCurrentUser) throws IOException {
     requireNonNull(principal, "Principal was null");
     requireNonNull(keytab, "Keytab was null");


### PR DESCRIPTION
`KerberosToken(String, File, boolean)` is deprecated in favor of `KerberosToken(String, File)`.

The boolean flag would log in the requested user with Hadoop's `UserGroupInformation` class. This
changed global state about who the active user was. In a multi-user environment, this potentially
made little sense as other users could overwrite eachother.

This patch includes a convenience constructor that doesn't have any side effects, but has the same
semantics as logging in a user with a keytab.