### PR TITLE
ACCUMULO-4636 system iterator improvements for 1.7

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -325,7 +325,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     ColumnVisibility cv = new ColumnVisibility(acuTableConf.get(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY));
     defaultSecurityLabel = cv.getExpression();
 
-    VisibilityFilter visFilter = new VisibilityFilter(colFilter, authorizations, defaultSecurityLabel);
+    SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(colFilter, authorizations, defaultSecurityLabel);
 
     return iterEnv.getTopLevelIterator(IteratorUtil.loadIterators(IteratorScope.scan, visFilter, extent, acuTableConf, options.serverSideIteratorList,
         options.serverSideIteratorOptions, iterEnv, false));

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockScannerBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockScannerBase.java
@@ -113,8 +113,8 @@ public class MockScannerBase extends ScannerOptions implements ScannerBase {
   public SortedKeyValueIterator<Key,Value> createFilter(SortedKeyValueIterator<Key,Value> inner) throws IOException {
     byte[] defaultLabels = {};
     inner = new ColumnFamilySkippingIterator(new DeletingIterator(inner, false));
-    ColumnQualifierFilter cqf = new ColumnQualifierFilter(inner, new HashSet<>(fetchedColumns));
-    VisibilityFilter vf = new VisibilityFilter(cqf, auths, defaultLabels);
+    SortedKeyValueIterator<Key,Value> cqf = ColumnQualifierFilter.wrap(inner, new HashSet<>(fetchedColumns));
+    SortedKeyValueIterator<Key,Value> vf = VisibilityFilter.wrap(cqf, auths, defaultLabels);
     AccumuloConfiguration conf = new MockConfiguration(table.settings);
     MockIteratorEnvironment iterEnv = new MockIteratorEnvironment(auths);
     SortedKeyValueIterator<Key,Value> result = iterEnv.getTopLevelIterator(IteratorUtil.loadIterators(IteratorScope.scan, vf, null, conf,

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
@@ -69,9 +69,10 @@ public abstract class Filter extends WrappingIterator implements OptionDescriber
    * Iterates over the source until an acceptable key/value pair is found.
    */
   protected void findTop() {
-    while (getSource().hasTop() && !getSource().getTopKey().isDeleted() && (negate == accept(getSource().getTopKey(), getSource().getTopValue()))) {
+    SortedKeyValueIterator<Key,Value> source = getSource();
+    while (source.hasTop() && !source.getTopKey().isDeleted() && (negate == accept(source.getTopKey(), source.getTopValue()))) {
       try {
-        getSource().next();
+        source.next();
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
@@ -78,27 +78,28 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
     if (finished == true || lastRowFound == null)
       return;
     int count = 0;
-    while (getSource().hasTop() && lastRowFound.equals(getSource().getTopKey().getRow())) {
+    SortedKeyValueIterator<Key,Value> source = getSource();
+    while (source.hasTop() && lastRowFound.equals(source.getTopKey().getRow())) {
 
       // try to efficiently jump to the next matching key
       if (count < numscans) {
         ++count;
-        getSource().next(); // scan
+        source.next(); // scan
       } else {
         // too many scans, just seek
         count = 0;
 
         // determine where to seek to, but don't go beyond the user-specified range
-        Key nextKey = getSource().getTopKey().followingKey(PartialKey.ROW);
+        Key nextKey = source.getTopKey().followingKey(PartialKey.ROW);
         if (!latestRange.afterEndKey(nextKey))
-          getSource().seek(new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()), latestColumnFamilies, latestInclusive);
+          source.seek(new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()), latestColumnFamilies, latestInclusive);
         else {
           finished = true;
           break;
         }
       }
     }
-    lastRowFound = getSource().hasTop() ? getSource().getTopKey().getRow(lastRowFound) : null;
+    lastRowFound = source.hasTop() ? source.getTopKey().getRow(lastRowFound) : null;
   }
 
   private boolean finished = true;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/ColumnFamilySkippingIterator.java
@@ -52,36 +52,37 @@ public class ColumnFamilySkippingIterator extends SkippingIterator implements In
 
   @Override
   protected void consume() throws IOException {
+    SortedKeyValueIterator<Key,Value> source = getSource();
     int count = 0;
 
     if (inclusive)
-      while (getSource().hasTop() && !colFamSet.contains(getSource().getTopKey().getColumnFamilyData())) {
+      while (source.hasTop() && !colFamSet.contains(source.getTopKey().getColumnFamilyData())) {
         if (count < 10) {
           // it is quicker to call next if we are close, but we never know if we are close
           // so give next a try a few times
-          getSource().next();
+          source.next();
           count++;
         } else {
-          ByteSequence higherCF = sortedColFams.higher(getSource().getTopKey().getColumnFamilyData());
+          ByteSequence higherCF = sortedColFams.higher(source.getTopKey().getColumnFamilyData());
           if (higherCF == null) {
             // seek to the next row
-            reseek(getSource().getTopKey().followingKey(PartialKey.ROW));
+            reseek(source.getTopKey().followingKey(PartialKey.ROW));
           } else {
             // seek to the next column family in the sorted list of column families
-            reseek(new Key(getSource().getTopKey().getRowData().toArray(), higherCF.toArray(), new byte[0], new byte[0], Long.MAX_VALUE));
+            reseek(new Key(source.getTopKey().getRowData().toArray(), higherCF.toArray(), new byte[0], new byte[0], Long.MAX_VALUE));
           }
 
           count = 0;
         }
       }
     else if (colFamSet != null && colFamSet.size() > 0)
-      while (getSource().hasTop() && colFamSet.contains(getSource().getTopKey().getColumnFamilyData())) {
+      while (source.hasTop() && colFamSet.contains(source.getTopKey().getColumnFamilyData())) {
         if (count < 10) {
-          getSource().next();
+          source.next();
           count++;
         } else {
           // seek to the next column family in the data
-          reseek(getSource().getTopKey().followingKey(PartialKey.ROW_COLFAM));
+          reseek(source.getTopKey().followingKey(PartialKey.ROW_COLFAM));
           count = 0;
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/ColumnQualifierFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/ColumnQualifierFilter.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.core.iterators.system;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
@@ -31,18 +30,36 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 public class ColumnQualifierFilter extends Filter {
-  private boolean scanColumns;
+  private final boolean scanColumns;
   private HashSet<ByteSequence> columnFamilies;
   private HashMap<ByteSequence,HashSet<ByteSequence>> columnsQualifiers;
 
-  public ColumnQualifierFilter() {}
-
   public ColumnQualifierFilter(SortedKeyValueIterator<Key,Value> iterator, Set<Column> columns) {
     setSource(iterator);
-    init(columns);
+    this.columnFamilies = new HashSet<>();
+    this.columnsQualifiers = new HashMap<>();
+
+    for (Column col : columns) {
+      if (col.columnQualifier != null) {
+        ArrayByteSequence cq = new ArrayByteSequence(col.columnQualifier);
+        HashSet<ByteSequence> cfset = this.columnsQualifiers.get(cq);
+        if (cfset == null) {
+          cfset = new HashSet<>();
+          this.columnsQualifiers.put(cq, cfset);
+        }
+
+        cfset.add(new ArrayByteSequence(col.columnFamily));
+      } else {
+        // this whole column family should pass
+        columnFamilies.add(new ArrayByteSequence(col.columnFamily));
+      }
+    }
+
+    // only take action when column qualifies are present
+    scanColumns = this.columnsQualifiers.size() > 0;
   }
 
-  public ColumnQualifierFilter(SortedKeyValueIterator<Key,Value> iterator, HashSet<ByteSequence> columnFamilies,
+  private ColumnQualifierFilter(SortedKeyValueIterator<Key,Value> iterator, HashSet<ByteSequence> columnFamilies,
       HashMap<ByteSequence,HashSet<ByteSequence>> columnsQualifiers, boolean scanColumns) {
     setSource(iterator);
     this.columnFamilies = columnFamilies;
@@ -65,33 +82,24 @@ public class ColumnQualifierFilter extends Filter {
     return cfset != null && cfset.contains(key.getColumnFamilyData());
   }
 
-  public void init(Set<Column> columns) {
-    this.columnFamilies = new HashSet<>();
-    this.columnsQualifiers = new HashMap<>();
-
-    for (Iterator<Column> iter = columns.iterator(); iter.hasNext();) {
-      Column col = iter.next();
-      if (col.columnQualifier != null) {
-        ArrayByteSequence cq = new ArrayByteSequence(col.columnQualifier);
-        HashSet<ByteSequence> cfset = this.columnsQualifiers.get(cq);
-        if (cfset == null) {
-          cfset = new HashSet<>();
-          this.columnsQualifiers.put(cq, cfset);
-        }
-
-        cfset.add(new ArrayByteSequence(col.columnFamily));
-      } else {
-        // this whole column family should pass
-        columnFamilies.add(new ArrayByteSequence(col.columnFamily));
-      }
-    }
-
-    // only take action when column qualifies are present
-    scanColumns = this.columnsQualifiers.size() > 0;
-  }
-
   @Override
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     return new ColumnQualifierFilter(getSource().deepCopy(env), columnFamilies, columnsQualifiers, scanColumns);
+  }
+
+  public static SortedKeyValueIterator<Key,Value> wrap(SortedKeyValueIterator<Key,Value> source, Set<Column> cols) {
+    boolean sawNonNullQual = false;
+    for (Column col : cols) {
+      if (col.getColumnQualifier() != null) {
+        sawNonNullQual = true;
+        break;
+      }
+    }
+
+    if (sawNonNullQual) {
+      return new ColumnQualifierFilter(source, cols);
+    } else {
+      return source;
+    }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VersioningIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VersioningIterator.java
@@ -97,11 +97,12 @@ public class VersioningIterator extends WrappingIterator implements OptionDescri
     super.next();
 
     int count = 0;
-    while (getSource().hasTop() && getSource().getTopKey().equals(keyToSkip, PartialKey.ROW_COLFAM_COLQUAL_COLVIS)) {
+    SortedKeyValueIterator<Key,Value> source = getSource();
+    while (source.hasTop() && source.getTopKey().equals(keyToSkip, PartialKey.ROW_COLFAM_COLQUAL_COLVIS)) {
       if (count < maxCount) {
         // it is quicker to call next if we are close, but we never know if we are close
         // so give next a try a few times
-        getSource().next();
+        source.next();
         count++;
       } else {
         reseek(keyToSkip.followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS));

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
@@ -22,23 +22,30 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.OptionDescriber;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.VisibilityEvaluator;
+import org.apache.accumulo.core.security.VisibilityParseException;
 import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.commons.collections.map.LRUMap;
-import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
-public class VisibilityFilter extends org.apache.accumulo.core.iterators.system.VisibilityFilter implements OptionDescriber {
+public class VisibilityFilter extends Filter implements OptionDescriber {
 
+  protected VisibilityEvaluator ve;
+  protected LRUMap cache;
+  private static final Logger log = LoggerFactory.getLogger(VisibilityFilter.class);
   private static final String AUTHS = "auths";
   private static final String FILTER_INVALID_ONLY = "filterInvalid";
 
@@ -47,9 +54,7 @@ public class VisibilityFilter extends org.apache.accumulo.core.iterators.system.
   /**
    *
    */
-  public VisibilityFilter() {
-    super();
-  }
+  public VisibilityFilter() {}
 
   @Override
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
@@ -61,29 +66,43 @@ public class VisibilityFilter extends org.apache.accumulo.core.iterators.system.
       String auths = options.get(AUTHS);
       Authorizations authObj = auths == null || auths.isEmpty() ? new Authorizations() : new Authorizations(auths.getBytes(UTF_8));
       this.ve = new VisibilityEvaluator(authObj);
-      this.defaultVisibility = new Text();
     }
     this.cache = new LRUMap(1000);
-    this.tmpVis = new Text();
   }
 
   @Override
   public boolean accept(Key k, Value v) {
+    ByteSequence testVis = k.getColumnVisibilityData();
     if (filterInvalid) {
-      Text testVis = k.getColumnVisibility(tmpVis);
       Boolean b = (Boolean) cache.get(testVis);
       if (b != null)
         return b;
       try {
-        new ColumnVisibility(testVis);
-        cache.put(new Text(testVis), true);
+        new ColumnVisibility(testVis.toArray());
+        cache.put(testVis, true);
         return true;
       } catch (BadArgumentException e) {
-        cache.put(new Text(testVis), false);
+        cache.put(testVis, false);
         return false;
       }
     } else {
-      return super.accept(k, v);
+      if (testVis.length() == 0) {
+        return true;
+      }
+
+      Boolean b = (Boolean) cache.get(testVis);
+      if (b != null)
+        return b;
+
+      try {
+        Boolean bb = ve.evaluate(new ColumnVisibility(testVis.toArray()));
+        cache.put(testVis, bb);
+        return bb;
+      } catch (VisibilityParseException | BadArgumentException e) {
+        log.error("Parse Error", e);
+        return false;
+      }
+
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/ColumnFilterTest.java
@@ -16,14 +16,21 @@
  */
 package org.apache.accumulo.core.iterators.system;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.TreeMap;
 
 import junit.framework.TestCase;
 
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.hadoop.io.Text;
+import org.junit.Assert;
 
 public class ColumnFilterTest extends TestCase {
 
@@ -40,39 +47,60 @@ public class ColumnFilterTest extends TestCase {
   }
 
   public void test1() {
-    HashSet<Column> columns = new HashSet<>();
+    TreeMap<Key,Value> data = new TreeMap<Key,Value>();
+    data.put(newKey("r1", "cf1", "cq1"), new Value());
+    data.put(newKey("r1", "cf2", "cq1"), new Value());
 
+    HashSet<Column> columns = new HashSet<>();
     columns.add(newColumn("cf1"));
 
-    ColumnQualifierFilter cf = new ColumnQualifierFilter(null, columns);
+    SortedMapIterator smi = new SortedMapIterator(data);
+    SortedKeyValueIterator<Key,Value> cf = ColumnQualifierFilter.wrap(smi, columns);
 
-    assertTrue(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
-    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
-
+    Assert.assertSame(smi, cf);
   }
 
-  public void test2() {
+  public void test2() throws Exception {
+
+    TreeMap<Key,Value> data = new TreeMap<Key,Value>();
+    data.put(newKey("r1", "cf1", "cq1"), new Value());
+    data.put(newKey("r1", "cf2", "cq1"), new Value());
+    data.put(newKey("r1", "cf2", "cq2"), new Value());
+
     HashSet<Column> columns = new HashSet<>();
 
     columns.add(newColumn("cf1"));
     columns.add(newColumn("cf2", "cq1"));
 
-    ColumnQualifierFilter cf = new ColumnQualifierFilter(null, columns);
+    SortedKeyValueIterator<Key,Value> cf = ColumnQualifierFilter.wrap(new SortedMapIterator(data), columns);
+    cf.seek(new Range(), Collections.<ByteSequence> emptySet(), false);
 
-    assertTrue(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
-    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
-    assertFalse(cf.accept(newKey("r1", "cf2", "cq2"), new Value(new byte[0])));
+    Assert.assertTrue(cf.hasTop());
+    Assert.assertEquals(newKey("r1", "cf1", "cq1"), cf.getTopKey());
+    cf.next();
+    Assert.assertTrue(cf.hasTop());
+    Assert.assertEquals(newKey("r1", "cf2", "cq1"), cf.getTopKey());
+    cf.next();
+    Assert.assertFalse(cf.hasTop());
   }
 
-  public void test3() {
+  public void test3() throws Exception {
+
+    TreeMap<Key,Value> data = new TreeMap<Key,Value>();
+    data.put(newKey("r1", "cf1", "cq1"), new Value());
+    data.put(newKey("r1", "cf2", "cq1"), new Value());
+    data.put(newKey("r1", "cf2", "cq2"), new Value());
+
     HashSet<Column> columns = new HashSet<>();
 
     columns.add(newColumn("cf2", "cq1"));
 
-    ColumnQualifierFilter cf = new ColumnQualifierFilter(null, columns);
+    SortedKeyValueIterator<Key,Value> cf = ColumnQualifierFilter.wrap(new SortedMapIterator(data), columns);
+    cf.seek(new Range(), Collections.<ByteSequence> emptySet(), false);
 
-    assertFalse(cf.accept(newKey("r1", "cf1", "cq1"), new Value(new byte[0])));
-    assertTrue(cf.accept(newKey("r1", "cf2", "cq1"), new Value(new byte[0])));
-    assertFalse(cf.accept(newKey("r1", "cf2", "cq2"), new Value(new byte[0])));
+    Assert.assertTrue(cf.hasTop());
+    Assert.assertEquals(newKey("r1", "cf2", "cq1"), cf.getTopKey());
+    cf.next();
+    Assert.assertFalse(cf.hasTop());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Level;
@@ -37,7 +38,7 @@ public class VisibilityFilterTest extends TestCase {
     TreeMap<Key,Value> tm = new TreeMap<>();
 
     tm.put(new Key("r1", "cf1", "cq1", "A&"), new Value(new byte[0]));
-    VisibilityFilter filter = new VisibilityFilter(new SortedMapIterator(tm), new Authorizations("A"), "".getBytes());
+    SortedKeyValueIterator<Key,Value> filter = VisibilityFilter.wrap(new SortedMapIterator(tm), new Authorizations("A"), "".getBytes());
 
     // suppress logging
     Level prevLevel = Logger.getLogger(VisibilityFilter.class).getLevel();
@@ -49,4 +50,21 @@ public class VisibilityFilterTest extends TestCase {
     Logger.getLogger(VisibilityFilter.class).setLevel(prevLevel);
   }
 
+  public void testEmptyAuths() throws IOException {
+    TreeMap<Key,Value> tm = new TreeMap<>();
+
+    tm.put(new Key("r1", "cf1", "cq1", ""), new Value(new byte[0]));
+    tm.put(new Key("r1", "cf1", "cq2", "C"), new Value(new byte[0]));
+    tm.put(new Key("r1", "cf1", "cq3", ""), new Value(new byte[0]));
+    SortedKeyValueIterator<Key,Value> filter = VisibilityFilter.wrap(new SortedMapIterator(tm), Authorizations.EMPTY, "".getBytes());
+
+    filter.seek(new Range(), new HashSet<ByteSequence>(), false);
+    assertTrue(filter.hasTop());
+    assertEquals(new Key("r1", "cf1", "cq1", ""), filter.getTopKey());
+    filter.next();
+    assertTrue(filter.hasTop());
+    assertEquals(new Key("r1", "cf1", "cq3", ""), filter.getTopKey());
+    filter.next();
+    assertFalse(filter.hasTop());
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
@@ -277,19 +277,19 @@ public class FilterTest {
     }
     assertTrue(tm.size() == 1000);
 
-    ColumnQualifierFilter a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    SortedKeyValueIterator<Key,Value> a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     assertEquals(size(a), 1000);
 
     hsc = new HashSet<>();
     hsc.add(new Column("a".getBytes(), "b".getBytes(), null));
-    a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     int size = size(a);
     assertTrue("size was " + size, size == 500);
 
     hsc = new HashSet<>();
-    a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     size = size(a);
     assertTrue("size was " + size, size == 1000);
@@ -313,20 +313,20 @@ public class FilterTest {
     }
     assertTrue(tm.size() == 1000);
 
-    VisibilityFilter a = new VisibilityFilter(new SortedMapIterator(tm), auths, le2.getExpression());
+    SortedKeyValueIterator<Key,Value> a = VisibilityFilter.wrap(new SortedMapIterator(tm), auths, le2.getExpression());
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     int size = size(a);
     assertTrue("size was " + size, size == 750);
   }
 
-  private ColumnQualifierFilter ncqf(TreeMap<Key,Value> tm, Column... columns) throws IOException {
+  private SortedKeyValueIterator<Key,Value> ncqf(TreeMap<Key,Value> tm, Column... columns) throws IOException {
     HashSet<Column> hsc = new HashSet<>();
 
     for (Column column : columns) {
       hsc.add(column);
     }
 
-    ColumnQualifierFilter a = new ColumnQualifierFilter(new SortedMapIterator(tm), hsc);
+    SortedKeyValueIterator<Key,Value> a = ColumnQualifierFilter.wrap(new SortedMapIterator(tm), hsc);
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     return a;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
@@ -31,9 +31,9 @@ import org.apache.accumulo.core.iterators.system.InterruptibleIterator;
 import org.apache.accumulo.server.AccumuloServerContext;
 
 public class ProblemReportingIterator implements InterruptibleIterator {
-  private SortedKeyValueIterator<Key,Value> source;
+  private final SortedKeyValueIterator<Key,Value> source;
   private boolean sawError = false;
-  private boolean continueOnError;
+  private final boolean continueOnError;
   private String resource;
   private String table;
   private final AccumuloServerContext context;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -521,13 +521,6 @@ public class InMemoryMap {
     private SourceSwitchingIterator ssi;
     private MemoryDataSource mds;
 
-    @Override
-    protected SortedKeyValueIterator<Key,Value> getSource() {
-      if (closed.get())
-        throw new IllegalStateException("Memory iterator is closed");
-      return super.getSource();
-    }
-
     private MemoryIterator(InterruptibleIterator source) {
       this(source, new AtomicBoolean(false));
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -185,7 +185,7 @@ class ScanDataSource implements DataSource {
 
     ColumnQualifierFilter colFilter = new ColumnQualifierFilter(cfsi, options.getColumnSet());
 
-    VisibilityFilter visFilter = new VisibilityFilter(colFilter, options.getAuthorizations(), options.getDefaultLabels());
+    SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(colFilter, options.getAuthorizations(), options.getDefaultLabels());
 
     if (!loadIters) {
       return visFilter;

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -431,8 +431,8 @@ public class CollectTabletStats {
     MultiIterator multiIter = new MultiIterator(iters, ke);
     DeletingIterator delIter = new DeletingIterator(multiIter, false);
     ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
-    ColumnQualifierFilter colFilter = new ColumnQualifierFilter(cfsi, columnSet);
-    VisibilityFilter visFilter = new VisibilityFilter(colFilter, authorizations, defaultLabels);
+    SortedKeyValueIterator<Key,Value> colFilter = ColumnQualifierFilter.wrap(cfsi, columnSet);
+    SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(colFilter, authorizations, defaultLabels);
 
     if (useTableIterators)
       return IteratorUtil.loadIterators(IteratorScope.scan, visFilter, ke, conf, ssiList, ssio, null);


### PR DESCRIPTION
Back ported some of the improvements from ACCUMULO-3079 and PR #244 to 1.7 (and will also merge with 1.8).  These improvements just include internal changes and leave out the new optimized server iterators introduced in 2.0.  

This PR is mainly a sanity check since there are a decent number of changes but I would also still accept any new feedback. 