### PR TITLE
ACCUMULO-1787: created TwoTierCompactionStrategy and its Test

### DIFF
--- a/docs/src/main/asciidoc/chapters/table_configuration.txt
+++ b/docs/src/main/asciidoc/chapters/table_configuration.txt
@@ -454,6 +454,28 @@ table. In 1.4 the ability to compact a range of a table was added. To use this
 feature specify start and stop rows for the compact command. This will only
 compact tablets that overlap the given row range.
 
+==== Compaction Strategies
+
+The default behavior of major compactions is defined in the class DefaultCompactionStrategy. 
+This behavior can be changed by overriding the following property with a fully qualified class name:
+
+  table.majc.compaction.strategy
+
+Custom compaction strategies can have additional properties that are specified following the prefix property:
+
+  table.majc.compaction.strategy.opts.*
+
+Accumulo provides a few classes that can be used as an alternative compaction strategy. These classes are located in the 
+org.apache.accumulo.tserver.compaction.* package. EverythingCompactionStrategy will simply compact all files. This is the 
+strategy used by the user "compact" command. SizeLimitCompactionStrategy compacts files no bigger than the limit set in the
+property table.majc.compaction.strategy.opts.sizeLimit. 
+
+TwoTierCompactionStrategy is a hybrid compaction strategy that supports two types of compression. If the total size of 
+files being compacted is larger than table.majc.compaction.strategy.opts.file.large.compress.threshold than a larger 
+compression type will be used. The larger compression type is specified in table.majc.compaction.strategy.opts.file.large.compress.type. 
+Otherwise, the configured table compression will be used. To use this strategy with minor compactions set table.file.compress.type=snappy 
+and set a different compress type in table.majc.compaction.strategy.opts.file.large.compress.type for larger files.
+
 === Pre-splitting tables
 
 Accumulo will balance and distribute tables across servers. Before a

--- a/docs/src/main/resources/examples/README.compactionStrategy
+++ b/docs/src/main/resources/examples/README.compactionStrategy
@@ -20,8 +20,8 @@ This tutorial uses the following Java classes, which can be found in org.apache.
 
  * DefaultCompactionStrategy.java - determines which files to compact based on table.compaction.major.ratio and table.file.max
  * EverythingCompactionStrategy.java - compacts all files
- * SizeLimitCompactionStrategy.java - compacts files no bigger than table.compacations.major.strategy.opts.sizeLimit
- * TwoTierCompactionStrategy.java - uses default compression for smaller files and table.custom.file.large.compress.type for larger files
+ * SizeLimitCompactionStrategy.java - compacts files no bigger than table.majc.compaction.strategy.opts.sizeLimit
+ * TwoTierCompactionStrategy.java - uses default compression for smaller files and table.majc.compaction.strategy.opts.file.large.compress.type for larger files
 
 This is an example of how to configure a compaction strategy. By default Accumulo will always use the DefaultCompactionStrategy, unless 
 these steps are taken to change the configuration.  Use the strategy and settings that best fits your Accumulo setup.

--- a/docs/src/main/resources/examples/README.compactionStrategy
+++ b/docs/src/main/resources/examples/README.compactionStrategy
@@ -24,21 +24,26 @@ This tutorial uses the following Java classes, which can be found in org.apache.
  * TwoTierCompactionStrategy.java - uses default compression for smaller files and table.majc.compaction.strategy.opts.file.large.compress.type for larger files
 
 This is an example of how to configure a compaction strategy. By default Accumulo will always use the DefaultCompactionStrategy, unless 
-these steps are taken to change the configuration.  Use the strategy and settings that best fits your Accumulo setup.
+these steps are taken to change the configuration.  Use the strategy and settings that best fits your Accumulo setup. This example shows
+how to configure and test one of the more complicated strategies, the TwoTierCompactionStrategy. Note that this example requires hadoop
+native libraries built with snappy in order to use snappy compression.
 
