### PR TITLE
ACCUMULO-4525: Replace meaningless method names

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.data.thrift.TRange;
 import org.apache.hadoop.io.Text;
 
 public class RangeTest extends TestCase {
-  private Range nr(String k1, String k2) {
+  private Range newRange(String k1, String k2) {
     Key ik1 = null;
     if (k1 != null)
       ik1 = new Key(new Text(k1), 0l);
@@ -44,7 +44,7 @@ public class RangeTest extends TestCase {
     return new Range(ik1, ik2);
   }
 
-  private List<Range> nrl(Range... ranges) {
+  private List<Range> newRangeList(Range... ranges) {
     return Arrays.asList(ranges);
   }
 
@@ -56,135 +56,135 @@ public class RangeTest extends TestCase {
   }
 
   public void testMergeOverlapping1() {
-    List<Range> rl = nrl(nr("a", "c"), nr("a", "b"));
-    List<Range> expected = nrl(nr("a", "c"));
+    List<Range> rl = newRangeList(newRange("a", "c"), newRange("a", "b"));
+    List<Range> expected = newRangeList(newRange("a", "c"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping2() {
-    List<Range> rl = nrl(nr("a", "c"), nr("d", "f"));
-    List<Range> expected = nrl(nr("a", "c"), nr("d", "f"));
+    List<Range> rl = newRangeList(newRange("a", "c"), newRange("d", "f"));
+    List<Range> expected = newRangeList(newRange("a", "c"), newRange("d", "f"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping3() {
-    List<Range> rl = nrl(nr("a", "e"), nr("b", "f"), nr("c", "r"), nr("g", "j"), nr("t", "x"));
-    List<Range> expected = nrl(nr("a", "r"), nr("t", "x"));
+    List<Range> rl = newRangeList(newRange("a", "e"), newRange("b", "f"), newRange("c", "r"), newRange("g", "j"), newRange("t", "x"));
+    List<Range> expected = newRangeList(newRange("a", "r"), newRange("t", "x"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping4() {
-    List<Range> rl = nrl(nr("a", "e"), nr("b", "f"), nr("c", "r"), nr("g", "j"));
-    List<Range> expected = nrl(nr("a", "r"));
+    List<Range> rl = newRangeList(newRange("a", "e"), newRange("b", "f"), newRange("c", "r"), newRange("g", "j"));
+    List<Range> expected = newRangeList(newRange("a", "r"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping5() {
-    List<Range> rl = nrl(nr("a", "e"));
-    List<Range> expected = nrl(nr("a", "e"));
+    List<Range> rl = newRangeList(newRange("a", "e"));
+    List<Range> expected = newRangeList(newRange("a", "e"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping6() {
-    List<Range> rl = nrl();
-    List<Range> expected = nrl();
+    List<Range> rl = newRangeList();
+    List<Range> expected = newRangeList();
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping7() {
-    List<Range> rl = nrl(nr("a", "e"), nr("g", "q"), nr("r", "z"));
-    List<Range> expected = nrl(nr("a", "e"), nr("g", "q"), nr("r", "z"));
+    List<Range> rl = newRangeList(newRange("a", "e"), newRange("g", "q"), newRange("r", "z"));
+    List<Range> expected = newRangeList(newRange("a", "e"), newRange("g", "q"), newRange("r", "z"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping8() {
-    List<Range> rl = nrl(nr("a", "c"), nr("a", "c"));
-    List<Range> expected = nrl(nr("a", "c"));
+    List<Range> rl = newRangeList(newRange("a", "c"), newRange("a", "c"));
+    List<Range> expected = newRangeList(newRange("a", "c"));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping9() {
-    List<Range> rl = nrl(nr(null, null));
-    List<Range> expected = nrl(nr(null, null));
+    List<Range> rl = newRangeList(newRange(null, null));
+    List<Range> expected = newRangeList(newRange(null, null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping10() {
-    List<Range> rl = nrl(nr(null, null), nr("a", "c"));
-    List<Range> expected = nrl(nr(null, null));
+    List<Range> rl = newRangeList(newRange(null, null), newRange("a", "c"));
+    List<Range> expected = newRangeList(newRange(null, null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping11() {
-    List<Range> rl = nrl(nr("a", "c"), nr(null, null));
-    List<Range> expected = nrl(nr(null, null));
+    List<Range> rl = newRangeList(newRange("a", "c"), newRange(null, null));
+    List<Range> expected = newRangeList(newRange(null, null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping12() {
-    List<Range> rl = nrl(nr("b", "d"), nr("c", null));
-    List<Range> expected = nrl(nr("b", null));
+    List<Range> rl = newRangeList(newRange("b", "d"), newRange("c", null));
+    List<Range> expected = newRangeList(newRange("b", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping13() {
-    List<Range> rl = nrl(nr("b", "d"), nr("a", null));
-    List<Range> expected = nrl(nr("a", null));
+    List<Range> rl = newRangeList(newRange("b", "d"), newRange("a", null));
+    List<Range> expected = newRangeList(newRange("a", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping14() {
-    List<Range> rl = nrl(nr("b", "d"), nr("e", null));
-    List<Range> expected = nrl(nr("b", "d"), nr("e", null));
+    List<Range> rl = newRangeList(newRange("b", "d"), newRange("e", null));
+    List<Range> expected = newRangeList(newRange("b", "d"), newRange("e", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping15() {
-    List<Range> rl = nrl(nr("b", "d"), nr("e", null), nr("c", "f"));
-    List<Range> expected = nrl(nr("b", null));
+    List<Range> rl = newRangeList(newRange("b", "d"), newRange("e", null), newRange("c", "f"));
+    List<Range> expected = newRangeList(newRange("b", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping16() {
-    List<Range> rl = nrl(nr("b", "d"), nr("f", null), nr("c", "e"));
-    List<Range> expected = nrl(nr("b", "e"), nr("f", null));
+    List<Range> rl = newRangeList(newRange("b", "d"), newRange("f", null), newRange("c", "e"));
+    List<Range> expected = newRangeList(newRange("b", "e"), newRange("f", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping17() {
-    List<Range> rl = nrl(nr("b", "d"), nr("r", null), nr("c", "e"), nr("g", "t"));
-    List<Range> expected = nrl(nr("b", "e"), nr("g", null));
+    List<Range> rl = newRangeList(newRange("b", "d"), newRange("r", null), newRange("c", "e"), newRange("g", "t"));
+    List<Range> expected = newRangeList(newRange("b", "e"), newRange("g", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping18() {
-    List<Range> rl = nrl(nr(null, "d"), nr("r", null), nr("c", "e"), nr("g", "t"));
-    List<Range> expected = nrl(nr(null, "e"), nr("g", null));
+    List<Range> rl = newRangeList(newRange(null, "d"), newRange("r", null), newRange("c", "e"), newRange("g", "t"));
+    List<Range> expected = newRangeList(newRange(null, "e"), newRange("g", null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping19() {
-    List<Range> rl = nrl(nr(null, "d"), nr("r", null), nr("c", "e"), nr("g", "t"), nr("d", "h"));
-    List<Range> expected = nrl(nr(null, null));
+    List<Range> rl = newRangeList(newRange(null, "d"), newRange("r", null), newRange("c", "e"), newRange("g", "t"), newRange("d", "h"));
+    List<Range> expected = newRangeList(newRange(null, null));
     check(Range.mergeOverlapping(rl), expected);
   }
 
   public void testMergeOverlapping20() {
 
-    List<Range> rl = nrl(new Range(new Text("a"), true, new Text("b"), false), new Range(new Text("b"), false, new Text("c"), false));
-    List<Range> expected = nrl(new Range(new Text("a"), true, new Text("b"), false), new Range(new Text("b"), false, new Text("c"), false));
+    List<Range> rl = newRangeList(new Range(new Text("a"), true, new Text("b"), false), new Range(new Text("b"), false, new Text("c"), false));
+    List<Range> expected = newRangeList(new Range(new Text("a"), true, new Text("b"), false), new Range(new Text("b"), false, new Text("c"), false));
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(new Range(new Text("a"), true, new Text("b"), false), new Range(new Text("b"), true, new Text("c"), false));
-    expected = nrl(new Range(new Text("a"), true, new Text("c"), false));
+    rl = newRangeList(new Range(new Text("a"), true, new Text("b"), false), new Range(new Text("b"), true, new Text("c"), false));
+    expected = newRangeList(new Range(new Text("a"), true, new Text("c"), false));
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(new Range(new Text("a"), true, new Text("b"), true), new Range(new Text("b"), false, new Text("c"), false));
-    expected = nrl(new Range(new Text("a"), true, new Text("c"), false));
+    rl = newRangeList(new Range(new Text("a"), true, new Text("b"), true), new Range(new Text("b"), false, new Text("c"), false));
+    expected = newRangeList(new Range(new Text("a"), true, new Text("c"), false));
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(new Range(new Text("a"), true, new Text("b"), true), new Range(new Text("b"), true, new Text("c"), false));
-    expected = nrl(new Range(new Text("a"), true, new Text("c"), false));
+    rl = newRangeList(new Range(new Text("a"), true, new Text("b"), true), new Range(new Text("b"), true, new Text("c"), false));
+    expected = newRangeList(new Range(new Text("a"), true, new Text("c"), false));
     check(Range.mergeOverlapping(rl), expected);
 
   }
@@ -197,24 +197,25 @@ public class RangeTest extends TestCase {
     Range ke4 = new KeyExtent("tab1", new Text("bails"), new Text("Sam")).toMetadataRange();
     Range ke5 = new KeyExtent("tab1", null, new Text("bails")).toMetadataRange();
 
-    List<Range> rl = nrl(ke1, ke2, ke3, ke4, ke5);
-    List<Range> expected = nrl(new KeyExtent("tab1", null, null).toMetadataRange());
+    List<Range> rl = newRangeList(ke1, ke2, ke3, ke4, ke5);
+    List<Range> expected = newRangeList(new KeyExtent("tab1", null, null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(ke1, ke2, ke4, ke5);
-    expected = nrl(new KeyExtent("tab1", new Text("Fails"), null).toMetadataRange(), new KeyExtent("tab1", null, new Text("Sam")).toMetadataRange());
+    rl = newRangeList(ke1, ke2, ke4, ke5);
+    expected = newRangeList(new KeyExtent("tab1", new Text("Fails"), null).toMetadataRange(), new KeyExtent("tab1", null, new Text("Sam")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(ke2, ke3, ke4, ke5);
-    expected = nrl(new KeyExtent("tab1", null, new Text("Bank")).toMetadataRange());
+    rl = newRangeList(ke2, ke3, ke4, ke5);
+    expected = newRangeList(new KeyExtent("tab1", null, new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(ke1, ke2, ke3, ke4);
-    expected = nrl(new KeyExtent("tab1", new Text("bails"), null).toMetadataRange());
+    rl = newRangeList(ke1, ke2, ke3, ke4);
+    expected = newRangeList(new KeyExtent("tab1", new Text("bails"), null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
-    rl = nrl(ke2, ke3, ke4);
-    expected = nrl(new KeyExtent("tab1", new Text("bails"), new Text("Bank")).toMetadataRange());
+    rl = newRangeList(ke2, ke3, ke4);
+    expected = newRangeList(new KeyExtent("tab1", new Text("bails"), new Text("Bank")).toMetadataRange());
+
     check(Range.mergeOverlapping(rl), expected);
   }
 
@@ -226,21 +227,24 @@ public class RangeTest extends TestCase {
 
             // System.out.println("b1:"+b1+" b2:"+b2+" b3:"+b3+" b4:"+b4);
 
-            List<Range> rl = nrl(new Range(new Key(new Text("a")), b1, new Key(new Text("m")), b2), new Range(new Key(new Text("b")), b3,
-                new Key(new Text("n")), b4));
-            List<Range> expected = nrl(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b4));
+            List<Range> rl = newRangeList(new Range(new Key(new Text("a")), b1, new Key(new Text("m")), b2), new Range(new Key(new Text("b")), b3, new Key(
+                new Text("n")), b4));
+            List<Range> expected = newRangeList(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b4));
             check(Range.mergeOverlapping(rl), expected);
 
-            rl = nrl(new Range(new Key(new Text("a")), b1, new Key(new Text("m")), b2), new Range(new Key(new Text("a")), b3, new Key(new Text("n")), b4));
-            expected = nrl(new Range(new Key(new Text("a")), b1 || b3, new Key(new Text("n")), b4));
+            rl = newRangeList(new Range(new Key(new Text("a")), b1, new Key(new Text("m")), b2), new Range(new Key(new Text("a")), b3, new Key(new Text("n")),
+                b4));
+            expected = newRangeList(new Range(new Key(new Text("a")), b1 || b3, new Key(new Text("n")), b4));
             check(Range.mergeOverlapping(rl), expected);
 
-            rl = nrl(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b2), new Range(new Key(new Text("b")), b3, new Key(new Text("n")), b4));
-            expected = nrl(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b2 || b4));
+            rl = newRangeList(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b2), new Range(new Key(new Text("b")), b3, new Key(new Text("n")),
+                b4));
+            expected = newRangeList(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b2 || b4));
             check(Range.mergeOverlapping(rl), expected);
 
-            rl = nrl(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b2), new Range(new Key(new Text("a")), b3, new Key(new Text("n")), b4));
-            expected = nrl(new Range(new Key(new Text("a")), b1 || b3, new Key(new Text("n")), b2 || b4));
+            rl = newRangeList(new Range(new Key(new Text("a")), b1, new Key(new Text("n")), b2), new Range(new Key(new Text("a")), b3, new Key(new Text("n")),
+                b4));
+            expected = newRangeList(new Range(new Key(new Text("a")), b1 || b3, new Key(new Text("n")), b2 || b4));
             check(Range.mergeOverlapping(rl), expected);
           }
 
@@ -248,33 +252,33 @@ public class RangeTest extends TestCase {
 
   public void testEqualsNull() {
 
-    assertTrue(nr(null, "d").equals(nr(null, "d")));
+    assertTrue(newRange(null, "d").equals(newRange(null, "d")));
 
-    assertTrue(nr(null, null).equals(nr(null, null)));
+    assertTrue(newRange(null, null).equals(newRange(null, null)));
 
-    assertTrue(nr("a", null).equals(nr("a", null)));
+    assertTrue(newRange("a", null).equals(newRange("a", null)));
 
-    assertFalse(nr(null, "d").equals(nr("a", "d")));
-    assertFalse(nr("a", "d").equals(nr(null, "d")));
+    assertFalse(newRange(null, "d").equals(newRange("a", "d")));
+    assertFalse(newRange("a", "d").equals(newRange(null, "d")));
 
-    assertFalse(nr(null, null).equals(nr("a", "d")));
-    assertFalse(nr("a", "d").equals(nr(null, null)));
+    assertFalse(newRange(null, null).equals(newRange("a", "d")));
+    assertFalse(newRange("a", "d").equals(newRange(null, null)));
 
-    assertFalse(nr("a", null).equals(nr("a", "d")));
-    assertFalse(nr("a", "d").equals(nr("a", null)));
+    assertFalse(newRange("a", null).equals(newRange("a", "d")));
+    assertFalse(newRange("a", "d").equals(newRange("a", null)));
   }
 
   public void testEquals() {
-    assertFalse(nr("b", "d").equals(nr("a", "d")));
-    assertFalse(nr("a", "d").equals(nr("b", "d")));
+    assertFalse(newRange("b", "d").equals(newRange("a", "d")));
+    assertFalse(newRange("a", "d").equals(newRange("b", "d")));
 
-    assertFalse(nr("x", "y").equals(nr("a", "d")));
-    assertFalse(nr("a", "d").equals(nr("x", "y")));
+    assertFalse(newRange("x", "y").equals(newRange("a", "d")));
+    assertFalse(newRange("a", "d").equals(newRange("x", "y")));
 
-    assertFalse(nr("a", "z").equals(nr("a", "d")));
-    assertFalse(nr("a", "d").equals(nr("a", "z")));
+    assertFalse(newRange("a", "z").equals(newRange("a", "d")));
+    assertFalse(newRange("a", "d").equals(newRange("a", "z")));
 
-    assertTrue(nr("a", "z").equals(nr("a", "z")));
+    assertTrue(newRange("a", "z").equals(newRange("a", "z")));
   }
 
   public void testRow1() {
@@ -415,7 +419,7 @@ public class RangeTest extends TestCase {
     assertTrue(rowRange.contains(new Key(new Text("r2")).followingKey(PartialKey.ROW)));
   }
 
-  private static Range nr(String r1, boolean r1i, String r2, boolean r2i) {
+  private static Range newRange(String r1, boolean r1i, String r2, boolean r2i) {
     Text tr1 = null;
     Text tr2 = null;
 
@@ -429,98 +433,98 @@ public class RangeTest extends TestCase {
 
   }
 
-  private static Key nk(String r) {
+  private static Key newKey(String r) {
     return new Key(new Text(r));
   }
 
   public void testClip1() {
-    Range fence = nr("a", false, "c", false);
+    Range fence = newRange("a", false, "c", false);
 
-    runClipTest(fence, nr("a", false, "c", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", false, "c", true), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", true), nr("a", false, "c", false));
+    runClipTest(fence, newRange("a", false, "c", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", false, "c", true), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", true), newRange("a", false, "c", false));
 
-    fence = nr("a", true, "c", false);
+    fence = newRange("a", true, "c", false);
 
-    runClipTest(fence, nr("a", false, "c", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", false), nr("a", true, "c", false));
-    runClipTest(fence, nr("a", false, "c", true), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", true), nr("a", true, "c", false));
+    runClipTest(fence, newRange("a", false, "c", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", false), newRange("a", true, "c", false));
+    runClipTest(fence, newRange("a", false, "c", true), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", true), newRange("a", true, "c", false));
 
-    fence = nr("a", false, "c", true);
+    fence = newRange("a", false, "c", true);
 
-    runClipTest(fence, nr("a", false, "c", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", false, "c", true), nr("a", false, "c", true));
-    runClipTest(fence, nr("a", true, "c", true), nr("a", false, "c", true));
+    runClipTest(fence, newRange("a", false, "c", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", false, "c", true), newRange("a", false, "c", true));
+    runClipTest(fence, newRange("a", true, "c", true), newRange("a", false, "c", true));
 
-    fence = nr("a", true, "c", true);
+    fence = newRange("a", true, "c", true);
 
-    runClipTest(fence, nr("a", false, "c", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", false), nr("a", true, "c", false));
-    runClipTest(fence, nr("a", false, "c", true), nr("a", false, "c", true));
-    runClipTest(fence, nr("a", true, "c", true), nr("a", true, "c", true));
+    runClipTest(fence, newRange("a", false, "c", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", false), newRange("a", true, "c", false));
+    runClipTest(fence, newRange("a", false, "c", true), newRange("a", false, "c", true));
+    runClipTest(fence, newRange("a", true, "c", true), newRange("a", true, "c", true));
   }
 
   public void testClip2() {
-    Range fence = nr("a", false, "c", false);
+    Range fence = newRange("a", false, "c", false);
 
-    runClipTest(fence, nr(null, true, null, true), nr("a", false, "c", false));
-    runClipTest(fence, nr(null, true, "c", true), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, null, true), nr("a", false, "c", false));
-    runClipTest(fence, nr("a", true, "c", true), nr("a", false, "c", false));
+    runClipTest(fence, newRange(null, true, null, true), newRange("a", false, "c", false));
+    runClipTest(fence, newRange(null, true, "c", true), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, null, true), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("a", true, "c", true), newRange("a", false, "c", false));
   }
 
   public void testClip3() {
-    Range fence = nr("a", false, "c", false);
+    Range fence = newRange("a", false, "c", false);
 
-    runClipTest(fence, nr("0", false, "z", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("0", true, "z", false), nr("a", false, "c", false));
-    runClipTest(fence, nr("0", false, "z", true), nr("a", false, "c", false));
-    runClipTest(fence, nr("0", true, "z", true), nr("a", false, "c", false));
+    runClipTest(fence, newRange("0", false, "z", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("0", true, "z", false), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("0", false, "z", true), newRange("a", false, "c", false));
+    runClipTest(fence, newRange("0", true, "z", true), newRange("a", false, "c", false));
 
-    runClipTest(fence, nr("0", false, "b", false), nr("a", false, "b", false));
-    runClipTest(fence, nr("0", true, "b", false), nr("a", false, "b", false));
-    runClipTest(fence, nr("0", false, "b", true), nr("a", false, "b", true));
-    runClipTest(fence, nr("0", true, "b", true), nr("a", false, "b", true));
+    runClipTest(fence, newRange("0", false, "b", false), newRange("a", false, "b", false));
+    runClipTest(fence, newRange("0", true, "b", false), newRange("a", false, "b", false));
+    runClipTest(fence, newRange("0", false, "b", true), newRange("a", false, "b", true));
+    runClipTest(fence, newRange("0", true, "b", true), newRange("a", false, "b", true));
 
-    runClipTest(fence, nr("a1", false, "z", false), nr("a1", false, "c", false));
-    runClipTest(fence, nr("a1", true, "z", false), nr("a1", true, "c", false));
-    runClipTest(fence, nr("a1", false, "z", true), nr("a1", false, "c", false));
-    runClipTest(fence, nr("a1", true, "z", true), nr("a1", true, "c", false));
+    runClipTest(fence, newRange("a1", false, "z", false), newRange("a1", false, "c", false));
+    runClipTest(fence, newRange("a1", true, "z", false), newRange("a1", true, "c", false));
+    runClipTest(fence, newRange("a1", false, "z", true), newRange("a1", false, "c", false));
+    runClipTest(fence, newRange("a1", true, "z", true), newRange("a1", true, "c", false));
 
-    runClipTest(fence, nr("a1", false, "b", false), nr("a1", false, "b", false));
-    runClipTest(fence, nr("a1", true, "b", false), nr("a1", true, "b", false));
-    runClipTest(fence, nr("a1", false, "b", true), nr("a1", false, "b", true));
-    runClipTest(fence, nr("a1", true, "b", true), nr("a1", true, "b", true));
+    runClipTest(fence, newRange("a1", false, "b", false), newRange("a1", false, "b", false));
+    runClipTest(fence, newRange("a1", true, "b", false), newRange("a1", true, "b", false));
+    runClipTest(fence, newRange("a1", false, "b", true), newRange("a1", false, "b", true));
+    runClipTest(fence, newRange("a1", true, "b", true), newRange("a1", true, "b", true));
   }
 
   public void testClip4() {
-    Range fence = new Range(nk("c"), false, nk("n"), false);
+    Range fence = new Range(newKey("c"), false, newKey("n"), false);
 
-    runClipTest(fence, new Range(nk("a"), false, nk("c"), false));
-    runClipTest(fence, new Range(nk("a"), false, nk("c"), true));
-    runClipTest(fence, new Range(nk("n"), false, nk("r"), false));
-    runClipTest(fence, new Range(nk("n"), true, nk("r"), false));
-    runClipTest(fence, new Range(nk("a"), true, nk("b"), false));
-    runClipTest(fence, new Range(nk("a"), true, nk("b"), true));
+    runClipTest(fence, new Range(newKey("a"), false, newKey("c"), false));
+    runClipTest(fence, new Range(newKey("a"), false, newKey("c"), true));
+    runClipTest(fence, new Range(newKey("n"), false, newKey("r"), false));
+    runClipTest(fence, new Range(newKey("n"), true, newKey("r"), false));
+    runClipTest(fence, new Range(newKey("a"), true, newKey("b"), false));
+    runClipTest(fence, new Range(newKey("a"), true, newKey("b"), true));
 
-    fence = new Range(nk("c"), true, nk("n"), true);
+    fence = new Range(newKey("c"), true, newKey("n"), true);
 
-    runClipTest(fence, new Range(nk("a"), false, nk("c"), false));
-    runClipTest(fence, new Range(nk("a"), false, nk("c"), true), new Range(nk("c"), true, nk("c"), true));
-    runClipTest(fence, new Range(nk("n"), false, nk("r"), false));
-    runClipTest(fence, new Range(nk("n"), true, nk("r"), false), new Range(nk("n"), true, nk("n"), true));
-    runClipTest(fence, new Range(nk("q"), false, nk("r"), false));
-    runClipTest(fence, new Range(nk("q"), true, nk("r"), false));
+    runClipTest(fence, new Range(newKey("a"), false, newKey("c"), false));
+    runClipTest(fence, new Range(newKey("a"), false, newKey("c"), true), new Range(newKey("c"), true, newKey("c"), true));
+    runClipTest(fence, new Range(newKey("n"), false, newKey("r"), false));
+    runClipTest(fence, new Range(newKey("n"), true, newKey("r"), false), new Range(newKey("n"), true, newKey("n"), true));
+    runClipTest(fence, new Range(newKey("q"), false, newKey("r"), false));
+    runClipTest(fence, new Range(newKey("q"), true, newKey("r"), false));
 
-    fence = nr("b", true, "b", true);
+    fence = newRange("b", true, "b", true);
 
-    runClipTest(fence, nr("b", false, "c", false));
-    runClipTest(fence, nr("b", true, "c", false), nr("b", true, "b", true));
-    runClipTest(fence, nr("a", false, "b", false));
-    runClipTest(fence, nr("a", false, "b", true), nr("b", true, "b", true));
+    runClipTest(fence, newRange("b", false, "c", false));
+    runClipTest(fence, newRange("b", true, "c", false), newRange("b", true, "b", true));
+    runClipTest(fence, newRange("a", false, "b", false));
+    runClipTest(fence, newRange("a", false, "b", true), newRange("b", true, "b", true));
 
   }
 
@@ -558,95 +562,95 @@ public class RangeTest extends TestCase {
     assertEquals(expected, clipped);
   }
 
-  private static Key nk(String r, String cf, String cq) {
+  private static Key newKey(String r, String cf, String cq) {
     return new Key(new Text(r), new Text(cf), new Text(cq));
   }
 
-  private static Key nk(String r, String cf, String cq, String cv) {
+  private static Key newKey(String r, String cf, String cq, String cv) {
     return new Key(new Text(r), new Text(cf), new Text(cq), new Text(cv));
   }
 
-  private static Column nc(String cf, String cq) {
+  private static Column newColumn(String cf, String cq) {
     return new Column(cf.getBytes(), cq == null ? null : cq.getBytes(), null);
   }
 
-  private static Column nc(String cf) {
-    return nc(cf, null);
+  private static Column newColumn(String cf) {
+    return newColumn(cf, null);
   }
 
-  private static Range nr(String row) {
+  private static Range newRange(String row) {
     return new Range(new Text(row));
   }
 
   public void testBound1() {
-    Range range1 = nr("row1");
+    Range range1 = newRange("row1");
 
-    Range range2 = range1.bound(nc("b"), nc("e"));
+    Range range2 = range1.bound(newColumn("b"), newColumn("e"));
 
-    assertFalse(range2.contains(nk("row1")));
-    assertFalse(range2.contains(nk("row1", "a", "z")));
-    assertTrue(range2.contains(nk("row1", "b", "")));
-    assertTrue(range2.contains(nk("row1", "b", "z")));
-    assertTrue(range2.contains(nk("row1", "c", "z")));
-    assertTrue(range2.contains(nk("row1", "e", "")));
-    assertTrue(range2.contains(nk("row1", "e", "z")));
-    assertFalse(range2.contains(nk("row1", "e", "").followingKey(PartialKey.ROW_COLFAM)));
-    assertFalse(range2.contains(nk("row1", "f", "")));
-    assertFalse(range2.contains(nk("row1", "f", "z")));
+    assertFalse(range2.contains(newKey("row1")));
+    assertFalse(range2.contains(newKey("row1", "a", "z")));
+    assertTrue(range2.contains(newKey("row1", "b", "")));
+    assertTrue(range2.contains(newKey("row1", "b", "z")));
+    assertTrue(range2.contains(newKey("row1", "c", "z")));
+    assertTrue(range2.contains(newKey("row1", "e", "")));
+    assertTrue(range2.contains(newKey("row1", "e", "z")));
+    assertFalse(range2.contains(newKey("row1", "e", "").followingKey(PartialKey.ROW_COLFAM)));
+    assertFalse(range2.contains(newKey("row1", "f", "")));
+    assertFalse(range2.contains(newKey("row1", "f", "z")));
 
   }
 
   public void testBound2() {
-    Range range1 = new Range(nk("row1", "b", "x"), true, nk("row1", "f", "x"), true);
+    Range range1 = new Range(newKey("row1", "b", "x"), true, newKey("row1", "f", "x"), true);
 
-    Range range2 = range1.bound(nc("a"), nc("g"));
+    Range range2 = range1.bound(newColumn("a"), newColumn("g"));
     assertEquals(range1, range2);
-    assertFalse(range2.contains(nk("row1", "a", "x")));
-    assertTrue(range2.contains(nk("row1", "b", "x")));
-    assertTrue(range2.contains(nk("row1", "f", "x")));
-    assertFalse(range2.contains(nk("row1", "g", "")));
+    assertFalse(range2.contains(newKey("row1", "a", "x")));
+    assertTrue(range2.contains(newKey("row1", "b", "x")));
+    assertTrue(range2.contains(newKey("row1", "f", "x")));
+    assertFalse(range2.contains(newKey("row1", "g", "")));
 
-    Range range3 = range1.bound(nc("c"), nc("d"));
-    assertFalse(range3.contains(nk("row1", "b", "x")));
-    assertTrue(range3.contains(nk("row1", "c", "")));
-    assertTrue(range3.contains(nk("row1", "c", "z")));
-    assertTrue(range3.contains(nk("row1", "d", "")));
-    assertTrue(range3.contains(nk("row1", "d", "z")));
-    assertFalse(range3.contains(nk("row1", "e", "")));
-    assertFalse(range3.contains(nk("row1", "f", "x")));
+    Range range3 = range1.bound(newColumn("c"), newColumn("d"));
+    assertFalse(range3.contains(newKey("row1", "b", "x")));
+    assertTrue(range3.contains(newKey("row1", "c", "")));
+    assertTrue(range3.contains(newKey("row1", "c", "z")));
+    assertTrue(range3.contains(newKey("row1", "d", "")));
+    assertTrue(range3.contains(newKey("row1", "d", "z")));
+    assertFalse(range3.contains(newKey("row1", "e", "")));
+    assertFalse(range3.contains(newKey("row1", "f", "x")));
 
-    Range range4 = range1.bound(nc("c", "w"), nc("d", "z"));
-    assertFalse(range4.contains(nk("row1", "b", "x")));
-    assertTrue(range4.contains(nk("row1", "c", "w")));
-    assertTrue(range4.contains(nk("row1", "c", "w", "")));
-    assertTrue(range4.contains(nk("row1", "c", "w", "a")));
-    assertTrue(range4.contains(nk("row1", "d", "z", "")));
-    assertTrue(range4.contains(nk("row1", "d", "z", "a")));
-    assertFalse(range4.contains(nk("row1", "d", "{", "")));
-    assertFalse(range4.contains(nk("row1", "d", "z", "a").followingKey(PartialKey.ROW_COLFAM_COLQUAL)));
-    assertFalse(range4.contains(nk("row1", "f", "x")));
+    Range range4 = range1.bound(newColumn("c", "w"), newColumn("d", "z"));
+    assertFalse(range4.contains(newKey("row1", "b", "x")));
+    assertTrue(range4.contains(newKey("row1", "c", "w")));
+    assertTrue(range4.contains(newKey("row1", "c", "w", "")));
+    assertTrue(range4.contains(newKey("row1", "c", "w", "a")));
+    assertTrue(range4.contains(newKey("row1", "d", "z", "")));
+    assertTrue(range4.contains(newKey("row1", "d", "z", "a")));
+    assertFalse(range4.contains(newKey("row1", "d", "{", "")));
+    assertFalse(range4.contains(newKey("row1", "d", "z", "a").followingKey(PartialKey.ROW_COLFAM_COLQUAL)));
+    assertFalse(range4.contains(newKey("row1", "f", "x")));
 
-    Range range5 = range1.bound(nc("b", "w"), nc("f", "z"));
+    Range range5 = range1.bound(newColumn("b", "w"), newColumn("f", "z"));
     assertEquals(range1, range5);
-    assertFalse(range5.contains(nk("row1", "b", "w")));
-    assertTrue(range5.contains(nk("row1", "b", "x")));
-    assertTrue(range5.contains(nk("row1", "f", "x")));
-    assertFalse(range5.contains(nk("row1", "f", "z")));
+    assertFalse(range5.contains(newKey("row1", "b", "w")));
+    assertTrue(range5.contains(newKey("row1", "b", "x")));
+    assertTrue(range5.contains(newKey("row1", "f", "x")));
+    assertFalse(range5.contains(newKey("row1", "f", "z")));
 
-    Range range6 = range1.bound(nc("b", "y"), nc("f", "w"));
-    assertFalse(range6.contains(nk("row1", "b", "x")));
-    assertTrue(range6.contains(nk("row1", "b", "y")));
-    assertTrue(range6.contains(nk("row1", "f", "w")));
-    assertTrue(range6.contains(nk("row1", "f", "w", "a")));
-    assertFalse(range6.contains(nk("row1", "f", "w").followingKey(PartialKey.ROW_COLFAM_COLQUAL)));
-    assertFalse(range6.contains(nk("row1", "f", "x")));
+    Range range6 = range1.bound(newColumn("b", "y"), newColumn("f", "w"));
+    assertFalse(range6.contains(newKey("row1", "b", "x")));
+    assertTrue(range6.contains(newKey("row1", "b", "y")));
+    assertTrue(range6.contains(newKey("row1", "f", "w")));
+    assertTrue(range6.contains(newKey("row1", "f", "w", "a")));
+    assertFalse(range6.contains(newKey("row1", "f", "w").followingKey(PartialKey.ROW_COLFAM_COLQUAL)));
+    assertFalse(range6.contains(newKey("row1", "f", "x")));
 
-    Range range7 = range1.bound(nc("a", "y"), nc("g", "w"));
+    Range range7 = range1.bound(newColumn("a", "y"), newColumn("g", "w"));
     assertEquals(range1, range7);
-    assertFalse(range7.contains(nk("row1", "b", "w")));
-    assertTrue(range7.contains(nk("row1", "b", "x")));
-    assertTrue(range7.contains(nk("row1", "f", "x")));
-    assertFalse(range7.contains(nk("row1", "f", "z")));
+    assertFalse(range7.contains(newKey("row1", "b", "w")));
+    assertTrue(range7.contains(newKey("row1", "b", "x")));
+    assertTrue(range7.contains(newKey("row1", "f", "x")));
+    assertFalse(range7.contains(newKey("row1", "f", "z")));
   }
 
   public void testString() {
@@ -769,7 +773,7 @@ public class RangeTest extends TestCase {
   }
 
   public void testReadFields() throws Exception {
-    Range r = nr("nuts", "soup");
+    Range r = newRange("nuts", "soup");
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
     r.write(dos);
@@ -803,7 +807,7 @@ public class RangeTest extends TestCase {
   }
 
   public void testThrift() {
-    Range r = nr("nuts", "soup");
+    Range r = newRange("nuts", "soup");
     TRange tr = r.toThrift();
     Range r2 = new Range(tr);
     assertEquals(r, r2);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/BlockIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/BlockIndexTest.java
@@ -69,7 +69,7 @@ public class BlockIndexTest {
     int num = 1000;
 
     for (int i = 0; i < num; i++) {
-      Key key = new Key(RFileTest.nf("", i), "cf1", "cq1");
+      Key key = new Key(RFileTest.formatString("", i), "cf1", "cq1");
       new RelativeKey(prevKey, key).write(out);
       new Value(new byte[0]).write(out);
       prevKey = key;
@@ -93,22 +93,22 @@ public class BlockIndexTest {
 
       BlockIndexEntry bie;
 
-      bie = blockIndex.seekBlock(new Key(RFileTest.nf("", row), "cf1", "cq1"), cacheBlock);
+      bie = blockIndex.seekBlock(new Key(RFileTest.formatString("", row), "cf1", "cq1"), cacheBlock);
       if (i == 0)
         Assert.assertSame(null, bie);
       else
         Assert.assertSame(indexEntries[i - 1], bie);
 
-      Assert.assertSame(bie, blockIndex.seekBlock(new Key(RFileTest.nf("", row - 1), "cf1", "cq1"), cacheBlock));
+      Assert.assertSame(bie, blockIndex.seekBlock(new Key(RFileTest.formatString("", row - 1), "cf1", "cq1"), cacheBlock));
 
-      bie = blockIndex.seekBlock(new Key(RFileTest.nf("", row + 1), "cf1", "cq1"), cacheBlock);
+      bie = blockIndex.seekBlock(new Key(RFileTest.formatString("", row + 1), "cf1", "cq1"), cacheBlock);
       Assert.assertSame(indexEntries[i], bie);
 
       RelativeKey rk = new RelativeKey();
       rk.setPrevKey(bie.getPrevKey());
       rk.readFields(cacheBlock);
 
-      Assert.assertEquals(rk.getKey(), new Key(RFileTest.nf("", row + 1), "cf1", "cq1"));
+      Assert.assertEquals(rk.getKey(), new Key(RFileTest.formatString("", row + 1), "cf1", "cq1"));
 
     }
     cacheBlock.close();
@@ -124,21 +124,21 @@ public class BlockIndexTest {
     int num = 1000;
 
     for (int i = 0; i < num; i++) {
-      Key key = new Key(RFileTest.nf("", 1), "cf1", "cq1");
+      Key key = new Key(RFileTest.formatString("", 1), "cf1", "cq1");
       new RelativeKey(prevKey, key).write(out);
       new Value(new byte[0]).write(out);
       prevKey = key;
     }
 
     for (int i = 0; i < num; i++) {
-      Key key = new Key(RFileTest.nf("", 3), "cf1", "cq1");
+      Key key = new Key(RFileTest.formatString("", 3), "cf1", "cq1");
       new RelativeKey(prevKey, key).write(out);
       new Value(new byte[0]).write(out);
       prevKey = key;
     }
 
     for (int i = 0; i < num; i++) {
-      Key key = new Key(RFileTest.nf("", 5), "cf1", "cq1");
+      Key key = new Key(RFileTest.formatString("", 5), "cf1", "cq1");
       new RelativeKey(prevKey, key).write(out);
       new Value(new byte[0]).write(out);
       prevKey = key;
@@ -155,11 +155,11 @@ public class BlockIndexTest {
     for (int i = 0; i < 257; i++)
       blockIndex = BlockIndex.getIndex(cacheBlock, new IndexEntry(prevKey, num, 0, 0, 0));
 
-    Assert.assertSame(null, blockIndex.seekBlock(new Key(RFileTest.nf("", 0), "cf1", "cq1"), cacheBlock));
-    Assert.assertSame(null, blockIndex.seekBlock(new Key(RFileTest.nf("", 1), "cf1", "cq1"), cacheBlock));
+    Assert.assertSame(null, blockIndex.seekBlock(new Key(RFileTest.formatString("", 0), "cf1", "cq1"), cacheBlock));
+    Assert.assertSame(null, blockIndex.seekBlock(new Key(RFileTest.formatString("", 1), "cf1", "cq1"), cacheBlock));
 
     for (int i = 2; i < 6; i++) {
-      Key seekKey = new Key(RFileTest.nf("", i), "cf1", "cq1");
+      Key seekKey = new Key(RFileTest.formatString("", i), "cf1", "cq1");
       BlockIndexEntry bie = blockIndex.seekBlock(seekKey, cacheBlock);
 
       Assert.assertTrue(bie.getPrevKey().compareTo(seekKey) < 0);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/CreateCompatTestFile.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/CreateCompatTestFile.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.Path;
 
 public class CreateCompatTestFile {
 
-  public static Set<ByteSequence> ncfs(String... colFams) {
+  public static Set<ByteSequence> newColFamSequence(String... colFams) {
     HashSet<ByteSequence> cfs = new HashSet<>();
 
     for (String cf : colFams) {
@@ -41,15 +41,15 @@ public class CreateCompatTestFile {
     return cfs;
   }
 
-  private static Key nk(String row, String cf, String cq, String cv, long ts) {
+  private static Key newKey(String row, String cf, String cq, String cv, long ts) {
     return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
   }
 
-  private static Value nv(String val) {
+  private static Value newValue(String val) {
     return new Value(val.getBytes());
   }
 
-  private static String nf(String prefix, int i) {
+  private static String formatStr(String prefix, int i) {
     return String.format(prefix + "%06d", i);
   }
 
@@ -59,23 +59,23 @@ public class CreateCompatTestFile {
     CachableBlockFile.Writer _cbw = new CachableBlockFile.Writer(fs, new Path(args[0]), "gz", null, conf, AccumuloConfiguration.getDefaultConfiguration());
     RFile.Writer writer = new RFile.Writer(_cbw, 1000);
 
-    writer.startNewLocalityGroup("lg1", ncfs(nf("cf_", 1), nf("cf_", 2)));
+    writer.startNewLocalityGroup("lg1", newColFamSequence(formatStr("cf_", 1), formatStr("cf_", 2)));
 
     for (int i = 0; i < 1000; i++) {
-      writer.append(nk(nf("r_", i), nf("cf_", 1), nf("cq_", 0), "", 1000 - i), nv(i + ""));
-      writer.append(nk(nf("r_", i), nf("cf_", 2), nf("cq_", 0), "", 1000 - i), nv(i + ""));
+      writer.append(newKey(formatStr("r_", i), formatStr("cf_", 1), formatStr("cq_", 0), "", 1000 - i), newValue(i + ""));
+      writer.append(newKey(formatStr("r_", i), formatStr("cf_", 2), formatStr("cq_", 0), "", 1000 - i), newValue(i + ""));
     }
 
-    writer.startNewLocalityGroup("lg2", ncfs(nf("cf_", 3)));
+    writer.startNewLocalityGroup("lg2", newColFamSequence(formatStr("cf_", 3)));
 
     for (int i = 0; i < 1000; i++) {
-      writer.append(nk(nf("r_", i), nf("cf_", 3), nf("cq_", 0), "", 1000 - i), nv(i + ""));
+      writer.append(newKey(formatStr("r_", i), formatStr("cf_", 3), formatStr("cq_", 0), "", 1000 - i), newValue(i + ""));
     }
 
     writer.startDefaultLocalityGroup();
 
     for (int i = 0; i < 1000; i++) {
-      writer.append(nk(nf("r_", i), nf("cf_", 4), nf("cq_", 0), "", 1000 - i), nv(i + ""));
+      writer.append(newKey(formatStr("r_", i), formatStr("cf_", 4), formatStr("cq_", 0), "", 1000 - i), newValue(i + ""));
     }
 
     writer.close();

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
@@ -41,14 +41,14 @@ public class KeyShortenerTest {
   /**
    * append 0xff to end of string
    */
-  private byte[] aff(String s) {
+  private byte[] apendFF(String s) {
     return Bytes.concat(s.getBytes(), FF);
   }
 
   /**
    * append 0x00 to end of string
    */
-  private byte[] a00(String s) {
+  private byte[] append00(String s) {
     return Bytes.concat(s.getBytes(), new byte[] {(byte) 0x00});
   }
 
@@ -62,74 +62,75 @@ public class KeyShortenerTest {
     throw new IllegalArgumentException();
   }
 
-  private Key nk(Object row, Object fam, Object qual, long ts) {
+  private Key newKey(Object row, Object fam, Object qual, long ts) {
     return new Key(toBytes(row), toBytes(fam), toBytes(qual), E, ts);
   }
 
   @Test
   public void testOneCharacterDifference() {
     // row has char that differs by one byte
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hbhahaha", "f89222", "q90232e"), nk(aff("r321ha"), E, E, 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hbhahaha", "f89222", "q90232e"), newKey(apendFF("r321ha"), E, E, 0));
 
     // family has char that differs by one byte
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89322", "q90232e"), nk("r321hahahaha", aff("f892"), E, 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89322", "q90232e"), newKey("r321hahahaha", apendFF("f892"), E, 0));
 
     // qualifier has char that differs by one byte
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89222", "q91232e"), nk("r321hahahaha", "f89222", aff("q90"), 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89222", "q91232e"), newKey("r321hahahaha", "f89222", apendFF("q90"), 0));
   }
 
   @Test
   public void testMultiCharacterDifference() {
     // row has char that differs by two bytes
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hchahaha", "f89222", "q90232e"), nk("r321hb", E, E, 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hchahaha", "f89222", "q90232e"), newKey("r321hb", E, E, 0));
 
     // family has char that differs by two bytes
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89422", "q90232e"), nk("r321hahahaha", "f893", E, 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89422", "q90232e"), newKey("r321hahahaha", "f893", E, 0));
 
     // qualifier has char that differs by two bytes
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89222", "q92232e"), nk("r321hahahaha", "f89222", "q91", 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89222", "q92232e"), newKey("r321hahahaha", "f89222", "q91", 0));
   }
 
   @Test
   public void testOneCharacterDifferenceAndFF() {
-    byte[] ff1 = Bytes.concat(aff("mop"), "b".getBytes());
-    byte[] ff2 = Bytes.concat(aff("mop"), FF, "b".getBytes());
+    byte[] ff1 = Bytes.concat(apendFF("mop"), "b".getBytes());
+    byte[] ff2 = Bytes.concat(apendFF("mop"), FF, "b".getBytes());
 
-    byte[] eff1 = Bytes.concat(aff("mop"), FF, FF);
-    byte[] eff2 = Bytes.concat(aff("mop"), FF, FF, FF);
+    byte[] eff1 = Bytes.concat(apendFF("mop"), FF, FF);
+    byte[] eff2 = Bytes.concat(apendFF("mop"), FF, FF, FF);
 
-    testKeys(nk(ff1, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"), nk(eff1, E, E, 0));
-    testKeys(nk("r1", ff1, "q90232e", 34), new Key("r1", "mor56", "q90232e"), nk("r1", eff1, E, 0));
-    testKeys(nk("r1", "f1", ff1, 34), new Key("r1", "f1", "mor56"), nk("r1", "f1", eff1, 0));
+    testKeys(newKey(ff1, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"), newKey(eff1, E, E, 0));
+    testKeys(newKey("r1", ff1, "q90232e", 34), new Key("r1", "mor56", "q90232e"), newKey("r1", eff1, E, 0));
+    testKeys(newKey("r1", "f1", ff1, 34), new Key("r1", "f1", "mor56"), newKey("r1", "f1", eff1, 0));
 
-    testKeys(nk(ff2, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"), nk(eff2, E, E, 0));
-    testKeys(nk("r1", ff2, "q90232e", 34), new Key("r1", "mor56", "q90232e"), nk("r1", eff2, E, 0));
-    testKeys(nk("r1", "f1", ff2, 34), new Key("r1", "f1", "mor56"), nk("r1", "f1", eff2, 0));
+    testKeys(newKey(ff2, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"), newKey(eff2, E, E, 0));
+    testKeys(newKey("r1", ff2, "q90232e", 34), new Key("r1", "mor56", "q90232e"), newKey("r1", eff2, E, 0));
+    testKeys(newKey("r1", "f1", ff2, 34), new Key("r1", "f1", "mor56"), newKey("r1", "f1", eff2, 0));
 
   }
 
   @Test
   public void testOneCharacterDifferenceAtEnd() {
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahahb", "f89222", "q90232e"), nk(a00("r321hahahaha"), E, E, 0));
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89223", "q90232e"), nk("r321hahahaha", a00("f89222"), E, 0));
-    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89222", "q90232f"), nk("r321hahahaha", "f89222", a00("q90232e"), 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahahb", "f89222", "q90232e"), newKey(append00("r321hahahaha"), E, E, 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89223", "q90232e"), newKey("r321hahahaha", append00("f89222"), E, 0));
+    testKeys(new Key("r321hahahaha", "f89222", "q90232e"), new Key("r321hahahaha", "f89222", "q90232f"),
+        newKey("r321hahahaha", "f89222", append00("q90232e"), 0));
   }
 
   @Test
   public void testSamePrefix() {
-    testKeys(new Key("r3boot4", "f89222", "q90232e"), new Key("r3boot452", "f89222", "q90232e"), nk(a00("r3boot4"), E, E, 0));
-    testKeys(new Key("r3boot4", "f892", "q90232e"), new Key("r3boot4", "f89222", "q90232e"), nk("r3boot4", a00("f892"), E, 0));
-    testKeys(new Key("r3boot4", "f89222", "q902"), new Key("r3boot4", "f89222", "q90232e"), nk("r3boot4", "f89222", a00("q902"), 0));
+    testKeys(new Key("r3boot4", "f89222", "q90232e"), new Key("r3boot452", "f89222", "q90232e"), newKey(append00("r3boot4"), E, E, 0));
+    testKeys(new Key("r3boot4", "f892", "q90232e"), new Key("r3boot4", "f89222", "q90232e"), newKey("r3boot4", append00("f892"), E, 0));
+    testKeys(new Key("r3boot4", "f89222", "q902"), new Key("r3boot4", "f89222", "q90232e"), newKey("r3boot4", "f89222", append00("q902"), 0));
   }
 
   @Test
   public void testSamePrefixAnd00() {
     Key prev = new Key("r3boot4", "f89222", "q90232e");
-    Assert.assertEquals(prev, KeyShortener.shorten(prev, nk(a00("r3boot4"), "f89222", "q90232e", 8)));
+    Assert.assertEquals(prev, KeyShortener.shorten(prev, newKey(append00("r3boot4"), "f89222", "q90232e", 8)));
     prev = new Key("r3boot4", "f892", "q90232e");
-    Assert.assertEquals(prev, KeyShortener.shorten(prev, nk("r3boot4", a00("f892"), "q90232e", 8)));
+    Assert.assertEquals(prev, KeyShortener.shorten(prev, newKey("r3boot4", append00("f892"), "q90232e", 8)));
     prev = new Key("r3boot4", "f89222", "q902");
-    Assert.assertEquals(prev, KeyShortener.shorten(prev, nk("r3boot4", "f89222", a00("q902"), 8)));
+    Assert.assertEquals(prev, KeyShortener.shorten(prev, newKey("r3boot4", "f89222", append00("q902"), 8)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -190,11 +190,11 @@ public class MultiThreadedRFileTest {
     }
   }
 
-  static Key nk(String row, String cf, String cq, String cv, long ts) {
+  static Key newKey(String row, String cf, String cq, String cv, long ts) {
     return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
   }
 
-  static Value nv(String val) {
+  static Value newValue(String val) {
     return new Value(val.getBytes());
   }
 
@@ -362,7 +362,7 @@ public class MultiThreadedRFileTest {
     String cf = getCf(locality);
     String cq = "cq" + pad(index);
 
-    return nk(row, cf, cq, "", 1);
+    return newKey(row, cf, cq, "", 1);
   }
 
   private String pad(int val) {
@@ -380,7 +380,7 @@ public class MultiThreadedRFileTest {
   }
 
   private Value getValue(int index) {
-    return nv("" + index);
+    return newValue("" + index);
   }
 
   private String getCf(int locality) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
@@ -129,7 +129,7 @@ public class RFileMetricsTest {
     // test an rfile with one entry in the default locality group
 
     trf.openWriter();
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
     trf.closeWriter();
 
     trf.openReader(false);
@@ -153,8 +153,8 @@ public class RFileMetricsTest {
     // test an rfile with two entries in the default locality group
 
     trf.openWriter();
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L2", 55), RFileTest.newValue("foo"));
     trf.closeWriter();
 
     trf.openReader(false);
@@ -185,7 +185,7 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf1"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
     trf.closeWriter();
 
     trf.openReader(false);
@@ -214,8 +214,8 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf1"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L2", 55), RFileTest.newValue("foo"));
     trf.closeWriter();
 
     trf.openReader(false);
@@ -246,15 +246,15 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf1"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L2", 55), RFileTest.newValue("foo"));
 
     Set<ByteSequence> lg2 = new HashSet<>();
     lg2.add(new ArrayByteSequence("cf2"));
 
     trf.writer.startNewLocalityGroup("lg2", lg2);
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "L2", 55), RFileTest.newValue("foo"));
 
     trf.closeWriter();
 
@@ -297,13 +297,13 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf1"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq2", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq2", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq2", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq2", "L2", 55), RFileTest.newValue("foo"));
 
     trf.writer.startDefaultLocalityGroup();
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "A", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "B", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "A", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "B", 55), RFileTest.newValue("foo"));
 
     trf.closeWriter();
 
@@ -347,16 +347,16 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf3"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq2", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq2", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq2", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq2", "L2", 55), RFileTest.newValue("foo"));
 
     trf.writer.startDefaultLocalityGroup();
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "A", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "B", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf4", "cq1", "A", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf4", "cq1", "B", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "A", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "B", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf4", "cq1", "A", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf4", "cq1", "B", 55), RFileTest.newValue("foo"));
 
     trf.closeWriter();
 
@@ -395,10 +395,10 @@ public class RFileMetricsTest {
     // test an rfile with four blocks in the default locality group
 
     trf.openWriter(20);// Each entry is a block
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq2", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq2", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq2", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq2", "L2", 55), RFileTest.newValue("foo"));
     trf.closeWriter();
 
     trf.openReader(false);
@@ -430,10 +430,10 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf3"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq2", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq2", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq2", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq2", "L2", 55), RFileTest.newValue("foo"));
     trf.closeWriter();
 
     trf.openReader(false);
@@ -465,16 +465,16 @@ public class RFileMetricsTest {
     lg1.add(new ArrayByteSequence("cf3"));
 
     trf.writer.startNewLocalityGroup("lg1", lg1);
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf1", "cq2", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq1", "L1", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf3", "cq2", "L2", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf1", "cq2", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq1", "L1", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf3", "cq2", "L2", 55), RFileTest.newValue("foo"));
 
     trf.writer.startDefaultLocalityGroup();
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "A", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf2", "cq1", "B", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf4", "cq1", "A", 55), RFileTest.nv("foo"));
-    trf.writer.append(RFileTest.nk("r1", "cf4", "cq1", "B", 55), RFileTest.nv("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "A", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf2", "cq1", "B", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf4", "cq1", "A", 55), RFileTest.newValue("foo"));
+    trf.writer.append(RFileTest.newKey("r1", "cf4", "cq1", "B", 55), RFileTest.newValue("foo"));
 
     trf.closeWriter();
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -285,15 +285,15 @@ public class RFileTest {
     }
   }
 
-  static Key nk(String row, String cf, String cq, String cv, long ts) {
+  static Key newKey(String row, String cf, String cq, String cv, long ts) {
     return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), cv.getBytes(), ts);
   }
 
-  static Value nv(String val) {
+  static Value newValue(String val) {
     return new Value(val.getBytes());
   }
 
-  static String nf(String prefix, int i) {
+  static String formatString(String prefix, int i) {
     return String.format(prefix + "%06d", i);
   }
 
@@ -326,31 +326,31 @@ public class RFileTest {
     TestRFile trf = new TestRFile(conf);
 
     trf.openWriter();
-    trf.writer.append(nk("r1", "cf1", "cq1", "L1", 55), nv("foo"));
+    trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 55), newValue("foo"));
     trf.closeWriter();
 
     trf.openReader();
     // seek before everything
     trf.seek(null);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("r1", "cf1", "cq1", "L1", 55)));
-    assertTrue(trf.iter.getTopValue().equals(nv("foo")));
+    assertTrue(trf.iter.getTopKey().equals(newKey("r1", "cf1", "cq1", "L1", 55)));
+    assertTrue(trf.iter.getTopValue().equals(newValue("foo")));
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // seek after the key
-    trf.seek(nk("r2", "cf1", "cq1", "L1", 55));
+    trf.seek(newKey("r2", "cf1", "cq1", "L1", 55));
     assertFalse(trf.iter.hasTop());
 
     // seek exactly to the key
-    trf.seek(nk("r1", "cf1", "cq1", "L1", 55));
+    trf.seek(newKey("r1", "cf1", "cq1", "L1", 55));
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("r1", "cf1", "cq1", "L1", 55)));
-    assertTrue(trf.iter.getTopValue().equals(nv("foo")));
+    assertTrue(trf.iter.getTopKey().equals(newKey("r1", "cf1", "cq1", "L1", 55)));
+    assertTrue(trf.iter.getTopValue().equals(newValue("foo")));
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
-    assertEquals(nk("r1", "cf1", "cq1", "L1", 55), trf.reader.getLastKey());
+    assertEquals(newKey("r1", "cf1", "cq1", "L1", 55), trf.reader.getLastKey());
 
     trf.closeReader();
   }
@@ -370,26 +370,26 @@ public class RFileTest {
     ArrayList<Value> expectedValues = new ArrayList<>(10000);
 
     for (int row = 0; row < 4; row++) {
-      String rowS = nf("r_", row);
+      String rowS = formatString("r_", row);
       for (int cf = 0; cf < 4; cf++) {
-        String cfS = nf("cf_", cf);
+        String cfS = formatString("cf_", cf);
         for (int cq = 0; cq < 4; cq++) {
-          String cqS = nf("cq_", cq);
+          String cqS = formatString("cq_", cq);
           for (int cv = 'A'; cv < 'A' + 4; cv++) {
             String cvS = "" + (char) cv;
             for (int ts = 4; ts > 0; ts--) {
-              Key k = nk(rowS, cfS, cqS, cvS, ts);
+              Key k = newKey(rowS, cfS, cqS, cvS, ts);
               // check below ensures when all key sizes are same more than one index block is created
               Assert.assertEquals(27, k.getSize());
               k.setDeleted(true);
-              Value v = nv("" + val);
+              Value v = newValue("" + val);
               trf.writer.append(k, v);
               expectedKeys.add(k);
               expectedValues.add(v);
 
-              k = nk(rowS, cfS, cqS, cvS, ts);
+              k = newKey(rowS, cfS, cqS, cvS, ts);
               Assert.assertEquals(27, k.getSize());
-              v = nv("" + val);
+              v = newValue("" + val);
               trf.writer.append(k, v);
               expectedKeys.add(k);
               expectedValues.add(v);
@@ -401,7 +401,7 @@ public class RFileTest {
       }
     }
 
-    // trf.writer.append(nk("r1","cf1","cq1","L1", 55), nv("foo"));
+    // trf.writer.append(newKey("r1","cf1","cq1","L1", 55), newValue("foo"));
     trf.closeWriter();
 
     trf.openReader();
@@ -531,37 +531,37 @@ public class RFileTest {
 
     trf.openWriter();
 
-    trf.writer.append(nk("r1", "cf1", "cq1", "L1", 55), nv("foo1"));
+    trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 55), newValue("foo1"));
     try {
-      trf.writer.append(nk("r0", "cf1", "cq1", "L1", 55), nv("foo1"));
+      trf.writer.append(newKey("r0", "cf1", "cq1", "L1", 55), newValue("foo1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
     }
 
     try {
-      trf.writer.append(nk("r1", "cf0", "cq1", "L1", 55), nv("foo1"));
+      trf.writer.append(newKey("r1", "cf0", "cq1", "L1", 55), newValue("foo1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
     }
 
     try {
-      trf.writer.append(nk("r1", "cf1", "cq0", "L1", 55), nv("foo1"));
+      trf.writer.append(newKey("r1", "cf1", "cq0", "L1", 55), newValue("foo1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
     }
 
     try {
-      trf.writer.append(nk("r1", "cf1", "cq1", "L0", 55), nv("foo1"));
+      trf.writer.append(newKey("r1", "cf1", "cq1", "L0", 55), newValue("foo1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
     }
 
     try {
-      trf.writer.append(nk("r1", "cf1", "cq1", "L1", 56), nv("foo1"));
+      trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 56), newValue("foo1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
@@ -574,25 +574,25 @@ public class RFileTest {
     TestRFile trf = new TestRFile(conf);
 
     trf.openWriter();
-    trf.writer.append(nk("r1", "cf1", "cq1", "L1", 55), nv("foo1"));
-    trf.writer.append(nk("r1", "cf1", "cq4", "L1", 56), nv("foo2"));
+    trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 55), newValue("foo1"));
+    trf.writer.append(newKey("r1", "cf1", "cq4", "L1", 56), newValue("foo2"));
     trf.closeWriter();
 
     trf.openReader();
 
     // test seeking between keys
-    trf.seek(nk("r1", "cf1", "cq3", "L1", 55));
+    trf.seek(newKey("r1", "cf1", "cq3", "L1", 55));
     assertTrue(trf.iter.hasTop());
-    assertEquals(nk("r1", "cf1", "cq4", "L1", 56), trf.iter.getTopKey());
-    assertEquals(nv("foo2"), trf.iter.getTopValue());
+    assertEquals(newKey("r1", "cf1", "cq4", "L1", 56), trf.iter.getTopKey());
+    assertEquals(newValue("foo2"), trf.iter.getTopValue());
 
     // test seeking right before previous seek
-    trf.seek(nk("r1", "cf1", "cq0", "L1", 55));
+    trf.seek(newKey("r1", "cf1", "cq0", "L1", 55));
     assertTrue(trf.iter.hasTop());
-    assertEquals(nk("r1", "cf1", "cq1", "L1", 55), trf.iter.getTopKey());
-    assertEquals(nv("foo1"), trf.iter.getTopValue());
+    assertEquals(newKey("r1", "cf1", "cq1", "L1", 55), trf.iter.getTopKey());
+    assertEquals(newValue("foo1"), trf.iter.getTopValue());
 
-    assertEquals(nk("r1", "cf1", "cq4", "L1", 56), trf.reader.getLastKey());
+    assertEquals(newKey("r1", "cf1", "cq4", "L1", 56), trf.reader.getLastKey());
 
     trf.closeReader();
   }
@@ -604,7 +604,7 @@ public class RFileTest {
 
     trf.openWriter();
     for (int i = 0; i < 500; i++) {
-      trf.writer.append(nk(nf("r_", i), "cf1", "cq1", "L1", 55), nv("foo1"));
+      trf.writer.append(newKey(formatString("r_", i), "cf1", "cq1", "L1", 55), newValue("foo1"));
     }
 
     trf.closeWriter();
@@ -613,19 +613,19 @@ public class RFileTest {
 
     // repeatedly seek to locations before the first key in the file
     for (int i = 0; i < 10; i++) {
-      trf.seek(nk(nf("q_", i), "cf1", "cq1", "L1", 55));
+      trf.seek(newKey(formatString("q_", i), "cf1", "cq1", "L1", 55));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), "cf1", "cq1", "L1", 55), trf.iter.getTopKey());
-      assertEquals(nv("foo1"), trf.iter.getTopValue());
+      assertEquals(newKey(formatString("r_", 0), "cf1", "cq1", "L1", 55), trf.iter.getTopKey());
+      assertEquals(newValue("foo1"), trf.iter.getTopValue());
     }
 
     // repeatedly seek to locations after the last key in the file
     for (int i = 0; i < 10; i++) {
-      trf.seek(nk(nf("s_", i), "cf1", "cq1", "L1", 55));
+      trf.seek(newKey(formatString("s_", i), "cf1", "cq1", "L1", 55));
       assertFalse(trf.iter.hasTop());
     }
 
-    assertEquals(nk(nf("r_", 499), "cf1", "cq1", "L1", 55), trf.reader.getLastKey());
+    assertEquals(newKey(formatString("r_", 499), "cf1", "cq1", "L1", 55), trf.reader.getLastKey());
 
     trf.closeReader();
   }
@@ -638,7 +638,7 @@ public class RFileTest {
 
     trf.openWriter();
     for (int i = 2; i < 50; i++) {
-      trf.writer.append(nk(nf("r_", i), "cf1", "cq1", "L1", 55), nv("foo" + i));
+      trf.writer.append(newKey(formatString("r_", i), "cf1", "cq1", "L1", 55), newValue("foo" + i));
     }
 
     trf.closeWriter();
@@ -646,38 +646,44 @@ public class RFileTest {
     trf.openReader();
 
     // test that has top returns false when end of range reached
-    trf.iter.seek(new Range(nk(nf("r_", 3), "cf1", "cq1", "L1", 55), true, nk(nf("r_", 4), "cf1", "cq1", "L1", 55), false), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey(formatString("r_", 3), "cf1", "cq1", "L1", 55), true, newKey(formatString("r_", 4), "cf1", "cq1", "L1", 55), false),
+        EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk(nf("r_", 3), "cf1", "cq1", "L1", 55)));
-    assertEquals(nv("foo" + 3), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey(formatString("r_", 3), "cf1", "cq1", "L1", 55)));
+    assertEquals(newValue("foo" + 3), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // test seeking to a range that is between two keys, should not return anything
-    trf.iter.seek(new Range(nk(nf("r_", 4) + "a", "cf1", "cq1", "L1", 55), true, nk(nf("r_", 4) + "b", "cf1", "cq1", "L1", 55), true), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey(formatString("r_", 4) + "a", "cf1", "cq1", "L1", 55), true, newKey(formatString("r_", 4) + "b", "cf1", "cq1", "L1", 55),
+        true), EMPTY_COL_FAMS, false);
     assertFalse(trf.iter.hasTop());
 
     // test seeking to another range after the previously seeked range, that is between the same two keys in the file
     // as the previously seeked range.... this test an optimization on RFile
-    trf.iter.seek(new Range(nk(nf("r_", 4) + "c", "cf1", "cq1", "L1", 55), true, nk(nf("r_", 4) + "d", "cf1", "cq1", "L1", 55), true), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey(formatString("r_", 4) + "c", "cf1", "cq1", "L1", 55), true, newKey(formatString("r_", 4) + "d", "cf1", "cq1", "L1", 55),
+        true), EMPTY_COL_FAMS, false);
     assertFalse(trf.iter.hasTop());
 
-    trf.iter.seek(new Range(nk(nf("r_", 4) + "e", "cf1", "cq1", "L1", 55), true, nk(nf("r_", 4) + "f", "cf1", "cq1", "L1", 55), true), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey(formatString("r_", 4) + "e", "cf1", "cq1", "L1", 55), true, newKey(formatString("r_", 4) + "f", "cf1", "cq1", "L1", 55),
+        true), EMPTY_COL_FAMS, false);
     assertFalse(trf.iter.hasTop());
 
     // now ensure we can seek somewhere, that triggering the optimization does not cause any problems
-    trf.iter.seek(new Range(nk(nf("r_", 5), "cf1", "cq1", "L1", 55), true, nk(nf("r_", 6), "cf1", "cq1", "L1", 55), false), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey(formatString("r_", 5), "cf1", "cq1", "L1", 55), true, newKey(formatString("r_", 6), "cf1", "cq1", "L1", 55), false),
+        EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk(nf("r_", 5), "cf1", "cq1", "L1", 55)));
-    assertEquals(nv("foo" + 5), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey(formatString("r_", 5), "cf1", "cq1", "L1", 55)));
+    assertEquals(newValue("foo" + 5), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // test seeking to range that is before the beginning of the file
-    trf.iter.seek(new Range(nk(nf("r_", 0), "cf1", "cq1", "L1", 55), true, nk(nf("r_", 2), "cf1", "cq1", "L1", 55), false), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey(formatString("r_", 0), "cf1", "cq1", "L1", 55), true, newKey(formatString("r_", 2), "cf1", "cq1", "L1", 55), false),
+        EMPTY_COL_FAMS, false);
     assertFalse(trf.iter.hasTop());
 
-    assertEquals(nk(nf("r_", 49), "cf1", "cq1", "L1", 55), trf.reader.getLastKey());
+    assertEquals(newKey(formatString("r_", 49), "cf1", "cq1", "L1", 55), trf.reader.getLastKey());
 
     trf.reader.close();
   }
@@ -689,7 +695,7 @@ public class RFileTest {
     trf.openWriter();
 
     for (int i = 0; i < 2500; i++) {
-      trf.writer.append(nk(nf("r_", i), "cf1", "cq1", "L1", 42), nv("foo" + i));
+      trf.writer.append(newKey(formatString("r_", i), "cf1", "cq1", "L1", 42), newValue("foo" + i));
     }
 
     trf.closeWriter();
@@ -697,23 +703,23 @@ public class RFileTest {
 
     // test seeking between each key forward
     for (int i = 0; i < 2499; i++) {
-      trf.seek(nk(nf("r_", i), "cf1", "cq1", "L1", 42).followingKey(PartialKey.ROW));
+      trf.seek(newKey(formatString("r_", i), "cf1", "cq1", "L1", 42).followingKey(PartialKey.ROW));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", i + 1), "cf1", "cq1", "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", i + 1), "cf1", "cq1", "L1", 42), trf.iter.getTopKey());
     }
 
     // test seeking between each key forward
     for (int i = 0; i < 2499; i += 2) {
-      trf.seek(nk(nf("r_", i), "cf1", "cq1", "L1", 42).followingKey(PartialKey.ROW));
+      trf.seek(newKey(formatString("r_", i), "cf1", "cq1", "L1", 42).followingKey(PartialKey.ROW));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", i + 1), "cf1", "cq1", "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", i + 1), "cf1", "cq1", "L1", 42), trf.iter.getTopKey());
     }
 
     // test seeking backwards between each key
     for (int i = 2498; i >= 0; i--) {
-      trf.seek(nk(nf("r_", i), "cf1", "cq1", "L1", 42).followingKey(PartialKey.ROW));
+      trf.seek(newKey(formatString("r_", i), "cf1", "cq1", "L1", 42).followingKey(PartialKey.ROW));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", i + 1), "cf1", "cq1", "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", i + 1), "cf1", "cq1", "L1", 42), trf.iter.getTopKey());
     }
 
     trf.closeReader();
@@ -724,7 +730,7 @@ public class RFileTest {
     trf.openWriter();
 
     for (int i = 0; i < 2500; i++) {
-      trf.writer.append(nk(nf("r_", 0), nf("cf_", i), "cq1", "L1", 42), nv("foo" + i));
+      trf.writer.append(newKey(formatString("r_", 0), formatString("cf_", i), "cq1", "L1", 42), newValue("foo" + i));
     }
 
     trf.closeWriter();
@@ -732,23 +738,23 @@ public class RFileTest {
 
     // test seeking between each key forward
     for (int i = 0; i < 2499; i++) {
-      trf.seek(nk(nf("r_", 0), nf("cf_", i), "cq1", "L1", 42).followingKey(PartialKey.ROW_COLFAM));
+      trf.seek(newKey(formatString("r_", 0), formatString("cf_", i), "cq1", "L1", 42).followingKey(PartialKey.ROW_COLFAM));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), nf("cf_", i + 1), "cq1", "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", 0), formatString("cf_", i + 1), "cq1", "L1", 42), trf.iter.getTopKey());
     }
 
     // test seeking between each key forward
     for (int i = 0; i < 2499; i += 2) {
-      trf.seek(nk(nf("r_", 0), nf("cf_", i), "cq1", "L1", 42).followingKey(PartialKey.ROW_COLFAM));
+      trf.seek(newKey(formatString("r_", 0), formatString("cf_", i), "cq1", "L1", 42).followingKey(PartialKey.ROW_COLFAM));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), nf("cf_", i + 1), "cq1", "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", 0), formatString("cf_", i + 1), "cq1", "L1", 42), trf.iter.getTopKey());
     }
 
     // test seeking backwards between each key
     for (int i = 2498; i >= 0; i--) {
-      trf.seek(nk(nf("r_", 0), nf("cf_", i), "cq1", "L1", 42).followingKey(PartialKey.ROW_COLFAM));
+      trf.seek(newKey(formatString("r_", 0), formatString("cf_", i), "cq1", "L1", 42).followingKey(PartialKey.ROW_COLFAM));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), nf("cf_", i + 1), "cq1", "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", 0), formatString("cf_", i + 1), "cq1", "L1", 42), trf.iter.getTopKey());
     }
 
     trf.closeReader();
@@ -759,7 +765,7 @@ public class RFileTest {
     trf.openWriter();
 
     for (int i = 0; i < 2500; i++) {
-      trf.writer.append(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i), "L1", 42), nv("foo" + i));
+      trf.writer.append(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i), "L1", 42), newValue("foo" + i));
     }
 
     trf.closeWriter();
@@ -767,29 +773,29 @@ public class RFileTest {
 
     // test seeking between each key forward
     for (int i = 0; i < 2499; i++) {
-      trf.seek(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i), "L1", 42).followingKey(PartialKey.ROW_COLFAM_COLQUAL));
+      trf.seek(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i), "L1", 42).followingKey(PartialKey.ROW_COLFAM_COLQUAL));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i + 1), "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i + 1), "L1", 42), trf.iter.getTopKey());
     }
 
     // test seeking between each key forward
     for (int i = 0; i < 2499; i += 2) {
-      trf.seek(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i), "L1", 42).followingKey(PartialKey.ROW_COLFAM_COLQUAL));
+      trf.seek(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i), "L1", 42).followingKey(PartialKey.ROW_COLFAM_COLQUAL));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i + 1), "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i + 1), "L1", 42), trf.iter.getTopKey());
     }
 
     // test seeking backwards between each key
     for (int i = 2498; i >= 0; i--) {
-      trf.seek(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i), "L1", 42).followingKey(PartialKey.ROW_COLFAM_COLQUAL));
+      trf.seek(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i), "L1", 42).followingKey(PartialKey.ROW_COLFAM_COLQUAL));
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("r_", 0), nf("cf_", 0), nf("cq_", i + 1), "L1", 42), trf.iter.getTopKey());
+      assertEquals(newKey(formatString("r_", 0), formatString("cf_", 0), formatString("cq_", i + 1), "L1", 42), trf.iter.getTopKey());
     }
 
     trf.closeReader();
   }
 
-  public static Set<ByteSequence> ncfs(String... colFams) {
+  public static Set<ByteSequence> newColFamByteSequence(String... colFams) {
     HashSet<ByteSequence> cfs = new HashSet<>();
 
     for (String cf : colFams) {
@@ -805,135 +811,135 @@ public class RFileTest {
 
     trf.openWriter(false);
 
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
 
-    trf.writer.append(nk("0000", "cf1", "doe,john", "", 4), nv("1123 West Left st"));
-    trf.writer.append(nk("0002", "cf2", "doe,jane", "", 5), nv("1124 East Right st"));
+    trf.writer.append(newKey("0000", "cf1", "doe,john", "", 4), newValue("1123 West Left st"));
+    trf.writer.append(newKey("0002", "cf2", "doe,jane", "", 5), newValue("1124 East Right st"));
 
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
 
-    trf.writer.append(nk("0001", "cf3", "buck,john", "", 4), nv("90 Slum st"));
-    trf.writer.append(nk("0003", "cf4", "buck,jane", "", 5), nv("09 Slum st"));
+    trf.writer.append(newKey("0001", "cf3", "buck,john", "", 4), newValue("90 Slum st"));
+    trf.writer.append(newKey("0003", "cf4", "buck,jane", "", 5), newValue("09 Slum st"));
 
     trf.writer.close();
 
     trf.openReader();
 
     // scan first loc group
-    Range r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf1", "cf2"), true);
+    Range r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf1", "cf2"), true);
     assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0002", "cf2", "doe,jane", "", 5)));
-    assertEquals(nv("1124 East Right st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0002", "cf2", "doe,jane", "", 5)));
+    assertEquals(newValue("1124 East Right st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan second loc group
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf3", "cf4"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf3", "cf4"), true);
     assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0001", "cf3", "buck,john", "", 4)));
-    assertEquals(nv("90 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0001", "cf3", "buck,john", "", 4)));
+    assertEquals(newValue("90 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0003", "cf4", "buck,jane", "", 5)));
-    assertEquals(nv("09 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0003", "cf4", "buck,jane", "", 5)));
+    assertEquals(newValue("09 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan all loc groups
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
     trf.iter.seek(r, EMPTY_COL_FAMS, false);
     assertEquals(2, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0001", "cf3", "buck,john", "", 4)));
-    assertEquals(nv("90 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0001", "cf3", "buck,john", "", 4)));
+    assertEquals(newValue("90 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0002", "cf2", "doe,jane", "", 5)));
-    assertEquals(nv("1124 East Right st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0002", "cf2", "doe,jane", "", 5)));
+    assertEquals(newValue("1124 East Right st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0003", "cf4", "buck,jane", "", 5)));
-    assertEquals(nv("09 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0003", "cf4", "buck,jane", "", 5)));
+    assertEquals(newValue("09 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan no loc groups
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("saint", "dogooder"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("saint", "dogooder"), true);
     assertEquals(0, trf.reader.getNumLocalityGroupsSeeked());
     assertFalse(trf.iter.hasTop());
 
     // scan a subset of second locality group
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf4"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf4"), true);
     assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0003", "cf4", "buck,jane", "", 5)));
-    assertEquals(nv("09 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0003", "cf4", "buck,jane", "", 5)));
+    assertEquals(newValue("09 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan a subset of second locality group
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf3"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf3"), true);
     assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0001", "cf3", "buck,john", "", 4)));
-    assertEquals(nv("90 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0001", "cf3", "buck,john", "", 4)));
+    assertEquals(newValue("90 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan subset of first loc group
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf1"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf1"), true);
     assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan subset of first loc group
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf2"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf2"), true);
     assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0002", "cf2", "doe,jane", "", 5)));
-    assertEquals(nv("1124 East Right st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0002", "cf2", "doe,jane", "", 5)));
+    assertEquals(newValue("1124 East Right st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
     // scan subset of all loc groups
-    r = new Range(nk("0000", "cf1", "doe,john", "", 4), true, nk("0003", "cf4", "buck,jane", "", 5), true);
-    trf.iter.seek(r, ncfs("cf1", "cf4"), true);
+    r = new Range(newKey("0000", "cf1", "doe,john", "", 4), true, newKey("0003", "cf4", "buck,jane", "", 5), true);
+    trf.iter.seek(r, newColFamByteSequence("cf1", "cf4"), true);
     assertEquals(2, trf.reader.getNumLocalityGroupsSeeked());
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0003", "cf4", "buck,jane", "", 5)));
-    assertEquals(nv("09 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0003", "cf4", "buck,jane", "", 5)));
+    assertEquals(newValue("09 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -948,8 +954,8 @@ public class RFileTest {
     TestRFile trf = new TestRFile(conf);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
     trf.writer.startDefaultLocalityGroup();
     trf.writer.close();
 
@@ -963,22 +969,22 @@ public class RFileTest {
     trf = new TestRFile(conf);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
-    trf.writer.append(nk("0000", "cf1", "doe,john", "", 4), nv("1123 West Left st"));
-    trf.writer.append(nk("0002", "cf2", "doe,jane", "", 5), nv("1124 East Right st"));
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.append(newKey("0000", "cf1", "doe,john", "", 4), newValue("1123 West Left st"));
+    trf.writer.append(newKey("0002", "cf2", "doe,jane", "", 5), newValue("1124 East Right st"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
     trf.writer.startDefaultLocalityGroup();
     trf.writer.close();
 
     trf.openReader();
     trf.iter.seek(new Range(new Text(""), null), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0002", "cf2", "doe,jane", "", 5)));
-    assertEquals(nv("1124 East Right st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0002", "cf2", "doe,jane", "", 5)));
+    assertEquals(newValue("1124 East Right st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -988,22 +994,22 @@ public class RFileTest {
     trf = new TestRFile(conf);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
-    trf.writer.append(nk("0001", "cf3", "buck,john", "", 4), nv("90 Slum st"));
-    trf.writer.append(nk("0003", "cf4", "buck,jane", "", 5), nv("09 Slum st"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
+    trf.writer.append(newKey("0001", "cf3", "buck,john", "", 4), newValue("90 Slum st"));
+    trf.writer.append(newKey("0003", "cf4", "buck,jane", "", 5), newValue("09 Slum st"));
     trf.writer.startDefaultLocalityGroup();
     trf.writer.close();
 
     trf.openReader();
     trf.iter.seek(new Range(new Text(""), null), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0001", "cf3", "buck,john", "", 4)));
-    assertEquals(nv("90 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0001", "cf3", "buck,john", "", 4)));
+    assertEquals(newValue("90 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0003", "cf4", "buck,jane", "", 5)));
-    assertEquals(nv("09 Slum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0003", "cf4", "buck,jane", "", 5)));
+    assertEquals(newValue("09 Slum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1013,22 +1019,22 @@ public class RFileTest {
     trf = new TestRFile(conf);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
     trf.writer.startDefaultLocalityGroup();
-    trf.writer.append(nk("0007", "good citizen", "q,john", "", 4), nv("70 Apple st"));
-    trf.writer.append(nk("0008", "model citizen", "q,jane", "", 5), nv("81 Plum st"));
+    trf.writer.append(newKey("0007", "good citizen", "q,john", "", 4), newValue("70 Apple st"));
+    trf.writer.append(newKey("0008", "model citizen", "q,jane", "", 5), newValue("81 Plum st"));
     trf.writer.close();
 
     trf.openReader();
     trf.iter.seek(new Range(new Text(""), null), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0007", "good citizen", "q,john", "", 4)));
-    assertEquals(nv("70 Apple st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0007", "good citizen", "q,john", "", 4)));
+    assertEquals(newValue("70 Apple st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0008", "model citizen", "q,jane", "", 5)));
-    assertEquals(nv("81 Plum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0008", "model citizen", "q,jane", "", 5)));
+    assertEquals(newValue("81 Plum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1038,32 +1044,32 @@ public class RFileTest {
     trf = new TestRFile(conf);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
-    trf.writer.append(nk("0000", "cf1", "doe,john", "", 4), nv("1123 West Left st"));
-    trf.writer.append(nk("0002", "cf2", "doe,jane", "", 5), nv("1124 East Right st"));
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.append(newKey("0000", "cf1", "doe,john", "", 4), newValue("1123 West Left st"));
+    trf.writer.append(newKey("0002", "cf2", "doe,jane", "", 5), newValue("1124 East Right st"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
     trf.writer.startDefaultLocalityGroup();
-    trf.writer.append(nk("0007", "good citizen", "q,john", "", 4), nv("70 Apple st"));
-    trf.writer.append(nk("0008", "model citizen", "q,jane", "", 5), nv("81 Plum st"));
+    trf.writer.append(newKey("0007", "good citizen", "q,john", "", 4), newValue("70 Apple st"));
+    trf.writer.append(newKey("0008", "model citizen", "q,jane", "", 5), newValue("81 Plum st"));
     trf.writer.close();
 
     trf.openReader();
     trf.iter.seek(new Range(new Text(""), null), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0002", "cf2", "doe,jane", "", 5)));
-    assertEquals(nv("1124 East Right st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0002", "cf2", "doe,jane", "", 5)));
+    assertEquals(newValue("1124 East Right st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0007", "good citizen", "q,john", "", 4)));
-    assertEquals(nv("70 Apple st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0007", "good citizen", "q,john", "", 4)));
+    assertEquals(newValue("70 Apple st"), trf.iter.getTopValue());
     trf.iter.next();
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0008", "model citizen", "q,jane", "", 5)));
-    assertEquals(nv("81 Plum st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0008", "model citizen", "q,jane", "", 5)));
+    assertEquals(newValue("81 Plum st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1077,17 +1083,17 @@ public class RFileTest {
     TestRFile trf = new TestRFile(conf);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("3mod10"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("3mod10"));
     for (int i = 3; i < 1024; i += 10) {
-      trf.writer.append(nk(nf("i", i), "3mod10", "", "", i + 2), nv("" + i));
+      trf.writer.append(newKey(formatString("i", i), "3mod10", "", "", i + 2), newValue("" + i));
     }
 
-    trf.writer.startNewLocalityGroup("lg2", ncfs("5mod10", "7mod10"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("5mod10", "7mod10"));
 
     for (int i = 5; i < 1024;) {
-      trf.writer.append(nk(nf("i", i), "5mod10", "", "", i + 2), nv("" + i));
+      trf.writer.append(newKey(formatString("i", i), "5mod10", "", "", i + 2), newValue("" + i));
       i += 2;
-      trf.writer.append(nk(nf("i", i), "7mod10", "", "", i + 2), nv("" + i));
+      trf.writer.append(newKey(formatString("i", i), "7mod10", "", "", i + 2), newValue("" + i));
       i += 8;
     }
 
@@ -1098,7 +1104,7 @@ public class RFileTest {
       if (m10 == 3 || m10 == 5 || m10 == 7)
         continue;
 
-      trf.writer.append(nk(nf("i", i), m10 + "mod10", "", "", i + 2), nv("" + i));
+      trf.writer.append(newKey(formatString("i", i), m10 + "mod10", "", "", i + 2), newValue("" + i));
 
     }
     trf.writer.close();
@@ -1109,26 +1115,26 @@ public class RFileTest {
     assertEquals(3, trf.reader.getNumLocalityGroupsSeeked());
     for (int i = 0; i < 1024; i++) {
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk(nf("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
-      assertEquals(nv("" + i), trf.iter.getTopValue());
+      assertEquals(newKey(formatString("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
+      assertEquals(newValue("" + i), trf.iter.getTopValue());
       trf.iter.next();
     }
     assertFalse(trf.iter.hasTop());
 
     // try reading each of the 10 column families separately
     for (int m = 0; m < 10; m++) {
-      trf.iter.seek(new Range(new Key(), true, null, true), ncfs(m + "mod10"), true);
+      trf.iter.seek(new Range(new Key(), true, null, true), newColFamByteSequence(m + "mod10"), true);
       assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
       for (int i = m; i < 1024; i += 10) {
         assertTrue(trf.iter.hasTop());
-        assertEquals(nk(nf("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
-        assertEquals(nv("" + i), trf.iter.getTopValue());
+        assertEquals(newKey(formatString("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
+        assertEquals(newValue("" + i), trf.iter.getTopValue());
         trf.iter.next();
       }
       assertFalse(trf.iter.hasTop());
 
       // test excluding an individual column family
-      trf.iter.seek(new Range(new Key(), true, null, true), ncfs(m + "mod10"), false);
+      trf.iter.seek(new Range(new Key(), true, null, true), newColFamByteSequence(m + "mod10"), false);
       if (m == 3)
         assertEquals(2, trf.reader.getNumLocalityGroupsSeeked());
       else
@@ -1139,8 +1145,8 @@ public class RFileTest {
           continue;
 
         assertTrue(trf.iter.hasTop());
-        assertEquals(nk(nf("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
-        assertEquals(nv("" + i), trf.iter.getTopValue());
+        assertEquals(newKey(formatString("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
+        assertEquals(newValue("" + i), trf.iter.getTopValue());
         trf.iter.next();
       }
       assertFalse(trf.iter.hasTop());
@@ -1151,20 +1157,20 @@ public class RFileTest {
 
     // try reading from cloned reader at the same time as parent reader
     for (int m = 0; m < 9; m++) {
-      trf.iter.seek(new Range(new Key(), true, null, true), ncfs(m + "mod10"), true);
+      trf.iter.seek(new Range(new Key(), true, null, true), newColFamByteSequence(m + "mod10"), true);
       assertEquals(1, trf.reader.getNumLocalityGroupsSeeked());
-      reader2.seek(new Range(new Key(), true, null, true), ncfs((m + 1) + "mod10"), true);
+      reader2.seek(new Range(new Key(), true, null, true), newColFamByteSequence((m + 1) + "mod10"), true);
       // assertEquals(1, reader2.getNumLocalityGroupsSeeked());
       for (int i = m; i < 1024; i += 10) {
         // System.out.println(m+","+i);
         assertTrue(trf.iter.hasTop());
-        assertEquals(nk(nf("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
-        assertEquals(nv("" + i), trf.iter.getTopValue());
+        assertEquals(newKey(formatString("i", i), (i % 10) + "mod10", "", "", i + 2), trf.iter.getTopKey());
+        assertEquals(newValue("" + i), trf.iter.getTopValue());
         trf.iter.next();
         if (i + 1 < 1024) {
           assertTrue(reader2.hasTop());
-          assertEquals(nk(nf("i", (i + 1)), ((i + 1) % 10) + "mod10", "", "", i + 3), reader2.getTopKey());
-          assertEquals(nv("" + (i + 1)), reader2.getTopValue());
+          assertEquals(newKey(formatString("i", (i + 1)), ((i + 1) % 10) + "mod10", "", "", i + 3), reader2.getTopKey());
+          assertEquals(newValue("" + (i + 1)), reader2.getTopValue());
           reader2.next();
         }
       }
@@ -1183,12 +1189,12 @@ public class RFileTest {
 
     trf.openWriter(false);
 
-    trf.writer.startNewLocalityGroup("lg1", ncfs("a", "b"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
 
-    trf.writer.append(nk("0007", "a", "cq1", "", 4), nv("1"));
+    trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
 
     try {
-      trf.writer.append(nk("0009", "c", "cq1", "", 4), nv("1"));
+      trf.writer.append(newKey("0009", "c", "cq1", "", 4), newValue("1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
@@ -1200,8 +1206,8 @@ public class RFileTest {
 
     trf.iter.seek(new Range(), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertEquals(nk("0007", "a", "cq1", "", 4), trf.iter.getTopKey());
-    assertEquals(nv("1"), trf.iter.getTopValue());
+    assertEquals(newKey("0007", "a", "cq1", "", 4), trf.iter.getTopKey());
+    assertEquals(newValue("1"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1216,21 +1222,21 @@ public class RFileTest {
 
     trf.openWriter(false);
 
-    trf.writer.startNewLocalityGroup("lg1", ncfs("a", "b"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
 
-    trf.writer.append(nk("0007", "a", "cq1", "", 4), nv("1"));
+    trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
 
     trf.writer.startDefaultLocalityGroup();
 
     try {
-      trf.writer.append(nk("0008", "a", "cq1", "", 4), nv("1"));
+      trf.writer.append(newKey("0008", "a", "cq1", "", 4), newValue("1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
     }
 
     try {
-      trf.writer.append(nk("0009", "b", "cq1", "", 4), nv("1"));
+      trf.writer.append(newKey("0009", "b", "cq1", "", 4), newValue("1"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
@@ -1242,8 +1248,8 @@ public class RFileTest {
 
     trf.iter.seek(new Range(), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
-    assertEquals(nk("0007", "a", "cq1", "", 4), trf.iter.getTopKey());
-    assertEquals(nv("1"), trf.iter.getTopValue());
+    assertEquals(newKey("0007", "a", "cq1", "", 4), trf.iter.getTopKey());
+    assertEquals(newValue("1"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1258,7 +1264,7 @@ public class RFileTest {
 
     trf.writer.startDefaultLocalityGroup();
     try {
-      trf.writer.startNewLocalityGroup("lg1", ncfs("a", "b"));
+      trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
       assertFalse(true);
     } catch (IllegalStateException ioe) {
 
@@ -1280,11 +1286,11 @@ public class RFileTest {
 
     trf.openWriter(false);
 
-    trf.writer.startNewLocalityGroup("lg1", ncfs("a", "b"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
 
-    trf.writer.append(nk("0007", "a", "cq1", "", 4), nv("1"));
+    trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
     try {
-      trf.writer.startNewLocalityGroup("lg1", ncfs("b", "c"));
+      trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("b", "c"));
       assertFalse(true);
     } catch (IllegalArgumentException ioe) {
 
@@ -1305,11 +1311,11 @@ public class RFileTest {
 
     trf.writer.startDefaultLocalityGroup();
     for (int i = 0; i < 2048; i++) {
-      trf.writer.append(nk("r0000", "cf1", "cq1", "", 1), nv("" + i));
+      trf.writer.append(newKey("r0000", "cf1", "cq1", "", 1), newValue("" + i));
     }
 
     for (int i = 2048; i < 4096; i++) {
-      trf.writer.append(nk("r0001", "cf1", "cq1", "", 1), nv("" + i));
+      trf.writer.append(newKey("r0001", "cf1", "cq1", "", 1), newValue("" + i));
     }
 
     trf.writer.close();
@@ -1325,55 +1331,55 @@ public class RFileTest {
 
     assertTrue(count > 4);
 
-    trf.iter.seek(new Range(nk("r0000", "cf1", "cq1", "", 1), true, nk("r0001", "cf1", "cq1", "", 1), false), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey("r0000", "cf1", "cq1", "", 1), true, newKey("r0001", "cf1", "cq1", "", 1), false), EMPTY_COL_FAMS, false);
 
     for (int i = 0; i < 2048; i++) {
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk("r0000", "cf1", "cq1", "", 1), trf.iter.getTopKey());
-      assertEquals(nv("" + i), trf.iter.getTopValue());
+      assertEquals(newKey("r0000", "cf1", "cq1", "", 1), trf.iter.getTopKey());
+      assertEquals(newValue("" + i), trf.iter.getTopValue());
       trf.iter.next();
     }
 
     assertFalse(trf.iter.hasTop());
 
-    trf.iter.seek(new Range(nk("r0000", "cf1", "cq1", "", 1), false, nk("r0001", "cf1", "cq1", "", 1), true), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey("r0000", "cf1", "cq1", "", 1), false, newKey("r0001", "cf1", "cq1", "", 1), true), EMPTY_COL_FAMS, false);
 
     for (int i = 2048; i < 4096; i++) {
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk("r0001", "cf1", "cq1", "", 1), trf.iter.getTopKey());
-      assertEquals(nv("" + i), trf.iter.getTopValue());
+      assertEquals(newKey("r0001", "cf1", "cq1", "", 1), trf.iter.getTopKey());
+      assertEquals(newValue("" + i), trf.iter.getTopValue());
       trf.iter.next();
     }
 
     assertFalse(trf.iter.hasTop());
 
-    trf.iter.seek(new Range(nk("r0001", "cf1", "cq1", "", 1), true, nk("r0001", "cf1", "cq1", "", 1), true), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey("r0001", "cf1", "cq1", "", 1), true, newKey("r0001", "cf1", "cq1", "", 1), true), EMPTY_COL_FAMS, false);
 
     for (int i = 2048; i < 4096; i++) {
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk("r0001", "cf1", "cq1", "", 1), trf.iter.getTopKey());
-      assertEquals(nv("" + i), trf.iter.getTopValue());
+      assertEquals(newKey("r0001", "cf1", "cq1", "", 1), trf.iter.getTopKey());
+      assertEquals(newValue("" + i), trf.iter.getTopValue());
       trf.iter.next();
     }
 
     assertFalse(trf.iter.hasTop());
 
-    trf.iter.seek(new Range(nk("r0002", "cf1", "cq1", "", 1), true, nk("r0002", "cf1", "cq1", "", 1), true), EMPTY_COL_FAMS, false);
+    trf.iter.seek(new Range(newKey("r0002", "cf1", "cq1", "", 1), true, newKey("r0002", "cf1", "cq1", "", 1), true), EMPTY_COL_FAMS, false);
     assertFalse(trf.iter.hasTop());
 
     trf.iter.seek(new Range((Key) null, null), EMPTY_COL_FAMS, false);
 
     for (int i = 0; i < 2048; i++) {
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk("r0000", "cf1", "cq1", "", 1), trf.iter.getTopKey());
-      assertEquals(nv("" + i), trf.iter.getTopValue());
+      assertEquals(newKey("r0000", "cf1", "cq1", "", 1), trf.iter.getTopKey());
+      assertEquals(newValue("" + i), trf.iter.getTopValue());
       trf.iter.next();
     }
 
     for (int i = 2048; i < 4096; i++) {
       assertTrue(trf.iter.hasTop());
-      assertEquals(nk("r0001", "cf1", "cq1", "", 1), trf.iter.getTopKey());
-      assertEquals(nv("" + i), trf.iter.getTopValue());
+      assertEquals(newKey("r0001", "cf1", "cq1", "", 1), trf.iter.getTopKey());
+      assertEquals(newValue("" + i), trf.iter.getTopValue());
       trf.iter.next();
     }
 
@@ -1386,7 +1392,7 @@ public class RFileTest {
     return String.format("cf%06d", i);
   }
 
-  private Set<ByteSequence> t18ncfs(int... colFams) {
+  private Set<ByteSequence> t18newColFamByteSequence(int... colFams) {
     HashSet<ByteSequence> cfs = new HashSet<>();
     for (int i : colFams) {
       cfs.add(new ArrayByteSequence(t18ncf(i)));
@@ -1397,7 +1403,7 @@ public class RFileTest {
 
   private void t18Append(TestRFile trf, HashSet<ByteSequence> allCf, int i) throws IOException {
     String cf = t18ncf(i);
-    trf.writer.append(nk("r0000", cf, "cq1", "", 1), nv("" + i));
+    trf.writer.append(newKey("r0000", cf, "cq1", "", 1), newValue("" + i));
     allCf.add(new ArrayByteSequence(cf));
   }
 
@@ -1442,15 +1448,15 @@ public class RFileTest {
 
     HashSet<ByteSequence> allCf = new HashSet<>();
 
-    trf.writer.startNewLocalityGroup("lg1", t18ncfs(0));
+    trf.writer.startNewLocalityGroup("lg1", t18newColFamByteSequence(0));
     for (int i = 0; i < 1; i++)
       t18Append(trf, allCf, i);
 
-    trf.writer.startNewLocalityGroup("lg2", t18ncfs(1, 2));
+    trf.writer.startNewLocalityGroup("lg2", t18newColFamByteSequence(1, 2));
     for (int i = 1; i < 3; i++)
       t18Append(trf, allCf, i);
 
-    trf.writer.startNewLocalityGroup("lg3", t18ncfs(3, 4, 5));
+    trf.writer.startNewLocalityGroup("lg3", t18newColFamByteSequence(3, 4, 5));
     for (int i = 3; i < 6; i++)
       t18Append(trf, allCf, i);
 
@@ -1464,22 +1470,22 @@ public class RFileTest {
 
     trf.openReader();
 
-    t18Verify(t18ncfs(0), trf.iter, trf.reader, allCf, 1, 3);
+    t18Verify(t18newColFamByteSequence(0), trf.iter, trf.reader, allCf, 1, 3);
     for (int i = 1; i < 10; i++)
-      t18Verify(t18ncfs(i), trf.iter, trf.reader, allCf, 1, 4);
+      t18Verify(t18newColFamByteSequence(i), trf.iter, trf.reader, allCf, 1, 4);
 
-    t18Verify(t18ncfs(max + 1), trf.iter, trf.reader, allCf, 1, 4);
+    t18Verify(t18newColFamByteSequence(max + 1), trf.iter, trf.reader, allCf, 1, 4);
 
-    t18Verify(t18ncfs(1, 2, 3, 4), trf.iter, trf.reader, allCf, 2, 3);
-    t18Verify(t18ncfs(1, 2, 3, 4, 5), trf.iter, trf.reader, allCf, 2, 2);
+    t18Verify(t18newColFamByteSequence(1, 2, 3, 4), trf.iter, trf.reader, allCf, 2, 3);
+    t18Verify(t18newColFamByteSequence(1, 2, 3, 4, 5), trf.iter, trf.reader, allCf, 2, 2);
 
-    t18Verify(t18ncfs(0, 1, 2, 3, 4), trf.iter, trf.reader, allCf, 3, 2);
-    t18Verify(t18ncfs(0, 1, 2, 3, 4, 5), trf.iter, trf.reader, allCf, 3, 1);
-    t18Verify(t18ncfs(0, 1, 2, 3, 4, 5, 6), trf.iter, trf.reader, allCf, 4, 1);
+    t18Verify(t18newColFamByteSequence(0, 1, 2, 3, 4), trf.iter, trf.reader, allCf, 3, 2);
+    t18Verify(t18newColFamByteSequence(0, 1, 2, 3, 4, 5), trf.iter, trf.reader, allCf, 3, 1);
+    t18Verify(t18newColFamByteSequence(0, 1, 2, 3, 4, 5, 6), trf.iter, trf.reader, allCf, 4, 1);
 
-    t18Verify(t18ncfs(0, 1), trf.iter, trf.reader, allCf, 2, 3);
-    t18Verify(t18ncfs(2, 3), trf.iter, trf.reader, allCf, 2, 4);
-    t18Verify(t18ncfs(5, 6), trf.iter, trf.reader, allCf, 2, 4);
+    t18Verify(t18newColFamByteSequence(0, 1), trf.iter, trf.reader, allCf, 2, 3);
+    t18Verify(t18newColFamByteSequence(2, 3), trf.iter, trf.reader, allCf, 2, 4);
+    t18Verify(t18newColFamByteSequence(5, 6), trf.iter, trf.reader, allCf, 2, 4);
 
     trf.closeReader();
   }
@@ -1492,10 +1498,10 @@ public class RFileTest {
     trf.openWriter(false);
 
     trf.openWriter(false);
-    trf.writer.startNewLocalityGroup("lg1", ncfs("cf1", "cf2"));
-    trf.writer.append(nk("0000", "cf1", "doe,john", "", 4), nv("1123 West Left st"));
-    trf.writer.append(nk("0002", "cf2", "doe,jane", "", 5), nv("1124 East Right st"));
-    trf.writer.startNewLocalityGroup("lg2", ncfs("cf3", "cf4"));
+    trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("cf1", "cf2"));
+    trf.writer.append(newKey("0000", "cf1", "doe,john", "", 4), newValue("1123 West Left st"));
+    trf.writer.append(newKey("0002", "cf2", "doe,jane", "", 5), newValue("1124 East Right st"));
+    trf.writer.startNewLocalityGroup("lg2", newColFamByteSequence("cf3", "cf4"));
 
     DataOutputStream dos = trf.writer.createMetaStore("count");
 
@@ -1514,8 +1520,8 @@ public class RFileTest {
     trf.iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0000", "cf1", "doe,john", "", 4)));
-    assertEquals(nv("1123 West Left st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0000", "cf1", "doe,john", "", 4)));
+    assertEquals(newValue("1123 West Left st"), trf.iter.getTopValue());
     trf.iter.next();
 
     DataInputStream in = trf.reader.getMetaStore("count");
@@ -1529,8 +1535,8 @@ public class RFileTest {
     in.close();
 
     assertTrue(trf.iter.hasTop());
-    assertTrue(trf.iter.getTopKey().equals(nk("0002", "cf2", "doe,jane", "", 5)));
-    assertEquals(nv("1124 East Right st"), trf.iter.getTopValue());
+    assertTrue(trf.iter.getTopKey().equals(newKey("0002", "cf2", "doe,jane", "", 5)));
+    assertEquals(newValue("1124 East Right st"), trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1544,7 +1550,7 @@ public class RFileTest {
     trf.openWriter();
 
     for (int i = 0; i < 2500; i++) {
-      trf.writer.append(nk(nf("r_", i), "cf1", "cq1", "L1", 42), nv("foo" + i));
+      trf.writer.append(newKey(formatString("r_", i), "cf1", "cq1", "L1", 42), newValue("foo" + i));
     }
 
     trf.closeWriter();
@@ -1557,7 +1563,7 @@ public class RFileTest {
     for (int count = 0; count < 100; count++) {
 
       int start = rand.nextInt(2300);
-      Range range = new Range(nk(nf("r_", start), "cf1", "cq1", "L1", 42), nk(nf("r_", start + 100), "cf1", "cq1", "L1", 42));
+      Range range = new Range(newKey(formatString("r_", start), "cf1", "cq1", "L1", 42), newKey(formatString("r_", start + 100), "cf1", "cq1", "L1", 42));
 
       trf.reader.seek(range, cfs, false);
 
@@ -1565,24 +1571,24 @@ public class RFileTest {
 
       for (int j = 0; j < numToScan; j++) {
         assertTrue(trf.reader.hasTop());
-        assertEquals(nk(nf("r_", start + j), "cf1", "cq1", "L1", 42), trf.reader.getTopKey());
+        assertEquals(newKey(formatString("r_", start + j), "cf1", "cq1", "L1", 42), trf.reader.getTopKey());
         trf.reader.next();
       }
 
       assertTrue(trf.reader.hasTop());
-      assertEquals(nk(nf("r_", start + numToScan), "cf1", "cq1", "L1", 42), trf.reader.getTopKey());
+      assertEquals(newKey(formatString("r_", start + numToScan), "cf1", "cq1", "L1", 42), trf.reader.getTopKey());
 
       // seek a little forward from the last range and read a few keys within the unconsumed portion of the last range
 
       int start2 = start + numToScan + rand.nextInt(3);
       int end2 = start2 + rand.nextInt(3);
 
-      range = new Range(nk(nf("r_", start2), "cf1", "cq1", "L1", 42), nk(nf("r_", end2), "cf1", "cq1", "L1", 42));
+      range = new Range(newKey(formatString("r_", start2), "cf1", "cq1", "L1", 42), newKey(formatString("r_", end2), "cf1", "cq1", "L1", 42));
       trf.reader.seek(range, cfs, false);
 
       for (int j = start2; j <= end2; j++) {
         assertTrue(trf.reader.hasTop());
-        assertEquals(nk(nf("r_", j), "cf1", "cq1", "L1", 42), trf.reader.getTopKey());
+        assertEquals(newKey(formatString("r_", j), "cf1", "cq1", "L1", 42), trf.reader.getTopKey());
         trf.reader.next();
       }
 
@@ -1627,14 +1633,14 @@ public class RFileTest {
     for (int start : new int[] {0, 10, 100, 998}) {
       for (int cf = 1; cf <= 4; cf++) {
         if (start == 0)
-          iter.seek(new Range(), ncfs(nf("cf_", cf)), true);
+          iter.seek(new Range(), newColFamByteSequence(formatString("cf_", cf)), true);
         else
-          iter.seek(new Range(nf("r_", start), null), ncfs(nf("cf_", cf)), true);
+          iter.seek(new Range(formatString("r_", start), null), newColFamByteSequence(formatString("cf_", cf)), true);
 
         for (int i = start; i < 1000; i++) {
           assertTrue(iter.hasTop());
-          assertEquals(nk(nf("r_", i), nf("cf_", cf), nf("cq_", 0), "", 1000 - i), iter.getTopKey());
-          assertEquals(nv(i + ""), iter.getTopValue());
+          assertEquals(newKey(formatString("r_", i), formatString("cf_", cf), formatString("cq_", 0), "", 1000 - i), iter.getTopKey());
+          assertEquals(newValue(i + ""), iter.getTopValue());
           iter.next();
         }
 
@@ -1642,15 +1648,15 @@ public class RFileTest {
       }
 
       if (start == 0)
-        iter.seek(new Range(), ncfs(), false);
+        iter.seek(new Range(), newColFamByteSequence(), false);
       else
-        iter.seek(new Range(nf("r_", start), null), ncfs(), false);
+        iter.seek(new Range(formatString("r_", start), null), newColFamByteSequence(), false);
 
       for (int i = start; i < 1000; i++) {
         for (int cf = 1; cf <= 4; cf++) {
           assertTrue(iter.hasTop());
-          assertEquals(nk(nf("r_", i), nf("cf_", cf), nf("cq_", 0), "", 1000 - i), iter.getTopKey());
-          assertEquals(nv(i + ""), iter.getTopValue());
+          assertEquals(newKey(formatString("r_", i), formatString("cf_", cf), formatString("cq_", 0), "", 1000 - i), iter.getTopKey());
+          assertEquals(newValue(i + ""), iter.getTopValue());
           iter.next();
         }
       }
@@ -1808,7 +1814,7 @@ public class RFileTest {
     conf = null;
   }
 
-  private Key nk(int r, int c) {
+  private Key newKey(int r, int c) {
     String row = String.format("r%06d", r);
     switch (c) {
       case 0:
@@ -1820,7 +1826,7 @@ public class RFileTest {
     }
   }
 
-  private Value nv(int r, int c) {
+  private Value newValue(int r, int c) {
     switch (c) {
       case 0:
         return new Value(("123" + r + " west st").getBytes());
@@ -1936,8 +1942,8 @@ public class RFileTest {
         trf.openWriter();
 
         for (int i = 0; i < num; i++) {
-          add(trf, nk(i, 0), nv(i, 0), dataHasher, sampleData, sampler);
-          add(trf, nk(i, 1), nv(i, 1), dataHasher, sampleData, sampler);
+          add(trf, newKey(i, 0), newValue(i, 0), dataHasher, sampleData, sampler);
+          add(trf, newKey(i, 1), newValue(i, 1), dataHasher, sampleData, sampler);
         }
 
         HashCode expectedDataHash = dataHasher.hash();
@@ -2016,7 +2022,7 @@ public class RFileTest {
 
         trf.openWriter(false, 1000);
 
-        trf.writer.startNewLocalityGroup("meta-lg", ncfs("metaA", "metaB"));
+        trf.writer.startNewLocalityGroup("meta-lg", newColFamByteSequence("metaA", "metaB"));
         for (int r = 0; r < num; r++) {
           String row = String.format("r%06d", r);
           Key k1 = new Key(row, "metaA", "q9", 7);
@@ -2061,13 +2067,13 @@ public class RFileTest {
         trf.openReader(false);
         FileSKVIterator sample = trf.reader.getSample(SamplerConfigurationImpl.newSamplerConfig(sampleConf));
 
-        checkSample(sample, sampleDataLG1, ncfs("metaA", "metaB"), true);
-        checkSample(sample, sampleDataLG1, ncfs("metaA"), true);
-        checkSample(sample, sampleDataLG1, ncfs("metaB"), true);
-        checkSample(sample, sampleDataLG1, ncfs("dataA"), false);
+        checkSample(sample, sampleDataLG1, newColFamByteSequence("metaA", "metaB"), true);
+        checkSample(sample, sampleDataLG1, newColFamByteSequence("metaA"), true);
+        checkSample(sample, sampleDataLG1, newColFamByteSequence("metaB"), true);
+        checkSample(sample, sampleDataLG1, newColFamByteSequence("dataA"), false);
 
-        checkSample(sample, sampleDataLG2, ncfs("metaA", "metaB"), false);
-        checkSample(sample, sampleDataLG2, ncfs("dataA"), true);
+        checkSample(sample, sampleDataLG2, newColFamByteSequence("metaA", "metaB"), false);
+        checkSample(sample, sampleDataLG2, newColFamByteSequence("dataA"), true);
 
         ArrayList<Entry<Key,Value>> allSampleData = new ArrayList<>();
         allSampleData.addAll(sampleDataLG1);
@@ -2080,7 +2086,7 @@ public class RFileTest {
           }
         });
 
-        checkSample(sample, allSampleData, ncfs("dataA", "metaA"), true);
+        checkSample(sample, allSampleData, newColFamByteSequence("dataA", "metaA"), true);
         checkSample(sample, allSampleData, EMPTY_COL_FAMS, false);
 
         trf.closeReader();

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RelativeKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RelativeKeyTest.java
@@ -129,17 +129,17 @@ public class RelativeKeyTest {
     Key prev = null;
     int val = 0;
     for (int row = 0; row < 4; row++) {
-      String rowS = RFileTest.nf("r_", row);
+      String rowS = RFileTest.formatString("r_", row);
       for (int cf = 0; cf < 4; cf++) {
-        String cfS = RFileTest.nf("cf_", cf);
+        String cfS = RFileTest.formatString("cf_", cf);
         for (int cq = 0; cq < 4; cq++) {
-          String cqS = RFileTest.nf("cq_", cq);
+          String cqS = RFileTest.formatString("cq_", cq);
           for (int cv = 'A'; cv < 'A' + 4; cv++) {
             String cvS = "" + (char) cv;
             for (int ts = 4; ts > 0; ts--) {
-              Key k = RFileTest.nk(rowS, cfS, cqS, cvS, ts);
+              Key k = RFileTest.newKey(rowS, cfS, cqS, cvS, ts);
               k.setDeleted(true);
-              Value v = RFileTest.nv("" + val);
+              Value v = RFileTest.newValue("" + val);
               expectedPositions.add(out.size());
               new RelativeKey(prev, k).write(out);
               prev = k;
@@ -147,8 +147,8 @@ public class RelativeKeyTest {
               expectedKeys.add(k);
               expectedValues.add(v);
 
-              k = RFileTest.nk(rowS, cfS, cqS, cvS, ts);
-              v = RFileTest.nv("" + val);
+              k = RFileTest.newKey(rowS, cfS, cqS, cvS, ts);
+              v = RFileTest.newValue("" + val);
               expectedPositions.add(out.size());
               new RelativeKey(prev, k).write(out);
               prev = k;

--- a/core/src/test/java/org/apache/accumulo/core/iterators/AggregatingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/AggregatingIteratorTest.java
@@ -69,31 +69,31 @@ public class AggregatingIteratorTest {
 
   }
 
-  static Key nk(int row, int colf, int colq, long ts, boolean deleted) {
-    Key k = nk(row, colf, colq, ts);
+  static Key newKey(int row, int colf, int colq, long ts, boolean deleted) {
+    Key k = newKey(row, colf, colq, ts);
     k.setDeleted(true);
     return k;
   }
 
-  static Key nk(int row, int colf, int colq, long ts) {
-    return new Key(nr(row), new Text(String.format("cf%03d", colf)), new Text(String.format("cq%03d", colq)), ts);
+  static Key newKey(int row, int colf, int colq, long ts) {
+    return new Key(newRow(row), new Text(String.format("cf%03d", colf)), new Text(String.format("cq%03d", colq)), ts);
   }
 
-  static Range nr(int row, int colf, int colq, long ts, boolean inclusive) {
-    return new Range(nk(row, colf, colq, ts), inclusive, null, true);
+  static Range newRow(int row, int colf, int colq, long ts, boolean inclusive) {
+    return new Range(newKey(row, colf, colq, ts), inclusive, null, true);
   }
 
-  static Range nr(int row, int colf, int colq, long ts) {
-    return nr(row, colf, colq, ts, true);
+  static Range newRow(int row, int colf, int colq, long ts) {
+    return newRow(row, colf, colq, ts, true);
   }
 
-  static void nkv(TreeMap<Key,Value> tm, int row, int colf, int colq, long ts, boolean deleted, String val) {
-    Key k = nk(row, colf, colq, ts);
+  static void newKeyValue(TreeMap<Key,Value> tm, int row, int colf, int colq, long ts, boolean deleted, String val) {
+    Key k = newKey(row, colf, colq, ts);
     k.setDeleted(deleted);
     tm.put(k, new Value(val.getBytes()));
   }
 
-  static Text nr(int row) {
+  static Text newRow(int row) {
     return new Text(String.format("r%03d", row));
   }
 
@@ -104,9 +104,9 @@ public class AggregatingIteratorTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that do not aggregate
-    nkv(tm1, 1, 1, 1, 1, false, "2");
-    nkv(tm1, 1, 1, 1, 2, false, "3");
-    nkv(tm1, 1, 1, 1, 3, false, "4");
+    newKeyValue(tm1, 1, 1, 1, 1, false, "2");
+    newKeyValue(tm1, 1, 1, 1, 2, false, "3");
+    newKeyValue(tm1, 1, 1, 1, 3, false, "4");
 
     AggregatingIterator ai = new AggregatingIterator();
 
@@ -115,19 +115,19 @@ public class AggregatingIteratorTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("4", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 1), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 1), ai.getTopKey());
     assertEquals("2", ai.getTopValue().toString());
 
     ai.next();
@@ -136,16 +136,16 @@ public class AggregatingIteratorTest {
 
     // try seeking
 
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 1), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 1), ai.getTopKey());
     assertEquals("2", ai.getTopValue().toString());
 
     ai.next();
@@ -153,7 +153,7 @@ public class AggregatingIteratorTest {
     assertFalse(ai.hasTop());
 
     // seek after everything
-    ai.seek(nr(1, 1, 1, 0), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 0), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
@@ -165,9 +165,9 @@ public class AggregatingIteratorTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, "2");
-    nkv(tm1, 1, 1, 1, 2, false, "3");
-    nkv(tm1, 1, 1, 1, 3, false, "4");
+    newKeyValue(tm1, 1, 1, 1, 1, false, "2");
+    newKeyValue(tm1, 1, 1, 1, 2, false, "3");
+    newKeyValue(tm1, 1, 1, 1, 3, false, "4");
 
     AggregatingIterator ai = new AggregatingIterator();
 
@@ -179,7 +179,7 @@ public class AggregatingIteratorTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
@@ -188,10 +188,10 @@ public class AggregatingIteratorTest {
 
     // try seeking to the beginning of a key that aggregates
 
-    ai.seek(nr(1, 1, 1, 3), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 3), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
@@ -199,20 +199,20 @@ public class AggregatingIteratorTest {
     assertFalse(ai.hasTop());
 
     // try seeking the middle of a key the aggregates
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
     // try seeking to the end of a key the aggregates
-    ai.seek(nr(1, 1, 1, 1), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 1), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
     // try seeking before a key the aggregates
-    ai.seek(nr(1, 1, 1, 4), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
@@ -227,13 +227,13 @@ public class AggregatingIteratorTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, "2");
-    nkv(tm1, 1, 1, 1, 2, false, "3");
-    nkv(tm1, 1, 1, 1, 3, false, "4");
+    newKeyValue(tm1, 1, 1, 1, 1, false, "2");
+    newKeyValue(tm1, 1, 1, 1, 2, false, "3");
+    newKeyValue(tm1, 1, 1, 1, 3, false, "4");
 
     // keys that do not aggregate
-    nkv(tm1, 2, 2, 1, 1, false, "2");
-    nkv(tm1, 2, 2, 1, 2, false, "3");
+    newKeyValue(tm1, 2, 2, 1, 1, false, "2");
+    newKeyValue(tm1, 2, 2, 1, 2, false, "3");
 
     AggregatingIterator ai = new AggregatingIterator();
 
@@ -245,19 +245,19 @@ public class AggregatingIteratorTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 1), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 1), ai.getTopKey());
     assertEquals("2", ai.getTopValue().toString());
 
     ai.next();
@@ -265,23 +265,23 @@ public class AggregatingIteratorTest {
     assertFalse(ai.hasTop());
 
     // seek after key that aggregates
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
     // seek before key that aggregates
-    ai.seek(nr(1, 1, 1, 4), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
   }
@@ -293,16 +293,16 @@ public class AggregatingIteratorTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that do not aggregate
-    nkv(tm1, 0, 0, 1, 1, false, "7");
+    newKeyValue(tm1, 0, 0, 1, 1, false, "7");
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, "2");
-    nkv(tm1, 1, 1, 1, 2, false, "3");
-    nkv(tm1, 1, 1, 1, 3, false, "4");
+    newKeyValue(tm1, 1, 1, 1, 1, false, "2");
+    newKeyValue(tm1, 1, 1, 1, 2, false, "3");
+    newKeyValue(tm1, 1, 1, 1, 3, false, "4");
 
     // keys that do not aggregate
-    nkv(tm1, 2, 2, 1, 1, false, "2");
-    nkv(tm1, 2, 2, 1, 2, false, "3");
+    newKeyValue(tm1, 2, 2, 1, 1, false, "2");
+    newKeyValue(tm1, 2, 2, 1, 2, false, "3");
 
     AggregatingIterator ai = new AggregatingIterator();
 
@@ -314,25 +314,25 @@ public class AggregatingIteratorTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(0, 0, 1, 1), ai.getTopKey());
+    assertEquals(newKey(0, 0, 1, 1), ai.getTopKey());
     assertEquals("7", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 1), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 1), ai.getTopKey());
     assertEquals("2", ai.getTopValue().toString());
 
     ai.next();
@@ -340,23 +340,23 @@ public class AggregatingIteratorTest {
     assertFalse(ai.hasTop());
 
     // seek test
-    ai.seek(nr(0, 0, 1, 0), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(0, 0, 1, 0), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
     // seek after key that aggregates
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", ai.getTopValue().toString());
 
   }
@@ -368,13 +368,13 @@ public class AggregatingIteratorTest {
     // the exact same keys w/ different values
 
     TreeMap<Key,Value> tm1 = new TreeMap<>();
-    nkv(tm1, 1, 1, 1, 1, false, "2");
+    newKeyValue(tm1, 1, 1, 1, 1, false, "2");
 
     TreeMap<Key,Value> tm2 = new TreeMap<>();
-    nkv(tm2, 1, 1, 1, 1, false, "3");
+    newKeyValue(tm2, 1, 1, 1, 1, false, "3");
 
     TreeMap<Key,Value> tm3 = new TreeMap<>();
-    nkv(tm3, 1, 1, 1, 1, false, "4");
+    newKeyValue(tm3, 1, 1, 1, 1, false, "4");
 
     AggregatingIterator ai = new AggregatingIterator();
     Map<String,String> opts = new HashMap<>();
@@ -390,7 +390,7 @@ public class AggregatingIteratorTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 1), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 1), ai.getTopKey());
     assertEquals("9", ai.getTopValue().toString());
   }
 
@@ -400,9 +400,9 @@ public class AggregatingIteratorTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, "2");
-    nkv(tm1, 1, 1, 1, 2, false, "3");
-    nkv(tm1, 1, 1, 1, 3, false, "4");
+    newKeyValue(tm1, 1, 1, 1, 1, false, "2");
+    newKeyValue(tm1, 1, 1, 1, 2, false, "3");
+    newKeyValue(tm1, 1, 1, 1, 3, false, "4");
 
     AggregatingIterator ai = new AggregatingIterator();
 
@@ -414,7 +414,7 @@ public class AggregatingIteratorTest {
 
     // try seeking to the beginning of a key that aggregates
 
-    ai.seek(nr(1, 1, 1, 3, false), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 3, false), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
@@ -427,9 +427,9 @@ public class AggregatingIteratorTest {
 
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
-    nkv(tm1, 1, 1, 1, 2, true, "");
-    nkv(tm1, 1, 1, 1, 3, false, "4");
-    nkv(tm1, 1, 1, 1, 4, false, "3");
+    newKeyValue(tm1, 1, 1, 1, 2, true, "");
+    newKeyValue(tm1, 1, 1, 1, 3, false, "4");
+    newKeyValue(tm1, 1, 1, 1, 4, false, "3");
 
     AggregatingIterator ai = new AggregatingIterator();
 
@@ -439,29 +439,29 @@ public class AggregatingIteratorTest {
 
     ai.init(new SortedMapIterator(tm1), opts, new DefaultIteratorEnvironment());
 
-    ai.seek(nr(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 4), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 4), ai.getTopKey());
     assertEquals("7", ai.getTopValue().toString());
 
     ai.next();
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2, true), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2, true), ai.getTopKey());
     assertEquals("", ai.getTopValue().toString());
 
     ai.next();
     assertFalse(ai.hasTop());
 
     tm1 = new TreeMap<>();
-    nkv(tm1, 1, 1, 1, 2, true, "");
+    newKeyValue(tm1, 1, 1, 1, 2, true, "");
     ai = new AggregatingIterator();
     ai.init(new SortedMapIterator(tm1), opts, new DefaultIteratorEnvironment());
 
-    ai.seek(nr(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2, true), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2, true), ai.getTopKey());
     assertEquals("", ai.getTopValue().toString());
 
     ai.next();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/FirstEntryInRowTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/FirstEntryInRowTest.java
@@ -37,16 +37,16 @@ public class FirstEntryInRowTest {
   private static final Map<String,String> EMPTY_MAP = new HashMap<>();
   private static final Collection<ByteSequence> EMPTY_SET = new HashSet<>();
 
-  private Key nk(String row, String cf, String cq, long time) {
+  private Key newKey(String row, String cf, String cq, long time) {
     return new Key(new Text(row), new Text(cf), new Text(cq), time);
   }
 
-  private Key nk(int row, int cf, int cq, long time) {
-    return nk(String.format("%06d", row), String.format("%06d", cf), String.format("%06d", cq), time);
+  private Key newKey(int row, int cf, int cq, long time) {
+    return newKey(String.format("%06d", row), String.format("%06d", cf), String.format("%06d", cq), time);
   }
 
   private void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, Value val) {
-    tm.put(nk(row, cf, cq, time), val);
+    tm.put(newKey(row, cf, cq, time), val);
   }
 
   private void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, String val) {
@@ -54,19 +54,19 @@ public class FirstEntryInRowTest {
   }
 
   private void put(TreeMap<Key,Value> tm, int row, int cf, int cq, long time, int val) {
-    tm.put(nk(row, cf, cq, time), new Value((val + "").getBytes()));
+    tm.put(newKey(row, cf, cq, time), new Value((val + "").getBytes()));
   }
 
-  private void aten(FirstEntryInRowIterator rdi, String row, String cf, String cq, long time, String val) throws Exception {
+  private void testAndCallNext(FirstEntryInRowIterator rdi, String row, String cf, String cq, long time, String val) throws Exception {
     assertTrue(rdi.hasTop());
-    assertEquals(nk(row, cf, cq, time), rdi.getTopKey());
+    assertEquals(newKey(row, cf, cq, time), rdi.getTopKey());
     assertEquals(val, rdi.getTopValue().toString());
     rdi.next();
   }
 
-  private void aten(FirstEntryInRowIterator rdi, int row, int cf, int cq, long time, int val) throws Exception {
+  private void testAndCallNext(FirstEntryInRowIterator rdi, int row, int cf, int cq, long time, int val) throws Exception {
     assertTrue(rdi.hasTop());
-    assertEquals(nk(row, cf, cq, time), rdi.getTopKey());
+    assertEquals(newKey(row, cf, cq, time), rdi.getTopKey());
     assertEquals(val, Integer.parseInt(rdi.getTopValue().toString()));
     rdi.next();
   }
@@ -85,9 +85,9 @@ public class FirstEntryInRowTest {
     fei.init(new SortedMapIterator(tm1), EMPTY_MAP, null);
 
     fei.seek(new Range(), EMPTY_SET, false);
-    aten(fei, "r1", "cf1", "cq1", 5, "v1");
-    aten(fei, "r2", "cf1", "cq1", 5, "v3");
-    aten(fei, "r3", "cf3", "cq6", 5, "v6");
+    testAndCallNext(fei, "r1", "cf1", "cq1", 5, "v1");
+    testAndCallNext(fei, "r2", "cf1", "cq1", 5, "v3");
+    testAndCallNext(fei, "r3", "cf3", "cq6", 5, "v6");
     assertFalse(fei.hasTop());
 
   }
@@ -106,21 +106,21 @@ public class FirstEntryInRowTest {
 
     FirstEntryInRowIterator fei = new FirstEntryInRowIterator();
     fei.init(new SortedMapIterator(tm1), EMPTY_MAP, null);
-    fei.seek(new Range(nk(0, 10, 0, 0), null), EMPTY_SET, false);
-    aten(fei, 1, 1, 3, 6, 1 * 1 * 3);
-    aten(fei, 2, 2, 3, 6, 2 * 2 * 3);
-    aten(fei, 3, 3, 3, 6, 3 * 3 * 3);
-    aten(fei, 4, 4, 3, 6, 4 * 4 * 3);
+    fei.seek(new Range(newKey(0, 10, 0, 0), null), EMPTY_SET, false);
+    testAndCallNext(fei, 1, 1, 3, 6, 1 * 1 * 3);
+    testAndCallNext(fei, 2, 2, 3, 6, 2 * 2 * 3);
+    testAndCallNext(fei, 3, 3, 3, 6, 3 * 3 * 3);
+    testAndCallNext(fei, 4, 4, 3, 6, 4 * 4 * 3);
     assertFalse(fei.hasTop());
 
-    fei.seek(new Range(nk(1, 1, 3, 6), nk(3, 3, 3, 6)), EMPTY_SET, false);
-    aten(fei, 1, 1, 3, 6, 1 * 1 * 3);
-    aten(fei, 2, 2, 3, 6, 2 * 2 * 3);
-    aten(fei, 3, 3, 3, 6, 3 * 3 * 3);
+    fei.seek(new Range(newKey(1, 1, 3, 6), newKey(3, 3, 3, 6)), EMPTY_SET, false);
+    testAndCallNext(fei, 1, 1, 3, 6, 1 * 1 * 3);
+    testAndCallNext(fei, 2, 2, 3, 6, 2 * 2 * 3);
+    testAndCallNext(fei, 3, 3, 3, 6, 3 * 3 * 3);
     assertFalse(fei.hasTop());
 
-    fei.seek(new Range(nk(1, 1, 3, 6), false, nk(3, 3, 3, 6), false), EMPTY_SET, false);
-    aten(fei, 2, 2, 3, 6, 2 * 2 * 3);
+    fei.seek(new Range(newKey(1, 1, 3, 6), false, newKey(3, 3, 3, 6), false), EMPTY_SET, false);
+    testAndCallNext(fei, 2, 2, 3, 6, 2 * 2 * 3);
     assertFalse(fei.hasTop());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -133,8 +133,8 @@ public class IteratorUtilTest {
 
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    MultiIteratorTest.nkv(tm, 1, 0, false, "1");
-    MultiIteratorTest.nkv(tm, 2, 0, false, "2");
+    MultiIteratorTest.newKeyValue(tm, 1, 0, false, "1");
+    MultiIteratorTest.newKeyValue(tm, 2, 0, false, "2");
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
@@ -143,13 +143,13 @@ public class IteratorUtilTest {
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(1, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(1, 0)));
     assertTrue(iter.getTopValue().toString().equals("4"));
 
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(2, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(2, 0)));
     assertTrue(iter.getTopValue().toString().equals("9"));
 
     iter.next();
@@ -165,8 +165,8 @@ public class IteratorUtilTest {
 
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    MultiIteratorTest.nkv(tm, 1, 0, false, "1");
-    MultiIteratorTest.nkv(tm, 2, 0, false, "2");
+    MultiIteratorTest.newKeyValue(tm, 1, 0, false, "1");
+    MultiIteratorTest.newKeyValue(tm, 2, 0, false, "2");
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
@@ -175,13 +175,13 @@ public class IteratorUtilTest {
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(1, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(1, 0)));
     assertTrue(iter.getTopValue().toString().equals("1"));
 
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(2, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(2, 0)));
     assertTrue(iter.getTopValue().toString().equals("2"));
 
     iter.next();
@@ -198,8 +198,8 @@ public class IteratorUtilTest {
 
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    MultiIteratorTest.nkv(tm, 1, 0, false, "1");
-    MultiIteratorTest.nkv(tm, 2, 0, false, "2");
+    MultiIteratorTest.newKeyValue(tm, 1, 0, false, "1");
+    MultiIteratorTest.newKeyValue(tm, 2, 0, false, "2");
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
@@ -211,13 +211,13 @@ public class IteratorUtilTest {
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(1, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(1, 0)));
     assertTrue(iter.getTopValue().toString().equals("2"));
 
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(2, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(2, 0)));
     assertTrue(iter.getTopValue().toString().equals("5"));
 
     iter.next();
@@ -237,8 +237,8 @@ public class IteratorUtilTest {
 
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    MultiIteratorTest.nkv(tm, 1, 0, false, "1");
-    MultiIteratorTest.nkv(tm, 2, 0, false, "2");
+    MultiIteratorTest.newKeyValue(tm, 1, 0, false, "1");
+    MultiIteratorTest.newKeyValue(tm, 2, 0, false, "2");
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
@@ -247,13 +247,13 @@ public class IteratorUtilTest {
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(1, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(1, 0)));
     assertTrue(iter.getTopValue().toString().equals("64"));
 
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(2, 0)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(2, 0)));
     assertTrue(iter.getTopValue().toString().equals("81"));
 
     iter.next();
@@ -273,8 +273,8 @@ public class IteratorUtilTest {
 
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    MultiIteratorTest.nkv(tm, 1, 850, false, "1");
-    MultiIteratorTest.nkv(tm, 2, 950, false, "2");
+    MultiIteratorTest.newKeyValue(tm, 1, 850, false, "1");
+    MultiIteratorTest.newKeyValue(tm, 2, 950, false, "2");
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
@@ -283,7 +283,7 @@ public class IteratorUtilTest {
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(iter.hasTop());
-    assertTrue(iter.getTopKey().equals(MultiIteratorTest.nk(2, 950)));
+    assertTrue(iter.getTopKey().equals(MultiIteratorTest.newKey(2, 950)));
     iter.next();
 
     assertFalse(iter.hasTop());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIteratorTest.java
@@ -34,16 +34,16 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
 
   private static final Collection<ByteSequence> EMPTY_SET = new HashSet<>();
 
-  Key nk(String row, String cf, String cq, long time) {
+  Key newKey(String row, String cf, String cq, long time) {
     return new Key(new Text(row), new Text(cf), new Text(cq), time);
   }
 
-  Key nk(int row, int cf, int cq, long time) {
-    return nk(String.format("%06d", row), String.format("%06d", cf), String.format("%06d", cq), time);
+  Key newKey(int row, int cf, int cq, long time) {
+    return newKey(String.format("%06d", row), String.format("%06d", cf), String.format("%06d", cq), time);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, Value val) {
-    tm.put(nk(row, cf, cq, time), val);
+    tm.put(newKey(row, cf, cq, time), val);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, String val) {
@@ -51,12 +51,12 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
   }
 
   void put(TreeMap<Key,Value> tm, int row, int cf, int cq, long time, int val) {
-    tm.put(nk(row, cf, cq, time), new Value((val + "").getBytes()));
+    tm.put(newKey(row, cf, cq, time), new Value((val + "").getBytes()));
   }
 
-  private void aten(ColumnFamilySkippingIterator rdi, String row, String cf, String cq, long time, String val) throws Exception {
+  private void testAndCallnext(ColumnFamilySkippingIterator rdi, String row, String cf, String cq, long time, String val) throws Exception {
     assertTrue(rdi.hasTop());
-    assertEquals(nk(row, cf, cq, time), rdi.getTopKey());
+    assertEquals(newKey(row, cf, cq, time), rdi.getTopKey());
     assertEquals(val, rdi.getTopValue().toString());
     rdi.next();
   }
@@ -87,22 +87,22 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
     HashSet<ByteSequence> colfams = new HashSet<>();
     colfams.add(new ArrayByteSequence("cf2"));
     cfi.seek(new Range(), colfams, true);
-    aten(cfi, "r2", "cf2", "cq4", 5, "v4");
-    aten(cfi, "r2", "cf2", "cq5", 5, "v5");
+    testAndCallnext(cfi, "r2", "cf2", "cq4", 5, "v4");
+    testAndCallnext(cfi, "r2", "cf2", "cq5", 5, "v5");
     assertFalse(cfi.hasTop());
 
     colfams.add(new ArrayByteSequence("cf3"));
     colfams.add(new ArrayByteSequence("cf4"));
     cfi.seek(new Range(), colfams, true);
-    aten(cfi, "r2", "cf2", "cq4", 5, "v4");
-    aten(cfi, "r2", "cf2", "cq5", 5, "v5");
-    aten(cfi, "r3", "cf3", "cq6", 5, "v6");
+    testAndCallnext(cfi, "r2", "cf2", "cq4", 5, "v4");
+    testAndCallnext(cfi, "r2", "cf2", "cq5", 5, "v5");
+    testAndCallnext(cfi, "r3", "cf3", "cq6", 5, "v6");
     assertFalse(cfi.hasTop());
 
     cfi.seek(new Range(), colfams, false);
-    aten(cfi, "r1", "cf1", "cq1", 5, "v1");
-    aten(cfi, "r1", "cf1", "cq3", 5, "v2");
-    aten(cfi, "r2", "cf1", "cq1", 5, "v3");
+    testAndCallnext(cfi, "r1", "cf1", "cq1", 5, "v1");
+    testAndCallnext(cfi, "r1", "cf1", "cq3", 5, "v2");
+    testAndCallnext(cfi, "r2", "cf1", "cq1", 5, "v3");
     assertFalse(cfi.hasTop());
 
   }
@@ -204,11 +204,11 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
     HashSet<ByteSequence> colfams = new HashSet<>();
     colfams.add(new ArrayByteSequence(String.format("%06d", 4)));
 
-    Range range = new Range(nk(0, 4, 0, 6), true, nk(0, 400, 0, 6), true);
+    Range range = new Range(newKey(0, 4, 0, 6), true, newKey(0, 400, 0, 6), true);
     cfi.seek(range, colfams, true);
 
     assertTrue(cfi.hasTop());
-    assertEquals(nk(0, 4, 0, 6), cfi.getTopKey());
+    assertEquals(newKey(0, 4, 0, 6), cfi.getTopKey());
     cfi.next();
     assertFalse(cfi.hasTop());
 
@@ -216,21 +216,21 @@ public class ColumnFamilySkippingIteratorTest extends TestCase {
     cfi.seek(range, colfams, true);
 
     assertTrue(cfi.hasTop());
-    assertEquals(nk(0, 4, 0, 6), cfi.getTopKey());
+    assertEquals(newKey(0, 4, 0, 6), cfi.getTopKey());
     cfi.next();
     assertFalse(cfi.hasTop());
 
-    range = new Range(nk(0, 4, 0, 6), true, nk(1, 400, 0, 6), true);
+    range = new Range(newKey(0, 4, 0, 6), true, newKey(1, 400, 0, 6), true);
     cfi.seek(range, colfams, true);
 
     assertTrue(cfi.hasTop());
-    assertEquals(nk(0, 4, 0, 6), cfi.getTopKey());
+    assertEquals(newKey(0, 4, 0, 6), cfi.getTopKey());
     cfi.next();
     assertTrue(cfi.hasTop());
-    assertEquals(nk(0, 500, 0, 6), cfi.getTopKey());
+    assertEquals(newKey(0, 500, 0, 6), cfi.getTopKey());
     cfi.next();
     assertTrue(cfi.hasTop());
-    assertEquals(nk(1, 4, 0, 6), cfi.getTopKey());
+    assertEquals(newKey(1, 4, 0, 6), cfi.getTopKey());
     cfi.next();
     assertFalse(cfi.hasTop());
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
@@ -27,52 +27,52 @@ import org.apache.hadoop.io.Text;
 
 public class ColumnFilterTest extends TestCase {
 
-  Key nk(String row, String cf, String cq) {
+  Key newKey(String row, String cf, String cq) {
     return new Key(new Text(row), new Text(cf), new Text(cq));
   }
 
-  Column nc(String cf) {
+  Column newColumn(String cf) {
     return new Column(cf.getBytes(), null, null);
   }
 
-  Column nc(String cf, String cq) {
+  Column newColumn(String cf, String cq) {
     return new Column(cf.getBytes(), cq.getBytes(), null);
   }
 
   public void test1() {
     HashSet<Column> columns = new HashSet<>();
 
-    columns.add(nc("cf1"));
+    columns.add(newColumn("cf1"));
 
     ColumnQualifierFilter cf = new ColumnQualifierFilter(null, columns);
 
-    assertTrue(cf.accept(nk("r1", "cf1", "cq1"), new Value(new byte[0])));
-    assertTrue(cf.accept(nk("r1", "cf2", "cq1"), new Value(new byte[0])));
+    assertTrue(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
+    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
 
   }
 
   public void test2() {
     HashSet<Column> columns = new HashSet<>();
 
-    columns.add(nc("cf1"));
-    columns.add(nc("cf2", "cq1"));
+    columns.add(newColumn("cf1"));
+    columns.add(newColumn("cf2", "cq1"));
 
     ColumnQualifierFilter cf = new ColumnQualifierFilter(null, columns);
 
-    assertTrue(cf.accept(nk("r1", "cf1", "cq1"), new Value(new byte[0])));
-    assertTrue(cf.accept(nk("r1", "cf2", "cq1"), new Value(new byte[0])));
-    assertFalse(cf.accept(nk("r1", "cf2", "cq2"), new Value(new byte[0])));
+    assertTrue(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
+    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
+    assertFalse(cf.accept(newKey("r1", "cf2", "cq2"), new Value(new byte[0])));
   }
 
   public void test3() {
     HashSet<Column> columns = new HashSet<>();
 
-    columns.add(nc("cf2", "cq1"));
+    columns.add(newColumn("cf2", "cq1"));
 
     ColumnQualifierFilter cf = new ColumnQualifierFilter(null, columns);
 
-    assertFalse(cf.accept(nk("r1", "cf1", "cq1"), new Value(new byte[0])));
-    assertTrue(cf.accept(nk("r1", "cf2", "cq1"), new Value(new byte[0])));
-    assertFalse(cf.accept(nk("r1", "cf2", "cq2"), new Value(new byte[0])));
+    assertFalse(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
+    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
+    assertFalse(cf.accept(newKey("r1", "cf2", "cq2"), new Value(new byte[0])));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
@@ -117,24 +117,24 @@ public class DeletingIteratorTest extends TestCase {
   public void test2() throws IOException {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    nkv(tm, "r000", 4, false, "v4");
-    nkv(tm, "r000", 3, false, "v3");
-    nkv(tm, "r000", 2, true, "v2");
-    nkv(tm, "r000", 1, false, "v1");
+    newKeyValue(tm, "r000", 4, false, "v4");
+    newKeyValue(tm, "r000", 3, false, "v3");
+    newKeyValue(tm, "r000", 2, true, "v2");
+    newKeyValue(tm, "r000", 1, false, "v1");
 
     DeletingIterator it = new DeletingIterator(new SortedMapIterator(tm), false);
 
     // SEEK two keys before delete
-    it.seek(nr("r000", 4), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 4), EMPTY_COL_FAMS, false);
 
     assertTrue(it.hasTop());
-    assertEquals(nk("r000", 4), it.getTopKey());
+    assertEquals(newKey("r000", 4), it.getTopKey());
     assertEquals("v4", it.getTopValue().toString());
 
     it.next();
 
     assertTrue(it.hasTop());
-    assertEquals(nk("r000", 3), it.getTopKey());
+    assertEquals(newKey("r000", 3), it.getTopKey());
     assertEquals("v3", it.getTopValue().toString());
 
     it.next();
@@ -142,20 +142,20 @@ public class DeletingIteratorTest extends TestCase {
     assertFalse(it.hasTop());
 
     // SEEK passed delete
-    it.seek(nr("r000", 1), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 1), EMPTY_COL_FAMS, false);
 
     assertFalse(it.hasTop());
 
     // SEEK to delete
-    it.seek(nr("r000", 2), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 2), EMPTY_COL_FAMS, false);
 
     assertFalse(it.hasTop());
 
     // SEEK right before delete
-    it.seek(nr("r000", 3), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 3), EMPTY_COL_FAMS, false);
 
     assertTrue(it.hasTop());
-    assertEquals(nk("r000", 3), it.getTopKey());
+    assertEquals(newKey("r000", 3), it.getTopKey());
     assertEquals("v3", it.getTopValue().toString());
 
     it.next();
@@ -167,23 +167,23 @@ public class DeletingIteratorTest extends TestCase {
   public void test3() throws IOException {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    nkv(tm, "r000", 3, false, "v3");
-    nkv(tm, "r000", 2, false, "v2");
-    nkv(tm, "r000", 2, true, "");
-    nkv(tm, "r000", 1, false, "v1");
+    newKeyValue(tm, "r000", 3, false, "v3");
+    newKeyValue(tm, "r000", 2, false, "v2");
+    newKeyValue(tm, "r000", 2, true, "");
+    newKeyValue(tm, "r000", 1, false, "v1");
 
     DeletingIterator it = new DeletingIterator(new SortedMapIterator(tm), false);
     it.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(it.hasTop());
-    assertEquals(nk("r000", 3), it.getTopKey());
+    assertEquals(newKey("r000", 3), it.getTopKey());
     assertEquals("v3", it.getTopValue().toString());
 
     it.next();
 
     assertFalse(it.hasTop());
 
-    it.seek(nr("r000", 2), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 2), EMPTY_COL_FAMS, false);
 
     assertFalse(it.hasTop());
   }
@@ -192,42 +192,42 @@ public class DeletingIteratorTest extends TestCase {
   public void test4() throws IOException {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    nkv(tm, "r000", 3, false, "v3");
-    nkv(tm, "r000", 2, false, "v2");
-    nkv(tm, "r000", 2, true, "");
-    nkv(tm, "r000", 1, false, "v1");
+    newKeyValue(tm, "r000", 3, false, "v3");
+    newKeyValue(tm, "r000", 2, false, "v2");
+    newKeyValue(tm, "r000", 2, true, "");
+    newKeyValue(tm, "r000", 1, false, "v1");
 
     DeletingIterator it = new DeletingIterator(new SortedMapIterator(tm), false);
 
-    it.seek(nr("r000", 3), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 3), EMPTY_COL_FAMS, false);
 
     assertTrue(it.hasTop());
-    assertEquals(nk("r000", 3), it.getTopKey());
+    assertEquals(newKey("r000", 3), it.getTopKey());
     assertEquals("v3", it.getTopValue().toString());
 
     it.next();
 
     assertFalse(it.hasTop());
 
-    it.seek(nr("r000", 3, false), EMPTY_COL_FAMS, false);
+    it.seek(newRange("r000", 3, false), EMPTY_COL_FAMS, false);
 
     assertFalse(it.hasTop());
   }
 
-  private Range nr(String row, long ts, boolean inclusive) {
-    return new Range(nk(row, ts), inclusive, null, true);
+  private Range newRange(String row, long ts, boolean inclusive) {
+    return new Range(newKey(row, ts), inclusive, null, true);
   }
 
-  private Range nr(String row, long ts) {
-    return nr(row, ts, true);
+  private Range newRange(String row, long ts) {
+    return newRange(row, ts, true);
   }
 
-  private Key nk(String row, long ts) {
+  private Key newKey(String row, long ts) {
     return new Key(new Text(row), ts);
   }
 
-  private void nkv(TreeMap<Key,Value> tm, String row, long ts, boolean deleted, String val) {
-    Key k = nk(row, ts);
+  private void newKeyValue(TreeMap<Key,Value> tm, String row, long ts, boolean deleted, String val) {
+    Key k = newKey(row, ts);
     k.setDeleted(deleted);
     tm.put(k, new Value(val.getBytes()));
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -38,21 +38,21 @@ public class MultiIteratorTest extends TestCase {
 
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
-  public static Key nk(int row, long ts) {
-    return new Key(nr(row), ts);
+  public static Key newKey(int row, long ts) {
+    return new Key(newRow(row), ts);
   }
 
-  public static Range nrng(int row, long ts) {
-    return new Range(nk(row, ts), null);
+  public static Range newRange(int row, long ts) {
+    return new Range(newKey(row, ts), null);
   }
 
-  public static void nkv(TreeMap<Key,Value> tm, int row, long ts, boolean deleted, String val) {
-    Key k = nk(row, ts);
+  public static void newKeyValue(TreeMap<Key,Value> tm, int row, long ts, boolean deleted, String val) {
+    Key k = newKey(row, ts);
     k.setDeleted(deleted);
     tm.put(k, new Value(val.getBytes()));
   }
 
-  public static Text nr(int row) {
+  public static Text newRow(int row) {
     return new Text(String.format("r%03d", row));
   }
 
@@ -85,9 +85,9 @@ public class MultiIteratorTest extends TestCase {
     int i = start;
     while (mi.hasTop()) {
       if (incrRow)
-        assertEquals(nk(i, 0), mi.getTopKey());
+        assertEquals(newKey(i, 0), mi.getTopKey());
       else
-        assertEquals(nk(0, i), mi.getTopKey());
+        assertEquals(newKey(0, i), mi.getTopKey());
 
       assertEquals("v" + i, mi.getTopValue().toString());
 
@@ -125,19 +125,19 @@ public class MultiIteratorTest extends TestCase {
     List<TreeMap<Key,Value>> tmpList = new ArrayList<>(2);
 
     for (int i = 0; i < 4; i++) {
-      nkv(tm1, 0, i, false, "v" + i);
+      newKeyValue(tm1, 0, i, false, "v" + i);
     }
     tmpList.add(tm1);
     tm1 = new TreeMap<>();
     for (int i = 4; i < 8; i++) {
-      nkv(tm1, 0, i, false, "v" + i);
+      newKeyValue(tm1, 0, i, false, "v" + i);
     }
     tmpList.add(tm1);
     for (int seek = -1; seek < 8; seek++) {
       if (seek == 7) {
         verify(seek, null, tmpList);
       }
-      verify(seek, nk(0, seek), tmpList);
+      verify(seek, newKey(0, seek), tmpList);
     }
   }
 
@@ -150,9 +150,9 @@ public class MultiIteratorTest extends TestCase {
 
     for (int i = 0; i < 8; i++) {
       if (i % 2 == 0)
-        nkv(tm1, 0, i, false, "v" + i);
+        newKeyValue(tm1, 0, i, false, "v" + i);
       else
-        nkv(tm2, 0, i, false, "v" + i);
+        newKeyValue(tm2, 0, i, false, "v" + i);
     }
     tmpList.add(tm1);
     tmpList.add(tm2);
@@ -160,7 +160,7 @@ public class MultiIteratorTest extends TestCase {
       if (seek == 7) {
         verify(seek, null, tmpList);
       }
-      verify(seek, nk(0, seek), tmpList);
+      verify(seek, newKey(0, seek), tmpList);
     }
   }
 
@@ -171,7 +171,7 @@ public class MultiIteratorTest extends TestCase {
     List<TreeMap<Key,Value>> tmpList = new ArrayList<>(2);
 
     for (int i = 0; i < 8; i++) {
-      nkv(tm1, 0, i, false, "v" + i);
+      newKeyValue(tm1, 0, i, false, "v" + i);
     }
     tmpList.add(tm1);
 
@@ -179,7 +179,7 @@ public class MultiIteratorTest extends TestCase {
       if (seek == 7) {
         verify(seek, null, tmpList);
       }
-      verify(seek, nk(0, seek), tmpList);
+      verify(seek, newKey(0, seek), tmpList);
     }
   }
 
@@ -194,7 +194,7 @@ public class MultiIteratorTest extends TestCase {
 
     assertFalse(mi.hasTop());
 
-    mi.seek(nrng(0, 6), EMPTY_COL_FAMS, false);
+    mi.seek(newRange(0, 6), EMPTY_COL_FAMS, false);
     assertFalse(mi.hasTop());
   }
 
@@ -207,16 +207,16 @@ public class MultiIteratorTest extends TestCase {
 
     for (int i = 0; i < 8; i++) {
       if (i % 2 == 0)
-        nkv(tm1, i, 0, false, "v" + i);
+        newKeyValue(tm1, i, 0, false, "v" + i);
       else
-        nkv(tm2, i, 0, false, "v" + i);
+        newKeyValue(tm2, i, 0, false, "v" + i);
     }
 
     tmpList.add(tm1);
     tmpList.add(tm2);
     for (int seek = -1; seek < 9; seek++) {
-      verify(Math.max(0, seek), 8, nk(seek, 0), null, null, true, true, tmpList);
-      verify(Math.max(0, seek), 8, nk(seek, 0), null, null, false, true, tmpList);
+      verify(Math.max(0, seek), 8, newKey(seek, 0), null, null, true, true, tmpList);
+      verify(Math.max(0, seek), 8, newKey(seek, 0), null, null, false, true, tmpList);
 
       for (int er = seek; er < 10; er++) {
 
@@ -227,9 +227,9 @@ public class MultiIteratorTest extends TestCase {
           noSeekEnd = 0;
         }
 
-        verify(0, noSeekEnd, null, nr(er), null, true, true, tmpList);
-        verify(Math.max(0, seek), end, nk(seek, 0), nr(er), null, true, true, tmpList);
-        verify(Math.max(0, seek), end, nk(seek, 0), nr(er), null, false, true, tmpList);
+        verify(0, noSeekEnd, null, newRow(er), null, true, true, tmpList);
+        verify(Math.max(0, seek), end, newKey(seek, 0), newRow(er), null, true, true, tmpList);
+        verify(Math.max(0, seek), end, newKey(seek, 0), newRow(er), null, false, true, tmpList);
 
         for (int per = -1; per < er; per++) {
 
@@ -247,9 +247,9 @@ public class MultiIteratorTest extends TestCase {
             noSeekEnd = noSeekStart;
           }
 
-          verify(noSeekStart, noSeekEnd, null, nr(er), nr(per), true, true, tmpList);
-          verify(Math.max(0, start), end, nk(seek, 0), nr(er), nr(per), true, true, tmpList);
-          verify(Math.max(0, start), end, nk(seek, 0), nr(er), nr(per), false, true, tmpList);
+          verify(noSeekStart, noSeekEnd, null, newRow(er), newRow(per), true, true, tmpList);
+          verify(Math.max(0, start), end, newKey(seek, 0), newRow(er), newRow(per), true, true, tmpList);
+          verify(Math.max(0, start), end, newKey(seek, 0), newRow(er), newRow(per), false, true, tmpList);
         }
       }
     }
@@ -258,70 +258,70 @@ public class MultiIteratorTest extends TestCase {
   public void test6() throws IOException {
     // TEst setting an endKey
     TreeMap<Key,Value> tm1 = new TreeMap<>();
-    nkv(tm1, 3, 0, false, "1");
-    nkv(tm1, 4, 0, false, "2");
-    nkv(tm1, 6, 0, false, "3");
+    newKeyValue(tm1, 3, 0, false, "1");
+    newKeyValue(tm1, 4, 0, false, "2");
+    newKeyValue(tm1, 6, 0, false, "3");
 
     List<SortedKeyValueIterator<Key,Value>> skvil = new ArrayList<>(1);
     skvil.add(new SortedMapIterator(tm1));
     MultiIterator mi = new MultiIterator(skvil, true);
-    mi.seek(new Range(null, true, nk(5, 9), false), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(null, true, newKey(5, 9), false), EMPTY_COL_FAMS, false);
 
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(3, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(3, 0)));
     assertTrue(mi.getTopValue().toString().equals("1"));
     mi.next();
 
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(4, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(4, 0)));
     assertTrue(mi.getTopValue().toString().equals("2"));
     mi.next();
 
     assertFalse(mi.hasTop());
 
-    mi.seek(new Range(nk(4, 10), true, nk(5, 9), false), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(newKey(4, 10), true, newKey(5, 9), false), EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(4, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(4, 0)));
     assertTrue(mi.getTopValue().toString().equals("2"));
     mi.next();
 
     assertFalse(mi.hasTop());
 
-    mi.seek(new Range(nk(4, 10), true, nk(6, 0), false), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(newKey(4, 10), true, newKey(6, 0), false), EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(4, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(4, 0)));
     assertTrue(mi.getTopValue().toString().equals("2"));
     mi.next();
 
     assertFalse(mi.hasTop());
 
-    mi.seek(new Range(nk(4, 10), true, nk(6, 0), true), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(newKey(4, 10), true, newKey(6, 0), true), EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(4, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(4, 0)));
     assertTrue(mi.getTopValue().toString().equals("2"));
     mi.next();
 
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(6, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(6, 0)));
     assertTrue(mi.getTopValue().toString().equals("3"));
     mi.next();
 
     assertFalse(mi.hasTop());
 
-    mi.seek(new Range(nk(4, 0), true, nk(6, 0), false), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(newKey(4, 0), true, newKey(6, 0), false), EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(4, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(4, 0)));
     assertTrue(mi.getTopValue().toString().equals("2"));
     mi.next();
 
     assertFalse(mi.hasTop());
 
-    mi.seek(new Range(nk(4, 0), false, nk(6, 0), false), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(newKey(4, 0), false, newKey(6, 0), false), EMPTY_COL_FAMS, false);
     assertFalse(mi.hasTop());
 
-    mi.seek(new Range(nk(4, 0), false, nk(6, 0), true), EMPTY_COL_FAMS, false);
+    mi.seek(new Range(newKey(4, 0), false, newKey(6, 0), true), EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
-    assertTrue(mi.getTopKey().equals(nk(6, 0)));
+    assertTrue(mi.getTopKey().equals(newKey(6, 0)));
     assertTrue(mi.getTopValue().toString().equals("3"));
     mi.next();
     assertFalse(mi.hasTop());
@@ -331,20 +331,21 @@ public class MultiIteratorTest extends TestCase {
   public void test7() throws IOException {
     // TEst setting an endKey
     TreeMap<Key,Value> tm1 = new TreeMap<>();
-    nkv(tm1, 0, 3, false, "1");
-    nkv(tm1, 0, 2, false, "2");
-    nkv(tm1, 0, 1, false, "3");
-    nkv(tm1, 0, 0, false, "4");
-    nkv(tm1, 1, 2, false, "5");
-    nkv(tm1, 1, 1, false, "6");
-    nkv(tm1, 1, 0, false, "7");
-    nkv(tm1, 2, 1, false, "8");
-    nkv(tm1, 2, 0, false, "9");
+    newKeyValue(tm1, 0, 3, false, "1");
+    newKeyValue(tm1, 0, 2, false, "2");
+    newKeyValue(tm1, 0, 1, false, "3");
+    newKeyValue(tm1, 0, 0, false, "4");
+    newKeyValue(tm1, 1, 2, false, "5");
+    newKeyValue(tm1, 1, 1, false, "6");
+    newKeyValue(tm1, 1, 0, false, "7");
+    newKeyValue(tm1, 2, 1, false, "8");
+    newKeyValue(tm1, 2, 0, false, "9");
 
     List<SortedKeyValueIterator<Key,Value>> skvil = new ArrayList<>(1);
     skvil.add(new SortedMapIterator(tm1));
 
-    KeyExtent extent = new KeyExtent("tablename", nr(1), nr(0));
+    KeyExtent extent = new KeyExtent("tablename", newRow(1), newRow(0));
+
     MultiIterator mi = new MultiIterator(skvil, extent);
 
     Range r1 = new Range((Text) null, (Text) null);
@@ -360,7 +361,7 @@ public class MultiIteratorTest extends TestCase {
     mi.next();
     assertFalse(mi.hasTop());
 
-    Range r2 = new Range(nk(0, 0), true, nk(1, 1), true);
+    Range r2 = new Range(newKey(0, 0), true, newKey(1, 1), true);
     mi.seek(r2, EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
     assertTrue(mi.getTopValue().toString().equals("5"));
@@ -370,32 +371,32 @@ public class MultiIteratorTest extends TestCase {
     mi.next();
     assertFalse(mi.hasTop());
 
-    Range r3 = new Range(nk(0, 0), false, nk(1, 1), false);
+    Range r3 = new Range(newKey(0, 0), false, newKey(1, 1), false);
     mi.seek(r3, EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
     assertTrue(mi.getTopValue().toString().equals("5"));
     mi.next();
     assertFalse(mi.hasTop());
 
-    Range r4 = new Range(nk(1, 2), true, nk(1, 1), false);
+    Range r4 = new Range(newKey(1, 2), true, newKey(1, 1), false);
     mi.seek(r4, EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
     assertTrue(mi.getTopValue().toString().equals("5"));
     mi.next();
     assertFalse(mi.hasTop());
 
-    Range r5 = new Range(nk(1, 2), false, nk(1, 1), true);
+    Range r5 = new Range(newKey(1, 2), false, newKey(1, 1), true);
     mi.seek(r5, EMPTY_COL_FAMS, false);
     assertTrue(mi.hasTop());
     assertTrue(mi.getTopValue().toString().equals("6"));
     mi.next();
     assertFalse(mi.hasTop());
 
-    Range r6 = new Range(nk(2, 1), true, nk(2, 0), true);
+    Range r6 = new Range(newKey(2, 1), true, newKey(2, 0), true);
     mi.seek(r6, EMPTY_COL_FAMS, false);
     assertFalse(mi.hasTop());
 
-    Range r7 = new Range(nk(0, 3), true, nk(0, 1), true);
+    Range r7 = new Range(newKey(0, 3), true, newKey(0, 1), true);
     mi.seek(r7, EMPTY_COL_FAMS, false);
     assertFalse(mi.hasTop());
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
@@ -36,21 +36,22 @@ import org.apache.hadoop.io.Text;
 
 public class SourceSwitchingIteratorTest extends TestCase {
 
-  Key nk(String row, String cf, String cq, long time) {
+  Key newKey(String row, String cf, String cq, long time) {
     return new Key(new Text(row), new Text(cf), new Text(cq), time);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, Value val) {
-    tm.put(nk(row, cf, cq, time), val);
+    tm.put(newKey(row, cf, cq, time), val);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, String val) {
     put(tm, row, cf, cq, time, new Value(val.getBytes()));
   }
 
-  private void ane(SortedKeyValueIterator<Key,Value> rdi, String row, String cf, String cq, long time, String val, boolean callNext) throws Exception {
+  private void testAndCallNext(SortedKeyValueIterator<Key,Value> rdi, String row, String cf, String cq, long time, String val, boolean callNext)
+      throws Exception {
     assertTrue(rdi.hasTop());
-    assertEquals(nk(row, cf, cq, time), rdi.getTopKey());
+    assertEquals(newKey(row, cf, cq, time), rdi.getTopKey());
     assertEquals(val, rdi.getTopValue().toString());
     if (callNext)
       rdi.next();
@@ -121,9 +122,9 @@ public class SourceSwitchingIteratorTest extends TestCase {
     SourceSwitchingIterator ssi = new SourceSwitchingIterator(tds);
 
     ssi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(ssi, "r1", "cf1", "cq1", 5, "v1", true);
-    ane(ssi, "r1", "cf1", "cq3", 5, "v2", true);
-    ane(ssi, "r2", "cf1", "cq1", 5, "v3", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq1", 5, "v1", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq3", 5, "v2", true);
+    testAndCallNext(ssi, "r2", "cf1", "cq1", 5, "v3", true);
     assertFalse(ssi.hasTop());
   }
 
@@ -138,7 +139,7 @@ public class SourceSwitchingIteratorTest extends TestCase {
     SourceSwitchingIterator ssi = new SourceSwitchingIterator(tds);
 
     ssi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(ssi, "r1", "cf1", "cq1", 5, "v1", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq1", 5, "v1", true);
 
     TreeMap<Key,Value> tm2 = new TreeMap<>();
     put(tm2, "r1", "cf1", "cq1", 5, "v4");
@@ -149,8 +150,8 @@ public class SourceSwitchingIteratorTest extends TestCase {
     TestDataSource tds2 = new TestDataSource(smi2);
     tds.next = tds2;
 
-    ane(ssi, "r1", "cf1", "cq3", 5, "v2", true);
-    ane(ssi, "r2", "cf1", "cq1", 5, "v6", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq3", 5, "v2", true);
+    testAndCallNext(ssi, "r2", "cf1", "cq1", 5, "v6", true);
     assertFalse(ssi.hasTop());
   }
 
@@ -170,7 +171,7 @@ public class SourceSwitchingIteratorTest extends TestCase {
     SourceSwitchingIterator ssi = new SourceSwitchingIterator(tds, true);
 
     ssi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(ssi, "r1", "cf1", "cq1", 5, "v1", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq1", 5, "v1", true);
 
     TreeMap<Key,Value> tm2 = new TreeMap<>(tm1);
     put(tm2, "r1", "cf1", "cq5", 5, "v7"); // should not see this because it should not switch until the row is finished
@@ -181,12 +182,12 @@ public class SourceSwitchingIteratorTest extends TestCase {
     TestDataSource tds2 = new TestDataSource(smi2);
     tds.next = tds2;
 
-    ane(ssi, "r1", "cf1", "cq2", 5, "v2", true);
-    ane(ssi, "r1", "cf1", "cq3", 5, "v3", true);
-    ane(ssi, "r1", "cf1", "cq4", 5, "v4", true);
-    ane(ssi, "r2", "cf1", "cq1", 5, "v8", true);
-    ane(ssi, "r3", "cf1", "cq1", 5, "v5", true);
-    ane(ssi, "r3", "cf1", "cq2", 5, "v6", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq2", 5, "v2", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq3", 5, "v3", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq4", 5, "v4", true);
+    testAndCallNext(ssi, "r2", "cf1", "cq1", 5, "v8", true);
+    testAndCallNext(ssi, "r3", "cf1", "cq1", 5, "v5", true);
+    testAndCallNext(ssi, "r3", "cf1", "cq2", 5, "v6", true);
 
   }
 
@@ -210,8 +211,8 @@ public class SourceSwitchingIteratorTest extends TestCase {
 
     ssi.seek(new Range(), new ArrayList<ByteSequence>(), false);
 
-    ane(ssi, "r1", "cf1", "cq1", 6, "v3", true);
-    ane(ssi, "r1", "cf1", "cq2", 6, "v4", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq1", 6, "v3", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq2", 6, "v4", true);
 
   }
 
@@ -240,9 +241,9 @@ public class SourceSwitchingIteratorTest extends TestCase {
     ssi.seek(new Range("r1"), new ArrayList<ByteSequence>(), false);
     dc1.seek(new Range("r2"), new ArrayList<ByteSequence>(), false);
 
-    ane(ssi, "r1", "cf1", "cq1", 6, "v3", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq1", 6, "v3", true);
     assertFalse(ssi.hasTop());
-    ane(dc1, "r2", "cf1", "cq2", 6, "v4", true);
+    testAndCallNext(dc1, "r2", "cf1", "cq2", 6, "v4", true);
     assertFalse(dc1.hasTop());
   }
 
@@ -261,7 +262,7 @@ public class SourceSwitchingIteratorTest extends TestCase {
     assertSame(flag, tds.iflag);
 
     ssi.seek(new Range("r1"), new ArrayList<ByteSequence>(), false);
-    ane(ssi, "r1", "cf1", "cq1", 5, "v1", true);
+    testAndCallNext(ssi, "r1", "cf1", "cq1", 5, "v1", true);
     assertFalse(ssi.hasTop());
 
     flag.set(true);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/BigDecimalCombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/BigDecimalCombinerTest.java
@@ -57,13 +57,13 @@ public class BigDecimalCombinerTest {
     columns = Collections.singletonList(new IteratorSetting.Column("cf001"));
 
     // keys that will aggregate
-    CombinerTest.nkv(tm1, 1, 1, 1, 1, false, BigDecimal.valueOf(2), encoder);
-    CombinerTest.nkv(tm1, 1, 1, 1, 2, false, BigDecimal.valueOf(2.3), encoder);
-    CombinerTest.nkv(tm1, 1, 1, 1, 3, false, BigDecimal.valueOf(-1.4E1), encoder);
+    CombinerTest.newKeyValue(tm1, 1, 1, 1, 1, false, BigDecimal.valueOf(2), encoder);
+    CombinerTest.newKeyValue(tm1, 1, 1, 1, 2, false, BigDecimal.valueOf(2.3), encoder);
+    CombinerTest.newKeyValue(tm1, 1, 1, 1, 3, false, BigDecimal.valueOf(-1.4E1), encoder);
 
     // and keys that will not aggregate
-    CombinerTest.nkv(tm1, 1, 2, 1, 1, false, BigDecimal.valueOf(99), encoder);
-    CombinerTest.nkv(tm1, 1, 3, 1, 1, false, BigDecimal.valueOf(-88), encoder);
+    CombinerTest.newKeyValue(tm1, 1, 2, 1, 1, false, BigDecimal.valueOf(99), encoder);
+    CombinerTest.newKeyValue(tm1, 1, 3, 1, 1, false, BigDecimal.valueOf(-88), encoder);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class BigDecimalCombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(CombinerTest.nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(CombinerTest.newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals(-9.7, encoder.decode(ai.getTopValue().get()).doubleValue(), delta);
 
     verify();
@@ -92,7 +92,7 @@ public class BigDecimalCombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(CombinerTest.nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(CombinerTest.newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals(-14.0, encoder.decode(ai.getTopValue().get()).doubleValue(), delta);
 
     verify();
@@ -108,7 +108,7 @@ public class BigDecimalCombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(CombinerTest.nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(CombinerTest.newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals(2.3, encoder.decode(ai.getTopValue().get()).doubleValue(), delta);
 
     verify();
@@ -118,11 +118,11 @@ public class BigDecimalCombinerTest {
     ai.next(); // Skip the combined key, since we've already looked at it by now
 
     // Should have exactly two more keys left over
-    assertEquals(CombinerTest.nk(1, 2, 1, 1), ai.getTopKey());
+    assertEquals(CombinerTest.newKey(1, 2, 1, 1), ai.getTopKey());
     assertEquals(99.0, encoder.decode(ai.getTopValue().get()).doubleValue(), delta);
     ai.next();
 
-    assertEquals(CombinerTest.nk(1, 3, 1, 1), ai.getTopKey());
+    assertEquals(CombinerTest.newKey(1, 3, 1, 1), ai.getTopKey());
     assertEquals(-88.0, encoder.decode(ai.getTopValue().get()).doubleValue(), delta);
     ai.next();
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilterTest.java
@@ -43,25 +43,25 @@ public class ColumnSliceFilterTest {
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
   private static final SortedMap<Key,Value> TEST_DATA = new TreeMap<>();
-  private static final Key KEY_1 = nkv(TEST_DATA, "boo1", "yup", "20080201", "dog");
-  private static final Key KEY_2 = nkv(TEST_DATA, "boo1", "yap", "20080202", "cat");
-  private static final Key KEY_3 = nkv(TEST_DATA, "boo2", "yap", "20080203", "hamster");
-  private static final Key KEY_4 = nkv(TEST_DATA, "boo2", "yop", "20080204", "lion");
-  private static final Key KEY_5 = nkv(TEST_DATA, "boo2", "yup", "20080206", "tiger");
-  private static final Key KEY_6 = nkv(TEST_DATA, "boo2", "yip", "20080203", "tiger");
+  private static final Key KEY_1 = newKeyValue(TEST_DATA, "boo1", "yup", "20080201", "dog");
+  private static final Key KEY_2 = newKeyValue(TEST_DATA, "boo1", "yap", "20080202", "cat");
+  private static final Key KEY_3 = newKeyValue(TEST_DATA, "boo2", "yap", "20080203", "hamster");
+  private static final Key KEY_4 = newKeyValue(TEST_DATA, "boo2", "yop", "20080204", "lion");
+  private static final Key KEY_5 = newKeyValue(TEST_DATA, "boo2", "yup", "20080206", "tiger");
+  private static final Key KEY_6 = newKeyValue(TEST_DATA, "boo2", "yip", "20080203", "tiger");
 
   private IteratorEnvironment iteratorEnvironment;
 
   private ColumnSliceFilter columnSliceFilter = new ColumnSliceFilter();
   private IteratorSetting is;
 
-  private static Key nkv(SortedMap<Key,Value> tm, String row, String cf, String cq, String val) {
-    Key k = nk(row, cf, cq);
+  private static Key newKeyValue(SortedMap<Key,Value> tm, String row, String cf, String cq, String val) {
+    Key k = newKey(row, cf, cq);
     tm.put(k, new Value(val.getBytes()));
     return k;
   }
 
-  private static Key nk(String row, String cf, String cq) {
+  private static Key newKey(String row, String cf, String cq) {
     return new Key(new Text(row), new Text(cf), new Text(cq));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -83,31 +83,31 @@ public class CombinerTest {
 
   static final IteratorEnvironment SCAN_IE = new CombinerIteratorEnvironment(IteratorScope.scan, false);
 
-  static Key nk(int row, int colf, int colq, long ts, boolean deleted) {
-    Key k = nk(row, colf, colq, ts);
+  static Key newKey(int row, int colf, int colq, long ts, boolean deleted) {
+    Key k = newKey(row, colf, colq, ts);
     k.setDeleted(deleted);
     return k;
   }
 
-  static Key nk(int row, int colf, int colq, long ts) {
-    return new Key(nr(row), new Text(String.format("cf%03d", colf)), new Text(String.format("cq%03d", colq)), ts);
+  static Key newKey(int row, int colf, int colq, long ts) {
+    return new Key(newRow(row), new Text(String.format("cf%03d", colf)), new Text(String.format("cq%03d", colq)), ts);
   }
 
-  static Range nr(int row, int colf, int colq, long ts, boolean inclusive) {
-    return new Range(nk(row, colf, colq, ts), inclusive, null, true);
+  static Range newRow(int row, int colf, int colq, long ts, boolean inclusive) {
+    return new Range(newKey(row, colf, colq, ts), inclusive, null, true);
   }
 
-  static Range nr(int row, int colf, int colq, long ts) {
-    return nr(row, colf, colq, ts, true);
+  static Range newRow(int row, int colf, int colq, long ts) {
+    return newRow(row, colf, colq, ts, true);
   }
 
-  static <V> void nkv(TreeMap<Key,Value> tm, int row, int colf, int colq, long ts, boolean deleted, V val, Encoder<V> encoder) {
-    Key k = nk(row, colf, colq, ts);
+  static <V> void newKeyValue(TreeMap<Key,Value> tm, int row, int colf, int colq, long ts, boolean deleted, V val, Encoder<V> encoder) {
+    Key k = newKey(row, colf, colq, ts);
     k.setDeleted(deleted);
     tm.put(k, new Value(encoder.encode(val)));
   }
 
-  static Text nr(int row) {
+  static Text newRow(int row) {
     return new Text(String.format("r%03d", row));
   }
 
@@ -118,9 +118,9 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that do not aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -132,19 +132,19 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("4", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 1), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 1), ai.getTopKey());
     assertEquals("2", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -153,16 +153,16 @@ public class CombinerTest {
 
     // try seeking
 
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 1), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 1), ai.getTopKey());
     assertEquals("2", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -170,7 +170,7 @@ public class CombinerTest {
     assertFalse(ai.hasTop());
 
     // seek after everything
-    ai.seek(nr(1, 1, 1, 0), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 0), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
@@ -183,9 +183,9 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -197,7 +197,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -206,10 +206,10 @@ public class CombinerTest {
 
     // try seeking to the beginning of a key that aggregates
 
-    ai.seek(nr(1, 1, 1, 3), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 3), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -217,20 +217,20 @@ public class CombinerTest {
     assertFalse(ai.hasTop());
 
     // try seeking the middle of a key the aggregates
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
     // try seeking to the end of a key the aggregates
-    ai.seek(nr(1, 1, 1, 1), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 1), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
     // try seeking before a key the aggregates
-    ai.seek(nr(1, 1, 1, 4), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -245,13 +245,13 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
 
     // keys that do not aggregate
-    nkv(tm1, 2, 2, 1, 1, false, 2l, encoder);
-    nkv(tm1, 2, 2, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 2, 2, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 2, 2, 1, 2, false, 3l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -263,19 +263,19 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 1), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 1), ai.getTopKey());
     assertEquals("2", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -283,23 +283,23 @@ public class CombinerTest {
     assertFalse(ai.hasTop());
 
     // seek after key that aggregates
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     // seek before key that aggregates
-    ai.seek(nr(1, 1, 1, 4), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
   }
@@ -311,13 +311,13 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
 
     // keys that do not aggregate
-    nkv(tm1, 2, 2, 1, 1, false, 2l, encoder);
-    nkv(tm1, 2, 2, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 2, 2, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 2, 2, 1, 2, false, 3l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -332,19 +332,19 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 1), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 1), ai.getTopKey());
     assertEquals("2", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -352,23 +352,23 @@ public class CombinerTest {
     assertFalse(ai.hasTop());
 
     // seek after key that aggregates
-    ai2.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai2.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai2.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai2.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai2.getTopKey());
     assertEquals("3", encoder.decode(ai2.getTopValue().get()).toString());
 
     // seek before key that aggregates
-    ai3.seek(nr(1, 1, 1, 4), EMPTY_COL_FAMS, false);
+    ai3.seek(newRow(1, 1, 1, 4), EMPTY_COL_FAMS, false);
 
     assertTrue(ai3.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai3.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai3.getTopKey());
     assertEquals("9", encoder.decode(ai3.getTopValue().get()).toString());
 
     ai3.next();
 
     assertTrue(ai3.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai3.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai3.getTopKey());
     assertEquals("3", encoder.decode(ai3.getTopValue().get()).toString());
   }
 
@@ -379,16 +379,16 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that do not aggregate
-    nkv(tm1, 0, 0, 1, 1, false, 7l, encoder);
+    newKeyValue(tm1, 0, 0, 1, 1, false, 7l, encoder);
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
 
     // keys that do not aggregate
-    nkv(tm1, 2, 2, 1, 1, false, 2l, encoder);
-    nkv(tm1, 2, 2, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 2, 2, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 2, 2, 1, 2, false, 3l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -400,25 +400,25 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(0, 0, 1, 1), ai.getTopKey());
+    assertEquals(newKey(0, 0, 1, 1), ai.getTopKey());
     assertEquals("7", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 1), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 1), ai.getTopKey());
     assertEquals("2", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -426,23 +426,23 @@ public class CombinerTest {
     assertFalse(ai.hasTop());
 
     // seek test
-    ai.seek(nr(0, 0, 1, 0), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(0, 0, 1, 0), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     // seek after key that aggregates
-    ai.seek(nr(1, 1, 1, 2), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 2), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("3", encoder.decode(ai.getTopValue().get()).toString());
 
     // combine all columns
@@ -455,19 +455,19 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(0, 0, 1, 1), ai.getTopKey());
+    assertEquals(newKey(0, 0, 1, 1), ai.getTopKey());
     assertEquals("7", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(2, 2, 1, 2), ai.getTopKey());
+    assertEquals(newKey(2, 2, 1, 2), ai.getTopKey());
     assertEquals("5", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -482,13 +482,13 @@ public class CombinerTest {
     // the exact same keys w/ different values
 
     TreeMap<Key,Value> tm1 = new TreeMap<>();
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
 
     TreeMap<Key,Value> tm2 = new TreeMap<>();
-    nkv(tm2, 1, 1, 1, 1, false, 3l, encoder);
+    newKeyValue(tm2, 1, 1, 1, 1, false, 3l, encoder);
 
     TreeMap<Key,Value> tm3 = new TreeMap<>();
-    nkv(tm3, 1, 1, 1, 1, false, 4l, encoder);
+    newKeyValue(tm3, 1, 1, 1, 1, false, 4l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -506,7 +506,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 1), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 1), ai.getTopKey());
     assertEquals("9", encoder.decode(ai.getTopValue().get()).toString());
   }
 
@@ -516,9 +516,9 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 2l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -530,7 +530,7 @@ public class CombinerTest {
 
     // try seeking to the beginning of a key that aggregates
 
-    ai.seek(nr(1, 1, 1, 3, false), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 3, false), EMPTY_COL_FAMS, false);
 
     assertFalse(ai.hasTop());
 
@@ -544,9 +544,9 @@ public class CombinerTest {
 
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
-    nkv(tm1, 1, 1, 1, 2, true, 0l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 4l, encoder);
-    nkv(tm1, 1, 1, 1, 4, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, true, 0l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 4, false, 3l, encoder);
 
     Combiner ai = new SummingCombiner();
 
@@ -556,29 +556,29 @@ public class CombinerTest {
 
     ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
 
-    ai.seek(nr(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 4), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 4), ai.getTopKey());
     assertEquals("7", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2, true), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2, true), ai.getTopKey());
     assertEquals("0", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
     assertFalse(ai.hasTop());
 
     tm1 = new TreeMap<>();
-    nkv(tm1, 1, 1, 1, 2, true, 0l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, true, 0l, encoder);
     ai = new SummingCombiner();
     ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
 
-    ai.seek(nr(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
+    ai.seek(newRow(1, 1, 1, 4, true), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 2, true), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 2, true), ai.getTopKey());
     assertEquals("0", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -639,9 +639,9 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, 4l, encoder);
-    nkv(tm1, 1, 1, 1, 2, false, 3l, encoder);
-    nkv(tm1, 1, 1, 1, 3, false, 2l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, 4l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, 3l, encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, 2l, encoder);
 
     Combiner ai = new MaxCombiner();
 
@@ -653,7 +653,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("4", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -666,7 +666,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertEquals("2", encoder.decode(ai.getTopValue().get()).toString());
 
     ai.next();
@@ -695,9 +695,9 @@ public class CombinerTest {
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
     // keys that aggregate
-    nkv(tm1, 1, 1, 1, 1, false, nal(1l, 2l), encoder);
-    nkv(tm1, 1, 1, 1, 2, false, nal(3l, 4l, 5l), encoder);
-    nkv(tm1, 1, 1, 1, 3, false, nal(), encoder);
+    newKeyValue(tm1, 1, 1, 1, 1, false, nal(1l, 2l), encoder);
+    newKeyValue(tm1, 1, 1, 1, 2, false, nal(3l, 4l, 5l), encoder);
+    newKeyValue(tm1, 1, 1, 1, 3, false, nal(), encoder);
 
     Combiner ai = new SummingArrayCombiner();
 
@@ -709,7 +709,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertBytesEqual(encoder.encode(nal(4l, 6l, 5l)), ai.getTopValue().get());
 
     ai.next();
@@ -724,7 +724,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertBytesEqual(encoder.encode(nal(4l, 6l, 5l)), ai.getTopValue().get());
 
     ai.next();
@@ -739,7 +739,7 @@ public class CombinerTest {
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
-    assertEquals(nk(1, 1, 1, 3), ai.getTopKey());
+    assertEquals(newKey(1, 1, 1, 3), ai.getTopKey());
     assertBytesEqual(encoder.encode(nal(4l, 6l, 5l)), ai.getTopValue().get());
 
     ai.next();
@@ -901,15 +901,15 @@ public class CombinerTest {
     IteratorEnvironment fullMajcIe = new CombinerIteratorEnvironment(IteratorScope.majc, true);
 
     // keys that aggregate
-    nkv(input, 1, 1, 1, 1, false, 4l, encoder);
-    nkv(input, 1, 1, 1, 2, true, 0l, encoder);
-    nkv(input, 1, 1, 1, 3, false, 2l, encoder);
-    nkv(input, 1, 1, 1, 4, false, 9l, encoder);
+    newKeyValue(input, 1, 1, 1, 1, false, 4l, encoder);
+    newKeyValue(input, 1, 1, 1, 2, true, 0l, encoder);
+    newKeyValue(input, 1, 1, 1, 3, false, 2l, encoder);
+    newKeyValue(input, 1, 1, 1, 4, false, 9l, encoder);
 
     TreeMap<Key,Value> expected = new TreeMap<>();
-    nkv(expected, 1, 1, 1, 1, false, 4l, encoder);
-    nkv(expected, 1, 1, 1, 2, true, 0l, encoder);
-    nkv(expected, 1, 1, 1, 4, false, 11l, encoder);
+    newKeyValue(expected, 1, 1, 1, 1, false, 4l, encoder);
+    newKeyValue(expected, 1, 1, 1, 2, true, 0l, encoder);
+    newKeyValue(expected, 1, 1, 1, 4, false, 11l, encoder);
 
     runDeleteHandlingTest(input, input, true, paritalMajcIe);
     runDeleteHandlingTest(input, expected, true, fullMajcIe);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -146,12 +146,12 @@ public class IndexedDocIteratorTest extends TestCase {
     trf.openWriter(false);
 
     TreeMap<Key,Value> inMemoryMap = createSortedMap(hitRatio, numRows, numDocsPerRow, columnFamilies, otherColumnFamilies, docs, negatedColumns);
-    trf.writer.startNewLocalityGroup("docs", RFileTest.ncfs(docColf.toString()));
+    trf.writer.startNewLocalityGroup("docs", RFileTest.newColFamByteSequence(docColf.toString()));
     for (Entry<Key,Value> entry : inMemoryMap.entrySet()) {
       if (entry.getKey().getColumnFamily().equals(docColf))
         trf.writer.append(entry.getKey(), entry.getValue());
     }
-    trf.writer.startNewLocalityGroup("terms", RFileTest.ncfs(indexColf.toString()));
+    trf.writer.startNewLocalityGroup("terms", RFileTest.newColFamByteSequence(indexColf.toString()));
     for (Entry<Key,Value> entry : inMemoryMap.entrySet()) {
       if (entry.getKey().getColumnFamily().equals(indexColf))
         trf.writer.append(entry.getKey(), entry.getValue());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RegExFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RegExFilterTest.java
@@ -39,13 +39,13 @@ public class RegExFilterTest {
 
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
-  private Key nkv(TreeMap<Key,Value> tm, String row, String cf, String cq, String val) {
-    Key k = nk(row, cf, cq);
+  private Key newKeyValue(TreeMap<Key,Value> tm, String row, String cf, String cq, String val) {
+    Key k = newKey(row, cf, cq);
     tm.put(k, new Value(val.getBytes()));
     return k;
   }
 
-  private Key nk(String row, String cf, String cq) {
+  private Key newKey(String row, String cf, String cq) {
     return new Key(new Text(row), new Text(cf), new Text(cq));
   }
 
@@ -53,9 +53,9 @@ public class RegExFilterTest {
   public void test1() throws IOException {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
-    Key k1 = nkv(tm, "boo1", "yup", "20080201", "dog");
-    Key k2 = nkv(tm, "boo1", "yap", "20080202", "cat");
-    Key k3 = nkv(tm, "boo2", "yip", "20080203", "hamster");
+    Key k1 = newKeyValue(tm, "boo1", "yup", "20080201", "dog");
+    Key k2 = newKeyValue(tm, "boo1", "yap", "20080202", "cat");
+    Key k3 = newKeyValue(tm, "boo2", "yip", "20080203", "hamster");
 
     RegExFilter rei = new RegExFilter();
     rei.describeOptions();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RowDeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RowDeletingIteratorTest.java
@@ -56,21 +56,21 @@ public class RowDeletingIteratorTest extends TestCase {
     }
   }
 
-  Key nk(String row, String cf, String cq, long time) {
+  Key newKey(String row, String cf, String cq, long time) {
     return new Key(new Text(row), new Text(cf), new Text(cq), time);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, Value val) {
-    tm.put(nk(row, cf, cq, time), val);
+    tm.put(newKey(row, cf, cq, time), val);
   }
 
   void put(TreeMap<Key,Value> tm, String row, String cf, String cq, long time, String val) {
     put(tm, row, cf, cq, time, new Value(val.getBytes()));
   }
 
-  private void ane(RowDeletingIterator rdi, String row, String cf, String cq, long time, String val) {
+  private void testAssertions(RowDeletingIterator rdi, String row, String cf, String cq, long time, String val) {
     assertTrue(rdi.hasTop());
-    assertEquals(nk(row, cf, cq, time), rdi.getTopKey());
+    assertEquals(newKey(row, cf, cq, time), rdi.getTopKey());
     assertEquals(val, rdi.getTopValue().toString());
   }
 
@@ -86,28 +86,28 @@ public class RowDeletingIteratorTest extends TestCase {
     rdi.init(new SortedMapIterator(tm1), null, new TestIE(IteratorScope.scan, false));
 
     rdi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
     for (int i = 0; i < 5; i++) {
-      rdi.seek(new Range(nk("r1", "cf1", "cq" + i, 5), null), new ArrayList<ByteSequence>(), false);
-      ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+      rdi.seek(new Range(newKey("r1", "cf1", "cq" + i, 5), null), new ArrayList<ByteSequence>(), false);
+      testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
     }
 
-    rdi.seek(new Range(nk("r11", "cf1", "cq1", 5), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    rdi.seek(new Range(newKey("r11", "cf1", "cq1", 5), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
     put(tm1, "r2", "", "", 10, RowDeletingIterator.DELETE_ROW_VALUE);
     rdi.seek(new Range(), new ArrayList<ByteSequence>(), false);
     assertFalse(rdi.hasTop());
 
     for (int i = 0; i < 5; i++) {
-      rdi.seek(new Range(nk("r1", "cf1", "cq" + i, 5), null), new ArrayList<ByteSequence>(), false);
+      rdi.seek(new Range(newKey("r1", "cf1", "cq" + i, 5), null), new ArrayList<ByteSequence>(), false);
       assertFalse(rdi.hasTop());
     }
 
     put(tm1, "r0", "cf1", "cq1", 5, "v1");
     rdi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r0", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r0", "cf1", "cq1", 5, "v1");
     rdi.next();
     assertFalse(rdi.hasTop());
 
@@ -127,31 +127,31 @@ public class RowDeletingIteratorTest extends TestCase {
     rdi.init(new SortedMapIterator(tm1), null, new TestIE(IteratorScope.scan, false));
 
     rdi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "cf1", "cq3", 15, "v1");
+    testAssertions(rdi, "r1", "cf1", "cq3", 15, "v1");
     rdi.next();
-    ane(rdi, "r1", "cf1", "cq5", 15, "v1");
+    testAssertions(rdi, "r1", "cf1", "cq5", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
-    rdi.seek(new Range(nk("r1", "cf1", "cq1", 5), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "cf1", "cq3", 15, "v1");
+    rdi.seek(new Range(newKey("r1", "cf1", "cq1", 5), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r1", "cf1", "cq3", 15, "v1");
     rdi.next();
-    ane(rdi, "r1", "cf1", "cq5", 15, "v1");
+    testAssertions(rdi, "r1", "cf1", "cq5", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
-    rdi.seek(new Range(nk("r1", "cf1", "cq4", 5), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "cf1", "cq5", 15, "v1");
+    rdi.seek(new Range(newKey("r1", "cf1", "cq4", 5), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r1", "cf1", "cq5", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
-    rdi.seek(new Range(nk("r1", "cf1", "cq5", 20), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "cf1", "cq5", 15, "v1");
+    rdi.seek(new Range(newKey("r1", "cf1", "cq5", 20), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r1", "cf1", "cq5", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
-    rdi.seek(new Range(nk("r1", "cf1", "cq9", 20), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    rdi.seek(new Range(newKey("r1", "cf1", "cq9", 20), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
   }
 
   public void test3() throws Exception {
@@ -170,18 +170,18 @@ public class RowDeletingIteratorTest extends TestCase {
     cols.add(new ArrayByteSequence("cf1".getBytes()));
 
     rdi.seek(new Range(), cols, true);
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
     cols.clear();
     cols.add(new ArrayByteSequence("".getBytes()));
     rdi.seek(new Range(), cols, false);
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
     cols.clear();
     rdi.seek(new Range(), cols, false);
-    ane(rdi, "r2", "", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "", "cq1", 5, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
   }
 
   public void test4() throws Exception {
@@ -197,23 +197,23 @@ public class RowDeletingIteratorTest extends TestCase {
     rdi.init(new SortedMapIterator(tm1), null, new TestIE(IteratorScope.minc, false));
 
     rdi.seek(new Range(), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "", "", 10, RowDeletingIterator.DELETE_ROW_VALUE.toString());
+    testAssertions(rdi, "r1", "", "", 10, RowDeletingIterator.DELETE_ROW_VALUE.toString());
     rdi.next();
-    ane(rdi, "r1", "cf1", "cq3", 15, "v1");
+    testAssertions(rdi, "r1", "cf1", "cq3", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
-    rdi.seek(new Range(nk("r1", "cf1", "cq3", 20), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "cf1", "cq3", 15, "v1");
+    rdi.seek(new Range(newKey("r1", "cf1", "cq3", 20), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r1", "cf1", "cq3", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
-    rdi.seek(new Range(nk("r1", "", "", 42), null), new ArrayList<ByteSequence>(), false);
-    ane(rdi, "r1", "", "", 10, RowDeletingIterator.DELETE_ROW_VALUE.toString());
+    rdi.seek(new Range(newKey("r1", "", "", 42), null), new ArrayList<ByteSequence>(), false);
+    testAssertions(rdi, "r1", "", "", 10, RowDeletingIterator.DELETE_ROW_VALUE.toString());
     rdi.next();
-    ane(rdi, "r1", "cf1", "cq3", 15, "v1");
+    testAssertions(rdi, "r1", "cf1", "cq3", 15, "v1");
     rdi.next();
-    ane(rdi, "r2", "cf1", "cq1", 5, "v1");
+    testAssertions(rdi, "r2", "cf1", "cq1", 5, "v1");
 
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -31,11 +31,11 @@ import org.junit.Test;
 
 public class CheckTabletMetadataTest {
 
-  private static Key nk(String row, ColumnFQ cfq) {
+  private static Key newKey(String row, ColumnFQ cfq) {
     return new Key(new Text(row), cfq.getColumnFamily(), cfq.getColumnQualifier());
   }
 
-  private static Key nk(String row, Text cf, String cq) {
+  private static Key newKey(String row, Text cf, String cq) {
     return new Key(row, cf.toString(), cq);
   }
 
@@ -93,18 +93,18 @@ public class CheckTabletMetadataTest {
 
     assertFail(tabletMeta, new KeyExtent("1", new Text("r"), new Text("m")), tsi);
 
-    assertFail(tabletMeta, ke, tsi, nk("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
 
-    assertFail(tabletMeta, ke, tsi, nk("1<", TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN));
 
-    assertFail(tabletMeta, ke, tsi, nk("1<", TabletsSection.ServerColumnFamily.TIME_COLUMN));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.ServerColumnFamily.TIME_COLUMN));
 
-    assertFail(tabletMeta, ke, tsi, nk("1<", TabletsSection.FutureLocationColumnFamily.NAME, "4"));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.FutureLocationColumnFamily.NAME, "4"));
 
     TreeMap<Key,Value> copy = new TreeMap<>(tabletMeta);
     put(copy, "1<", TabletsSection.CurrentLocationColumnFamily.NAME, "4", "127.0.0.1:9997");
     assertFail(copy, ke, tsi);
-    assertFail(copy, ke, tsi, nk("1<", TabletsSection.FutureLocationColumnFamily.NAME, "4"));
+    assertFail(copy, ke, tsi, newKey("1<", TabletsSection.FutureLocationColumnFamily.NAME, "4"));
 
     copy = new TreeMap<>(tabletMeta);
     put(copy, "1<", TabletsSection.CurrentLocationColumnFamily.NAME, "5", "127.0.0.1:9998");

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -127,23 +127,23 @@ public class InMemoryMapTest {
     imm.mutate(Collections.singletonList(m));
   }
 
-  static Key nk(String row, String column, long ts) {
+  static Key newKey(String row, String column, long ts) {
     String[] sa = column.split(":");
     Key k = new Key(new Text(row), new Text(sa[0]), new Text(sa[1]), ts);
     return k;
   }
 
-  static void ae(SortedKeyValueIterator<Key,Value> dc, String row, String column, int ts, String val) throws IOException {
+  static void testAndCallNext(SortedKeyValueIterator<Key,Value> dc, String row, String column, int ts, String val) throws IOException {
     assertTrue(dc.hasTop());
-    assertEquals(nk(row, column, ts), dc.getTopKey());
+    assertEquals(newKey(row, column, ts), dc.getTopKey());
     assertEquals(new Value(val.getBytes()), dc.getTopValue());
     dc.next();
 
   }
 
-  static void aeNoNext(SortedKeyValueIterator<Key,Value> dc, String row, String column, int ts, String val) throws IOException {
+  static void assertEqualsNoNext(SortedKeyValueIterator<Key,Value> dc, String row, String column, int ts, String val) throws IOException {
     assertTrue(dc.hasTop());
-    assertEquals(nk(row, column, ts), dc.getTopKey());
+    assertEquals(newKey(row, column, ts), dc.getTopKey());
     assertEquals(new Value(val.getBytes()), dc.getTopValue());
 
   }
@@ -191,7 +191,7 @@ public class InMemoryMapTest {
 
     ski2.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
     assertTrue(ski2.hasTop());
-    ae(ski2, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski2, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski2.hasTop());
 
   }
@@ -211,13 +211,13 @@ public class InMemoryMapTest {
     MemoryIterator ski2 = imm.skvIterator(null);
 
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar2");
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
     ski2.seek(new Range(new Text("r3")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski2, "r3", "foo:cq1", 3, "bara");
-    ae(ski2, "r3", "foo:cq1", 3, "bar9");
+    testAndCallNext(ski2, "r3", "foo:cq1", 3, "bara");
+    testAndCallNext(ski2, "r3", "foo:cq1", 3, "bar9");
     assertFalse(ski1.hasTop());
 
   }
@@ -234,21 +234,21 @@ public class InMemoryMapTest {
     imm.delete(0);
 
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar2");
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar2");
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
     ski1.seek(new Range(new Text("r2")), LocalityGroupUtil.EMPTY_CF_SET, false);
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(nk("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar2");
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
     ski1.close();
@@ -265,9 +265,9 @@ public class InMemoryMapTest {
     imm.delete(0);
 
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    aeNoNext(ski1, "r1", "foo:cq1", 3, "");
+    assertEqualsNoNext(ski1, "r1", "foo:cq1", 3, "");
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "");
     assertFalse(ski1.hasTop());
 
     ski1.close();
@@ -283,12 +283,12 @@ public class InMemoryMapTest {
 
     MemoryIterator ski1 = imm.skvIterator(null);
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar3");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar3");
 
     imm.delete(0);
 
-    ae(ski1, "r1", "foo:cq1", 3, "bar2");
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
     ski1.close();
@@ -301,12 +301,12 @@ public class InMemoryMapTest {
 
     ski1 = imm.skvIterator(null);
     ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
 
     imm.delete(0);
 
-    ae(ski1, "r1", "foo:cq2", 3, "bar2");
-    ae(ski1, "r1", "foo:cq3", 3, "bar3");
+    testAndCallNext(ski1, "r1", "foo:cq2", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq3", 3, "bar3");
     assertFalse(ski1.hasTop());
 
     ski1.close();
@@ -327,30 +327,30 @@ public class InMemoryMapTest {
 
     SortedKeyValueIterator<Key,Value> dc = ski1.deepCopy(new SampleIE());
 
-    ski1.seek(new Range(nk("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
 
-    dc.seek(new Range(nk("r1", "foo:cq2", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(dc, "r1", "foo:cq2", 3, "bar2");
+    dc.seek(new Range(newKey("r1", "foo:cq2", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    testAndCallNext(dc, "r1", "foo:cq2", 3, "bar2");
 
     imm.delete(0);
 
-    ae(ski1, "r1", "foo:cq2", 3, "bar2");
-    ae(dc, "r1", "foo:cq3", 3, "bar3");
-    ae(ski1, "r1", "foo:cq3", 3, "bar3");
-    ae(dc, "r1", "foo:cq4", 3, "bar4");
-    ae(ski1, "r1", "foo:cq4", 3, "bar4");
+    testAndCallNext(ski1, "r1", "foo:cq2", 3, "bar2");
+    testAndCallNext(dc, "r1", "foo:cq3", 3, "bar3");
+    testAndCallNext(ski1, "r1", "foo:cq3", 3, "bar3");
+    testAndCallNext(dc, "r1", "foo:cq4", 3, "bar4");
+    testAndCallNext(ski1, "r1", "foo:cq4", 3, "bar4");
     assertFalse(ski1.hasTop());
     assertFalse(dc.hasTop());
 
-    ski1.seek(new Range(nk("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
 
-    dc.seek(new Range(nk("r1", "foo:cq4", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(dc, "r1", "foo:cq4", 3, "bar4");
+    dc.seek(new Range(newKey("r1", "foo:cq4", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    testAndCallNext(dc, "r1", "foo:cq4", 3, "bar4");
     assertFalse(dc.hasTop());
 
-    ae(ski1, "r1", "foo:cq3", 3, "bar3");
-    ae(ski1, "r1", "foo:cq4", 3, "bar4");
+    testAndCallNext(ski1, "r1", "foo:cq3", 3, "bar3");
+    testAndCallNext(ski1, "r1", "foo:cq4", 3, "bar4");
     assertFalse(ski1.hasTop());
     assertFalse(dc.hasTop());
 
@@ -393,8 +393,8 @@ public class InMemoryMapTest {
         iflag.set(true);
     }
 
-    ae(dc, "r1", "foo:cq1", 3, "bar1");
-    ae(ski1, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(dc, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
 
     if (interleaving == 4) {
@@ -403,9 +403,9 @@ public class InMemoryMapTest {
         iflag.set(true);
     }
 
-    ae(ski1, "r1", "foo:cq2", 3, "bar2");
-    ae(dc, "r1", "foo:cq1", 3, "bar1");
-    ae(dc, "r1", "foo:cq2", 3, "bar2");
+    testAndCallNext(ski1, "r1", "foo:cq2", 3, "bar2");
+    testAndCallNext(dc, "r1", "foo:cq1", 3, "bar1");
+    testAndCallNext(dc, "r1", "foo:cq2", 3, "bar2");
     assertFalse(dc.hasTop());
     assertFalse(ski1.hasTop());
 
@@ -464,11 +464,11 @@ public class InMemoryMapTest {
 
     MemoryIterator skvi1 = imm.skvIterator(null);
 
-    skvi1.seek(new Range(nk("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(skvi1, "r1", "foo:cq3", 3, "bar3");
+    skvi1.seek(new Range(newKey("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    testAndCallNext(skvi1, "r1", "foo:cq3", 3, "bar3");
 
-    skvi1.seek(new Range(nk("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(skvi1, "r1", "foo:cq1", 3, "bar1");
+    skvi1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    testAndCallNext(skvi1, "r1", "foo:cq1", 3, "bar1");
 
   }
 
@@ -483,8 +483,8 @@ public class InMemoryMapTest {
 
     MemoryIterator skvi1 = imm.skvIterator(null);
     skvi1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ae(skvi1, "r1", "foo:cq", 3, "v2");
-    ae(skvi1, "r1", "foo:cq", 3, "v1");
+    testAndCallNext(skvi1, "r1", "foo:cq", 3, "v2");
+    testAndCallNext(skvi1, "r1", "foo:cq", 3, "v1");
   }
 
   private static final Logger log = Logger.getLogger(InMemoryMapTest.class);
@@ -733,7 +733,7 @@ public class InMemoryMapTest {
   private void mutate(InMemoryMap imm, String row, String cols, int ts, String val, Sampler sampler, TreeMap<Key,Value> expectedSample,
       TreeMap<Key,Value> expectedAll) {
     mutate(imm, row, cols, ts, val);
-    Key k1 = nk(row, cols, ts);
+    Key k1 = newKey(row, cols, ts);
     if (sampler.accept(k1)) {
       expectedSample.put(k1, new Value(val.getBytes()));
     }
@@ -836,52 +836,52 @@ public class InMemoryMapTest {
 
   private void seekLocalityGroups(SortedKeyValueIterator<Key,Value> iter1) throws IOException {
     iter1.seek(new Range(), newCFSet("cf1"), true);
-    ae(iter1, "r1", "cf1:x", 2, "1");
-    ae(iter1, "r1", "cf1:y", 2, "2");
-    ae(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r1", "cf1:x", 2, "1");
+    testAndCallNext(iter1, "r1", "cf1:y", 2, "2");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range("r2", "r4"), newCFSet("cf1"), true);
-    ae(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range(), newCFSet("cf3"), true);
-    ae(iter1, "r1", "cf3:z", 2, "3");
-    ae(iter1, "r4", "cf4:z", 5, "8");
-    ae(iter1, "r5", "cf3:z", 6, "A");
-    ae(iter1, "r5", "cf4:z", 6, "B");
+    testAndCallNext(iter1, "r1", "cf3:z", 2, "3");
+    testAndCallNext(iter1, "r4", "cf4:z", 5, "8");
+    testAndCallNext(iter1, "r5", "cf3:z", 6, "A");
+    testAndCallNext(iter1, "r5", "cf4:z", 6, "B");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range(), newCFSet("foo"), true);
-    ae(iter1, "r1", "foo:b", 2, "9");
-    ae(iter1, "r3", "foo:b", 4, "6");
-    ae(iter1, "r4", "foo:b", 5, "7");
+    testAndCallNext(iter1, "r1", "foo:b", 2, "9");
+    testAndCallNext(iter1, "r3", "foo:b", 4, "6");
+    testAndCallNext(iter1, "r4", "foo:b", 5, "7");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range(), newCFSet("cf1", "cf3"), true);
-    ae(iter1, "r1", "cf1:x", 2, "1");
-    ae(iter1, "r1", "cf1:y", 2, "2");
-    ae(iter1, "r1", "cf3:z", 2, "3");
-    ae(iter1, "r2", "cf2:x", 3, "5");
-    ae(iter1, "r4", "cf4:z", 5, "8");
-    ae(iter1, "r5", "cf3:z", 6, "A");
-    ae(iter1, "r5", "cf4:z", 6, "B");
+    testAndCallNext(iter1, "r1", "cf1:x", 2, "1");
+    testAndCallNext(iter1, "r1", "cf1:y", 2, "2");
+    testAndCallNext(iter1, "r1", "cf3:z", 2, "3");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r4", "cf4:z", 5, "8");
+    testAndCallNext(iter1, "r5", "cf3:z", 6, "A");
+    testAndCallNext(iter1, "r5", "cf4:z", 6, "B");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range("r2", "r4"), newCFSet("cf1", "cf3"), true);
-    ae(iter1, "r2", "cf2:x", 3, "5");
-    ae(iter1, "r4", "cf4:z", 5, "8");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r4", "cf4:z", 5, "8");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range(), newCFSet("cf1", "cf3", "foo"), true);
     assertAll(iter1);
 
     iter1.seek(new Range("r1", "r2"), newCFSet("cf1", "cf3", "foo"), true);
-    ae(iter1, "r1", "cf1:x", 2, "1");
-    ae(iter1, "r1", "cf1:y", 2, "2");
-    ae(iter1, "r1", "cf3:z", 2, "3");
-    ae(iter1, "r1", "foo:b", 2, "9");
-    ae(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r1", "cf1:x", 2, "1");
+    testAndCallNext(iter1, "r1", "cf1:y", 2, "2");
+    testAndCallNext(iter1, "r1", "cf3:z", 2, "3");
+    testAndCallNext(iter1, "r1", "foo:b", 2, "9");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
@@ -891,31 +891,31 @@ public class InMemoryMapTest {
     assertAll(iter1);
 
     iter1.seek(new Range(), newCFSet("cf1", "cf2"), false);
-    ae(iter1, "r1", "cf3:z", 2, "3");
-    ae(iter1, "r1", "foo:b", 2, "9");
-    ae(iter1, "r3", "foo:b", 4, "6");
-    ae(iter1, "r4", "cf4:z", 5, "8");
-    ae(iter1, "r4", "foo:b", 5, "7");
-    ae(iter1, "r5", "cf3:z", 6, "A");
-    ae(iter1, "r5", "cf4:z", 6, "B");
+    testAndCallNext(iter1, "r1", "cf3:z", 2, "3");
+    testAndCallNext(iter1, "r1", "foo:b", 2, "9");
+    testAndCallNext(iter1, "r3", "foo:b", 4, "6");
+    testAndCallNext(iter1, "r4", "cf4:z", 5, "8");
+    testAndCallNext(iter1, "r4", "foo:b", 5, "7");
+    testAndCallNext(iter1, "r5", "cf3:z", 6, "A");
+    testAndCallNext(iter1, "r5", "cf4:z", 6, "B");
     assertFalse(iter1.hasTop());
 
     iter1.seek(new Range("r2"), newCFSet("cf1", "cf3", "foo"), true);
-    ae(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
     assertFalse(iter1.hasTop());
   }
 
   private void assertAll(SortedKeyValueIterator<Key,Value> iter1) throws IOException {
-    ae(iter1, "r1", "cf1:x", 2, "1");
-    ae(iter1, "r1", "cf1:y", 2, "2");
-    ae(iter1, "r1", "cf3:z", 2, "3");
-    ae(iter1, "r1", "foo:b", 2, "9");
-    ae(iter1, "r2", "cf2:x", 3, "5");
-    ae(iter1, "r3", "foo:b", 4, "6");
-    ae(iter1, "r4", "cf4:z", 5, "8");
-    ae(iter1, "r4", "foo:b", 5, "7");
-    ae(iter1, "r5", "cf3:z", 6, "A");
-    ae(iter1, "r5", "cf4:z", 6, "B");
+    testAndCallNext(iter1, "r1", "cf1:x", 2, "1");
+    testAndCallNext(iter1, "r1", "cf1:y", 2, "2");
+    testAndCallNext(iter1, "r1", "cf3:z", 2, "3");
+    testAndCallNext(iter1, "r1", "foo:b", 2, "9");
+    testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
+    testAndCallNext(iter1, "r3", "foo:b", 4, "6");
+    testAndCallNext(iter1, "r4", "cf4:z", 5, "8");
+    testAndCallNext(iter1, "r4", "foo:b", 5, "7");
+    testAndCallNext(iter1, "r5", "cf3:z", 6, "A");
+    testAndCallNext(iter1, "r5", "cf4:z", 6, "B");
     assertFalse(iter1.hasTop());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/NativeMapPerformanceTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/NativeMapPerformanceTest.java
@@ -41,11 +41,11 @@ public class NativeMapPerformanceTest {
   private static final byte ROW_PREFIX[] = new byte[] {'r'};
   private static final byte COL_PREFIX[] = new byte[] {'c'};
 
-  static Key nk(int r, int c) {
+  static Key newKey(int r, int c) {
     return new Key(new Text(FastFormat.toZeroPaddedString(r, 9, 10, ROW_PREFIX)), new Text(FastFormat.toZeroPaddedString(c, 6, 10, COL_PREFIX)));
   }
 
-  static Mutation nm(int r) {
+  static Mutation newMutation(int r) {
     return new Mutation(new Text(FastFormat.toZeroPaddedString(r, 9, 10, ROW_PREFIX)));
   }
 
@@ -77,7 +77,7 @@ public class NativeMapPerformanceTest {
     if (nm != null) {
       for (int i = 0; i < numRows; i++) {
         int row = rand.nextInt(1000000000);
-        Mutation m = nm(row);
+        Mutation m = newMutation(row);
         for (int j = 0; j < numCols; j++) {
           int col = rand.nextInt(1000000);
           Value val = new Value("test".getBytes(UTF_8));
@@ -90,7 +90,7 @@ public class NativeMapPerformanceTest {
         int row = rand.nextInt(1000000000);
         for (int j = 0; j < numCols; j++) {
           int col = rand.nextInt(1000000);
-          Key key = nk(row, col);
+          Key key = newKey(row, col);
           Value val = new Value("test".getBytes(UTF_8));
           tm.put(key, val);
         }
@@ -134,14 +134,14 @@ public class NativeMapPerformanceTest {
     long tgs = System.currentTimeMillis();
     if (nm != null) {
       for (int i = 0; i < numLookups; i++) {
-        Key key = nk(rowsToLookup[i], colsToLookup[i]);
+        Key key = newKey(rowsToLookup[i], colsToLookup[i]);
         if (nm.get(key) == null) {
           throw new RuntimeException("Did not find " + rowsToLookup[i] + " " + colsToLookup[i] + " " + i);
         }
       }
     } else {
       for (int i = 0; i < numLookups; i++) {
-        Key key = nk(rowsToLookup[i], colsToLookup[i]);
+        Key key = newKey(rowsToLookup[i], colsToLookup[i]);
         if (tm.get(key) == null) {
           throw new RuntimeException("Did not find " + rowsToLookup[i] + " " + colsToLookup[i] + " " + i);
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -49,11 +49,11 @@ import org.junit.experimental.categories.Category;
 @Category(SunnyDayTests.class)
 public class NativeMapIT {
 
-  private Key nk(int r) {
+  private Key newKey(int r) {
     return new Key(new Text(String.format("r%09d", r)));
   }
 
-  private Key nk(int r, int cf, int cq, int cv, int ts, boolean deleted) {
+  private Key newKey(int r, int cf, int cq, int cv, int ts, boolean deleted) {
     Key k = new Key(new Text(String.format("r%09d", r)), new Text(String.format("cf%09d", cf)), new Text(String.format("cq%09d", cq)), new Text(String.format(
         "cv%09d", cv)), ts);
 
@@ -62,7 +62,7 @@ public class NativeMapIT {
     return k;
   }
 
-  private Value nv(int v) {
+  private Value newValue(int v) {
     return new Value(String.format("r%09d", v).getBytes(UTF_8));
   }
 
@@ -81,8 +81,8 @@ public class NativeMapIT {
     for (int i = start; i <= end; i++) {
       assertTrue(iter.hasNext());
       Entry<Key,Value> entry = iter.next();
-      assertEquals(nk(i), entry.getKey());
-      assertEquals(nv(i + valueOffset), entry.getValue());
+      assertEquals(newKey(i), entry.getKey());
+      assertEquals(newValue(i + valueOffset), entry.getValue());
     }
 
     assertFalse(iter.hasNext());
@@ -90,34 +90,34 @@ public class NativeMapIT {
 
   private void insertAndVerify(NativeMap nm, int start, int end, int valueOffset) {
     for (int i = start; i <= end; i++) {
-      nm.put(nk(i), nv(i + valueOffset));
+      nm.put(newKey(i), newValue(i + valueOffset));
     }
 
     for (int i = start; i <= end; i++) {
-      Value v = nm.get(nk(i));
+      Value v = nm.get(newKey(i));
       assertNotNull(v);
-      assertEquals(nv(i + valueOffset), v);
+      assertEquals(newValue(i + valueOffset), v);
 
-      Iterator<Entry<Key,Value>> iter2 = nm.iterator(nk(i));
+      Iterator<Entry<Key,Value>> iter2 = nm.iterator(newKey(i));
       assertTrue(iter2.hasNext());
       Entry<Key,Value> entry = iter2.next();
-      assertEquals(nk(i), entry.getKey());
-      assertEquals(nv(i + valueOffset), entry.getValue());
+      assertEquals(newKey(i), entry.getKey());
+      assertEquals(newValue(i + valueOffset), entry.getValue());
     }
 
-    assertNull(nm.get(nk(start - 1)));
+    assertNull(nm.get(newKey(start - 1)));
 
-    assertNull(nm.get(nk(end + 1)));
+    assertNull(nm.get(newKey(end + 1)));
 
     Iterator<Entry<Key,Value>> iter = nm.iterator();
     verifyIterator(start, end, valueOffset, iter);
 
     for (int i = start; i <= end; i++) {
-      iter = nm.iterator(nk(i));
+      iter = nm.iterator(newKey(i));
       verifyIterator(i, end, valueOffset, iter);
 
       // lookup nonexistant key that falls after existing key
-      iter = nm.iterator(nk(i, 1, 1, 1, 1, false));
+      iter = nm.iterator(newKey(i, 1, 1, 1, 1, false));
       verifyIterator(i + 1, end, valueOffset, iter);
     }
 
@@ -130,12 +130,12 @@ public class NativeMapIT {
         for (int k = 0; k < num; k++) {
           for (int l = 0; l < num; l++) {
             for (int ts = 0; ts < num; ts++) {
-              Key key = nk(i, j, k, l, ts, true);
+              Key key = newKey(i, j, k, l, ts, true);
               Value value = new Value((i + "_" + j + "_" + k + "_" + l + "_" + ts + "_" + true + "_" + run).getBytes(UTF_8));
 
               nm.put(key, value);
 
-              key = nk(i, j, k, l, ts, false);
+              key = newKey(i, j, k, l, ts, false);
               value = new Value((i + "_" + j + "_" + k + "_" + l + "_" + ts + "_" + false + "_" + run).getBytes(UTF_8));
 
               nm.put(key, value);
@@ -152,7 +152,7 @@ public class NativeMapIT {
         for (int k = 0; k < num; k++) {
           for (int l = 0; l < num; l++) {
             for (int ts = num - 1; ts >= 0; ts--) {
-              Key key = nk(i, j, k, l, ts, true);
+              Key key = newKey(i, j, k, l, ts, true);
               Value value = new Value((i + "_" + j + "_" + k + "_" + l + "_" + ts + "_" + true + "_" + run).getBytes(UTF_8));
 
               assertTrue(iter.hasNext());
@@ -160,7 +160,7 @@ public class NativeMapIT {
               assertEquals(key, entry.getKey());
               assertEquals(value, entry.getValue());
 
-              key = nk(i, j, k, l, ts, false);
+              key = newKey(i, j, k, l, ts, false);
               value = new Value((i + "_" + j + "_" + k + "_" + l + "_" + ts + "_" + false + "_" + run).getBytes(UTF_8));
 
               assertTrue(iter.hasNext());
@@ -180,7 +180,7 @@ public class NativeMapIT {
         for (int k = 0; k < num; k++) {
           for (int l = 0; l < num; l++) {
             for (int ts = 0; ts < num; ts++) {
-              Key key = nk(i, j, k, l, ts, true);
+              Key key = newKey(i, j, k, l, ts, true);
               Value value = new Value((i + "_" + j + "_" + k + "_" + l + "_" + ts + "_" + true + "_" + run).getBytes(UTF_8));
 
               assertEquals(value, nm.get(key));
@@ -191,7 +191,7 @@ public class NativeMapIT {
               assertEquals(key, entry.getKey());
               assertEquals(value, entry.getValue());
 
-              key = nk(i, j, k, l, ts, false);
+              key = newKey(i, j, k, l, ts, false);
               value = new Value((i + "_" + j + "_" + k + "_" + l + "_" + ts + "_" + false + "_" + run).getBytes(UTF_8));
 
               assertEquals(value, nm.get(key));
@@ -251,14 +251,14 @@ public class NativeMapIT {
     nm.delete();
 
     try {
-      nm.put(nk(1), nv(1));
+      nm.put(newKey(1), newValue(1));
       assertTrue(false);
     } catch (IllegalStateException e) {
 
     }
 
     try {
-      nm.get(nk(1));
+      nm.get(newKey(1));
       assertTrue(false);
     } catch (IllegalStateException e) {
 
@@ -272,7 +272,7 @@ public class NativeMapIT {
     }
 
     try {
-      nm.iterator(nk(1));
+      nm.iterator(newKey(1));
       assertTrue(false);
     } catch (IllegalStateException e) {
 
@@ -377,13 +377,13 @@ public class NativeMapIT {
 
     NativeMap nm = new NativeMap();
     for (int i = start; i <= end; i++) {
-      nm.put(nk(i), nv(i));
+      nm.put(newKey(i), newValue(i));
     }
 
     long mem1 = nm.getMemoryUsed();
 
     for (int i = start; i <= end; i++) {
-      nm.put(nk(i), nv(i));
+      nm.put(newKey(i), newValue(i));
     }
 
     long mem2 = nm.getMemoryUsed();
@@ -393,7 +393,7 @@ public class NativeMapIT {
     }
 
     for (int i = start; i <= end; i++) {
-      nm.put(nk(i), nv(i));
+      nm.put(newKey(i), newValue(i));
     }
 
     long mem3 = nm.getMemoryUsed();
@@ -436,7 +436,7 @@ public class NativeMapIT {
   }
 
   // random length random field
-  private static byte[] rlrf(Random r, int maxLen) {
+  private static byte[] getRandomBytes(Random r, int maxLen) {
     int len = r.nextInt(maxLen);
 
     byte f[] = new byte[len];
@@ -458,8 +458,9 @@ public class NativeMapIT {
 
     for (int i = 0; i < 100000; i++) {
 
-      Key k = new Key(rlrf(r, 97), rlrf(r, 13), rlrf(r, 31), rlrf(r, 11), (r.nextLong() & 0x7fffffffffffffffl), false, false);
-      Value v = new Value(rlrf(r, 511));
+      Key k = new Key(getRandomBytes(r, 97), getRandomBytes(r, 13), getRandomBytes(r, 31), getRandomBytes(r, 11), (r.nextLong() & 0x7fffffffffffffffl), false,
+          false);
+      Value v = new Value(getRandomBytes(r, 511));
 
       testData.add(new Pair<>(k, v));
     }
@@ -506,7 +507,7 @@ public class NativeMapIT {
       Collections.shuffle(testData, r);
       // insert unsorted data
       for (Pair<Key,Value> pair : testData) {
-        pair.getSecond().set(rlrf(r, 511));
+        pair.getSecond().set(getRandomBytes(r, 511));
         nm.put(pair.getFirst(), pair.getSecond());
       }
     }
@@ -583,29 +584,29 @@ public class NativeMapIT {
   public void testConcurrentIter() throws IOException {
     NativeMap nm = new NativeMap();
 
-    nm.put(nk(0), nv(0));
-    nm.put(nk(1), nv(1));
-    nm.put(nk(3), nv(3));
+    nm.put(newKey(0), newValue(0));
+    nm.put(newKey(1), newValue(1));
+    nm.put(newKey(3), newValue(3));
 
     SortedKeyValueIterator<Key,Value> iter = nm.skvIterator();
 
     // modify map after iter created
-    nm.put(nk(2), nv(2));
+    nm.put(newKey(2), newValue(2));
 
     assertTrue(iter.hasTop());
-    assertEquals(iter.getTopKey(), nk(0));
+    assertEquals(iter.getTopKey(), newKey(0));
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertEquals(iter.getTopKey(), nk(1));
+    assertEquals(iter.getTopKey(), newKey(1));
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertEquals(iter.getTopKey(), nk(2));
+    assertEquals(iter.getTopKey(), newKey(2));
     iter.next();
 
     assertTrue(iter.hasTop());
-    assertEquals(iter.getTopKey(), nk(3));
+    assertEquals(iter.getTopKey(), newKey(3));
     iter.next();
 
     assertFalse(iter.hasTop());


### PR DESCRIPTION
While trying to learn the internals of Accumulo, I found a lot of the method names in Test to be confusing. I think Tests are an under utilized learning tool for newcomers. Many method names in Test were clearly chosen for brevity rather than clarity which I think is a bad habit that doesn't help new Accumulo developers.

This PR is for 2.0 (branch with the most changes). I have similar changes for 1.7 and 1.8 branches. Tests should be the same functionally but I wanted other devs to see the changes and get their opinions. 