### PR TITLE
ACCUMULO-4594 Fix Kerberos documentation

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -72,13 +72,6 @@ function main() {
   export HADOOP_HOME=$HADOOP_PREFIX
   export HADOOP_HOME_WARN_SUPPRESS=true
 
-  if [ -f "${conf}/jaas.conf" ]; then
-    export JAVA_OPTS=("${JAVA_OPTS[@]}" "-Djava.security.auth.login.config=${conf}/jaas.conf")
-  fi
-  if [ -f "${conf}/krb5.conf" ]; then
-    export JAVA_OPTS=("${JAVA_OPTS[@]}" "-Djava.security.krb5.conf=${conf}/krb5.conf")
-  fi
-
   # This is default for hadoop 2.x; for another distribution, specify (DY)LD_LIBRARY_PATH explicitly above
   if [ -e "${HADOOP_PREFIX}/lib/native/libhadoop.so" ]; then
     export LD_LIBRARY_PATH="${HADOOP_PREFIX}/lib/native:${LD_LIBRARY_PATH}"     # For Linux

--- a/docs/src/main/asciidoc/chapters/kerberos.txt
+++ b/docs/src/main/asciidoc/chapters/kerberos.txt
@@ -216,12 +216,9 @@ Accumulo process: +masters+, +monitors+, +tservers+, +tracers+, and +gc+.
 Normally, no changes are needed in +accumulo-env.sh+ to enable Kerberos. Typically, the +krb5.conf+
 is installed on the local machine in +/etc/+, and the Java library implementations will look
 here to find the necessary configuration to communicate with the KDC. Some installations
-may require a different +krb5.conf+ to be used for Accumulo: +ACCUMULO_KRB5_CONF+ enables this.
-
-+ACCUMULO_KRB5_CONF+ can be configured to a directory containing a file named +krb5.conf+ or
-the path to the file itself. This will be provided to all Accumulo server and client processes
-via the JVM system property +java.security.krb5.conf+. If the environment variable is not set,
-+java.security.krb5.conf+ will not be set either.
+may require a different +krb5.conf+ to be used for Accumulo which can be accomplished 
+by adding the JVM system property +-Djava.security.krb5.conf=/path/to/other/krb5.conf+ to
++JAVA_OPTS+ in +accumulo-env.sh+.
 
 ===== KerberosAuthenticator
 


### PR DESCRIPTION
* Added documentation for configuring Kerberos using 2.0.0 scripts
* Removed kerberos config file references from accumulo command as
  these can be added by user to JAVA_OPTS in accumulo-env.sh