### PR TITLE
ACCUMULO-4655 Added a Response Time column to the monitor

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/master/thrift/TabletServerStatus.java
+++ b/core/src/main/java/org/apache/accumulo/core/master/thrift/TabletServerStatus.java
@@ -42,6 +42,7 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
   private static final org.apache.thrift.protocol.TField SYNCS_FIELD_DESC = new org.apache.thrift.protocol.TField("syncs", org.apache.thrift.protocol.TType.I64, (short)16);
   private static final org.apache.thrift.protocol.TField BULK_IMPORTS_FIELD_DESC = new org.apache.thrift.protocol.TField("bulkImports", org.apache.thrift.protocol.TType.LIST, (short)17);
   private static final org.apache.thrift.protocol.TField VERSION_FIELD_DESC = new org.apache.thrift.protocol.TField("version", org.apache.thrift.protocol.TType.STRING, (short)18);
+  private static final org.apache.thrift.protocol.TField RESPONSE_TIME_FIELD_DESC = new org.apache.thrift.protocol.TField("responseTime", org.apache.thrift.protocol.TType.I64, (short)19);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TabletServerStatusStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TabletServerStatusTupleSchemeFactory();
@@ -61,6 +62,7 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
   public long syncs; // required
   public java.util.List<BulkImportStatus> bulkImports; // required
   public java.lang.String version; // required
+  public long responseTime; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -78,7 +80,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     FLUSHS((short)15, "flushs"),
     SYNCS((short)16, "syncs"),
     BULK_IMPORTS((short)17, "bulkImports"),
-    VERSION((short)18, "version");
+    VERSION((short)18, "version"),
+    RESPONSE_TIME((short)19, "responseTime");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -123,6 +126,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
           return BULK_IMPORTS;
         case 18: // VERSION
           return VERSION;
+        case 19: // RESPONSE_TIME
+          return RESPONSE_TIME;
         default:
           return null;
       }
@@ -173,6 +178,7 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
   private static final int __DATACACHEREQUEST_ISSET_ID = 7;
   private static final int __FLUSHS_ISSET_ID = 8;
   private static final int __SYNCS_ISSET_ID = 9;
+  private static final int __RESPONSETIME_ISSET_ID = 10;
   private short __isset_bitfield = 0;
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
@@ -211,6 +217,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
             new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, BulkImportStatus.class))));
     tmpMap.put(_Fields.VERSION, new org.apache.thrift.meta_data.FieldMetaData("version", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.RESPONSE_TIME, new org.apache.thrift.meta_data.FieldMetaData("responseTime", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TabletServerStatus.class, metaDataMap);
   }
@@ -233,7 +241,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     long flushs,
     long syncs,
     java.util.List<BulkImportStatus> bulkImports,
-    java.lang.String version)
+    java.lang.String version,
+    long responseTime)
   {
     this();
     this.tableMap = tableMap;
@@ -261,6 +270,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     setSyncsIsSet(true);
     this.bulkImports = bulkImports;
     this.version = version;
+    this.responseTime = responseTime;
+    setResponseTimeIsSet(true);
   }
 
   /**
@@ -313,6 +324,7 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     if (other.isSetVersion()) {
       this.version = other.version;
     }
+    this.responseTime = other.responseTime;
   }
 
   public TabletServerStatus deepCopy() {
@@ -346,6 +358,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     this.syncs = 0;
     this.bulkImports = null;
     this.version = null;
+    setResponseTimeIsSet(false);
+    this.responseTime = 0;
   }
 
   public int getTableMapSize() {
@@ -739,6 +753,29 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     }
   }
 
+  public long getResponseTime() {
+    return this.responseTime;
+  }
+
+  public TabletServerStatus setResponseTime(long responseTime) {
+    this.responseTime = responseTime;
+    setResponseTimeIsSet(true);
+    return this;
+  }
+
+  public void unsetResponseTime() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __RESPONSETIME_ISSET_ID);
+  }
+
+  /** Returns true if field responseTime is set (has been assigned a value) and false otherwise */
+  public boolean isSetResponseTime() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __RESPONSETIME_ISSET_ID);
+  }
+
+  public void setResponseTimeIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __RESPONSETIME_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, java.lang.Object value) {
     switch (field) {
     case TABLE_MAP:
@@ -861,6 +898,14 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
       }
       break;
 
+    case RESPONSE_TIME:
+      if (value == null) {
+        unsetResponseTime();
+      } else {
+        setResponseTime((java.lang.Long)value);
+      }
+      break;
+
     }
   }
 
