### PR TITLE
ACCUMULO-4596 Remove env variable from general.dynamic.classpaths

### DIFF
--- a/assemble/conf/log4j.properties
+++ b/assemble/conf/log4j.properties
@@ -24,6 +24,7 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.logger.org.apache.accumulo.shell.Shell.audit=WARN
 
 log4j.logger.org.apache.accumulo.core.file.rfile.bcfile.Compression=WARN
+log4j.logger.org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader=WARN
 log4j.logger.org.apache.accumulo.test.TestRandomDeletes=WARN
 log4j.logger.org.apache.commons.vfs2.impl.DefaultFileSystemManager=WARN
 log4j.logger.org.apache.hadoop.io.compress=WARN

--- a/assemble/conf/templates/accumulo-env.sh
+++ b/assemble/conf/templates/accumulo-env.sh
@@ -48,7 +48,8 @@ JAVA_OPTS=("${ACCUMULO_JAVA_OPTS[@]}"
   '-XX:OnOutOfMemoryError=kill -9 %p'
   '-XX:-OmitStackTraceInFastThrow'
   '-Djava.net.preferIPv4Stack=true'
-  "-Daccumulo.native.lib.path=${lib}/native")
+  "-Daccumulo.native.lib.path=${lib}/native"
+  "-Daccumulo.dynamic.classpaths=${lib}/ext/[^.].*.jar")
 
 ## Make sure Accumulo native libraries are built since they are enabled by default
 ${bin}/accumulo-util build-native &> /dev/null

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -174,8 +174,9 @@ public enum Property {
       "A list of all of the places to look for a class. Order does matter, as it will look for the jar "
           + "starting in the first location to the last. Please note, hadoop conf and hadoop lib directories NEED to be here, "
           + "along with accumulo lib and zookeeper directory. Supports full regex on filename alone."), // needs special treatment in accumulo start jar
-  GENERAL_DYNAMIC_CLASSPATHS(AccumuloVFSClassLoader.DYNAMIC_CLASSPATH_PROPERTY_NAME, AccumuloVFSClassLoader.DEFAULT_DYNAMIC_CLASSPATH_VALUE,
-      PropertyType.STRING, "A list of all of the places where changes in jars or classes will force a reload of the classloader."),
+  GENERAL_DYNAMIC_CLASSPATHS(AccumuloVFSClassLoader.DYNAMIC_CLASSPATHS_SITE_PROPERTY, "", PropertyType.STRING,
+                             "A list of all of the places where changes in jars or classes will force a reload of the classloader. "
+                             + "List will appended to value set by the JVM system property - " + AccumuloVFSClassLoader.DYNAMIC_CLASSPATHS_JVM_PROPERTY),
   GENERAL_RPC_TIMEOUT("general.rpc.timeout", "120s", PropertyType.TIMEDURATION, "Time to wait on I/O for simple, short RPC calls"),
   @Experimental
   GENERAL_RPC_SERVER_TYPE("general.rpc.server.type", "", PropertyType.STRING,

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
@@ -204,4 +204,14 @@ public class AccumuloVFSClassLoaderTest {
 
     Whitebox.setInternalState(AccumuloVFSClassLoader.class, "loader", (AccumuloReloadingVFSClassLoader) null);
   }
+
+  @Test
+  public void testAddToClasspath() {
+    Assert.assertEquals("jar1", AccumuloVFSClassLoader.addToClasspath("", "jar1"));
+    Assert.assertEquals("jar1,jar2", AccumuloVFSClassLoader.addToClasspath("jar1", "jar2"));
+    Assert.assertEquals("", AccumuloVFSClassLoader.addToClasspath("", ""));
+    Assert.assertEquals("", AccumuloVFSClassLoader.addToClasspath("", null));
+    Assert.assertEquals("", AccumuloVFSClassLoader.addToClasspath(null, null));
+    Assert.assertEquals("jar1", AccumuloVFSClassLoader.addToClasspath("jar1", ""));
+  }
 }


### PR DESCRIPTION
* Removed default value for general.dynamic.classpaths which used
  ACCUMULO_HOME env variale
* Create system property 'accumulo.dynamic.classpaths' that sets
  same default value as before in accumulo-env.sh
* User can set dynamic classpaths in either location.  If both are
  set, the values are appended.