### PR TITLE
ACCUMULO-3521: minor improvements to iterators

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.io.Text;
+import org.apache.commons.lang.math.NumberUtils;
 
 public class FirstEntryInRowIterator extends SkippingIterator implements OptionDescriber {
 
@@ -75,7 +76,7 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
   // this is only ever called immediately after getting "next" entry
   @Override
   protected void consume() throws IOException {
-    if (finished == true || lastRowFound == null)
+    if (finished || lastRowFound == null)
       return;
     int count = 0;
     while (getSource().hasTop() && lastRowFound.equals(getSource().getTopKey().getRow())) {
@@ -139,13 +140,9 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
 
   @Override
   public boolean validateOptions(Map<String,String> options) {
-    try {
-      String o = options.get(NUM_SCANS_STRING_NAME);
-      if (o != null)
-        Integer.parseInt(o);
-    } catch (Exception e) {
-      throw new IllegalArgumentException("bad integer " + NUM_SCANS_STRING_NAME + ":" + options.get(NUM_SCANS_STRING_NAME), e);
-    }
+    String o = options.get(NUM_SCANS_STRING_NAME);
+    if (o != null && !NumberUtils.isNumber(o))
+      throw new IllegalArgumentException("bad integer " + NUM_SCANS_STRING_NAME + ":" + options.get(NUM_SCANS_STRING_NAME));
     return true;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
@@ -131,11 +131,7 @@ public abstract class TypedValueCombiner<V> extends Combiner {
       @SuppressWarnings("unchecked")
       Class<? extends Encoder<V>> clazz = (Class<? extends Encoder<V>>) AccumuloVFSClassLoader.loadClass(encoderClass, Encoder.class);
       encoder = clazz.newInstance();
-    } catch (ClassNotFoundException e) {
-      throw new IllegalArgumentException(e);
-    } catch (InstantiationException e) {
-      throw new IllegalArgumentException(e);
-    } catch (IllegalAccessException e) {
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
       throw new IllegalArgumentException(e);
     }
   }
@@ -190,10 +186,7 @@ public abstract class TypedValueCombiner<V> extends Combiner {
 
   private void setLossyness(Map<String,String> options) {
     String loss = options.get(LOSSY);
-    if (loss == null)
-      lossy = false;
-    else
-      lossy = Boolean.parseBoolean(loss);
+    lossy = loss != null && Boolean.parseBoolean(loss);
   }
 
   @Override


### PR DESCRIPTION
Updated iterators mentioned in [ACCUMULO-3521](https://issues.apache.org/jira/browse/ACCUMULO-3521), added tests to cover untested methods and deprecated OrIterator.  Couldn't find IteratorUtil.getMaxPriority and .findIterator methods.  StatsCombiner is in examples.