### PR TITLE
ACCUMULO-3238 Table.ID Namespace.ID Refactor

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.data.ConstraintViolationSummary;
@@ -68,13 +69,14 @@ public class MutationsRejectedException extends AccumuloException {
     Map<String,Set<SecurityErrorCode>> result = new HashMap<>();
 
     for (Entry<TabletId,Set<SecurityErrorCode>> entry : hashMap.entrySet()) {
-      String tableInfo = Tables.getPrintableTableInfoFromId(instance, entry.getKey().getTableId().toString());
+      TabletId tabletId = entry.getKey();
+      String tableInfo = Tables.getPrintableTableInfoFromId(instance, new Table.ID(tabletId.getTableId().toString()));
 
       if (!result.containsKey(tableInfo)) {
         result.put(tableInfo, new HashSet<SecurityErrorCode>());
       }
 
-      result.get(tableInfo).addAll(hashMap.get(entry.getKey()));
+      result.get(tableInfo).addAll(hashMap.get(tabletId));
     }
 
     return result.toString();

--- a/core/src/main/java/org/apache/accumulo/core/client/TableOfflineException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableOfflineException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 
 public class TableOfflineException extends RuntimeException {
@@ -26,7 +27,7 @@ public class TableOfflineException extends RuntimeException {
     if (tableId == null)
       return " <unknown table> ";
     try {
-      String tableName = Tables.getTableName(instance, tableId);
+      String tableName = Tables.getTableName(instance, new Table.ID(tableId));
       return tableName + " (" + tableId + ")";
     } catch (TableNotFoundException e) {
       return " <unknown table> (" + tableId + ")";

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/AbstractId.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/AbstractId.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * An abstract identifier class for comparing equality of identifiers of the same type.
+ */
+public abstract class AbstractId implements Comparable<AbstractId>, Serializable {
+
+  private static final long serialVersionUID = -155513612834787244L;
+  private final String canonical;
+  private Integer hashCode = null;
+
+  protected AbstractId(final String canonical) {
+    requireNonNull(canonical, "canonical cannot be null");
+    this.canonical = canonical;
+  }
+
+  /**
+   * The canonical ID
+   */
+  public final String canonicalID() {
+    return canonical;
+  }
+
+  public boolean isEmpty() {
+    return canonical.isEmpty();
+  }
+
+  /**
+   * AbstractID objects are considered equal if, and only if, they are of the same type and have the same canonical identifier.
+   */
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    return obj != null && Objects.equals(getClass(), obj.getClass()) && Objects.equals(canonicalID(), ((AbstractId) obj).canonicalID());
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashCode == null) {
+      hashCode = Objects.hash(canonicalID());
+    }
+    return hashCode;
+  }
+
+  /**
+   * Returns a string of the canonical ID
+   */
+  @Override
+  public String toString() {
+    return canonical;
+  }
+
+  /**
+   * Return a UTF_8 byte[] of the canonical ID.
+   */
+  public final byte[] getUtf8() {
+    return canonical.getBytes(UTF_8);
+  }
+
+  @Override
+  public int compareTo(AbstractId id) {
+    requireNonNull(id, "id cannot be null");
+    return this.canonicalID().compareTo(id.canonicalID());
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveScanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveScanImpl.java
@@ -60,7 +60,7 @@ public class ActiveScanImpl extends ActiveScan {
     this.user = activeScan.user;
     this.age = activeScan.age;
     this.idle = activeScan.idleTime;
-    this.tableName = Tables.getTableName(instance, activeScan.tableId);
+    this.tableName = Tables.getTableName(instance, new Table.ID(activeScan.tableId));
     this.type = ScanType.valueOf(activeScan.getType().name());
     this.state = ScanState.valueOf(activeScan.state.name());
     this.extent = new KeyExtent(activeScan.extent);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/BatchWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/BatchWriterImpl.java
@@ -25,10 +25,10 @@ import org.apache.accumulo.core.data.Mutation;
 
 public class BatchWriterImpl implements BatchWriter {
 
-  private final String tableId;
+  private final Table.ID tableId;
   private final TabletServerBatchWriter bw;
 
-  public BatchWriterImpl(ClientContext context, String tableId, BatchWriterConfig config) {
+  public BatchWriterImpl(ClientContext context, Table.ID tableId, BatchWriterConfig config) {
     checkArgument(context != null, "context is null");
     checkArgument(tableId != null, "tableId is null");
     if (config == null)

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
@@ -79,10 +79,10 @@ public class ConnectorImpl extends Connector {
     this.namespaceops = new NamespaceOperationsImpl(context, tableops);
   }
 
-  private String getTableId(String tableName) throws TableNotFoundException {
-    String tableId = Tables.getTableId(context.getInstance(), tableName);
+  private Table.ID getTableId(String tableName) throws TableNotFoundException {
+    Table.ID tableId = Tables.getTableId(context.getInstance(), tableName);
     if (Tables.getTableState(context.getInstance(), tableId) == TableState.OFFLINE)
-      throw new TableOfflineException(context.getInstance(), tableId);
+      throw new TableOfflineException(context.getInstance(), tableId.canonicalID());
     return tableId;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
@@ -14,18 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.server.conf;
+package org.apache.accumulo.core.client.impl;
 
-import org.apache.accumulo.core.client.impl.Namespace;
-import org.apache.accumulo.core.client.impl.Table;
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.client.Instance;
 
-public abstract class ServerConfiguration {
+public class Namespace {
 
-  abstract public TableConfiguration getTableConfiguration(Table.ID tableId);
+  /**
+   * Object representing an internal Namespace ID. This class was created to help with type safety. For help obtaining the value of a namespace ID from
+   * Zookeeper, see {@link Namespaces#getNamespaceId(Instance, String)}
+   */
+  public static class ID extends AbstractId {
+    private static final long serialVersionUID = 8931104141709170293L;
 
-  abstract public NamespaceConfiguration getNamespaceConfiguration(Namespace.ID namespaceId);
+    public static final ID ACCUMULO = new ID("+accumulo");
+    public static final ID DEFAULT = new ID("+default");
 
-  abstract public AccumuloConfiguration getSystemConfiguration();
+    public ID(String canonical) {
+      super(canonical);
+    }
+  }
+
+  public static final String ACCUMULO = "accumulo";
+  public static final String DEFAULT = "";
+  public static final String SEPARATOR = ".";
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -146,7 +146,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
   private Range range;
   private KeyExtent currentExtent;
   private Connector conn;
-  private String tableId;
+  private Table.ID tableId;
   private Authorizations authorizations;
   private Instance instance;
   private ScannerOptions options;
@@ -162,7 +162,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       this.range = range.bound(this.options.fetchedColumns.first(), this.options.fetchedColumns.last());
     }
 
-    this.tableId = table.toString();
+    this.tableId = new Table.ID(table.toString());
     this.authorizations = authorizations;
     this.readers = new ArrayList<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineScanner.java
@@ -41,14 +41,14 @@ public class OfflineScanner extends ScannerOptions implements Scanner {
   private Authorizations authorizations;
   private Text tableId;
 
-  public OfflineScanner(Instance instance, Credentials credentials, String tableId, Authorizations authorizations) {
+  public OfflineScanner(Instance instance, Credentials credentials, Table.ID tableId, Authorizations authorizations) {
     checkArgument(instance != null, "instance is null");
     checkArgument(credentials != null, "credentials is null");
     checkArgument(tableId != null, "tableId is null");
     checkArgument(authorizations != null, "authorizations is null");
     this.instance = instance;
     this.credentials = credentials;
-    this.tableId = new Text(tableId);
+    this.tableId = new Text(tableId.getUtf8());
     this.range = new Range((Key) null, (Key) null);
 
     this.authorizations = authorizations;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationOperationsImpl.java
@@ -117,7 +117,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
     });
   }
 
-  protected String getTableId(Connector conn, String tableName) throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+  protected Table.ID getTableId(Connector conn, String tableName) throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     TableOperations tops = conn.tableOperations();
 
     if (!conn.tableOperations().exists(tableName)) {
@@ -132,7 +132,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
       }
     }
 
-    return tableId;
+    return new Table.ID(tableId);
   }
 
   @Override
@@ -142,7 +142,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
     log.debug("Collecting referenced files for replication of table {}", tableName);
 
     Connector conn = context.getConnector();
-    String tableId = getTableId(conn, tableName);
+    Table.ID tableId = getTableId(conn, tableName);
 
     log.debug("Found id of {} for name {}", tableId, tableName);
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerImpl.java
@@ -46,7 +46,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
 
   private final ClientContext context;
   private Authorizations authorizations;
-  private String tableId;
+  private Table.ID tableId;
 
   private int size;
 
@@ -54,7 +54,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   private boolean isolated = false;
   private long readaheadThreshold = Constants.SCANNER_DEFAULT_READAHEAD_THRESHOLD;
 
-  public ScannerImpl(ClientContext context, String tableId, Authorizations authorizations) {
+  public ScannerImpl(ClientContext context, Table.ID tableId, Authorizations authorizations) {
     checkArgument(context != null, "context is null");
     checkArgument(tableId != null, "tableId is null");
     checkArgument(authorizations != null, "authorizations is null");

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
@@ -104,7 +104,7 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
 
   }
 
-  ScannerIterator(ClientContext context, String tableId, Authorizations authorizations, Range range, int size, int timeOut, ScannerOptions options,
+  ScannerIterator(ClientContext context, Table.ID tableId, Authorizations authorizations, Range range, int size, int timeOut, ScannerOptions options,
       boolean isolated, long readaheadThreshold) {
     this.timeOut = timeOut;
     this.readaheadThreshold = readaheadThreshold;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/SyncingTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/SyncingTabletLocator.java
@@ -51,7 +51,7 @@ public class SyncingTabletLocator extends TabletLocator {
     }
   }
 
-  public SyncingTabletLocator(final ClientContext context, final String tableId) {
+  public SyncingTabletLocator(final ClientContext context, final Table.ID tableId) {
     this(new Callable<TabletLocator>() {
       @Override
       public TabletLocator call() throws Exception {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Table.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Table.java
@@ -14,18 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.server.conf;
+package org.apache.accumulo.core.client.impl;
 
-import org.apache.accumulo.core.client.impl.Namespace;
-import org.apache.accumulo.core.client.impl.Table;
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.client.Instance;
 
-public abstract class ServerConfiguration {
+public class Table {
 
-  abstract public TableConfiguration getTableConfiguration(Table.ID tableId);
+  /**
+   * Object representing an internal table ID. This class was created to help with type safety. For help obtaining the value of a table ID from Zookeeper, see
+   * {@link Tables#getTableId(Instance, String)}
+   */
+  public static class ID extends AbstractId {
+    private static final long serialVersionUID = 7399913185860577809L;
 
-  abstract public NamespaceConfiguration getNamespaceConfiguration(Namespace.ID namespaceId);
+    public static final ID METADATA = new ID("!0");
+    public static final ID REPLICATION = new ID("+rep");
+    public static final ID ROOT = new ID("+r");
 
-  abstract public AccumuloConfiguration getSystemConfiguration();
+    public ID(final String canonical) {
+      super(canonical);
+    }
+  }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocator.java
@@ -74,16 +74,16 @@ public abstract class TabletLocator {
 
   private static class LocatorKey {
     String instanceId;
-    String tableName;
+    Table.ID tableId;
 
-    LocatorKey(String instanceId, String table) {
+    LocatorKey(String instanceId, Table.ID table) {
       this.instanceId = instanceId;
-      this.tableName = table;
+      this.tableId = table;
     }
 
     @Override
     public int hashCode() {
-      return instanceId.hashCode() + tableName.hashCode();
+      return instanceId.hashCode() + tableId.hashCode();
     }
 
     @Override
@@ -94,7 +94,7 @@ public abstract class TabletLocator {
     }
 
     public boolean equals(LocatorKey lk) {
-      return instanceId.equals(lk.instanceId) && tableName.equals(lk.tableName);
+      return instanceId.equals(lk.instanceId) && tableId.equals(lk.tableId);
     }
 
   }
@@ -108,7 +108,7 @@ public abstract class TabletLocator {
     locators.clear();
   }
 
-  public static synchronized TabletLocator getLocator(ClientContext context, String tableId) {
+  public static synchronized TabletLocator getLocator(ClientContext context, Table.ID tableId) {
     Instance instance = context.getInstance();
     LocatorKey key = new LocatorKey(instance.getInstanceID(), tableId);
     TabletLocator tl = locators.get(key);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletLocatorImpl.java
@@ -88,7 +88,7 @@ public class TabletLocatorImpl extends TabletLocator {
 
   static final EndRowComparator endRowComparator = new EndRowComparator();
 
-  protected String tableId;
+  protected Table.ID tableId;
   protected TabletLocator parent;
   protected TreeMap<Text,TabletLocation> metaCache = new TreeMap<>(endRowComparator);
   protected TabletLocationObtainer locationObtainer;
@@ -152,13 +152,13 @@ public class TabletLocatorImpl extends TabletLocator {
     }
   }
 
-  public TabletLocatorImpl(String tableId, TabletLocator parent, TabletLocationObtainer tlo, TabletServerLockChecker tslc) {
+  public TabletLocatorImpl(Table.ID tableId, TabletLocator parent, TabletLocationObtainer tlo, TabletServerLockChecker tslc) {
     this.tableId = tableId;
     this.parent = parent;
     this.locationObtainer = tlo;
     this.lockChecker = tslc;
 
-    this.lastTabletRow = new Text(tableId);
+    this.lastTabletRow = new Text(tableId.getUtf8());
     lastTabletRow.append(new byte[] {'<'}, 0, 1);
   }
 
@@ -474,7 +474,7 @@ public class TabletLocatorImpl extends TabletLocator {
 
   private void lookupTabletLocation(ClientContext context, Text row, boolean retry, LockCheckerSession lcSession) throws AccumuloException,
       AccumuloSecurityException, TableNotFoundException {
-    Text metadataRow = new Text(tableId);
+    Text metadataRow = new Text(tableId.getUtf8());
     metadataRow.append(new byte[] {';'}, 0, 1);
     metadataRow.append(row.getBytes(), 0, row.getLength());
     TabletLocation ptl = parent.locateTablet(context, metadataRow, false, retry);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchDeleter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchDeleter.java
@@ -35,10 +35,10 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 public class TabletServerBatchDeleter extends TabletServerBatchReader implements BatchDeleter {
 
   private final ClientContext context;
-  private String tableId;
+  private Table.ID tableId;
   private BatchWriterConfig bwConfig;
 
-  public TabletServerBatchDeleter(ClientContext context, String tableId, Authorizations authorizations, int numQueryThreads, BatchWriterConfig bwConfig)
+  public TabletServerBatchDeleter(ClientContext context, Table.ID tableId, Authorizations authorizations, int numQueryThreads, BatchWriterConfig bwConfig)
       throws TableNotFoundException {
     super(context, tableId, authorizations, numQueryThreads);
     this.context = context;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReader.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public class TabletServerBatchReader extends ScannerOptions implements BatchScanner {
   private static final Logger log = LoggerFactory.getLogger(TabletServerBatchReader.class);
 
-  private String tableId;
+  private Table.ID tableId;
   private int numThreads;
   private ExecutorService queryThreadPool;
 
@@ -54,7 +54,7 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
 
   private final int batchReaderInstance = getNextBatchReaderInstance();
 
-  public TabletServerBatchReader(ClientContext context, String tableId, Authorizations authorizations, int numQueryThreads) {
+  public TabletServerBatchReader(ClientContext context, Table.ID tableId, Authorizations authorizations, int numQueryThreads) {
     checkArgument(context != null, "context is null");
     checkArgument(tableId != null, "tableId is null");
     checkArgument(authorizations != null, "authorizations is null");

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
@@ -241,7 +241,7 @@ public class TabletServerBatchWriter {
     this.notifyAll();
   }
 
-  public synchronized void addMutation(String table, Mutation m) throws MutationsRejectedException {
+  public synchronized void addMutation(Table.ID table, Mutation m) throws MutationsRejectedException {
 
     if (closed)
       throw new IllegalStateException("Closed");
@@ -295,7 +295,7 @@ public class TabletServerBatchWriter {
     }
   }
 
-  public void addMutation(String table, Iterator<Mutation> iterator) throws MutationsRejectedException {
+  public void addMutation(Table.ID table, Iterator<Mutation> iterator) throws MutationsRejectedException {
     while (iterator.hasNext()) {
       addMutation(table, iterator.next());
     }
@@ -514,14 +514,14 @@ public class TabletServerBatchWriter {
     if (authorizationFailures.size() > 0) {
 
       // was a table deleted?
-      HashSet<String> tableIds = new HashSet<>();
+      HashSet<Table.ID> tableIds = new HashSet<>();
       for (KeyExtent ke : authorizationFailures.keySet())
         tableIds.add(ke.getTableId());
 
       Tables.clearCache(context.getInstance());
-      for (String tableId : tableIds)
+      for (Table.ID tableId : tableIds)
         if (!Tables.exists(context.getInstance(), tableId))
-          throw new TableDeletedException(tableId);
+          throw new TableDeletedException(tableId.canonicalID());
 
       synchronized (this) {
         somethingFailed = true;
@@ -609,7 +609,7 @@ public class TabletServerBatchWriter {
       return recentFailures;
     }
 
-    synchronized void add(String table, ArrayList<Mutation> tableFailures) {
+    synchronized void add(Table.ID table, ArrayList<Mutation> tableFailures) {
       init().addAll(table, tableFailures);
     }
 
@@ -660,7 +660,7 @@ public class TabletServerBatchWriter {
     private final SimpleThreadPool binningThreadPool;
     private final Map<String,TabletServerMutations<Mutation>> serversMutations;
     private final Set<String> queued;
-    private final Map<String,TabletLocator> locators;
+    private final Map<Table.ID,TabletLocator> locators;
 
     public MutationWriter(int numSendThreads) {
       serversMutations = new HashMap<>();
@@ -671,7 +671,7 @@ public class TabletServerBatchWriter {
       binningThreadPool.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
-    private synchronized TabletLocator getLocator(String tableId) {
+    private synchronized TabletLocator getLocator(Table.ID tableId) {
       TabletLocator ret = locators.get(tableId);
       if (ret == null) {
         ret = new TimeoutTabletLocator(timeout, context, tableId);
@@ -682,14 +682,12 @@ public class TabletServerBatchWriter {
     }
 
     private void binMutations(MutationSet mutationsToProcess, Map<String,TabletServerMutations<Mutation>> binnedMutations) {
-      String tableId = null;
+      Table.ID tableId = null;
       try {
-        Set<Entry<String,List<Mutation>>> es = mutationsToProcess.getMutations().entrySet();
-        for (Entry<String,List<Mutation>> entry : es) {
+        Set<Entry<Table.ID,List<Mutation>>> es = mutationsToProcess.getMutations().entrySet();
+        for (Entry<Table.ID,List<Mutation>> entry : es) {
           tableId = entry.getKey();
           TabletLocator locator = getLocator(tableId);
-
-          String table = entry.getKey();
           List<Mutation> tableMutations = entry.getValue();
 
           if (tableMutations != null) {
@@ -697,13 +695,13 @@ public class TabletServerBatchWriter {
             locator.binMutations(context, tableMutations, binnedMutations, tableFailures);
 
             if (tableFailures.size() > 0) {
-              failedMutations.add(table, tableFailures);
+              failedMutations.add(tableId, tableFailures);
 
               if (tableFailures.size() == tableMutations.size())
                 if (!Tables.exists(context.getInstance(), entry.getKey()))
-                  throw new TableDeletedException(entry.getKey());
-                else if (Tables.getTableState(context.getInstance(), table) == TableState.OFFLINE)
-                  throw new TableOfflineException(context.getInstance(), entry.getKey());
+                  throw new TableDeletedException(entry.getKey().canonicalID());
+                else if (Tables.getTableState(context.getInstance(), tableId) == TableState.OFFLINE)
+                  throw new TableOfflineException(context.getInstance(), entry.getKey().canonicalID());
             }
           }
 
@@ -845,7 +843,7 @@ public class TabletServerBatchWriter {
 
           long count = 0;
 
-          Set<String> tableIds = new TreeSet<>();
+          Set<Table.ID> tableIds = new TreeSet<>();
           for (Map.Entry<KeyExtent,List<Mutation>> entry : mutationBatch.entrySet()) {
             count += entry.getValue().size();
             tableIds.add(entry.getKey().getTableId());
@@ -893,11 +891,11 @@ public class TabletServerBatchWriter {
           if (log.isTraceEnabled())
             log.trace("failed to send mutations to {} : {}", location, e.getMessage());
 
-          HashSet<String> tables = new HashSet<>();
+          HashSet<Table.ID> tables = new HashSet<>();
           for (KeyExtent ke : mutationBatch.keySet())
             tables.add(ke.getTableId());
 
-          for (String table : tables)
+          for (Table.ID table : tables)
             getLocator(table).invalidateCache(context.getInstance(), location);
 
           failedMutations.add(location, tsm);
@@ -974,7 +972,7 @@ public class TabletServerBatchWriter {
               int numCommitted = (int) (long) entry.getValue();
               totalCommitted += numCommitted;
 
-              String tableId = failedExtent.getTableId();
+              Table.ID tableId = failedExtent.getTableId();
 
               getLocator(tableId).invalidateCache(failedExtent);
 
@@ -1015,14 +1013,14 @@ public class TabletServerBatchWriter {
 
   private static class MutationSet {
 
-    private final HashMap<String,List<Mutation>> mutations;
+    private final HashMap<Table.ID,List<Mutation>> mutations;
     private int memoryUsed = 0;
 
     MutationSet() {
       mutations = new HashMap<>();
     }
 
-    void addMutation(String table, Mutation mutation) {
+    void addMutation(Table.ID table, Mutation mutation) {
       List<Mutation> tabMutList = mutations.get(table);
       if (tabMutList == null) {
         tabMutList = new ArrayList<>();
@@ -1034,7 +1032,7 @@ public class TabletServerBatchWriter {
       memoryUsed += mutation.estimatedMemoryUsed();
     }
 
-    Map<String,List<Mutation>> getMutations() {
+    Map<Table.ID,List<Mutation>> getMutations() {
       return mutations;
     }
 
@@ -1047,10 +1045,10 @@ public class TabletServerBatchWriter {
     }
 
     public void addAll(MutationSet failures) {
-      Set<Entry<String,List<Mutation>>> es = failures.getMutations().entrySet();
+      Set<Entry<Table.ID,List<Mutation>>> es = failures.getMutations().entrySet();
 
-      for (Entry<String,List<Mutation>> entry : es) {
-        String table = entry.getKey();
+      for (Entry<Table.ID,List<Mutation>> entry : es) {
+        Table.ID table = entry.getKey();
 
         for (Mutation mutation : entry.getValue()) {
           addMutation(table, mutation);
@@ -1058,7 +1056,7 @@ public class TabletServerBatchWriter {
       }
     }
 
-    public void addAll(String table, List<Mutation> mutations) {
+    public void addAll(Table.ID table, List<Mutation> mutations) {
       for (Mutation mutation : mutations) {
         addMutation(table, mutation);
       }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -137,7 +137,7 @@ public class ThriftScanner {
   public static class ScanState {
 
     boolean isolated;
-    String tableId;
+    Table.ID tableId;
     Text startRow;
     boolean skipStartRow;
     long readaheadThreshold;
@@ -164,7 +164,7 @@ public class ThriftScanner {
 
     SamplerConfiguration samplerConfig;
 
-    public ScanState(ClientContext context, String tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns, int size,
+    public ScanState(ClientContext context, Table.ID tableId, Authorizations authorizations, Range range, SortedSet<Column> fetchedColumns, int size,
         List<IterInfo> serverSideIteratorList, Map<String,Map<String,String>> serverSideIteratorOptions, boolean isolated, long readaheadThreshold,
         SamplerConfiguration samplerConfig, long batchTimeOut, String classLoaderContext) {
       this.context = context;
@@ -248,9 +248,9 @@ public class ThriftScanner {
 
             if (loc == null) {
               if (!Tables.exists(instance, scanState.tableId))
-                throw new TableDeletedException(scanState.tableId);
+                throw new TableDeletedException(scanState.tableId.canonicalID());
               else if (Tables.getTableState(instance, scanState.tableId) == TableState.OFFLINE)
-                throw new TableOfflineException(instance, scanState.tableId);
+                throw new TableOfflineException(instance, scanState.tableId.canonicalID());
 
               error = "Failed to locate tablet for table : " + scanState.tableId + " row : " + scanState.startRow;
               if (!error.equals(lastError))
@@ -299,7 +299,7 @@ public class ThriftScanner {
         } catch (AccumuloSecurityException e) {
           Tables.clearCache(instance);
           if (!Tables.exists(instance, scanState.tableId))
-            throw new TableDeletedException(scanState.tableId);
+            throw new TableDeletedException(scanState.tableId.canonicalID());
           e.setTableInfo(Tables.getPrintableTableInfoFromId(instance, scanState.tableId));
           throw e;
         } catch (TApplicationException tae) {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TimeoutTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TimeoutTabletLocator.java
@@ -50,7 +50,7 @@ public class TimeoutTabletLocator extends SyncingTabletLocator {
     firstFailTime = null;
   }
 
-  public TimeoutTabletLocator(long timeout, final ClientContext context, final String table) {
+  public TimeoutTabletLocator(long timeout, final ClientContext context, final Table.ID table) {
     super(context, table);
     this.timeout = timeout;
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
@@ -48,9 +48,9 @@ public class Writer {
   private static final Logger log = LoggerFactory.getLogger(Writer.class);
 
   private ClientContext context;
-  private String tableId;
+  private Table.ID tableId;
 
-  public Writer(ClientContext context, String tableId) {
+  public Writer(ClientContext context, Table.ID tableId) {
     checkArgument(context != null, "context is null");
     checkArgument(tableId != null, "tableId is null");
     this.context = context;

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/impl/BatchInputSplit.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/impl/BatchInputSplit.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.core.client.mapred.impl;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Range;
 import org.apache.hadoop.mapred.InputSplit;
 
@@ -35,7 +36,7 @@ public class BatchInputSplit extends org.apache.accumulo.core.client.mapreduce.i
     super(split);
   }
 
-  public BatchInputSplit(String table, String tableId, Collection<Range> ranges, String[] location) {
+  public BatchInputSplit(String table, Table.ID tableId, Collection<Range> ranges, String[] location) {
     super(table, tableId, ranges, location);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/impl/BatchInputSplit.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/impl/BatchInputSplit.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.mapreduce.RangeInputSplit;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -45,8 +46,8 @@ public class BatchInputSplit extends RangeInputSplit {
     this.setRanges(split.getRanges());
   }
 
-  public BatchInputSplit(String table, String tableId, Collection<Range> ranges, String[] locations) {
-    super(table, tableId, new Range(), locations);
+  public BatchInputSplit(String table, Table.ID tableId, Collection<Range> ranges, String[] locations) {
+    super(table, tableId.canonicalID(), new Range(), locations);
     this.ranges = ranges;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
@@ -51,6 +51,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
 import org.apache.accumulo.core.client.impl.DelegationTokenImpl;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.TabletLocator;
 import org.apache.accumulo.core.client.mapreduce.InputTableConfig;
@@ -674,7 +675,7 @@ public class InputConfigurator extends ConfiguratorBase {
    *           if the table name set on the configuration doesn't exist
    * @since 1.6.0
    */
-  public static TabletLocator getTabletLocator(Class<?> implementingClass, Configuration conf, String tableId) throws TableNotFoundException {
+  public static TabletLocator getTabletLocator(Class<?> implementingClass, Configuration conf, Table.ID tableId) throws TableNotFoundException {
     String instanceType = conf.get(enumToConfKey(implementingClass, InstanceOpts.TYPE));
     if ("MockInstance".equals(instanceType))
       return DeprecationUtil.makeMockLocator();
@@ -849,7 +850,7 @@ public class InputConfigurator extends ConfiguratorBase {
     return null;
   }
 
-  public static Map<String,Map<KeyExtent,List<Range>>> binOffline(String tableId, List<Range> ranges, Instance instance, Connector conn)
+  public static Map<String,Map<KeyExtent,List<Range>>> binOffline(Table.ID tableId, List<Range> ranges, Instance instance, Connector conn)
       throws AccumuloException, TableNotFoundException {
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockTableOperations.java
@@ -366,9 +366,9 @@ class MockTableOperations extends TableOperationsHelper {
     for (Entry<String,MockTable> entry : acu.tables.entrySet()) {
       String table = entry.getKey();
       if (RootTable.NAME.equals(table))
-        result.put(table, RootTable.ID);
+        result.put(table, RootTable.ID.canonicalID());
       else if (MetadataTable.NAME.equals(table))
-        result.put(table, MetadataTable.ID);
+        result.put(table, MetadataTable.ID.canonicalID());
       else
         result.put(table, entry.getValue().getTableId());
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
@@ -57,7 +57,7 @@ public class MockTabletLocator extends TabletLocator {
   @Override
   public List<Range> binRanges(ClientContext context, List<Range> ranges, Map<String,Map<KeyExtent,List<Range>>> binnedRanges) throws AccumuloException,
       AccumuloSecurityException, TableNotFoundException {
-    binnedRanges.put("", Collections.singletonMap(new KeyExtent("", null, null), ranges));
+    binnedRanges.put("", Collections.singletonMap(new KeyExtent(null, null, null), ranges));
     return Collections.emptyList();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/impl/TabletIdImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/impl/TabletIdImpl.java
@@ -36,7 +36,7 @@ public class TabletIdImpl implements TabletId {
 
   @Override
   public Text getTableId() {
-    return new Text(ke.getTableId());
+    return new Text(ke.getTableId().getUtf8());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataServicer.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 
 /**
@@ -33,10 +34,10 @@ public abstract class MetadataServicer {
 
   public static MetadataServicer forTableName(ClientContext context, String tableName) throws AccumuloException, AccumuloSecurityException {
     checkArgument(tableName != null, "tableName is null");
-    return forTableId(context, context.getConnector().tableOperations().tableIdMap().get(tableName));
+    return forTableId(context, new Table.ID(context.getConnector().tableOperations().tableIdMap().get(tableName)));
   }
 
-  public static MetadataServicer forTableId(ClientContext context, String tableId) {
+  public static MetadataServicer forTableId(ClientContext context, Table.ID tableId) {
     checkArgument(tableId != null, "tableId is null");
     if (RootTable.ID.equals(tableId))
       return new ServicerForRootTable(context);
@@ -50,7 +51,7 @@ public abstract class MetadataServicer {
    *
    * @return the table id of the table currently being serviced
    */
-  public abstract String getServicedTableId();
+  public abstract Table.ID getServicedTableId();
 
   /**
    * Populate the provided data structure with the known tablets for the table being serviced

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataTable.java
@@ -17,12 +17,13 @@
 package org.apache.accumulo.core.metadata;
 
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 
 public class MetadataTable {
 
   public static final String OLD_NAME = "!METADATA";
 
-  public static final String ID = "!0";
+  public static final Table.ID ID = Table.ID.METADATA;
   public static final String NAME = Namespaces.ACCUMULO_NAMESPACE + ".metadata";
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.metadata;
 
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 
 /**
@@ -24,7 +25,7 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
  */
 public class RootTable {
 
-  public static final String ID = "+r";
+  public static final Table.ID ID = Table.ID.ROOT;
   public static final String NAME = Namespaces.ACCUMULO_NAMESPACE + ".root";
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ServicerForRootTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ServicerForRootTable.java
@@ -23,6 +23,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 
 /**
@@ -38,7 +39,7 @@ class ServicerForRootTable extends MetadataServicer {
   }
 
   @Override
-  public String getServicedTableId() {
+  public Table.ID getServicedTableId() {
     return RootTable.ID;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ServicerForUserTables.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ServicerForUserTables.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.metadata;
 
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 
 /**
  * A metadata servicer for user tables.<br>
@@ -24,7 +25,7 @@ import org.apache.accumulo.core.client.impl.ClientContext;
  */
 class ServicerForUserTables extends TableMetadataServicer {
 
-  public ServicerForUserTables(ClientContext context, String tableId) {
+  public ServicerForUserTables(ClientContext context, Table.ID tableId) {
     super(context, MetadataTable.NAME, tableId);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -39,17 +40,17 @@ import org.apache.hadoop.io.Text;
 abstract class TableMetadataServicer extends MetadataServicer {
 
   private final ClientContext context;
-  private String tableIdBeingServiced;
+  private Table.ID tableIdBeingServiced;
   private String serviceTableName;
 
-  public TableMetadataServicer(ClientContext context, String serviceTableName, String tableIdBeingServiced) {
+  public TableMetadataServicer(ClientContext context, String serviceTableName, Table.ID tableIdBeingServiced) {
     this.context = context;
     this.serviceTableName = serviceTableName;
     this.tableIdBeingServiced = tableIdBeingServiced;
   }
 
   @Override
-  public String getServicedTableId() {
+  public Table.ID getServicedTableId() {
     return tableIdBeingServiced;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataScanner.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
@@ -58,9 +59,9 @@ public class MetadataScanner {
 
     ColumnOptions overMetadataTable();
 
-    ColumnOptions overUserTableId(String tableId);
+    ColumnOptions overUserTableId(Table.ID tableId);
 
-    ColumnOptions overUserTableId(String tableId, Text startRow, Text endRow);
+    ColumnOptions overUserTableId(Table.ID tableId, Text startRow, Text endRow);
   }
 
   public static interface ColumnOptions {
@@ -111,7 +112,7 @@ public class MetadataScanner {
     private Scanner scanner;
     private ClientContext ctx;
     private String table;
-    private String userTableId;
+    private Table.ID userTableId;
     private EnumSet<FetchedColumns> fetchedCols = EnumSet.noneOf(FetchedColumns.class);
     private Text startRow;
     private Text endRow;
@@ -198,7 +199,7 @@ public class MetadataScanner {
     }
 
     @Override
-    public ColumnOptions overUserTableId(String tableId) {
+    public ColumnOptions overUserTableId(Table.ID tableId) {
       Preconditions.checkArgument(!tableId.equals(RootTable.ID) && !tableId.equals(MetadataTable.ID));
 
       this.table = MetadataTable.NAME;
@@ -219,7 +220,7 @@ public class MetadataScanner {
     }
 
     @Override
-    public ColumnOptions overUserTableId(String tableId, Text startRow, Text endRow) {
+    public ColumnOptions overUserTableId(Table.ID tableId, Text startRow, Text endRow) {
       this.table = MetadataTable.NAME;
       this.userTableId = tableId;
       this.startRow = startRow;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import org.apache.accumulo.core.client.admin.TimeType;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -45,12 +46,12 @@ public class MetadataSchema {
       return section.getRange();
     }
 
-    public static Range getRange(String tableId) {
-      return new Range(new Key(tableId + ';'), true, new Key(tableId + '<').followingKey(PartialKey.ROW), false);
+    public static Range getRange(Table.ID tableId) {
+      return new Range(new Key(tableId.canonicalID() + ';'), true, new Key(tableId.canonicalID() + '<').followingKey(PartialKey.ROW), false);
     }
 
-    public static Text getRow(String tableId, Text endRow) {
-      Text entry = new Text(tableId);
+    public static Text getRow(Table.ID tableId, Text endRow) {
+      Text entry = new Text(tableId.getUtf8());
 
       if (endRow == null) {
         // append delimiter for default tablet
@@ -259,9 +260,9 @@ public class MetadataSchema {
      * @param k
      *          Key to extract from
      */
-    public static String getTableId(Key k) {
+    public static Table.ID getTableId(Key k) {
       requireNonNull(k);
-      return k.getColumnQualifier().toString();
+      return new Table.ID(k.getColumnQualifier().toString());
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 
 import org.apache.accumulo.core.client.RowIterator;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -45,7 +46,7 @@ import com.google.common.net.HostAndPort;
 
 public class TabletMetadata {
 
-  private String tableId;
+  private Table.ID tableId;
   private Text prevEndRow;
   private Text endRow;
   private Location location;
@@ -86,7 +87,7 @@ public class TabletMetadata {
     }
   }
 
-  public String getTableId() {
+  public Table.ID getTableId() {
     return tableId;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationSchema.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.nio.charset.CharacterCodingException;
 
 import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.lexicoder.ULongLexicoder;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -96,9 +97,9 @@ public class ReplicationSchema {
      *          Key to extract from
      * @return The table ID
      */
-    public static String getTableId(Key k) {
+    public static Table.ID getTableId(Key k) {
       requireNonNull(k);
-      return k.getColumnQualifier().toString();
+      return new Table.ID(k.getColumnQualifier().toString());
     }
 
     /**
@@ -124,8 +125,8 @@ public class ReplicationSchema {
       scanner.fetchColumnFamily(NAME);
     }
 
-    public static Mutation add(Mutation m, String tableId, Value v) {
-      m.put(NAME, new Text(tableId), v);
+    public static Mutation add(Mutation m, Table.ID tableId, Value v) {
+      m.put(NAME, new Text(tableId.getUtf8()), v);
       return m;
     }
   }
@@ -217,8 +218,8 @@ public class ReplicationSchema {
      *          Serialized Status msg
      * @return The original Mutation
      */
-    public static Mutation add(Mutation m, String tableId, Value v) {
-      m.put(NAME, new Text(tableId), v);
+    public static Mutation add(Mutation m, Table.ID tableId, Value v) {
+      m.put(NAME, new Text(tableId.getUtf8()), v);
       return m;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTable.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
@@ -45,7 +46,7 @@ import com.google.common.collect.ImmutableMap;
 public class ReplicationTable {
   private static final Logger log = LoggerFactory.getLogger(ReplicationTable.class);
 
-  public static final String ID = "+rep";
+  public static final Table.ID ID = new Table.ID("+rep");
   public static final String NAME = Namespaces.ACCUMULO_NAMESPACE + ".replication";
 
   public static final String COMBINER_NAME = "statuscombiner";

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTarget.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTarget.java
@@ -22,6 +22,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
@@ -35,11 +36,11 @@ public class ReplicationTarget implements Writable {
 
   private String peerName;
   private String remoteIdentifier;
-  private String sourceTableId;
+  private Table.ID sourceTableId;
 
   public ReplicationTarget() {}
 
-  public ReplicationTarget(String peerName, String remoteIdentifier, String sourceTableId) {
+  public ReplicationTarget(String peerName, String remoteIdentifier, Table.ID sourceTableId) {
     this.peerName = peerName;
     this.remoteIdentifier = remoteIdentifier;
     this.sourceTableId = sourceTableId;
@@ -61,11 +62,11 @@ public class ReplicationTarget implements Writable {
     this.remoteIdentifier = remoteIdentifier;
   }
 
-  public String getSourceTableId() {
+  public Table.ID getSourceTableId() {
     return sourceTableId;
   }
 
-  public void setSourceTableId(String sourceTableId) {
+  public void setSourceTableId(Table.ID sourceTableId) {
     this.sourceTableId = sourceTableId;
   }
 
@@ -89,7 +90,7 @@ public class ReplicationTarget implements Writable {
       out.writeBoolean(false);
     } else {
       out.writeBoolean(true);
-      WritableUtils.writeString(out, sourceTableId);
+      WritableUtils.writeString(out, sourceTableId.canonicalID());
     }
   }
 
@@ -102,7 +103,7 @@ public class ReplicationTarget implements Writable {
       this.remoteIdentifier = WritableUtils.readString(in);
     }
     if (in.readBoolean()) {
-      this.sourceTableId = WritableUtils.readString(in);
+      this.sourceTableId = new Table.ID(WritableUtils.readString(in));
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.ServerClient;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -99,7 +100,7 @@ public class Gatherer {
   private static final Logger log = LoggerFactory.getLogger(Gatherer.class);
 
   private ClientContext ctx;
-  private String tableId;
+  private Table.ID tableId;
   private SummarizerFactory factory;
   private Text startRow = null;
   private Text endRow = null;
@@ -114,7 +115,7 @@ public class Gatherer {
 
   public Gatherer(ClientContext context, TSummaryRequest request, AccumuloConfiguration tableConfig) {
     this.ctx = context;
-    this.tableId = request.tableId;
+    this.tableId = new Table.ID(request.tableId);
     this.startRow = ByteBufferUtil.toText(request.bounds.startRow);
     this.endRow = ByteBufferUtil.toText(request.bounds.endRow);
     this.clipRange = new Range(startRow, false, endRow, true);

--- a/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.hadoop.io.Text;
 
@@ -84,6 +85,10 @@ public class ByteBufferUtil {
     } else {
       return new String(toBytes(bytes), UTF_8);
     }
+  }
+
+  public static Table.ID toTableId(ByteBuffer bytes) {
+    return new Table.ID(toString(bytes));
   }
 
   public static ByteBuffer toByteBuffers(ByteSequence bs) {

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
@@ -204,7 +205,7 @@ public class Merge {
 
   protected Iterator<Size> getSizeIterator(Connector conn, String tablename, Text start, Text end) throws MergeException {
     // open up metatadata, walk through the tablets.
-    String tableId;
+    Table.ID tableId;
     Scanner scanner;
     try {
       tableId = Tables.getTableId(conn.getInstance(), tablename);

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/ScannerImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/ScannerImplTest.java
@@ -39,7 +39,7 @@ public class ScannerImplTest {
 
   @Test
   public void testValidReadaheadValues() {
-    Scanner s = new ScannerImpl(context, "foo", Authorizations.EMPTY);
+    Scanner s = new ScannerImpl(context, new Table.ID("foo"), Authorizations.EMPTY);
     s.setReadaheadThreshold(0);
     s.setReadaheadThreshold(10);
     s.setReadaheadThreshold(Long.MAX_VALUE);
@@ -50,7 +50,7 @@ public class ScannerImplTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testInValidReadaheadValues() {
-    Scanner s = new ScannerImpl(context, "foo", Authorizations.EMPTY);
+    Scanner s = new ScannerImpl(context, new Table.ID("foo"), Authorizations.EMPTY);
     s.setReadaheadThreshold(-1);
     s.close();
   }
@@ -58,7 +58,7 @@ public class ScannerImplTest {
   @Test
   public void testGetAuthorizations() {
     Authorizations expected = new Authorizations("a,b");
-    Scanner s = new ScannerImpl(context, "foo", expected);
+    Scanner s = new ScannerImpl(context, new Table.ID("foo"), expected);
     assertEquals(expected, s.getAuthorizations());
     s.close();
   }
@@ -66,7 +66,7 @@ public class ScannerImplTest {
   @SuppressWarnings("resource")
   @Test(expected = IllegalArgumentException.class)
   public void testNullAuthorizationsFails() {
-    new ScannerImpl(context, "foo", null);
+    new ScannerImpl(context, new Table.ID("foo"), null);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
@@ -44,7 +44,7 @@ public class TableOperationsImplTest {
     Connector connector = EasyMock.createMock(Connector.class);
     Scanner scanner = EasyMock.createMock(Scanner.class);
 
-    Range range = new KeyExtent("1", null, null).toMetadataRange();
+    Range range = new KeyExtent(new Table.ID("1"), null, null).toMetadataRange();
 
     String user = "root";
     PasswordToken token = new PasswordToken("password");

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
@@ -65,7 +65,7 @@ public class TabletLocatorImplTest {
   private static final KeyExtent MTE = new KeyExtent(MetadataTable.ID, null, RTE.getEndRow());
 
   static KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(t, er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(new Table.ID(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   static Range nr(String k1, boolean si, String k2, boolean ei) {
@@ -143,7 +143,7 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(table, rootTabletCache, ttlo, tslc);
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Table.ID(table), rootTabletCache, ttlo, tslc);
 
     setLocation(tservers, rootTabLoc, RTE, MTE, metaTabLoc);
 
@@ -680,7 +680,7 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl("tab1", rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Table.ID("tab1"), rootTabletCache, ttlo, new YesLockChecker());
 
     locateTabletTest(tab1TabletCache, "r1", null, null);
 
@@ -1223,14 +1223,14 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("0", rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Table.ID("0"), rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
 
     // create two tablets that straddle a metadata split point
-    KeyExtent ke1 = new KeyExtent("0", new Text("0bbf20e"), null);
-    KeyExtent ke2 = new KeyExtent("0", new Text("0bc0756"), new Text("0bbf20e"));
+    KeyExtent ke1 = new KeyExtent(new Table.ID("0"), new Text("0bbf20e"), null);
+    KeyExtent ke2 = new KeyExtent(new Table.ID("0"), new Text("0bc0756"), new Text("0bbf20e"));
 
     setLocation(tservers, "tserver2", mte1, ke1, "tserver4");
     setLocation(tservers, "tserver3", mte2, ke2, "tserver5");
@@ -1250,7 +1250,7 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("0", rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Table.ID("0"), rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
@@ -1273,7 +1273,7 @@ public class TabletLocatorImplTest {
     KeyExtent mte4 = new KeyExtent(MetadataTable.ID, new Text("1;r"), new Text("1;j"));
     KeyExtent mte5 = new KeyExtent(MetadataTable.ID, null, new Text("1;r"));
 
-    KeyExtent ke1 = new KeyExtent("1", null, null);
+    KeyExtent ke1 = new KeyExtent(new Table.ID("1"), null, null);
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
@@ -1281,7 +1281,7 @@ public class TabletLocatorImplTest {
     RootTabletLocator rtl = new TestRootTabletLocator();
 
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl("1", rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Table.ID("1"), rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderTest.java
@@ -36,7 +36,7 @@ public class TabletServerBatchReaderTest {
   @Test
   public void testGetAuthorizations() {
     Authorizations expected = new Authorizations("a,b");
-    try (BatchScanner s = new TabletServerBatchReader(context, "foo", expected, 1)) {
+    try (BatchScanner s = new TabletServerBatchReader(context, new Table.ID("foo"), expected, 1)) {
       assertEquals(expected, s.getAuthorizations());
     }
   }
@@ -44,6 +44,6 @@ public class TabletServerBatchReaderTest {
   @SuppressWarnings("resource")
   @Test(expected = IllegalArgumentException.class)
   public void testNullAuthorizationsFails() {
-    new TabletServerBatchReader(context, "foo", null, 1);
+    new TabletServerBatchReader(context, new Table.ID("foo"), null, 1);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/mapreduce/impl/BatchInputSplitTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/mapreduce/impl/BatchInputSplitTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -45,7 +46,7 @@ public class BatchInputSplitTest {
   @Test
   public void testSimpleWritable() throws IOException {
     Range[] ranges = new Range[] {new Range(new Key("a"), new Key("b"))};
-    BatchInputSplit split = new BatchInputSplit("table", "1", Arrays.asList(ranges), new String[] {"localhost"});
+    BatchInputSplit split = new BatchInputSplit("table", new Table.ID("1"), Arrays.asList(ranges), new String[] {"localhost"});
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
@@ -66,7 +67,7 @@ public class BatchInputSplitTest {
   @Test
   public void testAllFieldsWritable() throws IOException {
     Range[] ranges = new Range[] {new Range(new Key("a"), new Key("b"))};
-    BatchInputSplit split = new BatchInputSplit("table", "1", Arrays.asList(ranges), new String[] {"localhost"});
+    BatchInputSplit split = new BatchInputSplit("table", new Table.ID("1"), Arrays.asList(ranges), new String[] {"localhost"});
 
     Set<Pair<Text,Text>> fetchedColumns = new HashSet<>();
 

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
@@ -37,6 +37,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
@@ -44,7 +45,7 @@ import org.junit.Test;
 
 public class KeyExtentTest {
   KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(t, er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(new Table.ID(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   KeyExtent ke;
@@ -62,7 +63,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertEquals(new Text("bar"), ke.getEndRow());
-    assertEquals("foo", ke.getTableId());
+    assertEquals("foo", ke.getTableId().canonicalID());
     assertNull(ke.getPrevEndRow());
 
     flattenedExtent = new Text("foo<");
@@ -70,7 +71,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertNull(ke.getEndRow());
-    assertEquals("foo", ke.getTableId());
+    assertEquals("foo", ke.getTableId().canonicalID());
     assertNull(ke.getPrevEndRow());
 
     flattenedExtent = new Text("foo;bar;");
@@ -78,7 +79,7 @@ public class KeyExtentTest {
     ke = new KeyExtent(flattenedExtent, (Text) null);
 
     assertEquals(new Text("bar;"), ke.getEndRow());
-    assertEquals("foo", ke.getTableId());
+    assertEquals("foo", ke.getTableId().canonicalID());
     assertNull(ke.getPrevEndRow());
 
   }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import junit.framework.TestCase;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.data.thrift.TRange;
 import org.apache.hadoop.io.Text;
@@ -191,30 +192,31 @@ public class RangeTest extends TestCase {
 
   public void testMergeOverlapping22() {
 
-    Range ke1 = new KeyExtent("tab1", new Text("Bank"), null).toMetadataRange();
-    Range ke2 = new KeyExtent("tab1", new Text("Fails"), new Text("Bank")).toMetadataRange();
-    Range ke3 = new KeyExtent("tab1", new Text("Sam"), new Text("Fails")).toMetadataRange();
-    Range ke4 = new KeyExtent("tab1", new Text("bails"), new Text("Sam")).toMetadataRange();
-    Range ke5 = new KeyExtent("tab1", null, new Text("bails")).toMetadataRange();
+    Range ke1 = new KeyExtent(new Table.ID("tab1"), new Text("Bank"), null).toMetadataRange();
+    Range ke2 = new KeyExtent(new Table.ID("tab1"), new Text("Fails"), new Text("Bank")).toMetadataRange();
+    Range ke3 = new KeyExtent(new Table.ID("tab1"), new Text("Sam"), new Text("Fails")).toMetadataRange();
+    Range ke4 = new KeyExtent(new Table.ID("tab1"), new Text("bails"), new Text("Sam")).toMetadataRange();
+    Range ke5 = new KeyExtent(new Table.ID("tab1"), null, new Text("bails")).toMetadataRange();
 
     List<Range> rl = newRangeList(ke1, ke2, ke3, ke4, ke5);
-    List<Range> expected = newRangeList(new KeyExtent("tab1", null, null).toMetadataRange());
+    List<Range> expected = newRangeList(new KeyExtent(new Table.ID("tab1"), null, null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke1, ke2, ke4, ke5);
-    expected = newRangeList(new KeyExtent("tab1", new Text("Fails"), null).toMetadataRange(), new KeyExtent("tab1", null, new Text("Sam")).toMetadataRange());
+    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), new Text("Fails"), null).toMetadataRange(), new KeyExtent(new Table.ID("tab1"), null, new Text(
+        "Sam")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke2, ke3, ke4, ke5);
-    expected = newRangeList(new KeyExtent("tab1", null, new Text("Bank")).toMetadataRange());
+    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), null, new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke1, ke2, ke3, ke4);
-    expected = newRangeList(new KeyExtent("tab1", new Text("bails"), null).toMetadataRange());
+    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), new Text("bails"), null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke2, ke3, ke4);
-    expected = newRangeList(new KeyExtent("tab1", new Text("bails"), new Text("Bank")).toMetadataRange());
+    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), new Text("bails"), new Text("Bank")).toMetadataRange());
 
     check(Range.mergeOverlapping(rl), expected);
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
@@ -138,7 +139,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -170,7 +171,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent("tab", null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -206,7 +207,7 @@ public class IteratorUtilTest {
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".addIter", "2," + AddingIter.class.getName());
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".sqIter", "1," + SquaringIter.class.getName());
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -242,7 +243,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -278,7 +279,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent("tab", null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -344,7 +345,7 @@ public class MultiIteratorTest extends TestCase {
     List<SortedKeyValueIterator<Key,Value>> skvil = new ArrayList<>(1);
     skvil.add(new SortedMapIterator(tm1));
 
-    KeyExtent extent = new KeyExtent("tablename", newRow(1), newRow(0));
+    KeyExtent extent = new KeyExtent(new Table.ID("tablename"), newRow(1), newRow(0));
 
     MultiIterator mi = new MultiIterator(skvil, extent);
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/MetadataServicerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/MetadataServicerTest.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.easymock.EasyMock;
 import org.junit.BeforeClass;
@@ -39,16 +40,16 @@ import org.junit.Test;
 public class MetadataServicerTest {
 
   private static final String userTableName = "tableName";
-  private static final String userTableId = "tableId";
+  private static final Table.ID userTableId = new Table.ID("tableId");
   private static ClientContext context;
 
   @BeforeClass
   public static void setupContext() throws Exception {
     HashMap<String,String> tableNameToIdMap = new HashMap<>();
-    tableNameToIdMap.put(RootTable.NAME, RootTable.ID);
-    tableNameToIdMap.put(MetadataTable.NAME, MetadataTable.ID);
-    tableNameToIdMap.put(ReplicationTable.NAME, ReplicationTable.ID);
-    tableNameToIdMap.put(userTableName, userTableId);
+    tableNameToIdMap.put(RootTable.NAME, RootTable.ID.canonicalID());
+    tableNameToIdMap.put(MetadataTable.NAME, MetadataTable.ID.canonicalID());
+    tableNameToIdMap.put(ReplicationTable.NAME, ReplicationTable.ID.canonicalID());
+    tableNameToIdMap.put(userTableName, userTableId.canonicalID());
 
     context = EasyMock.createMock(ClientContext.class);
     Connector conn = EasyMock.createMock(Connector.class);

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtilTest.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.core.replication;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
@@ -72,13 +73,13 @@ public class ReplicationConfigurationUtilTest {
 
   @Test
   public void regularTable() {
-    KeyExtent extent = new KeyExtent("1", new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("b"), new Text("a"));
     Assert.assertTrue("Table should be replicated", ReplicationConfigurationUtil.isEnabled(extent, conf));
   }
 
   @Test
   public void regularNonEnabledTable() {
-    KeyExtent extent = new KeyExtent("1", new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("b"), new Text("a"));
     Assert.assertFalse("Table should not be replicated", ReplicationConfigurationUtil.isEnabled(extent, new ConfigurationCopy(new HashMap<String,String>())));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationSchemaTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationSchemaTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.replication;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.replication.ReplicationSchema.OrderSection;
@@ -61,15 +62,15 @@ public class ReplicationSchemaTest {
 
   @Test
   public void extractTableId() {
-    String tableId = "1";
-    Key k = new Key(new Text("foo"), StatusSection.NAME, new Text(tableId));
+    Table.ID tableId = new Table.ID("1");
+    Key k = new Key(new Text("foo"), StatusSection.NAME, new Text(tableId.getUtf8()));
     Assert.assertEquals(tableId, StatusSection.getTableId(k));
   }
 
   @Test
   public void extractTableIdUsingText() {
-    String tableId = "1";
-    Key k = new Key(new Text("foo"), StatusSection.NAME, new Text(tableId));
+    Table.ID tableId = new Table.ID("1");
+    Key k = new Key(new Text("foo"), StatusSection.NAME, new Text(tableId.getUtf8()));
     Assert.assertEquals(tableId, StatusSection.getTableId(k));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationTargetTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationTargetTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.replication;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
@@ -29,18 +30,18 @@ public class ReplicationTargetTest {
 
   @Test
   public void properEquality() {
-    ReplicationTarget expected1 = new ReplicationTarget("foo", "bar", "1");
+    ReplicationTarget expected1 = new ReplicationTarget("foo", "bar", new Table.ID("1"));
 
-    Assert.assertEquals(expected1, new ReplicationTarget("foo", "bar", "1"));
-    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", "foo", "1"));
-    Assert.assertNotEquals(expected1, new ReplicationTarget("bar", "bar", "1"));
-    Assert.assertNotEquals(expected1, new ReplicationTarget(null, "bar", "1"));
-    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", null, "1"));
+    Assert.assertEquals(expected1, new ReplicationTarget("foo", "bar", new Table.ID("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", "foo", new Table.ID("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget("bar", "bar", new Table.ID("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget(null, "bar", new Table.ID("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", null, new Table.ID("1")));
   }
 
   @Test
   public void writableOut() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", "1");
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
 
@@ -64,7 +65,7 @@ public class ReplicationTargetTest {
 
   @Test
   public void staticFromTextHelper() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", "1");
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
     Text t = new Text();
@@ -75,7 +76,7 @@ public class ReplicationTargetTest {
 
   @Test
   public void staticToTextHelper() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", "1");
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
     Text t = new Text();
@@ -86,7 +87,7 @@ public class ReplicationTargetTest {
 
   @Test
   public void staticFromStringHelper() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", "1");
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
     Text t = new Text();

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.util.Merge.Size;
 import org.apache.hadoop.io.Text;
@@ -43,7 +44,7 @@ public class MergeTest {
           end = null;
         else
           end = new Text(String.format("%05d", tablets.size()));
-        KeyExtent extent = new KeyExtent("table", end, start);
+        KeyExtent extent = new KeyExtent(new Table.ID("table"), end, start);
         start = end;
         tablets.add(new Size(extent, size));
       }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImplTest.java
@@ -115,8 +115,8 @@ public class MiniAccumuloClusterImplTest {
     Assert.assertTrue("master state should be valid.", validStates.contains(stats.state));
     Assert.assertTrue("master goal state should be in " + validGoals + ". is " + stats.goalState, validGoals.contains(stats.goalState));
     Assert.assertNotNull("should have a table map.", stats.tableMap);
-    Assert.assertTrue("root table should exist in " + stats.tableMap.keySet(), stats.tableMap.keySet().contains(RootTable.ID));
-    Assert.assertTrue("meta table should exist in " + stats.tableMap.keySet(), stats.tableMap.keySet().contains(MetadataTable.ID));
+    Assert.assertTrue("root table should exist in " + stats.tableMap.keySet(), stats.tableMap.keySet().contains(RootTable.ID.canonicalID()));
+    Assert.assertTrue("meta table should exist in " + stats.tableMap.keySet(), stats.tableMap.keySet().contains(MetadataTable.ID.canonicalID()));
     Assert.assertTrue("our test table should exist in " + stats.tableMap.keySet(), stats.tableMap.keySet().contains(testTableID));
     Assert.assertNotNull("there should be tservers.", stats.tServerInfo);
     Assert.assertEquals(NUM_TSERVERS, stats.tServerInfo.size());

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -38,6 +38,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.ServerClient;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.TabletLocator;
 import org.apache.accumulo.core.client.impl.TabletLocator.TabletLocation;
 import org.apache.accumulo.core.client.impl.Translator;
@@ -129,7 +130,7 @@ public class BulkImporter {
     final Map<Path,List<KeyExtent>> completeFailures = Collections.synchronizedSortedMap(new TreeMap<Path,List<KeyExtent>>());
 
     ClientService.Client client = null;
-    final TabletLocator locator = TabletLocator.getLocator(context, tableId);
+    final TabletLocator locator = TabletLocator.getLocator(context, new Table.ID(tableId));
 
     try {
       final Map<Path,List<TabletLocation>> assignments = Collections.synchronizedSortedMap(new TreeMap<Path,List<TabletLocation>>());

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfWatcher.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.conf;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -54,24 +55,25 @@ class NamespaceConfWatcher implements Watcher {
     if (log.isTraceEnabled())
       log.trace("WatchedEvent : " + toString(event));
 
-    String namespaceId = null;
+    String namespaceIdStr = null;
     String key = null;
 
     if (path != null) {
       if (path.startsWith(namespacesPrefix)) {
-        namespaceId = path.substring(namespacesPrefixLength);
-        if (namespaceId.contains("/")) {
-          namespaceId = namespaceId.substring(0, namespaceId.indexOf('/'));
-          if (path.startsWith(namespacesPrefix + namespaceId + Constants.ZNAMESPACE_CONF + "/"))
-            key = path.substring((namespacesPrefix + namespaceId + Constants.ZNAMESPACE_CONF + "/").length());
+        namespaceIdStr = path.substring(namespacesPrefixLength);
+        if (namespaceIdStr.contains("/")) {
+          namespaceIdStr = namespaceIdStr.substring(0, namespaceIdStr.indexOf('/'));
+          if (path.startsWith(namespacesPrefix + namespaceIdStr + Constants.ZNAMESPACE_CONF + "/"))
+            key = path.substring((namespacesPrefix + namespaceIdStr + Constants.ZNAMESPACE_CONF + "/").length());
         }
       }
 
-      if (namespaceId == null) {
+      if (namespaceIdStr == null) {
         log.warn("Zookeeper told me about a path I was not watching: " + path + ", event " + toString(event));
         return;
       }
     }
+    Namespace.ID namespaceId = new Namespace.ID(namespaceIdStr);
 
     switch (event.getType()) {
       case NodeDataChanged:

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationObserver;
@@ -40,11 +41,11 @@ public class NamespaceConfiguration extends ObservableConfiguration {
 
   private final AccumuloConfiguration parent;
   private ZooCachePropertyAccessor propCacheAccessor = null;
-  protected String namespaceId = null;
+  protected Namespace.ID namespaceId = null;
   protected Instance inst = null;
   private ZooCacheFactory zcf = new ZooCacheFactory();
 
-  public NamespaceConfiguration(String namespaceId, Instance inst, AccumuloConfiguration parent) {
+  public NamespaceConfiguration(Namespace.ID namespaceId, Instance inst, AccumuloConfiguration parent) {
     this.inst = inst;
     this.parent = parent;
     this.namespaceId = namespaceId;
@@ -66,7 +67,7 @@ public class NamespaceConfiguration extends ObservableConfiguration {
   private synchronized ZooCachePropertyAccessor getPropCacheAccessor() {
     if (propCacheAccessor == null) {
       synchronized (propCaches) {
-        PropCacheKey key = new PropCacheKey(inst.getInstanceID(), namespaceId);
+        PropCacheKey key = new PropCacheKey(inst.getInstanceID(), namespaceId.canonicalID());
         ZooCache propCache = propCaches.get(key);
         if (propCache == null) {
           propCache = zcf.getZooCache(inst.getZooKeepers(), inst.getZooKeepersSessionTimeOut(), new NamespaceConfWatcher(inst));
@@ -106,7 +107,7 @@ public class NamespaceConfiguration extends ObservableConfiguration {
     getPropCacheAccessor().getProperties(props, getPath(), filter, parent, parentFilter);
   }
 
-  protected String getNamespaceId() {
+  protected Namespace.ID getNamespaceId() {
     return namespaceId;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.conf;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -52,24 +53,25 @@ class TableConfWatcher implements Watcher {
     if (log.isTraceEnabled())
       log.trace("WatchedEvent : " + toString(event));
 
-    String tableId = null;
+    String tableIdString = null;
     String key = null;
 
     if (path != null) {
       if (path.startsWith(tablesPrefix)) {
-        tableId = path.substring(tablesPrefix.length());
-        if (tableId.contains("/")) {
-          tableId = tableId.substring(0, tableId.indexOf('/'));
-          if (path.startsWith(tablesPrefix + tableId + Constants.ZTABLE_CONF + "/"))
-            key = path.substring((tablesPrefix + tableId + Constants.ZTABLE_CONF + "/").length());
+        tableIdString = path.substring(tablesPrefix.length());
+        if (tableIdString.contains("/")) {
+          tableIdString = tableIdString.substring(0, tableIdString.indexOf('/'));
+          if (path.startsWith(tablesPrefix + tableIdString + Constants.ZTABLE_CONF + "/"))
+            key = path.substring((tablesPrefix + tableIdString + Constants.ZTABLE_CONF + "/").length());
         }
       }
 
-      if (tableId == null) {
+      if (tableIdString == null) {
         log.warn("Zookeeper told me about a path I was not watching: " + path + ", event " + toString(event));
         return;
       }
     }
+    Table.ID tableId = new Table.ID(tableIdString);
 
     switch (event.getType()) {
       case NodeDataChanged:

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.ConfigurationObserver;
 import org.apache.accumulo.core.conf.ObservableConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -43,9 +44,9 @@ public class TableConfiguration extends ObservableConfiguration {
   private final NamespaceConfiguration parent;
   private ZooCacheFactory zcf = new ZooCacheFactory();
 
-  private final String tableId;
+  private final Table.ID tableId;
 
-  public TableConfiguration(Instance instance, String tableId, NamespaceConfiguration parent) {
+  public TableConfiguration(Instance instance, Table.ID tableId, NamespaceConfiguration parent) {
     this.instance = requireNonNull(instance);
     this.tableId = requireNonNull(tableId);
     this.parent = requireNonNull(parent);
@@ -58,7 +59,7 @@ public class TableConfiguration extends ObservableConfiguration {
   private synchronized ZooCachePropertyAccessor getPropCacheAccessor() {
     if (propCacheAccessor == null) {
       synchronized (propCaches) {
-        PropCacheKey key = new PropCacheKey(instance.getInstanceID(), tableId);
+        PropCacheKey key = new PropCacheKey(instance.getInstanceID(), tableId.canonicalID());
         ZooCache propCache = propCaches.get(key);
         if (propCache == null) {
           propCache = zcf.getZooCache(instance.getZooKeepers(), instance.getZooKeepersSessionTimeOut(), new TableConfWatcher(instance));
@@ -105,7 +106,7 @@ public class TableConfiguration extends ObservableConfiguration {
     getPropCacheAccessor().getProperties(props, getPath(), filter, parent, null);
   }
 
-  public String getTableId() {
+  public Table.ID getTableId() {
     return tableId;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableParentConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableParentConfiguration.java
@@ -18,6 +18,8 @@ package org.apache.accumulo.server.conf;
 
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 
@@ -26,16 +28,16 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
  */
 public class TableParentConfiguration extends NamespaceConfiguration {
 
-  private String tableId;
+  private Table.ID tableId;
 
-  public TableParentConfiguration(String tableId, Instance inst, AccumuloConfiguration parent) {
+  public TableParentConfiguration(Table.ID tableId, Instance inst, AccumuloConfiguration parent) {
     super(null, inst, parent);
     this.tableId = tableId;
     this.namespaceId = getNamespaceId();
   }
 
   @Override
-  protected String getNamespaceId() {
+  protected Namespace.ID getNamespaceId() {
     try {
       return Tables.getNamespaceId(inst, tableId);
     } catch (TableNotFoundException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -149,7 +149,7 @@ public class MetadataConstraints implements Constraint {
     }
 
     // ensure row is not less than Constants.METADATA_TABLE_ID
-    if (new Text(row).compareTo(new Text(MetadataTable.ID)) < 0) {
+    if (new Text(row).compareTo(new Text(MetadataTable.ID.getUtf8())) < 0) {
       violations = addViolation(violations, 5);
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.fs;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
@@ -32,7 +33,7 @@ public class PerTableVolumeChooser implements VolumeChooser {
   private final VolumeChooser fallbackVolumeChooser = new RandomVolumeChooser();
   // TODO Add hint of expected size to construction, see ACCUMULO-3410
   /* Track VolumeChooser instances so they can keep state. */
-  private final ConcurrentHashMap<String,VolumeChooser> tableSpecificChooser = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Table.ID,VolumeChooser> tableSpecificChooser = new ConcurrentHashMap<>();
   // TODO has to be lazily initialized currently because of the reliance on HdfsZooInstance. see ACCUMULO-3411
   private volatile ServerConfigurationFactory serverConfs;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironment.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironment.java
@@ -17,14 +17,15 @@
 package org.apache.accumulo.server.fs;
 
 import java.util.Optional;
+import org.apache.accumulo.core.client.impl.Table;
 
 public class VolumeChooserEnvironment {
 
-  private final Optional<String> tableId;
+  private final Optional<Table.ID> tableId;
   // scope is meant for non-table identifiers
   private String scope;
 
-  public VolumeChooserEnvironment(Optional<String> tableId) {
+  public VolumeChooserEnvironment(Optional<Table.ID> tableId) {
     this.tableId = tableId;
   }
 
@@ -32,7 +33,7 @@ public class VolumeChooserEnvironment {
     return tableId.isPresent();
   }
 
-  public String getTableId() {
+  public Table.ID getTableId() {
     return tableId.get();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.server.fs;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerConstants;
@@ -151,7 +152,7 @@ public interface VolumeManager {
   // Convert a file or directory metadata reference into a path
   Path getFullPath(Key key);
 
-  Path getFullPath(String tableId, String path);
+  Path getFullPath(Table.ID tableId, String path);
 
   // Given a filename, figure out the qualified path given multiple namespaces
   Path getFullPath(FileType fileType, String fileName) throws IOException;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -373,7 +374,7 @@ public class VolumeManagerImpl implements VolumeManager {
     // TODO sanity check col fam
     String relPath = key.getColumnQualifierData().toString();
     byte[] tableId = KeyExtent.tableOfMetadataRow(key.getRow());
-    return getFullPath(new String(tableId), relPath);
+    return getFullPath(new Table.ID(new String(tableId)), relPath);
   }
 
   @Override
@@ -400,7 +401,7 @@ public class VolumeManagerImpl implements VolumeManager {
   }
 
   @Override
-  public Path getFullPath(String tableId, String path) {
+  public Path getFullPath(Table.ID tableId, String path) {
     if (path.contains(":"))
       return new Path(path);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.IteratorSetting.Column;
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -451,11 +452,12 @@ public class Initialize implements KeywordExecutable {
   }
 
   private static class Tablet {
-    String tableId, dir;
+    Table.ID tableId;
+    String dir;
     Text prevEndRow, endRow;
     String[] files;
 
-    Tablet(String tableId, String dir, Text prevEndRow, Text endRow, String... files) {
+    Tablet(Table.ID tableId, String dir, Text prevEndRow, Text endRow, String... files) {
       this.tableId = tableId;
       this.dir = dir;
       this.prevEndRow = prevEndRow;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
@@ -149,10 +150,10 @@ public class LiveTServerSet implements Watcher {
       }
     }
 
-    public void flush(ZooLock lock, String tableId, byte[] startRow, byte[] endRow) throws TException {
+    public void flush(ZooLock lock, Table.ID tableId, byte[] startRow, byte[] endRow) throws TException {
       TabletClientService.Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), address, context);
       try {
-        client.flush(Tracer.traceInfo(), context.rpcCreds(), lockString(lock), tableId, startRow == null ? null : ByteBuffer.wrap(startRow),
+        client.flush(Tracer.traceInfo(), context.rpcCreds(), lockString(lock), tableId.canonicalID(), startRow == null ? null : ByteBuffer.wrap(startRow),
             endRow == null ? null : ByteBuffer.wrap(endRow));
       } finally {
         ThriftUtil.returnClient(client);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
@@ -129,10 +130,11 @@ public class ChaoticLoadBalancer extends TabletBalancer {
 
     for (Entry<TServerInstance,TabletServerStatus> e : current.entrySet()) {
       for (String tableId : e.getValue().getTableMap().keySet()) {
-        if (!moveMetadata && MetadataTable.ID.equals(tableId))
+        Table.ID id = new Table.ID(tableId);
+        if (!moveMetadata && MetadataTable.ID.equals(id))
           continue;
         try {
-          for (TabletStats ts : getOnlineTabletsForTable(e.getKey(), tableId)) {
+          for (TabletStats ts : getOnlineTabletsForTable(e.getKey(), id)) {
             KeyExtent ke = new KeyExtent(ts.extent);
             int index = r.nextInt(underCapacityTServer.size());
             TServerInstance dest = underCapacityTServer.get(index);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -110,7 +110,7 @@ public abstract class GroupBalancer extends TabletBalancer {
     }
 
     for (KeyExtent keyExtent : migrations) {
-      if (keyExtent.getTableId().equals(tableId)) {
+      if (keyExtent.getTableId().canonicalID().equals(tableId)) {
         return false;
       }
     }
@@ -774,7 +774,7 @@ public abstract class GroupBalancer extends TabletBalancer {
         Scanner scanner = new IsolatedScanner(context.getConnector().createScanner(MetadataTable.NAME, Authorizations.EMPTY));
         scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
         MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-        scanner.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+        scanner.setRange(MetadataSchema.TabletsSection.getRange(new org.apache.accumulo.core.client.impl.Table.ID(tableId)));
 
         RowIterator rowIter = new RowIterator(scanner);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -57,7 +58,7 @@ public class RegexGroupBalancer extends GroupBalancer {
 
   @Override
   protected long getWaitTime() {
-    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(tableId)
+    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(new Table.ID(tableId))
         .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     if (customProps.containsKey(WAIT_TIME_PROPERTY)) {
       return ConfigurationTypeHelper.getTimeInMillis(customProps.get(WAIT_TIME_PROPERTY));
@@ -69,7 +70,7 @@ public class RegexGroupBalancer extends GroupBalancer {
   @Override
   protected Function<KeyExtent,String> getPartitioner() {
 
-    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(tableId)
+    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(new Table.ID(tableId))
         .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     String regex = customProps.get(REGEX_PROPERTY);
     final String defaultGroup = customProps.get(DEFAUT_GROUP_PROPERTY);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -28,6 +28,7 @@ import java.util.SortedMap;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.state.tables.TableState;
@@ -43,21 +44,21 @@ public class TableLoadBalancer extends TabletBalancer {
 
   private static final Logger log = LoggerFactory.getLogger(TableLoadBalancer.class);
 
-  Map<String,TabletBalancer> perTableBalancers = new HashMap<>();
+  Map<Table.ID,TabletBalancer> perTableBalancers = new HashMap<>();
 
-  private TabletBalancer constructNewBalancerForTable(String clazzName, String table) throws Exception {
+  private TabletBalancer constructNewBalancerForTable(String clazzName, Table.ID tableId) throws Exception {
     String context = null;
-    context = this.context.getServerConfigurationFactory().getTableConfiguration(table).get(Property.TABLE_CLASSPATH);
+    context = this.context.getServerConfigurationFactory().getTableConfiguration(tableId).get(Property.TABLE_CLASSPATH);
     Class<? extends TabletBalancer> clazz;
     if (context != null && !context.equals(""))
       clazz = AccumuloVFSClassLoader.getContextManager().loadClass(context, clazzName, TabletBalancer.class);
     else
       clazz = AccumuloVFSClassLoader.loadClass(clazzName, TabletBalancer.class);
-    Constructor<? extends TabletBalancer> constructor = clazz.getConstructor(String.class);
-    return constructor.newInstance(table);
+    Constructor<? extends TabletBalancer> constructor = clazz.getConstructor(Table.ID.class);
+    return constructor.newInstance(tableId);
   }
 
-  protected String getLoadBalancerClassNameForTable(String table) {
+  protected String getLoadBalancerClassNameForTable(Table.ID table) {
     TableState tableState = TableManager.getInstance().getTableState(table);
     if (tableState == null)
       return null;
@@ -66,10 +67,10 @@ public class TableLoadBalancer extends TabletBalancer {
     return null;
   }
 
-  protected TabletBalancer getBalancerForTable(String table) {
-    TabletBalancer balancer = perTableBalancers.get(table);
+  protected TabletBalancer getBalancerForTable(Table.ID tableId) {
+    TabletBalancer balancer = perTableBalancers.get(tableId);
 
-    String clazzName = getLoadBalancerClassNameForTable(table);
+    String clazzName = getLoadBalancerClassNameForTable(tableId);
 
     if (clazzName == null)
       clazzName = DefaultLoadBalancer.class.getName();
@@ -78,32 +79,32 @@ public class TableLoadBalancer extends TabletBalancer {
         // the balancer class for this table does not match the class specified in the configuration
         try {
           // attempt to construct a balancer with the specified class
-          TabletBalancer newBalancer = constructNewBalancerForTable(clazzName, table);
+          TabletBalancer newBalancer = constructNewBalancerForTable(clazzName, tableId);
           if (newBalancer != null) {
             balancer = newBalancer;
-            perTableBalancers.put(table, balancer);
+            perTableBalancers.put(tableId, balancer);
             balancer.init(this.context);
           }
 
-          log.info("Loaded new class " + clazzName + " for table " + table);
+          log.info("Loaded new class " + clazzName + " for table " + tableId);
         } catch (Exception e) {
-          log.warn("Failed to load table balancer class " + clazzName + " for table " + table, e);
+          log.warn("Failed to load table balancer class " + clazzName + " for table " + tableId, e);
         }
       }
     }
     if (balancer == null) {
       try {
-        balancer = constructNewBalancerForTable(clazzName, table);
-        log.info("Loaded class " + clazzName + " for table " + table);
+        balancer = constructNewBalancerForTable(clazzName, tableId);
+        log.info("Loaded class " + clazzName + " for table " + tableId);
       } catch (Exception e) {
-        log.warn("Failed to load table balancer class " + clazzName + " for table " + table, e);
+        log.warn("Failed to load table balancer class " + clazzName + " for table " + tableId, e);
       }
 
       if (balancer == null) {
-        log.info("Using balancer " + DefaultLoadBalancer.class.getName() + " for table " + table);
-        balancer = new DefaultLoadBalancer(table);
+        log.info("Using balancer " + DefaultLoadBalancer.class.getName() + " for table " + tableId);
+        balancer = new DefaultLoadBalancer(tableId);
       }
-      perTableBalancers.put(table, balancer);
+      perTableBalancers.put(tableId, balancer);
       balancer.init(this.context);
     }
     return balancer;
@@ -113,7 +114,7 @@ public class TableLoadBalancer extends TabletBalancer {
   public void getAssignments(SortedMap<TServerInstance,TabletServerStatus> current, Map<KeyExtent,TServerInstance> unassigned,
       Map<KeyExtent,TServerInstance> assignments) {
     // separate the unassigned into tables
-    Map<String,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
+    Map<Table.ID,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
     for (Entry<KeyExtent,TServerInstance> e : unassigned.entrySet()) {
       Map<KeyExtent,TServerInstance> tableUnassigned = groupedUnassigned.get(e.getKey().getTableId());
       if (tableUnassigned == null) {
@@ -122,7 +123,7 @@ public class TableLoadBalancer extends TabletBalancer {
       }
       tableUnassigned.put(e.getKey(), e.getValue());
     }
-    for (Entry<String,Map<KeyExtent,TServerInstance>> e : groupedUnassigned.entrySet()) {
+    for (Entry<Table.ID,Map<KeyExtent,TServerInstance>> e : groupedUnassigned.entrySet()) {
       Map<KeyExtent,TServerInstance> newAssignments = new HashMap<>();
       getBalancerForTable(e.getKey()).getAssignments(current, e.getValue(), newAssignments);
       assignments.putAll(newAssignments);
@@ -152,7 +153,7 @@ public class TableLoadBalancer extends TabletBalancer {
       return minBalanceTime;
     for (String s : t.tableIdMap().values()) {
       ArrayList<TabletMigration> newMigrations = new ArrayList<>();
-      long tableBalanceTime = getBalancerForTable(s).balance(current, migrations, newMigrations);
+      long tableBalanceTime = getBalancerForTable(new Table.ID(s)).balance(current, migrations, newMigrations);
       if (tableBalanceTime < minBalanceTime)
         minBalanceTime = tableBalanceTime;
       migrationsOut.addAll(newMigrations);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -204,11 +205,11 @@ public abstract class TabletBalancer {
    * @throws TException
    *           any other problem
    */
-  public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, String tableId) throws ThriftSecurityException, TException {
+  public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, Table.ID tableId) throws ThriftSecurityException, TException {
     log.debug("Scanning tablet server " + tserver + " for table " + tableId);
     Client client = ThriftUtil.getClient(new TabletClientService.Client.Factory(), tserver.getLocation(), context);
     try {
-      return client.getTabletStats(Tracer.traceInfo(), context.rpcCreds(), tableId);
+      return client.getTabletStats(Tracer.traceInfo(), context.rpcCreds(), tableId.canonicalID());
     } catch (TTransportException e) {
       log.error("Unable to connect to " + tserver + ": " + e);
     } finally {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/CurrentState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/CurrentState.java
@@ -19,12 +19,13 @@ package org.apache.accumulo.server.master.state;
 import java.util.Collection;
 import java.util.Set;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.MasterState;
 
 public interface CurrentState {
 
-  Set<String> onlineTables();
+  Set<Table.ID> onlineTables();
 
   Set<TServerInstance> onlineTabletServers();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReportingIterator.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -35,10 +36,10 @@ public class ProblemReportingIterator implements InterruptibleIterator {
   private boolean sawError = false;
   private final boolean continueOnError;
   private String resource;
-  private String tableId;
+  private Table.ID tableId;
   private final AccumuloServerContext context;
 
-  public ProblemReportingIterator(AccumuloServerContext context, String tableId, String resource, boolean continueOnError,
+  public ProblemReportingIterator(AccumuloServerContext context, Table.ID tableId, String resource, boolean continueOnError,
       SortedKeyValueIterator<Key,Value> source) {
     this.context = context;
     this.tableId = tableId;

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/DistributedWorkQueueWorkAssignerHelper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/DistributedWorkQueueWorkAssignerHelper.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue;
 
@@ -72,6 +73,6 @@ public class DistributedWorkQueueWorkAssignerHelper {
     }
 
     return Maps.immutableEntry(filename, new ReplicationTarget(queueKey.substring(index + 1, secondIndex), queueKey.substring(secondIndex + 1, thirdIndex),
-        queueKey.substring(thirdIndex + 1)));
+        new Table.ID(queueKey.substring(thirdIndex + 1))));
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicationUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicationUtil.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -117,14 +118,14 @@ public class ReplicationUtil {
   public Set<ReplicationTarget> getReplicationTargets() {
     // The total set of configured targets
     final Set<ReplicationTarget> allConfiguredTargets = new HashSet<>();
-    final Map<String,String> tableNameToId = Tables.getNameToIdMap(context.getInstance());
+    final Map<String,Table.ID> tableNameToId = Tables.getNameToIdMap(context.getInstance());
 
     for (String table : tableNameToId.keySet()) {
       if (MetadataTable.NAME.equals(table) || RootTable.NAME.equals(table)) {
         continue;
       }
 
-      String localId = tableNameToId.get(table);
+      Table.ID localId = tableNameToId.get(table);
       if (null == localId) {
         log.trace("Could not determine ID for {}", table);
         continue;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/InsecurePermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/InsecurePermHandler.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.server.security.handler;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
@@ -85,26 +86,26 @@ public class InsecurePermHandler implements PermissionHandler {
   public void initTable(String table) throws AccumuloSecurityException {}
 
   @Override
-  public boolean hasNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public boolean hasNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {
     return true;
   }
 
   @Override
-  public boolean hasCachedNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public boolean hasCachedNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {
     return true;
   }
 
   @Override
-  public void grantNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public void grantNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {}
 
   @Override
-  public void revokeNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public void revokeNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {}
 
   @Override
-  public void cleanNamespacePermissions(String namespace) throws AccumuloSecurityException, NamespaceNotFoundException {}
+  public void cleanNamespacePermissions(Namespace.ID namespace) throws AccumuloSecurityException, NamespaceNotFoundException {}
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/KerberosPermissionHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/KerberosPermissionHandler.java
@@ -23,6 +23,7 @@ import java.util.Base64;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -76,13 +77,13 @@ public class KerberosPermissionHandler implements PermissionHandler {
   }
 
   @Override
-  public boolean hasNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public boolean hasNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {
     return zkPermissionHandler.hasNamespacePermission(Base64.getEncoder().encodeToString(user.getBytes(UTF_8)), namespace, permission);
   }
 
   @Override
-  public boolean hasCachedNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public boolean hasCachedNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {
     return zkPermissionHandler.hasCachedNamespacePermission(Base64.getEncoder().encodeToString(user.getBytes(UTF_8)), namespace, permission);
   }
@@ -108,13 +109,13 @@ public class KerberosPermissionHandler implements PermissionHandler {
   }
 
   @Override
-  public void grantNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public void grantNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {
     zkPermissionHandler.grantNamespacePermission(Base64.getEncoder().encodeToString(user.getBytes(UTF_8)), namespace, permission);
   }
 
   @Override
-  public void revokeNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  public void revokeNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException {
     zkPermissionHandler.revokeNamespacePermission(Base64.getEncoder().encodeToString(user.getBytes(UTF_8)), namespace, permission);
   }
@@ -125,7 +126,7 @@ public class KerberosPermissionHandler implements PermissionHandler {
   }
 
   @Override
-  public void cleanNamespacePermissions(String namespace) throws AccumuloSecurityException, NamespaceNotFoundException {
+  public void cleanNamespacePermissions(Namespace.ID namespace) throws AccumuloSecurityException, NamespaceNotFoundException {
     zkPermissionHandler.cleanNamespacePermissions(namespace);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/PermissionHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/PermissionHandler.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.server.security.handler;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -70,12 +71,13 @@ public interface PermissionHandler {
   /**
    * Used to get the namespace permission of a user for a namespace
    */
-  boolean hasNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException, NamespaceNotFoundException;
+  boolean hasNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
+      NamespaceNotFoundException;
 
   /**
    * Used to get the namespace permission of a user for a namespace, with caching. This method is for high frequency operations
    */
-  boolean hasCachedNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException,
+  boolean hasCachedNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
       NamespaceNotFoundException;
 
   /**
@@ -101,12 +103,14 @@ public interface PermissionHandler {
   /**
    * Gives the user the given namespace permission
    */
-  void grantNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException, NamespaceNotFoundException;
+  void grantNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
+      NamespaceNotFoundException;
 
   /**
    * Denies the user the given namespace permission.
    */
-  void revokeNamespacePermission(String user, String namespace, NamespacePermission permission) throws AccumuloSecurityException, NamespaceNotFoundException;
+  void revokeNamespacePermission(String user, Namespace.ID namespace, NamespacePermission permission) throws AccumuloSecurityException,
+      NamespaceNotFoundException;
 
   /**
    * Cleans up the permissions for a table. Used when a table gets deleted.
@@ -116,7 +120,7 @@ public interface PermissionHandler {
   /**
    * Cleans up the permissions for a namespace. Used when a namespace gets deleted.
    */
-  void cleanNamespacePermissions(String namespace) throws AccumuloSecurityException, NamespaceNotFoundException;
+  void cleanNamespacePermissions(Namespace.ID namespace) throws AccumuloSecurityException, NamespaceNotFoundException;
 
   /**
    * Initializes a new user

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
@@ -89,7 +90,7 @@ public class ZKAuthorizor implements Authorizor {
     Set<SystemPermission> rootPerms = new TreeSet<>();
     for (SystemPermission p : SystemPermission.values())
       rootPerms.add(p);
-    Map<String,Set<TablePermission>> tablePerms = new HashMap<>();
+    Map<Table.ID,Set<TablePermission>> tablePerms = new HashMap<>();
     // Allow the root user to flush the metadata tables
     tablePerms.put(MetadataTable.ID, Collections.singleton(TablePermission.ALTER_TABLE));
     tablePerms.put(RootTable.ID, Collections.singleton(TablePermission.ALTER_TABLE));

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableObserver.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableObserver.java
@@ -18,12 +18,13 @@ package org.apache.accumulo.server.tables;
 
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.master.state.tables.TableState;
 
 public interface TableObserver {
-  void initialize(Map<String,TableState> tableIdToStateMap);
+  void initialize(Map<Table.ID,TableState> tableIdToStateMap);
 
-  void stateChanged(String tableId, TableState tState);
+  void stateChanged(Table.ID tableId, TableState tState);
 
   void sessionExpired();
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
@@ -24,6 +24,7 @@ import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.server.client.HdfsZooInstance;
@@ -51,7 +52,7 @@ public class LargestFirstMemoryManager implements MemoryManager {
   // The fraction of memory that needs to be used before we begin flushing.
   private double compactionThreshold;
   private long maxObserved;
-  private final HashMap<String,Long> mincIdleThresholds = new HashMap<>();
+  private final HashMap<Table.ID,Long> mincIdleThresholds = new HashMap<>();
   private ServerConfiguration config = null;
 
   private static class TabletInfo {
@@ -139,13 +140,13 @@ public class LargestFirstMemoryManager implements MemoryManager {
   }
 
   protected long getMinCIdleThreshold(KeyExtent extent) {
-    String tableId = extent.getTableId();
+    Table.ID tableId = extent.getTableId();
     if (!mincIdleThresholds.containsKey(tableId))
       mincIdleThresholds.put(tableId, config.getTableConfiguration(tableId).getTimeInMillis(Property.TABLE_MINC_COMPACT_IDLETIME));
     return mincIdleThresholds.get(tableId);
   }
 
-  protected boolean tableExists(Instance instance, String tableId) {
+  protected boolean tableExists(Instance instance, Table.ID tableId) {
     // make sure that the table still exists by checking if it has a configuration
     return config.getTableConfiguration(tableId) != null;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -112,7 +112,7 @@ public class CheckForMetadataProblems {
 
       count++;
 
-      String tableName = (new KeyExtent(entry.getKey().getRow(), (Text) null)).getTableId();
+      String tableName = (new KeyExtent(entry.getKey().getRow(), (Text) null)).getTableId().canonicalID();
 
       TreeSet<KeyExtent> tablets = tables.get(tableName);
       if (tablets == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -101,7 +102,7 @@ public class FindOfflineTablets {
 
     Range range = MetadataSchema.TabletsSection.getRange();
     if (tableName != null) {
-      String tableId = Tables.getTableId(context.getInstance(), tableName);
+      Table.ID tableId = Tables.getTableId(context.getInstance(), tableName);
       range = new KeyExtent(tableId, null, null).toMetadataRange();
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/NamespacePropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/NamespacePropUtil.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.server.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
@@ -28,7 +29,7 @@ import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 import org.apache.zookeeper.KeeperException;
 
 public class NamespacePropUtil {
-  public static boolean setNamespaceProperty(String namespaceId, String property, String value) throws KeeperException, InterruptedException {
+  public static boolean setNamespaceProperty(Namespace.ID namespaceId, String property, String value) throws KeeperException, InterruptedException {
     if (!isPropertyValid(property, value))
       return false;
 
@@ -51,12 +52,12 @@ public class NamespacePropUtil {
     return true;
   }
 
-  public static void removeNamespaceProperty(String namespaceId, String property) throws InterruptedException, KeeperException {
+  public static void removeNamespaceProperty(Namespace.ID namespaceId, String property) throws InterruptedException, KeeperException {
     String zPath = getPath(namespaceId) + "/" + property;
     ZooReaderWriter.getInstance().recursiveDelete(zPath, NodeMissingPolicy.SKIP);
   }
 
-  private static String getPath(String namespaceId) {
+  private static String getPath(Namespace.ID namespaceId) {
     return ZooUtil.getRoot(HdfsZooInstance.getInstance()) + Constants.ZNAMESPACES + "/" + namespaceId + Constants.ZNAMESPACE_CONF;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -80,11 +81,12 @@ public class RandomizeVolumes {
       log.error("There are not enough volumes configured");
       return 1;
     }
-    String tableId = c.tableOperations().tableIdMap().get(tableName);
-    if (null == tableId) {
+    String tblStr = c.tableOperations().tableIdMap().get(tableName);
+    if (null == tblStr) {
       log.error("Could not determine the table ID for table " + tableName);
       return 2;
     }
+    Table.ID tableId = new Table.ID(tblStr);
     TableState tableState = TableManager.getInstance().getTableState(tableId);
     if (TableState.OFFLINE != tableState) {
       log.info("Taking " + tableName + " offline");
@@ -103,7 +105,7 @@ public class RandomizeVolumes {
       String directory;
       if (oldLocation.contains(":")) {
         String[] parts = oldLocation.split(Path.SEPARATOR);
-        String tableIdEntry = parts[parts.length - 2];
+        Table.ID tableIdEntry = new Table.ID(parts[parts.length - 2]);
         if (!tableIdEntry.equals(tableId)) {
           log.error("Unexpected table id found: " + tableIdEntry + ", expected " + tableId + "; skipping");
           continue;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -120,18 +121,18 @@ public class RemoveEntriesForMissingFiles {
     }
   }
 
-  private static int checkTable(ClientContext context, String table, Range range, boolean fix) throws Exception {
+  private static int checkTable(ClientContext context, String tableName, Range range, boolean fix) throws Exception {
 
     @SuppressWarnings({"rawtypes"})
     Map cache = new LRUMap(100000);
     Set<Path> processing = new HashSet<>();
     ExecutorService threadPool = Executors.newFixedThreadPool(16);
 
-    System.out.printf("Scanning : %s %s\n", table, range);
+    System.out.printf("Scanning : %s %s\n", tableName, range);
 
     VolumeManager fs = VolumeManagerImpl.get();
     Connector connector = context.getConnector();
-    Scanner metadata = connector.createScanner(table, Authorizations.EMPTY);
+    Scanner metadata = connector.createScanner(tableName, Authorizations.EMPTY);
     metadata.setRange(range);
     metadata.fetchColumnFamily(DataFileColumnFamily.NAME);
     int count = 0;
@@ -197,7 +198,7 @@ public class RemoveEntriesForMissingFiles {
     } else if (tableName.equals(MetadataTable.NAME)) {
       return checkTable(context, RootTable.NAME, MetadataSchema.TabletsSection.getRange(), fix);
     } else {
-      String tableId = Tables.getTableId(context.getInstance(), tableName);
+      Table.ID tableId = Tables.getTableId(context.getInstance(), tableName);
       Range range = new KeyExtent(tableId, null, null).toMetadataRange();
       return checkTable(context, MetadataTable.NAME, range, fix);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
@@ -194,7 +194,7 @@ public class ReplicationTableUtil {
 
   private static Mutation createUpdateMutation(Text row, Value v, KeyExtent extent) {
     Mutation m = new Mutation(row);
-    m.put(MetadataSchema.ReplicationSection.COLF, new Text(extent.getTableId()), v);
+    m.put(MetadataSchema.ReplicationSection.COLF, new Text(extent.getTableId().getUtf8()), v);
     return m;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -34,6 +34,7 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.Key;
@@ -177,7 +178,7 @@ public class TableDiskUsage {
         throw new RuntimeException(e);
       }
       mdScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      mdScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
+      mdScanner.setRange(new KeyExtent(new Table.ID(tableId), null, null).toMetadataRange());
 
       if (!mdScanner.iterator().hasNext()) {
         emptyTableIds.add(tableId);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TablePropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TablePropUtil.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.server.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
@@ -28,7 +29,7 @@ import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 import org.apache.zookeeper.KeeperException;
 
 public class TablePropUtil {
-  public static boolean setTableProperty(String tableId, String property, String value) throws KeeperException, InterruptedException {
+  public static boolean setTableProperty(Table.ID tableId, String property, String value) throws KeeperException, InterruptedException {
     if (!isPropertyValid(property, value))
       return false;
 
@@ -51,12 +52,12 @@ public class TablePropUtil {
     return true;
   }
 
-  public static void removeTableProperty(String tableId, String property) throws InterruptedException, KeeperException {
+  public static void removeTableProperty(Table.ID tableId, String property) throws InterruptedException, KeeperException {
     String zPath = getTablePath(tableId) + "/" + property;
     ZooReaderWriter.getInstance().recursiveDelete(zPath, NodeMissingPolicy.SKIP);
   }
 
-  private static String getTablePath(String tablename) {
-    return ZooUtil.getRoot(HdfsZooInstance.getInstance()) + Constants.ZTABLES + "/" + tablename + Constants.ZTABLE_CONF;
+  private static String getTablePath(Table.ID tableId) {
+    return ZooUtil.getRoot(HdfsZooInstance.getInstance()) + Constants.ZTABLES + "/" + tableId.canonicalID() + Constants.ZTABLE_CONF;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TabletIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TabletIterator.java
@@ -28,6 +28,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
@@ -119,8 +120,8 @@ public class TabletIterator implements Iterator<Map<Key,Value>> {
         lastEndRow = new KeyExtent(lastTablet, (Text) null).getEndRow();
 
         // do table transition sanity check
-        String lastTable = new KeyExtent(lastTablet, (Text) null).getTableId();
-        String currentTable = new KeyExtent(prevEndRowKey.getRow(), (Text) null).getTableId();
+        Table.ID lastTable = new KeyExtent(lastTablet, (Text) null).getTableId();
+        Table.ID currentTable = new KeyExtent(prevEndRowKey.getRow(), (Text) null).getTableId();
 
         if (!lastTable.equals(currentTable) && (per != null || lastEndRow != null)) {
           log.info("Metadata inconsistency on table transition : " + lastTable + " " + currentTable + " " + per + " " + lastEndRow);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.Range;
@@ -89,7 +90,7 @@ public class VerifyTabletAssignments {
 
     TreeMap<KeyExtent,String> tabletLocations = new TreeMap<>();
 
-    String tableId = Tables.getNameToIdMap(context.getInstance()).get(tableName);
+    Table.ID tableId = Tables.lookupTableId(context.getInstance(), tableName);
     MetadataServicer.forTableId(context, tableId).getTabletLocations(tabletLocations);
 
     final HashSet<KeyExtent> failures = new HashSet<>();

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.TabletLocator;
 import org.apache.accumulo.core.client.impl.TabletLocator.TabletLocation;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -52,7 +53,7 @@ import org.junit.Test;
 public class BulkImporterTest {
 
   static final SortedSet<KeyExtent> fakeMetaData = new TreeSet<>();
-  static final String tableId = "1";
+  static final Table.ID tableId = new Table.ID("1");
 
   static {
     fakeMetaData.add(new KeyExtent(tableId, new Text("a"), null));
@@ -163,19 +164,19 @@ public class BulkImporterTest {
     // a correct startRow so that findOverlappingTablets works as intended.
 
     // 1;2;1
-    KeyExtent extent = new KeyExtent("1", new Text("2"), new Text("1"));
+    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("2"), new Text("1"));
     Assert.assertEquals(new Text("1\0"), BulkImporter.getStartRowForExtent(extent));
 
     // 1;2<
-    extent = new KeyExtent("1", new Text("2"), null);
+    extent = new KeyExtent(new Table.ID("1"), new Text("2"), null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1<<
-    extent = new KeyExtent("1", null, null);
+    extent = new KeyExtent(new Table.ID("1"), null, null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1;8;7777777
-    extent = new KeyExtent("1", new Text("8"), new Text("7777777"));
+    extent = new KeyExtent(new Table.ID("1"), new Text("8"), new Text("7777777"));
     Assert.assertEquals(new Text("7777777\0"), BulkImporter.getStartRowForExtent(extent));
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
@@ -36,6 +36,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationObserver;
@@ -47,7 +48,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class NamespaceConfigurationTest {
-  private static final String NSID = "namespace";
+  private static final Namespace.ID NSID = new Namespace.ID("namespace");
   private static final String ZOOKEEPERS = "localhost";
   private static final int ZK_SESSION_TIMEOUT = 120000;
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.SiteConfiguration;
@@ -113,7 +114,7 @@ public class ServerConfigurationFactoryTest {
     assertNotNull(c);
   }
 
-  private static final String NSID = "NAMESPACE";
+  private static final Namespace.ID NSID = new Namespace.ID("NAMESPACE");
 
   @Test
   public void testGetNamespaceConfiguration() {

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
@@ -34,6 +34,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.ConfigurationObserver;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
@@ -43,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TableConfigurationTest {
-  private static final String TID = "table";
+  private static final Table.ID TID = new Table.ID("table");
   private static final String ZOOKEEPERS = "localhost";
   private static final int ZK_SESSION_TIMEOUT = 120000;
 

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
@@ -112,7 +113,7 @@ public class VolumeManagerImplTest {
     conf.set(Property.INSTANCE_VOLUMES, StringUtils.join(volumes, ","));
     conf.set(Property.GENERAL_VOLUME_CHOOSER, WrongVolumeChooser.class.getName());
     VolumeManager vm = VolumeManagerImpl.get(conf);
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(Optional.of("sometable"));
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(Optional.of(new Table.ID("sometable")));
     String choice = vm.choose(chooserEnv, volumes.toArray(new String[0]));
     Assert.assertTrue("shouldn't see invalid options from misbehaving chooser.", volumes.contains(choice));
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
@@ -50,10 +51,10 @@ public class ChaoticLoadBalancerTest {
       TabletServerStatus result = new TabletServerStatus();
       result.tableMap = new HashMap<>();
       for (KeyExtent extent : extents) {
-        String table = extent.getTableId();
-        TableInfo info = result.tableMap.get(table);
+        Table.ID table = extent.getTableId();
+        TableInfo info = result.tableMap.get(table.canonicalID());
         if (info == null)
-          result.tableMap.put(table, info = new TableInfo());
+          result.tableMap.put(table.canonicalID(), info = new TableInfo());
         info.onlineTablets++;
         info.recs = info.onlineTablets;
         info.ingestRate = 123.;
@@ -68,7 +69,7 @@ public class ChaoticLoadBalancerTest {
   class TestChaoticLoadBalancer extends ChaoticLoadBalancer {
 
     @Override
-    public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, String table) throws ThriftSecurityException, TException {
+    public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, Table.ID table) throws ThriftSecurityException, TException {
       List<TabletStats> result = new ArrayList<>();
       for (KeyExtent extent : servers.get(tserver).extents) {
         if (extent.getTableId().equals(table)) {
@@ -154,7 +155,7 @@ public class ChaoticLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(table, toText(end), toText(prev));
+    return new KeyExtent(new Table.ID(table), toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -29,6 +29,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.util.MapCounter;
@@ -67,7 +68,7 @@ public class GroupBalancerTest {
 
     public void addTablet(String er, String location) {
       TServerInstance tsi = new TServerInstance(location, 6);
-      tabletLocs.put(new KeyExtent("b", er == null ? null : new Text(er), null), new TServerInstance(location, 6));
+      tabletLocs.put(new KeyExtent(new Table.ID("b"), er == null ? null : new Text(er), null), new TServerInstance(location, 6));
       tservers.add(tsi);
     }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
@@ -90,11 +91,11 @@ public class HostRegexTableLoadBalancerReconfigurationTest extends BaseHostRegex
   }
 
   @Override
-  public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, String tableId) throws ThriftSecurityException, TException {
+  public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, Table.ID tableId) throws ThriftSecurityException, TException {
     List<TabletStats> tablets = new ArrayList<>();
     // Report assignment information
     for (Entry<KeyExtent,TServerInstance> e : this.assignments.entrySet()) {
-      if (e.getValue().equals(tserver) && e.getKey().getTableId().toString().equals(tableId)) {
+      if (e.getValue().equals(tserver) && e.getKey().getTableId().equals(tableId)) {
         TabletStats ts = new TabletStats();
         ts.setExtent(e.getKey().toThrift());
         tablets.add(ts);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -71,7 +72,7 @@ public class MergeInfoTest {
     String table = "table";
     Text endRow = new Text("end");
     Text prevEndRow = new Text("begin");
-    keyExtent = new KeyExtent(table, endRow, prevEndRow);
+    keyExtent = new KeyExtent(new Table.ID(table), endRow, prevEndRow);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.DELETE);
     mi.setState(MergeState.STARTED);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -88,10 +89,10 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_DifferentTables() {
-    expect(keyExtent.getTableId()).andReturn("table1");
+    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn("table2");
+    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table2"));
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.needsToBeChopped(keyExtent2));
@@ -99,9 +100,9 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_NotDelete() {
-    expect(keyExtent.getTableId()).andReturn("table1");
+    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn("table1");
+    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table1"));
     replay(keyExtent2);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(true);
     replay(keyExtent);
@@ -125,11 +126,11 @@ public class MergeInfoTest {
   }
 
   private void testNeedsToBeChopped_Delete(String prevEndRow, boolean expected) {
-    expect(keyExtent.getTableId()).andReturn("table1");
+    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn("table1");
+    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table1"));
     expect(keyExtent2.getPrevEndRow()).andReturn(prevEndRow != null ? new Text(prevEndRow) : null);
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -150,9 +151,9 @@ public class MergeInfoTest {
   public void testOverlaps_DoesNotNeedChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn("table1");
+    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn("table2");
+    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table2"));
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.overlaps(keyExtent2));
@@ -162,10 +163,10 @@ public class MergeInfoTest {
   public void testOverlaps_NeedsChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn("table1");
+    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn("table1");
+    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table1"));
     expect(keyExtent2.getPrevEndRow()).andReturn(new Text("prev"));
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -187,7 +188,7 @@ public class MergeInfoTest {
   }
 
   private static KeyExtent ke(String tableId, String endRow, String prevEndRow) {
-    return new KeyExtent(tableId, endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
@@ -33,6 +33,7 @@ import java.io.DataOutputStream;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.util.Encoding;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
@@ -43,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ProblemReportTest {
-  private static final String TABLE_ID = "table";
+  private static final Table.ID TABLE_ID = new Table.ID("table");
   private static final String RESOURCE = "resource";
   private static final String SERVER = "server";
 
@@ -64,7 +65,7 @@ public class ProblemReportTest {
   public void testGetters() {
     long now = System.currentTimeMillis();
     r = new ProblemReport(TABLE_ID, ProblemType.FILE_READ, RESOURCE, SERVER, null, now);
-    assertEquals(TABLE_ID, r.getTableName());
+    assertEquals(TABLE_ID, r.getTableId());
     assertSame(ProblemType.FILE_READ, r.getProblemType());
     assertEquals(RESOURCE, r.getResource());
     assertEquals(SERVER, r.getServer());
@@ -86,7 +87,7 @@ public class ProblemReportTest {
     ProblemReport r2 = new ProblemReport(TABLE_ID, ProblemType.FILE_READ, RESOURCE, SERVER, null);
     assertTrue(r.equals(r2));
     assertTrue(r2.equals(r));
-    ProblemReport rx1 = new ProblemReport(TABLE_ID + "x", ProblemType.FILE_READ, RESOURCE, SERVER, null);
+    ProblemReport rx1 = new ProblemReport(Table.ID.METADATA, ProblemType.FILE_READ, RESOURCE, SERVER, null);
     assertFalse(r.equals(rx1));
     ProblemReport rx2 = new ProblemReport(TABLE_ID, ProblemType.FILE_WRITE, RESOURCE, SERVER, null);
     assertFalse(r.equals(rx2));
@@ -115,10 +116,10 @@ public class ProblemReportTest {
     assertEquals(r.hashCode(), re2.hashCode());
   }
 
-  private byte[] makeZPathFileName(String table, ProblemType problemType, String resource) throws Exception {
+  private byte[] makeZPathFileName(Table.ID table, ProblemType problemType, String resource) throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
-    dos.writeUTF(table);
+    dos.writeUTF(table.canonicalID());
     dos.writeUTF(problemType.name());
     dos.writeUTF(resource);
     dos.close();
@@ -178,7 +179,7 @@ public class ProblemReportTest {
     replay(zoorw);
 
     r = ProblemReport.decodeZooKeeperEntry(node, zoorw, instance);
-    assertEquals(TABLE_ID, r.getTableName());
+    assertEquals(TABLE_ID, r.getTableId());
     assertSame(ProblemType.FILE_READ, r.getProblemType());
     assertEquals(RESOURCE, r.getResource());
     assertEquals(SERVER, r.getServer());

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -37,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ProblemReportingIteratorTest {
-  private static final String TABLE_ID = "table";
+  private static final Table.ID TABLE_ID = new Table.ID("table");
   private static final String RESOURCE = "resource";
 
   private InterruptibleIterator ii;

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.client.IteratorSetting.Column;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Writer;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
@@ -91,7 +92,7 @@ public class ReplicationTableUtilTest {
     String myFile = "file:////home/user/accumulo/wal/server+port/" + uuid;
 
     long createdTime = System.currentTimeMillis();
-    ReplicationTableUtil.updateFiles(context, new KeyExtent("1", null, null), myFile, StatusUtil.fileCreated(createdTime));
+    ReplicationTableUtil.updateFiles(context, new KeyExtent(new Table.ID("1"), null, null), myFile, StatusUtil.fileCreated(createdTime));
 
     verify(writer);
 
@@ -116,7 +117,7 @@ public class ReplicationTableUtilTest {
     String file = "file:///accumulo/wal/127.0.0.1+9997" + UUID.randomUUID();
     Path filePath = new Path(file);
     Text row = new Text(filePath.toString());
-    KeyExtent extent = new KeyExtent("1", new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("b"), new Text("a"));
 
     Mutation m = ReplicationTableUtil.createUpdateMutation(filePath, ProtobufUtil.toValue(stat), extent);
 
@@ -125,7 +126,7 @@ public class ReplicationTableUtilTest {
     ColumnUpdate col = m.getUpdates().get(0);
 
     Assert.assertEquals(MetadataSchema.ReplicationSection.COLF, new Text(col.getColumnFamily()));
-    Assert.assertEquals(extent.getTableId(), new Text(col.getColumnQualifier()).toString());
+    Assert.assertEquals(extent.getTableId().canonicalID(), new Text(col.getColumnQualifier()).toString());
     Assert.assertEquals(0, col.getColumnVisibility().length);
     Assert.assertArrayEquals(stat.toByteArray(), col.getValue());
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -243,25 +244,25 @@ public class GarbageCollectionAlgorithm {
   }
 
   private void cleanUpDeletedTableDirs(GarbageCollectionEnvironment gce, SortedMap<String,String> candidateMap) throws IOException {
-    HashSet<String> tableIdsWithDeletes = new HashSet<>();
+    HashSet<Table.ID> tableIdsWithDeletes = new HashSet<>();
 
     // find the table ids that had dirs deleted
     for (String delete : candidateMap.keySet()) {
       String[] tokens = delete.split("/");
       if (tokens.length == 2) {
         // its a directory
-        String tableId = delete.split("/")[0];
+        Table.ID tableId = new Table.ID(delete.split("/")[0]);
         tableIdsWithDeletes.add(tableId);
       }
     }
 
-    Set<String> tableIdsInZookeeper = gce.getTableIDs();
+    Set<Table.ID> tableIdsInZookeeper = gce.getTableIDs();
 
     tableIdsWithDeletes.removeAll(tableIdsInZookeeper);
 
     // tableIdsWithDeletes should now contain the set of deleted tables that had dirs deleted
 
-    for (String delTableId : tableIdsWithDeletes) {
+    for (Table.ID delTableId : tableIdsWithDeletes) {
       gce.deleteTableDirIfEmpty(delTableId);
     }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -27,6 +27,7 @@ import java.util.SortedMap;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
@@ -71,7 +72,7 @@ public interface GarbageCollectionEnvironment {
    *
    * @return The valueSet for the table name to table id map.
    */
-  Set<String> getTableIDs();
+  Set<Table.ID> getTableIDs();
 
   /**
    * Delete the given files from the provided {@link Map} of relative path to absolute path for each file that should be deleted
@@ -87,7 +88,7 @@ public interface GarbageCollectionEnvironment {
    * @param tableID
    *          The id of the table whose directory we are to operate on
    */
-  void deleteTableDirIfEmpty(String tableID) throws IOException;
+  void deleteTableDirIfEmpty(Table.ID tableID) throws IOException;
 
   /**
    * Increment the number of candidates for deletion for the current garbage collection run

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
@@ -291,7 +292,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     }
 
     @Override
-    public Set<String> getTableIDs() {
+    public Set<Table.ID> getTableIDs() {
       return Tables.getIdToNameMap(getInstance()).keySet();
     }
 
@@ -390,7 +391,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
                 }
                 String parts[] = fullPath.toString().split(Constants.ZTABLES)[1].split("/");
                 if (parts.length > 2) {
-                  String tableId = parts[1];
+                  Table.ID tableId = new Table.ID(parts[1]);
                   String tabletDir = parts[2];
                   TableManager.getInstance().updateTableStateCache(tableId);
                   TableState tableState = TableManager.getInstance().getTableState(tableId);
@@ -438,7 +439,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     }
 
     @Override
-    public void deleteTableDirIfEmpty(String tableID) throws IOException {
+    public void deleteTableDirIfEmpty(Table.ID tableID) throws IOException {
       // if dir exist and is empty, then empty list is returned...
       // hadoop 2.0 will throw an exception if the file does not exist
       for (String dir : ServerConstants.getTablesDirs()) {

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -30,6 +30,7 @@ import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -49,10 +50,10 @@ public class GarbageCollectionTest {
     TreeSet<String> candidates = new TreeSet<>();
     ArrayList<String> blips = new ArrayList<>();
     Map<Key,Value> references = new TreeMap<>();
-    HashSet<String> tableIds = new HashSet<>();
+    HashSet<Table.ID> tableIds = new HashSet<>();
 
     ArrayList<String> deletes = new ArrayList<>();
-    ArrayList<String> tablesDirsToDelete = new ArrayList<>();
+    ArrayList<Table.ID> tablesDirsToDelete = new ArrayList<>();
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
 
     @Override
@@ -76,7 +77,7 @@ public class GarbageCollectionTest {
     }
 
     @Override
-    public Set<String> getTableIDs() {
+    public Set<Table.ID> getTableIDs() {
       return tableIds;
     }
 
@@ -87,12 +88,12 @@ public class GarbageCollectionTest {
     }
 
     @Override
-    public void deleteTableDirIfEmpty(String tableID) {
+    public void deleteTableDirIfEmpty(Table.ID tableID) {
       tablesDirsToDelete.add(tableID);
     }
 
     public Key newFileReferenceKey(String tableId, String endRow, String file) {
-      String row = new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.DataFileColumnFamily.NAME.toString();
       String cq = file;
       Key key = new Key(row, cf, cq);
@@ -110,7 +111,7 @@ public class GarbageCollectionTest {
     }
 
     Key newDirReferenceKey(String tableId, String endRow) {
-      String row = new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily().toString();
       String cq = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier().toString();
       Key key = new Key(row, cf, cq);
@@ -533,7 +534,7 @@ public class GarbageCollectionTest {
 
     TestGCE gce = new TestGCE();
 
-    gce.tableIds.add("4");
+    gce.tableIds.add(new Table.ID("4"));
 
     gce.candidates.add("/4/t-0");
     gce.candidates.add("/4/t-0/F002.rf");
@@ -545,9 +546,9 @@ public class GarbageCollectionTest {
 
     gca.collect(gce);
 
-    HashSet<String> tids = new HashSet<>();
-    tids.add("5");
-    tids.add("6");
+    HashSet<Table.ID> tids = new HashSet<>();
+    tids.add(new Table.ID("5"));
+    tids.add(new Table.ID("6"));
 
     Assert.assertEquals(tids.size(), gce.tablesDirsToDelete.size());
     Assert.assertTrue(tids.containsAll(gce.tablesDirsToDelete));

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -41,6 +41,8 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.client.impl.AuthenticationTokenIdentifier;
 import org.apache.accumulo.core.client.impl.DelegationTokenConfigSerializer;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
@@ -111,8 +113,9 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
   }
 
   @Override
-  public long initiateFlush(TInfo tinfo, TCredentials c, String tableId) throws ThriftSecurityException, ThriftTableOperationException {
-    String namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
+  public long initiateFlush(TInfo tinfo, TCredentials c, String tableIdStr) throws ThriftSecurityException, ThriftTableOperationException {
+    Table.ID tableId = new Table.ID(tableIdStr);
+    Namespace.ID namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
     master.security.canFlush(c, tableId, namespaceId);
 
     String zTablePath = Constants.ZROOT + "/" + master.getInstance().getInstanceID() + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_FLUSH_ID;
@@ -129,22 +132,24 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
         }
       });
     } catch (NoNodeException nne) {
-      throw new ThriftTableOperationException(tableId, null, TableOperation.FLUSH, TableOperationExceptionType.NOTFOUND, null);
+      throw new ThriftTableOperationException(tableId.canonicalID(), null, TableOperation.FLUSH, TableOperationExceptionType.NOTFOUND, null);
     } catch (Exception e) {
       Master.log.warn("{}", e.getMessage(), e);
-      throw new ThriftTableOperationException(tableId, null, TableOperation.FLUSH, TableOperationExceptionType.OTHER, null);
+      throw new ThriftTableOperationException(tableId.canonicalID(), null, TableOperation.FLUSH, TableOperationExceptionType.OTHER, null);
     }
     return Long.parseLong(new String(fid));
   }
 
   @Override
-  public void waitForFlush(TInfo tinfo, TCredentials c, String tableId, ByteBuffer startRow, ByteBuffer endRow, long flushID, long maxLoops)
+  public void waitForFlush(TInfo tinfo, TCredentials c, String tableIdStr, ByteBuffer startRow, ByteBuffer endRow, long flushID, long maxLoops)
       throws ThriftSecurityException, ThriftTableOperationException {
-    String namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
+    Table.ID tableId = new Table.ID(tableIdStr);
+    Namespace.ID namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
     master.security.canFlush(c, tableId, namespaceId);
 
     if (endRow != null && startRow != null && ByteBufferUtil.toText(startRow).compareTo(ByteBufferUtil.toText(endRow)) >= 0)
-      throw new ThriftTableOperationException(tableId, null, TableOperation.FLUSH, TableOperationExceptionType.BAD_RANGE, "start row must be less than end row");
+      throw new ThriftTableOperationException(tableId.canonicalID(), null, TableOperation.FLUSH, TableOperationExceptionType.BAD_RANGE,
+          "start row must be less than end row");
 
     Set<TServerInstance> serversToFlush = new HashSet<>(master.tserverSet.getCurrentServers());
 
@@ -237,7 +242,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
         // TODO detect case of table offline AND tablets w/ logs? - ACCUMULO-1296
 
         if (tabletCount == 0 && !Tables.exists(master.getInstance(), tableId))
-          throw new ThriftTableOperationException(tableId, null, TableOperation.FLUSH, TableOperationExceptionType.NOTFOUND, null);
+          throw new ThriftTableOperationException(tableId.canonicalID(), null, TableOperation.FLUSH, TableOperationExceptionType.NOTFOUND, null);
 
       } catch (AccumuloException e) {
         Master.log.debug("Failed to scan " + MetadataTable.NAME + " table to wait for flush " + tableId, e);
@@ -254,12 +259,12 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
 
   }
 
-  private String getNamespaceIdFromTableId(TableOperation tableOp, String tableId) throws ThriftTableOperationException {
-    String namespaceId;
+  private Namespace.ID getNamespaceIdFromTableId(TableOperation tableOp, Table.ID tableId) throws ThriftTableOperationException {
+    Namespace.ID namespaceId;
     try {
       namespaceId = Tables.getNamespaceId(master.getInstance(), tableId);
     } catch (TableNotFoundException e) {
-      throw new ThriftTableOperationException(tableId, null, tableOp, TableOperationExceptionType.NOTFOUND, e.getMessage());
+      throw new ThriftTableOperationException(tableId.canonicalID(), null, tableOp, TableOperationExceptionType.NOTFOUND, e.getMessage());
     }
     return namespaceId;
   }
@@ -412,7 +417,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
   private void alterNamespaceProperty(TCredentials c, String namespace, String property, String value, TableOperation op) throws ThriftSecurityException,
       ThriftTableOperationException {
 
-    String namespaceId = null;
+    Namespace.ID namespaceId = null;
     namespaceId = ClientServiceHandler.checkNamespaceId(master.getInstance(), namespace, op);
 
     if (!master.security.canAlterNamespace(c, namespaceId))
@@ -426,19 +431,20 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
       }
     } catch (KeeperException.NoNodeException e) {
       // race condition... namespace no longer exists? This call will throw an exception if the namespace was deleted:
-      ClientServiceHandler.checkNamespaceId(master.getInstance(), namespaceId, op);
+      ClientServiceHandler.checkNamespaceId(master.getInstance(), namespace, op);
       log.info("Error altering namespace property", e);
-      throw new ThriftTableOperationException(namespaceId, namespace, op, TableOperationExceptionType.OTHER, "Problem altering namespaceproperty");
+      throw new ThriftTableOperationException(namespaceId.canonicalID(), namespace, op, TableOperationExceptionType.OTHER, "Problem altering namespaceproperty");
     } catch (Exception e) {
       log.error("Problem altering namespace property", e);
-      throw new ThriftTableOperationException(namespaceId, namespace, op, TableOperationExceptionType.OTHER, "Problem altering namespace property");
+      throw new ThriftTableOperationException(namespaceId.canonicalID(), namespace, op, TableOperationExceptionType.OTHER,
+          "Problem altering namespace property");
     }
   }
 
   private void alterTableProperty(TCredentials c, String tableName, String property, String value, TableOperation op) throws ThriftSecurityException,
       ThriftTableOperationException {
-    final String tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, op);
-    String namespaceId = getNamespaceIdFromTableId(op, tableId);
+    final Table.ID tableId = ClientServiceHandler.checkTableId(master.getInstance(), tableName, op);
+    Namespace.ID namespaceId = getNamespaceIdFromTableId(op, tableId);
     if (!master.security.canAlterTable(c, tableId, namespaceId))
       throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
@@ -452,10 +458,10 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
       // race condition... table no longer exists? This call will throw an exception if the table was deleted:
       ClientServiceHandler.checkTableId(master.getInstance(), tableName, op);
       log.info("Error altering table property", e);
-      throw new ThriftTableOperationException(tableId, tableName, op, TableOperationExceptionType.OTHER, "Problem altering table property");
+      throw new ThriftTableOperationException(tableId.canonicalID(), tableName, op, TableOperationExceptionType.OTHER, "Problem altering table property");
     } catch (Exception e) {
       log.error("Problem altering table property", e);
-      throw new ThriftTableOperationException(tableId, tableName, op, TableOperationExceptionType.OTHER, "Problem altering table property");
+      throw new ThriftTableOperationException(tableId.canonicalID(), tableName, op, TableOperationExceptionType.OTHER, "Problem altering table property");
     }
   }
 
@@ -517,7 +523,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
       throw new RuntimeException("Failed to obtain connector", e);
     }
 
-    final Text tableId = new Text(getTableId(master.getInstance(), tableName));
+    final Text tableId = new Text(getTableId(master.getInstance(), tableName).getUtf8());
 
     drainLog.trace("Waiting for {} to be replicated for {}", logsToWatch, tableId);
 
@@ -555,7 +561,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
     }
   }
 
-  protected String getTableId(Instance instance, String tableName) throws ThriftTableOperationException {
+  protected Table.ID getTableId(Instance instance, String tableName) throws ThriftTableOperationException {
     return ClientServiceHandler.checkTableId(instance, tableName, null);
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/FinishedWorkUpdater.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/FinishedWorkUpdater.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -95,7 +96,7 @@ public class FinishedWorkUpdater implements Runnable {
 
         log.debug("Processing work progress for {} with {} columns", serializedRow.getKey().getRow(), wholeRow.size());
 
-        Map<String,Long> tableIdToProgress = new HashMap<>();
+        Map<Table.ID,Long> tableIdToProgress = new HashMap<>();
         boolean error = false;
         Text buffer = new Text();
 
@@ -128,7 +129,7 @@ public class FinishedWorkUpdater implements Runnable {
         }
 
         // Update the replication table for each source table we found work records for
-        for (Entry<String,Long> entry : tableIdToProgress.entrySet()) {
+        for (Entry<Table.ID,Long> entry : tableIdToProgress.entrySet()) {
           // If the progress is 0, then no one has replicated anything, and we don't need to update anything
           if (0 == entry.getValue()) {
             continue;
@@ -145,7 +146,7 @@ public class FinishedWorkUpdater implements Runnable {
           Value serializedUpdatedStatus = ProtobufUtil.toValue(updatedStatus);
 
           // Pull the sourceTableId into a Text
-          String srcTableId = entry.getKey();
+          Table.ID srcTableId = entry.getKey();
 
           // Make the mutation
           StatusSection.add(replMutation, srcTableId, serializedUpdatedStatus);

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/SequentialWorkAssigner.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/SequentialWorkAssigner.java
@@ -97,7 +97,7 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       Entry<String,ReplicationTarget> entry = DistributedWorkQueueWorkAssignerHelper.fromQueueKey(work);
       String filename = entry.getKey();
       String peerName = entry.getValue().getPeerName();
-      String sourceTableId = entry.getValue().getSourceTableId();
+      String sourceTableId = entry.getValue().getSourceTableId().canonicalID();
 
       log.debug("In progress replication of {} from table with ID {} to peer {}", filename, sourceTableId, peerName);
 
@@ -158,7 +158,7 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       return true;
     }
 
-    String queuedWork = queuedWorkForPeer.get(target.getSourceTableId());
+    String queuedWork = queuedWorkForPeer.get(target.getSourceTableId().canonicalID());
 
     // If we have no work for the local table to the given peer, submit some!
     return null == queuedWork;
@@ -173,11 +173,11 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       this.queuedWorkByPeerName.put(target.getPeerName(), workForPeer);
     }
 
-    String queuedWork = workForPeer.get(target.getSourceTableId());
+    String queuedWork = workForPeer.get(target.getSourceTableId().canonicalID());
     if (null == queuedWork) {
       try {
         workQueue.addWork(queueKey, path.toString());
-        workForPeer.put(target.getSourceTableId(), queueKey);
+        workForPeer.put(target.getSourceTableId().canonicalID(), queueKey);
       } catch (KeeperException | InterruptedException e) {
         log.warn("Could not queue work for {} to {}", path, target, e);
         return false;
@@ -200,7 +200,7 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       return Collections.emptySet();
     }
 
-    String queuedWork = queuedWorkForPeer.get(target.getSourceTableId());
+    String queuedWork = queuedWorkForPeer.get(target.getSourceTableId().canonicalID());
     if (null == queuedWork) {
       return Collections.emptySet();
     } else {
@@ -216,9 +216,9 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       return;
     }
 
-    String queuedWork = queuedWorkForPeer.get(target.getSourceTableId());
+    String queuedWork = queuedWorkForPeer.get(target.getSourceTableId().canonicalID());
     if (queuedWork.equals(queueKey)) {
-      queuedWorkForPeer.remove(target.getSourceTableId());
+      queuedWorkForPeer.remove(target.getSourceTableId().canonicalID());
     } else {
       log.warn("removeQueuedWork called on {} with differing queueKeys, expected {} but was {}", target, queueKey, queuedWork);
       return;

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/StatusMaker.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/StatusMaker.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -106,7 +107,7 @@ public class StatusMaker {
         }
         // Extract the useful bits from the status key
         MetadataSchema.ReplicationSection.getFile(entry.getKey(), file);
-        String tableId = MetadataSchema.ReplicationSection.getTableId(entry.getKey());
+        Table.ID tableId = MetadataSchema.ReplicationSection.getTableId(entry.getKey());
 
         Status status;
         try {
@@ -158,10 +159,10 @@ public class StatusMaker {
   /**
    * Create a status record in the replication table
    */
-  protected boolean addStatusRecord(Text file, String tableId, Value v) {
+  protected boolean addStatusRecord(Text file, Table.ID tableId, Value v) {
     try {
       Mutation m = new Mutation(file);
-      m.put(StatusSection.NAME, new Text(tableId), v);
+      m.put(StatusSection.NAME, new Text(tableId.getUtf8()), v);
 
       try {
         replicationWriter.addMutation(m);
@@ -194,7 +195,7 @@ public class StatusMaker {
    * @param value
    *          Serialized version of the Status msg
    */
-  protected boolean addOrderRecord(Text file, String tableId, Status stat, Value value) {
+  protected boolean addOrderRecord(Text file, Table.ID tableId, Status stat, Value value) {
     try {
       if (!stat.hasCreatedTime()) {
         log.error("Status record ({}) for {} in table {} was written to metadata table which lacked createdTime", ProtobufUtil.toString(stat), file, tableId);

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -93,7 +94,7 @@ public class WorkMaker {
       for (Entry<Key,Value> entry : s) {
         // Extract the useful bits from the status key
         ReplicationSchema.StatusSection.getFile(entry.getKey(), file);
-        String tableId = ReplicationSchema.StatusSection.getTableId(entry.getKey());
+        Table.ID tableId = ReplicationSchema.StatusSection.getTableId(entry.getKey());
         log.debug("Processing replication status record for " + file + " on table " + tableId);
 
         Status status;
@@ -168,7 +169,7 @@ public class WorkMaker {
     return StatusUtil.isWorkRequired(status);
   }
 
-  protected void addWorkRecord(Text file, Value v, Map<String,String> targets, String sourceTableId) {
+  protected void addWorkRecord(Text file, Value v, Map<String,String> targets, Table.ID sourceTableId) {
     log.info("Adding work records for " + file + " to targets " + targets);
     try {
       Mutation m = new Mutation(file);

--- a/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -185,7 +186,7 @@ public class MergeStats {
     if (start == null) {
       start = new Text();
     }
-    String tableId = extent.getTableId();
+    Table.ID tableId = extent.getTableId();
     Text first = KeyExtent.getMetadataEntry(tableId, start);
     Range range = new Range(first, false, null, true);
     scanner.setRange(range.clip(MetadataSchema.TabletsSection.getRange()));

--- a/server/master/src/main/java/org/apache/accumulo/master/state/TableStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/TableStats.java
@@ -19,12 +19,13 @@ package org.apache.accumulo.master.state;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.master.thrift.MasterState;
 import org.apache.accumulo.server.master.state.TabletState;
 
 public class TableStats {
-  private Map<String,TableCounts> last = new HashMap<>();
-  private Map<String,TableCounts> next;
+  private Map<Table.ID,TableCounts> last = new HashMap<>();
+  private Map<Table.ID,TableCounts> next;
   private long startScan = 0;
   private long endScan = 0;
   private MasterState state;
@@ -34,7 +35,7 @@ public class TableStats {
     startScan = System.currentTimeMillis();
   }
 
-  public synchronized void update(String tableId, TabletState state) {
+  public synchronized void update(Table.ID tableId, TabletState state) {
     TableCounts counts = next.get(tableId);
     if (counts == null) {
       counts = new TableCounts();
@@ -50,7 +51,7 @@ public class TableStats {
     this.state = state;
   }
 
-  public synchronized Map<String,TableCounts> getLast() {
+  public synchronized Map<Table.ID,TableCounts> getLast() {
     return last;
   }
 
@@ -58,7 +59,7 @@ public class TableStats {
     return state;
   }
 
-  public synchronized TableCounts getLast(String tableId) {
+  public synchronized TableCounts getLast(Table.ID tableId) {
     TableCounts result = last.get(tableId);
     if (result == null)
       return new TableCounts();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CancelCompactions.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CancelCompactions.java
@@ -19,6 +19,8 @@ package org.apache.accumulo.master.tableOps;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
@@ -29,10 +31,10 @@ import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 public class CancelCompactions extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
-  private String tableId;
-  private String namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
 
-  public CancelCompactions(String namespaceId, String tableId) {
+  public CancelCompactions(Namespace.ID namespaceId, Table.ID tableId) {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ChangeTableState.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ChangeTableState.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.fate.Repo;
@@ -26,11 +28,11 @@ import org.slf4j.LoggerFactory;
 public class ChangeTableState extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
-  private String tableId;
-  private String namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
   private TableOperation top;
 
-  public ChangeTableState(String namespaceId, String tableId, TableOperation top) {
+  public ChangeTableState(Namespace.ID namespaceId, Table.ID tableId, TableOperation top) {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
     this.top = top;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
@@ -25,6 +25,8 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -61,7 +63,8 @@ class CleanUp extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private String tableId, namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
 
   private long creationTime;
 
@@ -76,7 +79,7 @@ class CleanUp extends MasterRepo {
 
   }
 
-  public CleanUp(String tableId, String namespaceId) {
+  public CleanUp(Table.ID tableId, Namespace.ID namespaceId) {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
     creationTime = System.currentTimeMillis();
@@ -174,7 +177,7 @@ class CleanUp extends MasterRepo {
           if (archiveFiles) {
             archiveFile(fs, dir, tableId);
           } else {
-            fs.deleteRecursively(new Path(dir, tableId));
+            fs.deleteRecursively(new Path(dir, tableId.canonicalID()));
           }
         }
       } catch (IOException e) {
@@ -212,8 +215,8 @@ class CleanUp extends MasterRepo {
     return null;
   }
 
-  protected void archiveFile(VolumeManager fs, String dir, String tableId) throws IOException {
-    Path tableDirectory = new Path(dir, tableId);
+  protected void archiveFile(VolumeManager fs, String dir, Table.ID tableId) throws IOException {
+    Path tableDirectory = new Path(dir, tableId.canonicalID());
     Volume v = fs.getVolumeByPath(tableDirectory);
     String basePath = v.getBasePath();
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUpBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUpBulkImport.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.master.tableOps;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -33,12 +34,12 @@ class CleanUpBulkImport extends MasterRepo {
 
   private static final Logger log = LoggerFactory.getLogger(CleanUpBulkImport.class);
 
-  private String tableId;
+  private Table.ID tableId;
   private String source;
   private String bulk;
   private String error;
 
-  public CleanUpBulkImport(String tableId, String source, String bulk, String error) {
+  public CleanUpBulkImport(Table.ID tableId, String source, String bulk, String error) {
     this.tableId = tableId;
     this.source = source;
     this.bulk = bulk;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneInfo.java
@@ -16,6 +16,9 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
+
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
@@ -24,11 +27,11 @@ class CloneInfo implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  String srcTableId;
+  Table.ID srcTableId;
   String tableName;
-  String tableId;
-  String namespaceId;
-  String srcNamespaceId;
+  Table.ID tableId;
+  Namespace.ID namespaceId;
+  Namespace.ID srcNamespaceId;
   Map<String,String> propertiesToSet;
   Set<String> propertiesToExclude;
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
@@ -19,6 +19,8 @@ package org.apache.accumulo.master.tableOps;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -28,7 +30,8 @@ public class CloneTable extends MasterRepo {
   private static final long serialVersionUID = 1L;
   private CloneInfo cloneInfo;
 
-  public CloneTable(String user, String namespaceId, String srcTableId, String tableName, Map<String,String> propertiesToSet, Set<String> propertiesToExclude) {
+  public CloneTable(String user, Namespace.ID namespaceId, Table.ID srcTableId, String tableName, Map<String,String> propertiesToSet,
+      Set<String> propertiesToExclude) {
     cloneInfo = new CloneInfo();
     cloneInfo.user = user;
     cloneInfo.srcTableId = srcTableId;
@@ -50,7 +53,7 @@ public class CloneTable extends MasterRepo {
 
     Utils.idLock.lock();
     try {
-      cloneInfo.tableId = Utils.getNextTableId(cloneInfo.tableName, environment.getInstance());
+      cloneInfo.tableId = Utils.getNextTableId(cloneInfo.tableName, environment.getInstance(), Table.ID.class);
       return new ClonePermissions(cloneInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CompleteBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CompleteBulkImport.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.master.tableOps;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
@@ -25,12 +26,12 @@ class CompleteBulkImport extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private String tableId;
+  private Table.ID tableId;
   private String source;
   private String bulk;
   private String error;
 
-  public CompleteBulkImport(String tableId, String source, String bulk, String error) {
+  public CompleteBulkImport(Table.ID tableId, String source, String bulk, String error) {
     this.tableId = tableId;
     this.source = source;
     this.bulk = bulk;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CopyFailed.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CopyFailed.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -53,12 +54,12 @@ class CopyFailed extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private String tableId;
+  private Table.ID tableId;
   private String source;
   private String bulk;
   private String error;
 
-  public CopyFailed(String tableId, String source, String bulk, String error) {
+  public CopyFailed(Table.ID tableId, String source, String bulk, String error) {
     this.tableId = tableId;
     this.source = source;
     this.bulk = bulk;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateImportDir.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateImportDir.java
@@ -52,7 +52,7 @@ class CreateImportDir extends MasterRepo {
       throw new IOException(tableInfo.exportDir + " is not in a volume configured for Accumulo");
     }
     log.info("Chose base table directory of " + base);
-    Path directory = new Path(base, tableInfo.tableId);
+    Path directory = new Path(base, tableInfo.tableId.canonicalID());
 
     Path newBulkDir = new Path(directory, Constants.BULK_PREFIX + namer.getNextName());
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.master.tableOps;
 
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 
@@ -42,7 +43,7 @@ public class CreateNamespace extends MasterRepo {
   public Repo<Master> call(long tid, Master master) throws Exception {
     Utils.idLock.lock();
     try {
-      namespaceInfo.namespaceId = Utils.getNextTableId(namespaceInfo.namespaceName, master.getInstance());
+      namespaceInfo.namespaceId = Utils.getNextTableId(namespaceInfo.namespaceName, master.getInstance(), Namespace.ID.class);
       return new SetupNamespacePermissions(namespaceInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
@@ -19,6 +19,8 @@ package org.apache.accumulo.master.tableOps;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.admin.TimeType;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -29,7 +31,7 @@ public class CreateTable extends MasterRepo {
 
   private TableInfo tableInfo;
 
-  public CreateTable(String user, String tableName, TimeType timeType, Map<String,String> props, String namespaceId) {
+  public CreateTable(String user, String tableName, TimeType timeType, Map<String,String> props, Namespace.ID namespaceId) {
     tableInfo = new TableInfo();
     tableInfo.tableName = tableName;
     tableInfo.timeType = TabletTime.getTimeID(timeType);
@@ -54,7 +56,7 @@ public class CreateTable extends MasterRepo {
 
     Utils.idLock.lock();
     try {
-      tableInfo.tableId = Utils.getNextTableId(tableInfo.tableName, master.getInstance());
+      tableInfo.tableId = Utils.getNextTableId(tableInfo.tableName, master.getInstance(), Table.ID.class);
       return new SetupPermissions(tableInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteNamespace.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -24,9 +25,9 @@ public class DeleteNamespace extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private String namespaceId;
+  private Namespace.ID namespaceId;
 
-  public DeleteNamespace(String namespaceId) {
+  public DeleteNamespace(Namespace.ID namespaceId) {
     this.namespaceId = namespaceId;
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/DeleteTable.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.fate.Repo;
@@ -26,10 +28,10 @@ public class DeleteTable extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private String tableId;
-  private String namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
 
-  public DeleteTable(String namespaceId, String tableId) {
+  public DeleteTable(Namespace.ID namespaceId, Table.ID tableId) {
     this.namespaceId = namespaceId;
     this.tableId = tableId;
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportInfo.java
@@ -16,6 +16,9 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
+
 import java.io.Serializable;
 
 class ExportInfo implements Serializable {
@@ -23,7 +26,7 @@ class ExportInfo implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public String tableName;
-  public String tableID;
+  public Table.ID tableID;
   public String exportDir;
-  public String namespaceID;
+  public Namespace.ID namespaceID;
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ExportTable.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -26,7 +28,7 @@ public class ExportTable extends MasterRepo {
 
   private final ExportInfo tableInfo;
 
-  public ExportTable(String namespaceId, String tableName, String tableId, String exportDir) throws ThriftTableOperationException {
+  public ExportTable(Namespace.ID namespaceId, String tableName, Table.ID tableId, String exportDir) throws ThriftTableOperationException {
     tableInfo = new ExportInfo();
     tableInfo.tableName = tableName;
     tableInfo.exportDir = exportDir;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishCancelCompaction.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishCancelCompaction.java
@@ -16,15 +16,17 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 
 class FinishCancelCompaction extends MasterRepo {
   private static final long serialVersionUID = 1L;
-  private String tableId;
-  private String namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
 
-  public FinishCancelCompaction(String namespaceId, String tableId) {
+  public FinishCancelCompaction(Namespace.ID namespaceId, Table.ID tableId) {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishCreateNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishCreateNamespace.java
@@ -49,7 +49,7 @@ class FinishCreateNamespace extends MasterRepo {
 
   @Override
   public String getReturn() {
-    return namespaceInfo.namespaceId;
+    return namespaceInfo.namespaceId.canonicalID();
   }
 
   @Override

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishCreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishCreateTable.java
@@ -53,7 +53,7 @@ class FinishCreateTable extends MasterRepo {
 
   @Override
   public String getReturn() {
-    return tableInfo.tableId;
+    return tableInfo.tableId.canonicalID();
   }
 
   @Override

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/FinishImportTable.java
@@ -59,7 +59,7 @@ class FinishImportTable extends MasterRepo {
 
   @Override
   public String getReturn() {
-    return tableInfo.tableId;
+    return tableInfo.tableId.canonicalID();
   }
 
   @Override

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
@@ -27,6 +27,8 @@ import java.util.zip.ZipInputStream;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.client.impl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.fate.Repo;
@@ -43,7 +45,7 @@ public class ImportTable extends MasterRepo {
 
   private ImportedTableInfo tableInfo;
 
-  public ImportTable(String user, String tableName, String exportDir, String namespaceId) {
+  public ImportTable(String user, String tableName, String exportDir, Namespace.ID namespaceId) {
     tableInfo = new ImportedTableInfo();
     tableInfo.tableName = tableName;
     tableInfo.user = user;
@@ -70,7 +72,7 @@ public class ImportTable extends MasterRepo {
     Utils.idLock.lock();
     try {
       Instance instance = env.getInstance();
-      tableInfo.tableId = Utils.getNextTableId(tableInfo.tableName, instance);
+      tableInfo.tableId = Utils.getNextTableId(tableInfo.tableName, instance, Table.ID.class);
       return new ImportSetupPermissions(tableInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportedTableInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportedTableInfo.java
@@ -16,6 +16,9 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
+
 import java.io.Serializable;
 
 class ImportedTableInfo implements Serializable {
@@ -25,7 +28,7 @@ class ImportedTableInfo implements Serializable {
   public String exportDir;
   public String user;
   public String tableName;
-  public String tableId;
+  public Table.ID tableId;
   public String importDir;
-  public String namespaceId;
+  public Namespace.ID namespaceId;
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/MapImportFileNames.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/MapImportFileNames.java
@@ -95,8 +95,8 @@ class MapImportFileNames extends MasterRepo {
       return new PopulateMetadataTable(tableInfo);
     } catch (IOException ioe) {
       log.warn("{}", ioe.getMessage(), ioe);
-      throw new AcceptableThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-          "Error writing mapping file " + path + " " + ioe.getMessage());
+      throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonicalID(), tableInfo.tableName, TableOperation.IMPORT,
+          TableOperationExceptionType.OTHER, "Error writing mapping file " + path + " " + ioe.getMessage());
     } finally {
       if (mappingsWriter != null)
         try {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/MoveExportedFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/MoveExportedFiles.java
@@ -50,8 +50,8 @@ class MoveExportedFiles extends MasterRepo {
 
       for (String oldFileName : fileNameMappings.keySet()) {
         if (!fs.exists(new Path(tableInfo.exportDir, oldFileName))) {
-          throw new AcceptableThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-              "File referenced by exported table does not exists " + oldFileName);
+          throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonicalID(), tableInfo.tableName, TableOperation.IMPORT,
+              TableOperationExceptionType.OTHER, "File referenced by exported table does not exists " + oldFileName);
         }
       }
 
@@ -67,8 +67,8 @@ class MoveExportedFiles extends MasterRepo {
       return new FinishImportTable(tableInfo);
     } catch (IOException ioe) {
       log.warn("{}", ioe.getMessage(), ioe);
-      throw new AcceptableThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-          "Error renaming files " + ioe.getMessage());
+      throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonicalID(), tableInfo.tableName, TableOperation.IMPORT,
+          TableOperationExceptionType.OTHER, "Error renaming files " + ioe.getMessage());
     }
   }
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/NamespaceCleanUp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/NamespaceCleanUp.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.fate.Repo;
@@ -31,9 +32,9 @@ class NamespaceCleanUp extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private String namespaceId;
+  private Namespace.ID namespaceId;
 
-  public NamespaceCleanUp(String namespaceId) {
+  public NamespaceCleanUp(Namespace.ID namespaceId) {
     this.namespaceId = namespaceId;
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/NamespaceInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/NamespaceInfo.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+
 import java.io.Serializable;
 import java.util.Map;
 
@@ -24,7 +26,7 @@ class NamespaceInfo implements Serializable {
   private static final long serialVersionUID = 1L;
 
   String namespaceName;
-  String namespaceId;
+  Namespace.ID namespaceId;
   String user;
 
   public Map<String,String> props;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadataTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadataTable.java
@@ -134,7 +134,7 @@ class PopulateMetadataTable extends MasterRepo {
               String newName = fileNameMappings.get(oldName);
 
               if (newName == null) {
-                throw new AcceptableThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT,
+                throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonicalID(), tableInfo.tableName, TableOperation.IMPORT,
                     TableOperationExceptionType.OTHER, "File " + oldName + " does not exist in import dir");
               }
 
@@ -183,8 +183,8 @@ class PopulateMetadataTable extends MasterRepo {
       return new MoveExportedFiles(tableInfo);
     } catch (IOException ioe) {
       log.warn("{}", ioe.getMessage(), ioe);
-      throw new AcceptableThriftTableOperationException(tableInfo.tableId, tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-          "Error reading " + path + " " + ioe.getMessage());
+      throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonicalID(), tableInfo.tableName, TableOperation.IMPORT,
+          TableOperationExceptionType.OTHER, "Error reading " + path + " " + ioe.getMessage());
     } finally {
       if (zis != null) {
         try {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/RenameNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/RenameNamespace.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.master.tableOps;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.client.impl.thrift.TableOperationExceptionType;
@@ -33,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class RenameNamespace extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
-  private String namespaceId;
+  private Namespace.ID namespaceId;
   private String oldName;
   private String newName;
 
@@ -42,7 +43,7 @@ public class RenameNamespace extends MasterRepo {
     return Utils.reserveNamespace(namespaceId, id, true, true, TableOperation.RENAME);
   }
 
-  public RenameNamespace(String namespaceId, String oldName, String newName) {
+  public RenameNamespace(Namespace.ID namespaceId, String oldName, String newName) {
     this.namespaceId = namespaceId;
     this.oldName = oldName;
     this.newName = newName;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/RenameTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/RenameTable.java
@@ -22,7 +22,9 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.impl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.client.impl.thrift.TableOperationExceptionType;
@@ -38,8 +40,8 @@ import org.slf4j.LoggerFactory;
 public class RenameTable extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
-  private String tableId;
-  private String namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
   private String oldTableName;
   private String newTableName;
 
@@ -48,7 +50,7 @@ public class RenameTable extends MasterRepo {
     return Utils.reserveNamespace(namespaceId, tid, false, true, TableOperation.RENAME) + Utils.reserveTable(tableId, tid, true, true, TableOperation.RENAME);
   }
 
-  public RenameTable(String namespaceId, String tableId, String oldTableName, String newTableName) throws NamespaceNotFoundException {
+  public RenameTable(Namespace.ID namespaceId, Table.ID tableId, String oldTableName, String newTableName) throws NamespaceNotFoundException {
     this.namespaceId = namespaceId;
     this.tableId = tableId;
     this.oldTableName = oldTableName;
@@ -63,7 +65,7 @@ public class RenameTable extends MasterRepo {
 
     // ensure no attempt is made to rename across namespaces
     if (newTableName.contains(".") && !namespaceId.equals(Namespaces.getNamespaceId(instance, qualifiedNewTableName.getFirst())))
-      throw new AcceptableThriftTableOperationException(tableId, oldTableName, TableOperation.RENAME, TableOperationExceptionType.INVALID_NAME,
+      throw new AcceptableThriftTableOperationException(tableId.canonicalID(), oldTableName, TableOperation.RENAME, TableOperationExceptionType.INVALID_NAME,
           "Namespace in new table name does not match the old table name");
 
     IZooReaderWriter zoo = ZooReaderWriter.getInstance();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableInfo.java
@@ -16,6 +16,9 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
+
 import java.io.Serializable;
 import java.util.Map;
 
@@ -24,8 +27,8 @@ class TableInfo implements Serializable {
   private static final long serialVersionUID = 1L;
 
   String tableName;
-  String tableId;
-  String namespaceId;
+  Table.ID tableId;
+  Namespace.ID namespaceId;
   char timeType;
   String user;
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOp.java
@@ -17,6 +17,8 @@
 package org.apache.accumulo.master.tableOps;
 
 import org.apache.accumulo.core.client.impl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.client.impl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -36,8 +38,8 @@ public class TableRangeOp extends MasterRepo {
 
   private static final long serialVersionUID = 1L;
 
-  private final String tableId;
-  private final String namespaceId;
+  private final Table.ID tableId;
+  private final Namespace.ID namespaceId;
   private byte[] startRow;
   private byte[] endRow;
   private Operation op;
@@ -47,7 +49,8 @@ public class TableRangeOp extends MasterRepo {
     return Utils.reserveNamespace(namespaceId, tid, false, true, TableOperation.MERGE) + Utils.reserveTable(tableId, tid, true, true, TableOperation.MERGE);
   }
 
-  public TableRangeOp(MergeInfo.Operation op, String namespaceId, String tableId, Text startRow, Text endRow) throws AcceptableThriftTableOperationException {
+  public TableRangeOp(MergeInfo.Operation op, Namespace.ID namespaceId, Table.ID tableId, Text startRow, Text endRow)
+      throws AcceptableThriftTableOperationException {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
     this.startRow = TextUtil.getBytes(startRow);
@@ -67,7 +70,7 @@ public class TableRangeOp extends MasterRepo {
 
     if (start != null && end != null)
       if (start.compareTo(end) >= 0)
-        throw new AcceptableThriftTableOperationException(tableId, null, TableOperation.MERGE, TableOperationExceptionType.BAD_RANGE,
+        throw new AcceptableThriftTableOperationException(tableId.canonicalID(), null, TableOperation.MERGE, TableOperationExceptionType.BAD_RANGE,
             "start row must be less than end row");
 
     env.mustBeOnline(tableId);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOpWait.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableRangeOpWait.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.master.tableOps;
 
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.master.state.MergeInfo;
@@ -40,10 +42,10 @@ class TableRangeOpWait extends MasterRepo {
   private static final Logger log = LoggerFactory.getLogger(TableRangeOpWait.class);
 
   private static final long serialVersionUID = 1L;
-  private String tableId;
-  private String namespaceId;
+  private Table.ID tableId;
+  private Namespace.ID namespaceId;
 
-  public TableRangeOpWait(String namespaceId, String tableId) {
+  public TableRangeOpWait(Namespace.ID namespaceId, Table.ID tableId) {
     this.tableId = tableId;
     this.namespaceId = namespaceId;
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/Utils.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/Utils.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.master.tableOps;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.lang.reflect.Constructor;
 import java.math.BigInteger;
 import java.util.Base64;
 import java.util.concurrent.locks.Lock;
@@ -25,8 +26,11 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.AbstractId;
 import org.apache.accumulo.core.client.impl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.TableOperation;
 import org.apache.accumulo.core.client.impl.thrift.TableOperationExceptionType;
@@ -46,18 +50,16 @@ public class Utils {
   private static final byte[] ZERO_BYTE = new byte[] {'0'};
   private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
-  static void checkTableDoesNotExist(Instance instance, String tableName, String tableId, TableOperation operation)
+  static void checkTableDoesNotExist(Instance instance, String tableName, Table.ID tableId, TableOperation operation)
       throws AcceptableThriftTableOperationException {
 
-    String id = Tables.getNameToIdMap(instance).get(tableName);
+    Table.ID id = Tables.lookupTableId(instance, tableName);
 
     if (id != null && !id.equals(tableId))
       throw new AcceptableThriftTableOperationException(null, tableName, operation, TableOperationExceptionType.EXISTS, null);
   }
 
-  static String getNextTableId(String tableName, Instance instance) throws AcceptableThriftTableOperationException {
-
-    String tableId = null;
+  static <T extends AbstractId> T getNextTableId(String tableName, Instance instance, Class<T> idClassType) throws AcceptableThriftTableOperationException {
     try {
       IZooReaderWriter zoo = ZooReaderWriter.getInstance();
       final String ntp = ZooUtil.getRoot(instance) + Constants.ZTABLES;
@@ -69,23 +71,25 @@ public class Utils {
           return nextId.toString(Character.MAX_RADIX).getBytes(UTF_8);
         }
       });
-      return new String(nid, UTF_8);
+      Constructor<T> constructor = idClassType.getConstructor(String.class);
+      return constructor.newInstance(new String(nid, UTF_8));
+      // return idClassType.cast(new String(nid, UTF_8));
     } catch (Exception e1) {
       log.error("Failed to assign tableId to " + tableName, e1);
-      throw new AcceptableThriftTableOperationException(tableId, tableName, TableOperation.CREATE, TableOperationExceptionType.OTHER, e1.getMessage());
+      throw new AcceptableThriftTableOperationException(null, tableName, TableOperation.CREATE, TableOperationExceptionType.OTHER, e1.getMessage());
     }
   }
 
   static final Lock tableNameLock = new ReentrantLock();
   static final Lock idLock = new ReentrantLock();
 
-  public static long reserveTable(String tableId, long tid, boolean writeLock, boolean tableMustExist, TableOperation op) throws Exception {
+  public static long reserveTable(Table.ID tableId, long tid, boolean writeLock, boolean tableMustExist, TableOperation op) throws Exception {
     if (getLock(tableId, tid, writeLock).tryLock()) {
       if (tableMustExist) {
         Instance instance = HdfsZooInstance.getInstance();
         IZooReaderWriter zk = ZooReaderWriter.getInstance();
         if (!zk.exists(ZooUtil.getRoot(instance) + Constants.ZTABLES + "/" + tableId))
-          throw new AcceptableThriftTableOperationException(tableId, "", op, TableOperationExceptionType.NOTFOUND, "Table does not exist");
+          throw new AcceptableThriftTableOperationException(tableId.canonicalID(), "", op, TableOperationExceptionType.NOTFOUND, "Table does not exist");
       }
       log.info("table " + tableId + " (" + Long.toHexString(tid) + ") locked for " + (writeLock ? "write" : "read") + " operation: " + op);
       return 0;
@@ -93,23 +97,24 @@ public class Utils {
       return 100;
   }
 
-  public static void unreserveTable(String tableId, long tid, boolean writeLock) throws Exception {
+  public static void unreserveTable(Table.ID tableId, long tid, boolean writeLock) throws Exception {
     getLock(tableId, tid, writeLock).unlock();
     log.info("table " + tableId + " (" + Long.toHexString(tid) + ") unlocked for " + (writeLock ? "write" : "read"));
   }
 
-  public static void unreserveNamespace(String namespaceId, long id, boolean writeLock) throws Exception {
+  public static void unreserveNamespace(Namespace.ID namespaceId, long id, boolean writeLock) throws Exception {
     getLock(namespaceId, id, writeLock).unlock();
     log.info("namespace " + namespaceId + " (" + Long.toHexString(id) + ") unlocked for " + (writeLock ? "write" : "read"));
   }
 
-  public static long reserveNamespace(String namespaceId, long id, boolean writeLock, boolean mustExist, TableOperation op) throws Exception {
+  public static long reserveNamespace(Namespace.ID namespaceId, long id, boolean writeLock, boolean mustExist, TableOperation op) throws Exception {
     if (getLock(namespaceId, id, writeLock).tryLock()) {
       if (mustExist) {
         Instance instance = HdfsZooInstance.getInstance();
         IZooReaderWriter zk = ZooReaderWriter.getInstance();
         if (!zk.exists(ZooUtil.getRoot(instance) + Constants.ZNAMESPACES + "/" + namespaceId))
-          throw new AcceptableThriftTableOperationException(namespaceId, "", op, TableOperationExceptionType.NAMESPACE_NOTFOUND, "Namespace does not exist");
+          throw new AcceptableThriftTableOperationException(namespaceId.canonicalID(), "", op, TableOperationExceptionType.NAMESPACE_NOTFOUND,
+              "Namespace does not exist");
       }
       log.info("namespace " + namespaceId + " (" + Long.toHexString(id) + ") locked for " + (writeLock ? "write" : "read") + " operation: " + op);
       return 0;
@@ -136,9 +141,9 @@ public class Utils {
     ZooReservation.release(ZooReaderWriter.getInstance(), resvPath, String.format("%016x", tid));
   }
 
-  private static Lock getLock(String tableId, long tid, boolean writeLock) throws Exception {
+  private static Lock getLock(AbstractId id, long tid, boolean writeLock) throws Exception {
     byte[] lockData = String.format("%016x", tid).getBytes(UTF_8);
-    ZooQueueLock qlock = new ZooQueueLock(ZooUtil.getRoot(HdfsZooInstance.getInstance()) + Constants.ZTABLE_LOCKS + "/" + tableId, false);
+    ZooQueueLock qlock = new ZooQueueLock(ZooUtil.getRoot(HdfsZooInstance.getInstance()) + Constants.ZTABLE_LOCKS + "/" + id, false);
     Lock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
     if (lock == null) {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, lockData);
@@ -150,14 +155,14 @@ public class Utils {
     return lock;
   }
 
-  public static Lock getReadLock(String tableId, long tid) throws Exception {
+  public static Lock getReadLock(AbstractId tableId, long tid) throws Exception {
     return Utils.getLock(tableId, tid, false);
   }
 
-  static void checkNamespaceDoesNotExist(Instance instance, String namespace, String namespaceId, TableOperation operation)
+  static void checkNamespaceDoesNotExist(Instance instance, String namespace, Namespace.ID namespaceId, TableOperation operation)
       throws AcceptableThriftTableOperationException {
 
-    String n = Namespaces.getNameToIdMap(instance).get(namespace);
+    Namespace.ID n = Namespaces.lookupNamespaceId(instance, namespace);
 
     if (n != null && !n.equals(namespaceId))
       throw new AcceptableThriftTableOperationException(null, namespace, operation, TableOperationExceptionType.NAMESPACE_EXISTS, null);

--- a/server/master/src/main/java/org/apache/accumulo/master/util/TableValidators.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/util/TableValidators.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.replication.ReplicationTable;
@@ -47,15 +48,16 @@ public class TableValidators {
     }
   };
 
-  public static final Validator<String> VALID_ID = new Validator<String>() {
+  public static final Validator<Table.ID> VALID_ID = new Validator<Table.ID>() {
     @Override
-    public boolean test(String tableId) {
+    public boolean test(Table.ID tableId) {
       return tableId != null
-          && (RootTable.ID.equals(tableId) || MetadataTable.ID.equals(tableId) || ReplicationTable.ID.equals(tableId) || tableId.matches(VALID_ID_REGEX));
+          && (RootTable.ID.equals(tableId) || MetadataTable.ID.equals(tableId) || ReplicationTable.ID.equals(tableId) || tableId.canonicalID().matches(
+              VALID_ID_REGEX));
     }
 
     @Override
-    public String invalidMessage(String tableId) {
+    public String invalidMessage(Table.ID tableId) {
       if (tableId == null)
         return "Table id cannot be null";
       return "Table IDs are base-36 numbers, represented with lowercase alphanumeric digits: " + tableId;
@@ -103,15 +105,15 @@ public class TableValidators {
     }
   };
 
-  public static final Validator<String> NOT_ROOT_ID = new Validator<String>() {
+  public static final Validator<Table.ID> NOT_ROOT_ID = new Validator<Table.ID>() {
 
     @Override
-    public boolean test(String tableId) {
+    public boolean test(Table.ID tableId) {
       return !RootTable.ID.equals(tableId);
     }
 
     @Override
-    public String invalidMessage(String tableId) {
+    public String invalidMessage(Table.ID tableId) {
       return "Table cannot be the " + RootTable.NAME + "(Id: " + RootTable.ID + ") table";
     }
   };

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/DistributedWorkQueueWorkAssignerHelperTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/DistributedWorkQueueWorkAssignerHelperTest.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.master.replication;
 import java.util.Map.Entry;
 import java.util.UUID;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHelper;
 import org.apache.hadoop.fs.Path;
@@ -34,7 +35,7 @@ public class DistributedWorkQueueWorkAssignerHelperTest {
   @Test
   public void createsValidZKNodeName() {
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", "1");
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
 
     String key = DistributedWorkQueueWorkAssignerHelper.getQueueKey(p.toString(), target);
 
@@ -44,7 +45,7 @@ public class DistributedWorkQueueWorkAssignerHelperTest {
   @Test
   public void queueKeySerialization() {
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", "1");
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
 
     String key = DistributedWorkQueueWorkAssignerHelper.getQueueKey(p.toString(), target);
 

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/SequentialWorkAssignerTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/SequentialWorkAssignerTest.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationTarget;
@@ -59,8 +60,8 @@ public class SequentialWorkAssignerTest {
     Map<String,String> cluster1Work = new TreeMap<>();
 
     // Two files for cluster1, one for table '1' and another for table '2' we havce assigned work for
-    cluster1Work.put("1", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", "1")));
-    cluster1Work.put("2", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", "2")));
+    cluster1Work.put("1", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", new Table.ID("1"))));
+    cluster1Work.put("2", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", new Table.ID("2"))));
 
     queuedWork.put("cluster1", cluster1Work);
 
@@ -75,11 +76,11 @@ public class SequentialWorkAssignerTest {
     // file1 replicated
     expect(
         zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
-            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", "1")))).andReturn(null);
+            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", new Table.ID("1"))))).andReturn(null);
     // file2 still needs to replicate
     expect(
         zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
-            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", "2")))).andReturn(new byte[0]);
+            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", new Table.ID("2"))))).andReturn(new byte[0]);
 
     replay(workQueue, zooCache, conn, inst);
 
@@ -88,6 +89,7 @@ public class SequentialWorkAssignerTest {
     verify(workQueue, zooCache, conn, inst);
 
     Assert.assertEquals(1, cluster1Work.size());
-    Assert.assertEquals(DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", "2")), cluster1Work.get("2"));
+    Assert.assertEquals(DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", new Table.ID("2"))),
+        cluster1Work.get("2"));
   }
 }

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/UnorderedWorkAssignerTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/UnorderedWorkAssignerTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationTarget;
@@ -57,7 +58,7 @@ public class UnorderedWorkAssignerTest {
 
   @Test
   public void workQueuedUsingFileName() throws Exception {
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", "1");
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
 
     DistributedWorkQueue workQueue = createMock(DistributedWorkQueue.class);
     Set<String> queuedWork = new HashSet<>();

--- a/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.server.master.state.Assignment;
@@ -190,7 +191,7 @@ public class RootTabletStateStoreTest {
     }
     assertEquals(count, 1);
 
-    KeyExtent notRoot = new KeyExtent("0", null, null);
+    KeyExtent notRoot = new KeyExtent(new Table.ID("0"), null, null);
     try {
       tstore.setLocations(Collections.singletonList(new Assignment(notRoot, server)));
       Assert.fail("should not get here");

--- a/server/master/src/test/java/org/apache/accumulo/master/tableOps/ImportTableTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/tableOps/ImportTableTest.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.master.tableOps;
 
 import java.util.Optional;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironment;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -35,7 +36,7 @@ public class ImportTableTest {
     Master master = EasyMock.createMock(Master.class);
     VolumeManager volumeManager = EasyMock.createMock(VolumeManager.class);
     ImportedTableInfo iti = new ImportedTableInfo();
-    iti.tableId = "5";
+    iti.tableId = new Table.ID("5");
 
     // Different volumes with different paths
     String[] tableDirs = new String[] {"hdfs://nn1:8020/apps/accumulo1/tables", "hdfs://nn2:8020/applications/accumulo/tables"};

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.MasterClient;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.gc.thrift.GCMonitorService;
@@ -156,7 +157,7 @@ public class Monitor implements HighlyAvailableService {
 
   private static volatile boolean fetching = false;
   private static MasterMonitorInfo mmi;
-  private static Map<String,Map<ProblemType,Integer>> problemSummary = Collections.emptyMap();
+  private static Map<Table.ID,Map<ProblemType,Integer>> problemSummary = Collections.emptyMap();
   private static Exception problemException;
   private static GCStatus gcStatus;
 
@@ -760,7 +761,7 @@ public class Monitor implements HighlyAvailableService {
     return problemException;
   }
 
-  public static Map<String,Map<ProblemType,Integer>> getProblemSummary() {
+  public static Map<Table.ID,Map<ProblemType,Integer>> getProblemSummary() {
     return problemSummary;
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemDetailInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemDetailInformation.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.monitor.rest.problems;
 
+import org.apache.accumulo.core.client.impl.Table;
+
 /**
  *
  * Generates a problem detail as a JSON object
@@ -27,7 +29,7 @@ public class ProblemDetailInformation {
 
   // Variable names become JSON keys
   public String tableName;
-  public String tableID;
+  public Table.ID tableID;
   public String type;
   public String server;
 
@@ -55,7 +57,7 @@ public class ProblemDetailInformation {
    * @param exception
    *          Exception of the problem
    */
-  public ProblemDetailInformation(String tableName, String tableID, String type, String server, Long time, String resource, String exception) {
+  public ProblemDetailInformation(String tableName, Table.ID tableID, String type, String server, Long time, String resource, String exception) {
     this.tableName = tableName;
     this.tableID = tableID;
     this.type = type;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemSummaryInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemSummaryInformation.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.monitor.rest.problems;
 
+import org.apache.accumulo.core.client.impl.Table;
+
 /**
  *
  * Generates a problem summary object
@@ -27,7 +29,7 @@ public class ProblemSummaryInformation {
 
   // Variable names become JSON keys
   public String tableName;
-  public String tableID;
+  public Table.ID tableID;
 
   public Integer fileRead;
   public Integer fileWrite;
@@ -49,7 +51,7 @@ public class ProblemSummaryInformation {
    * @param tableLoad
    *          Number of table loads
    */
-  public ProblemSummaryInformation(String tableName, String tableID, Integer fileRead, Integer fileWrite, Integer tableLoad) {
+  public ProblemSummaryInformation(String tableName, Table.ID tableID, Integer fileRead, Integer fileWrite, Integer tableLoad) {
     this.tableName = tableName;
     this.tableID = tableID;
     this.fileRead = fileRead;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/replication/ReplicationResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/replication/ReplicationResource.java
@@ -37,6 +37,8 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.impl.Table;
+import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -109,14 +111,14 @@ public class ReplicationResource {
     // Number of files per target we have to replicate
     Map<ReplicationTarget,Long> targetCounts = new HashMap<>();
 
-    Map<String,String> tableNameToId = tops.tableIdMap();
-    Map<String,String> tableIdToName = invert(tableNameToId);
+    Map<String,Table.ID> tableNameToId = Tables.getNameToIdMap(null);
+    Map<Table.ID,String> tableIdToName = invert(tableNameToId);
 
     for (String table : tops.list()) {
       if (MetadataTable.NAME.equals(table) || RootTable.NAME.equals(table)) {
         continue;
       }
-      String localId = tableNameToId.get(table);
+      Table.ID localId = tableNameToId.get(table);
       if (null == localId) {
         log.trace("Could not determine ID for {}", table);
         continue;
@@ -194,9 +196,9 @@ public class ReplicationResource {
     return replicationInformation;
   }
 
-  protected Map<String,String> invert(Map<String,String> map) {
-    Map<String,String> newMap = new HashMap<>(map.size());
-    for (Entry<String,String> entry : map.entrySet()) {
+  protected Map<Table.ID,String> invert(Map<String,Table.ID> map) {
+    Map<Table.ID,String> newMap = new HashMap<>(map.size());
+    for (Entry<String,Table.ID> entry : map.entrySet()) {
       newMap.put(entry.getValue(), entry.getKey());
     }
     return newMap;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TableInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TableInformation.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.monitor.rest.tables;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.master.thrift.TableInfo;
 
 /**
@@ -29,7 +30,7 @@ public class TableInformation {
 
   // Variable names become JSON keys
   public String tablename;
-  public String tableId;
+  public Table.ID tableId;
   public String tableState;
 
   public int tablets;
@@ -72,7 +73,7 @@ public class TableInformation {
    * @param tableState
    *          State of the table
    */
-  public TableInformation(String tableName, String tableId, String tableState) {
+  public TableInformation(String tableName, Table.ID tableId, String tableState) {
     this.tablename = tableName;
     this.tableId = tableId;
     this.tableState = tableState;
@@ -92,7 +93,7 @@ public class TableInformation {
    * @param tableState
    *          State of the table
    */
-  public TableInformation(String tableName, String tableId, TableInfo info, Double holdTime, String tableState) {
+  public TableInformation(String tableName, Table.ID tableId, TableInfo info, Double holdTime, String tableState) {
     this.tablename = tableName;
     this.tableId = tableId;
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/CurrentOperations.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/CurrentOperations.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.monitor.rest.tservers;
 
+import org.apache.accumulo.core.client.impl.Table;
+
 /**
  *
  * Generates the current operations for the tablet
@@ -28,7 +30,7 @@ public class CurrentOperations {
   // Variable names become JSON keys
   public String name;
   public String tablet;
-  public String tableID;
+  public Table.ID tableID;
   public long entries;
   public double ingest;
   public double query;
@@ -69,7 +71,7 @@ public class CurrentOperations {
    * @param majorAvgES
    *          Major compaction average ES
    */
-  public CurrentOperations(String name, String ID, String tablet, long entries, double ingest, double query, Double minorAvg, Double minorStdDev,
+  public CurrentOperations(String name, Table.ID ID, String tablet, long entries, double ingest, double query, Double minorAvg, Double minorStdDev,
       Double minorAvgES, Double majorAvg, Double majorStdDev, Double majorAvgES) {
     this.name = name;
     this.tableID = ID;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.monitor.Monitor;
@@ -236,7 +237,7 @@ public class WebViews {
   @Template(name = "/default.ftl")
   public Map<String,Object> getTables(@PathParam("tableID") String tableID) throws TableNotFoundException {
 
-    String table = Tables.getTableName(Monitor.getContext().getInstance(), tableID);
+    String tableName = Tables.getTableName(Monitor.getContext().getInstance(), new Table.ID(tableID));
 
     Map<String,Object> model = getModel();
     model.put("title", "Table Status");
@@ -244,7 +245,7 @@ public class WebViews {
     model.put("template", "table.ftl");
     model.put("js", "table.js");
     model.put("tableID", tableID);
-    model.put("table", table);
+    model.put("table", tableName);
 
     return model;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -69,7 +69,9 @@ import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.CompressedIterators;
 import org.apache.accumulo.core.client.impl.DurabilityImpl;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.ScannerImpl;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.TabletLocator;
 import org.apache.accumulo.core.client.impl.TabletType;
@@ -480,8 +482,8 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         long readaheadThreshold, TSamplerConfiguration tSamplerConfig, long batchTimeOut, String context) throws NotServingTabletException,
         ThriftSecurityException, org.apache.accumulo.core.tabletserver.thrift.TooManyFilesException, TSampleNotPresentException {
 
-      String tableId = new String(textent.getTable(), UTF_8);
-      String namespaceId;
+      Table.ID tableId = new Table.ID(new String(textent.getTable(), UTF_8));
+      Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
       } catch (TableNotFoundException e1) {
@@ -637,17 +639,17 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         List<IterInfo> ssiList, Map<String,Map<String,String>> ssio, List<ByteBuffer> authorizations, boolean waitForWrites,
         TSamplerConfiguration tSamplerConfig, long batchTimeOut, String context) throws ThriftSecurityException, TSampleNotPresentException {
       // find all of the tables that need to be scanned
-      final HashSet<String> tables = new HashSet<>();
+      final HashSet<Table.ID> tables = new HashSet<>();
       for (TKeyExtent keyExtent : tbatch.keySet()) {
-        tables.add(new String(keyExtent.getTable(), UTF_8));
+        tables.add(new Table.ID(new String(keyExtent.getTable(), UTF_8)));
       }
 
       if (tables.size() != 1)
         throw new IllegalArgumentException("Cannot batch scan over multiple tables");
 
       // check if user has permission to the tables
-      for (String tableId : tables) {
-        String namespaceId;
+      for (Table.ID tableId : tables) {
+        Namespace.ID namespaceId;
         try {
           namespaceId = Tables.getNamespaceId(getInstance(), tableId);
         } catch (TableNotFoundException e1) {
@@ -781,12 +783,12 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         return;
       }
 
-      String tableId = "";
+      Table.ID tableId = null;
       try {
         // if user has no permission to write to this table, add it to
         // the failures list
         boolean sameTable = us.currentTablet != null && (us.currentTablet.getExtent().getTableId().equals(keyExtent.getTableId()));
-        tableId = keyExtent.getTableId().toString();
+        tableId = keyExtent.getTableId();
         if (sameTable || security.canWrite(us.getCredentials(), tableId, Tables.getNamespaceId(getInstance(), tableId))) {
           long t2 = System.currentTimeMillis();
           us.authTimes.addStat(t2 - t1);
@@ -1074,8 +1076,8 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     public void update(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, TMutation tmutation, TDurability tdurability)
         throws NotServingTabletException, ConstraintViolationException, ThriftSecurityException {
 
-      final String tableId = new String(tkeyExtent.getTable(), UTF_8);
-      String namespaceId;
+      final Table.ID tableId = new Table.ID(new String(tkeyExtent.getTable(), UTF_8));
+      Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
       } catch (TableNotFoundException e1) {
@@ -1310,11 +1312,12 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     }
 
     @Override
-    public TConditionalSession startConditionalUpdate(TInfo tinfo, TCredentials credentials, List<ByteBuffer> authorizations, String tableId,
+    public TConditionalSession startConditionalUpdate(TInfo tinfo, TCredentials credentials, List<ByteBuffer> authorizations, String tableIdStr,
         TDurability tdurabilty, String classLoaderContext) throws ThriftSecurityException, TException {
 
+      Table.ID tableId = new Table.ID(tableIdStr);
       Authorizations userauths = null;
-      String namespaceId;
+      Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
       } catch (TableNotFoundException e) {
@@ -1354,7 +1357,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         }
       }
 
-      String tid = cs.tableId;
+      Table.ID tid = cs.tableId;
       long opid = writeTracker.startWrite(TabletType.type(new KeyExtent(tid, null, null)));
 
       try {
@@ -1405,8 +1408,8 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     public void splitTablet(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, ByteBuffer splitPoint) throws NotServingTabletException,
         ThriftSecurityException {
 
-      String tableId = new String(ByteBufferUtil.toBytes(tkeyExtent.table));
-      String namespaceId;
+      Table.ID tableId = new Table.ID(new String(ByteBufferUtil.toBytes(tkeyExtent.table)));
+      Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
       } catch (TableNotFoundException ex) {
@@ -1448,7 +1451,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         onlineTabletsCopy = new TreeMap<>(onlineTablets);
       }
       List<TabletStats> result = new ArrayList<>();
-      String text = tableId;
+      Table.ID text = new Table.ID(tableId);
       KeyExtent start = new KeyExtent(text, new Text(), null);
       for (Entry<KeyExtent,Tablet> entry : onlineTabletsCopy.tailMap(start).entrySet()) {
         KeyExtent ke = entry.getKey();
@@ -1623,7 +1626,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
       ArrayList<Tablet> tabletsToFlush = new ArrayList<>();
 
-      KeyExtent ke = new KeyExtent(tableId, ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(new Table.ID(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       synchronized (onlineTablets) {
         for (Tablet tablet : onlineTablets.values())
@@ -1741,7 +1744,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         throw new RuntimeException(e);
       }
 
-      KeyExtent ke = new KeyExtent(tableId, ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(new Table.ID(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       ArrayList<Tablet> tabletsToCompact = new ArrayList<>();
       synchronized (onlineTablets) {
@@ -1836,20 +1839,21 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     @Override
     public TSummaries startGetSummaries(TInfo tinfo, TCredentials credentials, TSummaryRequest request) throws ThriftSecurityException,
         ThriftTableOperationException, NoSuchScanIDException, TException {
-      String namespaceId;
+      Namespace.ID namespaceId;
+      Table.ID tableId = new Table.ID(request.getTableId());
       try {
-        namespaceId = Tables.getNamespaceId(TabletServer.this.getInstance(), request.getTableId());
+        namespaceId = Tables.getNamespaceId(TabletServer.this.getInstance(), tableId);
       } catch (TableNotFoundException e1) {
-        throw new ThriftTableOperationException(request.getTableId(), null, null, TableOperationExceptionType.NOTFOUND, null);
+        throw new ThriftTableOperationException(tableId.canonicalID(), null, null, TableOperationExceptionType.NOTFOUND, null);
       }
 
-      if (!security.canGetSummaries(credentials, request.getTableId(), namespaceId)) {
+      if (!security.canGetSummaries(credentials, tableId, namespaceId)) {
         throw new AccumuloSecurityException(credentials.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED).asThriftException();
       }
 
       ServerConfigurationFactory factory = TabletServer.this.getServerConfigurationFactory();
       ExecutorService es = resourceManager.getSummaryPartitionExecutor();
-      Future<SummaryCollection> future = new Gatherer(TabletServer.this, request, factory.getTableConfiguration(request.getTableId())).gather(es);
+      Future<SummaryCollection> future = new Gatherer(TabletServer.this, request, factory.getTableConfiguration(tableId)).gather(es);
 
       return startSummaryOperation(credentials, future);
     }
@@ -1864,8 +1868,8 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
       ServerConfigurationFactory factory = TabletServer.this.getServerConfigurationFactory();
       ExecutorService spe = resourceManager.getSummaryRemoteExecutor();
-      Future<SummaryCollection> future = new Gatherer(TabletServer.this, request, factory.getTableConfiguration(request.getTableId())).processPartition(spe,
-          modulus, remainder);
+      Future<SummaryCollection> future = new Gatherer(TabletServer.this, request, factory.getTableConfiguration(new Table.ID(request.getTableId())))
+          .processPartition(spe, modulus, remainder);
 
       return startSummaryOperation(credentials, future);
     }
@@ -1879,7 +1883,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       }
 
       ExecutorService srp = resourceManager.getSummaryRetrievalExecutor();
-      TableConfiguration tableCfg = confFactory.getTableConfiguration(request.getTableId());
+      TableConfiguration tableCfg = confFactory.getTableConfiguration(new Table.ID(request.getTableId()));
       BlockCache summaryCache = resourceManager.getSummaryCache();
       BlockCache indexCache = resourceManager.getIndexCache();
       FileSystemResolver volMgr = p -> fs.getVolumeByPath(p).getFileSystem();
@@ -2324,7 +2328,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
           log.warn("{}", e.getMessage());
         }
 
-        String tableId = extent.getTableId();
+        Table.ID tableId = extent.getTableId();
         ProblemReports.getInstance(TabletServer.this).report(new ProblemReport(tableId, TABLET_LOAD, extent.getUUID().toString(), getClientAddressString(), e));
       } finally {
         releaseRecoveryMemory(extent);
@@ -2747,7 +2751,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     if (extent.isRootTablet()) {
       return verifyRootTablet(extent, instance);
     }
-    String tableToVerify = MetadataTable.ID;
+    Table.ID tableToVerify = MetadataTable.ID;
     if (extent.isMeta())
       tableToVerify = RootTable.ID;
 
@@ -2965,7 +2969,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     SimpleTimer.getInstance(aconf).schedule(constraintTask, 0, 1000);
   }
 
-  public TabletServerStatus getStats(Map<String,MapCounter<ScanRunState>> scanCounts) {
+  public TabletServerStatus getStats(Map<Table.ID,MapCounter<ScanRunState>> scanCounts) {
     TabletServerStatus result = new TabletServerStatus();
 
     Map<KeyExtent,Tablet> onlineTabletsCopy;
@@ -2975,7 +2979,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     Map<String,TableInfo> tables = new HashMap<>();
 
     for (Entry<KeyExtent,Tablet> entry : onlineTabletsCopy.entrySet()) {
-      String tableId = entry.getKey().getTableId();
+      String tableId = entry.getKey().getTableId().canonicalID();
       TableInfo table = tables.get(tableId);
       if (table == null) {
         table = new TableInfo();
@@ -3005,11 +3009,11 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         table.majors.queued++;
     }
 
-    for (Entry<String,MapCounter<ScanRunState>> entry : scanCounts.entrySet()) {
-      TableInfo table = tables.get(entry.getKey());
+    for (Entry<Table.ID,MapCounter<ScanRunState>> entry : scanCounts.entrySet()) {
+      TableInfo table = tables.get(entry.getKey().canonicalID());
       if (table == null) {
         table = new TableInfo();
-        tables.put(entry.getKey(), table);
+        tables.put(entry.getKey().canonicalID(), table);
       }
 
       if (table.scans == null)
@@ -3028,7 +3032,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     }
 
     for (KeyExtent extent : offlineTabletsCopy) {
-      String tableId = extent.getTableId();
+      String tableId = extent.getTableId().canonicalID();
       TableInfo table = tables.get(tableId);
       if (table == null) {
         table = new TableInfo();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -29,6 +29,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.accumulo.core.cli.Help;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -84,7 +85,7 @@ public class LogReader {
       row = new Text(opts.row);
     if (opts.extent != null) {
       String sa[] = opts.extent.split(";");
-      ke = new KeyExtent(sa[0], new Text(sa[1]), new Text(sa[2]));
+      ke = new KeyExtent(new Table.ID(sa[0]), new Text(sa[1]), new Text(sa[2]));
     }
     if (opts.regexp != null) {
       Pattern pattern = Pattern.compile(opts.regexp);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -49,7 +50,8 @@ public class ReplicationServicerHandler implements Iface {
   }
 
   @Override
-  public long replicateLog(String tableId, WalEdits data, TCredentials tcreds) throws RemoteReplicationException, TException {
+  public long replicateLog(String tableIdStr, WalEdits data, TCredentials tcreds) throws RemoteReplicationException, TException {
+    Table.ID tableId = new Table.ID(tableIdStr);
     log.debug("Got replication request to tableID {} with {} edits", tableId, data.getEditsSize());
     tabletServer.getSecurityOperation().authenticateUser(tabletServer.rpcCreds(), tcreds);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ConditionalSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ConditionalSession.java
@@ -19,18 +19,19 @@ package org.apache.accumulo.tserver.session;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.Durability;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.thrift.TCredentials;
 
 public class ConditionalSession extends Session {
   public final TCredentials credentials;
   public final Authorizations auths;
-  public final String tableId;
+  public final Table.ID tableId;
   public final AtomicBoolean interruptFlag = new AtomicBoolean();
   public final Durability durability;
   public final String classLoaderContext;
 
-  public ConditionalSession(TCredentials credentials, Authorizations authorizations, String tableId, Durability durability, String classLoaderContext) {
+  public ConditionalSession(TCredentials credentials, Authorizations authorizations, Table.ID tableId, Durability durability, String classLoaderContext) {
     super(credentials);
     this.credentials = credentials;
     this.auths = authorizations;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -220,7 +220,7 @@ class DatafileManager {
       boolean inTheRightDirectory = false;
       Path parent = tpath.path().getParent().getParent();
       for (String tablesDir : ServerConstants.getTablesDirs()) {
-        if (parent.equals(new Path(tablesDir, tablet.getExtent().getTableId()))) {
+        if (parent.equals(new Path(tablesDir, tablet.getExtent().getTableId().canonicalID()))) {
           inTheRightDirectory = true;
           break;
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -54,6 +54,7 @@ import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.admin.CompactionStrategyConfig;
 import org.apache.accumulo.core.client.impl.DurabilityImpl;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -2131,8 +2132,8 @@ public class Tablet implements TabletCommitter {
       SortedMap<FileRef,DataFileValue> highDatafileSizes = new TreeMap<>();
       List<FileRef> highDatafilesToRemove = new ArrayList<>();
 
-      MetadataTableUtil.splitDatafiles(extent.getTableId(), midRow, splitRatio, firstAndLastRows, getDatafileManager().getDatafileSizes(), lowDatafileSizes,
-          highDatafileSizes, highDatafilesToRemove);
+      MetadataTableUtil.splitDatafiles(midRow, splitRatio, firstAndLastRows, getDatafileManager().getDatafileSizes(), lowDatafileSizes, highDatafileSizes,
+          highDatafilesToRemove);
 
       log.debug("Files for low split " + low + "  " + lowDatafileSizes.keySet());
       log.debug("Files for high split " + high + "  " + highDatafileSizes.keySet());
@@ -2617,7 +2618,7 @@ public class Tablet implements TabletCommitter {
     return scannedCount;
   }
 
-  private static String createTabletDirectory(VolumeManager fs, String tableId, Text endRow) {
+  private static String createTabletDirectory(VolumeManager fs, Table.ID tableId, Text endRow) {
     String lowDirectory;
 
     UniqueNameAllocator namer = UniqueNameAllocator.getInstance();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.tserver;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -49,7 +50,7 @@ public class AssignmentWatcherTest {
     RunnableStartedAt run = new RunnableStartedAt(task, System.currentTimeMillis());
     EasyMock.expect(conf.getTimeInMillis(Property.TSERV_ASSIGNMENT_DURATION_WARNING)).andReturn(0l);
 
-    assignments.put(new KeyExtent("1", null, null), run);
+    assignments.put(new KeyExtent(new Table.ID("1"), null, null), run);
 
     EasyMock.expect(task.getException()).andReturn(new Exception("Assignment warning happened"));
     EasyMock.expect(timer.schedule(watcher, 5000l)).andReturn(null);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.tserver;
 
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -70,7 +71,7 @@ public class CheckTabletMetadataTest {
   @Test
   public void testBadTabletMetadata() throws Exception {
 
-    KeyExtent ke = new KeyExtent("1", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("1"), null, null);
 
     TreeMap<Key,Value> tabletMeta = new TreeMap<>();
 
@@ -89,9 +90,9 @@ public class CheckTabletMetadataTest {
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 4));
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 5));
 
-    assertFail(tabletMeta, new KeyExtent("1", null, new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent(new Table.ID("1"), null, new Text("m")), tsi);
 
-    assertFail(tabletMeta, new KeyExtent("1", new Text("r"), new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent(new Table.ID("1"), new Text("r"), new Text("m")), tsi);
 
     assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.volume.Volume;
@@ -188,7 +189,7 @@ public class TabletServerSyncCheckTest {
     }
 
     @Override
-    public Path getFullPath(String tableId, String path) {
+    public Path getFullPath(Table.ID tableId, String path) {
       return null;
     }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -157,7 +158,7 @@ public class DefaultCompactionStrategyTest {
   }
 
   private MajorCompactionRequest createRequest(MajorCompactionReason reason, Object... objs) throws IOException {
-    return createRequest(new KeyExtent("0", null, null), reason, objs);
+    return createRequest(new KeyExtent(new Table.ID("0"), null, null), reason, objs);
   }
 
   private MajorCompactionRequest createRequest(KeyExtent extent, MajorCompactionReason reason, Object... objs) throws IOException {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -51,7 +52,7 @@ public class SizeLimitCompactionStrategyTest {
 
     slcs.init(opts);
 
-    KeyExtent ke = new KeyExtent("0", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
     MajorCompactionRequest mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, DefaultConfiguration.getInstance());
 
     mcr.setFiles(nfl("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G"));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -63,7 +64,7 @@ public class TwoTierCompactionStrategyTest {
   public void testDefaultCompaction() throws IOException {
     ttcs.init(opts);
     conf = DefaultConfiguration.getInstance();
-    KeyExtent ke = new KeyExtent("0", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "10M", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "100M", "f6", "100M", "f7", "100M", "f8",
         "100M");
@@ -82,7 +83,7 @@ public class TwoTierCompactionStrategyTest {
   public void testLargeCompaction() throws IOException {
     ttcs.init(opts);
     conf = DefaultConfiguration.getInstance();
-    KeyExtent ke = new KeyExtent("0", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G");
     mcr.setFiles(fileMap);
@@ -111,7 +112,7 @@ public class TwoTierCompactionStrategyTest {
   public void testFileSubsetCompaction() throws IOException {
     ttcs.init(opts);
     conf = DefaultConfiguration.getInstance();
-    KeyExtent ke = new KeyExtent("0", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "1G", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "10M", "f6", "10M", "f7", "10M");
     Map<FileRef,DataFileValue> filesToCompactMap = createFileMap("f2", "10M", "f3", "10M", "f4", "10M", "f5", "10M", "f6", "10M", "f7", "10M");

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.tserver.compaction.strategies;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.compaction.CompactionSettings;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -37,7 +38,7 @@ public class ConfigurableCompactionStrategyTest {
 
   @Test
   public void testOutputOptions() throws Exception {
-    MajorCompactionRequest mcr = new MajorCompactionRequest(new KeyExtent("1", null, null), MajorCompactionReason.USER, null);
+    MajorCompactionRequest mcr = new MajorCompactionRequest(new KeyExtent(new Table.ID("1"), null, null), MajorCompactionReason.USER, null);
 
     Map<FileRef,DataFileValue> files = new HashMap<>();
     files.put(new FileRef("hdfs://nn1/accumulo/tables/1/t-009/F00001.rf"), new DataFileValue(50000, 400));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEntryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEntryTest.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.tserver.log;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -29,7 +30,7 @@ public class LogEntryTest {
 
   @Test
   public void test() throws Exception {
-    KeyExtent extent = new KeyExtent("1", null, new Text(""));
+    KeyExtent extent = new KeyExtent(new Table.ID("1"), null, new Text(""));
     long ts = 12345678L;
     String server = "localhost:1234";
     String filename = "default/foo";

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -56,7 +57,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class SortedLogRecoveryTest {
 
-  static final KeyExtent extent = new KeyExtent("table", null, null);
+  static final KeyExtent extent = new KeyExtent(new Table.ID("table"), null, null);
   static final Text cf = new Text("cf");
   static final Text cq = new Text("cq");
   static final Value value = new Value("value".getBytes());

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -80,7 +81,7 @@ public class LogFileTest {
     assertEquals(key.seq, 3);
     assertEquals(key.tid, 4);
     assertEquals(key.filename, "some file");
-    KeyExtent tablet = new KeyExtent("table", new Text("bbbb"), new Text("aaaa"));
+    KeyExtent tablet = new KeyExtent(new Table.ID("table"), new Text("bbbb"), new Text("aaaa"));
     readWrite(DEFINE_TABLET, 5, 6, null, tablet, null, key, value);
     assertEquals(key.event, DEFINE_TABLET);
     assertEquals(key.seq, 5);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
@@ -77,7 +78,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("1", null, null);
+    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -92,7 +93,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("2", null, null);
+    key.tablet = new KeyExtent(new Table.ID("2"), null, null);
     key.tid = 2;
     value.mutations = Collections.emptyList();
 
@@ -123,7 +124,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("1", null, null);
+    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
     key.tid = 3;
     value.mutations = Collections.emptyList();
 
@@ -157,8 +158,8 @@ public class AccumuloReplicaSystemTest {
 
     Status status = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true).setClosed(false).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", "1"), dis, new Path("/accumulo/wals/tserver+port/wal"), status, Long.MAX_VALUE,
-        new HashSet<Integer>());
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+        Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(9, repl.entriesConsumed);
@@ -183,7 +184,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("1", null, null);
+    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -198,7 +199,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("2", null, null);
+    key.tablet = new KeyExtent(new Table.ID("2"), null, null);
     key.tid = 2;
     value.mutations = Collections.emptyList();
 
@@ -229,7 +230,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("1", null, null);
+    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
     key.tid = 3;
     value.mutations = Collections.emptyList();
 
@@ -265,8 +266,8 @@ public class AccumuloReplicaSystemTest {
     // If it were still open, more data could be appended that we need to process
     Status status = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true).setClosed(true).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", "1"), dis, new Path("/accumulo/wals/tserver+port/wal"), status, Long.MAX_VALUE,
-        new HashSet<Integer>());
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+        Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(Long.MAX_VALUE, repl.entriesConsumed);
@@ -300,7 +301,7 @@ public class AccumuloReplicaSystemTest {
     DataOutputStream out = new DataOutputStream(baos);
 
     // Replicate our 2 mutations to "peer", from tableid 1 to tableid 1
-    ars.writeValueAvoidingReplicationCycles(out, value, new ReplicationTarget("peer", "1", "1"));
+    ars.writeValueAvoidingReplicationCycles(out, value, new ReplicationTarget("peer", "1", new Table.ID("1")));
 
     out.close();
 
@@ -331,8 +332,8 @@ public class AccumuloReplicaSystemTest {
     // If it were still open, more data could be appended that we need to process
     Status status = Status.newBuilder().setBegin(100).setEnd(0).setInfiniteEnd(true).setClosed(true).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", "1"), dis, new Path("/accumulo/wals/tserver+port/wal"), status, Long.MAX_VALUE,
-        new HashSet<Integer>());
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+        Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(Long.MAX_VALUE, repl.entriesConsumed);
@@ -354,8 +355,8 @@ public class AccumuloReplicaSystemTest {
     // If it were still open, more data could be appended that we need to process
     Status status = Status.newBuilder().setBegin(100).setEnd(0).setInfiniteEnd(true).setClosed(false).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", "1"), dis, new Path("/accumulo/wals/tserver+port/wal"), status, Long.MAX_VALUE,
-        new HashSet<Integer>());
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+        Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(0, repl.entriesConsumed);
@@ -380,7 +381,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent("1", null, null);
+    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -418,7 +419,8 @@ public class AccumuloReplicaSystemTest {
     HashSet<Integer> tids = new HashSet<>();
 
     // Only consume the first mutation, not the second
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", "1"), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l, tids);
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l,
+        tids);
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(2, repl.entriesConsumed);
@@ -429,7 +431,7 @@ public class AccumuloReplicaSystemTest {
     status = Status.newBuilder(status).setBegin(2).build();
 
     // Consume the rest of the mutations
-    repl = ars.getWalEdits(new ReplicationTarget("peer", "1", "1"), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l, tids);
+    repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l, tids);
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(1, repl.entriesConsumed);
@@ -445,7 +447,7 @@ public class AccumuloReplicaSystemTest {
     WalEdits edits = new WalEdits(Collections.<ByteBuffer> emptyList());
     WalReplication walReplication = new WalReplication(edits, 0, 0, 0);
 
-    ReplicationTarget target = new ReplicationTarget("peer", "2", "1");
+    ReplicationTarget target = new ReplicationTarget("peer", "2", new Table.ID("1"));
     DataInputStream input = null;
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
     Status status = null;
@@ -474,7 +476,7 @@ public class AccumuloReplicaSystemTest {
     WalEdits edits = new WalEdits(Collections.<ByteBuffer> emptyList());
     WalReplication walReplication = new WalReplication(edits, 0, 5, 0);
 
-    ReplicationTarget target = new ReplicationTarget("peer", "2", "1");
+    ReplicationTarget target = new ReplicationTarget("peer", "2", new Table.ID("1"));
     DataInputStream input = null;
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
     Status status = null;
@@ -499,7 +501,7 @@ public class AccumuloReplicaSystemTest {
   @Test
   public void testUserPassword() throws Exception {
     AccumuloReplicaSystem ars = new AccumuloReplicaSystem();
-    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", "1");
+    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", new Table.ID("1"));
     String user = "user", password = "password";
 
     Map<String,String> confMap = new HashMap<>();
@@ -514,7 +516,7 @@ public class AccumuloReplicaSystemTest {
   @Test
   public void testUserKeytab() throws Exception {
     AccumuloReplicaSystem ars = new AccumuloReplicaSystem();
-    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", "1");
+    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", new Table.ID("1"));
     String user = "user", keytab = "/etc/security/keytabs/replication.keytab";
 
     Map<String,String> confMap = new HashMap<>();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
@@ -82,7 +83,7 @@ public class ReplicationProcessorTest {
     ReplicationProcessor proc = EasyMock.createMockBuilder(ReplicationProcessor.class)
         .addMockedMethods("getReplicaSystem", "doesFileExist", "getStatus", "getHelper").createMock();
 
-    ReplicationTarget target = new ReplicationTarget("peer", "1", "1");
+    ReplicationTarget target = new ReplicationTarget("peer", "1", new Table.ID("1"));
     Status status = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true).setClosed(true).build();
     Path path = new Path("/accumulo");
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DUCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DUCommand.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.DiskUsage;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
 import org.apache.accumulo.core.util.NumUtil;
 import org.apache.accumulo.shell.Shell;
@@ -50,7 +51,7 @@ public class DUCommand extends Command {
 
     if (cl.hasOption(optNamespace.getOpt())) {
       Instance instance = shellState.getInstance();
-      String namespaceId = Namespaces.getNamespaceId(instance, cl.getOptionValue(optNamespace.getOpt()));
+      Namespace.ID namespaceId = Namespaces.getNamespaceId(instance, cl.getOptionValue(optNamespace.getOpt()));
       tables.addAll(Namespaces.getTableNames(instance, namespaceId));
     }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteNamespaceCommand.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.accumulo.core.client.NamespaceNotFoundException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -60,11 +60,8 @@ public class DeleteNamespaceCommand extends Command {
   protected void doTableOp(final Shell shellState, final String namespace, boolean force) throws Exception {
     boolean resetContext = false;
     String currentTable = shellState.getTableName();
-    if (!Namespaces.getNameToIdMap(shellState.getInstance()).containsKey(namespace)) {
-      throw new NamespaceNotFoundException(null, namespace, null);
-    }
 
-    String namespaceId = Namespaces.getNamespaceId(shellState.getInstance(), namespace);
+    Namespace.ID namespaceId = Namespaces.getNamespaceId(shellState.getInstance(), namespace);
     List<String> tables = Namespaces.getTableNames(shellState.getInstance(), namespaceId);
     resetContext = tables.contains(currentTable);
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/RenameNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/RenameNamespaceCommand.java
@@ -26,7 +26,9 @@ import org.apache.accumulo.core.client.NamespaceExistsException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Namespace;
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -40,10 +42,10 @@ public class RenameNamespaceCommand extends Command {
     String old = cl.getArgs()[0];
     String newer = cl.getArgs()[1];
     boolean resetContext = false;
-    String currentTableId = "";
+    Table.ID currentTableId = null;
     if (!(shellState.getTableName() == null) && !shellState.getTableName().isEmpty()) {
-      String namespaceId = Namespaces.getNamespaceId(shellState.getInstance(), old);
-      List<String> tableIds = Namespaces.getTableIds(shellState.getInstance(), namespaceId);
+      Namespace.ID namespaceId = Namespaces.getNamespaceId(shellState.getInstance(), old);
+      List<Table.ID> tableIds = Namespaces.getTableIds(shellState.getInstance(), namespaceId);
       currentTableId = Tables.getTableId(shellState.getInstance(), shellState.getTableName());
       resetContext = tableIds.contains(currentTableId);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/TableOperation.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/TableOperation.java
@@ -24,6 +24,8 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.Namespaces;
+import org.apache.accumulo.core.client.impl.Namespace;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -55,8 +57,8 @@ public abstract class TableOperation extends Command {
       tableSet.add(cl.getOptionValue(optTableName.getOpt()));
     } else if (cl.hasOption(optNamespace.getOpt())) {
       Instance instance = shellState.getInstance();
-      String namespaceId = Namespaces.getNamespaceId(instance, cl.getOptionValue(optNamespace.getOpt()));
-      for (String tableId : Namespaces.getTableIds(instance, namespaceId)) {
+      Namespace.ID namespaceId = Namespaces.getNamespaceId(instance, cl.getOptionValue(optNamespace.getOpt()));
+      for (Table.ID tableId : Namespaces.getTableIds(instance, namespaceId)) {
         tableSet.add(Tables.getTableName(instance, tableId));
       }
     } else if (useCommandLine && cl.getArgs().length > 0) {

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -48,7 +49,7 @@ public class CloneIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    KeyExtent ke = new KeyExtent("0", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -62,9 +63,9 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
-    int rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(0, rc);
 
@@ -78,7 +79,7 @@ public class CloneIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    KeyExtent ke = new KeyExtent("0", null, null);
+    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -93,7 +94,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     Mutation mut2 = new Mutation(ke.getMetadataEntry());
     mut2.putDelete(DataFileColumnFamily.NAME.toString(), "/default_tablet/0_0.rf");
@@ -102,16 +103,16 @@ public class CloneIT extends AccumuloClusterHarness {
     bw1.addMutation(mut2);
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(1, rc);
 
-    rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -140,19 +141,19 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     bw1.addMutation(createTablet("0", "m", null, "/default_tablet", "/default_tablet/0_0.rf"));
     bw1.addMutation(createTablet("0", null, "m", "/t-1", "/default_tablet/0_0.rf"));
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -184,7 +185,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     bw1.addMutation(createTablet("0", "m", null, "/default_tablet", "/default_tablet/1_0.rf"));
     Mutation mut3 = createTablet("0", null, "m", "/t-1", "/default_tablet/1_0.rf");
@@ -193,16 +194,16 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(1, rc);
 
-    rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -221,7 +222,7 @@ public class CloneIT extends AccumuloClusterHarness {
   }
 
   private static Mutation deleteTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(tid, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(new Table.ID(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = new Mutation(ke.getMetadataEntry());
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
     TabletsSection.ServerColumnFamily.TIME_COLUMN.putDelete(mut);
@@ -232,7 +233,7 @@ public class CloneIT extends AccumuloClusterHarness {
   }
 
   private static Mutation createTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(tid, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(new Table.ID(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -258,7 +259,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     bw1.addMutation(createTablet("0", "f", null, "/d1", "/d1/file3"));
     bw1.addMutation(createTablet("0", "m", "f", "/d3", "/d1/file1"));
@@ -267,12 +268,12 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -306,7 +307,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     bw1.addMutation(deleteTablet("0", "m", null, "/d1", "/d1/file1"));
     bw1.addMutation(deleteTablet("0", null, "m", "/d2", "/d2/file2"));
@@ -320,7 +321,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(1, rc);
 
@@ -332,12 +333,12 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    rc = MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+    rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent("1", null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -372,7 +373,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, "0", "1", conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
 
     bw1.addMutation(deleteTablet("0", "m", null, "/d1", "/d1/file1"));
     Mutation mut = createTablet("0", null, null, "/d2", "/d2/file2");
@@ -382,7 +383,7 @@ public class CloneIT extends AccumuloClusterHarness {
     bw1.flush();
 
     try {
-      MetadataTableUtil.checkClone(tableName, "0", "1", conn, bw2);
+      MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
       assertTrue(false);
     } catch (TabletIterator.TabletDeletedException tde) {}
 

--- a/test/src/main/java/org/apache/accumulo/test/FileArchiveIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/FileArchiveIT.java
@@ -22,6 +22,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -64,7 +65,7 @@ public class FileArchiveIT extends ConfigurableMacBase {
 
     conn.tableOperations().create(tableName);
 
-    final String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Could not get table ID", tableId);
 
     BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig());
@@ -122,7 +123,7 @@ public class FileArchiveIT extends ConfigurableMacBase {
 
     conn.tableOperations().create(tableName);
 
-    final String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Could not get table ID", tableId);
 
     BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig());
@@ -179,7 +180,7 @@ public class FileArchiveIT extends ConfigurableMacBase {
 
     conn.tableOperations().create(tableName);
 
-    final String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Could not get table ID", tableId);
 
     BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -140,7 +140,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
     // Get all `file` colfams from the metadata table for the new table
     log.info("Imported into table with ID: {}", tableId);
     Scanner s = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+    s.setRange(MetadataSchema.TabletsSection.getRange(new org.apache.accumulo.core.client.impl.Table.ID(tableId)));
     s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
     MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
 

--- a/test/src/main/java/org/apache/accumulo/test/ListTables.java
+++ b/test/src/main/java/org/apache/accumulo/test/ListTables.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test;
 
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.server.cli.ClientOpts;
 
@@ -28,7 +29,7 @@ public class ListTables {
   public static void main(String[] args) throws Exception {
     ClientOpts opts = new ClientOpts();
     opts.parseArgs(ListTables.class.getName(), args);
-    for (Entry<String,String> table : Tables.getNameToIdMap(opts.getInstance()).entrySet())
+    for (Entry<String,Table.ID> table : Tables.getNameToIdMap(opts.getInstance()).entrySet())
       System.out.println(table.getKey() + " => " + table.getValue());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.Locations;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -70,7 +71,7 @@ public class LocatorIT extends AccumuloClusterHarness {
   }
 
   private static TabletId newTabletId(String tableId, String endRow, String prevRow) {
-    return new TabletIdImpl(new KeyExtent(tableId, endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow)));
+    return new TabletIdImpl(new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow)));
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test;
 
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Writer;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -45,7 +46,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
     Credentials credentials = new Credentials(getAdminPrincipal(), getAdminToken());
     ClientContext context = new ClientContext(getConnector().getInstance(), credentials, cluster.getClientConfig());
     Writer w = new Writer(context, MetadataTable.ID);
-    KeyExtent extent = new KeyExtent("5", null, null);
+    KeyExtent extent = new KeyExtent(new Table.ID("5"), null, null);
 
     Mutation m = new Mutation(extent.getMetadataEntry());
     // unknown columns should cause contraint violation

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -124,7 +125,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Table ID was null", tableId);
 
     LogEntry logEntry = new LogEntry(new KeyExtent(tableId, null, null), 0, "127.0.0.1:12345", emptyWalog.toURI().toString());
@@ -179,7 +180,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Table ID was null", tableId);
 
     LogEntry logEntry = new LogEntry(null, 0, "127.0.0.1:12345", partialHeaderWalog.toURI().toString());

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -910,8 +910,8 @@ public class NamespacesIT extends AccumuloClusterHarness {
     assertTrue(namespaces.contains(Namespaces.ACCUMULO_NAMESPACE));
     assertTrue(namespaces.contains(Namespaces.DEFAULT_NAMESPACE));
     assertFalse(namespaces.contains(namespace));
-    assertEquals(Namespaces.ACCUMULO_NAMESPACE_ID, map.get(Namespaces.ACCUMULO_NAMESPACE));
-    assertEquals(Namespaces.DEFAULT_NAMESPACE_ID, map.get(Namespaces.DEFAULT_NAMESPACE));
+    assertEquals(Namespaces.ACCUMULO_NAMESPACE_ID.canonicalID(), map.get(Namespaces.ACCUMULO_NAMESPACE));
+    assertEquals(Namespaces.DEFAULT_NAMESPACE_ID.canonicalID(), map.get(Namespaces.DEFAULT_NAMESPACE));
     assertNull(map.get(namespace));
 
     c.namespaceOperations().create(namespace);
@@ -922,8 +922,8 @@ public class NamespacesIT extends AccumuloClusterHarness {
     assertTrue(namespaces.contains(Namespaces.ACCUMULO_NAMESPACE));
     assertTrue(namespaces.contains(Namespaces.DEFAULT_NAMESPACE));
     assertTrue(namespaces.contains(namespace));
-    assertEquals(Namespaces.ACCUMULO_NAMESPACE_ID, map.get(Namespaces.ACCUMULO_NAMESPACE));
-    assertEquals(Namespaces.DEFAULT_NAMESPACE_ID, map.get(Namespaces.DEFAULT_NAMESPACE));
+    assertEquals(Namespaces.ACCUMULO_NAMESPACE_ID.canonicalID(), map.get(Namespaces.ACCUMULO_NAMESPACE));
+    assertEquals(Namespaces.DEFAULT_NAMESPACE_ID.canonicalID(), map.get(Namespaces.DEFAULT_NAMESPACE));
     assertNotNull(map.get(namespace));
 
     c.namespaceOperations().delete(namespace);
@@ -934,8 +934,8 @@ public class NamespacesIT extends AccumuloClusterHarness {
     assertTrue(namespaces.contains(Namespaces.ACCUMULO_NAMESPACE));
     assertTrue(namespaces.contains(Namespaces.DEFAULT_NAMESPACE));
     assertFalse(namespaces.contains(namespace));
-    assertEquals(Namespaces.ACCUMULO_NAMESPACE_ID, map.get(Namespaces.ACCUMULO_NAMESPACE));
-    assertEquals(Namespaces.DEFAULT_NAMESPACE_ID, map.get(Namespaces.DEFAULT_NAMESPACE));
+    assertEquals(Namespaces.ACCUMULO_NAMESPACE_ID.canonicalID(), map.get(Namespaces.ACCUMULO_NAMESPACE));
+    assertEquals(Namespaces.DEFAULT_NAMESPACE_ID.canonicalID(), map.get(Namespaces.DEFAULT_NAMESPACE));
     assertNull(map.get(namespace));
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
@@ -120,7 +120,7 @@ public class QueryMetadataTable {
         location = entry.getValue().toString();
       }
 
-      if (!entry.getKey().getRow().toString().startsWith(MetadataTable.ID))
+      if (!entry.getKey().getRow().toString().startsWith(MetadataTable.ID.canonicalID()))
         rowSet.add(entry.getKey().getRow());
       count++;
     }

--- a/test/src/main/java/org/apache/accumulo/test/RewriteTabletDirectoriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RewriteTabletDirectoriesIT.java
@@ -32,6 +32,7 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -99,7 +100,7 @@ public class RewriteTabletDirectoriesIT extends ConfigurableMacBase {
 
     BatchScanner scanner = c.createBatchScanner(MetadataTable.NAME, Authorizations.EMPTY, 1);
     DIRECTORY_COLUMN.fetch(scanner);
-    String tableId = c.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableId = new Table.ID(c.tableOperations().tableIdMap().get(tableName));
     assertNotNull("TableID for " + tableName + " was null", tableId);
     scanner.setRanges(Collections.singletonList(TabletsSection.getRange(tableId)));
     // verify the directory entries are all on v1, make a few entries relative

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.impl.Credentials;
 import org.apache.accumulo.core.client.impl.OfflineScanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.sample.RowSampler;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -204,7 +205,7 @@ public class SampleIT extends AccumuloClusterHarness {
     Set<String> es = Collections.emptySet();
     conn.tableOperations().clone(tableName, clone, false, em, es);
     conn.tableOperations().offline(clone, true);
-    String cloneID = conn.tableOperations().tableIdMap().get(clone);
+    Table.ID cloneID = new Table.ID(conn.tableOperations().tableIdMap().get(clone));
     OfflineScanner oScanner = new OfflineScanner(conn.getInstance(), new Credentials(getAdminPrincipal(), getAdminToken()), cloneID, Authorizations.EMPTY);
     if (sc != null) {
       oScanner.setSamplerConfiguration(sc);

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -86,7 +87,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
 
       // poke a partial split into the metadata table
       connector.securityOperations().grantTablePermission(getAdminPrincipal(), MetadataTable.NAME, TablePermission.WRITE);
-      String tableId = connector.tableOperations().tableIdMap().get(tableName);
+      Table.ID tableId = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
       KeyExtent extent = new KeyExtent(tableId, null, new Text("b"));
       Mutation m = extent.getPrevRowUpdateMutation();

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -63,7 +63,7 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
     int numThreads = 2;
     // Number of iterations per thread
     int iterations = 100000;
-    AccumuloConfiguration tableConf = new TableConfiguration(inst, table, defaultConf);
+    AccumuloConfiguration tableConf = new TableConfiguration(inst, new org.apache.accumulo.core.client.impl.Table.ID(table), defaultConf);
 
     long start = System.currentTimeMillis();
     ExecutorService svc = Executors.newFixedThreadPool(numThreads);

--- a/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -176,7 +177,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    String tableID = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -200,7 +201,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     String tableName2 = namespace2 + ".1";
 
     connector.tableOperations().create(tableName2);
-    String tableID2 = connector.tableOperations().tableIdMap().get(tableName2);
+    Table.ID tableID2 = new Table.ID(connector.tableOperations().tableIdMap().get(tableName2));
 
     // Add 10 splits to the table
     addSplits(connector, tableName2);
@@ -227,7 +228,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    String tableID = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -247,7 +248,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table2 on namespace2
     String tableName2 = namespace2 + ".1";
     connector.tableOperations().create(tableName2);
-    String tableID2 = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID2 = new Table.ID(connector.tableOperations().tableIdMap().get(tableName2));
 
     // / Add 10 splits to the table
     addSplits(connector, tableName2);
@@ -275,7 +276,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    String tableID = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -299,7 +300,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table2 on namespace2
     String tableName2 = namespace2 + ".1";
     connector.tableOperations().create(tableName2);
-    String tableID2 = connector.tableOperations().tableIdMap().get(tableName2);
+    Table.ID tableID2 = new Table.ID(connector.tableOperations().tableIdMap().get(tableName2));
 
     // Add 10 splits to the table
     addSplits(connector, tableName2);
@@ -327,7 +328,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    String tableID = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -359,7 +360,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    String tableID = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -378,7 +379,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     Connector connector = getConnector();
     String tableName = getUniqueNames(2)[0];
     connector.tableOperations().create(tableName);
-    String tableID = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.admin.DiskUsage;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -188,7 +189,7 @@ public class VolumeIT extends ConfigurableMacBase {
     String tableName = getUniqueNames(1)[0];
     connector.tableOperations().create(tableName, new NewTableConfiguration().withoutDefaultIterators());
 
-    String tableId = connector.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableId = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
 
     SortedSet<Text> partitions = new TreeSet<>();
     // with some splits
@@ -403,7 +404,7 @@ public class VolumeIT extends ConfigurableMacBase {
 
     verifyData(expected, conn.createScanner(tableName, Authorizations.EMPTY));
 
-    String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
     Scanner metaScanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(metaScanner);
     metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -20,6 +20,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.rpc.ThriftUtil;
@@ -63,8 +64,8 @@ public class WrongTabletTest {
 
       Mutation mutation = new Mutation(new Text("row_0003750001"));
       mutation.putDelete(new Text("colf"), new Text("colq"));
-      client.update(Tracer.traceInfo(), context.rpcCreds(), new KeyExtent("!!", null, new Text("row_0003750000")).toThrift(), mutation.toThrift(),
-          TDurability.DEFAULT);
+      client.update(Tracer.traceInfo(), context.rpcCreds(), new KeyExtent(new Table.ID("!!"), null, new Text("row_0003750000")).toThrift(),
+          mutation.toThrift(), TDurability.DEFAULT);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -38,6 +38,7 @@ import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -67,7 +68,7 @@ public class FunctionalTestUtils {
 
   public static int countRFiles(Connector c, String tableName) throws Exception {
     Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    String tableId = c.tableOperations().tableIdMap().get(tableName);
+    Table.ID tableId = new Table.ID(c.tableOperations().tableIdMap().get(tableName));
     scanner.setRange(MetadataSchema.TabletsSection.getRange(tableId));
     scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.impl.KeyExtent;
@@ -91,7 +92,7 @@ public class MasterAssignmentIT extends AccumuloClusterHarness {
   private TabletLocationState getTabletLocationState(Connector c, String tableId) throws FileNotFoundException, ConfigurationException {
     Credentials creds = new Credentials(getAdminPrincipal(), getAdminToken());
     ClientContext context = new ClientContext(c.getInstance(), creds, getCluster().getClientConfig());
-    MetaDataTableScanner s = new MetaDataTableScanner(context, new Range(KeyExtent.getMetadataEntry(tableId, null)));
+    MetaDataTableScanner s = new MetaDataTableScanner(context, new Range(KeyExtent.getMetadataEntry(new Table.ID(tableId), null)));
     TabletLocationState tlState = s.next();
     s.close();
     return tlState;

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TimeType;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -218,7 +219,7 @@ public class MergeIT extends AccumuloClusterHarness {
     protected void resetScanner() {
       try {
         Scanner ds = conn.createScanner(metadataTableName, Authorizations.EMPTY);
-        Text tablet = new KeyExtent("0", new Text("m"), null).getMetadataEntry();
+        Text tablet = new KeyExtent(new Table.ID("0"), new Text("m"), null).getMetadataEntry();
         ds.setRange(new Range(tablet, true, tablet, true));
 
         Mutation m = new Mutation(tablet);
@@ -249,11 +250,11 @@ public class MergeIT extends AccumuloClusterHarness {
     String metadataTableName = getUniqueNames(1)[0];
     getConnector().tableOperations().create(metadataTableName);
 
-    KeyExtent ke1 = new KeyExtent("0", new Text("m"), null);
+    KeyExtent ke1 = new KeyExtent(new Table.ID("0"), new Text("m"), null);
     Mutation mut1 = ke1.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut1, new Value("/d1".getBytes()));
 
-    KeyExtent ke2 = new KeyExtent("0", null, null);
+    KeyExtent ke2 = new KeyExtent(new Table.ID("0"), null, null);
     Mutation mut2 = ke2.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut2, new Value("/d2".getBytes()));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
@@ -165,7 +165,8 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
   private Table<String,String,MutableInt> getCounts(Connector conn, String tablename) throws TableNotFoundException {
     Scanner s = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     s.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
-    String tableId = conn.tableOperations().tableIdMap().get(tablename);
+    org.apache.accumulo.core.client.impl.Table.ID tableId = new org.apache.accumulo.core.client.impl.Table.ID(conn.tableOperations().tableIdMap()
+        .get(tablename));
     s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
 
     Table<String,String,MutableInt> groupLocationCounts = HashBasedTable.create();
@@ -175,7 +176,7 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
       if (group.endsWith("<")) {
         group = "03";
       } else {
-        group = group.substring(tableId.length() + 1).substring(0, 2);
+        group = group.substring(tableId.canonicalID().length() + 1).substring(0, 2);
       }
       String loc = new TServerInstance(entry.getValue(), entry.getKey().getColumnQualifier()).toString();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
@@ -147,7 +148,7 @@ public class SplitIT extends AccumuloClusterHarness {
     while (c.tableOperations().listSplits(table).size() < 10) {
       sleepUninterruptibly(15, TimeUnit.SECONDS);
     }
-    String id = c.tableOperations().tableIdMap().get(table);
+    Table.ID id = new Table.ID(c.tableOperations().tableIdMap().get(table));
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     KeyExtent extent = new KeyExtent(id, null, null);
     s.setRange(extent.toMetadataRange());

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.impl.ScannerImpl;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Writer;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -77,7 +78,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   private KeyExtent nke(String table, String endRow, String prevEndRow) {
-    return new KeyExtent(table, endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(new Table.ID(table), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   private void run() throws Exception {
@@ -166,8 +167,8 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     SortedMap<FileRef,DataFileValue> highDatafileSizes = new TreeMap<>();
     List<FileRef> highDatafilesToRemove = new ArrayList<>();
 
-    MetadataTableUtil.splitDatafiles(extent.getTableId(), midRow, splitRatio, new HashMap<FileRef,FileUtil.FileInfo>(), mapFiles, lowDatafileSizes,
-        highDatafileSizes, highDatafilesToRemove);
+    MetadataTableUtil.splitDatafiles(midRow, splitRatio, new HashMap<FileRef,FileUtil.FileInfo>(), mapFiles, lowDatafileSizes, highDatafileSizes,
+        highDatafilesToRemove);
 
     MetadataTableUtil.splitTablet(high, extent.getPrevEndRow(), splitRatio, context, zl);
     TServerInstance instance = new TServerInstance(location, zl.getSessionId());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -213,7 +214,7 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
 
     try {
 
-      String tableId = Tables.getTableId(instance, tableName);
+      Table.ID tableId = Tables.getTableId(instance, tableName);
 
       log.trace("tid: {}", tableId);
 
@@ -248,7 +249,7 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
    */
   private TableState getTableState(String tableName) throws TableNotFoundException {
 
-    String tableId = Tables.getTableId(connector.getInstance(), tableName);
+    Table.ID tableId = Tables.getTableId(connector.getInstance(), tableName);
 
     TableState tstate = Tables.getTableState(connector.getInstance(), tableId);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -85,7 +86,7 @@ public class TableIT extends AccumuloClusterHarness {
     to.flush(tableName, null, null, true);
     vopts.setTableName(tableName);
     VerifyIngest.verifyIngest(c, vopts, new ScannerOpts());
-    String id = to.tableIdMap().get(tableName);
+    Table.ID id = new Table.ID(to.tableIdMap().get(tableName));
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     s.setRange(new KeyExtent(id, null, null).toMetadataRange());
     s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -141,7 +141,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
     Map<KeyExtent,List<String>> markers = getRecoveryMarkers(c);
     // log.debug("markers " + markers);
     assertEquals("one tablet should have markers", 1, markers.keySet().size());
-    assertEquals("tableId of the keyExtent should be 1", "1", markers.keySet().iterator().next().getTableId());
+    assertEquals("tableId of the keyExtent should be 1", "1", markers.keySet().iterator().next().getTableId().canonicalID());
 
     // put some data in the WAL
     assertEquals(0, cluster.exec(SetGoalState.class, "NORMAL").waitFor());

--- a/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
@@ -168,7 +169,7 @@ public class CloseWriteAheadLogReferencesIT extends ConfigurableMacBase {
     Set<String> wals = Collections.singleton(file);
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
     Mutation m = new Mutation(file);
-    StatusSection.add(m, "1", ProtobufUtil.toValue(StatusUtil.ingestedUntil(1000)));
+    StatusSection.add(m, new Table.ID("1"), ProtobufUtil.toValue(StatusUtil.ingestedUntil(1000)));
     bw.addMutation(m);
     bw.close();
 

--- a/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -65,8 +66,8 @@ public class MergeStateIT extends ConfigurableMacBase {
     }
 
     @Override
-    public Set<String> onlineTables() {
-      return Collections.singleton("t");
+    public Set<Table.ID> onlineTables() {
+      return Collections.singleton(new Table.ID("t"));
     }
 
     @Override
@@ -113,7 +114,7 @@ public class MergeStateIT extends ConfigurableMacBase {
     // Create a fake METADATA table with these splits
     String splits[] = {"a", "e", "j", "o", "t", "z"};
     // create metadata for a table "t" with the splits above
-    String tableId = "t";
+    Table.ID tableId = new Table.ID("t");
     Text pr = null;
     for (String s : splits) {
       Text split = new Text(s);

--- a/test/src/main/java/org/apache/accumulo/test/master/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/SuspendedTabletsIT.java
@@ -317,7 +317,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
         while (scanner.hasNext()) {
           TabletLocationState tls = scanner.next();
 
-          if (!tls.extent.getTableId().equals(tableId)) {
+          if (!tls.extent.getTableId().canonicalID().equals(tableId)) {
             continue;
           }
           locationStates.put(tls.extent, tls);

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -77,7 +78,7 @@ public class MetadataBatchScanTest {
       splits.add((r.nextLong() & 0x7fffffffffffffffl) % 1000000000000l);
     }
 
-    String tid = "8";
+    Table.ID tid = new Table.ID("8");
     Text per = null;
 
     ArrayList<KeyExtent> extents = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.impl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
@@ -294,7 +295,7 @@ public class NullTserver {
 
     HostAndPort addr = HostAndPort.fromParts(InetAddress.getLocalHost().getHostName(), opts.port);
 
-    String tableId = Tables.getTableId(zki, opts.tableName);
+    Table.ID tableId = Tables.getTableId(zki, opts.tableName);
 
     // read the locations for the table
     Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();

--- a/test/src/main/java/org/apache/accumulo/test/replication/FinishedWorkUpdaterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/FinishedWorkUpdaterIT.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -66,7 +67,7 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
 
     String file = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(100).setEnd(200).setClosed(true).setInfiniteEnd(false).build();
-    ReplicationTarget target = new ReplicationTarget("peer", "table1", "1");
+    ReplicationTarget target = new ReplicationTarget("peer", "table1", new Table.ID("1"));
 
     // Create a single work record for a file to some peer
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
@@ -83,7 +84,7 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Entry<Key,Value> entry = Iterables.getOnlyElement(s);
 
     Assert.assertEquals(entry.getKey().getColumnFamily(), StatusSection.NAME);
-    Assert.assertEquals(entry.getKey().getColumnQualifier().toString(), target.getSourceTableId());
+    Assert.assertEquals(entry.getKey().getColumnQualifier().toString(), target.getSourceTableId().canonicalID());
 
     // We should only rely on the correct begin attribute being returned
     Status actual = Status.parseFrom(entry.getValue().get());
@@ -101,9 +102,9 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Status stat1 = Status.newBuilder().setBegin(100).setEnd(1000).setClosed(true).setInfiniteEnd(false).build(),
         stat2 = Status.newBuilder().setBegin(500).setEnd(1000).setClosed(true).setInfiniteEnd(false).build(),
         stat3 = Status.newBuilder().setBegin(1).setEnd(1000).setClosed(true).setInfiniteEnd(false).build();
-    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", "1"),
-        target2 = new ReplicationTarget("peer2", "table2", "1"),
-        target3 = new ReplicationTarget("peer3", "table3", "1");
+    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", new Table.ID("1")),
+        target2 = new ReplicationTarget("peer2", "table2", new Table.ID("1")),
+        target3 = new ReplicationTarget("peer3", "table3", new Table.ID("1"));
     // @formatter:on
 
     // Create a single work record for a file to some peer
@@ -123,7 +124,7 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Entry<Key,Value> entry = Iterables.getOnlyElement(s);
 
     Assert.assertEquals(entry.getKey().getColumnFamily(), StatusSection.NAME);
-    Assert.assertEquals(entry.getKey().getColumnQualifier().toString(), target1.getSourceTableId());
+    Assert.assertEquals(entry.getKey().getColumnQualifier().toString(), target1.getSourceTableId().canonicalID());
 
     // We should only rely on the correct begin attribute being returned
     Status actual = Status.parseFrom(entry.getValue().get());
@@ -141,9 +142,9 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Status stat1 = Status.newBuilder().setBegin(100).setEnd(1000).setClosed(true).setInfiniteEnd(true).build(),
         stat2 = Status.newBuilder().setBegin(1).setEnd(1000).setClosed(true).setInfiniteEnd(true).build(),
         stat3 = Status.newBuilder().setBegin(500).setEnd(1000).setClosed(true).setInfiniteEnd(true).build();
-    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", "1"),
-        target2 = new ReplicationTarget("peer2", "table2", "1"),
-        target3 = new ReplicationTarget("peer3", "table3", "1");
+    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", new Table.ID("1")),
+        target2 = new ReplicationTarget("peer2", "table2", new Table.ID("1")),
+        target3 = new ReplicationTarget("peer3", "table3", new Table.ID("1"));
     // @formatter:on
 
     // Create a single work record for a file to some peer
@@ -163,7 +164,7 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Entry<Key,Value> entry = Iterables.getOnlyElement(s);
 
     Assert.assertEquals(entry.getKey().getColumnFamily(), StatusSection.NAME);
-    Assert.assertEquals(entry.getKey().getColumnQualifier().toString(), target1.getSourceTableId());
+    Assert.assertEquals(entry.getKey().getColumnQualifier().toString(), target1.getSourceTableId().canonicalID());
 
     // We should only rely on the correct begin attribute being returned
     Status actual = Status.parseFrom(entry.getValue().get());

--- a/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.ClientExecReturn;
 import org.apache.accumulo.core.client.impl.Credentials;
 import org.apache.accumulo.core.client.impl.MasterClient;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -123,7 +124,7 @@ public class GarbageCollectorCommunicatesWithTServersIT extends ConfigurableMacB
    */
   private Set<String> getFilesForTable(String tableName) throws Exception {
     final Connector conn = getConnector();
-    final String tableId = conn.tableOperations().tableIdMap().get(tableName);
+    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
 
     Assert.assertNotNull("Could not determine table ID for " + tableName, tableId);
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -101,7 +102,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
     long createTime = System.currentTimeMillis();
     try {
       Mutation m = new Mutation("file:/accumulo/wal/HW10447.local+56808/93cdc17e-7521-44fa-87b5-37f45bcb92d3");
-      StatusSection.add(m, "1", StatusUtil.fileCreatedValue(createTime));
+      StatusSection.add(m, new Table.ID("1"), StatusUtil.fileCreatedValue(createTime));
       bw.addMutation(m);
     } finally {
       bw.close();
@@ -114,7 +115,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
     bw = ReplicationTable.getBatchWriter(conn);
     try {
       Mutation m = new Mutation("file:/accumulo/wal/HW10447.local+56808/93cdc17e-7521-44fa-87b5-37f45bcb92d3");
-      StatusSection.add(m, "1", ProtobufUtil.toValue(StatusUtil.replicated(Long.MAX_VALUE)));
+      StatusSection.add(m, new Table.ID("1"), ProtobufUtil.toValue(StatusUtil.replicated(Long.MAX_VALUE)));
       bw.addMutation(m);
     } finally {
       bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/replication/StatusMakerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/StatusMakerIT.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -101,10 +102,10 @@ public class StatusMakerIT extends ConfigurableMacBase {
     Text file = new Text();
     for (Entry<Key,Value> entry : s) {
       StatusSection.getFile(entry.getKey(), file);
-      String tableId = StatusSection.getTableId(entry.getKey());
+      Table.ID tableId = StatusSection.getTableId(entry.getKey());
 
       Assert.assertTrue("Found unexpected file: " + file, files.contains(file.toString()));
-      Assert.assertEquals(fileToTableId.get(file.toString()), new Integer(tableId));
+      Assert.assertEquals(fileToTableId.get(file.toString()), new Integer(tableId.canonicalID()));
       timeCreated = fileToTimeCreated.get(file.toString());
       Assert.assertNotNull(timeCreated);
       Assert.assertEquals(StatusUtil.fileCreated(timeCreated), Status.parseFrom(entry.getValue().get()));

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationSchema.OrderSection;
@@ -118,7 +119,8 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void createWorkForFilesNeedingIt() throws Exception {
-    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", "1"), target2 = new ReplicationTarget("cluster1", "table2", "2");
+    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", new Table.ID("1")), target2 = new ReplicationTarget("cluster1", "table2",
+        new Table.ID("2"));
     Text serializedTarget1 = target1.toText(), serializedTarget2 = target2.toText();
     String keyTarget1 = target1.getPeerName() + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target1.getRemoteIdentifier()
         + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target1.getSourceTableId(), keyTarget2 = target2.getPeerName()
@@ -174,7 +176,8 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void doNotCreateWorkForFilesNotNeedingIt() throws Exception {
-    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", "1"), target2 = new ReplicationTarget("cluster1", "table2", "2");
+    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", new Table.ID("1")), target2 = new ReplicationTarget("cluster1", "table2",
+        new Table.ID("2"));
     Text serializedTarget1 = target1.toText(), serializedTarget2 = target2.toText();
 
     // Create two mutations, both of which need replication work done
@@ -210,7 +213,7 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
     assigner.setQueuedWork(queuedWork);
 
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", "1");
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
     String serializedTarget = target.getPeerName() + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target.getRemoteIdentifier()
         + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target.getSourceTableId();
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/WorkMakerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/WorkMakerIT.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -62,7 +63,7 @@ public class WorkMakerIT extends ConfigurableMacBase {
     }
 
     @Override
-    public void addWorkRecord(Text file, Value v, Map<String,String> targets, String sourceTableId) {
+    public void addWorkRecord(Text file, Value v, Map<String,String> targets, Table.ID sourceTableId) {
       super.addWorkRecord(file, v, targets, sourceTableId);
     }
 
@@ -85,13 +86,13 @@ public class WorkMakerIT extends ConfigurableMacBase {
   public void singleUnitSingleTarget() throws Exception {
     String table = testName.getMethodName();
     conn.tableOperations().create(table);
-    String tableId = conn.tableOperations().tableIdMap().get(table);
+    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table));
     String file = "hdfs://localhost:8020/accumulo/wal/123456-1234-1234-12345678";
 
     // Create a status record for a file
     long timeCreated = System.currentTimeMillis();
     Mutation m = new Mutation(new Path(file).toString());
-    m.put(StatusSection.NAME, new Text(tableId), StatusUtil.fileCreatedValue(timeCreated));
+    m.put(StatusSection.NAME, new Text(tableId.getUtf8()), StatusUtil.fileCreatedValue(timeCreated));
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
     bw.addMutation(m);
     bw.flush();
@@ -127,12 +128,12 @@ public class WorkMakerIT extends ConfigurableMacBase {
     String table = testName.getMethodName();
     conn.tableOperations().create(table);
 
-    String tableId = conn.tableOperations().tableIdMap().get(table);
+    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table));
 
     String file = "hdfs://localhost:8020/accumulo/wal/123456-1234-1234-12345678";
 
     Mutation m = new Mutation(new Path(file).toString());
-    m.put(StatusSection.NAME, new Text(tableId), StatusUtil.fileCreatedValue(System.currentTimeMillis()));
+    m.put(StatusSection.NAME, new Text(tableId.getUtf8()), StatusUtil.fileCreatedValue(System.currentTimeMillis()));
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
     bw.addMutation(m);
     bw.flush();


### PR DESCRIPTION
* Replaced all occurrences of tableId and namespaceId Strings
  that aren't a part of the user facing API with type safe
  Table.ID and Namespace.ID objects.
* Table.ID and Namespace.ID both extend the abstract class AbstractId
* Created new methods in Tables and Namespaces for internal
  use of these type safe objects.

NOTES:
Utils.getNextTableId was used for both table ID and namespace so I used generics and reflection.
WriteExportFiles.exportTable() got dinged by FindBugs for not closing the OutputStreamWriter

Some questions/concerns:
RenameTable & Utils passes around a String tableID and long tid - is this “tid” the actual numeric tableID?
TableDiskUsage has internal and external IDs?  I didn't touch this class.
SequentialWorkAssigner & ReplicationTarget - peerName and tableID are both used as keys in the same map but peerName seems like a tableName in tests
TabletStateChangeIterator.onlineTables - set of Strings parsed from “tables” iterator options… looks like table names but calls: onlineTables.contains(tls.extent.getTableId())

