### PR TITLE
ACCUMULO-4693: Add instance-specific ProcessName to Hadoop2 metrics

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/Metrics2ThriftMetrics.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/Metrics2ThriftMetrics.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 
@@ -39,6 +40,7 @@ public class Metrics2ThriftMetrics implements Metrics, MetricsSource, ThriftMetr
     this.name = THRIFT_NAME + ",sub=" + serverName;
     this.desc = "Thrift Server Metrics - " + serverName + " " + threadName;
     this.registry = new MetricsRegistry(Interns.info(name, desc));
+    this.registry.tag(MsInfo.ProcessName, MetricsSystemHelper.getProcessName());
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsSystemHelper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsSystemHelper.java
@@ -16,9 +16,7 @@
  */
 package org.apache.accumulo.server.metrics;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
@@ -29,36 +27,14 @@ import org.apache.hadoop.metrics2.source.JvmMetricsInfo;
  */
 public class MetricsSystemHelper {
 
-  private static Map<String,String> serviceNameMap = new HashMap<>();
   private static String processName = "Unknown";
 
-  static {
-    serviceNameMap.put("master", "Master");
-    serviceNameMap.put("tserver", "TabletServer");
-    serviceNameMap.put("monitor", "Monitor");
-    serviceNameMap.put("gc", "GarbageCollector");
-    serviceNameMap.put("tracer", "Tracer");
-    serviceNameMap.put("shell", "Shell");
-  }
-
-  public static void configure(String application) {
-    String serviceName = application;
-    if (MetricsSystemHelper.serviceNameMap.containsKey(application)) {
-      serviceName = MetricsSystemHelper.serviceNameMap.get(application);
+  public static void configure(String serviceName) {
+    MetricsSystemHelper.processName = serviceName;
+    String serviceInstance = System.getProperty("accumulo.metrics.service.instance", "");
+    if (StringUtils.isNotBlank(serviceInstance)) {
+      MetricsSystemHelper.processName += serviceInstance;
     }
-
-    // a system property containing 'instance' can be used if more than one TabletServer is started on a host
-    String serviceInstance = "";
-    if (serviceName.equals("TabletServer")) {
-      for (Map.Entry<Object,Object> p : System.getProperties().entrySet()) {
-        if (((String) p.getKey()).contains("instance")) {
-          // get rid of all non-alphanumeric characters and then prefix with a -
-          serviceInstance = "-" + ((String) p.getValue()).replaceAll("[^a-zA-Z0-9]", "");
-          break;
-        }
-      }
-    }
-    MetricsSystemHelper.processName = serviceName + serviceInstance;
   }
 
   public static String getProcessName() {

--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsSystemHelper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/MetricsSystemHelper.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.server.metrics;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
@@ -31,6 +30,7 @@ import org.apache.hadoop.metrics2.source.JvmMetricsInfo;
 public class MetricsSystemHelper {
 
   private static Map<String,String> serviceNameMap = new HashMap<>();
+  private static String processName = "Unknown";
 
   static {
     serviceNameMap.put("master", "Master");
@@ -41,18 +41,28 @@ public class MetricsSystemHelper {
     serviceNameMap.put("shell", "Shell");
   }
 
+  public static void configure(String application) {
+    String serviceName = application;
+    if (MetricsSystemHelper.serviceNameMap.containsKey(application)) {
+      serviceName = MetricsSystemHelper.serviceNameMap.get(application);
+    }
+
+    // a system property containing 'instance' can be used if more than one TabletServer is started on a host
+    String serviceInstance = "";
+    if (serviceName.equals("TabletServer")) {
+      for (Map.Entry<Object,Object> p : System.getProperties().entrySet()) {
+        if (((String) p.getKey()).contains("instance")) {
+          // get rid of all non-alphanumeric characters and then prefix with a -
+          serviceInstance = "-" + ((String) p.getValue()).replaceAll("[^a-zA-Z0-9]", "");
+          break;
+        }
+      }
+    }
+    MetricsSystemHelper.processName = serviceName + serviceInstance;
+  }
+
   public static String getProcessName() {
-    String serviceName = System.getProperty("app", "Unknown");
-    if (MetricsSystemHelper.serviceNameMap.containsKey(serviceName)) {
-      serviceName = MetricsSystemHelper.serviceNameMap.get(serviceName);
-    }
-    // this system property is used if more than one TabletServer is started on a host
-    String serviceInstance = System.getProperty("accumulo.service.instance", "");
-    if (StringUtils.isNotBlank(serviceInstance)) {
-      // property ends with an underscore because it's used in log filenames
-      serviceInstance = "-" + serviceInstance.replaceAll("_", "");
-    }
-    return serviceName + serviceInstance;
+    return MetricsSystemHelper.processName;
   }
 
   private static class MetricsSystemHolder {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -151,7 +151,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
     final VolumeManager fs = VolumeManagerImpl.get();
-    MetricsSystemHelper.configure(app);
+    MetricsSystemHelper.configure(SimpleGarbageCollector.class.getSimpleName());
     Accumulo.init(fs, conf, app);
     Opts opts = new Opts();
     opts.parseArgs(app, args);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -90,6 +90,7 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.accumulo.server.fs.VolumeUtil;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.server.rpc.RpcWrapper;
 import org.apache.accumulo.server.rpc.ServerAddress;
@@ -150,6 +151,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
     final VolumeManager fs = VolumeManagerImpl.get();
+    MetricsSystemHelper.configure(app);
     Accumulo.init(fs, conf, app);
     Opts opts = new Opts();
     opts.parseArgs(app, args);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -122,6 +122,7 @@ import org.apache.accumulo.server.master.state.TabletState;
 import org.apache.accumulo.server.master.state.ZooStore;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.replication.ZooKeeperInitialization;
 import org.apache.accumulo.server.rpc.RpcWrapper;
 import org.apache.accumulo.server.rpc.ServerAddress;
@@ -1428,6 +1429,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
       String hostname = opts.getAddress();
       ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
       VolumeManager fs = VolumeManagerImpl.get();
+      MetricsSystemHelper.configure(app);
       Accumulo.init(fs, conf, app);
       Master master = new Master(conf, fs, hostname);
       DistributedTrace.enable(hostname, app, conf.getConfiguration());

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1429,7 +1429,7 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
       String hostname = opts.getAddress();
       ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
       VolumeManager fs = VolumeManagerImpl.get();
-      MetricsSystemHelper.configure(app);
+      MetricsSystemHelper.configure(Master.class.getSimpleName());
       Accumulo.init(fs, conf, app);
       Master master = new Master(conf, fs, hostname);
       DistributedTrace.enable(hostname, app, conf.getConfiguration());

--- a/server/master/src/main/java/org/apache/accumulo/master/metrics/Metrics2ReplicationMetrics.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/metrics/Metrics2ReplicationMetrics.java
@@ -25,11 +25,13 @@ import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.replication.ReplicationUtil;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 
@@ -50,7 +52,8 @@ public class Metrics2ReplicationMetrics implements Metrics, MetricsSource {
     this.master = master;
     this.system = system;
 
-    registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry.tag(MsInfo.ProcessName, MetricsSystemHelper.getProcessName());
     replicationUtil = new ReplicationUtil(master);
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -435,7 +435,7 @@ public class Monitor {
     context = new AccumuloServerContext(config);
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
-    MetricsSystemHelper.configure(app);
+    MetricsSystemHelper.configure(Monitor.class.getSimpleName());
     Accumulo.init(fs, config, app);
     Monitor monitor = new Monitor();
     DistributedTrace.enable(hostname, app, config.getConfiguration());

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -86,6 +86,7 @@ import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.monitor.LogService;
 import org.apache.accumulo.server.problems.ProblemReports;
 import org.apache.accumulo.server.problems.ProblemType;
@@ -434,6 +435,7 @@ public class Monitor {
     context = new AccumuloServerContext(config);
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + instance.getInstanceID());
+    MetricsSystemHelper.configure(app);
     Accumulo.init(fs, config, app);
     Monitor monitor = new Monitor();
     DistributedTrace.enable(hostname, app, config.getConfiguration());

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -58,6 +58,7 @@ import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.security.SecurityUtil;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
@@ -384,6 +385,7 @@ public class TraceServer implements Watcher {
     Instance instance = HdfsZooInstance.getInstance();
     ServerConfigurationFactory conf = new ServerConfigurationFactory(instance);
     VolumeManager fs = VolumeManagerImpl.get();
+    MetricsSystemHelper.configure(app);
     Accumulo.init(fs, conf, app);
     String hostname = opts.getAddress();
     TraceServer server = new TraceServer(conf, hostname);

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -385,7 +385,7 @@ public class TraceServer implements Watcher {
     Instance instance = HdfsZooInstance.getInstance();
     ServerConfigurationFactory conf = new ServerConfigurationFactory(instance);
     VolumeManager fs = VolumeManagerImpl.get();
-    MetricsSystemHelper.configure(app);
+    MetricsSystemHelper.configure(TraceServer.class.getSimpleName());
     Accumulo.init(fs, conf, app);
     String hostname = opts.getAddress();
     TraceServer server = new TraceServer(conf, hostname);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2959,7 +2959,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       String hostname = opts.getAddress();
       ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
       VolumeManager fs = VolumeManagerImpl.get();
-      MetricsSystemHelper.configure(app);
+      MetricsSystemHelper.configure(TabletServer.class.getSimpleName());
       Accumulo.init(fs, conf, app);
       final TabletServer server = new TabletServer(conf, fs);
       server.config(hostname);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -182,6 +182,7 @@ import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.master.tableOps.UserCompactionConfig;
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.server.problems.ProblemReport;
 import org.apache.accumulo.server.problems.ProblemReports;
 import org.apache.accumulo.server.replication.ZooKeeperInitialization;
@@ -2958,6 +2959,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       String hostname = opts.getAddress();
       ServerConfigurationFactory conf = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
       VolumeManager fs = VolumeManagerImpl.get();
+      MetricsSystemHelper.configure(app);
       Accumulo.init(fs, conf, app);
       final TabletServer server = new TabletServer(conf, fs);
       server.config(hostname);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerMetrics.java
@@ -17,11 +17,13 @@
 package org.apache.accumulo.tserver.metrics;
 
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.accumulo.tserver.TabletServer;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
@@ -44,6 +46,7 @@ public class Metrics2TabletServerMetrics implements Metrics, MetricsSource, Tabl
     util = new TabletServerMetricsUtil(tserver);
     this.system = system;
     this.registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry.tag(MsInfo.ProcessName, MetricsSystemHelper.getProcessName());
 
     entries = registry.newGauge(Interns.info(ENTRIES, "Number of entries"), 0l);
     entriesInMemory = registry.newGauge(Interns.info(ENTRIES_IN_MEM, "Number of entries in memory"), 0l);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerMinCMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerMinCMetrics.java
@@ -17,10 +17,9 @@
 package org.apache.accumulo.tserver.metrics;
 
 import org.apache.accumulo.server.metrics.Metrics;
-import org.apache.hadoop.metrics2.MetricsCollector;
-import org.apache.hadoop.metrics2.MetricsRecordBuilder;
-import org.apache.hadoop.metrics2.MetricsSource;
-import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
+import org.apache.hadoop.metrics2.*;
+import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableStat;
@@ -40,6 +39,7 @@ public class Metrics2TabletServerMinCMetrics implements Metrics, MetricsSource, 
   Metrics2TabletServerMinCMetrics(MetricsSystem system) {
     this.system = system;
     this.registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry.tag(MsInfo.ProcessName, MetricsSystemHelper.getProcessName());
 
     activeMinc = registry.newStat(MINC, "Minor compactions", "Ops", "Count", true);
     queuedMinc = registry.newStat(QUEUE, "Queued minor compactions", "Ops", "Count", true);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerMinCMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerMinCMetrics.java
@@ -18,7 +18,10 @@ package org.apache.accumulo.tserver.metrics;
 
 import org.apache.accumulo.server.metrics.Metrics;
 import org.apache.accumulo.server.metrics.MetricsSystemHelper;
-import org.apache.hadoop.metrics2.*;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerScanMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerScanMetrics.java
@@ -17,10 +17,12 @@
 package org.apache.accumulo.tserver.metrics;
 
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableStat;
@@ -39,6 +41,7 @@ public class Metrics2TabletServerScanMetrics implements Metrics, MetricsSource, 
   Metrics2TabletServerScanMetrics(MetricsSystem system) {
     this.system = system;
     this.registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry.tag(MsInfo.ProcessName, MetricsSystemHelper.getProcessName());
 
     scans = registry.newStat(SCAN, "Scans", "Ops", "Count", true);
     resultsPerScan = registry.newStat(RESULT_SIZE, "Results per scan", "Ops", "Count", true);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerUpdateMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/Metrics2TabletServerUpdateMetrics.java
@@ -17,10 +17,12 @@
 package org.apache.accumulo.tserver.metrics;
 
 import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.accumulo.server.metrics.MetricsSystemHelper;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MsInfo;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
@@ -42,6 +44,7 @@ public class Metrics2TabletServerUpdateMetrics implements Metrics, MetricsSource
   Metrics2TabletServerUpdateMetrics(MetricsSystem system) {
     this.system = system;
     this.registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry.tag(MsInfo.ProcessName, MetricsSystemHelper.getProcessName());
 
     permissionErrorsCounter = registry.newCounter(Interns.info(PERMISSION_ERRORS, "Permission Errors"), 0l);
     unknownTabletErrorsCounter = registry.newCounter(Interns.info(UNKNOWN_TABLET_ERRORS, "Unknown Tablet Errors"), 0l);


### PR DESCRIPTION
Create process name from system property -Dapp and instance from -Daccumulo.service.instance if applicable

By adding the ProcessName tag to the MetricsRegistry, this tag will be added to all created metrics,
allowing metrics consumers to deconflict metrics from different service instances