### PR TITLE
ACCUMULO-4376 add KeyBuilder

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -51,6 +51,26 @@ public class Key implements WritableComparable<Key>, Cloneable {
   protected long timestamp;
   protected boolean deleted;
 
+  /**
+   * Create a {@link Key} builder.
+   *
+   * @param copyBytes
+   *          if the bytes of the {@link Key} components should be copied
+   * @return the builder at the {@link KeyBuilder.RowStep}
+   */
+  public static KeyBuilder.RowStep builder(boolean copyBytes) {
+    return new KeyBuilder.AbstractKeyBuilder(copyBytes);
+  }
+
+  /**
+   * Create a {@link Key} builder. Copy bytes defaults to true.
+   *
+   * @return the builder at the {@link KeyBuilder.RowStep}
+   */
+  public static KeyBuilder.RowStep builder() {
+    return new KeyBuilder.AbstractKeyBuilder(true);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof Key)
@@ -60,7 +80,7 @@ public class Key implements WritableComparable<Key>, Cloneable {
 
   private static final byte EMPTY_BYTES[] = new byte[0];
 
-  private byte[] copyIfNeeded(byte ba[], int off, int len, boolean copyData) {
+  static byte[] copyIfNeeded(byte ba[], int off, int len, boolean copyData) {
     if (len == 0)
       return EMPTY_BYTES;
 
@@ -182,44 +202,6 @@ public class Key implements WritableComparable<Key>, Cloneable {
    */
   public Key(byte row[], int rOff, int rLen, byte cf[], int cfOff, int cfLen, byte cq[], int cqOff, int cqLen, byte cv[], int cvOff, int cvLen, long ts) {
     init(row, rOff, rLen, cf, cfOff, cfLen, cq, cqOff, cqLen, cv, cvOff, cvLen, ts, false, true);
-  }
-
-  /**
-   * Creates a key.
-   *
-   * @param row
-   *          bytes containing row ID
-   * @param rOff
-   *          offset into row where key's row ID begins (inclusive)
-   * @param rLen
-   *          length of row ID in row
-   * @param cf
-   *          bytes containing column family
-   * @param cfOff
-   *          offset into cf where key's column family begins (inclusive)
-   * @param cfLen
-   *          length of column family in cf
-   * @param cq
-   *          bytes containing column qualifier
-   * @param cqOff
-   *          offset into cq where key's column qualifier begins (inclusive)
-   * @param cqLen
-   *          length of column qualifier in cq
-   * @param cv
-   *          bytes containing column visibility
-   * @param cvOff
-   *          offset into cv where key's column visibility begins (inclusive)
-   * @param cvLen
-   *          length of column visibility in cv
-   * @param ts
-   *          timestamp
-   * @param deleted
-   *          delete marker
-   * @param copy
-   *          if true, forces copy of byte array values into key
-   */
-  public Key(byte row[], int rOff, int rLen, byte cf[], int cfOff, int cfLen, byte cq[], int cqOff, int cqLen, byte cv[], int cvOff, int cvLen, long ts, boolean deleted, boolean copy) {
-    init(row, rOff, rLen, cf, cfOff, cfLen, cq, cqOff, cqLen, cv, cvOff, cvLen, ts, deleted, copy);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -185,6 +185,44 @@ public class Key implements WritableComparable<Key>, Cloneable {
   }
 
   /**
+   * Creates a key.
+   *
+   * @param row
+   *          bytes containing row ID
+   * @param rOff
+   *          offset into row where key's row ID begins (inclusive)
+   * @param rLen
+   *          length of row ID in row
+   * @param cf
+   *          bytes containing column family
+   * @param cfOff
+   *          offset into cf where key's column family begins (inclusive)
+   * @param cfLen
+   *          length of column family in cf
+   * @param cq
+   *          bytes containing column qualifier
+   * @param cqOff
+   *          offset into cq where key's column qualifier begins (inclusive)
+   * @param cqLen
+   *          length of column qualifier in cq
+   * @param cv
+   *          bytes containing column visibility
+   * @param cvOff
+   *          offset into cv where key's column visibility begins (inclusive)
+   * @param cvLen
+   *          length of column visibility in cv
+   * @param ts
+   *          timestamp
+   * @param deleted
+   *          delete marker
+   * @param copy
+   *          if true, forces copy of byte array values into key
+   */
+  public Key(byte row[], int rOff, int rLen, byte cf[], int cfOff, int cfLen, byte cq[], int cqOff, int cqLen, byte cv[], int cvOff, int cvLen, long ts, boolean deleted, boolean copy) {
+    init(row, rOff, rLen, cf, cfOff, cfLen, cq, cqOff, cqLen, cv, cvOff, cvLen, ts, deleted, copy);
+  }
+
+  /**
    * Creates a key. The delete marker defaults to false. This constructor creates a copy of each specified array. If you don't want to create a copy of the
    * arrays, you should call {@link Key#Key(byte[] row, byte[] cf, byte[] cq, byte[] cv, long ts, boolean deleted, boolean copy)} instead.
    *

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -54,21 +54,23 @@ public class Key implements WritableComparable<Key>, Cloneable {
   /**
    * Create a {@link Key} builder.
    *
+   * @since 1.9
    * @param copyBytes
    *          if the bytes of the {@link Key} components should be copied
    * @return the builder at the {@link KeyBuilder.RowStep}
    */
   public static KeyBuilder.RowStep builder(boolean copyBytes) {
-    return new KeyBuilder.AbstractKeyBuilder(copyBytes);
+    return new KeyBuilder.KeyBuilderImpl(copyBytes);
   }
 
   /**
    * Create a {@link Key} builder. Copy bytes defaults to true.
    *
+   * @since 1.9
    * @return the builder at the {@link KeyBuilder.RowStep}
    */
   public static KeyBuilder.RowStep builder() {
-    return new KeyBuilder.AbstractKeyBuilder(true);
+    return new KeyBuilder.KeyBuilderImpl(true);
   }
 
   @Override
@@ -202,6 +204,45 @@ public class Key implements WritableComparable<Key>, Cloneable {
    */
   public Key(byte row[], int rOff, int rLen, byte cf[], int cfOff, int cfLen, byte cq[], int cqOff, int cqLen, byte cv[], int cvOff, int cvLen, long ts) {
     init(row, rOff, rLen, cf, cfOff, cfLen, cq, cqOff, cqLen, cv, cvOff, cvLen, ts, false, true);
+  }
+
+  /**
+   * Creates a key. The delete marker defaults to false. This constructor creates a copy of each specified array. If you don't want to create a copy of the
+   * arrays, you should call {@link Key#Key(byte[] row, byte[] cf, byte[] cq, byte[] cv, long ts, boolean deleted, boolean copy)} instead.
+   *
+   * @param row
+   *          bytes containing row ID
+   * @param rOff
+   *          offset into row where key's row ID begins (inclusive)
+   * @param rLen
+   *          length of row ID in row
+   * @param cf
+   *          bytes containing column family
+   * @param cfOff
+   *          offset into cf where key's column family begins (inclusive)
+   * @param cfLen
+   *          length of column family in cf
+   * @param cq
+   *          bytes containing column qualifier
+   * @param cqOff
+   *          offset into cq where key's column qualifier begins (inclusive)
+   * @param cqLen
+   *          length of column qualifier in cq
+   * @param cv
+   *          bytes containing column visibility
+   * @param cvOff
+   *          offset into cv where key's column visibility begins (inclusive)
+   * @param cvLen
+   *          length of column visibility in cv
+   * @param ts
+   *          timestamp
+   * @param deleted
+   *          delete marker
+   * @param copy
+   *          if true, forces copy of byte array values into key
+   */
+  Key(byte row[], int rOff, int rLen, byte cf[], int cfOff, int cfLen, byte cq[], int cqOff, int cqLen, byte cv[], int cvOff, int cvLen, long ts, boolean deleted, boolean copy) {
+    init(row, rOff, rLen, cf, cfOff, cfLen, cq, cqOff, cqLen, cv, cvOff, cvLen, ts, deleted, copy);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
@@ -48,7 +48,7 @@ public class KeyBuilder {
   public interface Build {
 
     /**
-     * Build a {@link Key} from this builder. copyBytes defaults to true.
+     * Build a {@link Key} from this builder.
      *
      * @return
      *          the {@link Key} built from this builder

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
@@ -20,11 +20,11 @@ package org.apache.accumulo.core.data;
 import org.apache.hadoop.io.Text;
 
 /**
- * A builder used to build <code>Key</code>s by defining their components.
+ * A builder used to build {@link Key}s by defining their components.
  *
  * The rules are:
  * <ul>
- *   <li>All components of the <code>Key</code> are optional except the row</li>
+ *   <li>All components of the {@link Key} are optional except the row</li>
  *   <li>Components not explicitly set default to empty byte array except the timestamp which
  *   defaults to <code>Long.MAX_VALUE</code></li>
  *   <li>The column qualifier can only be set if the column family has been set first</li>
@@ -40,239 +40,261 @@ import org.apache.hadoop.io.Text;
  */
 public class KeyBuilder {
 
-  public interface Build<T> {
+  public interface Build {
 
     /**
-     * Build a <code>Key</code> from this builder.
-     *
-     * @param copyBytes
-     *          if the byte arrays should be copied or not. If not, byte arrays will be reused in the resultant <code>Key</code>
-     * @return
-     *          the <code>Key</code> built from this builder
-     */
-    Key build(boolean copyBytes);
-
-    /**
-     * Build a <code>Key</code> from this builder. copyBytes defaults to true.
+     * Build a {@link Key} from this builder. copyBytes defaults to true.
      *
      * @return
-     *          the <code>Key</code> built from this builder
+     *          the {@link Key} built from this builder
      */
     Key build();
 
     /**
-     * Change the timestamp of the <code>Key</code> created.
+     * Change the timestamp of the {@link Key} created.
      *
      * @param timestamp
-     *          the timestamp to use for the <code>Key</code>
+     *          the timestamp to use for the {@link Key}
      * @return this builder
      */
-    Build<T> timestamp(long timestamp);
+    Build timestamp(long timestamp);
 
     /**
-     * Set the deleted marker of the <code>Key</code> to the parameter.
+     * Set the deleted marker of the {@link Key} to the parameter.
      *
      * @param deleted
-     *          if the <code>Key</code> should be marked as deleted or not
+     *          if the {@link Key} should be marked as deleted or not
      * @return this builder
      */
-    Build<T> deleted(boolean deleted);
+    Build deleted(boolean deleted);
   }
 
-  public interface ColumnFamilyStep<T> extends ColumnVisibilityStep<T> {
+  public interface RowStep extends Build {
 
     /**
-     * Set the column family of the <code>Key</code> that this builder will build to the parameter.
+     * Set the row of the {@link Key} that this builder will build to the parameter.
      *
-     * @param columnFamily
-     *          the column family to use for the <code>Key</code>
+     * @param row
+     *          the row to use for the key
      * @return this builder
      */
-    ColumnQualifierStep<T> columnFamily(final T columnFamily);
+    ColumnFamilyStep row(final Text row);
 
     /**
-     * Set the column family, qualifier and visibility of the <code>Key</code> that this builder will build to the parameter.
+     * Set the row of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param row
+     *          the row to use for the key
+     * @return this builder
+     */
+    ColumnFamilyStep row(final byte[] row);
+
+    /**
+     * Set the row of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param row
+     *          the row to use for the key
+     * @return this builder
+     */
+    ColumnFamilyStep row(final CharSequence row);
+  }
+
+  public interface ColumnFamilyStep extends ColumnVisibilityStep {
+
+    /**
+     * Set the column family of the {@link Key} that this builder will build to the parameter.
      *
      * @param columnFamily
-     *          the column family to use for the <code>Key</code>
+     *          the column family to use for the {@link Key}
+     * @return this builder
+     */
+    ColumnQualifierStep family(final byte[] columnFamily);
+
+    /**
+     * Set the column family of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param columnFamily
+     *          the column family to use for the {@link Key}
+     * @return this builder
+     */
+    ColumnQualifierStep family(final Text columnFamily);
+
+    /**
+     * Set the column family of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param columnFamily
+     *          the column family to use for the {@link Key}
+     * @return this builder
+     */
+    ColumnQualifierStep family(final CharSequence columnFamily);
+  }
+
+  public interface ColumnQualifierStep extends ColumnVisibilityStep {
+
+    /**
+     * Set the column qualifier of the {@link Key} that this builder will build to the parameter.
+     *
      * @param columnQualifier
-     *          the column qualifier to use for the <code>Key</code>
+     *          the column qualifier to use for the {@link Key}
+     * @return this builder
+     */
+    ColumnVisibilityStep qualifier(final byte[] columnQualifier);
+
+    /**
+     * Set the column qualifier of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param columnQualifier
+     *          the column qualifier to use for the {@link Key}
+     * @return this builder
+     */
+    ColumnVisibilityStep qualifier(final Text columnQualifier);
+
+    /**
+     * Set the column qualifier of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param columnQualifier
+     *          the column qualifier to use for the {@link Key}
+     * @return this builder
+     */
+    ColumnVisibilityStep qualifier(final CharSequence columnQualifier);
+  }
+
+  public interface ColumnVisibilityStep extends Build {
+
+    /**
+     * Set the column qualifier of the {@link Key} that this builder will build to the parameter.
+     *
      * @param columnVisibility
-     *          the column visibility to use for the <code>Key</code>
+     *          the column visibility to use for the {@link Key}
      * @return this builder
      */
-    Build<T> column(final T columnFamily, final T columnQualifier, final T columnVisibility);
+    Build visibility(final byte[] columnVisibility);
 
     /**
-     * Set the column family and the qualifier of the <code>Key</code> that this builder will build to the parameter.
-     *
-     * @param columnFamily
-     *          the column family to use for the <code>Key</code>
-     * @param columnQualifier
-     *          the column qualifier to use for the <code>Key</code>
-     * @return this builder
-     */
-    ColumnVisibilityStep<T> column(final T columnFamily, final T columnQualifier);
-  }
-
-  public interface ColumnQualifierStep<T> extends ColumnVisibilityStep<T> {
-
-    /**
-     * Set the column qualifier of the <code>Key</code> that this builder will build to the parameter.
-     *
-     * @param columnQualifier
-     *          the column qualifier to use for the <code>Key</code>
-     * @return this builder
-     */
-    ColumnVisibilityStep<T> columnQualifier(final T columnQualifier);
-  }
-
-  public interface ColumnVisibilityStep<T> extends Build<T> {
-    /**
-     * Set the column qualifier of the <code>Key</code> that this builder will build to the parameter.
+     * Set the column qualifier of the {@link Key} that this builder will build to the parameter.
      *
      * @param columnVisibility
-     *          the column visibility to use for the <code>Key</code>
+     *          the column visibility to use for the {@link Key}
      * @return this builder
      */
-    Build<T> columnVisibility(final T columnVisibility);
+    Build visibility(final Text columnVisibility);
+
+    /**
+     * Set the column qualifier of the {@link Key} that this builder will build to the parameter.
+     *
+     * @param columnVisibility
+     *          the column visibility to use for the {@link Key}
+     * @return this builder
+     */
+    Build visibility(final CharSequence columnVisibility);
   }
 
-  private static abstract class AbstractKeyBuilder<T> implements ColumnFamilyStep<T>, ColumnQualifierStep<T>,
-      ColumnVisibilityStep<T> {
+  static class AbstractKeyBuilder implements RowStep, ColumnFamilyStep, ColumnQualifierStep,
+      ColumnVisibilityStep {
 
     protected static final byte EMPTY_BYTES[] = new byte[0];
 
-    protected T row = null;
-    protected T columnFamily = null;
-    protected T columnQualifier = null;
-    protected T columnVisibility = null;
-    protected long timestamp = Long.MAX_VALUE;
-    protected boolean deleted = false;
+    private final boolean copyBytes;
+    private byte[] row = EMPTY_BYTES;
+    private byte[] family = EMPTY_BYTES;
+    private byte[] qualifier = EMPTY_BYTES;
+    private byte[] visibility = EMPTY_BYTES;
+    private long timestamp = Long.MAX_VALUE;
+    private boolean deleted = false;
 
-    final public ColumnFamilyStep<T> row(final T row) {
-      this.row = row;
+    AbstractKeyBuilder(boolean copyBytes) {
+      this.copyBytes = copyBytes;
+    }
+
+    private byte[] copyBytesIfNeeded(final byte[] bytes) {
+      return Key.copyIfNeeded(bytes, 0, bytes.length, this.copyBytes);
+    }
+
+    private byte[] copyBytesIfNeeded(Text text) {
+      return Key.copyIfNeeded(text.getBytes(), 0, text.getLength(), this.copyBytes);
+    }
+
+    public ColumnFamilyStep row(final byte[] row) {
+      this.row = copyBytesIfNeeded(row);
+      return this;
+    }
+
+    public ColumnFamilyStep row(final Text row) {
+      this.row = copyBytesIfNeeded(row);
+      return this;
+    }
+
+    public ColumnFamilyStep row(final CharSequence row) {
+      return row(new Text(row.toString()));
+    }
+
+    @Override
+    public ColumnQualifierStep family(final byte[] family) {
+      this.family = copyBytesIfNeeded(family);
+      return this;
+    }
+
+
+    @Override
+    public ColumnQualifierStep family(Text family) {
+      this.family = copyBytesIfNeeded(family);
       return this;
     }
 
     @Override
-    final public ColumnQualifierStep<T> columnFamily(final T columnFamily) {
-      this.columnFamily = columnFamily;
+    public ColumnQualifierStep family(CharSequence family) {
+      return family(new Text(family.toString()));
+    }
+
+    @Override
+    public ColumnVisibilityStep qualifier(byte[] qualifier) {
+      this.qualifier = copyBytesIfNeeded(qualifier);
       return this;
     }
 
     @Override
-    final public ColumnVisibilityStep<T> columnQualifier(final T columnQualifier) {
-      this.columnQualifier = columnQualifier;
+    public ColumnVisibilityStep qualifier(Text qualifier) {
+      this.qualifier = copyBytesIfNeeded(qualifier);
       return this;
     }
 
     @Override
-    final public Build<T> columnVisibility(final T columnVisibility) {
-      this.columnVisibility = columnVisibility;
+    public ColumnVisibilityStep qualifier(CharSequence qualifier) {
+      return qualifier(new Text(qualifier.toString()));
+    }
+
+    @Override
+    public Build visibility(byte[] visibility) {
+      this.visibility = copyBytesIfNeeded(visibility);
       return this;
     }
 
     @Override
-    final public Build<T> timestamp(long timestamp) {
+    public Build visibility(Text visibility) {
+      this.visibility = copyBytesIfNeeded(visibility);
+      return this;
+    }
+
+    @Override
+    public Build visibility(CharSequence visibility) {
+      return visibility(new Text(visibility.toString()));
+    }
+
+    @Override
+    final public Build timestamp(long timestamp) {
       this.timestamp = timestamp;
       return this;
     }
 
     @Override
-    public Build<T> deleted(boolean deleted) {
+    public Build deleted(boolean deleted) {
       this.deleted = deleted;
       return this;
     }
 
     @Override
     public Key build() {
-      return this.build(true);
+      return new Key(this.row, this.family, this.qualifier, this.visibility, this.timestamp, this.deleted, false);
     }
-
-    @Override
-    public Build<T> column(final T columnFamily, final T columnQualifier, final T columnVisibility) {
-      return this.columnFamily(columnFamily).columnQualifier(columnQualifier).columnVisibility(columnVisibility);
-    }
-
-    @Override
-    public ColumnVisibilityStep<T> column(final T columnFamily, final T columnQualifier) {
-      return this.columnFamily(columnFamily).columnQualifier(columnQualifier);
-    }
-  }
-
-  private static class TextKeyBuilder extends AbstractKeyBuilder<Text> {
-
-    private final Text EMPTY_TEXT = new Text();
-
-    @Override
-    public Key build(boolean copyBytes) {
-      Text columnFamily = (this.columnFamily == null) ? EMPTY_TEXT : this.columnFamily;
-      Text columnQualifier = (this.columnQualifier == null) ? EMPTY_TEXT : this.columnQualifier;
-      Text columnVisibility = (this.columnVisibility == null) ? EMPTY_TEXT : this.columnVisibility;
-      return new Key(row.getBytes(), 0, row.getLength(), columnFamily.getBytes(), 0, columnFamily.getLength(),
-          columnQualifier.getBytes(), 0, columnQualifier.getLength(), columnVisibility.getBytes(), 0,
-          columnVisibility.getLength(), timestamp, deleted, copyBytes);
-    }
-  }
-
-  private static class ByteArrayKeyBuilder extends AbstractKeyBuilder<byte[]> {
-
-    @Override
-    public Key build(boolean copyBytes) {
-      byte[] columnFamily = (this.columnFamily == null) ? EMPTY_BYTES : this.columnFamily;
-      byte[] columnQualifier = (this.columnQualifier == null) ? EMPTY_BYTES : this.columnQualifier;
-      byte[] columnVisibility = (this.columnVisibility == null) ? EMPTY_BYTES : this.columnVisibility;
-      return new Key(row, columnFamily, columnQualifier, columnVisibility, timestamp, deleted, copyBytes);
-    }
-  }
-
-  private static class CharSequenceKeyBuilder extends AbstractKeyBuilder<CharSequence> {
-
-    private final Text EMPTY_TEXT = new Text();
-
-    @Override
-    public Key build(boolean copyBytes) {
-      Text rowText = new Text(row.toString());
-      Text columnFamilyText = (this.columnFamily == null) ? EMPTY_TEXT : new Text(this.columnFamily.toString());
-      Text columnQualifierText = (this.columnQualifier == null) ? EMPTY_TEXT : new Text(this.columnQualifier.toString());
-      Text columnVisibilityText = (this.columnVisibility == null) ? EMPTY_TEXT : new Text(this.columnVisibility.toString());
-      return new Key(rowText.getBytes(), 0, rowText.getLength(), columnFamilyText.getBytes(), 0,
-          columnFamilyText.getLength(), columnQualifierText.getBytes(), 0, columnQualifierText.getLength(),
-          columnVisibilityText.getBytes(), 0, columnVisibilityText.getLength(), timestamp, deleted, copyBytes);
-    }
-  }
-
-  /**
-   * Set the row of the <code>Key</code> that this builder will build to the parameter.
-   *
-   * @param row
-   *          the row to use for the key
-   * @return this builder
-   */
-  public static ColumnFamilyStep<Text> row(final Text row) {
-    return new TextKeyBuilder().row(row);
-  }
-
-  /**
-   * Set the row of the <code>Key</code> that this builder will build to the parameter.
-   *
-   * @param row
-   *          the row to use for the key
-   * @return this builder
-   */
-  public static ColumnFamilyStep<byte[]> row(final byte[] row) {
-    return new ByteArrayKeyBuilder().row(row);
-  }
-
-  /**
-   * Set the row of the <code>Key</code> that this builder will build to the parameter.
-   *
-   * @param row
-   *          the row to use for the key
-   * @return this builder
-   */
-  public static ColumnFamilyStep<CharSequence> row( final CharSequence row) {
-    return new CharSequenceKeyBuilder().row(row);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
@@ -38,12 +38,12 @@ import org.apache.hadoop.io.Text;
  * The builder is mutable and not thread safe.
  *
  * @see org.apache.accumulo.core.data.Key
- * @since 1.9
+ * @since 2.0
  */
 public class KeyBuilder {
 
   /**
-   * @since 1.9
+   * @since 2.0
    */
   public interface Build {
 
@@ -75,7 +75,7 @@ public class KeyBuilder {
   }
 
   /**
-   * @since 1.9
+   * @since 2.0
    */
   public interface RowStep extends Build {
 
@@ -121,7 +121,7 @@ public class KeyBuilder {
   }
 
   /**
-   * @since 1.9
+   * @since 2.0
    */
   public interface ColumnFamilyStep extends ColumnVisibilityStep {
 
@@ -167,7 +167,7 @@ public class KeyBuilder {
   }
 
   /**
-   * @since 1.9
+   * @since 2.0
    */
   public interface ColumnQualifierStep extends ColumnVisibilityStep {
 
@@ -213,7 +213,7 @@ public class KeyBuilder {
   }
 
   /**
-   * @since 1.9
+   * @since 2.0
    */
   public interface ColumnVisibilityStep extends Build {
 
@@ -268,7 +268,7 @@ public class KeyBuilder {
   }
 
   /**
-   * @since 1.9
+   * @since 2.0
    */
   static class KeyBuilderImpl implements RowStep, ColumnFamilyStep, ColumnQualifierStep,
       ColumnVisibilityStep {

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.data;
+
+
+import org.apache.hadoop.io.Text;
+
+/**
+ * A builder used to build <code>Key</code>s by defining their components.
+ *
+ * The rules are:
+ * <ul>
+ *   <li>All components of the <code>Key</code> are optional except the row</li>
+ *   <li>Components not explicitly set default to empty byte array except the timestamp which
+ *   defaults to <code>Long.MAX_VALUE</code></li>
+ *   <li>The column qualifier can only be set if the column family has been set first</li>
+ *   <li>The column visibility can only be set if at least the column family has been set first</li>
+ * </ul>
+ *
+ * The builder supports three types of components: <code>byte[]</code>, <code>Text</code> and <code>CharSequence</code>.
+ *
+ * The builder is mutable and not thread safe.
+ *
+ * @see org.apache.accumulo.core.data.Key
+ * @since 1.8
+ */
+public class KeyBuilder {
+
+  public interface Build<T> {
+
+    /**
+     * Build a <code>Key</code> from this builder.
+     *
+     * @param copyBytes
+     *          if the byte arrays should be copied or not. If not, byte arrays will be reused in the resultant <code>Key</code>
+     * @return
+     *          the <code>Key</code> built from this builder
+     */
+    Key build(boolean copyBytes);
+
+    /**
+     * Build a <code>Key</code> from this builder. copyBytes defaults to true.
+     *
+     * @return
+     *          the <code>Key</code> built from this builder
+     */
+    Key build();
+
+    /**
+     * Change the timestamp of the <code>Key</code> created.
+     *
+     * @param timestamp
+     *          the timestamp to use for the <code>Key</code>
+     * @return this builder
+     */
+    Build<T> timestamp(long timestamp);
+
+    /**
+     * Set the deleted marker of the <code>Key</code> to the parameter.
+     *
+     * @param deleted
+     *          if the <code>Key</code> should be marked as deleted or not
+     * @return this builder
+     */
+    Build<T> deleted(boolean deleted);
+  }
+
+  public interface ColumnFamilyStep<T> extends ColumnVisibilityStep<T> {
+
+    /**
+     * Set the column family of the <code>Key</code> that this builder will build to the parameter.
+     *
+     * @param columnFamily
+     *          the column family to use for the <code>Key</code>
+     * @return this builder
+     */
+    ColumnQualifierStep<T> columnFamily(final T columnFamily);
+
+    /**
+     * Set the column family, qualifier and visibility of the <code>Key</code> that this builder will build to the parameter.
+     *
+     * @param columnFamily
+     *          the column family to use for the <code>Key</code>
+     * @param columnQualifier
+     *          the column qualifier to use for the <code>Key</code>
+     * @param columnVisibility
+     *          the column visibility to use for the <code>Key</code>
+     * @return this builder
+     */
+    Build<T> column(final T columnFamily, final T columnQualifier, final T columnVisibility);
+
+    /**
+     * Set the column family and the qualifier of the <code>Key</code> that this builder will build to the parameter.
+     *
+     * @param columnFamily
+     *          the column family to use for the <code>Key</code>
+     * @param columnQualifier
+     *          the column qualifier to use for the <code>Key</code>
+     * @return this builder
+     */
+    ColumnVisibilityStep<T> column(final T columnFamily, final T columnQualifier);
+  }
+
+  public interface ColumnQualifierStep<T> extends ColumnVisibilityStep<T> {
+
+    /**
+     * Set the column qualifier of the <code>Key</code> that this builder will build to the parameter.
+     *
+     * @param columnQualifier
+     *          the column qualifier to use for the <code>Key</code>
+     * @return this builder
+     */
+    ColumnVisibilityStep<T> columnQualifier(final T columnQualifier);
+  }
+
+  public interface ColumnVisibilityStep<T> extends Build<T> {
+    /**
+     * Set the column qualifier of the <code>Key</code> that this builder will build to the parameter.
+     *
+     * @param columnVisibility
+     *          the column visibility to use for the <code>Key</code>
+     * @return this builder
+     */
+    Build<T> columnVisibility(final T columnVisibility);
+  }
+
+  private static abstract class AbstractKeyBuilder<T> implements ColumnFamilyStep<T>, ColumnQualifierStep<T>,
+      ColumnVisibilityStep<T> {
+
+    protected static final byte EMPTY_BYTES[] = new byte[0];
+
+    protected T row = null;
+    protected T columnFamily = null;
+    protected T columnQualifier = null;
+    protected T columnVisibility = null;
+    protected long timestamp = Long.MAX_VALUE;
+    protected boolean deleted = false;
+
+    final public ColumnFamilyStep<T> row(final T row) {
+      this.row = row;
+      return this;
+    }
+
+    @Override
+    final public ColumnQualifierStep<T> columnFamily(final T columnFamily) {
+      this.columnFamily = columnFamily;
+      return this;
+    }
+
+    @Override
+    final public ColumnVisibilityStep<T> columnQualifier(final T columnQualifier) {
+      this.columnQualifier = columnQualifier;
+      return this;
+    }
+
+    @Override
+    final public Build<T> columnVisibility(final T columnVisibility) {
+      this.columnVisibility = columnVisibility;
+      return this;
+    }
+
+    @Override
+    final public Build<T> timestamp(long timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    @Override
+    public Build<T> deleted(boolean deleted) {
+      this.deleted = deleted;
+      return this;
+    }
+
+    @Override
+    public Key build() {
+      return this.build(true);
+    }
+
+    @Override
+    public Build<T> column(final T columnFamily, final T columnQualifier, final T columnVisibility) {
+      return this.columnFamily(columnFamily).columnQualifier(columnQualifier).columnVisibility(columnVisibility);
+    }
+
+    @Override
+    public ColumnVisibilityStep<T> column(final T columnFamily, final T columnQualifier) {
+      return this.columnFamily(columnFamily).columnQualifier(columnQualifier);
+    }
+  }
+
+  private static class TextKeyBuilder extends AbstractKeyBuilder<Text> {
+
+    private final Text EMPTY_TEXT = new Text();
+
+    @Override
+    public Key build(boolean copyBytes) {
+      Text columnFamily = (this.columnFamily == null) ? EMPTY_TEXT : this.columnFamily;
+      Text columnQualifier = (this.columnQualifier == null) ? EMPTY_TEXT : this.columnQualifier;
+      Text columnVisibility = (this.columnVisibility == null) ? EMPTY_TEXT : this.columnVisibility;
+      return new Key(row.getBytes(), 0, row.getLength(), columnFamily.getBytes(), 0, columnFamily.getLength(),
+          columnQualifier.getBytes(), 0, columnQualifier.getLength(), columnVisibility.getBytes(), 0,
+          columnVisibility.getLength(), timestamp, deleted, copyBytes);
+    }
+  }
+
+  private static class ByteArrayKeyBuilder extends AbstractKeyBuilder<byte[]> {
+
+    @Override
+    public Key build(boolean copyBytes) {
+      byte[] columnFamily = (this.columnFamily == null) ? EMPTY_BYTES : this.columnFamily;
+      byte[] columnQualifier = (this.columnQualifier == null) ? EMPTY_BYTES : this.columnQualifier;
+      byte[] columnVisibility = (this.columnVisibility == null) ? EMPTY_BYTES : this.columnVisibility;
+      return new Key(row, columnFamily, columnQualifier, columnVisibility, timestamp, deleted, copyBytes);
+    }
+  }
+
+  private static class CharSequenceKeyBuilder extends AbstractKeyBuilder<CharSequence> {
+
+    private final Text EMPTY_TEXT = new Text();
+
+    @Override
+    public Key build(boolean copyBytes) {
+      Text rowText = new Text(row.toString());
+      Text columnFamilyText = (this.columnFamily == null) ? EMPTY_TEXT : new Text(this.columnFamily.toString());
+      Text columnQualifierText = (this.columnQualifier == null) ? EMPTY_TEXT : new Text(this.columnQualifier.toString());
+      Text columnVisibilityText = (this.columnVisibility == null) ? EMPTY_TEXT : new Text(this.columnVisibility.toString());
+      return new Key(rowText.getBytes(), 0, rowText.getLength(), columnFamilyText.getBytes(), 0,
+          columnFamilyText.getLength(), columnQualifierText.getBytes(), 0, columnQualifierText.getLength(),
+          columnVisibilityText.getBytes(), 0, columnVisibilityText.getLength(), timestamp, deleted, copyBytes);
+    }
+  }
+
+  /**
+   * Set the row of the <code>Key</code> that this builder will build to the parameter.
+   *
+   * @param row
+   *          the row to use for the key
+   * @return this builder
+   */
+  public static ColumnFamilyStep<Text> row(final Text row) {
+    return new TextKeyBuilder().row(row);
+  }
+
+  /**
+   * Set the row of the <code>Key</code> that this builder will build to the parameter.
+   *
+   * @param row
+   *          the row to use for the key
+   * @return this builder
+   */
+  public static ColumnFamilyStep<byte[]> row(final byte[] row) {
+    return new ByteArrayKeyBuilder().row(row);
+  }
+
+  /**
+   * Set the row of the <code>Key</code> that this builder will build to the parameter.
+   *
+   * @param row
+   *          the row to use for the key
+   * @return this builder
+   */
+  public static ColumnFamilyStep<CharSequence> row( final CharSequence row) {
+    return new CharSequenceKeyBuilder().row(row);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
@@ -43,6 +43,8 @@ import org.apache.hadoop.io.Text;
 public class KeyBuilder {
 
   /**
+   * Base Builder interface which can be used to set the {@link Key} timestamp and delete marker and to build the {@link Key}.
+   *
    * @since 2.0
    */
   public interface Build {
@@ -75,6 +77,8 @@ public class KeyBuilder {
   }
 
   /**
+   * Builder step used to set the row part of the {@link Key}.
+   *
    * @since 2.0
    */
   public interface RowStep extends Build {
@@ -121,6 +125,8 @@ public class KeyBuilder {
   }
 
   /**
+   * Builder step used to set the columnFamily part of the {@link Key}.
+   *
    * @since 2.0
    */
   public interface ColumnFamilyStep extends ColumnVisibilityStep {
@@ -167,6 +173,8 @@ public class KeyBuilder {
   }
 
   /**
+   * Builder step used to set the column qualifier part of the {@link Key}.
+   *
    * @since 2.0
    */
   public interface ColumnQualifierStep extends ColumnVisibilityStep {
@@ -213,6 +221,8 @@ public class KeyBuilder {
   }
 
   /**
+   * Builder step used to set the column visibility part of the {@link Key}.
+   *
    * @since 2.0
    */
   public interface ColumnVisibilityStep extends Build {

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
@@ -22,7 +22,8 @@ import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class KeyBuilderTest {
 

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
@@ -1,0 +1,239 @@
+package org.apache.accumulo.core.data;
+
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class KeyBuilderTest {
+
+  private static final byte EMPTY_BYTES[] = new byte[0];
+  byte[] rowBytes = "row".getBytes();
+  byte[] familyBytes = "family".getBytes();
+  byte[] qualifierBytes = "qualifier".getBytes();
+  byte[] visibilityBytes = "visibility".getBytes();
+  Text rowText = new Text(rowBytes);
+  Text familyText = new Text(familyBytes);
+  Text qualifierText = new Text(qualifierBytes);
+  Text visibilityText = new Text(visibilityBytes);
+
+  @Test
+  public void testKeyBuildingFromRow() {
+    Key keyBuilt  = KeyBuilder.row("foo").build();
+    Key keyExpected = new Key("foo");
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamily() {
+    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").build();
+    Key keyExpected = new Key("foo", "bar");
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifier() {
+    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").columnQualifier("baz").build();
+    Key keyExpected = new Key("foo", "bar", "baz");
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibility() {
+    Key keyBuilt  = KeyBuilder.row("foo").columnFamily("bar").columnQualifier("baz").columnVisibility("v").build();
+    Key keyExpected = new Key("foo", "bar", "baz", "v");
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestamp() {
+    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").columnQualifier("baz").columnVisibility("v").timestamp(1L).build();
+    Key keyExpected = new Key("foo", "bar", "baz", "v", 1L);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampDeleted() {
+    Key keyBuilt =
+        KeyBuilder
+            .row("foo")
+            .columnFamily("bar")
+            .columnQualifier("baz")
+            .columnVisibility("v")
+            .timestamp(10L)
+            .deleted(true)
+            .build();
+    Key keyExpected = new Key("foo", "bar", "baz", "v", 10L);
+    keyExpected.setDeleted(true);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowVisibility() {
+    Key keyBuilt = KeyBuilder.row("foo").columnVisibility("v").build();
+    Key keyExpected = new Key("foo", "", "", "v");
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyVisibility() {
+    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").columnVisibility("v").build();
+    Key keyExpected = new Key("foo", "bar", "", "v");
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void textKeyBuildingFromRowTimestamp() {
+    Key keyBuilt = KeyBuilder.row("foo").timestamp(3L).build();
+    Key keyExpected = new Key("foo");
+    keyExpected.setTimestamp(3L);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowBytes() {
+    Key keyBuilt  = KeyBuilder.row(rowBytes).build();
+    Key keyExpected = new Key(rowBytes, EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES, Long.MAX_VALUE);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyBytes() {
+    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).build();
+    Key keyExpected = new Key(rowBytes, familyBytes, EMPTY_BYTES, EMPTY_BYTES, Long.MAX_VALUE);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierBytes() {
+    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnQualifier(qualifierBytes).build();
+    Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, EMPTY_BYTES, Long.MAX_VALUE);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityBytes() {
+    Key keyBuilt  = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnQualifier(qualifierBytes).columnVisibility(visibilityBytes).build();
+    Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, visibilityBytes, Long.MAX_VALUE);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampBytes() {
+    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnQualifier(qualifierBytes).columnVisibility(visibilityBytes).timestamp(1L).build();
+    Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, visibilityBytes, 1L);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampDeletedBytes() {
+    Key keyBuilt =
+        KeyBuilder
+            .row(rowBytes)
+            .columnFamily(familyBytes)
+            .columnQualifier(qualifierBytes)
+            .columnVisibility(visibilityBytes)
+            .timestamp(10L)
+            .deleted(true)
+            .build();
+    Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, visibilityBytes, 10L);
+    keyExpected.setDeleted(true);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowVisibilityBytes() {
+    Key keyBuilt = KeyBuilder.row(rowBytes).columnVisibility(visibilityBytes).build();
+    Key keyExpected = new Key(rowBytes, EMPTY_BYTES, EMPTY_BYTES, visibilityBytes, Long.MAX_VALUE);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyVisibilityBytes() {
+    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnVisibility(visibilityBytes).build();
+    Key keyExpected = new Key(rowBytes, familyBytes, EMPTY_BYTES, visibilityBytes, Long.MAX_VALUE);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void textKeyBuildingFromRowTimestampBytes() {
+    Key keyBuilt = KeyBuilder.row(rowBytes).timestamp(3L).build();
+    Key keyExpected = new Key(rowBytes, EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES, Long.MAX_VALUE);
+    keyExpected.setTimestamp(3L);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowText() {
+    Key keyBuilt  = KeyBuilder.row(rowText).build();
+    Key keyExpected = new Key(rowText);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyText() {
+    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).build();
+    Key keyExpected = new Key(rowText, familyText);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierText() {
+    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).columnQualifier(qualifierText).build();
+    Key keyExpected = new Key(rowText, familyText, qualifierText);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityText() {
+    Key keyBuilt  = KeyBuilder.row(rowText).columnFamily(familyText).columnQualifier(qualifierText).columnVisibility(visibilityText).build();
+    Key keyExpected = new Key(rowText, familyText, qualifierText, visibilityText);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampText() {
+    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).columnQualifier(qualifierText).columnVisibility(visibilityText).timestamp(1L).build();
+    Key keyExpected = new Key(rowText, familyText, qualifierText, visibilityText, 1L);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampDeletedText() {
+    Key keyBuilt =
+        KeyBuilder
+            .row(rowText)
+            .columnFamily(familyText)
+            .columnQualifier(qualifierText)
+            .columnVisibility(visibilityText)
+            .timestamp(10L)
+            .deleted(true)
+            .build();
+    Key keyExpected = new Key(rowText, familyText, qualifierText, visibilityText, 10L);
+    keyExpected.setDeleted(true);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowVisibilityText() {
+    Key keyBuilt = KeyBuilder.row(rowText).columnVisibility(visibilityText).build();
+    Key keyExpected = new Key(rowText, new Text(), new Text(), visibilityText);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void testKeyBuildingFromRowFamilyVisibilityText() {
+    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).columnVisibility(visibilityText).build();
+    Key keyExpected = new Key(rowText, familyText, new Text(), visibilityText);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+  @Test
+  public void textKeyBuildingFromRowTimestampText() {
+    Key keyBuilt = KeyBuilder.row(rowText).timestamp(3L).build();
+    Key keyExpected = new Key(rowText);
+    keyExpected.setTimestamp(3L);
+    assertEquals(keyBuilt, keyExpected);
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.core.data;
 
 import org.apache.hadoop.io.Text;
@@ -19,221 +35,248 @@ public class KeyBuilderTest {
 
   @Test
   public void testKeyBuildingFromRow() {
-    Key keyBuilt  = KeyBuilder.row("foo").build();
+    Key keyBuilt  = Key.builder().row("foo").build();
     Key keyExpected = new Key("foo");
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamily() {
-    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").build();
+    Key keyBuilt = Key.builder().row("foo").family("bar").build();
     Key keyExpected = new Key("foo", "bar");
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifier() {
-    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").columnQualifier("baz").build();
+    Key keyBuilt = Key.builder().row("foo").family("bar").qualifier("baz").build();
     Key keyExpected = new Key("foo", "bar", "baz");
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibility() {
-    Key keyBuilt  = KeyBuilder.row("foo").columnFamily("bar").columnQualifier("baz").columnVisibility("v").build();
+    Key keyBuilt = Key.builder().row("foo").family("bar").qualifier("baz").visibility("v").build();
     Key keyExpected = new Key("foo", "bar", "baz", "v");
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestamp() {
-    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").columnQualifier("baz").columnVisibility("v").timestamp(1L).build();
+    Key keyBuilt = Key.builder().row("foo").family("bar").qualifier("baz").visibility("v").timestamp(1L).build();
     Key keyExpected = new Key("foo", "bar", "baz", "v", 1L);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampDeleted() {
     Key keyBuilt =
-        KeyBuilder
+        Key.builder()
             .row("foo")
-            .columnFamily("bar")
-            .columnQualifier("baz")
-            .columnVisibility("v")
+            .family("bar")
+            .qualifier("baz")
+            .visibility("v")
             .timestamp(10L)
             .deleted(true)
             .build();
     Key keyExpected = new Key("foo", "bar", "baz", "v", 10L);
     keyExpected.setDeleted(true);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowVisibility() {
-    Key keyBuilt = KeyBuilder.row("foo").columnVisibility("v").build();
+    Key keyBuilt = Key.builder().row("foo").visibility("v").build();
     Key keyExpected = new Key("foo", "", "", "v");
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyVisibility() {
-    Key keyBuilt = KeyBuilder.row("foo").columnFamily("bar").columnVisibility("v").build();
+    Key keyBuilt = Key.builder().row("foo").family("bar").visibility("v").build();
     Key keyExpected = new Key("foo", "bar", "", "v");
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void textKeyBuildingFromRowTimestamp() {
-    Key keyBuilt = KeyBuilder.row("foo").timestamp(3L).build();
+    Key keyBuilt = Key.builder().row("foo").timestamp(3L).build();
     Key keyExpected = new Key("foo");
     keyExpected.setTimestamp(3L);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowBytes() {
-    Key keyBuilt  = KeyBuilder.row(rowBytes).build();
+    Key keyBuilt  = Key.builder().row(rowBytes).build();
     Key keyExpected = new Key(rowBytes, EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES, Long.MAX_VALUE);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyBytes() {
-    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).build();
+    Key keyBuilt = Key.builder().row(rowBytes).family(familyBytes).build();
     Key keyExpected = new Key(rowBytes, familyBytes, EMPTY_BYTES, EMPTY_BYTES, Long.MAX_VALUE);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierBytes() {
-    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnQualifier(qualifierBytes).build();
+    Key keyBuilt = Key.builder().row(rowBytes).family(familyBytes).qualifier(qualifierBytes).build();
     Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, EMPTY_BYTES, Long.MAX_VALUE);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityBytes() {
-    Key keyBuilt  = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnQualifier(qualifierBytes).columnVisibility(visibilityBytes).build();
+    Key keyBuilt  = Key.builder().row(rowBytes).family(familyBytes).qualifier(qualifierBytes).visibility(visibilityBytes).build();
     Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, visibilityBytes, Long.MAX_VALUE);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampBytes() {
-    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnQualifier(qualifierBytes).columnVisibility(visibilityBytes).timestamp(1L).build();
+    Key keyBuilt = Key.builder().row(rowBytes).family(familyBytes).qualifier(qualifierBytes).visibility(visibilityBytes).timestamp(1L).build();
     Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, visibilityBytes, 1L);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampDeletedBytes() {
     Key keyBuilt =
-        KeyBuilder
+        Key.builder()
             .row(rowBytes)
-            .columnFamily(familyBytes)
-            .columnQualifier(qualifierBytes)
-            .columnVisibility(visibilityBytes)
+            .family(familyBytes)
+            .qualifier(qualifierBytes)
+            .visibility(visibilityBytes)
             .timestamp(10L)
             .deleted(true)
             .build();
     Key keyExpected = new Key(rowBytes, familyBytes, qualifierBytes, visibilityBytes, 10L);
     keyExpected.setDeleted(true);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowVisibilityBytes() {
-    Key keyBuilt = KeyBuilder.row(rowBytes).columnVisibility(visibilityBytes).build();
+    Key keyBuilt = Key.builder().row(rowBytes).visibility(visibilityBytes).build();
     Key keyExpected = new Key(rowBytes, EMPTY_BYTES, EMPTY_BYTES, visibilityBytes, Long.MAX_VALUE);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyVisibilityBytes() {
-    Key keyBuilt = KeyBuilder.row(rowBytes).columnFamily(familyBytes).columnVisibility(visibilityBytes).build();
+    Key keyBuilt = Key.builder().row(rowBytes).family(familyBytes).visibility(visibilityBytes).build();
     Key keyExpected = new Key(rowBytes, familyBytes, EMPTY_BYTES, visibilityBytes, Long.MAX_VALUE);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void textKeyBuildingFromRowTimestampBytes() {
-    Key keyBuilt = KeyBuilder.row(rowBytes).timestamp(3L).build();
+    Key keyBuilt = Key.builder().row(rowBytes).timestamp(3L).build();
     Key keyExpected = new Key(rowBytes, EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES, Long.MAX_VALUE);
     keyExpected.setTimestamp(3L);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowText() {
-    Key keyBuilt  = KeyBuilder.row(rowText).build();
+    Key keyBuilt  = Key.builder().row(rowText).build();
     Key keyExpected = new Key(rowText);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyText() {
-    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).build();
+    Key keyBuilt = Key.builder().row(rowText).family(familyText).build();
     Key keyExpected = new Key(rowText, familyText);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierText() {
-    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).columnQualifier(qualifierText).build();
+    Key keyBuilt = Key.builder().row(rowText).family(familyText).qualifier(qualifierText).build();
     Key keyExpected = new Key(rowText, familyText, qualifierText);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityText() {
-    Key keyBuilt  = KeyBuilder.row(rowText).columnFamily(familyText).columnQualifier(qualifierText).columnVisibility(visibilityText).build();
+    Key keyBuilt  = Key.builder().row(rowText).family(familyText).qualifier(qualifierText).visibility(visibilityText).build();
     Key keyExpected = new Key(rowText, familyText, qualifierText, visibilityText);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampText() {
-    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).columnQualifier(qualifierText).columnVisibility(visibilityText).timestamp(1L).build();
+    Key keyBuilt = Key.builder().row(rowText).family(familyText).qualifier(qualifierText).visibility(visibilityText).timestamp(1L).build();
     Key keyExpected = new Key(rowText, familyText, qualifierText, visibilityText, 1L);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyQualifierVisibilityTimestampDeletedText() {
     Key keyBuilt =
-        KeyBuilder
+        Key.builder()
             .row(rowText)
-            .columnFamily(familyText)
-            .columnQualifier(qualifierText)
-            .columnVisibility(visibilityText)
+            .family(familyText)
+            .qualifier(qualifierText)
+            .visibility(visibilityText)
             .timestamp(10L)
             .deleted(true)
             .build();
     Key keyExpected = new Key(rowText, familyText, qualifierText, visibilityText, 10L);
     keyExpected.setDeleted(true);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowVisibilityText() {
-    Key keyBuilt = KeyBuilder.row(rowText).columnVisibility(visibilityText).build();
+    Key keyBuilt = Key.builder().row(rowText).visibility(visibilityText).build();
     Key keyExpected = new Key(rowText, new Text(), new Text(), visibilityText);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
   public void testKeyBuildingFromRowFamilyVisibilityText() {
-    Key keyBuilt = KeyBuilder.row(rowText).columnFamily(familyText).columnVisibility(visibilityText).build();
+    Key keyBuilt = Key.builder().row(rowText).family(familyText).visibility(visibilityText).build();
     Key keyExpected = new Key(rowText, familyText, new Text(), visibilityText);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
   @Test
-  public void textKeyBuildingFromRowTimestampText() {
-    Key keyBuilt = KeyBuilder.row(rowText).timestamp(3L).build();
+  public void testKeyBuildingFromRowTimestampText() {
+    Key keyBuilt = Key.builder().row(rowText).timestamp(3L).build();
     Key keyExpected = new Key(rowText);
     keyExpected.setTimestamp(3L);
-    assertEquals(keyBuilt, keyExpected);
+    assertEquals(keyExpected, keyBuilt);
   }
 
+  @Test
+  public void testKeyBuildingReusingBytes() {
+    byte[] reuse = new byte[] { 1, 2, 3 };
+    KeyBuilder.Build keyBuilder = Key.builder(false).row(reuse);
+    Key keyBuilt = keyBuilder.build();
+    assertEquals(reuse, keyBuilt.getRowBytes());
+  }
+
+  @Test
+  public void testKeyBuildingCopyBytes() {
+    byte[] reuse = new byte[] { 1, 2, 3 };
+    KeyBuilder.Build keyBuilder = Key.builder(true).row(reuse);
+    Key keyBuilt = keyBuilder.build();
+    assertNotEquals(reuse, keyBuilt.getRowBytes());
+    KeyBuilder.Build keyBuilder2 = Key.builder().row(reuse);
+    Key keyBuilt2 = keyBuilder.build();
+    assertNotEquals(reuse, keyBuilt2.getRowBytes());
+  }
+
+  @Test
+  public void testKeyHeterogeneous() {
+    Key keyBuilt = Key.builder().row(rowText).family(familyBytes).qualifier("foo").build();
+    Text fooText = new Text("foo");
+    Key keyExpected = new Key(rowText.getBytes(), 0, rowText.getLength(), familyBytes, 0, familyBytes.length,
+        fooText.getBytes(), 0, fooText.getLength(), EMPTY_BYTES, 0, 0, Long.MAX_VALUE);
+    assertEquals(keyExpected, keyBuilt);
+  }
 }


### PR DESCRIPTION
Adds the `KeyBuilder` as proposed in ACCUMULO-4376. For the design, I took inspiration from the Step Builder design pattern as described in [Vladimir Stankovic blog](http://www.svlada.com/step-builder-pattern/) to try to give some rules to the way `Key`s are built. I also added a new constructor to `Key` that accepts all the parameters, including `deleted` similar to to the `Key.init` method, that is used to build `Key`s from the fields.