### PR TITLE
ACCUMULO-4596 Improvements to standalone cluster testing

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -116,10 +116,12 @@ The following properties can be used to configure a standalone cluster:
 - `accumulo.it.cluster.standalone.admin.keytab`, Required: Keytab for the principal (only valid w/ Kerberos)
 - `accumulo.it.cluster.standalone.zookeepers`, Required: ZooKeeper quorum used by the standalone cluster
 - `accumulo.it.cluster.standalone.instance.name`, Required: Accumulo instance name for the cluster
-- `accumulo.it.cluster.standalone.hadoop.conf`, Required: `HADOOP_CONF_DIR`
-- `accumulo.it.cluster.standalone.home`, Optional: `ACCUMULO_HOME`
-- `accumulo.it.cluster.standalone.conf`, Optional: `ACCUMULO_CONF_DIR`
-- `accumulo.it.cluster.standalone.server.user`, Optional: The user Accumulo is running as (used to sudo when starting/stopping Accumulo). Default "accumulo"
+- `accumulo.it.cluster.standalone.hadoop.conf`, Required: Hadoop configuration directory
+- `accumulo.it.cluster.standalone.home`, Required: Accumulo installation directory on cluster
+- `accumulo.it.cluster.standalone.client.conf`, Required: Accumulo conf directory on client
+- `accumulo.it.cluster.standalone.server.conf`, Required: Accumulo conf directory on server
+- `accumulo.it.cluster.standalone.client.cmd.prefix`, Optional: Prefix that will be added to Accumulo client commands
+- `accumulo.it.cluster.standalone.server.cmd.prefix`, Optional: Prefix that will be added to Accumulo service commands
 
 Additionally, when running with Kerberos enabled, it is required that Kerberos principals already exist
 for the tests to use. As such, a number of properties exist to allow users to be passed down for tests
@@ -140,13 +142,6 @@ specified on the command line override properties set in a file.  For example, t
 what is executed for a standalone cluster.
 
   `mvn verify -Daccumulo.it.properties=/home/user/my_cluster.properties`
-
-For the optional properties, each of them will be extracted from the environment if not explicitly provided.
-Specifically, `ACCUMULO_HOME` and `ACCUMULO_CONF_DIR` are used to ensure the correct version of the bundled
-Accumulo scripts are invoked and, in the event that multiple Accumulo processes exist on the same physical machine,
-but for different instances, the correct version is terminated. `HADOOP_CONF_DIR` is used to ensure that the necessary
-files to construct the FileSystem object for the cluster can be constructed (e.g. core-site.xml and hdfs-site.xml),
-which is typically required to interact with HDFS.
 
 ## MapReduce job for Integration tests
 