-The command below sets the compression for smaller files and minor compactions.
+To begin, run the command to create a table for testing:
 
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.file.compress.type=snappy"
+    $ ./bin/accumulo shell -u root -p secret -e "createtable test1"
+
+The command below sets the compression for smaller files and minor compactions for that table.
+
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.file.compress.type=snappy -t test1"
 
 The commands below will configure the TwoTierCompactionStrategy to use gz compression for files larger than 1M. 
 
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy.opts.file.large.compress.threshold=1M"
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy.opts.file.large.compress.type=gz"
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy=org.apache.accumulo.tserver.compaction.TwoTierCompactionStrategy"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy.opts.file.large.compress.threshold=1M -t test1"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy.opts.file.large.compress.type=gz -t test1"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy=org.apache.accumulo.tserver.compaction.TwoTierCompactionStrategy -t test1"
 
 Generate some data and files in order to test the strategy:
 
-    $ ./bin/accumulo shell -u root -p secret -e "createtable test1"
     $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
     $ ./bin/accumulo shell -u root -p secret -e "flush -t test1"
     $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 11000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
@@ -50,7 +55,7 @@ Generate some data and files in order to test the strategy:
 
 View the tserver log in <accumulo_home>/logs for the compaction and find the name of the <rfile> that was compacted for your table. Print info about this file using the PrintInfo tool:
 
-    $ ./bin/accumulo org.apache.accumulo.core.file.rfile.PrintInfo <rfile>
+    $ ./bin/accumulo rfile-info <rfile>
 
 Details about the rfile will be printed and the compression type should match the type used in the compaction...
 Meta block     : RFile.index

--- a/docs/src/main/resources/examples/README.compactionStrategy
+++ b/docs/src/main/resources/examples/README.compactionStrategy
@@ -26,25 +26,31 @@ This tutorial uses the following Java classes, which can be found in org.apache.
 This is an example of how to configure a compaction strategy. By default Accumulo will always use the DefaultCompactionStrategy, unless 
 these steps are taken to change the configuration.  Use the strategy and settings that best fits your Accumulo setup.
 
-The commands below will configure the TwoTierCompactionStrategy to use gz compression for files larger than 10M. 
-
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy=org.apache.accumulo.tserver.compaction.TwoTierCompactionStrategy"
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.custom.file.large.compress.threshold=10M"
-    $ ./bin/accumulo shell -u root -p secret -e "config -s table.custom.file.large.compress.type=gz"
-
 The command below sets the compression for smaller files and minor compactions.
 
     $ ./bin/accumulo shell -u root -p secret -e "config -s table.file.compress.type=snappy"
 
-To test the strategy works run the commands:
+The commands below will configure the TwoTierCompactionStrategy to use gz compression for files larger than 1M. 
+
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy.opts.file.large.compress.threshold=1M"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy.opts.file.large.compress.type=gz"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy=org.apache.accumulo.tserver.compaction.TwoTierCompactionStrategy"
+
+Generate some data and files in order to test the strategy:
 
     $ ./bin/accumulo shell -u root -p secret -e "createtable test1"
     $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
-    $ ./bin/accumulo shell -u root -p secret -e "compact -t test1"
+    $ ./bin/accumulo shell -u root -p secret -e "flush -t test1"
+    $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 11000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/accumulo shell -u root -p secret -e "flush -t test1"
+    $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 12000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/accumulo shell -u root -p secret -e "flush -t test1"
+    $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 13000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/accumulo shell -u root -p secret -e "flush -t test1"
 
-View the tserver log in <accumulo_home>/logs for the compaction and find the name of the <rfile> that was recently compacted. Print info about this file using the PrintInfo tool:
+View the tserver log in <accumulo_home>/logs for the compaction and find the name of the <rfile> that was compacted for your table. Print info about this file using the PrintInfo tool:
 
-    $ bin/accumulo org.apache.accumulo.core.file.rfile.PrintInfo <rfile>
+    $ ./bin/accumulo org.apache.accumulo.core.file.rfile.PrintInfo <rfile>
 
 Details about the rfile will be printed and the compression type should match the type used in the compaction...
 Meta block     : RFile.index