@@ -911,6 +956,9 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     case VERSION:
       return getVersion();
 
+    case RESPONSE_TIME:
+      return getResponseTime();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -952,6 +1000,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
       return isSetBulkImports();
     case VERSION:
       return isSetVersion();
+    case RESPONSE_TIME:
+      return isSetResponseTime();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -1106,6 +1156,15 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
         return false;
     }
 
+    boolean this_present_responseTime = true;
+    boolean that_present_responseTime = true;
+    if (this_present_responseTime || that_present_responseTime) {
+      if (!(this_present_responseTime && that_present_responseTime))
+        return false;
+      if (this.responseTime != that.responseTime)
+        return false;
+    }
+
     return true;
   }
 
@@ -1152,6 +1211,8 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     hashCode = hashCode * 8191 + ((isSetVersion()) ? 131071 : 524287);
     if (isSetVersion())
       hashCode = hashCode * 8191 + version.hashCode();
+
+    hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(responseTime);
 
     return hashCode;
   }
@@ -1314,6 +1375,16 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.valueOf(isSetResponseTime()).compareTo(other.isSetResponseTime());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetResponseTime()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.responseTime, other.responseTime);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1412,6 +1483,10 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
     } else {
       sb.append(this.version);
     }
+    first = false;
+    if (!first) sb.append(", ");
+    sb.append("responseTime:");
+    sb.append(this.responseTime);
     first = false;
     sb.append(")");
     return sb.toString();
@@ -1613,6 +1688,14 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 19: // RESPONSE_TIME
+            if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
+              struct.responseTime = iprot.readI64();
+              struct.setResponseTimeIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1705,6 +1788,9 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
         oprot.writeString(struct.version);
         oprot.writeFieldEnd();
       }
+      oprot.writeFieldBegin(RESPONSE_TIME_FIELD_DESC);
+      oprot.writeI64(struct.responseTime);
+      oprot.writeFieldEnd();
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1768,7 +1854,10 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
       if (struct.isSetVersion()) {
         optionals.set(14);
       }