--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -39,7 +39,7 @@ function main() {
   # Set up variables needed by accumulo-env.sh
   export bin="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
   export basedir=$( cd -P "${bin}"/.. && pwd )
-  export conf="${basedir}/conf"
+  export conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
   export lib="${basedir}/lib"
   export cmd="$1"
 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -297,7 +297,7 @@ function main() {
   done
   bin="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
   basedir=$( cd -P "${bin}"/.. && pwd )
-  conf="${basedir}/conf"
+  conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
 
   accumulo_cmd="${bin}/accumulo"
   SSH='ssh -qnf -o ConnectTimeout=2'

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -117,7 +117,7 @@ function main() {
   # Set up variables needed by accumulo-env.sh
   export bin="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
   export basedir=$( cd -P "${bin}"/.. && pwd )
-  export conf="${basedir}/conf"
+  export conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
   export lib="${basedir}/lib"
 
   if [ -f "${conf}/accumulo-env.sh" ]; then

--- a/assemble/bin/accumulo-util
+++ b/assemble/bin/accumulo-util
@@ -644,7 +644,7 @@ function main() {
   done
   bin="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
   basedir=$( cd -P "${bin}"/.. && pwd )
-  conf="${basedir}/conf"
+  conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
   lib="${basedir}/lib"
 
   case "$1" in

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
@@ -60,18 +60,18 @@ public class StandaloneAccumuloCluster implements AccumuloCluster {
   private String accumuloHome, clientAccumuloConfDir, serverAccumuloConfDir, hadoopConfDir;
   private Path tmp;
   private List<ClusterUser> users;
-  private String serverUser;
+  private String clientCmdPrefix;
+  private String serverCmdPrefix;
 
-  public StandaloneAccumuloCluster(ClientConfiguration clientConf, Path tmp, List<ClusterUser> users, String serverUser) {
-    this(new ZooKeeperInstance(clientConf), clientConf, tmp, users, serverUser);
+  public StandaloneAccumuloCluster(ClientConfiguration clientConf, Path tmp, List<ClusterUser> users) {
+    this(new ZooKeeperInstance(clientConf), clientConf, tmp, users);
   }
 
-  public StandaloneAccumuloCluster(Instance instance, ClientConfiguration clientConf, Path tmp, List<ClusterUser> users, String serverUser) {
+  public StandaloneAccumuloCluster(Instance instance, ClientConfiguration clientConf, Path tmp, List<ClusterUser> users) {
     this.instance = instance;
     this.clientConf = clientConf;
     this.tmp = tmp;
     this.users = users;
-    this.serverUser = serverUser;
   }
 
   public String getAccumuloHome() {
@@ -96,6 +96,14 @@ public class StandaloneAccumuloCluster implements AccumuloCluster {
 
   public void setServerAccumuloConfDir(String accumuloConfDir) {
     this.serverAccumuloConfDir = accumuloConfDir;
+  }
+
+  public void setServerCmdPrefix(String serverCmdPrefix) {
+    this.serverCmdPrefix = serverCmdPrefix;
+  }
+
+  public void setClientCmdPrefix(String clientCmdPrefix) {
+    this.clientCmdPrefix = clientCmdPrefix;
   }
 
   public String getHadoopConfDir() {
@@ -134,9 +142,8 @@ public class StandaloneAccumuloCluster implements AccumuloCluster {
 
   @Override
   public StandaloneClusterControl getClusterControl() {
-    return new StandaloneClusterControl(serverUser, null == accumuloHome ? System.getenv("ACCUMULO_HOME") : accumuloHome,
-        null == clientAccumuloConfDir ? System.getenv("ACCUMULO_CONF_DIR") : clientAccumuloConfDir,
-        null == serverAccumuloConfDir ? System.getenv("ACCUMULO_CONF_DIR") : serverAccumuloConfDir);
+    return new StandaloneClusterControl(accumuloHome, clientAccumuloConfDir, serverAccumuloConfDir,
+                                        clientCmdPrefix, serverCmdPrefix);
   }
 
   @Override

--- a/minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControlTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControlTest.java
@@ -35,36 +35,38 @@ public class StandaloneClusterControlTest {
   public void testPaths() {
     String accumuloHome = "/usr/lib/accumulo", accumuloConfDir = "/etc/accumulo/conf", accumuloServerConfDir = "/etc/accumulo/conf/server";
 
-    StandaloneClusterControl control = new StandaloneClusterControl("accumulo", accumuloHome, accumuloConfDir, accumuloServerConfDir);
+    StandaloneClusterControl control = new StandaloneClusterControl(accumuloHome, accumuloConfDir, accumuloServerConfDir, "", "");
 
     assertEquals(accumuloHome, control.accumuloHome);
     assertEquals(accumuloConfDir, control.clientAccumuloConfDir);
+    assertEquals(accumuloServerConfDir, control.serverAccumuloConfDir);
 
     assertEquals(accumuloHome + "/bin/accumulo", control.accumuloPath);
-    assertEquals(accumuloHome + "/bin/start-server.sh", control.startServerPath);
+    assertEquals(accumuloHome + "/bin/accumulo-service", control.accumuloServicePath);
   }
 
   @Test
   public void mapreduceLaunchesLocally() throws Exception {
-    final String toolPath = "/usr/lib/accumulo/contrib/tool.sh";
+    final String accumuloUtilPath = "/usr/lib/accumulo/bin/accumulo-util";
     final String jar = "/home/user/my_project.jar";
     final Class<?> clz = Object.class;
     final String myClass = clz.getName();
     StandaloneClusterControl control = EasyMock.createMockBuilder(StandaloneClusterControl.class).addMockedMethod("exec", String.class, String[].class)
-        .addMockedMethod("getToolPath").addMockedMethod("getJarFromClass", Class.class).createMock();
+        .addMockedMethod("getAccumuloUtilPath").addMockedMethod("getJarFromClass", Class.class).createMock();
 
     final String[] toolArgs = new String[] {"-u", "user", "-p", "password"};
-    final String[] expectedCommands = new String[3 + toolArgs.length];
+    final String[] expectedCommands = new String[4 + toolArgs.length];
 
     int i = 0;
-    expectedCommands[i++] = toolPath;
+    expectedCommands[i++] = accumuloUtilPath;
+    expectedCommands[i++] = "hadoop-jar";
     expectedCommands[i++] = jar;
     expectedCommands[i++] = myClass;
     for (int j = 0; j < toolArgs.length; j++) {
       expectedCommands[i + j] = quote(toolArgs[j]);
     }
 
-    expect(control.getToolPath()).andReturn(toolPath);
+    expect(control.getAccumuloUtilPath()).andReturn(accumuloUtilPath);
     expect(control.getJarFromClass(anyObject(Class.class))).andReturn(jar);
     expect(control.exec(eq("localhost"), aryEq(expectedCommands))).andReturn(Maps.immutableEntry(0, ""));
 

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -131,13 +131,14 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase implements M
       case STANDALONE:
         StandaloneAccumuloClusterConfiguration conf = (StandaloneAccumuloClusterConfiguration) clusterConf;
         ClientConfiguration clientConf = conf.getClientConf();
-        StandaloneAccumuloCluster standaloneCluster = new StandaloneAccumuloCluster(conf.getInstance(), clientConf, conf.getTmpDirectory(), conf.getUsers(),
-            conf.getAccumuloServerUser());
+        StandaloneAccumuloCluster standaloneCluster = new StandaloneAccumuloCluster(conf.getInstance(), clientConf, conf.getTmpDirectory(), conf.getUsers());
         // If these are provided in the configuration, pass them into the cluster
         standaloneCluster.setAccumuloHome(conf.getAccumuloHome());
         standaloneCluster.setClientAccumuloConfDir(conf.getClientAccumuloConfDir());
         standaloneCluster.setServerAccumuloConfDir(conf.getServerAccumuloConfDir());
         standaloneCluster.setHadoopConfDir(conf.getHadoopConfDir());
+        standaloneCluster.setServerCmdPrefix(conf.getServerCmdPrefix());
+        standaloneCluster.setClientCmdPrefix(conf.getClientCmdPrefix());
 
         // For SASL, we need to get the Hadoop configuration files as well otherwise UGI will log in as SIMPLE instead of KERBEROS
         Configuration hadoopConfiguration = standaloneCluster.getHadoopConfiguration();

--- a/test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
@@ -71,6 +71,8 @@ public class StandaloneAccumuloClusterConfiguration extends AccumuloClusterPrope
   public static final String ACCUMULO_STANDALONE_HOME = ACCUMULO_STANDALONE_PREFIX + "home";
   public static final String ACCUMULO_STANDALONE_CLIENT_CONF = ACCUMULO_STANDALONE_PREFIX + "client.conf";
   public static final String ACCUMULO_STANDALONE_SERVER_CONF = ACCUMULO_STANDALONE_PREFIX + "server.conf";
+  public static final String ACCUMULO_STANDALONE_CLIENT_CMD_PREFIX = ACCUMULO_STANDALONE_PREFIX + "client.cmd.prefix";
+  public static final String ACCUMULO_STANDALONE_SERVER_CMD_PREFIX = ACCUMULO_STANDALONE_PREFIX + "server.cmd.prefix";
   public static final String ACCUMULO_STANDALONE_HADOOP_CONF = ACCUMULO_STANDALONE_PREFIX + "hadoop.conf";
 
   private Map<String,String> conf;
@@ -222,6 +224,14 @@ public class StandaloneAccumuloClusterConfiguration extends AccumuloClusterPrope
 
   public String getServerAccumuloConfDir() {
     return conf.get(ACCUMULO_STANDALONE_SERVER_CONF);
+  }
+
+  public String getServerCmdPrefix() {
+    return conf.get(ACCUMULO_STANDALONE_SERVER_CMD_PREFIX);
+  }
+
+  public String getClientCmdPrefix() {
+    return conf.get(ACCUMULO_STANDALONE_CLIENT_CMD_PREFIX);
   }
 
   @Override


### PR DESCRIPTION
* Limited use of bash env variables in standalone cluster testing
* Fixed standalone cluster testing sow that it work with Accumulo 2.0
  script changes
* Users now only need to configure Accumulo conf directory on client