### PR TITLE
ACCUMULO-4365: Fix trace test in ShellServerIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -264,6 +264,10 @@ public class ShellServerIT extends SharedMiniClusterBase {
     public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
       // Only one tserver to avoid race conditions on ZK propagation (auths and configuration)
       cfg.setNumTservers(1);
+      // Set the min span to 0 so we will definitely get all the traces back. See ACCUMULO-4365
+      Map<String,String> siteConf = cfg.getSiteConfig();
+      siteConf.put(Property.TRACE_SPAN_RECEIVER_PREFIX.getKey() + "tracer.span.min.ms", "0");
+      cfg.setSiteConfig(siteConf);
     }
   }
 


### PR DESCRIPTION
This test has been frustrating for some time now... After spending some time looking into a potential bug (possibly one similar to ACCUMULO-4191) I don't think a bug actually exists.

This test looked for "sendMutations" traces generated from the insert command but ACCUMULO-1755 changed the way mutations were handled in TabletServerBatchWriter. The multithreaded nature of mutations are now too unpredictable and time sensitive to reliably look for "sendMutations" traces here. 

Aside from ignoring the test, this is the best solution I can come up with...