### PR TITLE
ACCUMULO-4423 Annotate integration tests with categories

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -47,23 +47,27 @@ but are checking for regressions that were previously seen in the codebase. Thes
 resources, at least another gigabyte of memory over what Maven itself requires. As such, it's recommended to have at
 least 3-4GB of free memory and 10GB of free disk space.
 
-## Accumulo for testing
+## Test Categories
 
-The primary reason these tests take so much longer than the unit tests is that most are using an Accumulo instance to
-perform the test. It's a necessary evil; however, there are things we can do to improve this.
+Accumulo uses JUnit Category annotations to categorize certain integration tests based on their runtime requirements.
+Presently there are three different categories:
 
-## MiniAccumuloCluster
+### MiniAccumuloCluster (`MiniClusterOnlyTest`)
 
-By default, these tests will use a MiniAccumuloCluster which is a multi-process "implementation" of Accumulo, managed
-through Java interfaces. This MiniAccumuloCluster has the ability to use the local filesystem or Apache Hadoop's
+These tests use MiniAccumuloCluster (MAC) which is a multi-process "implementation" of Accumulo, managed
+through Java APIs. This MiniAccumuloCluster has the ability to use the local filesystem or Apache Hadoop's
 MiniDFSCluster, as well as starting one to many tablet servers. MiniAccumuloCluster tends to be a very useful tool in
 that it can automatically provide a workable instance that mimics how an actual deployment functions.
 
 The downside of using MiniAccumuloCluster is that a significant portion of each test is now devoted to starting and
 stopping the MiniAccumuloCluster.  While this is a surefire way to isolate tests from interferring with one another, it
-increases the actual runtime of the test by, on average, 10x.
+increases the actual runtime of the test by, on average, 10x. Some times the tests require the use of MAC because the
+test is being destructive or some special environment setup (e.g. Kerberos).
 
-## Standalone Cluster
+By default, these tests are run during the `integration-test` lifecycle phase using `mvn verify`. These tests can
+also be run at the `test` lifecycle phase using `mvn package -Pminicluster-unit-tests`.
+
+### Standalone Cluster (`AnyClusterTest`)
 
 An alternative to the MiniAccumuloCluster for testing, a standalone Accumulo cluster can also be configured for use by
 most tests. This requires a manual step of building and deploying the Accumulo cluster by hand. The build can then be
@@ -75,7 +79,9 @@ Use of a standalone cluster can be enabled using system properties on the Maven 
 providing a Java properties file on the Maven command line. The use of a properties file is recommended since it is
 typically a fixed file per standalone cluster you want to run the tests against.
 
-### Configuration
+These tests will always run during the `integration-test` lifecycle phase using `mvn verify`.
+
+## Configuration for Standalone clusters
 
 The following properties can be used to configure a standalone cluster:
 
@@ -128,4 +134,3 @@ at a time, for example the [Continuous Ingest][1] and [Randomwalk test][2] suite
 [3]: https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
 [4]: http://maven.apache.org/surefire/maven-surefire-plugin/
 [5]: http://maven.apache.org/surefire/maven-failsafe-plugin/
-

--- a/pom.xml
+++ b/pom.xml
@@ -1414,5 +1414,12 @@
         <accumulo.integrationTestsGroups>${accumulo.miniclusterTests}</accumulo.integrationTestsGroups>
       </properties>
     </profile>
+    <profile>
+      <id>standalone-capable-tests</id>
+      <properties>
+        <accumulo.integrationTestsExcludedGroups>${accumulo.miniclusterTests}</accumulo.integrationTestsExcludedGroups>
+        <accumulo.integrationTestsGroups>${accumulo.anyClusterTests}</accumulo.integrationTestsGroups>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -116,10 +116,11 @@
   </ciManagement>
   <properties>
     <accumulo.anyClusterTests>org.apache.accumulo.test.categories.AnyClusterTest</accumulo.anyClusterTests>
+    <accumulo.integrationTestsExcludedGroups />
+    <accumulo.integrationTestsGroups>${accumulo.anyClusterTests},${accumulo.miniclusterTests}</accumulo.integrationTestsGroups>
     <accumulo.miniclusterTests>org.apache.accumulo.test.categories.MiniClusterOnlyTest</accumulo.miniclusterTests>
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
-    <accumulo.skipMiniClusterInFailsafe>false</accumulo.skipMiniClusterInFailsafe>
     <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.50</bouncycastle.version>
@@ -1004,25 +1005,14 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
-            <id>run-minicluster-integration-tests</id>
+            <id>run-integration-tests</id>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
             <configuration>
