### PR TITLE
ACCUMULO-1280: many changes for closing iterators

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -370,7 +370,7 @@ public class BloomFilterLayer {
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    public synchronized void close() {
       bfl.close();
       reader.close();
     }
@@ -418,7 +418,7 @@ public class BloomFilterLayer {
     }
 
     @Override
-    public void closeDeepCopies() throws IOException {
+    public void closeDeepCopies() {
       reader.closeDeepCopies();
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/FileSKVIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileSKVIterator.java
@@ -32,8 +32,8 @@ public interface FileSKVIterator extends InterruptibleIterator, AutoCloseable {
 
   FileSKVIterator getSample(SamplerConfigurationImpl sampleConfig);
 
-  void closeDeepCopies() throws IOException;
+  void closeDeepCopies();
 
   @Override
-  void close() throws IOException;
+  void close();
 }

--- a/core/src/main/java/org/apache/accumulo/core/file/map/MapFileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/map/MapFileOperations.java
@@ -51,7 +51,7 @@ public class MapFileOperations extends FileOperations {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
       ((FileSKVIterator) reader).close();
     }
 
@@ -120,7 +120,7 @@ public class MapFileOperations extends FileOperations {
     }
 
     @Override
-    public void closeDeepCopies() throws IOException {
+    public void closeDeepCopies() {
       ((FileSKVIterator) reader).closeDeepCopies();
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiIndexIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiIndexIterator.java
@@ -65,12 +65,12 @@ class MultiIndexIterator extends HeapIterator implements FileSKVIterator {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     source.close();
   }
 
   @Override
-  public void closeDeepCopies() throws IOException {
+  public void closeDeepCopies() {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/ColumnFamilyCounter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/ColumnFamilyCounter.java
@@ -89,4 +89,11 @@ public class ColumnFamilyCounter implements SortedKeyValueIterator<Key,Value> {
     return null;
   }
 
+  @Override
+  public void close() {
+    if (source != null) {
+      source.close();
+    }
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/SortedKeyValueIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/SortedKeyValueIterator.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.io.WritableComparable;
  * An iterator that supports iterating over key and value pairs. Anything implementing this interface should return keys in sorted order.
  */
 
-public interface SortedKeyValueIterator<K extends WritableComparable<?>,V extends Writable> {
+public interface SortedKeyValueIterator<K extends WritableComparable<?>,V extends Writable> extends AutoCloseable {
   /**
    * Initializes the iterator. Data should not be read from the source in this method.
    *
@@ -147,4 +147,20 @@ public interface SortedKeyValueIterator<K extends WritableComparable<?>,V extend
    *              if not supported.
    */
   SortedKeyValueIterator<K,V> deepCopy(IteratorEnvironment env);
+
+  /**
+   * Closes any resources that were opened by the <tt>SortedKeyValueIterator</tt>. This method does nothing by default. The implementing class must close its
+   * <tt>SortedKeyValueIterator source</tt>. This will be provided in the <tt>init</tt> method or by the constructor.
+   *
+   * @exception UncheckedIOException
+   *              if an I/O error occurs.
+   * @exception UnsupportedOperationException
+   *              if not supported
+   * @exception RuntimeException
+   *              if another type of error occurs
+   */
+  @Override
+  default void close() {
+    // default implementation, do nothing
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/SortedKeyValueIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/SortedKeyValueIterator.java
@@ -158,6 +158,7 @@ public interface SortedKeyValueIterator<K extends WritableComparable<?>,V extend
    *              if not supported
    * @exception RuntimeException
    *              if another type of error occurs
+   * @since 2.0.0
    */
   @Override
   default void close() {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/WrappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/WrappingIterator.java
@@ -94,4 +94,8 @@ public abstract class WrappingIterator implements SortedKeyValueIterator<Key,Val
     seenSeek = true;
   }
 
+  @Override
+  public void close() {
+    getSource().close();
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/MapFileIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/MapFileIterator.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.core.iterators.system;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -147,13 +148,17 @@ public class MapFileIterator implements FileSKVIterator {
   }
 
   @Override
-  public void closeDeepCopies() throws IOException {
+  public void closeDeepCopies() {
     // nothing to do, deep copies are externally managed/closed
   }
 
   @Override
-  public void close() throws IOException {
-    reader.close();
+  public void close() {
+    try {
+      reader.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/MultiIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/MultiIterator.java
@@ -112,4 +112,10 @@ public class MultiIterator extends HeapIterator {
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public void close() {
+    // do nothing to prevent closing of resources that may be reused
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/SequenceFileIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/SequenceFileIterator.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.core.iterators.system;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,7 +47,7 @@ public class SequenceFileIterator implements FileSKVIterator {
   }
 
   @Override
-  public void closeDeepCopies() throws IOException {
+  public void closeDeepCopies() {
     throw new UnsupportedOperationException();
   }
 
@@ -104,8 +105,12 @@ public class SequenceFileIterator implements FileSKVIterator {
   }
 
   @Override
-  public void close() throws IOException {
-    reader.close();
+  public void close() {
+    try {
+      reader.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/TimeSettingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/TimeSettingIterator.java
@@ -89,4 +89,9 @@ public class TimeSettingIterator implements InterruptibleIterator {
     return source.getTopValue();
   }
 
+  @Override
+  public void close() {
+    source.close();
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/IndexedDocIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/IndexedDocIterator.java
@@ -228,4 +228,11 @@ public class IndexedDocIterator extends IntersectingIterator {
     setIndexColf(is, indexColf);
     setDocColfPrefix(is, docColfPrefix);
   }
+
+  @Override
+  public void close() {
+    super.close();
+    docSource.close();
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/LargeRowFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/LargeRowFilter.java
@@ -284,4 +284,9 @@ public class LargeRowFilter implements SortedKeyValueIterator<Key,Value>, Option
   public static void setMaxColumns(IteratorSetting is, int maxColumns) {
     is.addOption(MAX_COLUMNS, Integer.toString(maxColumns));
   }
+
+  @Override
+  public void close() {
+    source.close();
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowDeletingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowDeletingIterator.java
@@ -177,4 +177,9 @@ public class RowDeletingIterator implements SortedKeyValueIterator<Key,Value> {
 
   }
 
+  @Override
+  public void close() {
+    source.close();
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowEncodingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowEncodingIterator.java
@@ -19,10 +19,10 @@ package org.apache.accumulo.core.iterators.user;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.HashMap;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -206,6 +206,11 @@ public abstract class RowEncodingIterator implements SortedKeyValueIterator<Key,
 
     sourceIter.seek(range, columnFamilies, inclusive);
     prepKeys();
+  }
+
+  @Override
+  public void close() {
+    sourceIter.close();
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -302,6 +302,11 @@ abstract public class TransformingIterator extends WrappingIterator implements O
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    public void close() {
+      source.close();
+    }
+
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/WholeColumnFamilyIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/WholeColumnFamilyIterator.java
@@ -258,4 +258,9 @@ public class WholeColumnFamilyIterator implements SortedKeyValueIterator<Key,Val
     return true;
   }
 
+  @Override
+  public void close() {
+    sourceIter.close();
+  }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
@@ -269,8 +269,8 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
     HashSet<ByteSequence> colfams = new HashSet<>();
     colfams.add(new ArrayByteSequence("cf2"));
     cfi.seek(new Range(), colfams, true);
-    aten(cfi, "r2", "cf2", "cq4", 5, "v4");
-    aten(cfi, "r2", "cf2", "cq5", 5, "v5");
+    testAndCallnext(cfi, "r2", "cf2", "cq4", 5, "v4");
+    testAndCallnext(cfi, "r2", "cf2", "cq5", 5, "v5");
     assertFalse(cfi.hasTop());
 
     System.out.println("Closing ColumnFamilySkippingIterator");

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
@@ -18,9 +18,8 @@ package org.apache.accumulo.core.iterators.system;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.SortedMap;
 import java.util.TreeMap;
-
-import junit.framework.TestCase;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -29,6 +28,8 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class ColumnFamilySkippingIteratorTest extends TestCase {
 
@@ -235,5 +236,46 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
     assertFalse(cfi.hasTop());
 
     // System.out.println(ci.getCount());
+  }
+
+  private static class CloseTestIter extends SortedMapIterator {
+
+    int closeCallCount = 0;
+
+    public CloseTestIter(SortedMap<Key,Value> map) {
+      super(map);
+    }
+
+    @Override
+    public void close() {
+      System.out.println("Closing inner CloseIterator.");
+      closeCallCount++;
+    }
+  }
+
+  public void testClose() throws Exception {
+    TreeMap<Key,Value> tm = new TreeMap<>();
+    put(tm, "r1", "cf1", "cq1", 5, "v1");
+    put(tm, "r1", "cf1", "cq3", 5, "v2");
+    put(tm, "r2", "cf1", "cq1", 5, "v3");
+    put(tm, "r2", "cf2", "cq4", 5, "v4");
+    put(tm, "r2", "cf2", "cq5", 5, "v5");
+    put(tm, "r3", "cf3", "cq6", 5, "v6");
+
+    CloseTestIter closeIter = new CloseTestIter(tm);
+    ColumnFamilySkippingIterator cfi = new ColumnFamilySkippingIterator(closeIter);
+
+    assertEquals(0, closeIter.closeCallCount);
+    HashSet<ByteSequence> colfams = new HashSet<>();
+    colfams.add(new ArrayByteSequence("cf2"));
+    cfi.seek(new Range(), colfams, true);
+    aten(cfi, "r2", "cf2", "cq4", 5, "v4");
+    aten(cfi, "r2", "cf2", "cq5", 5, "v5");
+    assertFalse(cfi.hasTop());
+
+    System.out.println("Closing ColumnFamilySkippingIterator");
+    cfi.close();
+
+    assertEquals(1, closeIter.closeCallCount);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
@@ -17,13 +17,16 @@
 package org.apache.accumulo.core.iterators.system;
 
 import java.util.HashSet;
-
-import junit.framework.TestCase;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class ColumnFilterTest extends TestCase {
 
@@ -74,5 +77,40 @@ public class ColumnFilterTest extends TestCase {
     assertFalse(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
     assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
     assertFalse(cf.accept(newKey("r1", "cf2", "cq2"), new Value(new byte[0])));
+  }
+
+  private static class CloseTestIter extends SortedMapIterator {
+
+    int closeCallCount = 0;
+
+    public CloseTestIter(SortedMap<Key,Value> map) {
+      super(map);
+    }
+
+    @Override
+    public void close() {
+      System.out.println("Closing inner CloseIterator.");
+      closeCallCount++;
+    }
+  }
+
+  public void testClose() throws Exception {
+    TreeMap<Key,Value> tm = new TreeMap<>();
+    tm.put(nk("r1", "cf1", "cq1"), new Value("val1".getBytes()));
+    tm.put(nk("r2", "cf2", "cq1"), new Value("val2".getBytes()));
+    HashSet<Column> columns = new HashSet<>();
+    columns.add(nc("cf2", "cq1"));
+
+    CloseTestIter closeIter = new CloseTestIter(tm);
+    ColumnQualifierFilter cf = new ColumnQualifierFilter(closeIter, columns);
+
+    assertEquals(0, closeIter.closeCallCount);
+    assertTrue(cf.accept(nk("r1", "cf2", "cq1"), new Value(new byte[0])));
+    assertFalse(cf.accept(nk("r1", "cf2", "cq2"), new Value(new byte[0])));
+
+    System.out.println("Closing ColumnQualifierFilter");
+    cf.close();
+
+    assertEquals(1, closeIter.closeCallCount);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
@@ -96,17 +96,17 @@ public class ColumnFilterTest extends TestCase {
 
   public void testClose() throws Exception {
     TreeMap<Key,Value> tm = new TreeMap<>();
-    tm.put(nk("r1", "cf1", "cq1"), new Value("val1".getBytes()));
-    tm.put(nk("r2", "cf2", "cq1"), new Value("val2".getBytes()));
+    tm.put(newKey("r1", "cf1", "cq1"), new Value("val1".getBytes()));
+    tm.put(newKey("r2", "cf2", "cq1"), new Value("val2".getBytes()));
     HashSet<Column> columns = new HashSet<>();
-    columns.add(nc("cf2", "cq1"));
+    columns.add(newColumn("cf2", "cq1"));
 
     CloseTestIter closeIter = new CloseTestIter(tm);
     ColumnQualifierFilter cf = new ColumnQualifierFilter(closeIter, columns);
 
     assertEquals(0, closeIter.closeCallCount);
-    assertTrue(cf.accept(nk("r1", "cf2", "cq1"), new Value(new byte[0])));
-    assertFalse(cf.accept(nk("r1", "cf2", "cq2"), new Value(new byte[0])));
+    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
+    assertFalse(cf.accept(newKey("r1", "cf2", "cq2"), new Value(new byte[0])));
 
     System.out.println("Closing ColumnQualifierFilter");
     cf.close();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
@@ -250,19 +250,19 @@ public class DeletingIteratorTest extends TestCase {
 
   public void testClose() throws Exception {
     TreeMap<Key,Value> tm = new TreeMap<>();
-    nkv(tm, "r000", 3, false, "v3");
-    nkv(tm, "r000", 2, false, "v2");
-    nkv(tm, "r000", 2, true, "");
-    nkv(tm, "r000", 1, false, "v1");
+    newKeyValue(tm, "r000", 3, false, "v3");
+    newKeyValue(tm, "r000", 2, false, "v2");
+    newKeyValue(tm, "r000", 2, true, "");
+    newKeyValue(tm, "r000", 1, false, "v1");
 
     CloseTestIter closeIter = new CloseTestIter(tm);
     DeletingIterator it = new DeletingIterator(closeIter, false);
 
-    it.seek(nr("r000", 3), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 3), EMPTY_COL_FAMS, false);
 
     assertEquals(0, closeIter.closeCallCount);
     assertTrue(it.hasTop());
-    assertEquals(nk("r000", 3), it.getTopKey());
+    assertEquals(newKey("r000", 3), it.getTopKey());
     assertEquals("v3", it.getTopValue().toString());
 
     it.next();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
@@ -20,9 +20,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.SortedMap;
 import java.util.TreeMap;
-
-import junit.framework.TestCase;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -30,6 +29,8 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class DeletingIteratorTest extends TestCase {
 
@@ -231,4 +232,47 @@ public class DeletingIteratorTest extends TestCase {
     k.setDeleted(deleted);
     tm.put(k, new Value(val.getBytes()));
   }
+
+  private static class CloseTestIter extends SortedMapIterator {
+
+    int closeCallCount = 0;
+
+    public CloseTestIter(SortedMap<Key,Value> map) {
+      super(map);
+    }
+
+    @Override
+    public void close() {
+      System.out.println("Closing inner CloseIterator.");
+      closeCallCount++;
+    }
+  }
+
+  public void testClose() throws Exception {
+    TreeMap<Key,Value> tm = new TreeMap<>();
+    nkv(tm, "r000", 3, false, "v3");
+    nkv(tm, "r000", 2, false, "v2");
+    nkv(tm, "r000", 2, true, "");
+    nkv(tm, "r000", 1, false, "v1");
+
+    CloseTestIter closeIter = new CloseTestIter(tm);
+    DeletingIterator it = new DeletingIterator(closeIter, false);
+
+    it.seek(nr("r000", 3), EMPTY_COL_FAMS, false);
+
+    assertEquals(0, closeIter.closeCallCount);
+    assertTrue(it.hasTop());
+    assertEquals(nk("r000", 3), it.getTopKey());
+    assertEquals("v3", it.getTopValue().toString());
+
+    it.next();
+
+    assertFalse(it.hasTop());
+
+    System.out.println("Closing DeletingIterator");
+    it.close();
+
+    assertEquals(1, closeIter.closeCallCount);
+  }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -422,9 +422,9 @@ public class MultiIteratorTest extends TestCase {
   public void testDoNothingClose() throws Exception {
 
     TreeMap<Key,Value> tm = new TreeMap<>();
-    nkv(tm, 0, 3, false, "1");
-    nkv(tm, 0, 2, false, "2");
-    nkv(tm, 0, 1, false, "3");
+    newKeyValue(tm, 0, 3, false, "1");
+    newKeyValue(tm, 0, 2, false, "2");
+    newKeyValue(tm, 0, 1, false, "3");
     List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<>(1);
 
     CloseTestIter closeIter1 = new CloseTestIter("closeIter1", tm);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.ByteSequence;
@@ -399,5 +400,47 @@ public class MultiIteratorTest extends TestCase {
     Range r7 = new Range(newKey(0, 3), true, newKey(0, 1), true);
     mi.seek(r7, EMPTY_COL_FAMS, false);
     assertFalse(mi.hasTop());
+  }
+
+  private static class CloseTestIter extends SortedMapIterator {
+
+    int closeCallCount = 0;
+    String name;
+
+    public CloseTestIter(String name, SortedMap<Key,Value> map) {
+      super(map);
+      this.name = name;
+    }
+
+    @Override
+    public void close() {
+      System.out.println("Closing " + this.name);
+      closeCallCount++;
+    }
+  }
+
+  public void testDoNothingClose() throws Exception {
+
+    TreeMap<Key,Value> tm = new TreeMap<>();
+    nkv(tm, 0, 3, false, "1");
+    nkv(tm, 0, 2, false, "2");
+    nkv(tm, 0, 1, false, "3");
+    List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<>(1);
+
+    CloseTestIter closeIter1 = new CloseTestIter("closeIter1", tm);
+    iters.add(closeIter1);
+
+    MultiIterator mi = new MultiIterator(iters, true);
+
+    assertEquals(0, closeIter1.closeCallCount);
+    assertFalse(mi.hasTop());
+
+    mi.seek(new Range(), EMPTY_COL_FAMS, false);
+    assertTrue(mi.hasTop());
+
+    System.out.println("Attempting to call Close on MultiIterator");
+    mi.close();
+
+    assertEquals(0, closeIter1.closeCallCount);
   }
 }

--- a/docs/src/main/asciidoc/chapters/iterator_design.txt
+++ b/docs/src/main/asciidoc/chapters/iterator_design.txt
@@ -182,6 +182,12 @@ early programming assignments which implement their own tree data structures. `d
 copy on its sources (the children), copies itself, attaches the copies of the children, and
 then returns itself.
 
+==== `close`
+
+This method should close any resources created by the iterator.  In particular, this method should call `close`
+on the `source` provided by the first argument of the `init` method.  By default this method will do nothing.
+If the iterator does not have a `source` or any other resources to close, then the the default implementation will suffice.
+
 === TabletServer invocation of Iterators
 
 The following code is a general outline for how TabletServers invoke Iterators.

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
@@ -117,4 +117,9 @@ public class ProblemReportingIterator implements InterruptibleIterator {
   public void setInterruptFlag(AtomicBoolean flag) {
     ((InterruptibleIterator) source).setInterruptFlag(flag);
   }
+
+  @Override
+  public void close() {
+    source.close();
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -163,7 +163,7 @@ public class FileUtil {
         try {
           if (reader != null)
             reader.close();
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
           log.error("{}", e.getMessage(), e);
         }
 
@@ -171,14 +171,14 @@ public class FileUtil {
           try {
             if (r != null)
               ((FileSKVIterator) r).close();
-          } catch (IOException e) {
+          } catch (RuntimeException e) {
             // continue closing
             log.error("{}", e.getMessage(), e);
           }
 
         try {
           writer.close();
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
           log.error("{}", e.getMessage(), e);
           throw e;
         }
@@ -371,7 +371,7 @@ public class FileUtil {
       try {
         if (r != null)
           r.close();
-      } catch (IOException e) {
+      } catch (RuntimeException e) {
         // okay, try to close the rest anyway
         log.error("{}", e.getMessage(), e);
       }
@@ -418,7 +418,7 @@ public class FileUtil {
         try {
           if (reader != null)
             reader.close();
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
           log.error("{}", e.getMessage(), e);
         }
       }
@@ -457,7 +457,7 @@ public class FileUtil {
         if (reader != null) {
           try {
             reader.close();
-          } catch (IOException ioe) {
+          } catch (RuntimeException ioe) {
             log.warn("failed to close " + mapfile, ioe);
           }
         }
@@ -494,7 +494,7 @@ public class FileUtil {
         try {
           if (reader != null)
             reader.close();
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
           log.error("{}", e.getMessage(), e);
         }
       }
@@ -541,7 +541,7 @@ public class FileUtil {
       try {
         if (index != null)
           index.close();
-      } catch (IOException e) {
+      } catch (RuntimeException e) {
         // continue with next file
         log.error("{}", e.getMessage(), e);
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -366,7 +366,7 @@ public class FileManager {
       for (FileSKVIterator reader : readers) {
         try {
           reader.closeDeepCopies();
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
           log.warn("{}", e.getMessage(), e);
           sawIOException = true;
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -711,7 +711,7 @@ public class InMemoryMap {
           try {
             if (mds.reader != null)
               mds.reader.close();
-          } catch (IOException e) {
+          } catch (RuntimeException e) {
             log.warn("{}", e.getMessage(), e);
           }
         }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -130,10 +130,10 @@ public class DefaultCompactionStrategyTest {
     }
 
     @Override
-    public void closeDeepCopies() throws IOException {}
+    public void closeDeepCopies() {}
 
     @Override
-    public void close() throws IOException {}
+    public void close() {}
 
     @Override
     public FileSKVIterator getSample(SamplerConfigurationImpl sampleConfig) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.tserver.tablet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.apache.accumulo.core.iterators.system.ColumnFamilySkippingIterator;
+import org.apache.accumulo.core.iterators.system.DeletingIterator;
+import org.apache.accumulo.core.iterators.system.MultiIterator;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+public class CompactorTest extends TestCase {
+  private static class CloseTestIter extends SortedMapIterator {
+
+    int closeCallCount = 0;
+
+    public CloseTestIter(SortedMap<Key,Value> map) {
+      super(map);
+    }
+
+    @Override
+    public void close() {
+      System.out.println("Closing inner CloseIterator.");
+      closeCallCount++;
+    }
+  }
+
+  private static class CloseCountingTestIter extends CountingIterator {
+
+    int closeCallCount = 0;
+
+    public CloseCountingTestIter(SortedKeyValueIterator<Key,Value> source, AtomicLong entriesRead) {
+      super(source, entriesRead);
+    }
+
+    @Override
+    public void close() {
+      System.out.println("Closing inner CloseCountingTestIter.");
+      closeCallCount++;
+    }
+  }
+
+  /**
+   * Test that the top level iterator will close upon exiting try-with-resources and that only the appropriate iterators below it will be closed. MultiIterator
+   * should not call close on its source since it could be reused.
+   */
+  @Test
+  public void testIteratorCloseStopsAtMultiIterator() {
+    CloseTestIter lowestCloseIter = new CloseTestIter(new TreeMap<>());
+
+    try {
+      List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<>(1);
+      iters.add(lowestCloseIter);
+
+      MultiIterator mitr = new MultiIterator(iters, new Range());
+      CloseCountingTestIter citr = new CloseCountingTestIter(mitr, new AtomicLong(1));
+      DeletingIterator delIter = new DeletingIterator(citr, true);
+      ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
+
+      assertEquals(0, lowestCloseIter.closeCallCount);
+      assertEquals(0, citr.closeCallCount);
+      try (SortedKeyValueIterator<Key,Value> itr = cfsi) {
+        itr.seek(new Range(), new ArrayList<ByteSequence>(), false);
+        while (itr.hasTop()) {
+          itr.next();
+        }
+      } finally {
+        System.out.println("Finished try with resources");
+        assertEquals(0, lowestCloseIter.closeCallCount);
+        assertEquals(1, citr.closeCallCount);
+      }
+    } catch (Exception e) {
+      assertTrue("Exception occurred " + e.getMessage(), false);
+    }
+    assertEquals(0, lowestCloseIter.closeCallCount);
+  }
+
+}

--- a/test/src/test/java/org/apache/accumulo/test/functional/ValueReversingIterator.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ValueReversingIterator.java
@@ -65,4 +65,9 @@ public class ValueReversingIterator implements SortedKeyValueIterator<Key,Value>
   public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
     source.seek(range, columnFamilies, inclusive);
   }
+
+  @Override
+  public void close() {
+    source.close();
+  }
 }


### PR DESCRIPTION
Looking for feedback on first round of changes and if there are more places close can be called.
- made SortedKeyValueIterator extend AutoCloseable
- in SKVI - defined default close method so it is not required by implementations
- in SKVI - defined default closeSafely to allow calling of close in a Java 8 stream
- implemented close method where Iterator contained a SKVI source
- modified Scanner and Compactor to utilize AutoCloseable and try-with-resources

TODO: write test to verify close on wrapped iterators will propagate through
