### PR TITLE
ACCUMULO-4642 Changes to remove ServerConfiguration.getInstance()

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/Accumulo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/Accumulo.java
@@ -28,9 +28,9 @@ import java.util.Arrays;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.util.AddressUtil;
@@ -102,11 +102,11 @@ public class Accumulo {
     return ServerConstants.getInstanceIdLocation(v);
   }
 
-  public static void init(VolumeManager fs, ServerConfigurationFactory serverConfig, String application) throws IOException {
+  public static void init(VolumeManager fs, Instance instance, ServerConfigurationFactory serverConfig, String application) throws IOException {
     final AccumuloConfiguration conf = serverConfig.getSystemConfiguration();
 
     log.info(application + " starting");
-    log.info("Instance " + serverConfig.getInstance().getInstanceID());
+    log.info("Instance " + instance.getInstanceID());
     int dataVersion = Accumulo.getAccumuloPersistentVersion(fs);
     log.info("Data Version " + dataVersion);
     Accumulo.waitForZookeeperAndHdfs(fs);

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloServerContext.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.server;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
-
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -53,15 +52,15 @@ public class AccumuloServerContext extends ClientContext {
   /**
    * Construct a server context from the server's configuration
    */
-  public AccumuloServerContext(ServerConfigurationFactory confFactory) {
-    this(confFactory, null);
+  public AccumuloServerContext(Instance instance, ServerConfigurationFactory confFactory) {
+    this(instance, confFactory, null);
   }
 
   /**
    * Construct a server context from the server's configuration
    */
-  public AccumuloServerContext(ServerConfigurationFactory confFactory, AuthenticationTokenSecretManager secretManager) {
-    super(confFactory.getInstance(), getCredentials(confFactory.getInstance()), confFactory.getSystemConfiguration());
+  private AccumuloServerContext(Instance instance, ServerConfigurationFactory confFactory, AuthenticationTokenSecretManager secretManager) {
+    super(instance, getCredentials(instance), confFactory.getSystemConfiguration());
     this.confFactory = confFactory;
     this.secretManager = secretManager;
     if (null != getSaslParams()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfiguration.java
@@ -16,7 +16,6 @@
  */
 package org.apache.accumulo.server.conf;
 
-import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 
 public abstract class ServerConfiguration {
@@ -26,7 +25,5 @@ public abstract class ServerConfiguration {
   abstract public NamespaceConfiguration getNamespaceConfiguration(String namespaceId);
 
   abstract public AccumuloConfiguration getSystemConfiguration();
-
-  abstract public Instance getInstance();
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -192,8 +192,4 @@ public class ServerConfigurationFactory extends ServerConfiguration {
     return conf;
   }
 
-  @Override
-  public Instance getInstance() {
-    return instance;
-  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.server.conf;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -44,9 +46,9 @@ public class TableConfiguration extends ObservableConfiguration {
   private final String tableId;
 
   public TableConfiguration(Instance instance, String tableId, NamespaceConfiguration parent) {
-    this.instance = instance;
-    this.tableId = tableId;
-    this.parent = parent;
+    this.instance = requireNonNull(instance);
+    this.tableId = requireNonNull(tableId);
+    this.parent = requireNonNull(parent);
   }
 
   void setZooCacheFactory(ZooCacheFactory zcf) {

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -355,7 +355,8 @@ public class Initialize implements KeywordExecutable {
       return false;
     }
 
-    final ServerConfigurationFactory confFactory = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
+    final Instance instance = HdfsZooInstance.getInstance();
+    final ServerConfigurationFactory confFactory = new ServerConfigurationFactory(instance);
 
     // When we're using Kerberos authentication, we need valid credentials to perform initialization. If the user provided some, use them.
     // If they did not, fall back to the credentials present in accumulo-site.xml that the servers will use themselves.
@@ -385,7 +386,7 @@ public class Initialize implements KeywordExecutable {
     }
 
     try {
-      AccumuloServerContext context = new AccumuloServerContext(confFactory);
+      AccumuloServerContext context = new AccumuloServerContext(instance, confFactory);
       initSecurity(context, opts, uuid.toString(), rootUser);
     } catch (Exception e) {
       log.error("FATAL: Failed to initialize security", e);
@@ -775,7 +776,7 @@ public class Initialize implements KeywordExecutable {
       if (opts.resetSecurity) {
         log.info("Resetting security on accumulo.");
         Instance instance = HdfsZooInstance.getInstance();
-        AccumuloServerContext context = new AccumuloServerContext(new ServerConfigurationFactory(instance));
+        AccumuloServerContext context = new AccumuloServerContext(instance, new ServerConfigurationFactory(instance));
         if (isInitialized(fs)) {
           if (!opts.forceResetSecurity) {
             ConsoleReader c = getConsoleReader();

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
@@ -164,5 +165,8 @@ public class ChaoticLoadBalancer extends TabletBalancer {
 
   @Override
   public void init(ServerConfigurationFactory conf) {}
+
+  @Override
+  public void init(AccumuloServerContext context) {}
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -38,8 +38,8 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.conf.ServerConfiguration;
-import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -242,9 +242,9 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
   }
 
   @Override
-  public void init(ServerConfigurationFactory conf) {
-    super.init(conf);
-    parseConfiguration(conf);
+  public void init(AccumuloServerContext context) {
+    super.init(context);
+    parseConfiguration(context.getServerConfigurationFactory());
   }
 
   @Override
@@ -382,12 +382,12 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
 
   @Override
   public void propertyChanged(String key) {
-    parseConfiguration(this.configuration);
+    parseConfiguration(context.getServerConfigurationFactory());
   }
 
   @Override
   public void propertiesChanged() {
-    parseConfiguration(this.configuration);
+    parseConfiguration(context.getServerConfigurationFactory());
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
@@ -57,7 +57,8 @@ public class RegexGroupBalancer extends GroupBalancer {
 
   @Override
   protected long getWaitTime() {
-    Map<String,String> customProps = configuration.getTableConfiguration(tableId).getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(tableId)
+        .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     if (customProps.containsKey(WAIT_TIME_PROPERTY)) {
       return ConfigurationTypeHelper.getTimeInMillis(customProps.get(WAIT_TIME_PROPERTY));
     }
@@ -68,7 +69,8 @@ public class RegexGroupBalancer extends GroupBalancer {
   @Override
   protected Function<KeyExtent,String> getPartitioner() {
 
-    Map<String,String> customProps = configuration.getTableConfiguration(tableId).getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(tableId)
+        .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     String regex = customProps.get(REGEX_PROPERTY);
     final String defaultGroup = customProps.get(DEFAUT_GROUP_PROPERTY);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -47,8 +47,7 @@ public class TableLoadBalancer extends TabletBalancer {
 
   private TabletBalancer constructNewBalancerForTable(String clazzName, String table) throws Exception {
     String context = null;
-    if (null != configuration)
-      context = configuration.getTableConfiguration(table).get(Property.TABLE_CLASSPATH);
+    context = this.context.getServerConfigurationFactory().getTableConfiguration(table).get(Property.TABLE_CLASSPATH);
     Class<? extends TabletBalancer> clazz;
     if (context != null && !context.equals(""))
       clazz = AccumuloVFSClassLoader.getContextManager().loadClass(context, clazzName, TabletBalancer.class);
@@ -63,7 +62,7 @@ public class TableLoadBalancer extends TabletBalancer {
     if (tableState == null)
       return null;
     if (tableState.equals(TableState.ONLINE))
-      return configuration.getTableConfiguration(table).get(Property.TABLE_LOAD_BALANCER);
+      return this.context.getServerConfigurationFactory().getTableConfiguration(table).get(Property.TABLE_LOAD_BALANCER);
     return null;
   }
 
@@ -83,7 +82,7 @@ public class TableLoadBalancer extends TabletBalancer {
           if (newBalancer != null) {
             balancer = newBalancer;
             perTableBalancers.put(table, balancer);
-            balancer.init(configuration);
+            balancer.init(this.context);
           }
 
           log.info("Loaded new class " + clazzName + " for table " + table);
@@ -105,7 +104,7 @@ public class TableLoadBalancer extends TabletBalancer {
         balancer = new DefaultLoadBalancer(table);
       }
       perTableBalancers.put(table, balancer);
-      balancer.init(configuration);
+      balancer.init(this.context);
     }
     return balancer;
   }
@@ -135,7 +134,7 @@ public class TableLoadBalancer extends TabletBalancer {
   protected TableOperations getTableOperations() {
     if (tops == null)
       try {
-        tops = context.getConnector().tableOperations();
+        tops = this.context.getConnector().tableOperations();
       } catch (AccumuloException e) {
         log.error("Unable to access table operations from within table balancer", e);
       } catch (AccumuloSecurityException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Client;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.server.AccumuloServerContext;
+import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
@@ -55,16 +56,25 @@ public abstract class TabletBalancer {
 
   private static final Logger log = LoggerFactory.getLogger(TabletBalancer.class);
 
-  protected ServerConfigurationFactory configuration;
-
   protected AccumuloServerContext context;
 
   /**
    * Initialize the TabletBalancer. This gives the balancer the opportunity to read the configuration.
+   *
+   * @deprecated since 2.0.0; use {@link #init(AccumuloServerContext)} instead.
    */
+  @Deprecated
   public void init(ServerConfigurationFactory conf) {
-    context = new AccumuloServerContext(conf);
-    configuration = conf;
+    init(new AccumuloServerContext(HdfsZooInstance.getInstance(), conf));
+  }
+
+  /**
+   * Initialize the TabletBalancer. This gives the balancer the opportunity to read the configuration.
+   *
+   * @since 2.0.0
+   */
+  public void init(AccumuloServerContext context) {
+    this.context = context;
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
@@ -300,7 +301,8 @@ public class ProblemReports implements Iterable<ProblemReport> {
   }
 
   public static void main(String args[]) throws Exception {
-    getInstance(new AccumuloServerContext(new ServerConfigurationFactory(HdfsZooInstance.getInstance()))).printProblems();
+    Instance instance = HdfsZooInstance.getInstance();
+    getInstance(new AccumuloServerContext(instance, new ServerConfigurationFactory(instance))).printProblems();
   }
 
   public Map<String,Map<ProblemType,Integer>> summarize() {

--- a/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
@@ -24,9 +24,9 @@ import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
+import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,7 +146,8 @@ public class LargestFirstMemoryManager implements MemoryManager {
   }
 
   protected boolean tableExists(Instance instance, String tableId) {
-    return Tables.exists(instance, tableId);
+    // make sure that the table still exists by checking if it has a configuration
+    return config.getTableConfiguration(tableId) != null;
   }
 
   @Override
@@ -154,7 +155,7 @@ public class LargestFirstMemoryManager implements MemoryManager {
     if (maxMemory < 0)
       throw new IllegalStateException("need to initialize " + LargestFirstMemoryManager.class.getName());
 
-    final Instance instance = config.getInstance();
+    final Instance instance = HdfsZooInstance.getInstance();
     final int maxMinCs = maxConcurrentMincs * numWaitingMultiplier;
 
     mincIdleThresholds.clear();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -213,7 +213,7 @@ public class Admin implements KeywordExecutable {
     ServerConfigurationFactory confFactory = new ServerConfigurationFactory(instance);
 
     try {
-      ClientContext context = new AccumuloServerContext(confFactory);
+      ClientContext context = new AccumuloServerContext(instance, confFactory);
 
       int rc = 0;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Tables;
@@ -51,7 +52,8 @@ public class FindOfflineTablets {
   public static void main(String[] args) throws Exception {
     ClientOpts opts = new ClientOpts();
     opts.parseArgs(FindOfflineTablets.class.getName(), args);
-    AccumuloServerContext context = new AccumuloServerContext(new ServerConfigurationFactory(opts.getInstance()));
+    Instance instance = opts.getInstance();
+    AccumuloServerContext context = new AccumuloServerContext(instance, new ServerConfigurationFactory(opts.getInstance()));
     findOffline(context, null);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -21,6 +21,7 @@ import java.util.Map.Entry;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.data.Key;
@@ -38,13 +39,11 @@ import org.apache.accumulo.server.log.WalStateManager;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 import org.apache.hadoop.fs.Path;
 
-/**
- *
- */
 public class ListVolumesUsed {
 
   public static void main(String[] args) throws Exception {
-    listVolumes(new AccumuloServerContext(new ServerConfigurationFactory(HdfsZooInstance.getInstance())));
+    Instance instance = HdfsZooInstance.getInstance();
+    listVolumes(new AccumuloServerContext(instance, new ServerConfigurationFactory(instance)));
   }
 
   private static String getTableURI(String rootTabletDir) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
@@ -58,7 +59,8 @@ public class RandomizeVolumes {
     opts.parseArgs(RandomizeVolumes.class.getName(), args);
     Connector c;
     if (opts.getToken() == null) {
-      AccumuloServerContext context = new AccumuloServerContext(new ServerConfigurationFactory(opts.getInstance()));
+      Instance instance = opts.getInstance();
+      AccumuloServerContext context = new AccumuloServerContext(instance, new ServerConfigurationFactory(instance));
       c = context.getConnector();
     } else {
       c = opts.getConnector();

--- a/server/base/src/test/java/org/apache/accumulo/server/AccumuloServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/AccumuloServerContextTest.java
@@ -23,10 +23,8 @@ import java.io.DataOutputStream;
 import java.security.PrivilegedExceptionAction;
 import java.util.Iterator;
 import java.util.Map.Entry;
-
 import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
-import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -68,7 +66,6 @@ public class AccumuloServerContextTest {
     testUser.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
       public Void run() throws Exception {
-        Instance instance = EasyMock.createMock(Instance.class);
 
         ClientConfiguration clientConf = ClientConfiguration.loadDefault();
         clientConf.setProperty(ClientProperty.INSTANCE_RPC_SASL_ENABLED, "true");
@@ -88,7 +85,6 @@ public class AccumuloServerContextTest {
         ServerConfigurationFactory factory = EasyMock.createMock(ServerConfigurationFactory.class);
         EasyMock.expect(factory.getSystemConfiguration()).andReturn(conf).anyTimes();
         EasyMock.expect(factory.getSiteConfiguration()).andReturn(siteConfig).anyTimes();
-        EasyMock.expect(factory.getInstance()).andReturn(instance).anyTimes();
 
         AccumuloServerContext context = EasyMock.createMockBuilder(AccumuloServerContext.class).addMockedMethod("enforceKerberosLogin")
             .addMockedMethod("getConfiguration").addMockedMethod("getServerConfigurationFactory").addMockedMethod("getCredentials").createMock();

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -92,12 +92,6 @@ public class ServerConfigurationFactoryTest {
   }
 
   @Test
-  public void testGetInstance() {
-    ready();
-    assertSame(instance, scf.getInstance());
-  }
-
-  @Test
   public void testGetDefaultConfiguration() {
     ready();
     DefaultConfiguration c = scf.getDefaultConfiguration();

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.fate.util.UtilWaitThread;
+import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.thrift.TException;
@@ -42,7 +43,7 @@ public class HostRegexTableLoadBalancerReconfigurationTest extends BaseHostRegex
   @Test
   public void testConfigurationChanges() {
 
-    init(factory);
+    init(new AccumuloServerContext(instance, factory));
     Map<KeyExtent,TServerInstance> unassigned = new HashMap<>();
     for (List<KeyExtent> extents : tableExtents.values()) {
       for (KeyExtent ke : extents) {

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
@@ -332,7 +332,7 @@ public class TServerUtilsTest {
   }
 
   private ServerAddress startServer() throws Exception {
-    AccumuloServerContext ctx = new AccumuloServerContext(factory);
+    AccumuloServerContext ctx = new AccumuloServerContext(instance, factory);
     ClientServiceHandler clientHandler = new ClientServiceHandler(ctx, null, null);
     Iface rpcProxy = RpcWrapper.service(clientHandler);
     Processor<Iface> processor = new Processor<>(rpcProxy);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -150,10 +150,10 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
     final VolumeManager fs = VolumeManagerImpl.get();
-    Accumulo.init(fs, conf, app);
+    Accumulo.init(fs, instance, conf, app);
     Opts opts = new Opts();
     opts.parseArgs(app, args);
-    SimpleGarbageCollector gc = new SimpleGarbageCollector(opts, fs, conf);
+    SimpleGarbageCollector gc = new SimpleGarbageCollector(opts, instance, fs, conf);
 
     DistributedTrace.enable(opts.getAddress(), app, conf.getSystemConfiguration());
     try {
@@ -169,8 +169,8 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
    * @param opts
    *          options
    */
-  public SimpleGarbageCollector(Opts opts, VolumeManager fs, ServerConfigurationFactory confFactory) {
-    super(confFactory);
+  public SimpleGarbageCollector(Opts opts, Instance instance, VolumeManager fs, ServerConfigurationFactory confFactory) {
+    super(instance, confFactory);
     this.opts = opts;
     this.fs = fs;
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -71,7 +71,6 @@ public class SimpleGarbageCollectorTest {
     opts = new Opts();
     systemConfig = createSystemConfig();
     ServerConfigurationFactory factory = createMock(ServerConfigurationFactory.class);
-    expect(factory.getInstance()).andReturn(instance).anyTimes();
     expect(factory.getSystemConfiguration()).andReturn(systemConfig).anyTimes();
     expect(factory.getSiteConfiguration()).andReturn(siteConfig).anyTimes();
 
@@ -102,7 +101,7 @@ public class SimpleGarbageCollectorTest {
     replay(instance, factory, siteConfig);
 
     credentials = SystemCredentials.get(instance);
-    gc = new SimpleGarbageCollector(opts, volMgr, factory);
+    gc = new SimpleGarbageCollector(opts, instance, volMgr, factory);
   }
 
   @Test

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter.Mutator;
 import org.apache.accumulo.master.tableOps.TraceRepo;
 import org.apache.accumulo.master.tserverOps.ShutdownTServer;
+import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.client.ClientServiceHandler;
 import org.apache.accumulo.server.master.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.master.balancer.DefaultLoadBalancer;
@@ -465,7 +466,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
     if (property.equals(Property.MASTER_TABLET_BALANCER.getKey())) {
       TabletBalancer balancer = master.getConfiguration().instantiateClassProperty(Property.MASTER_TABLET_BALANCER, TabletBalancer.class,
           new DefaultLoadBalancer());
-      balancer.init(master.getConfigurationFactory());
+      balancer.init(new AccumuloServerContext(instance, master.getConfigurationFactory()));
       master.tabletBalancer = balancer;
       log.info("tablet balancer changed to " + master.tabletBalancer.getClass().getName());
     }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -412,7 +412,7 @@ public class Monitor implements HighlyAvailableService {
       if (locks != null && locks.size() > 0) {
         Collections.sort(locks);
         address = new ServerServices(new String(zk.getData(path + "/" + locks.get(0), null), UTF_8)).getAddress(Service.GC_CLIENT);
-        GCMonitorService.Client client = ThriftUtil.getClient(new GCMonitorService.Client.Factory(), address, new AccumuloServerContext(config));
+        GCMonitorService.Client client = ThriftUtil.getClient(new GCMonitorService.Client.Factory(), address, new AccumuloServerContext(instance, config));
         try {
           result = client.getStatus(Tracer.traceInfo(), getContext().rpcCreds());
         } finally {
@@ -436,10 +436,10 @@ public class Monitor implements HighlyAvailableService {
     VolumeManager fs = VolumeManagerImpl.get();
     instance = HdfsZooInstance.getInstance();
     config = new ServerConfigurationFactory(instance);
-    context = new AccumuloServerContext(config);
+    context = new AccumuloServerContext(instance, config);
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
-    Accumulo.init(fs, config, app);
+    Accumulo.init(fs, instance, config, app);
     Monitor monitor = new Monitor();
     // Servlets need access to limit requests when the monitor is not active, but Servlets are instantiated
     // via reflection. Expose the service this way instead.

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -345,12 +345,11 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
   private final ZooAuthenticationKeyWatcher authKeyWatcher;
   private final WalStateManager walMarker;
 
-  public TabletServer(ServerConfigurationFactory confFactory, VolumeManager fs) throws IOException {
-    super(confFactory);
+  public TabletServer(Instance instance, ServerConfigurationFactory confFactory, VolumeManager fs) throws IOException {
+    super(instance, confFactory);
     this.confFactory = confFactory;
     this.fs = fs;
     final AccumuloConfiguration aconf = getConfiguration();
-    Instance instance = getInstance();
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
     this.sessionManager = new SessionManager(aconf);
@@ -3064,10 +3063,11 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       ServerOpts opts = new ServerOpts();
       opts.parseArgs(app, args);
       String hostname = opts.getAddress();
-      ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
+      Instance instance = HdfsZooInstance.getInstance();
+      ServerConfigurationFactory conf = new ServerConfigurationFactory(instance);
       VolumeManager fs = VolumeManagerImpl.get();
-      Accumulo.init(fs, conf, app);
-      final TabletServer server = new TabletServer(conf, fs);
+      Accumulo.init(fs, instance, conf, app);
+      final TabletServer server = new TabletServer(instance, conf, fs);
       server.config(hostname);
       DistributedTrace.enable(hostname, app, conf.getSystemConfiguration());
       if (UserGroupInformation.isSecurityEnabled()) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/LargestFirstMemoryManagerTest.java
@@ -79,10 +79,6 @@ public class LargestFirstMemoryManagerTest {
         return delegate.getNamespaceConfiguration(namespaceId);
       }
 
-      @Override
-      public Instance getInstance() {
-        return delegate.getInstance();
-      }
     };
     mgr.init(config);
     MemoryManagementActions result;
@@ -194,10 +190,6 @@ public class LargestFirstMemoryManagerTest {
         return delegate.getNamespaceConfiguration(namespaceId);
       }
 
-      @Override
-      public Instance getInstance() {
-        return delegate.getInstance();
-      }
     };
     mgr.init(config);
     MemoryManagementActions result;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListBulkCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListBulkCommand.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.MasterClient;
 import org.apache.accumulo.core.client.impl.thrift.ThriftNotActiveServiceException;
 import org.apache.accumulo.core.master.thrift.MasterClientService;
@@ -52,7 +53,8 @@ public class ListBulkCommand extends Command {
 
     MasterMonitorInfo stats;
     MasterClientService.Iface client = null;
-    AccumuloServerContext context = new AccumuloServerContext(new ServerConfigurationFactory(shellState.getInstance()));
+    Instance instance = shellState.getInstance();
+    AccumuloServerContext context = new AccumuloServerContext(instance, new ServerConfigurationFactory(instance));
     while (true) {
       try {
         client = MasterClient.getConnectionWithRetry(context);

--- a/test/src/main/java/org/apache/accumulo/test/GetMasterStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetMasterStats.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.MasterClient;
 import org.apache.accumulo.core.client.impl.thrift.ThriftNotActiveServiceException;
 import org.apache.accumulo.core.master.thrift.BulkImportStatus;
@@ -42,7 +43,8 @@ public class GetMasterStats {
   public static void main(String[] args) throws Exception {
     MasterClientService.Iface client = null;
     MasterMonitorInfo stats = null;
-    AccumuloServerContext context = new AccumuloServerContext(new ServerConfigurationFactory(HdfsZooInstance.getInstance()));
+    Instance instance = HdfsZooInstance.getInstance();
+    AccumuloServerContext context = new AccumuloServerContext(instance, new ServerConfigurationFactory(instance));
     while (true) {
       try {
         client = MasterClient.getConnectionWithRetry(context);

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -119,7 +119,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
   private long getSyncs() throws Exception {
     Connector c = getConnector();
     ServerConfigurationFactory confFactory = new ServerConfigurationFactory(c.getInstance());
-    AccumuloServerContext context = new AccumuloServerContext(confFactory);
+    AccumuloServerContext context = new AccumuloServerContext(c.getInstance(), confFactory);
     for (String address : c.instanceOperations().getTabletServers()) {
       TabletClientService.Client client = ThriftUtil.getTServerClient(HostAndPort.fromString(address), context);
       TabletServerStatus status = client.getTabletServerStatus(null, context.rpcCreds());

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -48,7 +48,7 @@ public class WrongTabletTest {
     final HostAndPort location = HostAndPort.fromString(opts.location);
     final Instance inst = opts.getInstance();
     final ServerConfigurationFactory conf = new ServerConfigurationFactory(inst);
-    final ClientContext context = new AccumuloServerContext(conf) {
+    final ClientContext context = new AccumuloServerContext(inst, conf) {
       @Override
       public synchronized Credentials getCredentials() {
         try {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -82,7 +82,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
 
   private void run() throws Exception {
     Instance inst = HdfsZooInstance.getInstance();
-    AccumuloServerContext c = new AccumuloServerContext(new ServerConfigurationFactory(inst));
+    AccumuloServerContext c = new AccumuloServerContext(inst, new ServerConfigurationFactory(inst));
     String zPath = ZooUtil.getRoot(inst) + "/testLock";
     IZooReaderWriter zoo = ZooReaderWriter.getInstance();
     zoo.putPersistentData(zPath, new byte[0], NodeExistsPolicy.OVERWRITE);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.security.thrift.TCredentials;
@@ -99,7 +100,8 @@ public class ZombieTServer {
   public static void main(String[] args) throws Exception {
     Random random = new Random(System.currentTimeMillis() % 1000);
     int port = random.nextInt(30000) + 2000;
-    AccumuloServerContext context = new AccumuloServerContext(new ServerConfigurationFactory(HdfsZooInstance.getInstance()));
+    Instance instance = HdfsZooInstance.getInstance();
+    AccumuloServerContext context = new AccumuloServerContext(instance, new ServerConfigurationFactory(instance));
 
     TransactionWatcher watcher = new TransactionWatcher();
     final ThriftClientHandler tch = new ThriftClientHandler(context, watcher);

--- a/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
@@ -95,7 +95,6 @@ public class CloseWriteAheadLogReferencesIT extends ConfigurableMacBase {
     final AccumuloConfiguration systemConf = new ConfigurationCopy(new HashMap<String,String>());
     ServerConfigurationFactory factory = createMock(ServerConfigurationFactory.class);
     expect(factory.getSystemConfiguration()).andReturn(systemConf).anyTimes();
-    expect(factory.getInstance()).andReturn(mockInst).anyTimes();
     expect(factory.getSiteConfiguration()).andReturn(siteConfig).anyTimes();
 
     // Just make the SiteConfiguration delegate to our AccumuloConfiguration
@@ -123,7 +122,7 @@ public class CloseWriteAheadLogReferencesIT extends ConfigurableMacBase {
     }).anyTimes();
 
     replay(mockInst, factory, siteConfig);
-    refs = new WrappedCloseWriteAheadLogReferences(new AccumuloServerContext(factory));
+    refs = new WrappedCloseWriteAheadLogReferences(new AccumuloServerContext(mockInst, factory));
   }
 
   @Test


### PR DESCRIPTION
A first step in the bigger refactoring effort for [ACCUMULO-4050](https://issues.apache.org/jira/browse/ACCUMULO-4050).  These changes remove ServerConfiguration.getInstance() and make more use of AccumuloServerContext across TableBalancer classes.  Also deprecates TabletBalancer.init(ServerConfigurationFactory conf) replacing with init(AccumuloServerContext context) to assist in the configuration changes.  

Even without the completion of ACCUMULO-4050, these changes will help simplify the configuration internals of Accumulo.