### PR TITLE
ACCUMULO-4494 Add families and inclusive to IteratorTestInput

### DIFF
--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestInput.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestInput.java
@@ -18,12 +18,14 @@ package org.apache.accumulo.iteratortest;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -37,22 +39,45 @@ public class IteratorTestInput {
   private final Class<? extends SortedKeyValueIterator<Key,Value>> iteratorClass;
   private final Map<String,String> iteratorOptions;
   private final Range range;
+  private final Collection<ByteSequence> families;
+  private final boolean inclusive;
   private final SortedMap<Key,Value> input;
 
   /**
    * Construct an instance of the test input.
    *
    * @param iteratorClass
-   *          The class for the iterator to test
+   *          The class for the iterator to test.
    * @param iteratorOptions
-   *          Options, if any, to provide to the iterator ({@link IteratorSetting}'s Map of properties)
+   *          Options, if any, to provide to the iterator ({@link IteratorSetting}'s Map of properties).
    * @param range
-   *          The Range of data to query ({@link Scanner#setRange(Range)})
+   *          The Range of data to query ({@link Scanner#setRange(Range)}). By default no column families filter is specified.
    * @param input
    *          A sorted collection of Key-Value pairs acting as the table.
    */
   public IteratorTestInput(Class<? extends SortedKeyValueIterator<Key,Value>> iteratorClass, Map<String,String> iteratorOptions, Range range,
       SortedMap<Key,Value> input) {
+    this(iteratorClass, iteratorOptions, range, input, Collections.<ByteSequence> emptySet(), false);
+  }
+
+  /**
+   * Construct an instance of the test input.
+   *
+   * @param iteratorClass
+   *          The class for the iterator to test.
+   * @param iteratorOptions
+   *          Options, if any, to provide to the iterator ({@link IteratorSetting}'s Map of properties).
+   * @param range
+   *          The Range of data to query ({@link Scanner#setRange(Range)})
+   * @param input
+   *          A sorted collection of Key-Value pairs acting as the table.
+   * @param families
+   *          Column families passed to {@link SortedKeyValueIterator#seek}.
+   * @param inclusive
+   *          Whether the families are inclusive or exclusive.
+   */
+  public IteratorTestInput(Class<? extends SortedKeyValueIterator<Key,Value>> iteratorClass, Map<String,String> iteratorOptions, Range range,
+      SortedMap<Key,Value> input, Collection<ByteSequence> families, boolean inclusive) {
     // Already immutable
     this.iteratorClass = requireNonNull(iteratorClass);
     // Make it immutable to the test
@@ -61,6 +86,8 @@ public class IteratorTestInput {
     this.range = requireNonNull(range);
     // Make it immutable to the test
     this.input = Collections.unmodifiableSortedMap((requireNonNull(input)));
+    this.families = Collections.unmodifiableCollection(requireNonNull(families));
+    this.inclusive = inclusive;
   }
 
   public Class<? extends SortedKeyValueIterator<Key,Value>> getIteratorClass() {
@@ -75,15 +102,44 @@ public class IteratorTestInput {
     return range;
   }
 
+  public Collection<ByteSequence> getFamilies() {
+    return families;
+  }
+
+  public boolean isInclusive() {
+    return inclusive;
+  }
+
   public SortedMap<Key,Value> getInput() {
     return input;
   }
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder(64);
-    sb.append("[iteratorClass=").append(iteratorClass).append(", iteratorOptions=").append(iteratorOptions).append(", range=").append(range)
-        .append(", input='").append(input).append("']");
-    return sb.toString();
+    return "[iteratorClass=" + iteratorClass + ", iteratorOptions=" + iteratorOptions + ", range=" + range + ", families=" + families + ", inclusive="
+        + inclusive + ", input='" + input + "']";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    IteratorTestInput that = (IteratorTestInput) o;
+
+    return inclusive == that.inclusive && iteratorClass.equals(that.iteratorClass) && iteratorOptions.equals(that.iteratorOptions) && range.equals(that.range)
+        && families.equals(that.families) && input.equals(that.input);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = iteratorClass.hashCode();
+    result = 31 * result + iteratorOptions.hashCode();
+    result = 31 * result + range.hashCode();
+    result = 31 * result + families.hashCode();
+    result = 31 * result + (inclusive ? 1 : 0);
+    result = 31 * result + input.hashCode();
+    return result;
   }
 }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestRunner.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestRunner.java
@@ -72,7 +72,7 @@ public class IteratorTestRunner {
     for (IteratorTestCase testCase : testCases) {
       log.info("Invoking {} on {}", testCase.getClass().getName(), testInput.getIteratorClass().getName());
 
-      IteratorTestOutput actualOutput = null;
+      IteratorTestOutput actualOutput;
 
       try {
         actualOutput = testCase.test(testInput);

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/DeepCopyTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/DeepCopyTestCase.java
@@ -17,10 +17,8 @@
 package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.TreeMap;
 
-import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
@@ -44,7 +42,7 @@ public class DeepCopyTestCase extends OutputVerifyingTestCase {
 
       SortedKeyValueIterator<Key,Value> copy = skvi.deepCopy(new SimpleIteratorEnvironment());
 
-      copy.seek(testInput.getRange(), Collections.<ByteSequence> emptySet(), false);
+      copy.seek(testInput.getRange(), testInput.getFamilies(), testInput.isInclusive());
       return new IteratorTestOutput(consume(copy));
     } catch (IOException e) {
       return new IteratorTestOutput(e);

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Random;
-import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.ByteSequence;
@@ -57,8 +55,8 @@ public class IsolatedDeepCopiesTestCase extends OutputVerifyingTestCase {
       SortedKeyValueIterator<Key,Value> copy2 = copy1.deepCopy(new SimpleIteratorEnvironment());
 
       Range seekRange = testInput.getRange();
-      Set<ByteSequence> seekColumnFamilies = Collections.<ByteSequence> emptySet();
-      boolean seekInclusive = false;
+      Collection<ByteSequence> seekColumnFamilies = testInput.getFamilies();
+      boolean seekInclusive = testInput.isInclusive();
 
       skvi.seek(testInput.getRange(), seekColumnFamilies, seekInclusive);
       copy1.seek(testInput.getRange(), seekColumnFamilies, seekInclusive);
@@ -72,7 +70,7 @@ public class IsolatedDeepCopiesTestCase extends OutputVerifyingTestCase {
     }
   }
 
-  TreeMap<Key,Value> consumeMany(Collection<SortedKeyValueIterator<Key,Value>> iterators, Range range, Set<ByteSequence> seekColumnFamilies,
+  TreeMap<Key,Value> consumeMany(Collection<SortedKeyValueIterator<Key,Value>> iterators, Range range, Collection<ByteSequence> seekColumnFamilies,
       boolean seekInclusive) throws IOException {
     TreeMap<Key,Value> data = new TreeMap<>();
     // All of the copies should have consistent results from concurrent use
@@ -149,6 +147,7 @@ public class IsolatedDeepCopiesTestCase extends OutputVerifyingTestCase {
     }
 
     // Copy the value
+    assert (topValue != null) : "getTopValue() should always be called with iterators from test()";
     return new Value(topValue);
   }
 

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
@@ -17,11 +17,9 @@
 package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Random;
 import java.util.TreeMap;
 
-import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
@@ -51,7 +49,7 @@ public class MultipleHasTopCalls extends OutputVerifyingTestCase {
 
     try {
       skvi.init(source, testInput.getIteratorOptions(), new SimpleIteratorEnvironment());
-      skvi.seek(testInput.getRange(), Collections.<ByteSequence> emptySet(), false);
+      skvi.seek(testInput.getRange(), testInput.getFamilies(), testInput.isInclusive());
       return new IteratorTestOutput(consume(skvi));
     } catch (IOException e) {
       return new IteratorTestOutput(e);

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
@@ -17,7 +17,7 @@
 package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.Random;
 import java.util.TreeMap;
 
@@ -57,7 +57,7 @@ public class ReSeekTestCase extends OutputVerifyingTestCase {
 
     try {
       skvi.init(source, testInput.getIteratorOptions(), new SimpleIteratorEnvironment());
-      skvi.seek(testInput.getRange(), Collections.<ByteSequence> emptySet(), false);
+      skvi.seek(testInput.getRange(), testInput.getFamilies(), testInput.isInclusive());
       return new IteratorTestOutput(consume(skvi, testInput));
     } catch (IOException e) {
       return new IteratorTestOutput(e);
@@ -67,6 +67,8 @@ public class ReSeekTestCase extends OutputVerifyingTestCase {
   TreeMap<Key,Value> consume(SortedKeyValueIterator<Key,Value> skvi, IteratorTestInput testInput) throws IOException {
     final TreeMap<Key,Value> data = new TreeMap<>();
     final Range origRange = testInput.getRange();
+    final Collection<ByteSequence> origFamilies = testInput.getFamilies();
+    final boolean origInclusive = testInput.isInclusive();
     int reseekCount = random.nextInt(RESEEK_INTERVAL);
 
     int i = 0;
@@ -89,12 +91,12 @@ public class ReSeekTestCase extends OutputVerifyingTestCase {
 
         skvi.init(sourceCopy, testInput.getIteratorOptions(), new SimpleIteratorEnvironment());
 
-        // The new range, resume where we left off (non-inclusive)
+        // The new range, resume where we left off (non-inclusive), with same families filter
         final Range newRange = new Range(reSeekStartKey, false, origRange.getEndKey(), origRange.isEndKeyInclusive());
         log.debug("Re-seeking to {}", newRange);
 
         // Seek there
-        skvi.seek(newRange, Collections.<ByteSequence> emptySet(), false);
+        skvi.seek(newRange, origFamilies, origInclusive);
       } else {
         // Every other time, it's a simple call to next()
         skvi.next();


### PR DESCRIPTION
Changed the relevant tests to use the new information.
Added equals() and hashCode() for good measure.
By default the families is empty and inclusive is false,
so no existing code should break.
Inserted a couple side changes to clear compiler warnings.