### PR TITLE
ACCUMULO-2806: changed permissions of /accumulo to 700

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
  * A wrapper around multiple hadoop FileSystem objects, which are assumed to be different volumes. This also concentrates a bunch of meta-operations like
@@ -124,6 +125,9 @@ public interface VolumeManager {
 
   // forward to the appropriate FileSystem object
   boolean mkdirs(Path directory) throws IOException;
+
+  // forward to the appropriate FileSystem object
+  boolean mkdirs(Path path, FsPermission permission) throws IOException;
 
   // forward to the appropriate FileSystem object
   FSDataInputStream open(Path path) throws IOException;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -274,6 +274,11 @@ public class VolumeManagerImpl implements VolumeManager {
   }
 
   @Override
+  public boolean mkdirs(Path path, FsPermission permission) throws IOException {
+    return getVolumeByPath(path).getFileSystem().mkdirs(path, permission);
+  }
+
+  @Override
   public FSDataInputStream open(Path path) throws IOException {
     return getVolumeByPath(path).getFileSystem().open(path);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -103,6 +103,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.zookeeper.KeeperException;
@@ -402,7 +403,7 @@ public class Initialize implements KeywordExecutable {
 
   private static void initDirs(VolumeManager fs, UUID uuid, String[] baseDirs, boolean print) throws IOException {
     for (String baseDir : baseDirs) {
-      fs.mkdirs(new Path(new Path(baseDir, ServerConstants.VERSION_DIR), "" + ServerConstants.DATA_VERSION));
+      fs.mkdirs(new Path(new Path(baseDir, ServerConstants.VERSION_DIR), "" + ServerConstants.DATA_VERSION), new FsPermission("700"));
 
       // create an instance id
       Path iidLocation = new Path(baseDir, ServerConstants.INSTANCE_ID_DIR);


### PR DESCRIPTION
Simple fix for ACCUMULO-2806.  I had overcomplicated the issue by attempting to set the permissions independently for each directory under /accumulo but I think just securing permissions at the top will work fine. 

My question for the community, will this change break/complicate 3rd party tools? 