### PR TITLE
ACCUMULO-4505: Fix for Shell erroneously reading accumulo-site.xml

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -127,7 +127,7 @@ public class Initialize implements KeywordExecutable {
   private static final String TABLE_TABLETS_TABLET_DIR = "/table_info";
 
   private static ConsoleReader reader = null;
-  private static IZooReaderWriter zoo = ZooReaderWriter.getInstance();
+  private static IZooReaderWriter zoo = null;
 
   private static ConsoleReader getConsoleReader() throws IOException {
     if (reader == null)
@@ -745,6 +745,7 @@ public class Initialize implements KeywordExecutable {
     opts.parseArgs(Initialize.class.getName(), args);
 
     try {
+      zoo = ZooReaderWriter.getInstance();
       AccumuloConfiguration acuConf = SiteConfiguration.getInstance();
       SecurityUtil.serverLogin(acuConf);
       Configuration conf = CachedConfiguration.getInstance();

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -60,7 +60,6 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.thrift.TConstraintViolationSummary;
@@ -492,7 +491,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     if (instanceName == null) {
       instanceName = clientConfig.get(ClientProperty.INSTANCE_NAME);
     }
-    AccumuloConfiguration conf = SiteConfiguration.getInstance(ClientContext.convertClientConfig(clientConfig));
+    AccumuloConfiguration conf = ClientContext.convertClientConfig(clientConfig);
     String keepers = getZooKeepers(keepersOption, clientConfig, conf);
     if (instanceName == null) {
       Path instanceDir = new Path(VolumeConfiguration.getVolumeUris(conf)[0], "instance_id");

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
@@ -311,6 +311,13 @@ public class ShellOptionsJC {
     if (useSasl()) {
       clientConfig.setProperty(ClientProperty.INSTANCE_RPC_SASL_ENABLED, "true");
     }
+    if (!getZooKeeperInstance().isEmpty()) {
+      List<String> zkOpts = getZooKeeperInstance();
+      String instanceName = zkOpts.get(0);
+      String hosts = zkOpts.get(1);
+      clientConfig.setProperty(ClientProperty.INSTANCE_ZK_HOST, hosts);
+      clientConfig.setProperty(ClientProperty.INSTANCE_NAME, instanceName);
+    }
 
     // Automatically try to add in the proper ZK from accumulo-site for backwards compat.
     if (!clientConfig.containsKey(ClientProperty.INSTANCE_ZK_HOST.getKey())) {


### PR DESCRIPTION
Fixes in a couple places for ACCUMULO-4505. Shell was getting the site instance config (which read accumulo-site) when everything it needed was already in ClientConfig. ShellOptionsJC was ignoring zookeeper properties passed in by the user.  The Initialize class is not executed when the Shell is run but a static initialization of Zookeeper was forcing a read of accumulo-site when the class was loaded by getExecutables in Main. 