### PR TITLE
ACCUMULO-4392: Expose metrics2 JVM metrics

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsSystemHelper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsSystemHelper.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.server.metrics;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
@@ -31,6 +30,7 @@ import org.apache.hadoop.metrics2.source.JvmMetricsInfo;
 public class MetricsSystemHelper {
 
   private static Map<String,String> serviceNameMap = new HashMap<>();
+  private static String processName = "Unknown";
 
   static {
     serviceNameMap.put("master", "Master");
@@ -41,18 +41,28 @@ public class MetricsSystemHelper {
     serviceNameMap.put("shell", "Shell");
   }
 
+  public static void configure(String application) {
+    String serviceName = application;
+    if (MetricsSystemHelper.serviceNameMap.containsKey(application)) {
+      serviceName = MetricsSystemHelper.serviceNameMap.get(application);
+    }
+
+    // a system property containing 'instance' can be used if more than one TabletServer is started on a host
+    String serviceInstance = "";
+    if (serviceName.equals("TabletServer")) {
+      for (Map.Entry<Object,Object> p : System.getProperties().entrySet()) {
+        if (((String) p.getKey()).contains("instance")) {
+          // get rid of all non-alphanumeric characters and then prefix with a -
+          serviceInstance = "-" + ((String) p.getValue()).replaceAll("[^a-zA-Z0-9]", "");
+          break;
+        }
+      }
+    }
+    MetricsSystemHelper.processName = serviceName + serviceInstance;
+  }
+
   public static String getProcessName() {
-    String serviceName = System.getProperty("app", "Unknown");
-    if (MetricsSystemHelper.serviceNameMap.containsKey(serviceName)) {
-      serviceName = MetricsSystemHelper.serviceNameMap.get(serviceName);
-    }
-    // this system property is used if more than one TabletServer is started on a host
-    String serviceInstance = System.getProperty("accumulo.service.instance", "");
-    if (StringUtils.isNotBlank(serviceInstance)) {
-      // property ends with an underscore because it's used in log filenames
-      serviceInstance = "-" + serviceInstance.replaceAll("_", "");
-    }
-    return serviceName + serviceInstance;
+    return MetricsSystemHelper.processName;
   }
 
   private static class MetricsSystemHolder {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -90,6 +90,7 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.accumulo.server.fs.VolumeUtil;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.server.rpc.RpcWrapper;
 import org.apache.accumulo.server.rpc.ServerAddress;
@@ -150,6 +151,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
     final VolumeManager fs = VolumeManagerImpl.get();
+    MetricsSystemHelper.configure(app);
     Accumulo.init(fs, conf, app);
     Opts opts = new Opts();
     opts.parseArgs(app, args);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -122,6 +122,7 @@ import org.apache.accumulo.server.master.state.TabletState;
 import org.apache.accumulo.server.master.state.ZooStore;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.replication.ZooKeeperInitialization;
 import org.apache.accumulo.server.rpc.RpcWrapper;
 import org.apache.accumulo.server.rpc.ServerAddress;
@@ -1428,6 +1429,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
       String hostname = opts.getAddress();
       ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
       VolumeManager fs = VolumeManagerImpl.get();
+      MetricsSystemHelper.configure(app);
       Accumulo.init(fs, conf, app);
       Master master = new Master(conf, fs, hostname);
       DistributedTrace.enable(hostname, app, conf.getConfiguration());

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -86,6 +86,7 @@ import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.monitor.LogService;
 import org.apache.accumulo.server.problems.ProblemReports;
 import org.apache.accumulo.server.problems.ProblemType;
@@ -434,6 +435,7 @@ public class Monitor {
     context = new AccumuloServerContext(config);
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
+    MetricsSystemHelper.configure(app);
     Accumulo.init(fs, config, app);
     Monitor monitor = new Monitor();
     DistributedTrace.enable(hostname, app, config.getConfiguration());

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -58,6 +58,7 @@ import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.security.SecurityUtil;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
@@ -384,6 +385,7 @@ public class TraceServer implements Watcher {
     Instance instance = HdfsZooInstance.getInstance();
     ServerConfigurationFactory conf = new ServerConfigurationFactory(instance);
     VolumeManager fs = VolumeManagerImpl.get();
+    MetricsSystemHelper.configure(app);
     Accumulo.init(fs, conf, app);
     String hostname = opts.getAddress();
     TraceServer server = new TraceServer(conf, hostname);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -182,6 +182,7 @@ import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.master.tableOps.UserCompactionConfig;
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.problems.ProblemReport;
 import org.apache.accumulo.server.problems.ProblemReports;
 import org.apache.accumulo.server.replication.ZooKeeperInitialization;
@@ -2958,6 +2959,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       String hostname = opts.getAddress();
       ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
       VolumeManager fs = VolumeManagerImpl.get();
+      MetricsSystemHelper.configure(app);
       Accumulo.init(fs, conf, app);
       final TabletServer server = new TabletServer(conf, fs);
       server.config(hostname);


### PR DESCRIPTION
Create process name from system property -Dapp and instance from -Daccumulo.service.instance if applicable

By passing the process name to JVMMetrics, it will add this tag to its MetricsRegistry and this tag will be added to all created metrics, allowing metrics consumers to deconflict JVM metrics from different service instances