--- a/docs/src/main/resources/examples/README.compactionStrategy
+++ b/docs/src/main/resources/examples/README.compactionStrategy
@@ -1,0 +1,54 @@
+Title: Apache Accumulo Customizing the Compaction Strategy 
+Notice:    Licensed to the Apache Software Foundation (ASF) under one
+           or more contributor license agreements.  See the NOTICE file
+           distributed with this work for additional information
+           regarding copyright ownership.  The ASF licenses this file
+           to you under the Apache License, Version 2.0 (the
+           "License"); you may not use this file except in compliance
+           with the License.  You may obtain a copy of the License at
+           .
+             http://www.apache.org/licenses/LICENSE-2.0
+           .
+           Unless required by applicable law or agreed to in writing,
+           software distributed under the License is distributed on an
+           "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+           KIND, either express or implied.  See the License for the
+           specific language governing permissions and limitations
+           under the License.
+
+This tutorial uses the following Java classes, which can be found in org.apache.accumulo.tserver.compaction: 
+
+ * DefaultCompactionStrategy.java - determines which files to compact based on table.compaction.major.ratio and table.file.max
+ * EverythingCompactionStrategy.java - compacts all files
+ * SizeLimitCompactionStrategy.java - compacts files no bigger than table.compacations.major.strategy.opts.sizeLimit
+ * TwoTierCompactionStrategy.java - uses default compression for smaller files and table.custom.file.large.compress.type for larger files
+
+This is an example of how to configure a compaction strategy. By default Accumulo will always use the DefaultCompactionStrategy, unless 
+these steps are taken to change the configuration.  Use the strategy and settings that best fits your Accumulo setup.
+
+The commands below will configure the TwoTierCompactionStrategy to use gz compression for files larger than 10M. 
+
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.majc.compaction.strategy=org.apache.accumulo.tserver.compaction.TwoTierCompactionStrategy"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.custom.file.large.compress.threshold=10M"
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.custom.file.large.compress.type=gz"
+
+The command below sets the compression for smaller files and minor compactions.
+
+    $ ./bin/accumulo shell -u root -p secret -e "config -s table.file.compress.type=snappy"
+
+To test the strategy works run the commands:
+
+    $ ./bin/accumulo shell -u root -p secret -e "createtable test1"
+    $ ./bin/accumulo org.apache.accumulo.examples.simple.client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/accumulo shell -u root -p secret -e "compact -t test1"
+
+View the tserver log in <accumulo_home>/logs for the compaction and find the name of the <rfile> that was recently compacted. Print info about this file using the PrintInfo tool:
+
+    $ bin/accumulo org.apache.accumulo.core.file.rfile.PrintInfo <rfile>
+
+Details about the rfile will be printed and the compression type should match the type used in the compaction...
+Meta block     : RFile.index
+      Raw size             : 512 bytes
+      Compressed size      : 278 bytes
+      Compression type     : gz
+

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategy.java
@@ -18,15 +18,11 @@ package org.apache.accumulo.tserver.compaction;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.server.fs.FileRef;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 
 /**
  * A hybrid compaction strategy that supports two types of compression. If total size of files being compacted is larger than

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategy.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.tserver.compaction;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.server.fs.FileRef;
+
+/**
+ * A hybrid compaction strategy that supports two types of compression. If total size of files being compacted is less than
+ * <tt>table.custom.file.small.compress.threshold</tt> than the faster compression type will be used. The faster compression type is specified in
+ * <tt>table.custom.file.small.compress.type</tt>. Otherwise, the normal table compression will be used.
+ *
+ */
+public class TwoTierCompactionStrategy extends DefaultCompactionStrategy {
+
+  /**
+   * Threshold memory in bytes. Files smaller than this threshold will use <tt>table.custom.file.small.compress.type</tt> for compression
+   */
+  public static final String TABLE_SMALL_FILE_COMPRESSION_THRESHOLD = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "file.small.compress.threshold";
+  /**
+   * Type of compression to use if small threshold is surpassed. One of "gz","lzo","snappy", or "none"
+   */
+  public static final String TABLE_SMALL_FILE_COMPRESSION_TYPE = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "file.small.compress.type";
+
+  /**
+   * Helper method to check for required table properties.
+   *
+   * @param objectsToVerify
+   *          any objects that shouldn't be null
+   * @throws IllegalArgumentException
+   *           if any object in {@code objectsToVerify} is null
+   *
+   */
+  public void verifyRequiredProperties(Object... objectsToVerify) throws IllegalArgumentException {
+    for (Object obj : objectsToVerify) {
+      if (obj == null) {
+        throw new IllegalArgumentException("Missing required Table properties for " + this.getClass().getName());
+      }
+    }
+  }
+
+  @Override
+  public boolean shouldCompact(MajorCompactionRequest request) {
+    return super.shouldCompact(request);
+  }
+
+  @Override
+  public void gatherInformation(MajorCompactionRequest request) throws IOException {
+    super.gatherInformation(request);
+  }
+
+  @Override
+  public CompactionPlan getCompactionPlan(MajorCompactionRequest request) {
+    CompactionPlan plan = super.getCompactionPlan(request);
+    plan.writeParameters = new WriteParameters();
+    Map<String,String> tableProperties = request.getTableProperties();
+    verifyRequiredProperties(tableProperties);
+
+    String smallFileCompressionType = tableProperties.get(TABLE_SMALL_FILE_COMPRESSION_TYPE);
+    String threshold = tableProperties.get(TABLE_SMALL_FILE_COMPRESSION_THRESHOLD);
+    verifyRequiredProperties(smallFileCompressionType, threshold);
+    Long smallFileCompressionThreshold = AccumuloConfiguration.getMemoryInBytes(threshold);
+
+    long totalSize = 0;
+    for (Entry<FileRef,DataFileValue> entry : request.getFiles().entrySet()) {
+      totalSize += entry.getValue().getSize();
+    }
+    if (totalSize < smallFileCompressionThreshold) {
+      plan.writeParameters.setCompressType(smallFileCompressionType);
+    }
+    return plan;
+  }
+
+}

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.tserver.compaction;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -71,8 +72,11 @@ public class TwoTierCompactionStrategyTest {
     mcr.setFiles(fileMap);
 
     Assert.assertTrue(ttcs.shouldCompact(mcr));
-    Assert.assertEquals(fileMap.keySet(), new HashSet<>(ttcs.getCompactionPlan(mcr).inputFiles));
     Assert.assertEquals(8, mcr.getFiles().size());
+
+    List<FileRef> filesToCompact = ttcs.getCompactionPlan(mcr).inputFiles;
+    Assert.assertEquals(fileMap.keySet(), new HashSet<>(filesToCompact));
+    Assert.assertEquals(8, filesToCompact.size());
     Assert.assertEquals(null, ttcs.getCompactionPlan(mcr).writeParameters.getCompressType());
   }
 
