### PR TITLE
ACCUMULO-4681 Created Table & Namespace WeakReference map

### DIFF
--- a/core/src/main/findbugs/exclude-filter.xml
+++ b/core/src/main/findbugs/exclude-filter.xml
@@ -102,4 +102,13 @@
     <Class name="org.apache.accumulo.core.client.impl.ScannerOptionsTest" />
     <Bug code="NP" pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS" />
   </Match>
+  <Match>
+    <!-- These are specifically for testing GC  -->
+    <Or>
+      <Class name="org.apache.accumulo.core.client.impl.TableTest" />
+      <Class name="org.apache.accumulo.core.client.impl.NamespaceTest" />
+    </Or>
+    <Method name="garbageCollect" params="java.lang.Integer" returns="void" />
+    <Bug code="DM" pattern="DM_GC" />
+  </Match>
 </FindBugsFilter>

--- a/core/src/main/findbugs/exclude-filter.xml
+++ b/core/src/main/findbugs/exclude-filter.xml
@@ -102,13 +102,4 @@
     <Class name="org.apache.accumulo.core.client.impl.ScannerOptionsTest" />
     <Bug code="NP" pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS" />
   </Match>
-  <Match>
-    <!-- These are specifically for testing GC  -->
-    <Or>
-      <Class name="org.apache.accumulo.core.client.impl.TableTest" />
-      <Class name="org.apache.accumulo.core.client.impl.NamespaceTest" />
-    </Or>
-    <Method name="garbageCollect" params="java.lang.Integer" returns="void" />
-    <Bug code="DM" pattern="DM_GC" />
-  </Match>
 </FindBugsFilter>

