### PR TITLE
Added version to the REST API

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
@@ -46,6 +46,7 @@ public class TabletServerInformation {
   public String hostname;
   public long lastContact;
   public double osload;
+  public String version;
 
   public CompactionsTypes compactions;
 
@@ -135,6 +136,7 @@ public class TabletServerInformation {
     this.compactions = new CompactionsTypes(scansCompacting, major, minor);
 
     this.osload = thriftStatus.osLoad;
+    this.version = thriftStatus.version;
     this.lookups = thriftStatus.lookups;
 
     this.dataCacheHits = thriftStatus.dataCacheHits;


### PR DESCRIPTION
Added Tserver Accumulo version to the REST API as discussed in #280. This does not display the version on the Monitor, but it can be seen when making the REST api call. I can add another column to display it if people want it.