### PR TITLE
[ACCUMULO-4535] Fix NPE in HostRegexTableLoadBalancer

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.server.conf.ServerConfiguration;
+import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -254,7 +255,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
   }
 
   @Override
-  public void init(ServerConfiguration conf) {
+  public void init(ServerConfigurationFactory conf) {
     super.init(conf);
     parseConfiguration(conf);
   }


### PR DESCRIPTION
An addition to this would be to remove `TabletLoader#init(ServerConfiguration)` entirely.  Would prevent future errors, but may break custom load balancers.  Maybe it'd be best to do this in a future release where there is no real expectation of backwards compatibility.