### PR TITLE
ACCUMULO-4444: added check for null token in ConnectorImpl

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
@@ -55,7 +55,9 @@ public class ConnectorImpl extends Connector {
   private ReplicationOperations replicationops = null;
 
   public ConnectorImpl(final ClientContext context) throws AccumuloException, AccumuloSecurityException {
-    checkArgument(context != null, "context is null");
+    checkArgument(context != null, "Context is null");
+    checkArgument(context.getCredentials() != null, "Credentials are null");
+    checkArgument(context.getCredentials().getToken() != null, "Authentication token is null");
     if (context.getCredentials().getToken().isDestroyed())
       throw new AccumuloSecurityException(context.getCredentials().getPrincipal(), SecurityErrorCode.TOKEN_EXPIRED);
 


### PR DESCRIPTION
Added check to ConnectorImpl constructor to prevent NPE.  Included "password is missing" in the message to make it more helpful for the CLI tools and since its the most likely reason as to why the Authentican token is null (see [org.apache.accumulo.core.cli.ClientOpts.getToken()](https://github.com/apache/accumulo/blob/1.7/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java#L127)).