-      oprot.writeBitSet(optionals, 15);
+      if (struct.isSetResponseTime()) {
+        optionals.set(15);
+      }
+      oprot.writeBitSet(optionals, 16);
       if (struct.isSetTableMap()) {
         {
           oprot.writeI32(struct.tableMap.size());
@@ -1833,12 +1922,15 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
       if (struct.isSetVersion()) {
         oprot.writeString(struct.version);
       }
+      if (struct.isSetResponseTime()) {
+        oprot.writeI64(struct.responseTime);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, TabletServerStatus struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(15);
+      java.util.BitSet incoming = iprot.readBitSet(16);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TMap _map16 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
@@ -1930,6 +2022,10 @@ public class TabletServerStatus implements org.apache.thrift.TBase<TabletServerS
       if (incoming.get(14)) {
         struct.version = iprot.readString();
         struct.setVersionIsSet(true);
+      }
+      if (incoming.get(15)) {
+        struct.responseTime = iprot.readI64();
+        struct.setResponseTimeIsSet(true);
       }
     }
   }

--- a/core/src/main/thrift/master.thrift
+++ b/core/src/main/thrift/master.thrift
@@ -86,6 +86,7 @@ struct TabletServerStatus {
   16:i64 syncs
   17:list<BulkImportStatus> bulkImports
   18:string version
+  19:i64 responseTime
 }
 
 enum MasterState {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
@@ -121,11 +121,17 @@ public class LiveTServerSet implements Watcher {
       if (usePooledConnection == true)
         throw new UnsupportedOperationException();
 
+      long start = System.currentTimeMillis();
+
       TTransport transport = ThriftUtil.createTransport(address, context);
 
       try {
         TabletClientService.Client client = ThriftUtil.createClient(new TabletClientService.Client.Factory(), transport);
-        return client.getTabletServerStatus(Tracer.traceInfo(), context.rpcCreds());
+        TabletServerStatus status = client.getTabletServerStatus(Tracer.traceInfo(), context.rpcCreds());
+        if (status != null) {
+          status.setResponseTime(System.currentTimeMillis() - start);
+        }
+        return status;
       } finally {
         if (transport != null)
           transport.close();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
@@ -45,6 +45,7 @@ public class TabletServerInformation {
 
   public String hostname;
   public long lastContact;
+  public long responseTime;
   public double osload;
 
   public CompactionsTypes compactions;
@@ -109,6 +110,7 @@ public class TabletServerInformation {
     this.server = this.ip = this.hostname = thriftStatus.name;
     this.tablets = summary.tablets;
     this.lastContact = now - thriftStatus.lastContact;
+    this.responseTime = thriftStatus.responseTime;
     this.entries = summary.recs;
     this.ingest = summary.ingestRate;
     this.query = summary.queryRate;

--- a/server/monitor/src/main/resources/resources/js/global.js
+++ b/server/monitor/src/main/resources/resources/js/global.js
@@ -27,6 +27,7 @@ var descriptions = {
       ' memory and not yet written to disk.',
   'Ingest' : 'The number of Key/Value pairs inserted. (Note that deletes' +
       ' are "inserted")',
+  'Response Time' : 'The time it took for the tserver to return its status.',
   'Entries Read' : 'The number of Key/Value pairs read on the server side.' +
       'Not all key values read may be returned to client because of filtering.',
   'Entries Returned' : 'The number of Key/Value pairs returned to clients' +

--- a/server/monitor/src/main/resources/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/resources/js/tservers.js
@@ -205,6 +205,9 @@ function refreshTServersTable() {
       items.push(createRightCell(val.lastContact,
           timeDuration(val.lastContact)));
 
+      items.push(createRightCell(val.responseTime,
+          timeDuration(val.responseTime)));
+
       items.push(createRightCell(val.entries,
           bigNumberForQuantity(val.entries)));
 
@@ -290,7 +293,7 @@ function createHeader() {
   var items = [];
 
   var columns = ['Server&nbsp;', 'Hosted&nbsp;Tablets&nbsp;',
-      'Last&nbsp;Contact&nbsp;', 'Entries&nbsp;', 'Ingest&nbsp;',
+      'Last&nbsp;Contact&nbsp;', 'Response&nbsp;Time&nbsp;', 'Entries&nbsp;', 'Ingest&nbsp;',
       'Query&nbsp;', 'Hold&nbsp;Time&nbsp;', 'Running<br>Scans&nbsp;',
       'Minor<br>Compactions&nbsp;', 'Major<br>Compactions&nbsp;',
       'Index Cache<br>Hit Rate&nbsp;', 'Data Cache<br>Hit Rate&nbsp;',

--- a/server/monitor/src/main/resources/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/resources/js/tservers.js
@@ -299,7 +299,7 @@ function createHeader() {
       'Index Cache<br>Hit Rate&nbsp;', 'Data Cache<br>Hit Rate&nbsp;',
       'OS&nbsp;Load&nbsp;'];
 
-  var titles = ['', '', '', descriptions['Entries'], descriptions['Ingest'],
+  var titles = ['', '', '', descriptions['Response Time'], descriptions['Entries'], descriptions['Ingest'],
       descriptions['Query'], descriptions['Hold Time'],
       descriptions['Running Scans'], descriptions['Minor Compactions'],
       descriptions['Major Compactions'], descriptions['Index Cache Hit Rate'],

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2978,6 +2978,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
   }
 
   public TabletServerStatus getStats(Map<Table.ID,MapCounter<ScanRunState>> scanCounts) {
+    long start = System.currentTimeMillis();
     TabletServerStatus result = new TabletServerStatus();
 
     Map<KeyExtent,Tablet> onlineTabletsCopy;
@@ -3066,6 +3067,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     result.bulkImports.addAll(clientHandler.getBulkLoadStatus());
     result.bulkImports.addAll(bulkImportStatus.getBulkLoadStatus());
     result.version = getVersion();
+    result.responseTime = System.currentTimeMillis() - start;
     return result;
   }
 


### PR DESCRIPTION
Added a Response Time column to the monitor which shows how long it took to get status from that tserver.
This is useful in determining whether long Last Contact times are dues to one or more tservers or whether
this is due to churn in the master.