-              <skip>${accumulo.skipMiniClusterInFailsafe}</skip>
-              <groups>${accumulo.miniclusterTests}</groups>
-            </configuration>
-          </execution>
-          <execution>
-            <!-- Run only the anyCluster tests -->
-            <id>run-anyCluster-integration-tests</id>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-            <configuration>
-              <groups>${accumulo.anyClusterTests}</groups>
+              <excludeGroups>${accumulo.integrationTestsExcludedGroups}</excludeGroups>
+              <groups>${accumulo.integrationTestsGroups}</groups>
             </configuration>
           </execution>
         </executions>
@@ -1416,6 +1406,13 @@
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <profile>
+      <id>only-minicluster-tests</id>
+      <properties>
+        <accumulo.integrationTestsExcludedGroups>${accumulo.anyClusterTests}</accumulo.integrationTestsExcludedGroups>
+        <accumulo.integrationTestsGroups>${accumulo.miniclusterTests}</accumulo.integrationTestsGroups>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,11 @@
     <url>https://builds.apache.org/view/A-D/view/Accumulo/</url>
   </ciManagement>
   <properties>
+    <accumulo.anyClusterTests>org.apache.accumulo.test.categories.AnyClusterTest</accumulo.anyClusterTests>
+    <accumulo.miniclusterTests>org.apache.accumulo.test.categories.MiniClusterOnlyTest</accumulo.miniclusterTests>
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
+    <accumulo.skipMiniClusterInFailsafe>false</accumulo.skipMiniClusterInFailsafe>
     <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.50</bouncycastle.version>
@@ -240,7 +243,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -1001,11 +1004,26 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
-            <id>run-integration-tests</id>
+            <id>run-minicluster-integration-tests</id>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <configuration>
+              <skip>${accumulo.skipMiniClusterInFailsafe}</skip>
+              <groups>${accumulo.miniclusterTests}</groups>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Run only the anyCluster tests -->
+            <id>run-anyCluster-integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <groups>${accumulo.anyClusterTests}</groups>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -224,6 +224,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <systemPropertyVariables>
+              <!-- Set this for the minicluster-unit-test profile -->
+              <timeout.factor>${timeout.factor}</timeout.factor>
               <org.apache.accumulo.test.functional.useCredProviderForIT>${useCredProviderForIT}</org.apache.accumulo.test.functional.useCredProviderForIT>
               <org.apache.accumulo.test.functional.useSslForIT>${useSslForIT}</org.apache.accumulo.test.functional.useSslForIT>
               <org.apache.accumulo.test.functional.useKrbForIT>${useKrbForIT}</org.apache.accumulo.test.functional.useKrbForIT>
@@ -272,6 +274,42 @@
           <scope>test</scope>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>minicluster-unit-tests</id>
+      <properties>
+        <accumulo.skipMiniClusterInFailsafe>true</accumulo.skipMiniClusterInFailsafe>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                <!-- Adds an execution for the minicluster-only tests at the test phase -->
+                <execution>
+                  <id>run-minicluster-unit-tests</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <phase>test</phase>
+                  <configuration>
+                    <groups>${accumulo.miniclusterTests}</groups>
+                    <!-- Includes still limit the search-space for groups -->
+                    <includes>
+                      <include>**/Test*.java</include>
+                      <include>**/*Test.java</include>
+                      <include>**/*TestCase.java</include>
+                      <include>**/*IT.java</include>
+                    </includes>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -224,8 +224,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <systemPropertyVariables>
-              <!-- Set this for the minicluster-unit-test profile -->
-              <timeout.factor>${timeout.factor}</timeout.factor>
               <org.apache.accumulo.test.functional.useCredProviderForIT>${useCredProviderForIT}</org.apache.accumulo.test.functional.useCredProviderForIT>
               <org.apache.accumulo.test.functional.useSslForIT>${useSslForIT}</org.apache.accumulo.test.functional.useSslForIT>
               <org.apache.accumulo.test.functional.useKrbForIT>${useKrbForIT}</org.apache.accumulo.test.functional.useKrbForIT>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -281,34 +281,32 @@
         <accumulo.skipMiniClusterInFailsafe>true</accumulo.skipMiniClusterInFailsafe>
       </properties>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <executions>
-                <!-- Adds an execution for the minicluster-only tests at the test phase -->
-                <execution>
-                  <id>run-minicluster-unit-tests</id>
-                  <goals>
-                    <goal>test</goal>
-                  </goals>
-                  <phase>test</phase>
-                  <configuration>
-                    <groups>${accumulo.miniclusterTests}</groups>
-                    <!-- Includes still limit the search-space for groups -->
-                    <includes>
-                      <include>**/Test*.java</include>
-                      <include>**/*Test.java</include>
-                      <include>**/*TestCase.java</include>
-                      <include>**/*IT.java</include>
-                    </includes>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <!-- Adds an execution for the minicluster-only tests at the test phase -->
+              <execution>
+                <id>run-minicluster-unit-tests</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+                <configuration>
+                  <groups>${accumulo.miniclusterTests}</groups>
+                  <!-- Includes still limit the search-space for groups -->
+                  <includes>
+                    <include>**/Test*.java</include>
+                    <include>**/*Test.java</include>
+                    <include>**/*TestCase.java</include>
+                    <include>**/*IT.java</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -275,39 +275,5 @@
         </dependency>
       </dependencies>
     </profile>
-    <profile>
-      <id>minicluster-unit-tests</id>
-      <properties>
-        <accumulo.skipMiniClusterInFailsafe>true</accumulo.skipMiniClusterInFailsafe>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-              <!-- Adds an execution for the minicluster-only tests at the test phase -->
-              <execution>
-                <id>run-minicluster-unit-tests</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <phase>test</phase>
-                <configuration>
-                  <groups>${accumulo.miniclusterTests}</groups>
-                  <!-- Includes still limit the search-space for groups -->
-                  <includes>
-                    <include>**/Test*.java</include>
-                    <include>**/*Test.java</include>
-                    <include>**/*TestCase.java</include>
-                    <include>**/*IT.java</include>
-                  </includes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/test/src/test/java/org/apache/accumulo/harness/AccumuloClusterIT.java
+++ b/test/src/test/java/org/apache/accumulo/harness/AccumuloClusterIT.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.harness.conf.AccumuloMiniClusterConfiguration;
 import org.apache.accumulo.harness.conf.StandaloneAccumuloClusterConfiguration;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.categories.AnyClusterTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -52,12 +53,14 @@ import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * General Integration-Test base class that provides access to an Accumulo instance for testing. This instance could be MAC or a standalone instance.
  */
