### PR TITLE
ACCUMULO-4361 Configure ShellServerIT to run with one tserver

### DIFF
--- a/test/src/test/java/org/apache/accumulo/harness/SharedMiniClusterIT.java
+++ b/test/src/test/java/org/apache/accumulo/harness/SharedMiniClusterIT.java
@@ -34,8 +34,6 @@ import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +43,10 @@ import org.slf4j.LoggerFactory;
  * There isn't a good way to build this off of the {@link AccumuloClusterIT} (as would be the logical place) because we need to start the MiniAccumuloCluster in
  * a static BeforeClass-annotated method. Because it is static and invoked before any other BeforeClass methods in the implementation, the actual test classes
  * can't expose any information to tell the base class that it is to perform the one-MAC-per-class semantics.
+ *
+ * Implementations of this class must be sure to invoke {@link #startMiniCluster()} or {@link #startMiniClusterWithConfig(MiniClusterConfigurationCallback)} in
+ * a method annotated with the {@link org.junit.BeforeClass} JUnit annotation and {@link #stopMiniCluster()} in a method annotated with the
+ * {@link org.junit.AfterClass} JUnit annotation.
  */
 public abstract class SharedMiniClusterIT extends AccumuloIT implements ClusterUsers {
   private static final Logger log = LoggerFactory.getLogger(SharedMiniClusterIT.class);
@@ -56,8 +58,21 @@ public abstract class SharedMiniClusterIT extends AccumuloIT implements ClusterU
   private static MiniAccumuloClusterImpl cluster;
   private static TestingKdc krb;
 
-  @BeforeClass
+  /**
+   * Starts a MiniAccumuloCluster instance with the default configuration.
+   */
   public static void startMiniCluster() throws Exception {
+    startMiniClusterWithConfig(MiniClusterConfigurationCallback.NO_CALLBACK);
+  }
+
+  /**
+   * Starts a MiniAccumuloCluster instance with the default configuration but also provides the caller the opportunity to update the configuration before the
+   * MiniAccumuloCluster is started.
+   *
+   * @param miniClusterCallback
+   *          A callback to configure the minicluster before it is started.
+   */
+  public static void startMiniClusterWithConfig(MiniClusterConfigurationCallback miniClusterCallback) throws Exception {
     File baseDir = new File(System.getProperty("user.dir") + "/target/mini-tests");
     assertTrue(baseDir.mkdirs() || baseDir.isDirectory());
 
@@ -81,7 +96,8 @@ public abstract class SharedMiniClusterIT extends AccumuloIT implements ClusterU
       token = new PasswordToken(rootPassword);
     }
 
-    cluster = harness.create(SharedMiniClusterIT.class.getName(), System.currentTimeMillis() + "_" + new Random().nextInt(Short.MAX_VALUE), token, krb);
+    cluster = harness.create(SharedMiniClusterIT.class.getName(), System.currentTimeMillis() + "_" + new Random().nextInt(Short.MAX_VALUE), token,
+        miniClusterCallback, krb);
     cluster.start();
 
     if (null != krb) {
@@ -106,7 +122,9 @@ public abstract class SharedMiniClusterIT extends AccumuloIT implements ClusterU
     }
   }
 
-  @AfterClass
+  /**
+   * Stops the MiniAccumuloCluster and related services if they are running.
+   */
   public static void stopMiniCluster() throws Exception {
     if (null != cluster) {
       try {

--- a/test/src/test/java/org/apache/accumulo/test/ArbitraryTablePropertiesIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/ArbitraryTablePropertiesIT.java
@@ -26,7 +26,9 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.SharedMiniClusterIT;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,16 @@ public class ArbitraryTablePropertiesIT extends SharedMiniClusterIT {
   @Override
   protected int defaultTimeoutSeconds() {
     return 30;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   // Test set, get, and remove arbitrary table properties on the root account

--- a/test/src/test/java/org/apache/accumulo/test/CreateTableWithNewTableConfigIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/CreateTableWithNewTableConfigIT.java
@@ -33,7 +33,9 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.SharedMiniClusterIT;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,16 @@ public class CreateTableWithNewTableConfigIT extends SharedMiniClusterIT {
   @Override
   protected int defaultTimeoutSeconds() {
     return 30;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   public int numProperties(Connector connector, String tableName) throws AccumuloException, TableNotFoundException {

--- a/test/src/test/java/org/apache/accumulo/test/SplitCancelsMajCIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/SplitCancelsMajCIT.java
@@ -34,6 +34,8 @@ import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.SharedMiniClusterIT;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.io.Text;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 // ACCUMULO-2862
@@ -42,6 +44,16 @@ public class SplitCancelsMajCIT extends SharedMiniClusterIT {
   @Override
   public int defaultTimeoutSeconds() {
     return 2 * 60;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   @Test

--- a/test/src/test/java/org/apache/accumulo/test/functional/CleanUpIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/CleanUpIT.java
@@ -29,7 +29,9 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.CleanUp;
 import org.apache.accumulo.harness.SharedMiniClusterIT;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,16 @@ public class CleanUpIT extends SharedMiniClusterIT {
   @Override
   protected int defaultTimeoutSeconds() {
     return 30;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   @Test

--- a/test/src/test/java/org/apache/accumulo/test/functional/DeletedTablesDontFlushIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/DeletedTablesDontFlushIT.java
@@ -27,6 +27,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.harness.SharedMiniClusterIT;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 // ACCUMULO-2880
@@ -35,6 +37,16 @@ public class DeletedTablesDontFlushIT extends SharedMiniClusterIT {
   @Override
   public int defaultTimeoutSeconds() {
     return 60;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   @Test

--- a/test/src/test/java/org/apache/accumulo/test/functional/SimpleMacIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/SimpleMacIT.java
@@ -17,9 +17,22 @@
 package org.apache.accumulo.test.functional;
 
 import org.apache.accumulo.harness.SharedMiniClusterIT;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 /**
  * @deprecated since 1.6.2; use {@link SharedMiniClusterIT} instead
  */
 @Deprecated
-public class SimpleMacIT extends SharedMiniClusterIT {}
+public class SimpleMacIT extends SharedMiniClusterIT {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
+  }
+}

--- a/test/src/test/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -53,6 +53,8 @@ import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletStateChangeIterator;
 import org.apache.accumulo.server.zookeeper.ZooLock;
 import org.apache.hadoop.io.Text;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.base.Predicate;
@@ -67,6 +69,16 @@ public class TabletStateChangeIteratorIT extends SharedMiniClusterIT {
   @Override
   public int defaultTimeoutSeconds() {
     return 2 * 60;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   @Test

--- a/test/src/test/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
@@ -233,6 +233,8 @@ public abstract class SimpleProxyBase extends SharedMiniClusterIT {
     if (null != proxyServer) {
       proxyServer.stop();
     }
+
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   final IteratorSetting setting = new IteratorSetting(100, "slow", SlowIterator.class.getName(), Collections.singletonMap("sleepTime", "200"));

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TBinaryProxyIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TBinaryProxyIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.proxy;
 
+import org.apache.accumulo.harness.SharedMiniClusterIT;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.junit.BeforeClass;
 
@@ -26,6 +27,7 @@ public class TBinaryProxyIT extends SimpleProxyBase {
 
   @BeforeClass
   public static void setProtocol() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
     SimpleProxyBase.factory = new TBinaryProtocol.Factory();
     setUpProxy();
   }

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TCompactProxyIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TCompactProxyIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.proxy;
 
+import org.apache.accumulo.harness.SharedMiniClusterIT;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.junit.BeforeClass;
 
@@ -26,6 +27,7 @@ public class TCompactProxyIT extends SimpleProxyBase {
 
   @BeforeClass
   public static void setProtocol() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
     SimpleProxyBase.factory = new TCompactProtocol.Factory();
     setUpProxy();
   }

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TJsonProtocolProxyIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TJsonProtocolProxyIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.proxy;
 
+import org.apache.accumulo.harness.SharedMiniClusterIT;
 import org.apache.thrift.protocol.TJSONProtocol;
 import org.junit.BeforeClass;
 
@@ -26,6 +27,7 @@ public class TJsonProtocolProxyIT extends SimpleProxyBase {
 
   @BeforeClass
   public static void setProtocol() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
     SimpleProxyBase.factory = new TJSONProtocol.Factory();
     setUpProxy();
   }

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TTupleProxyIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TTupleProxyIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.proxy;
 
+import org.apache.accumulo.harness.SharedMiniClusterIT;
 import org.apache.thrift.protocol.TTupleProtocol;
 import org.junit.BeforeClass;
 
@@ -26,6 +27,7 @@ public class TTupleProxyIT extends SimpleProxyBase {
 
   @BeforeClass
   public static void setProtocol() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
     SimpleProxyBase.factory = new TTupleProtocol.Factory();
     setUpProxy();
   }

--- a/test/src/test/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
@@ -42,7 +42,9 @@ import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.server.util.ReplicationTableUtil;
 import org.apache.hadoop.io.Text;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.Iterables;
@@ -52,6 +54,16 @@ public class StatusCombinerMacIT extends SharedMiniClusterIT {
   @Override
   public int defaultTimeoutSeconds() {
     return 60;
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterIT.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    SharedMiniClusterIT.stopMiniCluster();
   }
 
   @Test


### PR DESCRIPTION
Refactored SharedMiniClusterIT a little bit to work around the
static initialization of the MAC which previously would not have
allowed tests to control how MAC is configured. This has the downside
of forcing new tests to remember to define BeforeClass and AfterClass
annotated methods which call the corresponding methods on SharedMiniClusterIT.