### PR TITLE
ACCUMULO-3283 MetadataTableUtil.getTabletEntries creates ColumnFQ twice

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -1050,8 +1050,8 @@ public class MetadataTableUtil {
     }
 
     for (Entry<Key,Value> entry : tabletKeyValues.entrySet()) {
-
-      if (columns != null && !colSet.contains(new ColumnFQ(entry.getKey()))) {
+      ColumnFQ currentKey = new ColumnFQ(entry.getKey());
+      if (columns != null && !colSet.contains(currentKey)) {
         continue;
       }
 
@@ -1063,7 +1063,7 @@ public class MetadataTableUtil {
         tabletEntries.put(row, colVals);
       }
 
-      colVals.put(new ColumnFQ(entry.getKey()), entry.getValue());
+      colVals.put(currentKey, entry.getValue());
     }
 
     return tabletEntries;


### PR DESCRIPTION
Storing the initial object to be reused later in the same code block.