@@ -82,12 +86,14 @@ public class TwoTierCompactionStrategyTest {
     KeyExtent ke = new KeyExtent("0", null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G");
-
     mcr.setFiles(fileMap);
 
     Assert.assertTrue(ttcs.shouldCompact(mcr));
-    Assert.assertEquals(fileMap.keySet(), new HashSet<>(ttcs.getCompactionPlan(mcr).inputFiles));
     Assert.assertEquals(4, mcr.getFiles().size());
+
+    List<FileRef> filesToCompact = ttcs.getCompactionPlan(mcr).inputFiles;
+    Assert.assertEquals(fileMap.keySet(), new HashSet<>(filesToCompact));
+    Assert.assertEquals(4, filesToCompact.size());
     Assert.assertEquals(largeCompressionType, ttcs.getCompactionPlan(mcr).writeParameters.getCompressType());
   }
 
@@ -106,6 +112,24 @@ public class TwoTierCompactionStrategyTest {
     } catch (IllegalArgumentException iae) {} catch (Throwable t) {
       Assert.assertTrue("IllegalArgumentException should have been thrown.", false);
     }
+  }
+
+  @Test
+  public void testFileSubsetCompaction() throws IOException {
+    conf = createProperTableConfiguration();
+    KeyExtent ke = new KeyExtent("0", null, null);
+    mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, conf);
+    Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "1G", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "10M", "f6", "10M", "f7", "10M");
+    Map<FileRef,DataFileValue> filesToCompactMap = createFileMap("f2", "10M", "f3", "10M", "f4", "10M", "f5", "10M", "f6", "10M", "f7", "10M");
+    mcr.setFiles(fileMap);
+
+    Assert.assertTrue(ttcs.shouldCompact(mcr));
+    Assert.assertEquals(7, mcr.getFiles().size());
+
+    List<FileRef> filesToCompact = ttcs.getCompactionPlan(mcr).inputFiles;
+    Assert.assertEquals(filesToCompactMap.keySet(), new HashSet<>(filesToCompact));
+    Assert.assertEquals(6, filesToCompact.size());
+    Assert.assertEquals(null, ttcs.getCompactionPlan(mcr).writeParameters.getCompressType());
   }
 
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.tserver.compaction;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.data.impl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.server.fs.FileRef;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests org.apache.accumulo.tserver.compaction.TwoTierCompactionStrategy
+ */
+public class TwoTierCompactionStrategyTest {
+  private String smallCompressionType = "snappy";
+  private TwoTierCompactionStrategy ttcs = null;
+  private MajorCompactionRequest mcr = null;
+  private AccumuloConfiguration conf = null;
+
+  private Map<FileRef,DataFileValue> createFileMap(String... sa) {
+
+    HashMap<FileRef,DataFileValue> ret = new HashMap<>();
+    for (int i = 0; i < sa.length; i += 2) {
+      ret.put(new FileRef("hdfs://nn1/accumulo/tables/5/t-0001/" + sa[i]), new DataFileValue(AccumuloConfiguration.getMemoryInBytes(sa[i + 1]), 1));
+    }
+
+    return ret;
+  }
+
+  private AccumuloConfiguration createProperTableConfiguration() {
+    ConfigurationCopy result = new ConfigurationCopy(AccumuloConfiguration.getDefaultConfiguration());
+    result.set(TwoTierCompactionStrategy.TABLE_SMALL_FILE_COMPRESSION_TYPE, smallCompressionType);
+    result.set(TwoTierCompactionStrategy.TABLE_SMALL_FILE_COMPRESSION_THRESHOLD, "500M");
+    return result;
+  }
+
+  @Before
+  public void setup() {
+    ttcs = new TwoTierCompactionStrategy();
+
+  }
+
+  @Test
+  public void testDefaultCompaction() throws IOException {
+    conf = createProperTableConfiguration();
+    KeyExtent ke = new KeyExtent("0", null, null);
+    mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, conf);
+    Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G");
+    mcr.setFiles(fileMap);
+
+    Assert.assertTrue(ttcs.shouldCompact(mcr));
+    Assert.assertEquals(fileMap.keySet(), new HashSet<>(ttcs.getCompactionPlan(mcr).inputFiles));
+    Assert.assertEquals(4, mcr.getFiles().size());
+    Assert.assertEquals(null, ttcs.getCompactionPlan(mcr).writeParameters.getCompressType());
+  }
+
+  @Test
+  public void testSmallCompaction() throws IOException {
+    conf = createProperTableConfiguration();
+    KeyExtent ke = new KeyExtent("0", null, null);
+    mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, conf);
+    Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "10M", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "100M", "f6", "100M", "f7", "100M", "f8",
+        "100M");
+    mcr.setFiles(fileMap);
+
+    Assert.assertTrue(ttcs.shouldCompact(mcr));
+    Assert.assertEquals(fileMap.keySet(), new HashSet<>(ttcs.getCompactionPlan(mcr).inputFiles));
+    Assert.assertEquals(8, mcr.getFiles().size());
+    Assert.assertEquals(smallCompressionType, ttcs.getCompactionPlan(mcr).writeParameters.getCompressType());
+  }
+
+  @Test
+  public void testMissingConfigProperties() {
+    conf = AccumuloConfiguration.getDefaultConfiguration();
+    KeyExtent ke = new KeyExtent("0", null, null);
+    mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, null, conf);
+    Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "10M", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "100M", "f6", "100M", "f7", "100M", "f8",
+        "100M");
+    mcr.setFiles(fileMap);
+
+    try {
+      ttcs.getCompactionPlan(mcr);
+      Assert.assertTrue("IllegalArgumentException should have been thrown.", false);
+    } catch (IllegalArgumentException iae) {} catch (Throwable t) {
+      Assert.assertTrue("IllegalArgumentException should have been thrown.", false);
+    }
+  }
+
+}


### PR DESCRIPTION
Created a new Compaction Strategy based on the request in ACCUMULO-1787. It is a hybrid compaction strategy that supports two types of compression. If total size of files being compacted is less than table.custom.file.small.compress.threshold than the faster compression type will be used. The faster compression type is specified in table.custom.file.small.compress.type. Otherwise, the normal table compression will be used.