### PR TITLE
Log naming

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -154,20 +154,27 @@ export JAVA_HOME HADOOP_PREFIX ZOOKEEPER_HOME LD_LIBRARY_PATH DYLD_LIBRARY_PATH
 
 # Strip the instance from $1
 APP=$1
-INSTANCE="1"
+# Avoid setting an instance unless it's necessary to ensure consistency in filenames
+INSTANCE=""
+# Avoid setting a pointless system property
+INSTANCE_OPT=""
 if [[ "$1" =~ .*-.* ]]; then
-  APP=`echo $1 | cut -d"-" -f1`
-  INSTANCE=`echo $1 | cut -d"-" -f2`
+  APP="$(echo $1 | cut -d'-' -f1)"
+  # Appending the trailing underscore to make single-tserver deploys look how they did
+  INSTANCE="$(echo $1 | cut -d'-' -f2)_"
 
   #Rewrite the input arguments
   set -- "$APP" "${@:2}"
+
+  # The extra system property we'll pass to the java cmd
+  INSTANCE_OPT="-Daccumulo.service.instance=${INSTANCE}"
 fi
 
 #
 # app isn't used anywhere, but it makes the process easier to spot when ps/top/snmp truncate the command line
 JAVA="${JAVA_HOME}/bin/java"
 exec "$JAVA" "-Dapp=$1" \
-   "-Dinstance=$INSTANCE" \
+   $INSTANCE_OPT \
    $ACCUMULO_OPTS \
    -classpath "${CLASSPATH}" \
    -XX:OnOutOfMemoryError="${ACCUMULO_KILL_CMD:-kill -9 %p}" \

--- a/assemble/bin/config.sh
+++ b/assemble/bin/config.sh
@@ -118,11 +118,15 @@ else
   export NUMA_CMD=""
 fi
 
-# NUMA sanity checks
-if [[ -z $NUM_TSERVERS ]]; then
-   echo "NUM_TSERVERS is missing in accumulo-env.sh, please check your configuration."
+NUM_TSERVERS=${NUM_TSERVERS:-1}
+
+# Validate that NUM_TSERVERS is a positive integer
+if ! [[ $NUM_TSERVERS =~ ^[0-9]+$ ]]; then
+   echo "NUM_TSERVERS, when defined in accumulo-env.sh, should be a positive number, is '$NUM_TSERVERS'"
    exit 1
 fi
+
+# NUMA sanity checks
 if [[ $NUM_TSERVERS -eq 1 && -n $TSERVER_NUMA_OPTIONS ]]; then
    echo "TSERVER_NUMA_OPTIONS declared when NUM_TSERVERS is 1, use ACCUMULO_NUMACTL_OPTIONS instead"
    exit 1

--- a/assemble/bin/start-daemon.sh
+++ b/assemble/bin/start-daemon.sh
@@ -138,8 +138,15 @@ else
          fi
       fi
 
+      OUTFILE="${ACCUMULO_LOG_DIR}/${SERVICE}_${t}_${LOGHOST}.out"
+      ERRFILE="${ACCUMULO_LOG_DIR}/${SERVICE}_${t}_${LOGHOST}.err"
+
+      # Rotate the .out and .err files
+      rotate_log "$OUTFILE" ${ACCUMULO_NUM_OUT_FILES}
+      rotate_log "$ERRFILE" ${ACCUMULO_NUM_OUT_FILES}
+
       # Fork the process, store the pid
-      nohup ${NUMA_CMD} "$COMMAND" "${SERVICE}" --address "${ADDRESS}" >"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.out" 2>"${ACCUMULO_LOG_DIR}/${SERVICE}_${LOGHOST}.err" < /dev/null &
+      nohup ${NUMA_CMD} "$COMMAND" "${SERVICE}" --address "${ADDRESS}" >"$OUTFILE" 2>"$ERRFILE" < /dev/null &
       echo $! > ${PID_FILE}
 
    done

