### PR TITLE
ACCUMULO-4446 Added log INFO when acquiring Monitor lock.

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -499,8 +499,6 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
 
     // Sleep for an initial period, giving the master time to start up and
     // old data files to be unused
-    log.info("Trying to acquire ZooKeeper lock for garbage collector");
-
     try {
       getZooLock(startStatsService());
     } catch (Exception ex) {
@@ -667,6 +665,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
   }
 
   private void getZooLock(HostAndPort addr) throws KeeperException, InterruptedException {
+    log.info("Acquiring Garbage Collector lock.");
     String path = ZooUtil.getRoot(getInstance()) + Constants.ZGC_LOCK;
 
     LockWatcher lockWatcher = new LockWatcher() {
@@ -692,7 +691,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     while (true) {
       lock = new ZooLock(path);
       if (lock.tryLock(lockWatcher, new ServerServices(addr.toString(), Service.GC_CLIENT).toString().getBytes())) {
-        log.debug("Got GC ZooKeeper lock");
+        log.info("Got Garbage Collector lock.");
         return;
       }
       log.debug("Failed to get GC ZooKeeper lock, will retry");

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -665,7 +665,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
   }
 
   private void getZooLock(HostAndPort addr) throws KeeperException, InterruptedException {
-    log.info("Acquiring Garbage Collector lock.");
+    log.info("Attempting to acquire Garbage Collector Lock");
     String path = ZooUtil.getRoot(getInstance()) + Constants.ZGC_LOCK;
 
     LockWatcher lockWatcher = new LockWatcher() {
@@ -691,10 +691,10 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     while (true) {
       lock = new ZooLock(path);
       if (lock.tryLock(lockWatcher, new ServerServices(addr.toString(), Service.GC_CLIENT).toString().getBytes())) {
-        log.info("Got Garbage Collector lock.");
+        log.info("Acquired Garbage Collector Lock");
         return;
       }
-      log.debug("Failed to get GC ZooKeeper lock, will retry");
+      log.debug("Failed to acquire GC ZooKeeper lock, will retry");
       sleepUninterruptibly(1, TimeUnit.SECONDS);
     }
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1400,7 +1400,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
   }
 
   private void getMasterLock(final String zMasterLoc) throws KeeperException, InterruptedException {
-    log.info("Acquiring Master lock");
+    log.info("Attempting to acquire Master Lock");
 
     final String masterClientAddress = hostname + ":" + getConfiguration().getPort(Property.MASTER_CLIENTPORT)[0];
 
@@ -1424,7 +1424,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
 
       sleepUninterruptibly(TIME_TO_WAIT_BETWEEN_LOCK_CHECKS, TimeUnit.MILLISECONDS);
     }
-    log.info("Got Master lock.");
+    log.info("Acquired Master Lock");
     setMasterState(MasterState.HAVE_LOCK);
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1400,7 +1400,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
   }
 
   private void getMasterLock(final String zMasterLoc) throws KeeperException, InterruptedException {
-    log.info("trying to get master lock");
+    log.info("Acquiring Master lock");
 
     final String masterClientAddress = hostname + ":" + getConfiguration().getPort(Property.MASTER_CLIENTPORT)[0];
 
@@ -1424,7 +1424,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
 
       sleepUninterruptibly(TIME_TO_WAIT_BETWEEN_LOCK_CHECKS, TimeUnit.MILLISECONDS);
     }
-
+    log.info("Got Master lock.");
     setMasterState(MasterState.HAVE_LOCK);
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -634,6 +634,7 @@ public class Monitor implements HighlyAvailableService {
       }
     }
 
+    log.info("Acquiring Monitor lock");
     // Get a ZooLock for the monitor
     while (true) {
       MoniterLockWatcher monitorLockWatcher = new MoniterLockWatcher();
@@ -647,6 +648,7 @@ public class Monitor implements HighlyAvailableService {
       }
 
       if (!monitorLockWatcher.failedToAcquireLock) {
+        log.warn("Failed to acquire Monitor lock. Monitor lock is in unknown state.");
         throw new IllegalStateException("monitor lock in unknown state");
       }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -634,7 +634,7 @@ public class Monitor implements HighlyAvailableService {
       }
     }
 
-    log.info("Acquiring Monitor lock");
+    log.info("Attempting to acquire Monitor Lock");
     // Get a ZooLock for the monitor
     while (true) {
       MoniterLockWatcher monitorLockWatcher = new MoniterLockWatcher();
@@ -656,7 +656,7 @@ public class Monitor implements HighlyAvailableService {
       sleepUninterruptibly(getContext().getConfiguration().getTimeInMillis(Property.MONITOR_LOCK_CHECK_INTERVAL), TimeUnit.MILLISECONDS);
     }
 
-    log.info("Got Monitor lock.");
+    log.info("Acquired Monitor Lock " + monitorLock.getLockPath());
   }
 
   /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2310,6 +2310,8 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
   }
 
   public ZooLock getLock() {
+    log.info("Acquiring Tablet Server Lock");
+    log.info("Lock Acquired");
     return tabletServerLock;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2359,12 +2359,12 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       for (int i = 0; i < 120 / 5; i++) {
         zoo.putPersistentData(zPath, new byte[0], NodeExistsPolicy.SKIP);
 
+        log.info("Attempting to acquire Tablet Server Lock");        
         if (tabletServerLock.tryLock(lw, lockContent)) {
-          log.info("Obtained tablet server lock " + tabletServerLock.getLockPath());
+          log.info("Acquired Tablet Server Lock " + tabletServerLock.getLockPath());
           lockID = tabletServerLock.getLockID().serialize(ZooUtil.getRoot(getInstance()) + Constants.ZTSERVERS + "/");
           return;
         }
-        log.info("Waiting for tablet server lock");
         sleepUninterruptibly(5, TimeUnit.SECONDS);
       }
       String msg = "Too many retries, exiting.";

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2359,7 +2359,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       for (int i = 0; i < 120 / 5; i++) {
         zoo.putPersistentData(zPath, new byte[0], NodeExistsPolicy.SKIP);
 
-        log.info("Attempting to acquire Tablet Server Lock");        
+        log.info("Attempting to acquire Tablet Server Lock");
         if (tabletServerLock.tryLock(lw, lockContent)) {
           log.info("Acquired Tablet Server Lock " + tabletServerLock.getLockPath());
           lockID = tabletServerLock.getLockID().serialize(ZooUtil.getRoot(getInstance()) + Constants.ZTSERVERS + "/");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2310,8 +2310,6 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
   }
 
   public ZooLock getLock() {
-    log.info("Acquiring Tablet Server Lock");
-    log.info("Lock Acquired");
     return tabletServerLock;
   }
 
@@ -2362,7 +2360,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         zoo.putPersistentData(zPath, new byte[0], NodeExistsPolicy.SKIP);
 
         if (tabletServerLock.tryLock(lw, lockContent)) {
-          log.debug("Obtained tablet server lock " + tabletServerLock.getLockPath());
+          log.info("Obtained tablet server lock " + tabletServerLock.getLockPath());
           lockID = tabletServerLock.getLockID().serialize(ZooUtil.getRoot(getInstance()) + Constants.ZTSERVERS + "/");
           return;
         }


### PR DESCRIPTION
Fix for ACCUMULO-4446. I added the log INFO right before acquiring the Monitor lock, and a log WARN if the lock fails. On the issue @joshelser wrote:

> Ensuring that these exist for the Master, TabletServer, and SimpleGarbageCollector would also be great!

but I am not sure where this would go, if anyone can point me in the right direction I'll add them and push the changes.

 