### PR TITLE
ACCUMULO-4577: modified exception thrown by Tables.getNamespaceId

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Tables.java
@@ -227,7 +227,7 @@ public class Tables {
    * @throws IllegalArgumentException
    *           if the table doesn't exist in ZooKeeper
    */
-  public static String getNamespaceId(Instance instance, String tableId) throws IllegalArgumentException {
+  public static String getNamespaceId(Instance instance, String tableId) throws TableNotFoundException {
     checkArgument(instance != null, "instance is null");
     checkArgument(tableId != null, "tableId is null");
 
@@ -236,7 +236,7 @@ public class Tables {
 
     // We might get null out of ZooCache if this tableID doesn't exist
     if (null == n) {
-      throw new IllegalArgumentException("Table with id " + tableId + " does not exist");
+      throw new TableNotFoundException(tableId, null, null);
     }
 
     return new String(n, UTF_8);

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -194,10 +194,14 @@ public class ClientServiceHandler implements ClientService.Iface {
   }
 
   @Override
-  public void grantTablePermission(TInfo tinfo, TCredentials credentials, String user, String tableName, byte permission) throws ThriftSecurityException,
-      ThriftTableOperationException {
+  public void grantTablePermission(TInfo tinfo, TCredentials credentials, String user, String tableName, byte permission) throws TException {
     String tableId = checkTableId(instance, tableName, TableOperation.PERMISSION);
-    String namespaceId = Tables.getNamespaceId(instance, tableId);
+    String namespaceId;
+    try {
+      namespaceId = Tables.getNamespaceId(instance, tableId);
+    } catch (TableNotFoundException e) {
+      throw new TException(e);
+    }
 
     security.grantTablePermission(credentials, user, tableId, TablePermission.getPermissionById(permission), namespaceId);
   }
@@ -215,10 +219,14 @@ public class ClientServiceHandler implements ClientService.Iface {
   }
 
   @Override
-  public void revokeTablePermission(TInfo tinfo, TCredentials credentials, String user, String tableName, byte permission) throws ThriftSecurityException,
-      ThriftTableOperationException {
+  public void revokeTablePermission(TInfo tinfo, TCredentials credentials, String user, String tableName, byte permission) throws TException {
     String tableId = checkTableId(instance, tableName, TableOperation.PERMISSION);
-    String namespaceId = Tables.getNamespaceId(instance, tableId);
+    String namespaceId;
+    try {
+      namespaceId = Tables.getNamespaceId(instance, tableId);
+    } catch (TableNotFoundException e) {
+      throw new TException(e);
+    }
 
     security.revokeTablePermission(credentials, user, tableId, TablePermission.getPermissionById(permission), namespaceId);
   }
@@ -436,6 +444,8 @@ public class ClientServiceHandler implements ClientService.Iface {
     } catch (AccumuloException e) {
       throw new TException(e);
     } catch (IOException e) {
+      throw new TException(e);
+    } catch (TableNotFoundException e) {
       throw new TException(e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableParentConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableParentConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.server.conf;
 
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 
@@ -35,6 +36,10 @@ public class TableParentConfiguration extends NamespaceConfiguration {
 
   @Override
   protected String getNamespaceId() {
-    return Tables.getNamespaceId(inst, tableId);
+    try {
+      return Tables.getNamespaceId(inst, tableId);
+    } catch (TableNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/FateServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/FateServiceHandler.java
@@ -171,7 +171,7 @@ class FateServiceHandler implements FateService.Iface {
         });
 
         String tableId = ClientServiceHandler.checkTableId(master.getInstance(), oldTableName, tableOp);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canRename;
         try {
@@ -232,8 +232,8 @@ class FateServiceHandler implements FateService.Iface {
           propertiesToSet.put(entry.getKey(), entry.getValue());
         }
 
-        master.fate.seedTransaction(opid, new TraceRepo<>(new CloneTable(c.getPrincipal(), srcTableId, tableName, propertiesToSet, propertiesToExclude)),
-            autoCleanup);
+        master.fate.seedTransaction(opid, new TraceRepo<>(new CloneTable(c.getPrincipal(), namespaceId, srcTableId, tableName, propertiesToSet,
+            propertiesToExclude)), autoCleanup);
 
         break;
       }
@@ -242,7 +242,7 @@ class FateServiceHandler implements FateService.Iface {
         String tableName = validateTableNameArgument(arguments.get(0), tableOp, NOT_SYSTEM);
 
         final String tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, tableOp);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canDeleteTable;
         try {
@@ -260,7 +260,7 @@ class FateServiceHandler implements FateService.Iface {
       case TABLE_ONLINE: {
         TableOperation tableOp = TableOperation.ONLINE;
         final String tableId = validateTableIdArgument(arguments.get(0), tableOp, NOT_ROOT_ID);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canOnlineOfflineTable;
         try {
@@ -279,7 +279,7 @@ class FateServiceHandler implements FateService.Iface {
       case TABLE_OFFLINE: {
         TableOperation tableOp = TableOperation.OFFLINE;
         final String tableId = validateTableIdArgument(arguments.get(0), tableOp, NOT_ROOT_ID);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canOnlineOfflineTable;
         try {
@@ -302,7 +302,7 @@ class FateServiceHandler implements FateService.Iface {
         Text endRow = ByteBufferUtil.toText(arguments.get(2));
 
         final String tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, tableOp);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canMerge;
         try {
@@ -326,7 +326,7 @@ class FateServiceHandler implements FateService.Iface {
         Text endRow = ByteBufferUtil.toText(arguments.get(2));
 
         final String tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, tableOp);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canDeleteRange;
         try {
@@ -350,7 +350,7 @@ class FateServiceHandler implements FateService.Iface {
         boolean setTime = Boolean.parseBoolean(ByteBufferUtil.toString(arguments.get(3)));
 
         final String tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, tableOp);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canBulkImport;
         try {
@@ -373,7 +373,7 @@ class FateServiceHandler implements FateService.Iface {
         byte[] endRow = ByteBufferUtil.toBytes(arguments.get(2));
         List<IteratorSetting> iterators = IteratorUtil.decodeIteratorSettings(ByteBufferUtil.toBytes(arguments.get(3)));
         CompactionStrategyConfig compactionStrategy = CompactionStrategyConfigUtil.decode(ByteBufferUtil.toBytes(arguments.get(4)));
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canCompact;
         try {
@@ -393,7 +393,7 @@ class FateServiceHandler implements FateService.Iface {
       case TABLE_CANCEL_COMPACT: {
         TableOperation tableOp = TableOperation.COMPACT_CANCEL;
         String tableId = validateTableIdArgument(arguments.get(0), tableOp, null);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canCancelCompact;
         try {
@@ -440,7 +440,7 @@ class FateServiceHandler implements FateService.Iface {
         String exportDir = ByteBufferUtil.toString(arguments.get(1));
 
         String tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, tableOp);
-        String namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+        String namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canExport;
         try {
@@ -453,12 +453,22 @@ class FateServiceHandler implements FateService.Iface {
         if (!canExport)
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
-        master.fate.seedTransaction(opid, new TraceRepo<>(new ExportTable(tableName, tableId, exportDir)), autoCleanup);
+        master.fate.seedTransaction(opid, new TraceRepo<>(new ExportTable(namespaceId, tableName, tableId, exportDir)), autoCleanup);
         break;
       }
       default:
         throw new UnsupportedOperationException();
     }
+  }
+
+  private String getNamespaceIdFromTableId(TableOperation tableOp, String tableId) throws ThriftTableOperationException {
+    String namespaceId;
+    try {
+      namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
+    } catch (TableNotFoundException e) {
+      throw new ThriftTableOperationException(tableId, null, tableOp, TableOperationExceptionType.NOTFOUND, e.getMessage());
+    }
+    return namespaceId;
   }
 
   /**

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
@@ -19,38 +19,23 @@ package org.apache.accumulo.master.tableOps;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.accumulo.core.client.Instance;
-import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
-import org.apache.accumulo.core.client.impl.thrift.TableOperationExceptionType;
-import org.apache.accumulo.core.client.impl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
-import org.apache.accumulo.server.client.HdfsZooInstance;
 
 public class CloneTable extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
   private CloneInfo cloneInfo;
 
-  public CloneTable(String user, String srcTableId, String tableName, Map<String,String> propertiesToSet, Set<String> propertiesToExclude)
-      throws ThriftTableOperationException {
+  public CloneTable(String user, String namespaceId, String srcTableId, String tableName, Map<String,String> propertiesToSet, Set<String> propertiesToExclude) {
     cloneInfo = new CloneInfo();
     cloneInfo.user = user;
     cloneInfo.srcTableId = srcTableId;
     cloneInfo.tableName = tableName;
     cloneInfo.propertiesToExclude = propertiesToExclude;
     cloneInfo.propertiesToSet = propertiesToSet;
-    Instance inst = HdfsZooInstance.getInstance();
-    try {
-      cloneInfo.srcNamespaceId = Tables.getNamespaceId(inst, cloneInfo.srcTableId);
-    } catch (IllegalArgumentException e) {
-      if (inst == null || cloneInfo.srcTableId == null) {
-        // just throw the exception if the illegal argument was thrown by the argument checker and not due to table non-existence
-        throw e;
-      }
-      throw new ThriftTableOperationException(cloneInfo.srcTableId, "", TableOperation.CLONE, TableOperationExceptionType.NOTFOUND, "Table does not exist");
-    }
+    cloneInfo.srcNamespaceId = namespaceId;
   }
 
   @Override

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportTable.java
@@ -16,10 +16,9 @@
  */
 package org.apache.accumulo.master.tableOps;
 
-import org.apache.accumulo.core.client.impl.Tables;
+import org.apache.accumulo.core.client.impl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
-import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.hadoop.fs.Path;
 
 public class ExportTable extends MasterRepo {
@@ -27,12 +26,12 @@ public class ExportTable extends MasterRepo {
 
   private final ExportInfo tableInfo;
 
-  public ExportTable(String tableName, String tableId, String exportDir) {
+  public ExportTable(String namespaceId, String tableName, String tableId, String exportDir) throws ThriftTableOperationException {
     tableInfo = new ExportInfo();
     tableInfo.tableName = tableName;
     tableInfo.exportDir = exportDir;
     tableInfo.tableID = tableId;
-    tableInfo.namespaceID = Tables.getNamespaceId(HdfsZooInstance.getInstance(), tableId);
+    tableInfo.namespaceID = namespaceId;
   }
 
   @Override


### PR DESCRIPTION
I modified Tables.getNamespaceId() to throw a more appropriate TableNotFoundException.  Most of the work occurred in the handling of the new exception.  I handled the exception on a case by case basis, usually re-throwing an exception that the calling methods were built to handle and made sense in that scenario.  Since the exception can be handled different ways, I am looking for feedback on the different scenarios.