### PR TITLE
ACCUMULO-4476 User manual references old version

### DIFF
--- a/docs/src/main/asciidoc/chapters/administration.txt
+++ b/docs/src/main/asciidoc/chapters/administration.txt
@@ -69,14 +69,17 @@ service to attempt to bind. The ports in the range will be tried in a 1-up manne
 at the low end of the range to, and including, the high end of the range.
 
 === Installation
-Choose a directory for the Accumulo installation. This directory will be referenced
-by the environment variable +$ACCUMULO_HOME+. Run the following:
 
-  $ tar xzf accumulo-1.6.0-bin.tar.gz    # unpack to subdirectory
-  $ mv accumulo-1.6.0 $ACCUMULO_HOME # move to desired location
+Download a binary distribution of Accumulo and install it to a directory on a disk with
+sufficient space:
 
-Repeat this step at each machine within the cluster. Usually all machines have the
-same +$ACCUMULO_HOME+.
+  cd <install directory>
+  tar xzf accumulo-X.Y.Z-bin.tar.gz   # Replace 'X.Y.Z' with your Accumulo version
+  cd accumulo-X.Y.Z
+
+Repeat this step on each machine in your cluster. Typically, the same +<install directory>+
+is chosen for all machines in the cluster. When you configure Accumulo, the +$ACCUMULO_HOME+
+environment variable should be set to +/path/to/<install directory>/accumulo-X.Y.Z+.
 
 === Dependencies
 Accumulo requires HDFS and ZooKeeper to be configured and running


### PR DESCRIPTION
* Changed version reference in installation instructions from 1.6.0
  to X.Y.Z so that it doesn't need to be updated for each release.