--- a/assemble/bin/start-daemon.sh
+++ b/assemble/bin/start-daemon.sh
@@ -138,8 +138,10 @@ else
          fi
       fi
 
-      OUTFILE="${ACCUMULO_LOG_DIR}/${SERVICE}_${t}_${LOGHOST}.out"
-      ERRFILE="${ACCUMULO_LOG_DIR}/${SERVICE}_${t}_${LOGHOST}.err"
+      # We want the files to be consistently named with the log files
+      # server_identifier_hostname.{out,err}, e.g. tserver_2_fqdn.out
+      OUTFILE="${ACCUMULO_LOG_DIR}/${S}_${t}_${LOGHOST}.out"
+      ERRFILE="${ACCUMULO_LOG_DIR}/${S}_${t}_${LOGHOST}.err"
 
       # Rotate the .out and .err files
       rotate_log "$OUTFILE" ${ACCUMULO_NUM_OUT_FILES}

--- a/assemble/conf/templates/generic_logger.properties
+++ b/assemble/conf/templates/generic_logger.properties
@@ -15,7 +15,7 @@
 
 # Write out everything at the DEBUG level to the debug log
 log4j.appender.A2=org.apache.log4j.RollingFileAppender
-log4j.appender.A2.File=${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${org.apache.accumulo.core.ip.localhost.hostname}_fromprops.debug.log
+log4j.appender.A2.File=${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${accumulo.service.instance}${org.apache.accumulo.core.ip.localhost.hostname}_fromprops.debug.log
 log4j.appender.A2.MaxFileSize=1000MB
 log4j.appender.A2.MaxBackupIndex=10
 log4j.appender.A2.Threshold=DEBUG
@@ -24,7 +24,7 @@ log4j.appender.A2.layout.ConversionPattern=%d{ISO8601} [%-8c{2}] %-5p: %m%n
 
 # Write out INFO and higher to the regular log
 log4j.appender.A3=org.apache.log4j.RollingFileAppender
-log4j.appender.A3.File=${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${org.apache.accumulo.core.ip.localhost.hostname}_fromprops.log
+log4j.appender.A3.File=${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${accumulo.service.instance}${org.apache.accumulo.core.ip.localhost.hostname}_fromprops.log
 log4j.appender.A3.MaxFileSize=1000MB
 log4j.appender.A3.MaxBackupIndex=10
 log4j.appender.A3.Threshold=INFO

--- a/assemble/conf/templates/generic_logger.xml
+++ b/assemble/conf/templates/generic_logger.xml
@@ -20,7 +20,7 @@
 
   <!-- Write out everything at the DEBUG level to the debug log -->
   <appender name="A2" class="org.apache.log4j.RollingFileAppender">
-     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${instance}_${org.apache.accumulo.core.ip.localhost.hostname}.debug.log"/>
+     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${accumulo.service.instance}${org.apache.accumulo.core.ip.localhost.hostname}.debug.log"/>
      <param name="MaxFileSize"    value="1000MB"/>
      <param name="MaxBackupIndex" value="10"/>
      <param name="Threshold"      value="DEBUG"/>
@@ -31,7 +31,7 @@
 
   <!--  Write out INFO and higher to the regular log -->
   <appender name="A3" class="org.apache.log4j.RollingFileAppender">
-     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${instance}_${org.apache.accumulo.core.ip.localhost.hostname}.log"/>
+     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${accumulo.service.instance}${org.apache.accumulo.core.ip.localhost.hostname}.log"/>
      <param name="MaxFileSize"    value="1000MB"/>
      <param name="MaxBackupIndex" value="10"/>
      <param name="Threshold"      value="INFO"/>


### PR DESCRIPTION
Numerous changes on top of @dlmarion's in #138:

* Use a system property (since global) that points to Accumulo using it
* Update generic_logger.properties template
* Only set system property when instance for service is provided
* Default to "1" when NUM_TSERVERS isn't defined (instead of erroring)
* Restore original log names when single tserver is used
* Avoid duplicative numbers in log file names (e.g. tserver-1_1_fqdn...)