+@Category(AnyClusterTest.class)
 public abstract class AccumuloClusterIT extends AccumuloIT implements MiniClusterConfigurationCallback, ClusterUsers {
   private static final Logger log = LoggerFactory.getLogger(AccumuloClusterIT.class);
   private static final String TRUE = Boolean.toString(true);

--- a/test/src/test/java/org/apache/accumulo/harness/SharedMiniClusterIT.java
+++ b/test/src/test/java/org/apache/accumulo/harness/SharedMiniClusterIT.java
@@ -31,9 +31,11 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,7 @@ import org.slf4j.LoggerFactory;
  * a method annotated with the {@link org.junit.BeforeClass} JUnit annotation and {@link #stopMiniCluster()} in a method annotated with the
  * {@link org.junit.AfterClass} JUnit annotation.
  */
+@Category(MiniClusterOnlyTest.class)
 public abstract class SharedMiniClusterIT extends AccumuloIT implements ClusterUsers {
   private static final Logger log = LoggerFactory.getLogger(SharedMiniClusterIT.class);
   public static final String TRUE = Boolean.toString(true);

--- a/test/src/test/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/NamespacesIT.java
@@ -77,14 +77,17 @@ import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.examples.simple.constraints.NumericValueConstraint;
 import org.apache.accumulo.harness.AccumuloClusterIT;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.io.Text;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 // Testing default namespace configuration with inheritance requires altering the system state and restoring it back to normal
 // Punt on this for now and just let it use a minicluster.
+@Category(MiniClusterOnlyTest.class)
 public class NamespacesIT extends AccumuloClusterIT {
 
   private Connector c;

--- a/test/src/test/java/org/apache/accumulo/test/categories/AnyClusterTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/categories/AnyClusterTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.categories;
+
+/**
+ * Interface to be used with JUnit Category annotation to denote that the IntegrationTest can be used with any kind of cluster (a MiniAccumuloCluster or a
+ * StandaloneAccumuloCluster).
+ */
+public interface AnyClusterTest {
+
+}

--- a/test/src/test/java/org/apache/accumulo/test/categories/MiniClusterOnlyTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/categories/MiniClusterOnlyTest.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.categories;
+
+/**
+ * Interface to be used with JUnit Category annotation to denote that the IntegrationTest requires the use of a MiniAccumuloCluster.
+ */
+public interface MiniClusterOnlyTest {
+
+}

--- a/test/src/test/java/org/apache/accumulo/test/categories/package-info.java
+++ b/test/src/test/java/org/apache/accumulo/test/categories/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * JUnit categories for the various types of Accumulo integration tests.
+ */
+package org.apache.accumulo.test.categories;
+

--- a/test/src/test/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
@@ -40,13 +40,16 @@ import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.harness.AccumuloClusterIT;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(MiniClusterOnlyTest.class)
 public class ClassLoaderIT extends AccumuloClusterIT {
 
   private static final long ZOOKEEPER_PROPAGATION_TIME = 10 * 1000;

--- a/test/src/test/java/org/apache/accumulo/test/functional/ConfigurableMacIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ConfigurableMacIT.java
@@ -40,12 +40,14 @@ import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.minicluster.impl.ZooKeeperBindException;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.accumulo.test.util.CertUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,7 @@ import org.slf4j.LoggerFactory;
  * General Integration-Test base class that provides access to a {@link MiniAccumuloCluster} for testing. Tests using these typically do very disruptive things
  * to the instance, and require specific configuration. Most tests don't need this level of control and should extend {@link AccumuloClusterIT} instead.
  */
+@Category(MiniClusterOnlyTest.class)
 public class ConfigurableMacIT extends AccumuloIT {
   public static final Logger log = LoggerFactory.getLogger(ConfigurableMacIT.class);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -68,6 +68,7 @@ import org.apache.accumulo.harness.TestingKdc;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.minikdc.MiniKdc;
@@ -77,6 +78,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +88,7 @@ import com.google.common.collect.Sets;
 /**
  * MAC test which uses {@link MiniKdc} to simulate ta secure environment. Can be used as a sanity check for Kerberos/SASL testing.
  */
+@Category(MiniClusterOnlyTest.class)
 public class KerberosIT extends AccumuloIT {
   private static final Logger log = LoggerFactory.getLogger(KerberosIT.class);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/KerberosProxyIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/KerberosProxyIT.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.proxy.thrift.ScanResult;
 import org.apache.accumulo.proxy.thrift.TimeType;
 import org.apache.accumulo.proxy.thrift.WriterOptions;
 import org.apache.accumulo.server.util.PortUtils;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -71,6 +72,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +80,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Tests impersonation of clients by the proxy over SASL
  */
+@Category(MiniClusterOnlyTest.class)
 public class KerberosProxyIT extends AccumuloIT {
   private static final Logger log = LoggerFactory.getLogger(KerberosProxyIT.class);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.harness.MiniClusterHarness;
 import org.apache.accumulo.harness.TestingKdc;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.minikdc.MiniKdc;
@@ -54,6 +55,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +64,7 @@ import com.google.common.collect.Iterables;
 /**
  * MAC test which uses {@link MiniKdc} to simulate ta secure environment. Can be used as a sanity check for Kerberos/SASL testing.
  */
+@Category(MiniClusterOnlyTest.class)
 public class KerberosRenewalIT extends AccumuloIT {
   private static final Logger log = LoggerFactory.getLogger(KerberosRenewalIT.class);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -53,15 +53,18 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterIT;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.io.Text;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // This test verifies the default permissions so a clean instance must be used. A shared instance might
 // not be representative of a fresh installation.
+@Category(MiniClusterOnlyTest.class)
 public class PermissionsIT extends AccumuloClusterIT {
   private static final Logger log = LoggerFactory.getLogger(PermissionsIT.class);
 

--- a/test/src/test/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/TableIT.java
@@ -39,15 +39,18 @@ import org.apache.accumulo.harness.AccumuloClusterIT;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.VerifyIngest;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.google.common.collect.Iterators;
 
+@Category(MiniClusterOnlyTest.class)
 public class TableIT extends AccumuloClusterIT {
 
   @Override

--- a/test/src/test/java/org/apache/accumulo/test/replication/KerberosReplicationIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/replication/KerberosReplicationIT.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.minicluster.impl.ProcessReference;
 import org.apache.accumulo.server.replication.ReplicaSystemFactory;
+import org.apache.accumulo.test.categories.MiniClusterOnlyTest;
 import org.apache.accumulo.test.functional.KerberosIT;
 import org.apache.accumulo.tserver.TabletServer;
 import org.apache.accumulo.tserver.replication.AccumuloReplicaSystem;
@@ -54,6 +55,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +64,7 @@ import com.google.common.collect.Iterators;
 /**
  * Ensure that replication occurs using keytabs instead of password (not to mention SASL)
  */
+@Category(MiniClusterOnlyTest.class)
 public class KerberosReplicationIT extends AccumuloIT {
   private static final Logger log = LoggerFactory.getLogger(KerberosIT.class);
 

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -34,5 +34,11 @@
       <groupId>org.apache.htrace</groupId>
       <artifactId>htrace-core</artifactId>
     </dependency>
+    <!-- Otherwise will see complaints from failsafe WRT groups -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Differentiates tests which always use a minicluster and those
which can use a minicluster or a standalone cluster. Out-of-the-box
test invocation should not have changed.

Includes updated documentation to TESTING.md as well.