--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -70,7 +70,7 @@ public class MutationsRejectedException extends AccumuloException {
 
     for (Entry<TabletId,Set<SecurityErrorCode>> entry : hashMap.entrySet()) {
       TabletId tabletId = entry.getKey();
-      String tableInfo = Tables.getPrintableTableInfoFromId(instance, new Table.ID(tabletId.getTableId().toString()));
+      String tableInfo = Tables.getPrintableTableInfoFromId(instance, Table.ID.of(tabletId.getTableId().toString()));
 
       if (!result.containsKey(tableInfo)) {
         result.put(tableInfo, new HashSet<SecurityErrorCode>());

--- a/core/src/main/java/org/apache/accumulo/core/client/TableOfflineException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableOfflineException.java
@@ -27,7 +27,7 @@ public class TableOfflineException extends RuntimeException {
     if (tableId == null)
       return " <unknown table> ";
     try {
-      String tableName = Tables.getTableName(instance, new Table.ID(tableId));
+      String tableName = Tables.getTableName(instance, Table.ID.of(tableId));
       return tableName + " (" + tableId + ")";
     } catch (TableNotFoundException e) {
       return " <unknown table> (" + tableId + ")";

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/AbstractId.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/AbstractId.java
@@ -21,10 +21,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-
-import com.google.common.cache.Cache;
 
 /**
  * An abstract identifier class for comparing equality of identifiers of the same type.
@@ -35,7 +31,7 @@ public abstract class AbstractId implements Comparable<AbstractId>, Serializable
   private final String canonical;
   private Integer hashCode = null;
 
-  AbstractId(final String canonical) {
+  protected AbstractId(final String canonical) {
     requireNonNull(canonical, "canonical cannot be null");
     this.canonical = canonical;
   }
@@ -88,27 +84,6 @@ public abstract class AbstractId implements Comparable<AbstractId>, Serializable
   public int compareTo(AbstractId id) {
     requireNonNull(id, "id cannot be null");
     return this.canonicalID().compareTo(id.canonicalID());
-  }
-
-  /**
-   * Method used to obtain ID key from cache and prevent duplicates in the cache.
-   *
-   * @param cache
-   *          existing ID cache
-   * @param canonicalKey
-   *          canonical string cache key
-   * @param newInstanceFunction
-   *          function to call for creating new ID keys when canonicalKey is not present in cache
-   * @param <T>
-   *          type of AbstractID
-   * @return ID pulled from the cache
-   */
-  static <T extends AbstractId> T dedupeId(Cache<String,T> cache, String canonicalKey, Callable<T> newInstanceFunction) {
-    try {
-      return cache.get(canonicalKey, newInstanceFunction);
-    } catch (ExecutionException e) {
-      throw new AssertionError("This should never happen: ID constructor should never return null.");
-    }
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveScanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ActiveScanImpl.java
@@ -60,7 +60,7 @@ public class ActiveScanImpl extends ActiveScan {
     this.user = activeScan.user;
     this.age = activeScan.age;
     this.idle = activeScan.idleTime;
-    this.tableName = Tables.getTableName(instance, new Table.ID(activeScan.tableId));
+    this.tableName = Tables.getTableName(instance, Table.ID.of(activeScan.tableId));
     this.type = ScanType.valueOf(activeScan.getType().name());
     this.state = ScanState.valueOf(activeScan.state.name());
     this.extent = new KeyExtent(activeScan.extent);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
@@ -16,9 +16,6 @@
  */
 package org.apache.accumulo.core.client.impl;
 
-import java.lang.ref.WeakReference;
-import java.util.WeakHashMap;
-
 import org.apache.accumulo.core.client.Instance;
 
 import com.google.common.cache.Cache;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.core.client.impl;
 
+import java.util.concurrent.ExecutionException;
+
 import org.apache.accumulo.core.client.Instance;
 
 import com.google.common.cache.Cache;
@@ -30,8 +32,8 @@ public class Namespace {
    * Object representing an internal Namespace ID. This class was created to help with type safety. For help obtaining the value of a namespace ID from
    * Zookeeper, see {@link Namespaces#getNamespaceId(Instance, String)}
    *
-   * Uses an internal WeakHashMap and private constructor for storing a WeakReference of every Namespace.ID. Therefore, a Namespace.ID can't be instantiated
-   * outside this class and is accessed by calling Namespace.ID.{@link #of(String)}.
+   * Uses an internal cache and private constructor for storing a WeakReference of every Namespace.ID. Therefore, a Namespace.ID can't be instantiated outside
+   * this class and is accessed by calling Namespace.ID.{@link #of(String)}.
    */
   public static class ID extends AbstractId {
     private static final long serialVersionUID = 8931104141709170293L;
@@ -52,7 +54,11 @@ public class Namespace {
      * @return Namespace.ID object
      */
     public static Namespace.ID of(final String canonical) {
-      return dedupeId(cache, canonical, () -> new ID(canonical));
+      try {
+        return cache.get(canonical, () -> new Namespace.ID(canonical));
+      } catch (ExecutionException e) {
+        throw new AssertionError("This should never happen: ID constructor should never return null.");
+      }
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
@@ -21,6 +21,9 @@ import java.util.WeakHashMap;
 
 import org.apache.accumulo.core.client.Instance;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
 public class Namespace {
   public static final String ACCUMULO = "accumulo";
   public static final String DEFAULT = "";
@@ -35,7 +38,7 @@ public class Namespace {
    */
   public static class ID extends AbstractId {
     private static final long serialVersionUID = 8931104141709170293L;
-    static final WeakHashMap<String,WeakReference<Namespace.ID>> namespaceIds = new WeakHashMap<>();
+    static final Cache<String,ID> cache = CacheBuilder.newBuilder().weakValues().build();
 
     public static final ID ACCUMULO = of("+accumulo");
     public static final ID DEFAULT = of("+default");
@@ -52,24 +55,7 @@ public class Namespace {
      * @return Namespace.ID object
      */
     public static Namespace.ID of(final String canonical) {
-      return dedupeNamespaceId(canonical);
-    }
-
-    private static Namespace.ID dedupeNamespaceId(String idString) {
-      synchronized (namespaceIds) {
-        Namespace.ID namespaceId;
-        WeakReference<Namespace.ID> namespaceIdRef = namespaceIds.get(idString);
-        if (namespaceIdRef != null) {
-          namespaceId = namespaceIdRef.get();
-          if (namespaceId != null) {
-            return namespaceId;
-          }
-        }
-
-        namespaceId = new ID(idString);
-        namespaceIds.put(idString, new WeakReference<>(namespaceId));
-        return namespaceId;
-      }
+      return dedupeId(cache, canonical, () -> new ID(canonical));
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Namespace.java
@@ -16,27 +16,61 @@
  */
 package org.apache.accumulo.core.client.impl;
 
+import java.lang.ref.WeakReference;
+import java.util.WeakHashMap;
+
 import org.apache.accumulo.core.client.Instance;
 
 public class Namespace {
-
-  /**
-   * Object representing an internal Namespace ID. This class was created to help with type safety. For help obtaining the value of a namespace ID from
-   * Zookeeper, see {@link Namespaces#getNamespaceId(Instance, String)}
-   */
-  public static class ID extends AbstractId {
-    private static final long serialVersionUID = 8931104141709170293L;
-
-    public static final ID ACCUMULO = new ID("+accumulo");
-    public static final ID DEFAULT = new ID("+default");
-
-    public ID(String canonical) {
-      super(canonical);
-    }
-  }
-
   public static final String ACCUMULO = "accumulo";
   public static final String DEFAULT = "";
   public static final String SEPARATOR = ".";
 
+  /**
+   * Object representing an internal Namespace ID. This class was created to help with type safety. For help obtaining the value of a namespace ID from
+   * Zookeeper, see {@link Namespaces#getNamespaceId(Instance, String)}
+   *
+   * Uses an internal WeakHashMap and private constructor for storing a WeakReference of every Namespace.ID. Therefore, a Namespace.ID can't be instantiated
+   * outside this class and is accessed by calling Namespace.ID.{@link #of(String)}.
+   */
+  public static class ID extends AbstractId {
+    private static final long serialVersionUID = 8931104141709170293L;
+    static final WeakHashMap<String,WeakReference<Namespace.ID>> namespaceIds = new WeakHashMap<>();
+
+    public static final ID ACCUMULO = of("+accumulo");
+    public static final ID DEFAULT = of("+default");
+
+    private ID(String canonical) {
+      super(canonical);
+    }
+
+    /**
+     * Get a Namespace.ID object for the provided canonical string.
+     *
+     * @param canonical
+     *          Namespace ID string
+     * @return Namespace.ID object
+     */
+    public static Namespace.ID of(final String canonical) {
+      return dedupeNamespaceId(canonical);
+    }
+
+    private static Namespace.ID dedupeNamespaceId(String idString) {
+      synchronized (namespaceIds) {
+        Namespace.ID namespaceId;
+        WeakReference<Namespace.ID> namespaceIdRef = namespaceIds.get(idString);
+        if (namespaceIdRef != null) {
+          namespaceId = namespaceIdRef.get();
+          if (namespaceId != null) {
+            return namespaceId;
+          }
+        }
+
+        namespaceId = new ID(idString);
+        namespaceIds.put(idString, new WeakReference<>(namespaceId));
+        return namespaceId;
+      }
+    }
+
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Namespaces.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Namespaces.java
@@ -125,7 +125,7 @@ public class Namespaces {
    */
   public static SortedMap<Namespace.ID,String> getIdToNameMap(Instance instance) {
     SortedMap<Namespace.ID,String> idMap = new TreeMap<>();
-    getAllNamespaces(instance, (id, name) -> idMap.put(new Namespace.ID(id), name));
+    getAllNamespaces(instance, (id, name) -> idMap.put(Namespace.ID.of(id), name));
     return idMap;
   }
 
@@ -134,7 +134,7 @@ public class Namespaces {
    */
   public static SortedMap<String,Namespace.ID> getNameToIdMap(Instance instance) {
     SortedMap<String,Namespace.ID> nameMap = new TreeMap<>();
-    getAllNamespaces(instance, (id, name) -> nameMap.put(name, new Namespace.ID(id)));
+    getAllNamespaces(instance, (id, name) -> nameMap.put(name, Namespace.ID.of(id)));
     return nameMap;
   }
 
@@ -145,7 +145,7 @@ public class Namespaces {
     final ArrayList<Namespace.ID> singleId = new ArrayList<>(1);
     getAllNamespaces(instance, (id, name) -> {
       if (name.equals(namespaceName))
-        singleId.add(new Namespace.ID(id));
+        singleId.add(Namespace.ID.of(id));
     });
     if (singleId.isEmpty())
       throw new NamespaceNotFoundException(null, namespaceName, "getNamespaceId() failed to find namespace");

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -162,7 +162,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       this.range = range.bound(this.options.fetchedColumns.first(), this.options.fetchedColumns.last());
     }
 
-    this.tableId = new Table.ID(table.toString());
+    this.tableId = Table.ID.of(table.toString());
     this.authorizations = authorizations;
     this.readers = new ArrayList<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationOperationsImpl.java
@@ -132,7 +132,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
       }
     }
 
-    return new Table.ID(tableId);
+    return Table.ID.of(tableId);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Table.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Table.java
@@ -16,9 +16,6 @@
  */
 package org.apache.accumulo.core.client.impl;
 
-import java.lang.ref.WeakReference;
-import java.util.WeakHashMap;
-
 import org.apache.accumulo.core.client.Instance;
 
 import com.google.common.cache.Cache;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Table.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Table.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.core.client.impl;
 
+import java.util.concurrent.ExecutionException;
+
 import org.apache.accumulo.core.client.Instance;
 
 import com.google.common.cache.Cache;
@@ -50,7 +52,11 @@ public class Table {
      * @return Table.ID object
      */
     public static ID of(final String canonical) {
-      return dedupeId(cache, canonical, () -> new ID(canonical));
+      try {
+        return cache.get(canonical, () -> new Table.ID(canonical));
+      } catch (ExecutionException e) {
+        throw new AssertionError("This should never happen: ID constructor should never return null.");
+      }
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Tables.java
@@ -228,7 +228,7 @@ public class Tables {
       throw new TableNotFoundException(tableId.canonicalID(), null, null);
     }
 
-    return new Namespace.ID(new String(n, UTF_8));
+    return Namespace.ID.of(new String(n, UTF_8));
   }
 
   /**
@@ -247,7 +247,7 @@ public class Tables {
       if (nId == null) {
         namespaceName = null;
       } else {
-        Namespace.ID namespaceId = new Namespace.ID(new String(nId, UTF_8));
+        Namespace.ID namespaceId = Namespace.ID.of(new String(nId, UTF_8));
         if (!namespaceId.equals(Namespace.ID.DEFAULT)) {
           try {
             namespaceName = namespaceIdToNameMap.get(namespaceId);
@@ -270,13 +270,13 @@ public class Tables {
 
   public static SortedMap<Table.ID,String> getIdToNameMap(Instance instance) {
     SortedMap<Table.ID,String> map = new TreeMap<>();
-    getAllTables(instance, (id, name) -> map.put(new Table.ID(id), name));
+    getAllTables(instance, (id, name) -> map.put(Table.ID.of(id), name));
     return map;
   }
 
   public static SortedMap<String,Table.ID> getNameToIdMap(Instance instance) {
     SortedMap<String,Table.ID> map = new TreeMap<>();
-    getAllTables(instance, (id, name) -> map.put(name, new Table.ID(id)));
+    getAllTables(instance, (id, name) -> map.put(name, Table.ID.of(id)));
     return map;
   }
 
@@ -287,7 +287,7 @@ public class Tables {
     ArrayList<Table.ID> singleId = new ArrayList<>(1);
     getAllTables(instance, (id, name) -> {
       if (name.equals(tableName))
-        singleId.add(new Table.ID(id));
+        singleId.add(Table.ID.of(id));
     });
     if (singleId.isEmpty())
       return null;

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
@@ -544,13 +544,13 @@ public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
 
         try {
           if (isOffline) {
-            scanner = new OfflineScanner(instance, new Credentials(principal, token), new Table.ID(baseSplit.getTableId()), authorizations);
+            scanner = new OfflineScanner(instance, new Credentials(principal, token), Table.ID.of(baseSplit.getTableId()), authorizations);
           } else if (DeprecationUtil.isMockInstance(instance)) {
             scanner = instance.getConnector(principal, token).createScanner(baseSplit.getTableName(), authorizations);
           } else {
             ClientConfiguration clientConf = getClientConfiguration(job);
             ClientContext context = new ClientContext(instance, new Credentials(principal, token), clientConf);
-            scanner = new ScannerImpl(context, new Table.ID(baseSplit.getTableId()), authorizations);
+            scanner = new ScannerImpl(context, Table.ID.of(baseSplit.getTableId()), authorizations);
           }
           if (isIsolated) {
             log.info("Creating isolated scanner");

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
@@ -572,13 +572,13 @@ public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
 
         try {
           if (isOffline) {
-            scanner = new OfflineScanner(instance, new Credentials(principal, token), new Table.ID(split.getTableId()), authorizations);
+            scanner = new OfflineScanner(instance, new Credentials(principal, token), Table.ID.of(split.getTableId()), authorizations);
           } else if (DeprecationUtil.isMockInstance(instance)) {
             scanner = instance.getConnector(principal, token).createScanner(split.getTableName(), authorizations);
           } else {
             ClientConfiguration clientConf = getClientConfiguration(attempt);
             ClientContext context = new ClientContext(instance, new Credentials(principal, token), clientConf);
-            scanner = new ScannerImpl(context, new Table.ID(split.getTableId()), authorizations);
+            scanner = new ScannerImpl(context, Table.ID.of(split.getTableId()), authorizations);
           }
           if (isIsolated) {
             log.info("Creating isolated scanner");

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/impl/MockTabletLocator.java
@@ -57,7 +57,7 @@ public class MockTabletLocator extends TabletLocator {
   @Override
   public List<Range> binRanges(ClientContext context, List<Range> ranges, Map<String,Map<KeyExtent,List<Range>>> binnedRanges) throws AccumuloException,
       AccumuloSecurityException, TableNotFoundException {
-    binnedRanges.put("", Collections.singletonMap(new KeyExtent(null, null, null), ranges));
+    binnedRanges.put("", Collections.singletonMap(new KeyExtent(), ranges));
     return Collections.emptyList();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/impl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/impl/KeyExtent.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -62,7 +63,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   private Text textEndRow;
   private Text textPrevEndRow;
 
-  private final Table.ID EMPTY_ID = Table.ID.of("");
+  private static final Table.ID EMPTY_ID = Table.ID.of("");
 
   private void check() {
 
@@ -152,9 +153,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
    *
    */
   public void setTableId(Table.ID tId) {
-
-    if (tId == null)
-      throw new IllegalArgumentException("null table id not allowed");
+    Objects.requireNonNull(tId, "null table id not allowed");
 
     this.tableId = tId;
 
@@ -248,7 +247,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
       per.readFields(in);
       setPrevEndRow(per, false, true);
     } else {
-      setPrevEndRow((Text) null);
+      setPrevEndRow(null);
     }
 
     hashCode = 0;
@@ -616,7 +615,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
   public static KeyExtent findContainingExtent(KeyExtent extent, SortedSet<KeyExtent> extents) {
 
     KeyExtent lookupExtent = new KeyExtent(extent);
-    lookupExtent.setPrevEndRow((Text) null);
+    lookupExtent.setPrevEndRow(null);
 
     SortedSet<KeyExtent> tailSet = extents.tailSet(lookupExtent);
 
@@ -733,7 +732,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
       return getPrevEndRow() == null;
 
     if (!prevExtent.getTableId().equals(getTableId()))
-      throw new IllegalArgumentException("Cannot compare accross tables " + prevExtent + " " + this);
+      throw new IllegalArgumentException("Cannot compare across tables " + prevExtent + " " + this);
 
     if (prevExtent.getEndRow() == null)
       return false;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataServicer.java
@@ -34,7 +34,7 @@ public abstract class MetadataServicer {
 
   public static MetadataServicer forTableName(ClientContext context, String tableName) throws AccumuloException, AccumuloSecurityException {
     checkArgument(tableName != null, "tableName is null");
-    return forTableId(context, new Table.ID(context.getConnector().tableOperations().tableIdMap().get(tableName)));
+    return forTableId(context, Table.ID.of(context.getConnector().tableOperations().tableIdMap().get(tableName)));
   }
 
   public static MetadataServicer forTableId(ClientContext context, Table.ID tableId) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -262,7 +262,7 @@ public class MetadataSchema {
      */
     public static Table.ID getTableId(Key k) {
       requireNonNull(k);
-      return new Table.ID(k.getColumnQualifier().toString());
+      return Table.ID.of(k.getColumnQualifier().toString());
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationSchema.java
@@ -99,7 +99,7 @@ public class ReplicationSchema {
      */
     public static Table.ID getTableId(Key k) {
       requireNonNull(k);
-      return new Table.ID(k.getColumnQualifier().toString());
+      return Table.ID.of(k.getColumnQualifier().toString());
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTable.java
@@ -46,7 +46,7 @@ import com.google.common.collect.ImmutableMap;
 public class ReplicationTable {
   private static final Logger log = LoggerFactory.getLogger(ReplicationTable.class);
 
-  public static final Table.ID ID = new Table.ID("+rep");
+  public static final Table.ID ID = Table.ID.of("+rep");
   public static final String NAME = Namespace.ACCUMULO + ".replication";
 
   public static final String COMBINER_NAME = "statuscombiner";

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTarget.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTarget.java
@@ -103,7 +103,7 @@ public class ReplicationTarget implements Writable {
       this.remoteIdentifier = WritableUtils.readString(in);
     }
     if (in.readBoolean()) {
-      this.sourceTableId = new Table.ID(WritableUtils.readString(in));
+      this.sourceTableId = Table.ID.of(WritableUtils.readString(in));
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -115,7 +115,7 @@ public class Gatherer {
 
   public Gatherer(ClientContext context, TSummaryRequest request, AccumuloConfiguration tableConfig) {
     this.ctx = context;
-    this.tableId = new Table.ID(request.tableId);
+    this.tableId = Table.ID.of(request.tableId);
     this.startRow = ByteBufferUtil.toText(request.bounds.startRow);
     this.endRow = ByteBufferUtil.toText(request.bounds.endRow);
     this.clipRange = new Range(startRow, false, endRow, true);

--- a/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
@@ -88,7 +88,7 @@ public class ByteBufferUtil {
   }
 
   public static Table.ID toTableId(ByteBuffer bytes) {
-    return new Table.ID(toString(bytes));
+    return Table.ID.of(toString(bytes));
   }
 
   public static ByteBuffer toByteBuffers(ByteSequence bs) {

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/NamespaceTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/NamespaceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests the Namespace ID class, mainly the internal WeakHashMap.
+ */
+public class NamespaceTest {
+
+  @After
+  public void cleanup() {
+    garbageCollect(Namespace.ID.namespaceIds.size());
+  }
+
+  @Test
+  public void testWeakHashMapIncreases() {
+    // ensure initial size contains just the built in Namespace IDs (accumulo, default)
+    assertEquals(2, Namespace.ID.namespaceIds.size());
+
+    String namespaceString = new String("namespace-testWeakHashMapIncreases");
+    Namespace.ID nsId = Namespace.ID.of(namespaceString);
+    assertEquals(3, Namespace.ID.namespaceIds.size());
+    assertEquals(namespaceString, nsId.canonicalID());
+  }
+
+  @Test
+  public void testWeakHashMapNoDuplicates() {
+    String namespaceString = new String("namespace-testWeakHashMapNoDuplicates");
+    Namespace.ID nsId = Namespace.ID.of(namespaceString);
+    assertEquals(3, Namespace.ID.namespaceIds.size());
+    assertEquals(namespaceString, nsId.canonicalID());
+
+    // ensure duplicates are not created
+    Namespace.ID builtInNamespaceId = Namespace.ID.of("+accumulo");
+    assertEquals(Namespace.ID.ACCUMULO, builtInNamespaceId);
+    builtInNamespaceId = Namespace.ID.of("+default");
+    assertEquals(Namespace.ID.DEFAULT, builtInNamespaceId);
+    nsId = Namespace.ID.of(namespaceString);
+    assertEquals(3, Namespace.ID.namespaceIds.size());
+    assertEquals(namespaceString, nsId.canonicalID());
+  }
+
+  @Test
+  public void testWeakHashMapDecreases() {
+    // get bunch of namespace IDs that are not used
+    for (int i = 0; i < 1000; i++)
+      Namespace.ID.of(new String("namespace" + i));
+  }
+
+  private void garbageCollect(Integer initialSize) {
+    System.out.println("GC with initial Size = " + initialSize);
+    int count = 0;
+    while (Namespace.ID.namespaceIds.size() >= initialSize && count < 10) {
+      System.gc();
+      count++;
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        fail("Thread interrupted while waiting for GC");
+        break;
+      }
+      System.out.println("after GC: Size of namespaceIds = " + Namespace.ID.namespaceIds.size());
+    }
+    assertTrue("Size of WeakHashMap did not decrease after GC.", Namespace.ID.namespaceIds.size() < initialSize);
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/NamespaceTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/NamespaceTest.java
@@ -17,10 +17,7 @@
 package org.apache.accumulo.core.client.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -28,27 +25,21 @@ import org.junit.Test;
  */
 public class NamespaceTest {
 
-  @After
-  public void cleanup() {
-    garbageCollect(Namespace.ID.namespaceIds.size());
-  }
-
   @Test
   public void testWeakHashMapIncreases() {
-    // ensure initial size contains just the built in Namespace IDs (accumulo, default)
-    assertEquals(2, Namespace.ID.namespaceIds.size());
-
-    String namespaceString = new String("namespace-testWeakHashMapIncreases");
+    String namespaceString = "namespace-testWeakHashMapIncreases";
+    Integer initialSize = Namespace.ID.cache.asMap().size();
     Namespace.ID nsId = Namespace.ID.of(namespaceString);
-    assertEquals(3, Namespace.ID.namespaceIds.size());
+    assertEquals(initialSize + 1, Namespace.ID.cache.asMap().size());
     assertEquals(namespaceString, nsId.canonicalID());
   }
 
   @Test
   public void testWeakHashMapNoDuplicates() {
-    String namespaceString = new String("namespace-testWeakHashMapNoDuplicates");
+    String namespaceString = "namespace-testWeakHashMapNoDuplicates";
+    Integer initialSize = Namespace.ID.cache.asMap().size();
     Namespace.ID nsId = Namespace.ID.of(namespaceString);
-    assertEquals(3, Namespace.ID.namespaceIds.size());
+    assertEquals(initialSize + 1, Namespace.ID.cache.asMap().size());
     assertEquals(namespaceString, nsId.canonicalID());
 
     // ensure duplicates are not created
@@ -57,32 +48,7 @@ public class NamespaceTest {
     builtInNamespaceId = Namespace.ID.of("+default");
     assertEquals(Namespace.ID.DEFAULT, builtInNamespaceId);
     nsId = Namespace.ID.of(namespaceString);
-    assertEquals(3, Namespace.ID.namespaceIds.size());
+    assertEquals(initialSize + 1, Namespace.ID.cache.asMap().size());
     assertEquals(namespaceString, nsId.canonicalID());
   }
-
-  @Test
-  public void testWeakHashMapDecreases() {
-    // get bunch of namespace IDs that are not used
-    for (int i = 0; i < 1000; i++)
-      Namespace.ID.of(new String("namespace" + i));
-  }
-
-  private void garbageCollect(Integer initialSize) {
-    System.out.println("GC with initial Size = " + initialSize);
-    int count = 0;
-    while (Namespace.ID.namespaceIds.size() >= initialSize && count < 10) {
-      System.gc();
-      count++;
-      try {
-        Thread.sleep(5000);
-      } catch (InterruptedException e) {
-        fail("Thread interrupted while waiting for GC");
-        break;
-      }
-      System.out.println("after GC: Size of namespaceIds = " + Namespace.ID.namespaceIds.size());
-    }
-    assertTrue("Size of WeakHashMap did not decrease after GC.", Namespace.ID.namespaceIds.size() < initialSize);
-  }
-
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/NamespaceTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/NamespaceTest.java
@@ -64,20 +64,18 @@ public class NamespaceTest {
 
   @Test(timeout = 60_000)
   public void testCacheDecreasesAfterGC() {
-    generateJunkCacheEntries();
     Long initialSize = Namespace.ID.cache.asMap().entrySet().stream().count();
+    generateJunkCacheEntries();
     Long postGCSize;
-    System.out.println("Namespace.ID.cache.asMap().entrySet().stream().count() = " + initialSize);
     do {
       System.gc();
       try {
-        Thread.sleep(5000);
+        Thread.sleep(500);
       } catch (InterruptedException e) {
         fail("Thread interrupted while waiting for GC");
       }
       postGCSize = Namespace.ID.cache.asMap().entrySet().stream().count();
-      System.out.println("After GC: Namespace.ID.cache.asMap().entrySet().stream().count() = " + postGCSize);
-    } while (postGCSize == initialSize);
+    } while (postGCSize > initialSize);
 
     assertTrue("Cache did not decrease with GC.", Namespace.ID.cache.asMap().entrySet().stream().count() < initialSize);
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/ScannerImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/ScannerImplTest.java
@@ -39,7 +39,7 @@ public class ScannerImplTest {
 
   @Test
   public void testValidReadaheadValues() {
-    Scanner s = new ScannerImpl(context, new Table.ID("foo"), Authorizations.EMPTY);
+    Scanner s = new ScannerImpl(context, Table.ID.of("foo"), Authorizations.EMPTY);
     s.setReadaheadThreshold(0);
     s.setReadaheadThreshold(10);
     s.setReadaheadThreshold(Long.MAX_VALUE);
@@ -50,7 +50,7 @@ public class ScannerImplTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testInValidReadaheadValues() {
-    Scanner s = new ScannerImpl(context, new Table.ID("foo"), Authorizations.EMPTY);
+    Scanner s = new ScannerImpl(context, Table.ID.of("foo"), Authorizations.EMPTY);
     s.setReadaheadThreshold(-1);
     s.close();
   }
@@ -58,7 +58,7 @@ public class ScannerImplTest {
   @Test
   public void testGetAuthorizations() {
     Authorizations expected = new Authorizations("a,b");
-    Scanner s = new ScannerImpl(context, new Table.ID("foo"), expected);
+    Scanner s = new ScannerImpl(context, Table.ID.of("foo"), expected);
     assertEquals(expected, s.getAuthorizations());
     s.close();
   }
@@ -66,7 +66,7 @@ public class ScannerImplTest {
   @SuppressWarnings("resource")
   @Test(expected = IllegalArgumentException.class)
   public void testNullAuthorizationsFails() {
-    new ScannerImpl(context, new Table.ID("foo"), null);
+    new ScannerImpl(context, Table.ID.of("foo"), null);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
@@ -44,7 +44,7 @@ public class TableOperationsImplTest {
     Connector connector = EasyMock.createMock(Connector.class);
     Scanner scanner = EasyMock.createMock(Scanner.class);
 
-    Range range = new KeyExtent(new Table.ID("1"), null, null).toMetadataRange();
+    Range range = new KeyExtent(Table.ID.of("1"), null, null).toMetadataRange();
 
     String user = "root";
     PasswordToken token = new PasswordToken("password");

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableTest.java
@@ -67,20 +67,18 @@ public class TableTest {
 
   @Test(timeout = 60_000)
   public void testCacheDecreasesAfterGC() {
-    generateJunkCacheEntries();
     Long initialSize = Table.ID.cache.asMap().entrySet().stream().count();
+    generateJunkCacheEntries();
     Long postGCSize;
-    System.out.println("Table.ID.cache.asMap().entrySet().stream().count() = " + initialSize);
     do {
       System.gc();
       try {
-        Thread.sleep(5000);
+        Thread.sleep(500);
       } catch (InterruptedException e) {
         fail("Thread interrupted while waiting for GC");
       }
       postGCSize = Table.ID.cache.asMap().entrySet().stream().count();
-      System.out.println("After GC: Table.ID.cache.asMap().entrySet().stream().count() = " + postGCSize);
-    } while (postGCSize == initialSize);
+    } while (postGCSize > initialSize);
 
     assertTrue("Cache did not decrease with GC.", Table.ID.cache.asMap().entrySet().stream().count() < initialSize);
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests the Table ID class, mainly the internal WeakHashMap.
+ */
+public class TableTest {
+
+  @After
+  public void cleanup() {
+    garbageCollect(Table.ID.tableIds.size());
+  }
+
+  @Test
+  public void testWeakHashMapIncreases() {
+    // ensure initial size contains just the built in Table IDs (metadata, root, replication)
+    assertEquals(3, Table.ID.tableIds.size());
+
+    String tableString = new String("table-testWeakHashMapIncreases");
+    Table.ID table1 = Table.ID.of(tableString);
+    assertEquals(4, Table.ID.tableIds.size());
+    assertEquals(tableString, table1.canonicalID());
+  }
+
+  @Test
+  public void testWeakHashMapNoDuplicates() {
+    String tableString = new String("table-testWeakHashMapNoDuplicates");
+    Table.ID table1 = Table.ID.of(tableString);
+    assertEquals(4, Table.ID.tableIds.size());
+    assertEquals(tableString, table1.canonicalID());
+
+    // ensure duplicates are not created
+    Table.ID builtInTableId = Table.ID.of("!0");
+    assertEquals(Table.ID.METADATA, builtInTableId);
+    builtInTableId = Table.ID.of("+r");
+    assertEquals(Table.ID.ROOT, builtInTableId);
+    builtInTableId = Table.ID.of("+rep");
+    assertEquals(Table.ID.REPLICATION, builtInTableId);
+    table1 = Table.ID.of(tableString);
+    assertEquals(4, Table.ID.tableIds.size());
+    assertEquals(tableString, table1.canonicalID());
+  }
+
+  @Test
+  public void testWeakHashMapDecreases() {
+    // get bunch of table IDs that are not used
+    for (int i = 0; i < 1000; i++)
+      Table.ID.of(new String("table" + i));
+  }
+
+  private void garbageCollect(Integer initialSize) {
+    System.out.println("GC with initial Size = " + initialSize);
+    int count = 0;
+    while (Table.ID.tableIds.size() >= initialSize && count < 10) {
+      System.gc();
+      count++;
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        fail("Thread interrupted while waiting for GC");
+        break;
+      }
+      System.out.println("after GC: Size of tableIds = " + Table.ID.tableIds.size());
+    }
+    assertTrue("Size of WeakHashMap did not decrease after GC.", Table.ID.tableIds.size() < initialSize);
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
@@ -65,7 +65,7 @@ public class TabletLocatorImplTest {
   private static final KeyExtent MTE = new KeyExtent(MetadataTable.ID, null, RTE.getEndRow());
 
   static KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(new Table.ID(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(Table.ID.of(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   static Range nr(String k1, boolean si, String k2, boolean ei) {
@@ -143,7 +143,7 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Table.ID(table), rootTabletCache, ttlo, tslc);
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(Table.ID.of(table), rootTabletCache, ttlo, tslc);
 
     setLocation(tservers, rootTabLoc, RTE, MTE, metaTabLoc);
 
@@ -680,7 +680,7 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(new Table.ID("tab1"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab1TabletCache = new TabletLocatorImpl(Table.ID.of("tab1"), rootTabletCache, ttlo, new YesLockChecker());
 
     locateTabletTest(tab1TabletCache, "r1", null, null);
 
@@ -1223,14 +1223,14 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Table.ID("0"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(Table.ID.of("0"), rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
 
     // create two tablets that straddle a metadata split point
-    KeyExtent ke1 = new KeyExtent(new Table.ID("0"), new Text("0bbf20e"), null);
-    KeyExtent ke2 = new KeyExtent(new Table.ID("0"), new Text("0bc0756"), new Text("0bbf20e"));
+    KeyExtent ke1 = new KeyExtent(Table.ID.of("0"), new Text("0bbf20e"), null);
+    KeyExtent ke2 = new KeyExtent(Table.ID.of("0"), new Text("0bc0756"), new Text("0bbf20e"));
 
     setLocation(tservers, "tserver2", mte1, ke1, "tserver4");
     setLocation(tservers, "tserver3", mte2, ke2, "tserver5");
@@ -1250,7 +1250,7 @@ public class TabletLocatorImplTest {
 
     RootTabletLocator rtl = new TestRootTabletLocator();
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Table.ID("0"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(Table.ID.of("0"), rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");
@@ -1273,7 +1273,7 @@ public class TabletLocatorImplTest {
     KeyExtent mte4 = new KeyExtent(MetadataTable.ID, new Text("1;r"), new Text("1;j"));
     KeyExtent mte5 = new KeyExtent(MetadataTable.ID, null, new Text("1;r"));
 
-    KeyExtent ke1 = new KeyExtent(new Table.ID("1"), null, null);
+    KeyExtent ke1 = new KeyExtent(Table.ID.of("1"), null, null);
 
     TServers tservers = new TServers();
     TestTabletLocationObtainer ttlo = new TestTabletLocationObtainer(tservers);
@@ -1281,7 +1281,7 @@ public class TabletLocatorImplTest {
     RootTabletLocator rtl = new TestRootTabletLocator();
 
     TabletLocatorImpl rootTabletCache = new TabletLocatorImpl(MetadataTable.ID, rtl, ttlo, new YesLockChecker());
-    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(new Table.ID("1"), rootTabletCache, ttlo, new YesLockChecker());
+    TabletLocatorImpl tab0TabletCache = new TabletLocatorImpl(Table.ID.of("1"), rootTabletCache, ttlo, new YesLockChecker());
 
     setLocation(tservers, "tserver1", RTE, mte1, "tserver2");
     setLocation(tservers, "tserver1", RTE, mte2, "tserver3");

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderTest.java
@@ -36,7 +36,7 @@ public class TabletServerBatchReaderTest {
   @Test
   public void testGetAuthorizations() {
     Authorizations expected = new Authorizations("a,b");
-    try (BatchScanner s = new TabletServerBatchReader(context, new Table.ID("foo"), expected, 1)) {
+    try (BatchScanner s = new TabletServerBatchReader(context, Table.ID.of("foo"), expected, 1)) {
       assertEquals(expected, s.getAuthorizations());
     }
   }
@@ -44,6 +44,6 @@ public class TabletServerBatchReaderTest {
   @SuppressWarnings("resource")
   @Test(expected = IllegalArgumentException.class)
   public void testNullAuthorizationsFails() {
-    new TabletServerBatchReader(context, new Table.ID("foo"), null, 1);
+    new TabletServerBatchReader(context, Table.ID.of("foo"), null, 1);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/mapreduce/impl/BatchInputSplitTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/mapreduce/impl/BatchInputSplitTest.java
@@ -46,7 +46,7 @@ public class BatchInputSplitTest {
   @Test
   public void testSimpleWritable() throws IOException {
     Range[] ranges = new Range[] {new Range(new Key("a"), new Key("b"))};
-    BatchInputSplit split = new BatchInputSplit("table", new Table.ID("1"), Arrays.asList(ranges), new String[] {"localhost"});
+    BatchInputSplit split = new BatchInputSplit("table", Table.ID.of("1"), Arrays.asList(ranges), new String[] {"localhost"});
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
@@ -67,7 +67,7 @@ public class BatchInputSplitTest {
   @Test
   public void testAllFieldsWritable() throws IOException {
     Range[] ranges = new Range[] {new Range(new Key("a"), new Key("b"))};
-    BatchInputSplit split = new BatchInputSplit("table", new Table.ID("1"), Arrays.asList(ranges), new String[] {"localhost"});
+    BatchInputSplit split = new BatchInputSplit("table", Table.ID.of("1"), Arrays.asList(ranges), new String[] {"localhost"});
 
     Set<Pair<Text,Text>> fetchedColumns = new HashSet<>();
 

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 
 public class KeyExtentTest {
   KeyExtent nke(String t, String er, String per) {
-    return new KeyExtent(new Table.ID(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
+    return new KeyExtent(Table.ID.of(t), er == null ? null : new Text(er), per == null ? null : new Text(per));
   }
 
   KeyExtent ke;

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -192,31 +192,31 @@ public class RangeTest extends TestCase {
 
   public void testMergeOverlapping22() {
 
-    Range ke1 = new KeyExtent(new Table.ID("tab1"), new Text("Bank"), null).toMetadataRange();
-    Range ke2 = new KeyExtent(new Table.ID("tab1"), new Text("Fails"), new Text("Bank")).toMetadataRange();
-    Range ke3 = new KeyExtent(new Table.ID("tab1"), new Text("Sam"), new Text("Fails")).toMetadataRange();
-    Range ke4 = new KeyExtent(new Table.ID("tab1"), new Text("bails"), new Text("Sam")).toMetadataRange();
-    Range ke5 = new KeyExtent(new Table.ID("tab1"), null, new Text("bails")).toMetadataRange();
+    Range ke1 = new KeyExtent(Table.ID.of("tab1"), new Text("Bank"), null).toMetadataRange();
+    Range ke2 = new KeyExtent(Table.ID.of("tab1"), new Text("Fails"), new Text("Bank")).toMetadataRange();
+    Range ke3 = new KeyExtent(Table.ID.of("tab1"), new Text("Sam"), new Text("Fails")).toMetadataRange();
+    Range ke4 = new KeyExtent(Table.ID.of("tab1"), new Text("bails"), new Text("Sam")).toMetadataRange();
+    Range ke5 = new KeyExtent(Table.ID.of("tab1"), null, new Text("bails")).toMetadataRange();
 
     List<Range> rl = newRangeList(ke1, ke2, ke3, ke4, ke5);
-    List<Range> expected = newRangeList(new KeyExtent(new Table.ID("tab1"), null, null).toMetadataRange());
+    List<Range> expected = newRangeList(new KeyExtent(Table.ID.of("tab1"), null, null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke1, ke2, ke4, ke5);
-    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), new Text("Fails"), null).toMetadataRange(), new KeyExtent(new Table.ID("tab1"), null, new Text(
+    expected = newRangeList(new KeyExtent(Table.ID.of("tab1"), new Text("Fails"), null).toMetadataRange(), new KeyExtent(Table.ID.of("tab1"), null, new Text(
         "Sam")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke2, ke3, ke4, ke5);
-    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), null, new Text("Bank")).toMetadataRange());
+    expected = newRangeList(new KeyExtent(Table.ID.of("tab1"), null, new Text("Bank")).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke1, ke2, ke3, ke4);
-    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), new Text("bails"), null).toMetadataRange());
+    expected = newRangeList(new KeyExtent(Table.ID.of("tab1"), new Text("bails"), null).toMetadataRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke2, ke3, ke4);
-    expected = newRangeList(new KeyExtent(new Table.ID("tab1"), new Text("bails"), new Text("Bank")).toMetadataRange());
+    expected = newRangeList(new KeyExtent(Table.ID.of("tab1"), new Text("bails"), new Text("Bank")).toMetadataRange());
 
     check(Range.mergeOverlapping(rl), expected);
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -139,7 +139,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(Table.ID.of("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -171,7 +171,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.majc, source, new KeyExtent(Table.ID.of("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -207,7 +207,7 @@ public class IteratorUtilTest {
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".addIter", "2," + AddingIter.class.getName());
     conf.set(Property.TABLE_ITERATOR_PREFIX + IteratorScope.minc.name() + ".sqIter", "1," + SquaringIter.class.getName());
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(Table.ID.of("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -243,7 +243,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(Table.ID.of("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 
@@ -279,7 +279,7 @@ public class IteratorUtilTest {
 
     SortedMapIterator source = new SortedMapIterator(tm);
 
-    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(new Table.ID("tab"), null, null), conf,
+    SortedKeyValueIterator<Key,Value> iter = IteratorUtil.loadIterators(IteratorScope.minc, source, new KeyExtent(Table.ID.of("tab"), null, null), conf,
         new DefaultIteratorEnvironment(conf));
     iter.seek(new Range(), EMPTY_COL_FAMS, false);
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -345,7 +345,7 @@ public class MultiIteratorTest extends TestCase {
     List<SortedKeyValueIterator<Key,Value>> skvil = new ArrayList<>(1);
     skvil.add(new SortedMapIterator(tm1));
 
-    KeyExtent extent = new KeyExtent(new Table.ID("tablename"), newRow(1), newRow(0));
+    KeyExtent extent = new KeyExtent(Table.ID.of("tablename"), newRow(1), newRow(0));
 
     MultiIterator mi = new MultiIterator(skvil, extent);
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/MetadataServicerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/MetadataServicerTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 public class MetadataServicerTest {
 
   private static final String userTableName = "tableName";
-  private static final Table.ID userTableId = new Table.ID("tableId");
+  private static final Table.ID userTableId = Table.ID.of("tableId");
   private static ClientContext context;
 
   @BeforeClass

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtilTest.java
@@ -73,13 +73,13 @@ public class ReplicationConfigurationUtilTest {
 
   @Test
   public void regularTable() {
-    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent(Table.ID.of("1"), new Text("b"), new Text("a"));
     Assert.assertTrue("Table should be replicated", ReplicationConfigurationUtil.isEnabled(extent, conf));
   }
 
   @Test
   public void regularNonEnabledTable() {
-    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent(Table.ID.of("1"), new Text("b"), new Text("a"));
     Assert.assertFalse("Table should not be replicated", ReplicationConfigurationUtil.isEnabled(extent, new ConfigurationCopy(new HashMap<String,String>())));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationSchemaTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationSchemaTest.java
@@ -62,14 +62,14 @@ public class ReplicationSchemaTest {
 
   @Test
   public void extractTableId() {
-    Table.ID tableId = new Table.ID("1");
+    Table.ID tableId = Table.ID.of("1");
     Key k = new Key(new Text("foo"), StatusSection.NAME, new Text(tableId.getUtf8()));
     Assert.assertEquals(tableId, StatusSection.getTableId(k));
   }
 
   @Test
   public void extractTableIdUsingText() {
-    Table.ID tableId = new Table.ID("1");
+    Table.ID tableId = Table.ID.of("1");
     Key k = new Key(new Text("foo"), StatusSection.NAME, new Text(tableId.getUtf8()));
     Assert.assertEquals(tableId, StatusSection.getTableId(k));
   }

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationTargetTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationTargetTest.java
@@ -30,18 +30,18 @@ public class ReplicationTargetTest {
 
   @Test
   public void properEquality() {
-    ReplicationTarget expected1 = new ReplicationTarget("foo", "bar", new Table.ID("1"));
+    ReplicationTarget expected1 = new ReplicationTarget("foo", "bar", Table.ID.of("1"));
 
-    Assert.assertEquals(expected1, new ReplicationTarget("foo", "bar", new Table.ID("1")));
-    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", "foo", new Table.ID("1")));
-    Assert.assertNotEquals(expected1, new ReplicationTarget("bar", "bar", new Table.ID("1")));
-    Assert.assertNotEquals(expected1, new ReplicationTarget(null, "bar", new Table.ID("1")));
-    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", null, new Table.ID("1")));
+    Assert.assertEquals(expected1, new ReplicationTarget("foo", "bar", Table.ID.of("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", "foo", Table.ID.of("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget("bar", "bar", Table.ID.of("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget(null, "bar", Table.ID.of("1")));
+    Assert.assertNotEquals(expected1, new ReplicationTarget("foo", null, Table.ID.of("1")));
   }
 
   @Test
   public void writableOut() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", Table.ID.of("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
 
@@ -65,7 +65,7 @@ public class ReplicationTargetTest {
 
   @Test
   public void staticFromTextHelper() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", Table.ID.of("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
     Text t = new Text();
@@ -76,7 +76,7 @@ public class ReplicationTargetTest {
 
   @Test
   public void staticToTextHelper() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", Table.ID.of("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
     Text t = new Text();
@@ -87,7 +87,7 @@ public class ReplicationTargetTest {
 
   @Test
   public void staticFromStringHelper() throws Exception {
-    ReplicationTarget expected = new ReplicationTarget("foo", "bar", new Table.ID("1"));
+    ReplicationTarget expected = new ReplicationTarget("foo", "bar", Table.ID.of("1"));
     DataOutputBuffer buffer = new DataOutputBuffer();
     expected.write(buffer);
     Text t = new Text();

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -44,7 +44,7 @@ public class MergeTest {
           end = null;
         else
           end = new Text(String.format("%05d", tablets.size()));
-        KeyExtent extent = new KeyExtent(new Table.ID("table"), end, start);
+        KeyExtent extent = new KeyExtent(Table.ID.of("table"), end, start);
         start = end;
         tablets.add(new Size(extent, size));
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -130,7 +130,7 @@ public class BulkImporter {
     final Map<Path,List<KeyExtent>> completeFailures = Collections.synchronizedSortedMap(new TreeMap<Path,List<KeyExtent>>());
 
     ClientService.Client client = null;
-    final TabletLocator locator = TabletLocator.getLocator(context, new Table.ID(tableId));
+    final TabletLocator locator = TabletLocator.getLocator(context, Table.ID.of(tableId));
 
     try {
       final Map<Path,List<TabletLocation>> assignments = Collections.synchronizedSortedMap(new TreeMap<Path,List<TabletLocation>>());

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfWatcher.java
@@ -73,7 +73,7 @@ class NamespaceConfWatcher implements Watcher {
         return;
       }
     }
-    Namespace.ID namespaceId = new Namespace.ID(namespaceIdStr);
+    Namespace.ID namespaceId = Namespace.ID.of(namespaceIdStr);
 
     switch (event.getType()) {
       case NodeDataChanged:

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
@@ -71,7 +71,7 @@ class TableConfWatcher implements Watcher {
         return;
       }
     }
-    Table.ID tableId = new Table.ID(tableIdString);
+    Table.ID tableId = Table.ID.of(tableIdString);
 
     switch (event.getType()) {
       case NodeDataChanged:

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -374,7 +374,7 @@ public class VolumeManagerImpl implements VolumeManager {
     // TODO sanity check col fam
     String relPath = key.getColumnQualifierData().toString();
     byte[] tableId = KeyExtent.tableOfMetadataRow(key.getRow());
-    return getFullPath(new Table.ID(new String(tableId)), relPath);
+    return getFullPath(Table.ID.of(new String(tableId)), relPath);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -130,7 +130,7 @@ public class ChaoticLoadBalancer extends TabletBalancer {
 
     for (Entry<TServerInstance,TabletServerStatus> e : current.entrySet()) {
       for (String tableId : e.getValue().getTableMap().keySet()) {
-        Table.ID id = new Table.ID(tableId);
+        Table.ID id = Table.ID.of(tableId);
         if (!moveMetadata && MetadataTable.ID.equals(id))
           continue;
         try {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -276,7 +276,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
     if (status != null && status.tableMap != null) {
       Map<String,TableInfo> tableMap = status.tableMap;
       for (Entry<String,TableInfo> entry : tableMap.entrySet()) {
-        result.put(new Table.ID(entry.getKey()), entry.getValue().onlineTablets);
+        result.put(Table.ID.of(entry.getKey()), entry.getValue().onlineTablets);
       }
     }
     return result;
@@ -304,7 +304,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
       double busy = info.ingestRate + info.queryRate;
       if (busy > busiest) {
         busiest = busy;
-        result = new Table.ID(entry.getKey());
+        result = Table.ID.of(entry.getKey());
       }
     }
     return result;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -774,7 +774,7 @@ public abstract class GroupBalancer extends TabletBalancer {
         Scanner scanner = new IsolatedScanner(context.getConnector().createScanner(MetadataTable.NAME, Authorizations.EMPTY));
         scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
         MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-        scanner.setRange(MetadataSchema.TabletsSection.getRange(new org.apache.accumulo.core.client.impl.Table.ID(tableId)));
+        scanner.setRange(MetadataSchema.TabletsSection.getRange(org.apache.accumulo.core.client.impl.Table.ID.of(tableId)));
 
         RowIterator rowIter = new RowIterator(scanner);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -197,7 +197,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
     tableIdToTableName = new HashMap<>();
     poolNameToRegexPattern = new HashMap<>();
     for (Entry<String,String> table : t.tableIdMap().entrySet()) {
-      Table.ID tableId = new Table.ID(table.getValue());
+      Table.ID tableId = Table.ID.of(table.getValue());
       tableIdToTableName.put(tableId, table.getKey());
       conf.getTableConfiguration(tableId).addObserver(this);
       Map<String,String> customProps = conf.getTableConfiguration(tableId).getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
@@ -344,7 +344,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
               continue;
             }
             try {
-              List<TabletStats> outOfBoundsTablets = getOnlineTabletsForTable(e.getKey(), new Table.ID(tid));
+              List<TabletStats> outOfBoundsTablets = getOnlineTabletsForTable(e.getKey(), Table.ID.of(tid));
               if (null == outOfBoundsTablets) {
                 continue;
               }
@@ -422,7 +422,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
     }
 
     for (String s : tableIdMap.values()) {
-      Table.ID tableId = new Table.ID(s);
+      Table.ID tableId = Table.ID.of(s);
       String tableName = tableIdToTableName.get(tableId);
       String regexTableName = getPoolNameForTable(tableName);
       SortedMap<TServerInstance,TabletServerStatus> currentView = currentGrouped.get(regexTableName);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
@@ -58,7 +58,7 @@ public class RegexGroupBalancer extends GroupBalancer {
 
   @Override
   protected long getWaitTime() {
-    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(new Table.ID(tableId))
+    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(Table.ID.of(tableId))
         .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     if (customProps.containsKey(WAIT_TIME_PROPERTY)) {
       return ConfigurationTypeHelper.getTimeInMillis(customProps.get(WAIT_TIME_PROPERTY));
@@ -70,7 +70,7 @@ public class RegexGroupBalancer extends GroupBalancer {
   @Override
   protected Function<KeyExtent,String> getPartitioner() {
 
-    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(new Table.ID(tableId))
+    Map<String,String> customProps = context.getServerConfigurationFactory().getTableConfiguration(Table.ID.of(tableId))
         .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     String regex = customProps.get(REGEX_PROPERTY);
     final String defaultGroup = customProps.get(DEFAUT_GROUP_PROPERTY);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -153,7 +153,7 @@ public class TableLoadBalancer extends TabletBalancer {
       return minBalanceTime;
     for (String s : t.tableIdMap().values()) {
       ArrayList<TabletMigration> newMigrations = new ArrayList<>();
-      long tableBalanceTime = getBalancerForTable(new Table.ID(s)).balance(current, migrations, newMigrations);
+      long tableBalanceTime = getBalancerForTable(Table.ID.of(s)).balance(current, migrations, newMigrations);
       if (tableBalanceTime < minBalanceTime)
         minBalanceTime = tableBalanceTime;
       migrationsOut.addAll(newMigrations);

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
@@ -189,7 +189,7 @@ public class ProblemReport {
     ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
     DataInputStream dis = new DataInputStream(bais);
 
-    Table.ID tableId = new Table.ID(dis.readUTF());
+    Table.ID tableId = Table.ID.of(dis.readUTF());
     String problemType = dis.readUTF();
     String resource = dis.readUTF();
 
@@ -201,7 +201,7 @@ public class ProblemReport {
   }
 
   public static ProblemReport decodeMetadataEntry(Entry<Key,Value> entry) throws IOException {
-    Table.ID tableId = new Table.ID(entry.getKey().getRow().toString().substring("~err_".length()));
+    Table.ID tableId = Table.ID.of(entry.getKey().getRow().toString().substring("~err_".length()));
     String problemType = entry.getKey().getColumnFamily().toString();
     String resource = entry.getKey().getColumnQualifier().toString();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/DistributedWorkQueueWorkAssignerHelper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/DistributedWorkQueueWorkAssignerHelper.java
@@ -73,6 +73,6 @@ public class DistributedWorkQueueWorkAssignerHelper {
     }
 
     return Maps.immutableEntry(filename, new ReplicationTarget(queueKey.substring(index + 1, secondIndex), queueKey.substring(secondIndex + 1, thirdIndex),
-        new Table.ID(queueKey.substring(thirdIndex + 1))));
+        Table.ID.of(queueKey.substring(thirdIndex + 1))));
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -172,7 +172,7 @@ public class TableManager {
     synchronized (tableStateCache) {
       for (String tableId : zooStateCache.getChildren(ZooUtil.getRoot(instance) + Constants.ZTABLES))
         if (zooStateCache.get(ZooUtil.getRoot(instance) + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_STATE) != null)
-          updateTableStateCache(new Table.ID(tableId));
+          updateTableStateCache(Table.ID.of(tableId));
     }
   }
 
@@ -252,7 +252,7 @@ public class TableManager {
         if (suffix.contains("/")) {
           String[] sa = suffix.split("/", 2);
           if (Constants.ZTABLE_STATE.equals("/" + sa[1]))
-            tableId = new Table.ID(sa[0]);
+            tableId = Table.ID.of(sa[0]);
         }
         if (tableId == null) {
           log.warn("Unknown path in " + event);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -743,7 +743,7 @@ public class MetadataTableUtil {
   }
 
   private static int compareEndRows(Text endRow1, Text endRow2) {
-    return new KeyExtent(new Table.ID("0"), endRow1, null).compareTo(new KeyExtent(new Table.ID("0"), endRow2, null));
+    return new KeyExtent(Table.ID.of("0"), endRow1, null).compareTo(new KeyExtent(Table.ID.of("0"), endRow2, null));
   }
 
   @VisibleForTesting
@@ -958,7 +958,7 @@ public class MetadataTableUtil {
 
     // new KeyExtent is only added to force update to write to the metadata table, not the root table
     // because bulk loads aren't supported to the metadata table
-    update(context, m, new KeyExtent(new Table.ID("anythingNotMetadata"), null, null));
+    update(context, m, new KeyExtent(Table.ID.of("anythingNotMetadata"), null, null));
   }
 
   public static void removeBulkLoadInProgressFlag(AccumuloServerContext context, String path) {
@@ -968,7 +968,7 @@ public class MetadataTableUtil {
 
     // new KeyExtent is only added to force update to write to the metadata table, not the root table
     // because bulk loads aren't supported to the metadata table
-    update(context, m, new KeyExtent(new Table.ID("anythingNotMetadata"), null, null));
+    update(context, m, new KeyExtent(Table.ID.of("anythingNotMetadata"), null, null));
   }
 
   /**
@@ -1010,7 +1010,7 @@ public class MetadataTableUtil {
 
   public static void moveMetaDeleteMarkersFrom14(ClientContext context) {
     // new KeyExtent is only added to force update to write to the metadata table, not the root table
-    KeyExtent notMetadata = new KeyExtent(new Table.ID("anythingNotMetadata"), null, null);
+    KeyExtent notMetadata = new KeyExtent(Table.ID.of("anythingNotMetadata"), null, null);
 
     // move delete markers from the normal delete keyspace to the root tablet delete keyspace if the files are for the !METADATA table
     try (Scanner scanner = new ScannerImpl(context, MetadataTable.ID, Authorizations.EMPTY)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
@@ -86,7 +86,7 @@ public class RandomizeVolumes {
       log.error("Could not determine the table ID for table " + tableName);
       return 2;
     }
-    Table.ID tableId = new Table.ID(tblStr);
+    Table.ID tableId = Table.ID.of(tblStr);
     TableState tableState = TableManager.getInstance().getTableState(tableId);
     if (TableState.OFFLINE != tableState) {
       log.info("Taking " + tableName + " offline");
@@ -105,7 +105,7 @@ public class RandomizeVolumes {
       String directory;
       if (oldLocation.contains(":")) {
         String[] parts = oldLocation.split(Path.SEPARATOR);
-        Table.ID tableIdEntry = new Table.ID(parts[parts.length - 2]);
+        Table.ID tableIdEntry = Table.ID.of(parts[parts.length - 2]);
         if (!tableIdEntry.equals(tableId)) {
           log.error("Unexpected table id found: " + tableIdEntry + ", expected " + tableId + "; skipping");
           continue;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -178,7 +178,7 @@ public class TableDiskUsage {
         throw new RuntimeException(e);
       }
       mdScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      mdScanner.setRange(new KeyExtent(new Table.ID(tableId), null, null).toMetadataRange());
+      mdScanner.setRange(new KeyExtent(Table.ID.of(tableId), null, null).toMetadataRange());
 
       if (!mdScanner.iterator().hasNext()) {
         emptyTableIds.add(tableId);

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -53,7 +53,7 @@ import org.junit.Test;
 public class BulkImporterTest {
 
   static final SortedSet<KeyExtent> fakeMetaData = new TreeSet<>();
-  static final Table.ID tableId = new Table.ID("1");
+  static final Table.ID tableId = Table.ID.of("1");
 
   static {
     fakeMetaData.add(new KeyExtent(tableId, new Text("a"), null));
@@ -164,19 +164,19 @@ public class BulkImporterTest {
     // a correct startRow so that findOverlappingTablets works as intended.
 
     // 1;2;1
-    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("2"), new Text("1"));
+    KeyExtent extent = new KeyExtent(Table.ID.of("1"), new Text("2"), new Text("1"));
     Assert.assertEquals(new Text("1\0"), BulkImporter.getStartRowForExtent(extent));
 
     // 1;2<
-    extent = new KeyExtent(new Table.ID("1"), new Text("2"), null);
+    extent = new KeyExtent(Table.ID.of("1"), new Text("2"), null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1<<
-    extent = new KeyExtent(new Table.ID("1"), null, null);
+    extent = new KeyExtent(Table.ID.of("1"), null, null);
     Assert.assertEquals(null, BulkImporter.getStartRowForExtent(extent));
 
     // 1;8;7777777
-    extent = new KeyExtent(new Table.ID("1"), new Text("8"), new Text("7777777"));
+    extent = new KeyExtent(Table.ID.of("1"), new Text("8"), new Text("7777777"));
     Assert.assertEquals(new Text("7777777\0"), BulkImporter.getStartRowForExtent(extent));
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
@@ -47,7 +47,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class NamespaceConfigurationTest {
-  private static final Namespace.ID NSID = new Namespace.ID("namespace");
+  private static final Namespace.ID NSID = Namespace.ID.of("namespace");
   private static final String ZOOKEEPERS = "localhost";
   private static final int ZK_SESSION_TIMEOUT = 120000;
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -114,7 +114,7 @@ public class ServerConfigurationFactoryTest {
     assertNotNull(c);
   }
 
-  private static final Namespace.ID NSID = new Namespace.ID("NAMESPACE");
+  private static final Namespace.ID NSID = Namespace.ID.of("NAMESPACE");
 
   @Test
   public void testGetNamespaceConfiguration() {

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
@@ -44,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TableConfigurationTest {
-  private static final Table.ID TID = new Table.ID("table");
+  private static final Table.ID TID = Table.ID.of("table");
   private static final String ZOOKEEPERS = "localhost";
   private static final int ZK_SESSION_TIMEOUT = 120000;
 

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
@@ -113,7 +113,7 @@ public class VolumeManagerImplTest {
     conf.set(Property.INSTANCE_VOLUMES, StringUtils.join(volumes, ","));
     conf.set(Property.GENERAL_VOLUME_CHOOSER, WrongVolumeChooser.class.getName());
     VolumeManager vm = VolumeManagerImpl.get(conf);
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(Optional.of(new Table.ID("sometable")));
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(Optional.of(Table.ID.of("sometable")));
     String choice = vm.choose(chooserEnv, volumes.toArray(new String[0]));
     Assert.assertTrue("shouldn't see invalid options from misbehaving chooser.", volumes.contains(choice));
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -179,9 +179,9 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
     }
   }
 
-  protected static final TestTable FOO = new TestTable("foo", new Table.ID("1"));
-  protected static final TestTable BAR = new TestTable("bar", new Table.ID("2"));
-  protected static final TestTable BAZ = new TestTable("baz", new Table.ID("3"));
+  protected static final TestTable FOO = new TestTable("foo", Table.ID.of("1"));
+  protected static final TestTable BAR = new TestTable("bar", Table.ID.of("2"));
+  protected static final TestTable BAZ = new TestTable("baz", Table.ID.of("3"));
 
   protected class TestDefaultBalancer extends DefaultLoadBalancer {
     @Override

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -155,7 +155,7 @@ public class ChaoticLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(new Table.ID(table), toText(end), toText(prev));
+    return new KeyExtent(Table.ID.of(table), toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -280,7 +280,7 @@ public class DefaultLoadBalancerTest {
   }
 
   private static KeyExtent makeExtent(String table, String end, String prev) {
-    return new KeyExtent(new Table.ID(table), toText(end), toText(prev));
+    return new KeyExtent(Table.ID.of(table), toText(end), toText(prev));
   }
 
   private static Text toText(String value) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -68,7 +68,7 @@ public class GroupBalancerTest {
 
     public void addTablet(String er, String location) {
       TServerInstance tsi = new TServerInstance(location, 6);
-      tabletLocs.put(new KeyExtent(new Table.ID("b"), er == null ? null : new Text(er), null), new TServerInstance(location, 6));
+      tabletLocs.put(new KeyExtent(Table.ID.of("b"), er == null ? null : new Text(er), null), new TServerInstance(location, 6));
       tservers.add(tsi);
     }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -176,9 +176,9 @@ public class TableLoadBalancerTest {
     tls.balance(state, migrations, migrationsOut);
     int count = 0;
     Map<Table.ID,Integer> movedByTable = new HashMap<>();
-    movedByTable.put(new Table.ID(t1Id), Integer.valueOf(0));
-    movedByTable.put(new Table.ID(t2Id), Integer.valueOf(0));
-    movedByTable.put(new Table.ID(t3Id), Integer.valueOf(0));
+    movedByTable.put(Table.ID.of(t1Id), Integer.valueOf(0));
+    movedByTable.put(Table.ID.of(t2Id), Integer.valueOf(0));
+    movedByTable.put(Table.ID.of(t3Id), Integer.valueOf(0));
     for (TabletMigration migration : migrationsOut) {
       if (migration.oldServer.equals(svr))
         count++;

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
@@ -72,7 +72,7 @@ public class MergeInfoTest {
     String table = "table";
     Text endRow = new Text("end");
     Text prevEndRow = new Text("begin");
-    keyExtent = new KeyExtent(new Table.ID(table), endRow, prevEndRow);
+    keyExtent = new KeyExtent(Table.ID.of(table), endRow, prevEndRow);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.DELETE);
     mi.setState(MergeState.STARTED);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -89,10 +89,10 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_DifferentTables() {
-    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent.getTableId()).andReturn(Table.ID.of("table1"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table2"));
+    expect(keyExtent2.getTableId()).andReturn(Table.ID.of("table2"));
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.needsToBeChopped(keyExtent2));
@@ -100,9 +100,9 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_NotDelete() {
-    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent.getTableId()).andReturn(Table.ID.of("table1"));
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent2.getTableId()).andReturn(Table.ID.of("table1"));
     replay(keyExtent2);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(true);
     replay(keyExtent);
@@ -126,11 +126,11 @@ public class MergeInfoTest {
   }
 
   private void testNeedsToBeChopped_Delete(String prevEndRow, boolean expected) {
-    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent.getTableId()).andReturn(Table.ID.of("table1"));
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent2.getTableId()).andReturn(Table.ID.of("table1"));
     expect(keyExtent2.getPrevEndRow()).andReturn(prevEndRow != null ? new Text(prevEndRow) : null);
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -151,9 +151,9 @@ public class MergeInfoTest {
   public void testOverlaps_DoesNotNeedChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent.getTableId()).andReturn(Table.ID.of("table1"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table2"));
+    expect(keyExtent2.getTableId()).andReturn(Table.ID.of("table2"));
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.overlaps(keyExtent2));
@@ -163,10 +163,10 @@ public class MergeInfoTest {
   public void testOverlaps_NeedsChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent.getTableId()).andReturn(Table.ID.of("table1"));
     expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(new Table.ID("table1"));
+    expect(keyExtent2.getTableId()).andReturn(Table.ID.of("table1"));
     expect(keyExtent2.getPrevEndRow()).andReturn(new Text("prev"));
     expectLastCall().anyTimes();
     replay(keyExtent2);
@@ -188,7 +188,7 @@ public class MergeInfoTest {
   }
 
   private static KeyExtent ke(String tableId, String endRow, String prevEndRow) {
-    return new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(Table.ID.of(tableId), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
@@ -44,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ProblemReportTest {
-  private static final Table.ID TABLE_ID = new Table.ID("table");
+  private static final Table.ID TABLE_ID = Table.ID.of("table");
   private static final String RESOURCE = "resource";
   private static final String SERVER = "server";
 

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
@@ -38,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ProblemReportingIteratorTest {
-  private static final Table.ID TABLE_ID = new Table.ID("table");
+  private static final Table.ID TABLE_ID = Table.ID.of("table");
   private static final String RESOURCE = "resource";
 
   private InterruptibleIterator ii;

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
@@ -92,7 +92,7 @@ public class ReplicationTableUtilTest {
     String myFile = "file:////home/user/accumulo/wal/server+port/" + uuid;
 
     long createdTime = System.currentTimeMillis();
-    ReplicationTableUtil.updateFiles(context, new KeyExtent(new Table.ID("1"), null, null), myFile, StatusUtil.fileCreated(createdTime));
+    ReplicationTableUtil.updateFiles(context, new KeyExtent(Table.ID.of("1"), null, null), myFile, StatusUtil.fileCreated(createdTime));
 
     verify(writer);
 
@@ -117,7 +117,7 @@ public class ReplicationTableUtilTest {
     String file = "file:///accumulo/wal/127.0.0.1+9997" + UUID.randomUUID();
     Path filePath = new Path(file);
     Text row = new Text(filePath.toString());
-    KeyExtent extent = new KeyExtent(new Table.ID("1"), new Text("b"), new Text("a"));
+    KeyExtent extent = new KeyExtent(Table.ID.of("1"), new Text("b"), new Text("a"));
 
     Mutation m = ReplicationTableUtil.createUpdateMutation(filePath, ProtobufUtil.toValue(stat), extent);
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -251,7 +251,7 @@ public class GarbageCollectionAlgorithm {
       String[] tokens = delete.split("/");
       if (tokens.length == 2) {
         // its a directory
-        Table.ID tableId = new Table.ID(delete.split("/")[0]);
+        Table.ID tableId = Table.ID.of(delete.split("/")[0]);
         tableIdsWithDeletes.add(tableId);
       }
     }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -391,7 +391,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
                 }
                 String parts[] = fullPath.toString().split(Constants.ZTABLES)[1].split("/");
                 if (parts.length > 2) {
-                  Table.ID tableId = new Table.ID(parts[1]);
+                  Table.ID tableId = Table.ID.of(parts[1]);
                   String tabletDir = parts[2];
                   TableManager.getInstance().updateTableStateCache(tableId);
                   TableState tableState = TableManager.getInstance().getTableState(tableId);

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -93,7 +93,7 @@ public class GarbageCollectionTest {
     }
 
     public Key newFileReferenceKey(String tableId, String endRow, String file) {
-      String row = new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(Table.ID.of(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.DataFileColumnFamily.NAME.toString();
       String cq = file;
       Key key = new Key(row, cf, cq);
@@ -111,7 +111,7 @@ public class GarbageCollectionTest {
     }
 
     Key newDirReferenceKey(String tableId, String endRow) {
-      String row = new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
+      String row = new KeyExtent(Table.ID.of(tableId), endRow == null ? null : new Text(endRow), null).getMetadataEntry().toString();
       String cf = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily().toString();
       String cq = MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier().toString();
       Key key = new Key(row, cf, cq);
@@ -534,7 +534,7 @@ public class GarbageCollectionTest {
 
     TestGCE gce = new TestGCE();
 
-    gce.tableIds.add(new Table.ID("4"));
+    gce.tableIds.add(Table.ID.of("4"));
 
     gce.candidates.add("/4/t-0");
     gce.candidates.add("/4/t-0/F002.rf");
@@ -547,8 +547,8 @@ public class GarbageCollectionTest {
     gca.collect(gce);
 
     HashSet<Table.ID> tids = new HashSet<>();
-    tids.add(new Table.ID("5"));
-    tids.add(new Table.ID("6"));
+    tids.add(Table.ID.of("5"));
+    tids.add(Table.ID.of("6"));
 
     Assert.assertEquals(tids.size(), gce.tablesDirsToDelete.size());
     Assert.assertTrue(tids.containsAll(gce.tablesDirsToDelete));

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -114,7 +114,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
 
   @Override
   public long initiateFlush(TInfo tinfo, TCredentials c, String tableIdStr) throws ThriftSecurityException, ThriftTableOperationException {
-    Table.ID tableId = new Table.ID(tableIdStr);
+    Table.ID tableId = Table.ID.of(tableIdStr);
     Namespace.ID namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
     master.security.canFlush(c, tableId, namespaceId);
 
@@ -143,7 +143,7 @@ public class MasterClientServiceHandler extends FateServiceHandler implements Ma
   @Override
   public void waitForFlush(TInfo tinfo, TCredentials c, String tableIdStr, ByteBuffer startRow, ByteBuffer endRow, long flushID, long maxLoops)
       throws ThriftSecurityException, ThriftTableOperationException {
-    Table.ID tableId = new Table.ID(tableIdStr);
+    Table.ID tableId = Table.ID.of(tableIdStr);
     Namespace.ID namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
     master.security.canFlush(c, tableId, namespaceId);
 

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/RemoveCompleteReplicationRecords.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/RemoveCompleteReplicationRecords.java
@@ -174,7 +174,7 @@ public class RemoveCompleteReplicationRecords implements Runnable {
 
       Table.ID tableId;
       if (StatusSection.NAME.equals(colf)) {
-        tableId = new Table.ID(colq.toString());
+        tableId = Table.ID.of(colq.toString());
       } else if (WorkSection.NAME.equals(colf)) {
         ReplicationTarget target = ReplicationTarget.from(colq);
         tableId = target.getSourceTableId();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
@@ -53,7 +53,7 @@ public class CloneTable extends MasterRepo {
 
     Utils.idLock.lock();
     try {
-      cloneInfo.tableId = Table.ID.of(Utils.getNextTableId(cloneInfo.tableName, environment.getInstance()));
+      cloneInfo.tableId = Utils.getNextId(cloneInfo.tableName, environment.getInstance(), Table.ID::of);
       return new ClonePermissions(cloneInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CloneTable.java
@@ -53,7 +53,7 @@ public class CloneTable extends MasterRepo {
 
     Utils.idLock.lock();
     try {
-      cloneInfo.tableId = Utils.getNextTableId(cloneInfo.tableName, environment.getInstance(), Table.ID.class);
+      cloneInfo.tableId = Table.ID.of(Utils.getNextTableId(cloneInfo.tableName, environment.getInstance()));
       return new ClonePermissions(cloneInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
@@ -43,7 +43,7 @@ public class CreateNamespace extends MasterRepo {
   public Repo<Master> call(long tid, Master master) throws Exception {
     Utils.idLock.lock();
     try {
-      namespaceInfo.namespaceId = Namespace.ID.of(Utils.getNextTableId(namespaceInfo.namespaceName, master.getInstance()));
+      namespaceInfo.namespaceId = Utils.getNextId(namespaceInfo.namespaceName, master.getInstance(), Namespace.ID::of);
       return new SetupNamespacePermissions(namespaceInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateNamespace.java
@@ -43,7 +43,7 @@ public class CreateNamespace extends MasterRepo {
   public Repo<Master> call(long tid, Master master) throws Exception {
     Utils.idLock.lock();
     try {
-      namespaceInfo.namespaceId = Utils.getNextTableId(namespaceInfo.namespaceName, master.getInstance(), Namespace.ID.class);
+      namespaceInfo.namespaceId = Namespace.ID.of(Utils.getNextTableId(namespaceInfo.namespaceName, master.getInstance()));
       return new SetupNamespacePermissions(namespaceInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
@@ -56,7 +56,7 @@ public class CreateTable extends MasterRepo {
 
     Utils.idLock.lock();
     try {
-      tableInfo.tableId = Table.ID.of(Utils.getNextTableId(tableInfo.tableName, master.getInstance()));
+      tableInfo.tableId = Utils.getNextId(tableInfo.tableName, master.getInstance(), Table.ID::of);
       return new SetupPermissions(tableInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CreateTable.java
@@ -56,7 +56,7 @@ public class CreateTable extends MasterRepo {
 
     Utils.idLock.lock();
     try {
-      tableInfo.tableId = Utils.getNextTableId(tableInfo.tableName, master.getInstance(), Table.ID.class);
+      tableInfo.tableId = Table.ID.of(Utils.getNextTableId(tableInfo.tableName, master.getInstance()));
       return new SetupPermissions(tableInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
@@ -72,7 +72,7 @@ public class ImportTable extends MasterRepo {
     Utils.idLock.lock();
     try {
       Instance instance = env.getInstance();
-      tableInfo.tableId = Table.ID.of(Utils.getNextTableId(tableInfo.tableName, instance));
+      tableInfo.tableId = Utils.getNextId(tableInfo.tableName, instance, Table.ID::of);
       return new ImportSetupPermissions(tableInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ImportTable.java
@@ -72,7 +72,7 @@ public class ImportTable extends MasterRepo {
     Utils.idLock.lock();
     try {
       Instance instance = env.getInstance();
-      tableInfo.tableId = Utils.getNextTableId(tableInfo.tableName, instance, Table.ID.class);
+      tableInfo.tableId = Table.ID.of(Utils.getNextTableId(tableInfo.tableName, instance));
       return new ImportSetupPermissions(tableInfo);
     } finally {
       Utils.idLock.unlock();

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/DistributedWorkQueueWorkAssignerHelperTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/DistributedWorkQueueWorkAssignerHelperTest.java
@@ -35,7 +35,7 @@ public class DistributedWorkQueueWorkAssignerHelperTest {
   @Test
   public void createsValidZKNodeName() {
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
 
     String key = DistributedWorkQueueWorkAssignerHelper.getQueueKey(p.toString(), target);
 
@@ -45,7 +45,7 @@ public class DistributedWorkQueueWorkAssignerHelperTest {
   @Test
   public void queueKeySerialization() {
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
 
     String key = DistributedWorkQueueWorkAssignerHelper.getQueueKey(p.toString(), target);
 

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/SequentialWorkAssignerTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/SequentialWorkAssignerTest.java
@@ -60,8 +60,8 @@ public class SequentialWorkAssignerTest {
     Map<String,String> cluster1Work = new TreeMap<>();
 
     // Two files for cluster1, one for table '1' and another for table '2' we havce assigned work for
-    cluster1Work.put("1", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", new Table.ID("1"))));
-    cluster1Work.put("2", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", new Table.ID("2"))));
+    cluster1Work.put("1", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", Table.ID.of("1"))));
+    cluster1Work.put("2", DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", Table.ID.of("2"))));
 
     queuedWork.put("cluster1", cluster1Work);
 
@@ -76,11 +76,11 @@ public class SequentialWorkAssignerTest {
     // file1 replicated
     expect(
         zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
-            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", new Table.ID("1"))))).andReturn(null);
+            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1", new ReplicationTarget("cluster1", "1", Table.ID.of("1"))))).andReturn(null);
     // file2 still needs to replicate
     expect(
         zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
-            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", new Table.ID("2"))))).andReturn(new byte[0]);
+            + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", Table.ID.of("2"))))).andReturn(new byte[0]);
 
     replay(workQueue, zooCache, conn, inst);
 
@@ -89,7 +89,7 @@ public class SequentialWorkAssignerTest {
     verify(workQueue, zooCache, conn, inst);
 
     Assert.assertEquals(1, cluster1Work.size());
-    Assert.assertEquals(DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", new Table.ID("2"))),
+    Assert.assertEquals(DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2", new ReplicationTarget("cluster1", "2", Table.ID.of("2"))),
         cluster1Work.get("2"));
   }
 }

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/UnorderedWorkAssignerTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/UnorderedWorkAssignerTest.java
@@ -58,7 +58,7 @@ public class UnorderedWorkAssignerTest {
 
   @Test
   public void workQueuedUsingFileName() throws Exception {
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
 
     DistributedWorkQueue workQueue = createMock(DistributedWorkQueue.class);
     Set<String> queuedWork = new HashSet<>();

--- a/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
@@ -191,7 +191,7 @@ public class RootTabletStateStoreTest {
     }
     assertEquals(count, 1);
 
-    KeyExtent notRoot = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent notRoot = new KeyExtent(Table.ID.of("0"), null, null);
     try {
       tstore.setLocations(Collections.singletonList(new Assignment(notRoot, server)));
       Assert.fail("should not get here");

--- a/server/master/src/test/java/org/apache/accumulo/master/tableOps/ImportTableTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/tableOps/ImportTableTest.java
@@ -36,7 +36,7 @@ public class ImportTableTest {
     Master master = EasyMock.createMock(Master.class);
     VolumeManager volumeManager = EasyMock.createMock(VolumeManager.class);
     ImportedTableInfo iti = new ImportedTableInfo();
-    iti.tableId = new Table.ID("5");
+    iti.tableId = Table.ID.of("5");
 
     // Different volumes with different paths
     String[] tableDirs = new String[] {"hdfs://nn1:8020/apps/accumulo1/tables", "hdfs://nn2:8020/applications/accumulo/tables"};

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemsResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemsResource.java
@@ -96,7 +96,7 @@ public class ProblemsResource {
   public void clearTableProblems(@QueryParam("s") String tableID) {
     Logger log = LoggerFactory.getLogger(Monitor.class);
     try {
-      ProblemReports.getInstance(Monitor.getContext()).deleteProblemReports(new Table.ID(tableID));
+      ProblemReports.getInstance(Monitor.getContext()).deleteProblemReports(Table.ID.of(tableID));
     } catch (Exception e) {
       log.error("Failed to delete problem reports for table " + tableID, e);
     }
@@ -147,7 +147,7 @@ public class ProblemsResource {
   public void clearDetailsProblems(@QueryParam("table") String tableID, @QueryParam("resource") String resource, @QueryParam("ptype") String ptype) {
     Logger log = LoggerFactory.getLogger(Monitor.class);
     try {
-      ProblemReports.getInstance(Monitor.getContext()).deleteProblemReport(new Table.ID(tableID), ProblemType.valueOf(ptype), resource);
+      ProblemReports.getInstance(Monitor.getContext()).deleteProblemReport(Table.ID.of(tableID), ProblemType.valueOf(ptype), resource);
     } catch (Exception e) {
       log.error("Failed to delete problem reports for table " + tableID, e);
     }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
@@ -103,7 +103,7 @@ public class TablesResource {
 
     if (Monitor.getMmi() != null && Monitor.getMmi().tableMap != null)
       for (Entry<String,TableInfo> te : Monitor.getMmi().tableMap.entrySet())
-        tableStats.put(Tables.getPrintableTableInfoFromId(inst, new Table.ID(te.getKey())), te.getValue());
+        tableStats.put(Tables.getPrintableTableInfoFromId(inst, Table.ID.of(te.getKey())), te.getValue());
     Map<String,Double> compactingByTable = TableInfoUtil.summarizeTableStats(Monitor.getMmi());
     TableManager tableManager = TableManager.getInstance();
     List<TableInformation> tables = new ArrayList<>();
@@ -203,7 +203,7 @@ public class TablesResource {
   @GET
   public TabletServers getParticipatingTabletServers(@PathParam("tableId") String tableIdStr) throws Exception {
     Instance instance = Monitor.getContext().getInstance();
-    Table.ID tableId = new Table.ID(tableIdStr);
+    Table.ID tableId = Table.ID.of(tableIdStr);
 
     TabletServers tabletServers = new TabletServers(Monitor.getMmi().tServerInfo.size());
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -237,7 +237,7 @@ public class WebViews {
   @Template(name = "/default.ftl")
   public Map<String,Object> getTables(@PathParam("tableID") String tableID) throws TableNotFoundException {
 
-    String tableName = Tables.getTableName(Monitor.getContext().getInstance(), new Table.ID(tableID));
+    String tableName = Tables.getTableName(Monitor.getContext().getInstance(), Table.ID.of(tableID));
 
     Map<String,Object> model = getModel();
     model.put("title", "Table Status");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -490,7 +490,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         long readaheadThreshold, TSamplerConfiguration tSamplerConfig, long batchTimeOut, String context) throws NotServingTabletException,
         ThriftSecurityException, org.apache.accumulo.core.tabletserver.thrift.TooManyFilesException, TSampleNotPresentException {
 
-      Table.ID tableId = new Table.ID(new String(textent.getTable(), UTF_8));
+      Table.ID tableId = Table.ID.of(new String(textent.getTable(), UTF_8));
       Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
@@ -649,7 +649,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       // find all of the tables that need to be scanned
       final HashSet<Table.ID> tables = new HashSet<>();
       for (TKeyExtent keyExtent : tbatch.keySet()) {
-        tables.add(new Table.ID(new String(keyExtent.getTable(), UTF_8)));
+        tables.add(Table.ID.of(new String(keyExtent.getTable(), UTF_8)));
       }
 
       if (tables.size() != 1)
@@ -1084,7 +1084,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     public void update(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, TMutation tmutation, TDurability tdurability)
         throws NotServingTabletException, ConstraintViolationException, ThriftSecurityException {
 
-      final Table.ID tableId = new Table.ID(new String(tkeyExtent.getTable(), UTF_8));
+      final Table.ID tableId = Table.ID.of(new String(tkeyExtent.getTable(), UTF_8));
       Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
@@ -1323,7 +1323,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     public TConditionalSession startConditionalUpdate(TInfo tinfo, TCredentials credentials, List<ByteBuffer> authorizations, String tableIdStr,
         TDurability tdurabilty, String classLoaderContext) throws ThriftSecurityException, TException {
 
-      Table.ID tableId = new Table.ID(tableIdStr);
+      Table.ID tableId = Table.ID.of(tableIdStr);
       Authorizations userauths = null;
       Namespace.ID namespaceId;
       try {
@@ -1416,7 +1416,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     public void splitTablet(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, ByteBuffer splitPoint) throws NotServingTabletException,
         ThriftSecurityException {
 
-      Table.ID tableId = new Table.ID(new String(ByteBufferUtil.toBytes(tkeyExtent.table)));
+      Table.ID tableId = Table.ID.of(new String(ByteBufferUtil.toBytes(tkeyExtent.table)));
       Namespace.ID namespaceId;
       try {
         namespaceId = Tables.getNamespaceId(getInstance(), tableId);
@@ -1459,7 +1459,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         onlineTabletsCopy = new TreeMap<>(onlineTablets);
       }
       List<TabletStats> result = new ArrayList<>();
-      Table.ID text = new Table.ID(tableId);
+      Table.ID text = Table.ID.of(tableId);
       KeyExtent start = new KeyExtent(text, new Text(), null);
       for (Entry<KeyExtent,Tablet> entry : onlineTabletsCopy.tailMap(start).entrySet()) {
         KeyExtent ke = entry.getKey();
@@ -1634,7 +1634,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
       ArrayList<Tablet> tabletsToFlush = new ArrayList<>();
 
-      KeyExtent ke = new KeyExtent(new Table.ID(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(Table.ID.of(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       synchronized (onlineTablets) {
         for (Tablet tablet : onlineTablets.values())
@@ -1752,7 +1752,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         throw new RuntimeException(e);
       }
 
-      KeyExtent ke = new KeyExtent(new Table.ID(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
+      KeyExtent ke = new KeyExtent(Table.ID.of(tableId), ByteBufferUtil.toText(endRow), ByteBufferUtil.toText(startRow));
 
       ArrayList<Tablet> tabletsToCompact = new ArrayList<>();
       synchronized (onlineTablets) {
@@ -1848,7 +1848,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     public TSummaries startGetSummaries(TInfo tinfo, TCredentials credentials, TSummaryRequest request) throws ThriftSecurityException,
         ThriftTableOperationException, NoSuchScanIDException, TException {
       Namespace.ID namespaceId;
-      Table.ID tableId = new Table.ID(request.getTableId());
+      Table.ID tableId = Table.ID.of(request.getTableId());
       try {
         namespaceId = Tables.getNamespaceId(TabletServer.this.getInstance(), tableId);
       } catch (TableNotFoundException e1) {
@@ -1876,7 +1876,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
       ServerConfigurationFactory factory = TabletServer.this.getServerConfigurationFactory();
       ExecutorService spe = resourceManager.getSummaryRemoteExecutor();
-      Future<SummaryCollection> future = new Gatherer(TabletServer.this, request, factory.getTableConfiguration(new Table.ID(request.getTableId())))
+      Future<SummaryCollection> future = new Gatherer(TabletServer.this, request, factory.getTableConfiguration(Table.ID.of(request.getTableId())))
           .processPartition(spe, modulus, remainder);
 
       return startSummaryOperation(credentials, future);
@@ -1891,7 +1891,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       }
 
       ExecutorService srp = resourceManager.getSummaryRetrievalExecutor();
-      TableConfiguration tableCfg = confFactory.getTableConfiguration(new Table.ID(request.getTableId()));
+      TableConfiguration tableCfg = confFactory.getTableConfiguration(Table.ID.of(request.getTableId()));
       BlockCache summaryCache = resourceManager.getSummaryCache();
       BlockCache indexCache = resourceManager.getIndexCache();
       FileSystemResolver volMgr = p -> fs.getVolumeByPath(p).getFileSystem();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -85,7 +85,7 @@ public class LogReader {
       row = new Text(opts.row);
     if (opts.extent != null) {
       String sa[] = opts.extent.split(";");
-      ke = new KeyExtent(new Table.ID(sa[0]), new Text(sa[1]), new Text(sa[2]));
+      ke = new KeyExtent(Table.ID.of(sa[0]), new Text(sa[1]), new Text(sa[2]));
     }
     if (opts.regexp != null) {
       Pattern pattern = Pattern.compile(opts.regexp);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
@@ -51,7 +51,7 @@ public class ReplicationServicerHandler implements Iface {
 
   @Override
   public long replicateLog(String tableIdStr, WalEdits data, TCredentials tcreds) throws RemoteReplicationException, TException {
-    Table.ID tableId = new Table.ID(tableIdStr);
+    Table.ID tableId = Table.ID.of(tableIdStr);
     log.debug("Got replication request to tableID {} with {} edits", tableId, data.getEditsSize());
     tabletServer.getSecurityOperation().authenticateUser(tabletServer.rpcCreds(), tcreds);
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
@@ -50,7 +50,7 @@ public class AssignmentWatcherTest {
     RunnableStartedAt run = new RunnableStartedAt(task, System.currentTimeMillis());
     EasyMock.expect(conf.getTimeInMillis(Property.TSERV_ASSIGNMENT_DURATION_WARNING)).andReturn(0l);
 
-    assignments.put(new KeyExtent(new Table.ID("1"), null, null), run);
+    assignments.put(new KeyExtent(Table.ID.of("1"), null, null), run);
 
     EasyMock.expect(task.getException()).andReturn(new Exception("Assignment warning happened"));
     EasyMock.expect(timer.schedule(watcher, 5000l)).andReturn(null);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -71,7 +71,7 @@ public class CheckTabletMetadataTest {
   @Test
   public void testBadTabletMetadata() throws Exception {
 
-    KeyExtent ke = new KeyExtent(new Table.ID("1"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("1"), null, null);
 
     TreeMap<Key,Value> tabletMeta = new TreeMap<>();
 
@@ -90,9 +90,9 @@ public class CheckTabletMetadataTest {
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 4));
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.2:9997", 5));
 
-    assertFail(tabletMeta, new KeyExtent(new Table.ID("1"), null, new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent(Table.ID.of("1"), null, new Text("m")), tsi);
 
-    assertFail(tabletMeta, new KeyExtent(new Table.ID("1"), new Text("r"), new Text("m")), tsi);
+    assertFail(tabletMeta, new KeyExtent(Table.ID.of("1"), new Text("r"), new Text("m")), tsi);
 
     assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/LargestFirstMemoryManagerTest.java
@@ -196,7 +196,7 @@ public class LargestFirstMemoryManagerTest {
     mgr.init(config);
     MemoryManagementActions result;
     // one tablet is really big and the other is for a nonexistent table
-    KeyExtent extent = new KeyExtent(new Table.ID("2"), new Text("j"), null);
+    KeyExtent extent = new KeyExtent(Table.ID.of("2"), new Text("j"), null);
     result = mgr.getMemoryManagementActions(tablets(t(extent, ZERO, ONE_GIG, 0), t(k("j"), ZERO, ONE_GIG, 0)));
     assertEquals(1, result.tabletsToMinorCompact.size());
     assertEquals(extent, result.tabletsToMinorCompact.get(0));
@@ -238,7 +238,7 @@ public class LargestFirstMemoryManagerTest {
   }
 
   private static KeyExtent k(String endRow) {
-    return new KeyExtent(new Table.ID("1"), new Text(endRow), null);
+    return new KeyExtent(Table.ID.of("1"), new Text(endRow), null);
   }
 
   private static class TestTabletState implements TabletState {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -158,7 +158,7 @@ public class DefaultCompactionStrategyTest {
   }
 
   private MajorCompactionRequest createRequest(MajorCompactionReason reason, Object... objs) throws IOException {
-    return createRequest(new KeyExtent(new Table.ID("0"), null, null), reason, objs);
+    return createRequest(new KeyExtent(Table.ID.of("0"), null, null), reason, objs);
   }
 
   private MajorCompactionRequest createRequest(KeyExtent extent, MajorCompactionReason reason, Object... objs) throws IOException {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
@@ -52,7 +52,7 @@ public class SizeLimitCompactionStrategyTest {
 
     slcs.init(opts);
 
-    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("0"), null, null);
     MajorCompactionRequest mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, DefaultConfiguration.getInstance());
 
     mcr.setFiles(nfl("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G"));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/TwoTierCompactionStrategyTest.java
@@ -64,7 +64,7 @@ public class TwoTierCompactionStrategyTest {
   public void testDefaultCompaction() throws IOException {
     ttcs.init(opts);
     conf = DefaultConfiguration.getInstance();
-    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("0"), null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "10M", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "100M", "f6", "100M", "f7", "100M", "f8",
         "100M");
@@ -83,7 +83,7 @@ public class TwoTierCompactionStrategyTest {
   public void testLargeCompaction() throws IOException {
     ttcs.init(opts);
     conf = DefaultConfiguration.getInstance();
-    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("0"), null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "2G", "f2", "2G", "f3", "2G", "f4", "2G");
     mcr.setFiles(fileMap);
@@ -112,7 +112,7 @@ public class TwoTierCompactionStrategyTest {
   public void testFileSubsetCompaction() throws IOException {
     ttcs.init(opts);
     conf = DefaultConfiguration.getInstance();
-    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("0"), null, null);
     mcr = new MajorCompactionRequest(ke, MajorCompactionReason.NORMAL, conf);
     Map<FileRef,DataFileValue> fileMap = createFileMap("f1", "1G", "f2", "10M", "f3", "10M", "f4", "10M", "f5", "10M", "f6", "10M", "f7", "10M");
     Map<FileRef,DataFileValue> filesToCompactMap = createFileMap("f2", "10M", "f3", "10M", "f4", "10M", "f5", "10M", "f6", "10M", "f7", "10M");

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
@@ -38,7 +38,7 @@ public class ConfigurableCompactionStrategyTest {
 
   @Test
   public void testOutputOptions() throws Exception {
-    MajorCompactionRequest mcr = new MajorCompactionRequest(new KeyExtent(new Table.ID("1"), null, null), MajorCompactionReason.USER, null);
+    MajorCompactionRequest mcr = new MajorCompactionRequest(new KeyExtent(Table.ID.of("1"), null, null), MajorCompactionReason.USER, null);
 
     Map<FileRef,DataFileValue> files = new HashMap<>();
     files.put(new FileRef("hdfs://nn1/accumulo/tables/1/t-009/F00001.rf"), new DataFileValue(50000, 400));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEntryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEntryTest.java
@@ -30,7 +30,7 @@ public class LogEntryTest {
 
   @Test
   public void test() throws Exception {
-    KeyExtent extent = new KeyExtent(new Table.ID("1"), null, new Text(""));
+    KeyExtent extent = new KeyExtent(Table.ID.of("1"), null, new Text(""));
     long ts = 12345678L;
     String server = "localhost:1234";
     String filename = "default/foo";

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -57,7 +57,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class SortedLogRecoveryTest {
 
-  static final KeyExtent extent = new KeyExtent(new Table.ID("table"), null, null);
+  static final KeyExtent extent = new KeyExtent(Table.ID.of("table"), null, null);
   static final Text cf = new Text("cf");
   static final Text cq = new Text("cq");
   static final Value value = new Value("value".getBytes());

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -81,7 +81,7 @@ public class LogFileTest {
     assertEquals(key.seq, 3);
     assertEquals(key.tid, 4);
     assertEquals(key.filename, "some file");
-    KeyExtent tablet = new KeyExtent(new Table.ID("table"), new Text("bbbb"), new Text("aaaa"));
+    KeyExtent tablet = new KeyExtent(Table.ID.of("table"), new Text("bbbb"), new Text("aaaa"));
     readWrite(DEFINE_TABLET, 5, 6, null, tablet, null, key, value);
     assertEquals(key.event, DEFINE_TABLET);
     assertEquals(key.seq, 5);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
@@ -78,7 +78,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("1"), null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -93,7 +93,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("2"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("2"), null, null);
     key.tid = 2;
     value.mutations = Collections.emptyList();
 
@@ -124,7 +124,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("1"), null, null);
     key.tid = 3;
     value.mutations = Collections.emptyList();
 
@@ -158,7 +158,7 @@ public class AccumuloReplicaSystemTest {
 
     Status status = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true).setClosed(false).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", Table.ID.of("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
         Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
@@ -184,7 +184,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("1"), null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -199,7 +199,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("2"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("2"), null, null);
     key.tid = 2;
     value.mutations = Collections.emptyList();
 
@@ -230,7 +230,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("1"), null, null);
     key.tid = 3;
     value.mutations = Collections.emptyList();
 
@@ -266,7 +266,7 @@ public class AccumuloReplicaSystemTest {
     // If it were still open, more data could be appended that we need to process
     Status status = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true).setClosed(true).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", Table.ID.of("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
         Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
@@ -301,7 +301,7 @@ public class AccumuloReplicaSystemTest {
     DataOutputStream out = new DataOutputStream(baos);
 
     // Replicate our 2 mutations to "peer", from tableid 1 to tableid 1
-    ars.writeValueAvoidingReplicationCycles(out, value, new ReplicationTarget("peer", "1", new Table.ID("1")));
+    ars.writeValueAvoidingReplicationCycles(out, value, new ReplicationTarget("peer", "1", Table.ID.of("1")));
 
     out.close();
 
@@ -332,7 +332,7 @@ public class AccumuloReplicaSystemTest {
     // If it were still open, more data could be appended that we need to process
     Status status = Status.newBuilder().setBegin(100).setEnd(0).setInfiniteEnd(true).setClosed(true).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", Table.ID.of("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
         Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
@@ -355,7 +355,7 @@ public class AccumuloReplicaSystemTest {
     // If it were still open, more data could be appended that we need to process
     Status status = Status.newBuilder().setBegin(100).setEnd(0).setInfiniteEnd(true).setClosed(false).build();
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", Table.ID.of("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status,
         Long.MAX_VALUE, new HashSet<Integer>());
 
     // We stopped because we got to the end of the file
@@ -381,7 +381,7 @@ public class AccumuloReplicaSystemTest {
      * look like in a WAL. They are solely for testing that each LogEvents is handled, order is not important.
      */
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID("1"), null, null);
+    key.tablet = new KeyExtent(Table.ID.of("1"), null, null);
     key.tid = 1;
 
     key.write(dos);
@@ -419,7 +419,7 @@ public class AccumuloReplicaSystemTest {
     HashSet<Integer> tids = new HashSet<>();
 
     // Only consume the first mutation, not the second
-    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l,
+    WalReplication repl = ars.getWalEdits(new ReplicationTarget("peer", "1", Table.ID.of("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l,
         tids);
 
     // We stopped because we got to the end of the file
@@ -431,7 +431,7 @@ public class AccumuloReplicaSystemTest {
     status = Status.newBuilder(status).setBegin(2).build();
 
     // Consume the rest of the mutations
-    repl = ars.getWalEdits(new ReplicationTarget("peer", "1", new Table.ID("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l, tids);
+    repl = ars.getWalEdits(new ReplicationTarget("peer", "1", Table.ID.of("1")), dis, new Path("/accumulo/wals/tserver+port/wal"), status, 1l, tids);
 
     // We stopped because we got to the end of the file
     Assert.assertEquals(1, repl.entriesConsumed);
@@ -447,7 +447,7 @@ public class AccumuloReplicaSystemTest {
     WalEdits edits = new WalEdits(Collections.<ByteBuffer> emptyList());
     WalReplication walReplication = new WalReplication(edits, 0, 0, 0);
 
-    ReplicationTarget target = new ReplicationTarget("peer", "2", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("peer", "2", Table.ID.of("1"));
     DataInputStream input = null;
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
     Status status = null;
@@ -476,7 +476,7 @@ public class AccumuloReplicaSystemTest {
     WalEdits edits = new WalEdits(Collections.<ByteBuffer> emptyList());
     WalReplication walReplication = new WalReplication(edits, 0, 5, 0);
 
-    ReplicationTarget target = new ReplicationTarget("peer", "2", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("peer", "2", Table.ID.of("1"));
     DataInputStream input = null;
     Path p = new Path("/accumulo/wals/tserver+port/" + UUID.randomUUID().toString());
     Status status = null;
@@ -501,7 +501,7 @@ public class AccumuloReplicaSystemTest {
   @Test
   public void testUserPassword() throws Exception {
     AccumuloReplicaSystem ars = new AccumuloReplicaSystem();
-    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", Table.ID.of("1"));
     String user = "user", password = "password";
 
     Map<String,String> confMap = new HashMap<>();
@@ -516,7 +516,7 @@ public class AccumuloReplicaSystemTest {
   @Test
   public void testUserKeytab() throws Exception {
     AccumuloReplicaSystem ars = new AccumuloReplicaSystem();
-    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("peer", "peer_table", Table.ID.of("1"));
     String user = "user", keytab = "/etc/security/keytabs/replication.keytab";
 
     Map<String,String> confMap = new HashMap<>();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
@@ -83,7 +83,7 @@ public class ReplicationProcessorTest {
     ReplicationProcessor proc = EasyMock.createMockBuilder(ReplicationProcessor.class)
         .addMockedMethods("getReplicaSystem", "doesFileExist", "getStatus", "getHelper").createMock();
 
-    ReplicationTarget target = new ReplicationTarget("peer", "1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("peer", "1", Table.ID.of("1"));
     Status status = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true).setClosed(true).build();
     Path path = new Path("/accumulo");
 

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -49,7 +49,7 @@ public class CloneIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("0"), null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -63,9 +63,9 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
-    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(0, rc);
 
@@ -79,7 +79,7 @@ public class CloneIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    KeyExtent ke = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke = new KeyExtent(Table.ID.of("0"), null, null);
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -94,7 +94,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     Mutation mut2 = new Mutation(ke.getMetadataEntry());
     mut2.putDelete(DataFileColumnFamily.NAME.toString(), "/default_tablet/0_0.rf");
@@ -103,16 +103,16 @@ public class CloneIT extends AccumuloClusterHarness {
     bw1.addMutation(mut2);
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(1, rc);
 
-    rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(Table.ID.of("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -141,19 +141,19 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     bw1.addMutation(createTablet("0", "m", null, "/default_tablet", "/default_tablet/0_0.rf"));
     bw1.addMutation(createTablet("0", null, "m", "/t-1", "/default_tablet/0_0.rf"));
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(Table.ID.of("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -185,7 +185,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     bw1.addMutation(createTablet("0", "m", null, "/default_tablet", "/default_tablet/1_0.rf"));
     Mutation mut3 = createTablet("0", null, "m", "/t-1", "/default_tablet/1_0.rf");
@@ -194,16 +194,16 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(1, rc);
 
-    rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(Table.ID.of("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -222,7 +222,7 @@ public class CloneIT extends AccumuloClusterHarness {
   }
 
   private static Mutation deleteTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(new Table.ID(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(Table.ID.of(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = new Mutation(ke.getMetadataEntry());
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
     TabletsSection.ServerColumnFamily.TIME_COLUMN.putDelete(mut);
@@ -233,7 +233,7 @@ public class CloneIT extends AccumuloClusterHarness {
   }
 
   private static Mutation createTablet(String tid, String endRow, String prevRow, String dir, String file) throws Exception {
-    KeyExtent ke = new KeyExtent(new Table.ID(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
+    KeyExtent ke = new KeyExtent(Table.ID.of(tid), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow));
     Mutation mut = ke.getPrevRowUpdateMutation();
 
     TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0".getBytes()));
@@ -259,7 +259,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     bw1.addMutation(createTablet("0", "f", null, "/d1", "/d1/file3"));
     bw1.addMutation(createTablet("0", "m", "f", "/d3", "/d1/file1"));
@@ -268,12 +268,12 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(Table.ID.of("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -307,7 +307,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     bw1.addMutation(deleteTablet("0", "m", null, "/d1", "/d1/file1"));
     bw1.addMutation(deleteTablet("0", null, "m", "/d2", "/d2/file2"));
@@ -321,7 +321,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    int rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    int rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(1, rc);
 
@@ -333,12 +333,12 @@ public class CloneIT extends AccumuloClusterHarness {
 
     bw1.flush();
 
-    rc = MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    rc = MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     assertEquals(0, rc);
 
     Scanner scanner = conn.createScanner(tableName, Authorizations.EMPTY);
-    scanner.setRange(new KeyExtent(new Table.ID("1"), null, null).toMetadataRange());
+    scanner.setRange(new KeyExtent(Table.ID.of("1"), null, null).toMetadataRange());
 
     HashSet<String> files = new HashSet<>();
 
@@ -373,7 +373,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
     BatchWriter bw2 = conn.createBatchWriter(tableName, new BatchWriterConfig());
 
-    MetadataTableUtil.initializeClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+    MetadataTableUtil.initializeClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
 
     bw1.addMutation(deleteTablet("0", "m", null, "/d1", "/d1/file1"));
     Mutation mut = createTablet("0", null, null, "/d2", "/d2/file2");
@@ -383,7 +383,7 @@ public class CloneIT extends AccumuloClusterHarness {
     bw1.flush();
 
     try {
-      MetadataTableUtil.checkClone(tableName, new Table.ID("0"), new Table.ID("1"), conn, bw2);
+      MetadataTableUtil.checkClone(tableName, Table.ID.of("0"), Table.ID.of("1"), conn, bw2);
       assertTrue(false);
     } catch (TabletIterator.TabletDeletedException tde) {}
 

--- a/test/src/main/java/org/apache/accumulo/test/FileArchiveIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/FileArchiveIT.java
@@ -65,7 +65,7 @@ public class FileArchiveIT extends ConfigurableMacBase {
 
     conn.tableOperations().create(tableName);
 
-    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    final Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Could not get table ID", tableId);
 
     BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig());
@@ -123,7 +123,7 @@ public class FileArchiveIT extends ConfigurableMacBase {
 
     conn.tableOperations().create(tableName);
 
-    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    final Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Could not get table ID", tableId);
 
     BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig());
@@ -180,7 +180,7 @@ public class FileArchiveIT extends ConfigurableMacBase {
 
     conn.tableOperations().create(tableName);
 
-    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    final Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Could not get table ID", tableId);
 
     BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -140,7 +140,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
     // Get all `file` colfams from the metadata table for the new table
     log.info("Imported into table with ID: {}", tableId);
     Scanner s = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    s.setRange(MetadataSchema.TabletsSection.getRange(new org.apache.accumulo.core.client.impl.Table.ID(tableId)));
+    s.setRange(MetadataSchema.TabletsSection.getRange(org.apache.accumulo.core.client.impl.Table.ID.of(tableId)));
     s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
     MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
 

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -71,7 +71,7 @@ public class LocatorIT extends AccumuloClusterHarness {
   }
 
   private static TabletId newTabletId(String tableId, String endRow, String prevRow) {
-    return new TabletIdImpl(new KeyExtent(new Table.ID(tableId), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow)));
+    return new TabletIdImpl(new KeyExtent(Table.ID.of(tableId), endRow == null ? null : new Text(endRow), prevRow == null ? null : new Text(prevRow)));
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -46,7 +46,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
     Credentials credentials = new Credentials(getAdminPrincipal(), getAdminToken());
     ClientContext context = new ClientContext(getConnector().getInstance(), credentials, cluster.getClientConfig());
     Writer w = new Writer(context, MetadataTable.ID);
-    KeyExtent extent = new KeyExtent(new Table.ID("5"), null, null);
+    KeyExtent extent = new KeyExtent(Table.ID.of("5"), null, null);
 
     Mutation m = new Mutation(extent.getMetadataEntry());
     // unknown columns should cause contraint violation

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -125,7 +125,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Table ID was null", tableId);
 
     LogEntry logEntry = new LogEntry(new KeyExtent(tableId, null, null), 0, "127.0.0.1:12345", emptyWalog.toURI().toString());
@@ -180,7 +180,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
     String tableName = getUniqueNames(1)[0];
     conn.tableOperations().create(tableName);
 
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     Assert.assertNotNull("Table ID was null", tableId);
 
     LogEntry logEntry = new LogEntry(null, 0, "127.0.0.1:12345", partialHeaderWalog.toURI().toString());

--- a/test/src/main/java/org/apache/accumulo/test/RewriteTabletDirectoriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RewriteTabletDirectoriesIT.java
@@ -100,7 +100,7 @@ public class RewriteTabletDirectoriesIT extends ConfigurableMacBase {
 
     BatchScanner scanner = c.createBatchScanner(MetadataTable.NAME, Authorizations.EMPTY, 1);
     DIRECTORY_COLUMN.fetch(scanner);
-    Table.ID tableId = new Table.ID(c.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableId = Table.ID.of(c.tableOperations().tableIdMap().get(tableName));
     assertNotNull("TableID for " + tableName + " was null", tableId);
     scanner.setRanges(Collections.singletonList(TabletsSection.getRange(tableId)));
     // verify the directory entries are all on v1, make a few entries relative

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -205,7 +205,7 @@ public class SampleIT extends AccumuloClusterHarness {
     Set<String> es = Collections.emptySet();
     conn.tableOperations().clone(tableName, clone, false, em, es);
     conn.tableOperations().offline(clone, true);
-    Table.ID cloneID = new Table.ID(conn.tableOperations().tableIdMap().get(clone));
+    Table.ID cloneID = Table.ID.of(conn.tableOperations().tableIdMap().get(clone));
     OfflineScanner oScanner = new OfflineScanner(conn.getInstance(), new Credentials(getAdminPrincipal(), getAdminToken()), cloneID, Authorizations.EMPTY);
     if (sc != null) {
       oScanner.setSamplerConfiguration(sc);

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -87,7 +87,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
 
       // poke a partial split into the metadata table
       connector.securityOperations().grantTablePermission(getAdminPrincipal(), MetadataTable.NAME, TablePermission.WRITE);
-      Table.ID tableId = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+      Table.ID tableId = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
       KeyExtent extent = new KeyExtent(tableId, null, new Text("b"));
       Mutation m = extent.getPrevRowUpdateMutation();

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -63,7 +63,7 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
     int numThreads = 2;
     // Number of iterations per thread
     int iterations = 100000;
-    AccumuloConfiguration tableConf = new TableConfiguration(inst, new org.apache.accumulo.core.client.impl.Table.ID(table), defaultConf);
+    AccumuloConfiguration tableConf = new TableConfiguration(inst, org.apache.accumulo.core.client.impl.Table.ID.of(table), defaultConf);
 
     long start = System.currentTimeMillis();
     ExecutorService svc = Executors.newFixedThreadPool(numThreads);

--- a/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
@@ -177,7 +177,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableID = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -201,7 +201,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     String tableName2 = namespace2 + ".1";
 
     connector.tableOperations().create(tableName2);
-    Table.ID tableID2 = new Table.ID(connector.tableOperations().tableIdMap().get(tableName2));
+    Table.ID tableID2 = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName2));
 
     // Add 10 splits to the table
     addSplits(connector, tableName2);
@@ -228,7 +228,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableID = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -248,7 +248,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table2 on namespace2
     String tableName2 = namespace2 + ".1";
     connector.tableOperations().create(tableName2);
-    Table.ID tableID2 = new Table.ID(connector.tableOperations().tableIdMap().get(tableName2));
+    Table.ID tableID2 = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName2));
 
     // / Add 10 splits to the table
     addSplits(connector, tableName2);
@@ -276,7 +276,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableID = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -300,7 +300,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table2 on namespace2
     String tableName2 = namespace2 + ".1";
     connector.tableOperations().create(tableName2);
-    Table.ID tableID2 = new Table.ID(connector.tableOperations().tableIdMap().get(tableName2));
+    Table.ID tableID2 = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName2));
 
     // Add 10 splits to the table
     addSplits(connector, tableName2);
@@ -328,7 +328,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableID = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -360,7 +360,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     // Create table1 on namespace1
     String tableName = namespace1 + ".1";
     connector.tableOperations().create(tableName);
-    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableID = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);
@@ -379,7 +379,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     Connector connector = getConnector();
     String tableName = getUniqueNames(2)[0];
     connector.tableOperations().create(tableName);
-    Table.ID tableID = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableID = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     // Add 10 splits to the table
     addSplits(connector, tableName);

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -189,7 +189,7 @@ public class VolumeIT extends ConfigurableMacBase {
     String tableName = getUniqueNames(1)[0];
     connector.tableOperations().create(tableName, new NewTableConfiguration().withoutDefaultIterators());
 
-    Table.ID tableId = new Table.ID(connector.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableId = Table.ID.of(connector.tableOperations().tableIdMap().get(tableName));
 
     SortedSet<Text> partitions = new TreeSet<>();
     // with some splits
@@ -404,7 +404,7 @@ public class VolumeIT extends ConfigurableMacBase {
 
     verifyData(expected, conn.createScanner(tableName, Authorizations.EMPTY));
 
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     Scanner metaScanner = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(metaScanner);
     metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -64,8 +64,8 @@ public class WrongTabletTest {
 
       Mutation mutation = new Mutation(new Text("row_0003750001"));
       mutation.putDelete(new Text("colf"), new Text("colq"));
-      client.update(Tracer.traceInfo(), context.rpcCreds(), new KeyExtent(new Table.ID("!!"), null, new Text("row_0003750000")).toThrift(),
-          mutation.toThrift(), TDurability.DEFAULT);
+      client.update(Tracer.traceInfo(), context.rpcCreds(), new KeyExtent(Table.ID.of("!!"), null, new Text("row_0003750000")).toThrift(), mutation.toThrift(),
+          TDurability.DEFAULT);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -68,7 +68,7 @@ public class FunctionalTestUtils {
 
   public static int countRFiles(Connector c, String tableName) throws Exception {
     Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    Table.ID tableId = new Table.ID(c.tableOperations().tableIdMap().get(tableName));
+    Table.ID tableId = Table.ID.of(c.tableOperations().tableIdMap().get(tableName));
     scanner.setRange(MetadataSchema.TabletsSection.getRange(tableId));
     scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
@@ -92,7 +92,7 @@ public class MasterAssignmentIT extends AccumuloClusterHarness {
   private TabletLocationState getTabletLocationState(Connector c, String tableId) throws FileNotFoundException, ConfigurationException {
     Credentials creds = new Credentials(getAdminPrincipal(), getAdminToken());
     ClientContext context = new ClientContext(c.getInstance(), creds, getCluster().getClientConfig());
-    MetaDataTableScanner s = new MetaDataTableScanner(context, new Range(KeyExtent.getMetadataEntry(new Table.ID(tableId), null)));
+    MetaDataTableScanner s = new MetaDataTableScanner(context, new Range(KeyExtent.getMetadataEntry(Table.ID.of(tableId), null)));
     TabletLocationState tlState = s.next();
     s.close();
     return tlState;

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
@@ -219,7 +219,7 @@ public class MergeIT extends AccumuloClusterHarness {
     protected void resetScanner() {
       try {
         Scanner ds = conn.createScanner(metadataTableName, Authorizations.EMPTY);
-        Text tablet = new KeyExtent(new Table.ID("0"), new Text("m"), null).getMetadataEntry();
+        Text tablet = new KeyExtent(Table.ID.of("0"), new Text("m"), null).getMetadataEntry();
         ds.setRange(new Range(tablet, true, tablet, true));
 
         Mutation m = new Mutation(tablet);
@@ -250,11 +250,11 @@ public class MergeIT extends AccumuloClusterHarness {
     String metadataTableName = getUniqueNames(1)[0];
     getConnector().tableOperations().create(metadataTableName);
 
-    KeyExtent ke1 = new KeyExtent(new Table.ID("0"), new Text("m"), null);
+    KeyExtent ke1 = new KeyExtent(Table.ID.of("0"), new Text("m"), null);
     Mutation mut1 = ke1.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut1, new Value("/d1".getBytes()));
 
-    KeyExtent ke2 = new KeyExtent(new Table.ID("0"), null, null);
+    KeyExtent ke2 = new KeyExtent(Table.ID.of("0"), null, null);
     Mutation mut2 = ke2.getPrevRowUpdateMutation();
     TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut2, new Value("/d2".getBytes()));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
@@ -165,8 +165,8 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
   private Table<String,String,MutableInt> getCounts(Connector conn, String tablename) throws TableNotFoundException {
     Scanner s = conn.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     s.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
-    org.apache.accumulo.core.client.impl.Table.ID tableId = new org.apache.accumulo.core.client.impl.Table.ID(conn.tableOperations().tableIdMap()
-        .get(tablename));
+    org.apache.accumulo.core.client.impl.Table.ID tableId = org.apache.accumulo.core.client.impl.Table.ID
+        .of(conn.tableOperations().tableIdMap().get(tablename));
     s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
 
     Table<String,String,MutableInt> groupLocationCounts = HashBasedTable.create();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -148,7 +148,7 @@ public class SplitIT extends AccumuloClusterHarness {
     while (c.tableOperations().listSplits(table).size() < 10) {
       sleepUninterruptibly(15, TimeUnit.SECONDS);
     }
-    Table.ID id = new Table.ID(c.tableOperations().tableIdMap().get(table));
+    Table.ID id = Table.ID.of(c.tableOperations().tableIdMap().get(table));
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     KeyExtent extent = new KeyExtent(id, null, null);
     s.setRange(extent.toMetadataRange());

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -78,7 +78,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   private KeyExtent nke(String table, String endRow, String prevEndRow) {
-    return new KeyExtent(new Table.ID(table), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
+    return new KeyExtent(Table.ID.of(table), endRow == null ? null : new Text(endRow), prevEndRow == null ? null : new Text(prevEndRow));
   }
 
   private void run() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -86,7 +86,7 @@ public class TableIT extends AccumuloClusterHarness {
     to.flush(tableName, null, null, true);
     vopts.setTableName(tableName);
     VerifyIngest.verifyIngest(c, vopts, new ScannerOpts());
-    Table.ID id = new Table.ID(to.tableIdMap().get(tableName));
+    Table.ID id = Table.ID.of(to.tableIdMap().get(tableName));
     Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     s.setRange(new KeyExtent(id, null, null).toMetadataRange());
     s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -111,7 +111,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
     state = new State() {
       @Override
       public Collection<MergeInfo> merges() {
-        Table.ID tableIdToModify = new Table.ID(getConnector().tableOperations().tableIdMap().get(t3));
+        Table.ID tableIdToModify = Table.ID.of(getConnector().tableOperations().tableIdMap().get(t3));
         return Collections.singletonList(new MergeInfo(new KeyExtent(tableIdToModify, null, null), MergeInfo.Operation.MERGE));
       }
     };
@@ -128,7 +128,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
   }
 
   private void addDuplicateLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
-    Table.ID tableIdToModify = new Table.ID(getConnector().tableOperations().tableIdMap().get(tableNameToModify));
+    Table.ID tableIdToModify = Table.ID.of(getConnector().tableOperations().tableIdMap().get(tableNameToModify));
     Mutation m = new Mutation(new KeyExtent(tableIdToModify, null, null).getMetadataEntry());
     m.put(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME, new Text("1234567"), new Value("fake:9005".getBytes(UTF_8)));
     BatchWriter bw = getConnector().createBatchWriter(table, null);
@@ -137,7 +137,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
   }
 
   private void reassignLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
-    Table.ID tableIdToModify = new Table.ID(getConnector().tableOperations().tableIdMap().get(tableNameToModify));
+    Table.ID tableIdToModify = Table.ID.of(getConnector().tableOperations().tableIdMap().get(tableNameToModify));
     Scanner scanner = getConnector().createScanner(table, Authorizations.EMPTY);
     scanner.setRange(new KeyExtent(tableIdToModify, null, null).toMetadataRange());
     scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
@@ -152,7 +152,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
   }
 
   private void removeLocation(String table, String tableNameToModify) throws TableNotFoundException, MutationsRejectedException {
-    Table.ID tableIdToModify = new Table.ID(getConnector().tableOperations().tableIdMap().get(tableNameToModify));
+    Table.ID tableIdToModify = Table.ID.of(getConnector().tableOperations().tableIdMap().get(tableNameToModify));
     BatchDeleter deleter = getConnector().createBatchDeleter(table, Authorizations.EMPTY, 1, new BatchWriterConfig());
     deleter.setRanges(Collections.singleton(new KeyExtent(tableIdToModify, null, null).toMetadataRange()));
     deleter.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);

--- a/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
@@ -168,7 +168,7 @@ public class CloseWriteAheadLogReferencesIT extends ConfigurableMacBase {
     Set<String> wals = Collections.singleton(file);
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
     Mutation m = new Mutation(file);
-    StatusSection.add(m, new Table.ID("1"), ProtobufUtil.toValue(StatusUtil.ingestedUntil(1000)));
+    StatusSection.add(m, Table.ID.of("1"), ProtobufUtil.toValue(StatusUtil.ingestedUntil(1000)));
     bw.addMutation(m);
     bw.close();
 

--- a/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
@@ -67,7 +67,7 @@ public class MergeStateIT extends ConfigurableMacBase {
 
     @Override
     public Set<Table.ID> onlineTables() {
-      return Collections.singleton(new Table.ID("t"));
+      return Collections.singleton(Table.ID.of("t"));
     }
 
     @Override
@@ -114,7 +114,7 @@ public class MergeStateIT extends ConfigurableMacBase {
     // Create a fake METADATA table with these splits
     String splits[] = {"a", "e", "j", "o", "t", "z"};
     // create metadata for a table "t" with the splits above
-    Table.ID tableId = new Table.ID("t");
+    Table.ID tableId = Table.ID.of("t");
     Text pr = null;
     for (String s : splits) {
       Text split = new Text(s);

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
@@ -78,7 +78,7 @@ public class MetadataBatchScanTest {
       splits.add((r.nextLong() & 0x7fffffffffffffffl) % 1000000000000l);
     }
 
-    Table.ID tid = new Table.ID("8");
+    Table.ID tid = Table.ID.of("8");
     Text per = null;
 
     ArrayList<KeyExtent> extents = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/replication/FinishedWorkUpdaterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/FinishedWorkUpdaterIT.java
@@ -66,7 +66,7 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
 
     String file = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(100).setEnd(200).setClosed(true).setInfiniteEnd(false).build();
-    ReplicationTarget target = new ReplicationTarget("peer", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("peer", "table1", Table.ID.of("1"));
 
     // Create a single work record for a file to some peer
     BatchWriter bw = ReplicationTable.getBatchWriter(conn);
@@ -101,9 +101,9 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Status stat1 = Status.newBuilder().setBegin(100).setEnd(1000).setClosed(true).setInfiniteEnd(false).build(),
         stat2 = Status.newBuilder().setBegin(500).setEnd(1000).setClosed(true).setInfiniteEnd(false).build(),
         stat3 = Status.newBuilder().setBegin(1).setEnd(1000).setClosed(true).setInfiniteEnd(false).build();
-    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", new Table.ID("1")),
-        target2 = new ReplicationTarget("peer2", "table2", new Table.ID("1")),
-        target3 = new ReplicationTarget("peer3", "table3", new Table.ID("1"));
+    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", Table.ID.of("1")),
+        target2 = new ReplicationTarget("peer2", "table2", Table.ID.of("1")),
+        target3 = new ReplicationTarget("peer3", "table3", Table.ID.of("1"));
     // @formatter:on
 
     // Create a single work record for a file to some peer
@@ -141,9 +141,9 @@ public class FinishedWorkUpdaterIT extends ConfigurableMacBase {
     Status stat1 = Status.newBuilder().setBegin(100).setEnd(1000).setClosed(true).setInfiniteEnd(true).build(),
         stat2 = Status.newBuilder().setBegin(1).setEnd(1000).setClosed(true).setInfiniteEnd(true).build(),
         stat3 = Status.newBuilder().setBegin(500).setEnd(1000).setClosed(true).setInfiniteEnd(true).build();
-    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", new Table.ID("1")),
-        target2 = new ReplicationTarget("peer2", "table2", new Table.ID("1")),
-        target3 = new ReplicationTarget("peer3", "table3", new Table.ID("1"));
+    ReplicationTarget target1 = new ReplicationTarget("peer1", "table1", Table.ID.of("1")),
+        target2 = new ReplicationTarget("peer2", "table2", Table.ID.of("1")),
+        target3 = new ReplicationTarget("peer3", "table3", Table.ID.of("1"));
     // @formatter:on
 
     // Create a single work record for a file to some peer

--- a/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
@@ -124,7 +124,7 @@ public class GarbageCollectorCommunicatesWithTServersIT extends ConfigurableMacB
    */
   private Set<String> getFilesForTable(String tableName) throws Exception {
     final Connector conn = getConnector();
-    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    final Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
 
     Assert.assertNotNull("Could not determine table ID for " + tableName, tableId);
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/RemoveCompleteReplicationRecordsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/RemoveCompleteReplicationRecordsIT.java
@@ -78,7 +78,7 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
   }
 
   private Table.ID createTableId(int i) {
-    return new Table.ID(Integer.toString(i));
+    return Table.ID.of(Integer.toString(i));
   }
 
   @Test
@@ -165,14 +165,14 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     // Add two records that we can delete
     String fileToRemove = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
     Mutation m = new Mutation(fileToRemove);
-    StatusSection.add(m, new Table.ID("5"), ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
+    StatusSection.add(m, Table.ID.of("5"), ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
     replBw.addMutation(m);
 
     numRecords++;
 
     fileToRemove = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
     m = new Mutation(fileToRemove);
-    StatusSection.add(m, new Table.ID("6"), ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
+    StatusSection.add(m, Table.ID.of("6"), ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(false).build()));
     replBw.addMutation(m);
 
     numRecords++;
@@ -229,14 +229,14 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     String fileToRemove = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
     filesToRemove.add(fileToRemove);
     Mutation m = new Mutation(fileToRemove);
-    ReplicationTarget target = new ReplicationTarget("peer1", "5", new Table.ID("5"));
+    ReplicationTarget target = new ReplicationTarget("peer1", "5", Table.ID.of("5"));
     Value value = ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(true).setCreatedTime(time).build());
-    StatusSection.add(m, new Table.ID("5"), value);
+    StatusSection.add(m, Table.ID.of("5"), value);
     WorkSection.add(m, target.toText(), value);
     replBw.addMutation(m);
 
     m = OrderSection.createMutation(fileToRemove, time);
-    OrderSection.add(m, new Table.ID("5"), value);
+    OrderSection.add(m, Table.ID.of("5"), value);
     replBw.addMutation(m);
     time++;
 
@@ -246,13 +246,13 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     filesToRemove.add(fileToRemove);
     m = new Mutation(fileToRemove);
     value = ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(true).setCreatedTime(time).build());
-    target = new ReplicationTarget("peer1", "6", new Table.ID("6"));
-    StatusSection.add(m, new Table.ID("6"), value);
+    target = new ReplicationTarget("peer1", "6", Table.ID.of("6"));
+    StatusSection.add(m, Table.ID.of("6"), value);
     WorkSection.add(m, target.toText(), value);
     replBw.addMutation(m);
 
     m = OrderSection.createMutation(fileToRemove, time);
-    OrderSection.add(m, new Table.ID("6"), value);
+    OrderSection.add(m, Table.ID.of("6"), value);
     replBw.addMutation(m);
     time++;
 
@@ -308,13 +308,13 @@ public class RemoveCompleteReplicationRecordsIT extends ConfigurableMacBase {
     // Add two records that we can delete
     String fileToRemove = "/accumulo/wal/tserver+port/" + UUID.randomUUID();
     Mutation m = new Mutation(fileToRemove);
-    ReplicationTarget target = new ReplicationTarget("peer1", "5", new Table.ID("5"));
+    ReplicationTarget target = new ReplicationTarget("peer1", "5", Table.ID.of("5"));
     Value value = ProtobufUtil.toValue(builder.setBegin(10000).setEnd(10000).setClosed(true).build());
-    StatusSection.add(m, new Table.ID("5"), value);
+    StatusSection.add(m, Table.ID.of("5"), value);
     WorkSection.add(m, target.toText(), value);
-    target = new ReplicationTarget("peer2", "5", new Table.ID("5"));
+    target = new ReplicationTarget("peer2", "5", Table.ID.of("5"));
     WorkSection.add(m, target.toText(), value);
-    target = new ReplicationTarget("peer3", "5", new Table.ID("5"));
+    target = new ReplicationTarget("peer3", "5", Table.ID.of("5"));
     WorkSection.add(m, target.toText(), ProtobufUtil.toValue(builder.setClosed(false).build()));
     replBw.addMutation(m);
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -159,7 +159,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       for (UUID id : entry.getValue()) {
         Pair<WalState,Path> state = wals.state(entry.getKey(), id);
         for (String tableId : serverToTableID.get(entry.getKey())) {
-          logs.put(state.getSecond().toString(), new Table.ID(tableId));
+          logs.put(state.getSecond().toString(), Table.ID.of(tableId));
         }
       }
     }
@@ -676,7 +676,7 @@ public class ReplicationIT extends ConfigurableMacBase {
 
     String table = "table";
     conn.tableOperations().create(table);
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(table));
 
     Assert.assertNotNull(tableId);
 
@@ -974,7 +974,7 @@ public class ReplicationIT extends ConfigurableMacBase {
     writeSomeData(conn, table1, 2000, 50);
     conn.tableOperations().flush(table1, null, null, true);
 
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table1));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(table1));
     Assert.assertNotNull("Table ID was null", tableId);
 
     // Make sure the replication table exists at this point
@@ -1220,7 +1220,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       }
     }
 
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table1));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(table1));
     Assert.assertNotNull("Could not determine table id for " + table1, tableId);
 
     // Write some data to table1

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
@@ -90,7 +90,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
       @Override
       protected Table.ID getTableId(Instance inst, String tableName) throws ThriftTableOperationException {
         try {
-          return new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+          return Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
         } catch (Exception e) {
           throw new RuntimeException(e);
         }
@@ -114,7 +114,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   @Test
   public void waitsUntilEntriesAreReplicated() throws Exception {
     conn.tableOperations().create("foo");
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get("foo"));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get("foo"));
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID(), file2 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -210,8 +210,8 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     conn.tableOperations().create("foo");
     conn.tableOperations().create("bar");
 
-    Table.ID tableId1 = new Table.ID(conn.tableOperations().tableIdMap().get("foo"));
-    Table.ID tableId2 = new Table.ID(conn.tableOperations().tableIdMap().get("bar"));
+    Table.ID tableId1 = Table.ID.of(conn.tableOperations().tableIdMap().get("foo"));
+    Table.ID tableId2 = Table.ID.of(conn.tableOperations().tableIdMap().get("bar"));
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID(), file2 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -293,7 +293,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   public void inprogressReplicationRecordsBlockExecution() throws Exception {
     conn.tableOperations().create("foo");
 
-    Table.ID tableId1 = new Table.ID(conn.tableOperations().tableIdMap().get("foo"));
+    Table.ID tableId1 = Table.ID.of(conn.tableOperations().tableIdMap().get("foo"));
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();
@@ -371,7 +371,7 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
   public void laterCreatedLogsDontBlockExecution() throws Exception {
     conn.tableOperations().create("foo");
 
-    Table.ID tableId1 = new Table.ID(conn.tableOperations().tableIdMap().get("foo"));
+    Table.ID tableId1 = Table.ID.of(conn.tableOperations().tableIdMap().get("foo"));
 
     String file1 = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     Status stat = Status.newBuilder().setBegin(0).setEnd(10000).setInfiniteEnd(false).setClosed(false).build();

--- a/test/src/main/java/org/apache/accumulo/test/replication/SequentialWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/SequentialWorkAssignerIT.java
@@ -105,7 +105,7 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void createWorkForFilesInCorrectOrder() throws Exception {
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
     Text serializedTarget = target.toText();
 
     // Create two mutations, both of which need replication work done
@@ -164,10 +164,10 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void workAcrossTablesHappensConcurrently() throws Exception {
-    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
     Text serializedTarget1 = target1.toText();
 
-    ReplicationTarget target2 = new ReplicationTarget("cluster1", "table2", new Table.ID("2"));
+    ReplicationTarget target2 = new ReplicationTarget("cluster1", "table2", Table.ID.of("2"));
     Text serializedTarget2 = target2.toText();
 
     // Create two mutations, both of which need replication work done
@@ -233,10 +233,10 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void workAcrossPeersHappensConcurrently() throws Exception {
-    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
     Text serializedTarget1 = target1.toText();
 
-    ReplicationTarget target2 = new ReplicationTarget("cluster2", "table1", new Table.ID("1"));
+    ReplicationTarget target2 = new ReplicationTarget("cluster2", "table1", Table.ID.of("1"));
     Text serializedTarget2 = target2.toText();
 
     // Create two mutations, both of which need replication work done
@@ -304,7 +304,7 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void reprocessingOfCompletedWorkRemovesWork() throws Exception {
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
     Text serializedTarget = target.toText();
 
     // Create two mutations, both of which need replication work done

--- a/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
@@ -102,7 +102,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
     long createTime = System.currentTimeMillis();
     try {
       Mutation m = new Mutation("file:/accumulo/wal/HW10447.local+56808/93cdc17e-7521-44fa-87b5-37f45bcb92d3");
-      StatusSection.add(m, new Table.ID("1"), StatusUtil.fileCreatedValue(createTime));
+      StatusSection.add(m, Table.ID.of("1"), StatusUtil.fileCreatedValue(createTime));
       bw.addMutation(m);
     } finally {
       bw.close();
@@ -115,7 +115,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
     bw = ReplicationTable.getBatchWriter(conn);
     try {
       Mutation m = new Mutation("file:/accumulo/wal/HW10447.local+56808/93cdc17e-7521-44fa-87b5-37f45bcb92d3");
-      StatusSection.add(m, new Table.ID("1"), ProtobufUtil.toValue(StatusUtil.replicated(Long.MAX_VALUE)));
+      StatusSection.add(m, Table.ID.of("1"), ProtobufUtil.toValue(StatusUtil.replicated(Long.MAX_VALUE)));
       bw.addMutation(m);
     } finally {
       bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
@@ -119,8 +119,8 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void createWorkForFilesNeedingIt() throws Exception {
-    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", new Table.ID("1")), target2 = new ReplicationTarget("cluster1", "table2",
-        new Table.ID("2"));
+    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", Table.ID.of("1")), target2 = new ReplicationTarget("cluster1", "table2",
+        Table.ID.of("2"));
     Text serializedTarget1 = target1.toText(), serializedTarget2 = target2.toText();
     String keyTarget1 = target1.getPeerName() + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target1.getRemoteIdentifier()
         + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target1.getSourceTableId(), keyTarget2 = target2.getPeerName()
@@ -176,8 +176,8 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
   @Test
   public void doNotCreateWorkForFilesNotNeedingIt() throws Exception {
-    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", new Table.ID("1")), target2 = new ReplicationTarget("cluster1", "table2",
-        new Table.ID("2"));
+    ReplicationTarget target1 = new ReplicationTarget("cluster1", "table1", Table.ID.of("1")), target2 = new ReplicationTarget("cluster1", "table2",
+        Table.ID.of("2"));
     Text serializedTarget1 = target1.toText(), serializedTarget2 = target2.toText();
 
     // Create two mutations, both of which need replication work done
@@ -213,7 +213,7 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
     assigner.setQueuedWork(queuedWork);
 
-    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", new Table.ID("1"));
+    ReplicationTarget target = new ReplicationTarget("cluster1", "table1", Table.ID.of("1"));
     String serializedTarget = target.getPeerName() + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target.getRemoteIdentifier()
         + DistributedWorkQueueWorkAssignerHelper.KEY_SEPARATOR + target.getSourceTableId();
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
@@ -78,7 +78,7 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     conn.securityOperations().grantTablePermission("root", MetadataTable.NAME, TablePermission.WRITE);
     conn.tableOperations().create(tableName);
 
-    final Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(tableName));
+    final Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(tableName));
     final int numericTableId = Integer.parseInt(tableId.canonicalID());
     final int fakeTableId = numericTableId + 1;
 
@@ -114,7 +114,7 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     value.write(out);
 
     key.event = LogEvents.DEFINE_TABLET;
-    key.tablet = new KeyExtent(new Table.ID(Integer.toString(fakeTableId)), null, null);
+    key.tablet = new KeyExtent(Table.ID.of(Integer.toString(fakeTableId)), null, null);
     key.seq = 1l;
     key.tid = 1;
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/WorkMakerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/WorkMakerIT.java
@@ -86,7 +86,7 @@ public class WorkMakerIT extends ConfigurableMacBase {
   public void singleUnitSingleTarget() throws Exception {
     String table = testName.getMethodName();
     conn.tableOperations().create(table);
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(table));
     String file = "hdfs://localhost:8020/accumulo/wal/123456-1234-1234-12345678";
 
     // Create a status record for a file
@@ -128,7 +128,7 @@ public class WorkMakerIT extends ConfigurableMacBase {
     String table = testName.getMethodName();
     conn.tableOperations().create(table);
 
-    Table.ID tableId = new Table.ID(conn.tableOperations().tableIdMap().get(table));
+    Table.ID tableId = Table.ID.of(conn.tableOperations().tableIdMap().get(table));
 
     String file = "hdfs://localhost:8020/accumulo/wal/123456-1234-1234-12345678";
 


### PR DESCRIPTION
Moved the de-dupe ID code out of KeyExtent to Table and Namespace.  Created "of" static methods to access ID objects stored in internal WeakHashMap.  Replaced all occurrences of "new ID" with static "of" methods.  Created 2 new tests for these changes: NamespaceTest and TableTest.