### PR TITLE
Remove slash from links to news archive

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -47,7 +47,7 @@
           <li id="nav_getinvolved"><a href="{{ site.baseurl }}/get_involved">Get Involved</a></li>
           <li id="nav_mailinglists"><a href="{{ site.baseurl }}/mailing_list">Mailing Lists</a></li>
           <li id="nav_people"><a href="{{ site.baseurl }}/people">People</a></li>
-          <li id="nav_news"><a href="{{ site.baseurl }}/news/">News Archive</a></li>
+          <li id="nav_news"><a href="{{ site.baseurl }}/news">News Archive</a></li>
           <li id="nav_projects"><a href="{{ site.baseurl }}/projects">Community Projects</a></li>
           <li id="nav_thanks"><a href="{{ site.baseurl }}/thanks">Thanks</a></li>
           <li class="divider"></li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,4 +5,4 @@ layout: skeleton
 
 {{ content }}
 
-<p><strong>View all posts in the <a href="{{ site.baseurl }}/news/">news archive</a></strong></p>
+<p><strong>View all posts in the <a href="{{ site.baseurl }}/news">news archive</a></strong></p>

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ legal_notice: Apache Accumulo, Accumulo, Apache Hadoop, Apache Thrift, Apache, t
         </div>
         {% endfor %}
         <div id="news-archive-link">
-         <p>View all posts in the <a href="{{ site.baseurl }}/news/">news archive</a></p>
+         <p>View all posts in the <a href="{{ site.baseurl }}/news">news archive</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
It's causing page not found error in production.