### PR TITLE
Discuss ACCUMULO-3079: collapsing the iterator stack to improve performance

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockScannerBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockScannerBase.java
@@ -133,8 +133,8 @@ public class MockScannerBase extends ScannerOptions implements ScannerBase {
   public SortedKeyValueIterator<Key,Value> createFilter(SortedKeyValueIterator<Key,Value> inner) throws IOException {
     byte[] defaultLabels = {};
     inner = new ColumnFamilySkippingIterator(new DeletingIterator(inner, false));
-    ColumnQualifierFilter cqf = new ColumnQualifierFilter(inner, new HashSet<>(fetchedColumns));
-    VisibilityFilter vf = new VisibilityFilter(cqf, auths, defaultLabels);
+    SortedKeyValueIterator<Key,Value> cqf = ColumnQualifierFilter.wrap(inner, new HashSet<>(fetchedColumns));
+    SortedKeyValueIterator<Key,Value> vf = VisibilityFilter.wrap(cqf, auths, defaultLabels);
     AccumuloConfiguration conf = new MockConfiguration(table.settings);
     MockIteratorEnvironment iterEnv = new MockIteratorEnvironment(auths);
     SortedKeyValueIterator<Key,Value> result = iterEnv.getTopLevelIterator(IteratorUtil.loadIterators(IteratorScope.scan, vf, null, conf,

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
@@ -69,9 +69,10 @@ public abstract class Filter extends WrappingIterator implements OptionDescriber
    * Iterates over the source until an acceptable key/value pair is found.
    */
   protected void findTop() {
-    while (getSource().hasTop() && !getSource().getTopKey().isDeleted() && (negate == accept(getSource().getTopKey(), getSource().getTopValue()))) {
+    SortedKeyValueIterator<Key,Value> source = getSource();
+    while (source.hasTop() && !source.getTopKey().isDeleted() && (negate == accept(source.getTopKey(), source.getTopValue()))) {
       try {
-        getSource().next();
+        source.next();
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
@@ -79,27 +79,28 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
     if (finished || lastRowFound == null)
       return;
     int count = 0;
-    while (getSource().hasTop() && lastRowFound.equals(getSource().getTopKey().getRow())) {
+    SortedKeyValueIterator<Key,Value> source = getSource();
+    while (source.hasTop() && lastRowFound.equals(source.getTopKey().getRow())) {
 
       // try to efficiently jump to the next matching key
       if (count < numscans) {
         ++count;
-        getSource().next(); // scan
+        source.next(); // scan
       } else {
         // too many scans, just seek
         count = 0;
 
         // determine where to seek to, but don't go beyond the user-specified range
-        Key nextKey = getSource().getTopKey().followingKey(PartialKey.ROW);
+        Key nextKey = source.getTopKey().followingKey(PartialKey.ROW);
         if (!latestRange.afterEndKey(nextKey))
-          getSource().seek(new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()), latestColumnFamilies, latestInclusive);
+          source.seek(new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()), latestColumnFamilies, latestInclusive);
         else {
           finished = true;
           break;
         }
       }
     }
-    lastRowFound = getSource().hasTop() ? getSource().getTopKey().getRow(lastRowFound) : null;
+    lastRowFound = source.hasTop() ? source.getTopKey().getRow(lastRowFound) : null;
   }
 
   private boolean finished = true;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.data.thrift.IterInfo;
 import org.apache.accumulo.core.iterators.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.iterators.system.ColumnQualifierFilter;
 import org.apache.accumulo.core.iterators.system.DeletingIterator;
-import org.apache.accumulo.core.iterators.system.SynchronizedIterator;
 import org.apache.accumulo.core.iterators.system.VisibilityFilter;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
 import org.apache.accumulo.core.security.Authorizations;
@@ -255,7 +254,7 @@ public class IteratorUtil {
       Collection<IterInfo> iters, Map<String,Map<String,String>> iterOpts, IteratorEnvironment env, boolean useAccumuloClassLoader, String context,
       Map<String,Class<? extends SortedKeyValueIterator<K,V>>> classCache) throws IOException {
     // wrap the source in a SynchronizedIterator in case any of the additional configured iterators want to use threading
-    SortedKeyValueIterator<K,V> prev = new SynchronizedIterator<>(source);
+    SortedKeyValueIterator<K,V> prev = source;
 
     try {
       for (IterInfo iterInfo : iters) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
@@ -395,7 +395,7 @@ public class IteratorUtil {
       byte[] defaultVisibility) throws IOException {
     DeletingIterator delIter = new DeletingIterator(source, false);
     ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
-    ColumnQualifierFilter colFilter = new ColumnQualifierFilter(cfsi, cols);
-    return new VisibilityFilter(colFilter, auths, defaultVisibility);
+    SortedKeyValueIterator<Key,Value> colFilter = ColumnQualifierFilter.wrap(cfsi, cols);
+    return VisibilityFilter.wrap(colFilter, auths, defaultVisibility);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/ServerFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/ServerFilter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.iterators;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+
+/**
+ * An optimized version of {@link org.apache.accumulo.core.iterators.Filter}. This class grants protected access to the read only <code>source</code> iterator.
+ * For performance reasons, the <code>source</code> iterator is declared final and subclasses directly access it, no longer requiring calls to getSource(). The
+ * {@link #init(SortedKeyValueIterator, Map, IteratorEnvironment)} method is not supported since the source can only be assigned in the constructor.
+ *
+ * @since 2.0
+ */
+public abstract class ServerFilter extends ServerWrappingIterator {
+
+  public ServerFilter(SortedKeyValueIterator<Key,Value> source) {
+    super(source);
+  }
+
+  @Override
+  public abstract SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env);
+
+  @Override
+  public void next() throws IOException {
+    source.next();
+    findTop();
+  }
+
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+    source.seek(range, columnFamilies, inclusive);
+    findTop();
+  }
+
+  /**
+   * Iterates over the source until an acceptable key/value pair is found.
+   */
+  private void findTop() throws IOException {
+    while (source.hasTop()) {
+      Key top = source.getTopKey();
+      if (top.isDeleted() || (accept(top, source.getTopValue()))) {
+        break;
+      }
+      source.next();
+    }
+  }
+
+  /**
+   * @return <tt>true</tt> if the key/value pair is accepted by the filter.
+   */
+  public abstract boolean accept(Key k, Value v);
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/ServerSkippingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/ServerSkippingIterator.java
@@ -14,61 +14,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.core.iterators.system;
+package org.apache.accumulo.core.iterators;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.IteratorEnvironment;
-import org.apache.accumulo.core.iterators.ServerWrappingIterator;
-import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 /**
+ * An optimized version of {@link org.apache.accumulo.core.iterators.SkippingIterator}. This class grants protected access to the read only <code>source</code>
+ * iterator. For performance reasons, the <code>source</code> iterator is declared final and subclasses directly access it, no longer requiring calls to
+ * getSource().
  *
+ * @since 2.0
  */
-public class StatsIterator extends ServerWrappingIterator {
+public abstract class ServerSkippingIterator extends ServerWrappingIterator {
 
-  private int numRead = 0;
-  private AtomicLong seekCounter;
-  private AtomicLong readCounter;
-
-  public StatsIterator(SortedKeyValueIterator<Key,Value> source, AtomicLong seekCounter, AtomicLong readCounter) {
+  public ServerSkippingIterator(SortedKeyValueIterator<Key,Value> source) {
     super(source);
-    this.seekCounter = seekCounter;
-    this.readCounter = readCounter;
   }
 
   @Override
   public void next() throws IOException {
     source.next();
-    numRead++;
-
-    if (numRead % 23 == 0) {
-      readCounter.addAndGet(numRead);
-      numRead = 0;
-    }
+    consume();
   }
 
-  @Override
-  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
-    return new StatsIterator(source.deepCopy(env), seekCounter, readCounter);
-  }
+  protected abstract void consume() throws IOException;
 
   @Override
   public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
     source.seek(range, columnFamilies, inclusive);
-    seekCounter.incrementAndGet();
-    readCounter.addAndGet(numRead);
-    numRead = 0;
+    consume();
   }
 
-  public void report() {
-    readCounter.addAndGet(numRead);
-    numRead = 0;
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/ServerWrappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/ServerWrappingIterator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.iterators;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+
+/**
+ * An optimized version of {@link org.apache.accumulo.core.iterators.WrappingIterator}. This class grants protected access to the read only <code>source</code>
+ * iterator. For performance reasons, the <code>source</code> iterator is declared final and subclasses directly access it, no longer requiring calls to
+ * getSource(). The {@link #init(SortedKeyValueIterator, Map, IteratorEnvironment)} method is not supported since the source can only be assigned in the
+ * constructor. As with the WrappingIterator, the {@link #deepCopy(IteratorEnvironment)} method is not supported.
+ *
+ * @since 2.0
+ */
+public abstract class ServerWrappingIterator implements SortedKeyValueIterator<Key,Value> {
+
+  protected final SortedKeyValueIterator<Key,Value> source;
+
+  public ServerWrappingIterator(SortedKeyValueIterator<Key,Value> source) {
+    this.source = source;
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Key getTopKey() {
+    return source.getTopKey();
+  }
+
+  @Override
+  public Value getTopValue() {
+    return source.getTopValue();
+  }
+
+  @Override
+  public boolean hasTop() {
+    return source.hasTop();
+  }
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void next() throws IOException {
+    source.next();
+  }
+
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+    source.seek(range, columnFamilies, inclusive);
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/SynchronizedServerFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/SynchronizedServerFilter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.iterators;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+
+/**
+ * A SortedKeyValueIterator similar to {@link org.apache.accumulo.core.iterators.ServerFilter} but with the implemented methods marked as synchronized. The
+ * {@link #init(SortedKeyValueIterator, Map, IteratorEnvironment)} method is also not supported since the source can only be assigned in the constructor.
+ *
+ * @since 2.0
+ */
+public abstract class SynchronizedServerFilter implements SortedKeyValueIterator<Key,Value> {
+
+  protected final SortedKeyValueIterator<Key,Value> source;
+
+  public SynchronizedServerFilter(SortedKeyValueIterator<Key,Value> source) {
+    this.source = source;
+  }
+
+  @Override
+  public abstract SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env);
+
+  @Override
+  public synchronized void next() throws IOException {
+    source.next();
+    findTop();
+  }
+
+  @Override
+  public synchronized void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+    source.seek(range, columnFamilies, inclusive);
+    findTop();
+  }
+
+  @Override
+  public synchronized Key getTopKey() {
+    return source.getTopKey();
+  }
+
+  @Override
+  public synchronized Value getTopValue() {
+    return source.getTopValue();
+  }
+
+  @Override
+  public synchronized boolean hasTop() {
+    return source.hasTop();
+  }
+
+  /**
+   * Iterates over the source until an acceptable key/value pair is found.
+   */
+  private void findTop() throws IOException {
+    while (source.hasTop()) {
+      Key top = source.getTopKey();
+      if (top.isDeleted() || (accept(top, source.getTopValue()))) {
+        break;
+      }
+      source.next();
+    }
+  }
+
+  /**
+   * @return <tt>true</tt> if the key/value pair is accepted by the filter.
+   */
+  protected abstract boolean accept(Key k, Value v);
+
+  @Override
+  public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/SynchronizedIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/SynchronizedIterator.java
@@ -33,12 +33,11 @@ import org.apache.hadoop.io.WritableComparable;
  */
 public class SynchronizedIterator<K extends WritableComparable<?>,V extends Writable> implements SortedKeyValueIterator<K,V> {
 
-  private SortedKeyValueIterator<K,V> source = null;
+  private final SortedKeyValueIterator<K,V> source;
 
   @Override
   public synchronized void init(SortedKeyValueIterator<K,V> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
-    this.source = source;
-    source.init(source, options, env);
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -70,8 +69,6 @@ public class SynchronizedIterator<K extends WritableComparable<?>,V extends Writ
   public synchronized SortedKeyValueIterator<K,V> deepCopy(IteratorEnvironment env) {
     return new SynchronizedIterator<>(source.deepCopy(env));
   }
-
-  public SynchronizedIterator() {}
 
   public SynchronizedIterator(SortedKeyValueIterator<K,V> source) {
     this.source = source;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityFilter.java
@@ -16,54 +16,56 @@
  */
 package org.apache.accumulo.core.iterators.system;
 
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.SynchronizedServerFilter;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.VisibilityEvaluator;
 import org.apache.accumulo.core.security.VisibilityParseException;
 import org.apache.accumulo.core.util.BadArgumentException;
-import org.apache.accumulo.core.util.TextUtil;
 import org.apache.commons.collections.map.LRUMap;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class VisibilityFilter extends Filter {
+/**
+ * A SortedKeyValueIterator that filters based on ColumnVisibility and optimized for use with system iterators. Prior to 2.0, this class extended
+ * {@link org.apache.accumulo.core.iterators.Filter} and all system iterators where wrapped with a <code>SynchronizedIterator</code> during creation of the
+ * iterator stack in {@link org.apache.accumulo.core.iterators.IteratorUtil} .loadIterators(). For performance reasons, the synchronization was pushed down the
+ * stack to this class.
+ */
+public class VisibilityFilter extends SynchronizedServerFilter {
   protected VisibilityEvaluator ve;
-  protected Text defaultVisibility;
+  protected ByteSequence defaultVisibility;
   protected LRUMap cache;
-  protected Text tmpVis;
   protected Authorizations authorizations;
 
   private static final Logger log = LoggerFactory.getLogger(VisibilityFilter.class);
 
-  public VisibilityFilter() {}
-
   public VisibilityFilter(SortedKeyValueIterator<Key,Value> iterator, Authorizations authorizations, byte[] defaultVisibility) {
-    setSource(iterator);
+    super(iterator);
     this.ve = new VisibilityEvaluator(authorizations);
     this.authorizations = authorizations;
-    this.defaultVisibility = new Text(defaultVisibility);
+    this.defaultVisibility = new ArrayByteSequence(defaultVisibility);
     this.cache = new LRUMap(1000);
-    this.tmpVis = new Text();
   }
 
   @Override
-  public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
-    return new VisibilityFilter(getSource().deepCopy(env), authorizations, TextUtil.getBytes(defaultVisibility));
+  public synchronized SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+    return new VisibilityFilter(source.deepCopy(env), authorizations, defaultVisibility.toArray());
   }
 
   @Override
-  public boolean accept(Key k, Value v) {
-    Text testVis = k.getColumnVisibility(tmpVis);
+  protected boolean accept(Key k, Value v) {
+    ByteSequence testVis = k.getColumnVisibilityData();
 
-    if (testVis.getLength() == 0 && defaultVisibility.getLength() == 0)
+    if (testVis.length() == 0 && defaultVisibility.length() == 0)
       return true;
-    else if (testVis.getLength() == 0)
+    else if (testVis.length() == 0)
       testVis = defaultVisibility;
 
     Boolean b = (Boolean) cache.get(testVis);
@@ -71,8 +73,8 @@ public class VisibilityFilter extends Filter {
       return b;
 
     try {
-      Boolean bb = ve.evaluate(new ColumnVisibility(testVis));
-      cache.put(new Text(testVis), bb);
+      Boolean bb = ve.evaluate(new ColumnVisibility(testVis.toArray()));
+      cache.put(testVis, bb);
       return bb;
     } catch (VisibilityParseException e) {
       log.error("Parse Error", e);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VersioningIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VersioningIterator.java
@@ -97,11 +97,12 @@ public class VersioningIterator extends WrappingIterator implements OptionDescri
     super.next();
 
     int count = 0;
-    while (getSource().hasTop() && getSource().getTopKey().equals(keyToSkip, PartialKey.ROW_COLFAM_COLQUAL_COLVIS)) {
+    SortedKeyValueIterator<Key,Value> source = getSource();
+    while (source.hasTop() && source.getTopKey().equals(keyToSkip, PartialKey.ROW_COLFAM_COLQUAL_COLVIS)) {
       if (count < maxCount) {
         // it is quicker to call next if we are close, but we never know if we are close
         // so give next a try a few times
-        getSource().next();
+        source.next();
         count++;
       } else {
         reseek(keyToSkip.followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS));

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
@@ -22,21 +22,30 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.VisibilityEvaluator;
+import org.apache.accumulo.core.security.VisibilityParseException;
 import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.commons.collections.map.LRUMap;
-import org.apache.hadoop.io.Text;
+import org.apache.log4j.Logger;
 
 /**
- *
+ * A SortedKeyValueIterator that filters based on ColumnVisibility.
  */
-public class VisibilityFilter extends org.apache.accumulo.core.iterators.system.VisibilityFilter {
+public class VisibilityFilter extends Filter implements OptionDescriber {
+
+  protected VisibilityEvaluator ve;
+  protected LRUMap cache;
+
+  private static final Logger log = Logger.getLogger(VisibilityFilter.class);
 
   private static final String AUTHS = "auths";
   private static final String FILTER_INVALID_ONLY = "filterInvalid";
@@ -46,9 +55,7 @@ public class VisibilityFilter extends org.apache.accumulo.core.iterators.system.
   /**
    *
    */
-  public VisibilityFilter() {
-    super();
-  }
+  public VisibilityFilter() {}
 
   @Override
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
@@ -60,29 +67,45 @@ public class VisibilityFilter extends org.apache.accumulo.core.iterators.system.
       String auths = options.get(AUTHS);
       Authorizations authObj = auths == null || auths.isEmpty() ? new Authorizations() : new Authorizations(auths.getBytes(UTF_8));
       this.ve = new VisibilityEvaluator(authObj);
-      this.defaultVisibility = new Text();
     }
     this.cache = new LRUMap(1000);
-    this.tmpVis = new Text();
   }
 
   @Override
   public boolean accept(Key k, Value v) {
+    ByteSequence testVis = k.getColumnVisibilityData();
     if (filterInvalid) {
-      Text testVis = k.getColumnVisibility(tmpVis);
       Boolean b = (Boolean) cache.get(testVis);
       if (b != null)
         return b;
       try {
-        new ColumnVisibility(testVis);
-        cache.put(new Text(testVis), true);
+        new ColumnVisibility(testVis.toArray());
+        cache.put(testVis, true);
         return true;
       } catch (BadArgumentException e) {
-        cache.put(new Text(testVis), false);
+        cache.put(testVis, false);
         return false;
       }
     } else {
-      return super.accept(k, v);
+      if (testVis.length() == 0) {
+        return true;
+      }
+
+      Boolean b = (Boolean) cache.get(testVis);
+      if (b != null)
+        return b;
+
+      try {
+        Boolean bb = ve.evaluate(new ColumnVisibility(testVis.toArray()));
+        cache.put(testVis, bb);
+        return bb;
+      } catch (VisibilityParseException e) {
+        log.error("Parse Error", e);
+        return false;
+      } catch (BadArgumentException e) {
+        log.error("Parse Error", e);
+        return false;
+      }
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Level;
@@ -37,7 +38,7 @@ public class VisibilityFilterTest extends TestCase {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
     tm.put(new Key("r1", "cf1", "cq1", "A&"), new Value(new byte[0]));
-    VisibilityFilter filter = new VisibilityFilter(new SortedMapIterator(tm), new Authorizations("A"), "".getBytes());
+    SortedKeyValueIterator<Key,Value> filter = VisibilityFilter.wrap(new SortedMapIterator(tm), new Authorizations("A"), "".getBytes());
 
     // suppress logging
     Level prevLevel = Logger.getLogger(VisibilityFilter.class).getLevel();
@@ -49,4 +50,21 @@ public class VisibilityFilterTest extends TestCase {
     Logger.getLogger(VisibilityFilter.class).setLevel(prevLevel);
   }
 
+  public void testEmptyAuths() throws IOException {
+    TreeMap<Key,Value> tm = new TreeMap<>();
+
+    tm.put(new Key("r1", "cf1", "cq1", ""), new Value(new byte[0]));
+    tm.put(new Key("r1", "cf1", "cq2", "C"), new Value(new byte[0]));
+    tm.put(new Key("r1", "cf1", "cq3", ""), new Value(new byte[0]));
+    SortedKeyValueIterator<Key,Value> filter = VisibilityFilter.wrap(new SortedMapIterator(tm), Authorizations.EMPTY, "".getBytes());
+
+    filter.seek(new Range(), new HashSet<ByteSequence>(), false);
+    assertTrue(filter.hasTop());
+    assertEquals(new Key("r1", "cf1", "cq1", ""), filter.getTopKey());
+    filter.next();
+    assertTrue(filter.hasTop());
+    assertEquals(new Key("r1", "cf1", "cq3", ""), filter.getTopKey());
+    filter.next();
+    assertFalse(filter.hasTop());
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
@@ -358,19 +358,19 @@ public class FilterTest {
     }
     assertEquals(1000, tm.size());
 
-    ColumnQualifierFilter a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    SortedKeyValueIterator<Key,Value> a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     assertEquals(1000, size(a));
 
     hsc = new HashSet<>();
     hsc.add(new Column("a".getBytes(), "b".getBytes(), null));
-    a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     int size = size(a);
     assertEquals(500, size);
 
     hsc = new HashSet<>();
-    a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     size = size(a);
     assertEquals(1000, size);
@@ -394,20 +394,20 @@ public class FilterTest {
     }
     assertEquals(1000, tm.size());
 
-    VisibilityFilter a = new VisibilityFilter(new SortedMapIterator(tm), auths, le2.getExpression());
+    SortedKeyValueIterator<Key,Value> a = VisibilityFilter.wrap(new SortedMapIterator(tm), auths, le2.getExpression());
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     int size = size(a);
     assertEquals(750, size);
   }
 
-  private ColumnQualifierFilter ncqf(TreeMap<Key,Value> tm, Column... columns) throws IOException {
+  private SortedKeyValueIterator<Key,Value> ncqf(TreeMap<Key,Value> tm, Column... columns) throws IOException {
     HashSet<Column> hsc = new HashSet<>();
 
     for (Column column : columns) {
       hsc.add(column);
     }
 
-    ColumnQualifierFilter a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    SortedKeyValueIterator<Key,Value> a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     return a;
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -81,7 +81,7 @@ public class TransformingIteratorTest {
   private void setUpTransformIterator(Class<? extends TransformingIterator> clazz, boolean setupAuths) throws IOException {
     SortedMapIterator source = new SortedMapIterator(data);
     ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(source);
-    VisibilityFilter visFilter = new VisibilityFilter(cfsi, authorizations, new byte[0]);
+    SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(cfsi, authorizations, new byte[0]);
     ReuseIterator reuserIter = new ReuseIterator();
     reuserIter.init(visFilter, EMPTY_OPTS, null);
     try {

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
@@ -31,9 +31,9 @@ import org.apache.accumulo.core.iterators.system.InterruptibleIterator;
 import org.apache.accumulo.server.AccumuloServerContext;
 
 public class ProblemReportingIterator implements InterruptibleIterator {
-  private SortedKeyValueIterator<Key,Value> source;
+  private final SortedKeyValueIterator<Key,Value> source;
   private boolean sawError = false;
-  private boolean continueOnError;
+  private final boolean continueOnError;
   private String resource;
   private String tableId;
   private final AccumuloServerContext context;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -683,13 +683,6 @@ public class InMemoryMap {
     private SourceSwitchingIterator ssi;
     private MemoryDataSource mds;
 
-    @Override
-    protected SortedKeyValueIterator<Key,Value> getSource() {
-      if (closed.get())
-        throw new IllegalStateException("Memory iterator is closed");
-      return super.getSource();
-    }
-
     private MemoryIterator(InterruptibleIterator source) {
       this(source, new AtomicBoolean(false));
     }

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -431,8 +431,8 @@ public class CollectTabletStats {
     MultiIterator multiIter = new MultiIterator(iters, ke);
     DeletingIterator delIter = new DeletingIterator(multiIter, false);
     ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
-    ColumnQualifierFilter colFilter = new ColumnQualifierFilter(cfsi, columnSet);
-    VisibilityFilter visFilter = new VisibilityFilter(colFilter, authorizations, defaultLabels);
+    SortedKeyValueIterator<Key,Value> colFilter = ColumnQualifierFilter.wrap(cfsi, columnSet);
+    SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(colFilter, authorizations, defaultLabels);
 
     if (useTableIterators)
       return IteratorUtil.loadIterators(IteratorScope.scan, visFilter, ke, conf, ssiList, ssio, null);


### PR DESCRIPTION
Applied the changes from the patch submitted by Adam Fuchs on [ACCUMULO-3079](https://issues.apache.org/jira/browse/ACCUMULO-3079) to master. This PR is to bring these changes back into discussion.  Created JMH benchmark tests [here](https://github.com/milleruntime/jmh-test/blob/master/src/main/java/org/sample/MyBenchmark.java).  I tried to isolate the tests to only the system iterators acting on data in memory.  

I have attached the results from the benchmark tests. 
[jmh-accumulo-benchmark-results.txt](https://github.com/apache/accumulo/files/906333/jmh-accumulo-benchmark-results.txt)

The JMH tests can be built and run from [here](https://github.com/milleruntime/jmh-test). After cloning the repo, simply run:
`mvn clean install`
`java -jar target/benchmarks.jar -i 100 -f 1`