### PR TITLE
ACCUMULO-1055: Configurable maximum size in which to perform merging minor compactions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -444,8 +444,8 @@ public enum Property {
   TABLE_MINC_COMPACT_IDLETIME("table.compaction.minor.idle", "5m", PropertyType.TIMEDURATION,
       "After a tablet has been idle (no mutations) for this time period it may have its "
           + "in-memory map flushed to disk in a minor compaction. There is no guarantee an idle " + "tablet will be compacted."),
-  TABLE_MINC_MAX_MERGE_FILE_SIZE("table.compaction.minor.merge.file.size.max", "50M", PropertyType.MEMORY,
-      "The max file size used for a merging minor compaction."),
+  TABLE_MINC_MAX_MERGE_FILE_SIZE("table.compaction.minor.merge.file.size.max", "0", PropertyType.MEMORY,
+      "The max file size used for a merging minor compaction. The default value of 0 disables a max file size."),
   TABLE_SCAN_MAXMEM("table.scan.max.memory", "512K", PropertyType.MEMORY,
       "The maximum amount of memory that will be used to cache results of a client query/scan. "
           + "Once this limit is reached, the buffered data is sent to the client."),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -444,6 +444,8 @@ public enum Property {
   TABLE_MINC_COMPACT_IDLETIME("table.compaction.minor.idle", "5m", PropertyType.TIMEDURATION,
       "After a tablet has been idle (no mutations) for this time period it may have its "
           + "in-memory map flushed to disk in a minor compaction. There is no guarantee an idle " + "tablet will be compacted."),
+  TABLE_MINC_MAX_MERGE_FILE_SIZE("table.compaction.minor.merge.file.size.max", "50M", PropertyType.MEMORY,
+      "The max file size used for a merging minor compaction."),
   TABLE_SCAN_MAXMEM("table.scan.max.memory", "512K", PropertyType.MEMORY,
       "The maximum amount of memory that will be used to cache results of a client query/scan. "
           + "Once this limit is reached, the buffered data is sent to the client."),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -298,7 +298,11 @@ class DatafileManager {
     if (datafileSizes.size() >= maxFiles) {
       // find the smallest file
 
-      long min = maxMergingMinorCompactionFileSize;
+      long maxFileSize = Long.MAX_VALUE;
+      if (maxMergingMinorCompactionFileSize > 0) {
+        maxFileSize = maxMergingMinorCompactionFileSize;
+      }
+      long min = maxFileSize;
       FileRef minName = null;
 
       for (Entry<FileRef,DataFileValue> entry : datafileSizes.entrySet()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -484,7 +484,8 @@ public class Tablet implements TabletCommitter {
 
     // do this last after tablet is completely setup because it
     // could cause major compaction to start
-    datafileManager = new DatafileManager(this, datafiles);
+    Long maxFileSize = AccumuloConfiguration.getMemoryInBytes(tableConfiguration.get(Property.TABLE_MINC_MAX_MERGE_FILE_SIZE));
+    datafileManager = new DatafileManager(this, datafiles, maxFileSize);
 
     computeNumEntries();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -484,8 +484,7 @@ public class Tablet implements TabletCommitter {
 
     // do this last after tablet is completely setup because it
     // could cause major compaction to start
-    Long maxFileSize = AccumuloConfiguration.getMemoryInBytes(tableConfiguration.get(Property.TABLE_MINC_MAX_MERGE_FILE_SIZE));
-    datafileManager = new DatafileManager(this, datafiles, maxFileSize);
+    datafileManager = new DatafileManager(this, datafiles);
 
     computeNumEntries();
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/DatafileManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/DatafileManagerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.tserver.tablet;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.impl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.server.conf.TableConfiguration;
+import org.apache.accumulo.server.fs.FileRef;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for org.apache.accumulo.tserver.tablet.DatafileManager
+ */
+public class DatafileManagerTest {
+  private Tablet tablet;
+  private KeyExtent extent;
+  private TableConfiguration tableConf;
+
+  private SortedMap<FileRef,DataFileValue> createFileMap(String... sa) {
+    SortedMap<FileRef,DataFileValue> ret = new TreeMap<>();
+    for (int i = 0; i < sa.length; i += 2) {
+      ret.put(new FileRef("hdfs://nn1/accumulo/tables/5/t-0001/" + sa[i]), new DataFileValue(AccumuloConfiguration.getMemoryInBytes(sa[i + 1]), 1));
+    }
+    return ret;
+  }
+
+  @Before
+  public void setupMockClasses() {
+    tablet = EasyMock.createMock(Tablet.class);
+    extent = EasyMock.createMock(KeyExtent.class);
+    tableConf = EasyMock.createMock(TableConfiguration.class);
+
+    EasyMock.expect(tablet.getExtent()).andReturn(extent);
+    EasyMock.expect(tablet.getTableConfiguration()).andReturn(tableConf);
+    EasyMock.expect(tableConf.getMaxFilesPerTablet()).andReturn(5);
+
+    EasyMock.replay(tablet, tableConf);
+  }
+
+  /*
+   * Test max file size (table.compaction.minor.merge.file.size.max) exceeded when calling reserveMergingMinorCompactionFile
+   */
+  @Test
+  public void testReserveMergingMinorCompactionFile_MaxExceeded() throws IOException {
+    Long maxMergeFileSize = Long.valueOf(1000);
+    SortedMap<FileRef,DataFileValue> testFiles = createFileMap("largefile", "10M", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
+
+    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
+
+    EasyMock.verify(tablet, tableConf);
+
+    assertEquals(null, mergeFile);
+  }
+
+  /*
+   * Test max files not reached (table.file.max) when calling reserveMergingMinorCompactionFile
+   */
+  @Test
+  public void testReserveMergingMinorCompactionFile_MaxFilesNotReached() throws IOException {
+    Long maxMergeFileSize = Long.valueOf(1000);
+    SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallfile", "100B", "file2", "100M", "file3", "100M", "file4", "100M");
+
+    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
+
+    EasyMock.verify(tablet, tableConf);
+
+    assertEquals(null, mergeFile);
+  }
+
+  /*
+   * Test the smallest file is chosen for merging minor compaction
+   */
+  @Test
+  public void testReserveMergingMinorCompactionFile() throws IOException {
+    Long maxMergeFileSize = Long.valueOf(1000);
+    SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallfile", "100B", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
+
+    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
+
+    EasyMock.verify(tablet, tableConf);
+
+    assertEquals("smallfile", mergeFile.path().getName());
+  }
+
+}

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/DatafileManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/DatafileManagerTest.java
@@ -23,6 +23,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.server.conf.TableConfiguration;
@@ -56,8 +57,6 @@ public class DatafileManagerTest {
     EasyMock.expect(tablet.getExtent()).andReturn(extent);
     EasyMock.expect(tablet.getTableConfiguration()).andReturn(tableConf);
     EasyMock.expect(tableConf.getMaxFilesPerTablet()).andReturn(5);
-
-    EasyMock.replay(tablet, tableConf);
   }
 
   /*
@@ -65,10 +64,14 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFile_MaxExceeded() throws IOException {
-    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("1000B");
+    String maxMergeFileSize = "1000B";
+    EasyMock.expect(tablet.getTableConfiguration()).andReturn(tableConf);
+    EasyMock.expect(tableConf.get(Property.TABLE_MINC_MAX_MERGE_FILE_SIZE)).andReturn(maxMergeFileSize);
+    EasyMock.replay(tablet, tableConf);
+
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("largefile", "10M", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
 
-    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    DatafileManager dfm = new DatafileManager(tablet, testFiles);
     FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
 
     EasyMock.verify(tablet, tableConf);
@@ -81,10 +84,11 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFile_MaxFilesNotReached() throws IOException {
-    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("1000B");
+    EasyMock.replay(tablet, tableConf);
+
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallfile", "100B", "file2", "100M", "file3", "100M", "file4", "100M");
 
-    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    DatafileManager dfm = new DatafileManager(tablet, testFiles);
     FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
 
     EasyMock.verify(tablet, tableConf);
@@ -97,10 +101,14 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFile() throws IOException {
-    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("1000B");
+    String maxMergeFileSize = "1000B";
+    EasyMock.expect(tablet.getTableConfiguration()).andReturn(tableConf);
+    EasyMock.expect(tableConf.get(Property.TABLE_MINC_MAX_MERGE_FILE_SIZE)).andReturn(maxMergeFileSize);
+    EasyMock.replay(tablet, tableConf);
+
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallfile", "100B", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
 
-    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    DatafileManager dfm = new DatafileManager(tablet, testFiles);
     FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
 
     EasyMock.verify(tablet, tableConf);
@@ -113,10 +121,14 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFileDisabled() throws IOException {
-    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("0");
+    String maxMergeFileSize = "0";
+    EasyMock.expect(tablet.getTableConfiguration()).andReturn(tableConf);
+    EasyMock.expect(tableConf.get(Property.TABLE_MINC_MAX_MERGE_FILE_SIZE)).andReturn(maxMergeFileSize);
+    EasyMock.replay(tablet, tableConf);
+
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallishfile", "10M", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
 
-    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    DatafileManager dfm = new DatafileManager(tablet, testFiles);
     FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
 
     EasyMock.verify(tablet, tableConf);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/DatafileManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/DatafileManagerTest.java
@@ -65,7 +65,7 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFile_MaxExceeded() throws IOException {
-    Long maxMergeFileSize = Long.valueOf(1000);
+    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("1000B");
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("largefile", "10M", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
 
     DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
@@ -81,7 +81,7 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFile_MaxFilesNotReached() throws IOException {
-    Long maxMergeFileSize = Long.valueOf(1000);
+    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("1000B");
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallfile", "100B", "file2", "100M", "file3", "100M", "file4", "100M");
 
     DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
@@ -97,7 +97,7 @@ public class DatafileManagerTest {
    */
   @Test
   public void testReserveMergingMinorCompactionFile() throws IOException {
-    Long maxMergeFileSize = Long.valueOf(1000);
+    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("1000B");
     SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallfile", "100B", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
 
     DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
@@ -106,6 +106,22 @@ public class DatafileManagerTest {
     EasyMock.verify(tablet, tableConf);
 
     assertEquals("smallfile", mergeFile.path().getName());
+  }
+
+  /*
+   * Test disabled max file size for merging minor compaction
+   */
+  @Test
+  public void testReserveMergingMinorCompactionFileDisabled() throws IOException {
+    Long maxMergeFileSize = AccumuloConfiguration.getMemoryInBytes("0");
+    SortedMap<FileRef,DataFileValue> testFiles = createFileMap("smallishfile", "10M", "file2", "100M", "file3", "100M", "file4", "100M", "file5", "100M");
+
+    DatafileManager dfm = new DatafileManager(tablet, testFiles, maxMergeFileSize);
+    FileRef mergeFile = dfm.reserveMergingMinorCompactionFile();
+
+    EasyMock.verify(tablet, tableConf);
+
+    assertEquals("smallishfile", mergeFile.path().getName());
   }
 
 }


### PR DESCRIPTION
Created the new property table.compaction.minor.merge.file.size.max with default value of 50M. Looking for feedback whether 50M is an appropriate default value.
Modified Tablet and DatafileManager to prevent minor compaction merge files from being larger than the max set in the new property.
Created DatafileManagerTest to test 3 different scenarios in reserveMergingMinorCompactionFile.