### PR TITLE
ACCUMULO-4702 Code fixes to work with Guava 23

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConditionalWriterImpl.java
@@ -76,6 +76,7 @@ import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.NamingThreadFactory;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
@@ -92,8 +93,6 @@ import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 class ConditionalWriterImpl implements ConditionalWriter {
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/InstanceOperationsImpl.java
@@ -42,14 +42,13 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Client;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.AddressUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Provides a class for administering the accumulo instance

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/MasterClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/MasterClient.java
@@ -29,13 +29,12 @@ import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.client.impl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.master.thrift.MasterClientService;
 import org.apache.accumulo.core.rpc.ThriftUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class MasterClient {
   private static final Logger log = LoggerFactory.getLogger(MasterClient.class);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ReplicationClient.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.client.impl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.replication.thrift.ReplicationCoordinator;
 import org.apache.accumulo.core.replication.thrift.ReplicationServicer;
 import org.apache.accumulo.core.rpc.ThriftUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.thrift.TServiceClient;
@@ -36,8 +37,6 @@ import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class ReplicationClient {
   private static final Logger log = LoggerFactory.getLogger(ReplicationClient.class);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -98,6 +98,7 @@ import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.CachedConfiguration;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.NamingThreadFactory;
@@ -117,7 +118,6 @@ import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 
 import com.google.common.base.Joiner;
-import com.google.common.net.HostAndPort;
 
 public class TableOperationsImpl extends TableOperationsHelper {
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReaderIterator.java
@@ -60,6 +60,7 @@ import org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.hadoop.io.Text;
 import org.apache.htrace.wrappers.TraceRunnable;
@@ -69,8 +70,6 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-
-import com.google.common.net.HostAndPort;
 
 public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value>> {
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchWriter.java
@@ -69,6 +69,7 @@ import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TApplicationException;
@@ -79,7 +80,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
-import com.google.common.net.HostAndPort;
 
 /*
  * Differences from previous TabletServerBatchWriter

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -59,14 +59,13 @@ import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-
-import com.google.common.net.HostAndPort;
 
 public class ThriftScanner {
   private static final Logger log = Logger.getLogger(ThriftScanner.class);

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportKey.java
@@ -20,9 +20,9 @@ import static java.util.Objects.requireNonNull;
 
 import org.apache.accumulo.core.rpc.SaslConnectionParams;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
+import org.apache.accumulo.core.util.HostAndPort;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.net.HostAndPort;
 
 @VisibleForTesting
 public class ThriftTransportKey {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportPool.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.util.Daemon;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
@@ -40,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.net.HostAndPort;
 
 public class ThriftTransportPool {
   private static SecurityPermission TRANSPORT_POOL_PERMISSION = new SecurityPermission("transportPoolPermission");

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/Writer.java
@@ -32,14 +32,13 @@ import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.tabletserver.thrift.TDurability;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.apache.thrift.TServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class Writer {
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/TTimeoutTransport.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/TTimeoutTransport.java
@@ -27,11 +27,10 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.channels.spi.SelectorProvider;
 
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.thrift.transport.TIOStreamTransport;
 import org.apache.thrift.transport.TTransport;
-
-import com.google.common.net.HostAndPort;
 
 public class TTimeoutTransport {
 
@@ -62,7 +61,7 @@ public class TTimeoutTransport {
   }
 
   public static TTransport create(HostAndPort addr, long timeoutMillis) throws IOException {
-    return create(new InetSocketAddress(addr.getHostText(), addr.getPort()), timeoutMillis);
+    return create(new InetSocketAddress(addr.getHost(), addr.getPort()), timeoutMillis);
   }
 
   public static TTransport create(SocketAddress addr, long timeoutMillis) throws IOException {

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.ThriftTransportPool;
 import org.apache.accumulo.core.rpc.SaslConnectionParams.SaslMechanism;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.thrift.TException;
@@ -49,8 +50,6 @@ import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Factory methods for creating Thrift client objects
@@ -244,7 +243,7 @@ public class ThriftUtil {
 
         // TSSLTransportFactory handles timeout 0 -> forever natively
         if (sslParams.useJsse()) {
-          transport = TSSLTransportFactory.getClientSocket(address.getHostText(), address.getPort(), timeout);
+          transport = TSSLTransportFactory.getClientSocket(address.getHost(), address.getPort(), timeout);
         } else {
           // JDK6's factory doesn't appear to pass the protocol onto the Socket properly so we have
           // to do some magic to make sure that happens. Not an issue in JDK7
@@ -260,7 +259,7 @@ public class ThriftUtil {
               new String[] {sslParams.getClientProtocol()});
 
           // Create the TSocket from that
-          transport = createClient(wrappingSslSockFactory, address.getHostText(), address.getPort(), timeout);
+          transport = createClient(wrappingSslSockFactory, address.getHost(), address.getPort(), timeout);
           // TSSLTransportFactory leaves transports open, so no need to open here
         }
 
@@ -270,7 +269,7 @@ public class ThriftUtil {
           throw new IllegalStateException("Expected Kerberos security to be enabled if SASL is in use");
         }
 
-        log.trace("Creating SASL connection to {}:{}", address.getHostText(), address.getPort());
+        log.trace("Creating SASL connection to {}:{}", address.getHost(), address.getPort());
 
         // Make sure a timeout is set
         try {
@@ -303,7 +302,7 @@ public class ThriftUtil {
           }
 
           // Is this pricey enough that we want to cache it?
-          final String hostname = InetAddress.getByName(address.getHostText()).getCanonicalHostName();
+          final String hostname = InetAddress.getByName(address.getHost()).getCanonicalHostName();
 
           final SaslMechanism mechanism = saslParams.getMechanism();
 
@@ -335,7 +334,7 @@ public class ThriftUtil {
       } else {
         log.trace("Opening normal transport");
         if (timeout == 0) {
-          transport = new TSocket(address.getHostText(), address.getPort());
+          transport = new TSocket(address.getHost(), address.getPort());
           transport.open();
         } else {
           try {

--- a/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
@@ -16,7 +16,7 @@
  */
 package org.apache.accumulo.core.util;
 
-import com.google.common.net.HostAndPort;
+import org.apache.accumulo.core.util.HostAndPort;
 
 public class AddressUtil extends org.apache.accumulo.fate.util.AddressUtil {
 

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -22,6 +22,13 @@ import java.io.Serializable;
 import com.google.common.base.Strings;
 
 /**
+ * This class was copied from Guava release 23.0 to replace the older Guava 14 version that had been used in Accumulo.
+ * It was annotated as Beta by Google, therefore unstable to use in a core Accumulo library.  We learned this the hard
+ * way when Guava version 20 deprecated the getHostText method and then removed the method all together in version 22.
+ *
+ * Unused methods and annotations were removed to reduce maintenance costs.
+ *
+ * Javadoc from Guava 23.0 release:
  * An immutable representation of a host and port.
  *
  * <p>

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
  * This class was copied from Guava release 23.0 to replace the older Guava 14 version that had been used in Accumulo.
  * It was annotated as Beta by Google, therefore unstable to use in a core Accumulo library.  We learned this the hard
  * way when Guava version 20 deprecated the getHostText method and then removed the method all together in version 22.
+ * See ACCUMULO-4702
  *
  * Unused methods and annotations were removed to reduce maintenance costs.
  *

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.accumulo.core.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.io.Serializable;
+
+import com.google.common.base.Strings;
+
+/**
+ * An immutable representation of a host and port.
+ *
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * HostAndPort hp = HostAndPort.fromString(&quot;[2001:db8::1]&quot;).withDefaultPort(80).requireBracketsForIPv6();
+ * hp.getHost(); // returns &quot;2001:db8::1&quot;
+ * hp.getPort(); // returns 80
+ * hp.toString(); // returns &quot;[2001:db8::1]:80&quot;
+ * </pre>
+ *
+ * <p>
+ * Here are some examples of recognized formats:
+ * <ul>
+ * <li>example.com
+ * <li>example.com:80
+ * <li>192.0.2.1
+ * <li>192.0.2.1:80
+ * <li>[2001:db8::1] - {@link #getHost()} omits brackets
+ * <li>[2001:db8::1]:80 - {@link #getHost()} omits brackets
+ * <li>2001:db8::1 - Use requireBracketsForIPv6() to prohibit this
+ * </ul>
+ *
+ * <p>
+ * Note that this is not an exhaustive list, because these methods are only concerned with brackets, colons, and port numbers. Full validation of the host field
+ * (if desired) is the caller's responsibility.
+ *
+ * @author Paul Marks
+ * @since 10.0
+ */
+
+public final class HostAndPort implements Serializable {
+  /** Magic value indicating the absence of a port number. */
+  private static final int NO_PORT = -1;
+
+  /** Hostname, IPv4/IPv6 literal, or unvalidated nonsense. */
+  private final String host;
+
+  /** Validated port number in the range [0..65535], or NO_PORT */
+  private final int port;
+
+  /** True if the parsed host has colons, but no surrounding brackets. */
+  private final boolean hasBracketlessColons;
+
+  private HostAndPort(String host, int port, boolean hasBracketlessColons) {
+    this.host = host;
+    this.port = port;
+    this.hasBracketlessColons = hasBracketlessColons;
+  }
+
+  /**
+   * Returns the portion of this {@code HostAndPort} instance that should represent the hostname or IPv4/IPv6 literal.
+   *
+   * <p>
+   * A successful parse does not imply any degree of sanity in this field. For additional validation, see the HostSpecifier class.
+   *
+   * @since 20.0 (since 10.0 as {@code getHostText})
+   */
+  public String getHost() {
+    return host;
+  }
+
+  /** Return true if this instance has a defined port. */
+  public boolean hasPort() {
+    return port >= 0;
+  }
+
+  /**
+   * Get the current port number, failing if no port is defined.
+   *
+   * @return a validated port number, in the range [0..65535]
+   * @throws IllegalStateException
+   *           if no port is defined. You can use {@link #withDefaultPort(int)} to prevent this from occurring.
+   */
+  public int getPort() {
+    checkState(hasPort());
+    return port;
+  }
+
+  /**
+   * Build a HostAndPort instance from separate host and port values.
+   *
+   * <p>
+   * Note: Non-bracketed IPv6 literals are allowed. Use #requireBracketsForIPv6() to prohibit these.
+   *
+   * @param host
+   *          the host string to parse. Must not contain a port number.
+   * @param port
+   *          a port number from [0..65535]
+   * @return if parsing was successful, a populated HostAndPort object.
+   * @throws IllegalArgumentException
+   *           if {@code host} contains a port number, or {@code port} is out of range.
+   */
+  public static HostAndPort fromParts(String host, int port) {
+    checkArgument(isValidPort(port), "Port out of range: %s", port);
+    HostAndPort parsedHost = fromString(host);
+    checkArgument(!parsedHost.hasPort(), "Host has a port: %s", host);
+    return new HostAndPort(parsedHost.host, port, parsedHost.hasBracketlessColons);
+  }
+
+  /**
+   * Split a freeform string into a host and port, without strict validation.
+   *
+   * Note that the host-only formats will leave the port field undefined. You can use {@link #withDefaultPort(int)} to patch in a default value.
+   *
+   * @param hostPortString
+   *          the input string to parse.
+   * @return if parsing was successful, a populated HostAndPort object.
+   * @throws IllegalArgumentException
+   *           if nothing meaningful could be parsed.
+   */
+  public static HostAndPort fromString(String hostPortString) {
+    java.util.Objects.requireNonNull(hostPortString);
+    String host;
+    String portString = null;
+    boolean hasBracketlessColons = false;
+
+    if (hostPortString.startsWith("[")) {
+      String[] hostAndPort = getHostAndPortFromBracketedHost(hostPortString);
+      host = hostAndPort[0];
+      portString = hostAndPort[1];
+    } else {
+      int colonPos = hostPortString.indexOf(':');
+      if (colonPos >= 0 && hostPortString.indexOf(':', colonPos + 1) == -1) {
+        // Exactly 1 colon. Split into host:port.
+        host = hostPortString.substring(0, colonPos);
+        portString = hostPortString.substring(colonPos + 1);
+      } else {
+        // 0 or 2+ colons. Bare hostname or IPv6 literal.
+        host = hostPortString;
+        hasBracketlessColons = (colonPos >= 0);
+      }
+    }
+
+    int port = NO_PORT;
+    if (!Strings.isNullOrEmpty(portString)) {
+      // Try to parse the whole port string as a number.
+      // JDK7 accepts leading plus signs. We don't want to.
+      checkArgument(!portString.startsWith("+"), "Unparseable port number: %s", hostPortString);
+      try {
+        port = Integer.parseInt(portString);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Unparseable port number: " + hostPortString);
+      }
+      checkArgument(isValidPort(port), "Port number out of range: %s", hostPortString);
+    }
+
+    return new HostAndPort(host, port, hasBracketlessColons);
+  }
+
+  /**
+   * Parses a bracketed host-port string, throwing IllegalArgumentException if parsing fails.
+   *
+   * @param hostPortString
+   *          the full bracketed host-port specification. Post might not be specified.
+   * @return an array with 2 strings: host and port, in that order.
+   * @throws IllegalArgumentException
+   *           if parsing the bracketed host-port string fails.
+   */
+  private static String[] getHostAndPortFromBracketedHost(String hostPortString) {
+    int colonIndex = 0;
+    int closeBracketIndex = 0;
+    checkArgument(hostPortString.charAt(0) == '[', "Bracketed host-port string must start with a bracket: %s", hostPortString);
+    colonIndex = hostPortString.indexOf(':');
+    closeBracketIndex = hostPortString.lastIndexOf(']');
+    checkArgument(colonIndex > -1 && closeBracketIndex > colonIndex, "Invalid bracketed host/port: %s", hostPortString);
+
+    String host = hostPortString.substring(1, closeBracketIndex);
+    if (closeBracketIndex + 1 == hostPortString.length()) {
+      return new String[] {host, ""};
+    } else {
+      checkArgument(hostPortString.charAt(closeBracketIndex + 1) == ':', "Only a colon may follow a close bracket: %s", hostPortString);
+      for (int i = closeBracketIndex + 2; i < hostPortString.length(); ++i) {
+        checkArgument(Character.isDigit(hostPortString.charAt(i)), "Port must be numeric: %s", hostPortString);
+      }
+      return new String[] {host, hostPortString.substring(closeBracketIndex + 2)};
+    }
+  }
+
+  /**
+   * Provide a default port if the parsed string contained only a host.
+   *
+   * You can chain this after {@link #fromString(String)} to include a port in case the port was omitted from the input string. If a port was already provided,
+   * then this method is a no-op.
+   *
+   * @param defaultPort
+   *          a port number, from [0..65535]
+   * @return a HostAndPort instance, guaranteed to have a defined port.
+   */
+  public HostAndPort withDefaultPort(int defaultPort) {
+    checkArgument(isValidPort(defaultPort));
+    if (hasPort() || port == defaultPort) {
+      return this;
+    }
+    return new HostAndPort(host, defaultPort, hasBracketlessColons);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other instanceof HostAndPort) {
+      HostAndPort that = (HostAndPort) other;
+      return java.util.Objects.equals(this.host, that.host) && this.port == that.port && this.hasBracketlessColons == that.hasBracketlessColons;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(host, port, hasBracketlessColons);
+  }
+
+  /** Rebuild the host:port string, including brackets if necessary. */
+  @Override
+  public String toString() {
+    // "[]:12345" requires 8 extra bytes.
+    StringBuilder builder = new StringBuilder(host.length() + 8);
+    if (host.indexOf(':') >= 0) {
+      builder.append('[').append(host).append(']');
+    } else {
+      builder.append(host);
+    }
+    if (hasPort()) {
+      builder.append(':').append(port);
+    }
+    return builder.toString();
+  }
+
+  /** Return true for valid port numbers. */
+  private static boolean isValidPort(int port) {
+    return port >= 0 && port <= 65535;
+  }
+
+  private static final long serialVersionUID = 0;
+}

--- a/core/src/main/java/org/apache/accumulo/core/util/ServerServices.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ServerServices.java
@@ -18,7 +18,7 @@ package org.apache.accumulo.core.util;
 
 import java.util.EnumMap;
 
-import com.google.common.net.HostAndPort;
+import org.apache.accumulo.core.util.HostAndPort;
 
 public class ServerServices implements Comparable<ServerServices> {
   public static enum Service {

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/ThriftTransportKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/ThriftTransportKeyTest.java
@@ -32,14 +32,13 @@ import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.rpc.SaslConnectionParams;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class ThriftTransportKeyTest {
 

--- a/proxy/src/main/java/org/apache/accumulo/proxy/Proxy.java
+++ b/proxy/src/main/java/org/apache/accumulo/proxy/Proxy.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.proxy.thrift.AccumuloProxy;
 import org.apache.accumulo.server.metrics.MetricsFactory;
@@ -53,7 +54,6 @@ import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.google.auto.service.AutoService;
 import com.google.common.io.Files;
-import com.google.common.net.HostAndPort;
 
 @AutoService(KeywordExecutable.class)
 public class Proxy implements KeywordExecutable {

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.CachedConfiguration;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.NamingThreadFactory;
 import org.apache.accumulo.core.util.StopWatch;
 import org.apache.accumulo.core.util.UtilWaitThread;
@@ -71,8 +72,6 @@ import org.apache.htrace.wrappers.TraceRunnable;
 import org.apache.thrift.TServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class BulkImporter {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/LiveTServerSet.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.AddressUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.server.master.state.TServerInstance;
@@ -55,8 +56,6 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class LiveTServerSet implements Watcher {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TServerInstance.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TServerInstance.java
@@ -27,9 +27,8 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.util.AddressUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.io.Text;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * A tablet is assigned to a tablet server at the given address as long as it is alive and well. When the tablet server is restarted, the instance information
@@ -113,7 +112,7 @@ public class TServerInstance implements Comparable<TServerInstance>, Serializabl
   }
 
   public String host() {
-    return getLocation().getHostText();
+    return getLocation().getHost();
   }
 
   public String hostPort() {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/ZooTabletStateStore.java
@@ -26,11 +26,10 @@ import java.util.List;
 
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.commons.lang.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class ZooTabletStateStore extends TabletStateStore {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ServerAddress.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ServerAddress.java
@@ -16,9 +16,8 @@
  */
 package org.apache.accumulo.server.rpc;
 
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.thrift.server.TServer;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Encapsulate a Thrift server and the address, host and port, to which it is bound.

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.rpc.SslConnectionParams;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.UGIAssumingTransportFactory;
 import org.apache.accumulo.core.util.Daemon;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.fate.util.LoggingRunnable;
@@ -61,8 +62,6 @@ import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Factory methods for creating Thrift server objects
@@ -177,7 +176,7 @@ public class TServerUtils {
   public static ServerAddress createNonBlockingServer(HostAndPort address, TProcessor processor, TProtocolFactory protocolFactory, final String serverName,
       String threadName, final int numThreads, final int numSTThreads, long timeBetweenThreadChecks, long maxMessageSize) throws TTransportException {
 
-    final TNonblockingServerSocket transport = new TNonblockingServerSocket(new InetSocketAddress(address.getHostText(), address.getPort()));
+    final TNonblockingServerSocket transport = new TNonblockingServerSocket(new InetSocketAddress(address.getHost(), address.getPort()));
     final CustomNonBlockingServer.Args options = new CustomNonBlockingServer.Args(transport);
 
     options.protocolFactory(protocolFactory);
@@ -192,7 +191,7 @@ public class TServerUtils {
     options.processorFactory(new TProcessorFactory(processor));
 
     if (address.getPort() == 0) {
-      address = HostAndPort.fromParts(address.getHostText(), transport.getPort());
+      address = HostAndPort.fromParts(address.getHost(), transport.getPort());
     }
 
     return new ServerAddress(new CustomNonBlockingServer(options), address);
@@ -259,7 +258,7 @@ public class TServerUtils {
     TThreadPoolServer server = createTThreadPoolServer(transport, processor, ThriftUtil.transportFactory(maxMessageSize), protocolFactory, pool);
 
     if (address.getPort() == 0) {
-      address = HostAndPort.fromParts(address.getHostText(), transport.getServerSocket().getLocalPort());
+      address = HostAndPort.fromParts(address.getHost(), transport.getServerSocket().getLocalPort());
       log.info("Blocking Server bound on {}", address);
     }
 
@@ -366,13 +365,13 @@ public class TServerUtils {
       SslConnectionParams sslParams, String serverName, int numThreads, int numSimpleTimerThreads, long timeBetweenThreadChecks) throws TTransportException {
     TServerSocket transport;
     try {
-      transport = getSslServerSocket(address.getPort(), (int) socketTimeout, InetAddress.getByName(address.getHostText()), sslParams);
+      transport = getSslServerSocket(address.getPort(), (int) socketTimeout, InetAddress.getByName(address.getHost()), sslParams);
     } catch (UnknownHostException e) {
       throw new TTransportException(e);
     }
 
     if (address.getPort() == 0) {
-      address = HostAndPort.fromParts(address.getHostText(), transport.getServerSocket().getLocalPort());
+      address = HostAndPort.fromParts(address.getHost(), transport.getServerSocket().getLocalPort());
       log.info("SSL Thread Pool Server bound on {}", address);
     }
 
@@ -387,12 +386,12 @@ public class TServerUtils {
     // We'd really prefer to use THsHaServer (or similar) to avoid 1 RPC == 1 Thread that the TThreadPoolServer does,
     // but sadly this isn't the case. Because TSaslTransport needs to issue a handshake when it open()'s which will fail
     // when the server does an accept() to (presumably) wake up the eventing system.
-    log.info("Creating SASL thread pool thrift server on listening on {}:{}", address.getHostText(), address.getPort());
+    log.info("Creating SASL thread pool thrift server on listening on {}:{}", address.getHost(), address.getPort());
     TServerSocket transport = new TServerSocket(address.getPort(), (int) socketTimeout);
 
     String hostname, fqdn;
     try {
-      hostname = InetAddress.getByName(address.getHostText()).getCanonicalHostName();
+      hostname = InetAddress.getByName(address.getHost()).getCanonicalHostName();
       fqdn = InetAddress.getLocalHost().getCanonicalHostName();
     } catch (UnknownHostException e) {
       throw new TTransportException(e);
@@ -442,7 +441,7 @@ public class TServerUtils {
 
     if (address.getPort() == 0) {
       // If we chose a port dynamically, make a new use it (along with the proper hostname)
-      address = HostAndPort.fromParts(address.getHostText(), transport.getServerSocket().getLocalPort());
+      address = HostAndPort.fromParts(address.getHost(), transport.getServerSocket().getLocalPort());
       log.info("SASL thrift server bound on {}", address);
     }
 
@@ -529,7 +528,7 @@ public class TServerUtils {
     thread.start();
 
     // check for the special "bind to everything address"
-    if (serverAddress.address.getHostText().equals("0.0.0.0")) {
+    if (serverAddress.address.getHost().equals("0.0.0.0")) {
       // can't get the address from the bind, so we'll do our best to invent our hostname
       try {
         serverAddress = new ServerAddress(finalServer, HostAndPort.fromParts(InetAddress.getLocalHost().getHostName(), serverAddress.address.getPort()));

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.AddressUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
@@ -75,7 +76,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Lists;
-import com.google.common.net.HostAndPort;
 
 @AutoService(KeywordExecutable.class)
 public class Admin implements KeywordExecutable {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/LocalityCheck.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/LocalityCheck.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.cli.ClientOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
@@ -37,8 +38,6 @@ import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
-import com.google.common.net.HostAndPort;
 
 public class LocalityCheck {
 
@@ -95,7 +94,7 @@ public class LocalityCheck {
         allBlocks++;
         for (String location : blockLocation.getHosts()) {
           HostAndPort hap = HostAndPort.fromParts(location, 0);
-          if (hap.getHostText().equals(host)) {
+          if (hap.getHost().equals(host)) {
             matchingBlocks++;
             break;
           }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -50,6 +50,7 @@ import org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.cli.ClientOpts;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
@@ -58,7 +59,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.Parameter;
-import com.google.common.net.HostAndPort;
 
 public class VerifyTabletAssignments {
   private static final Logger log = LoggerFactory.getLogger(VerifyTabletAssignments.class);

--- a/server/base/src/main/java/org/apache/accumulo/server/watcher/MonitorLog4jWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/watcher/MonitorLog4jWatcher.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.server.watcher;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 import org.apache.log4j.Appender;
@@ -28,8 +29,6 @@ import org.apache.log4j.helpers.FileWatchdog;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Watcher that updates the monitor's log4j port from ZooKeeper in a system property
@@ -114,7 +113,7 @@ public class MonitorLog4jWatcher extends FileWatchdog implements Watcher {
       String hostPortString = new String(ZooReaderWriter.getInstance().getData(path, null), UTF_8);
       HostAndPort hostAndPort = HostAndPort.fromString(hostPortString);
 
-      System.setProperty(HOST_PROPERTY_NAME, hostAndPort.getHostText());
+      System.setProperty(HOST_PROPERTY_NAME, hostAndPort.getHost());
       System.setProperty(PORT_PROPERTY_NAME, Integer.toString(hostAndPort.getPort()));
 
       log.info("Changing monitor log4j address to " + hostAndPort.toString());

--- a/server/base/src/test/java/org/apache/accumulo/server/AccumuloTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/AccumuloTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileNotFoundException;
 
-import com.google.common.collect.Sets;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.commons.io.FileUtils;
@@ -35,6 +34,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.Sets;
 
 public class AccumuloTest {
   private FileSystem fs;

--- a/server/base/src/test/java/org/apache/accumulo/server/master/LiveTServerSetTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/LiveTServerSetTest.java
@@ -23,14 +23,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.master.LiveTServerSet.Listener;
 import org.apache.accumulo.server.master.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.master.LiveTServerSet.TServerInfo;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.easymock.EasyMock;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class LiveTServerSetTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -33,13 +33,12 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class ChaoticLoadBalancerTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -36,14 +36,13 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class DefaultLoadBalancerTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.master.state.TServerInstance;
@@ -44,8 +45,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class TableLoadBalancerTest {
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -58,6 +58,7 @@ import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.AddressUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.ServerConstants;
@@ -75,7 +76,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
-import com.google.common.net.HostAndPort;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 public class GarbageCollectWriteAheadLogs {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.gc;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -70,6 +71,7 @@ import org.apache.accumulo.core.trace.ProbabilitySampler;
 import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.NamingThreadFactory;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.ServerServices;
@@ -111,7 +113,6 @@ import com.beust.jcommander.Parameter;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
-import com.google.common.net.HostAndPort;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 public class SimpleGarbageCollector extends AccumuloServerContext implements Iface {
@@ -500,7 +501,7 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
         });
       } catch (ReplicationTableOfflineException e) {
         // No elements that we need to preclude
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
       }
     }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
@@ -49,6 +49,7 @@ import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
@@ -63,7 +64,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.net.HostAndPort;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 /**

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -61,6 +61,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSectio
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -82,7 +83,6 @@ import org.junit.rules.TestName;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.google.common.net.HostAndPort;
 
 public class GarbageCollectWriteAheadLogsTest {
   private static final long BLOCK_SIZE = 64000000L;

--- a/server/gc/src/test/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferencesTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferencesTest.java
@@ -59,6 +59,7 @@ import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.replication.StatusUtil;
@@ -75,7 +76,6 @@ import org.junit.rules.TestName;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.net.HostAndPort;
 
 public class CloseWriteAheadLogReferencesTest {
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/LoadFiles.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.trace.Tracer;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.fate.Repo;
@@ -52,8 +53,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.htrace.wrappers.TraceExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 class LoadFiles extends MasterRepo {
 

--- a/server/master/src/test/java/org/apache/accumulo/master/TestMergeState.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/TestMergeState.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.master.state.MergeStats;
 import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
@@ -50,8 +51,6 @@ import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 /**
  *

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/MasterReplicationCoordinatorTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/MasterReplicationCoordinatorTest.java
@@ -20,14 +20,13 @@ import java.util.Collections;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 /**
  *

--- a/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/state/RootTabletStateStoreTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.master.state.Assignment;
 import org.apache.accumulo.server.master.state.DistributedStore;
 import org.apache.accumulo.server.master.state.DistributedStoreException;
@@ -39,8 +40,6 @@ import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class RootTabletStateStoreTest {
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -50,6 +50,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Client;
 import org.apache.accumulo.core.trace.DistributedTrace;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.Daemon;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
@@ -95,8 +96,6 @@ import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Serve master statistics with an embedded web server.

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/ZooKeeperStatus.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/ZooKeeperStatus.java
@@ -26,13 +26,12 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.rpc.TTimeoutTransport;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class ZooKeeperStatus implements Runnable {
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/MasterServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/MasterServlet.java
@@ -56,7 +56,7 @@ public class MasterServlet extends BasicServlet {
   @Override
   protected String getTitle(HttpServletRequest req) {
     List<String> masters = Monitor.getContext().getInstance().getMasterLocations();
-    return "Master Server" + (masters.size() == 0 ? "" : ":" + AddressUtil.parseAddress(masters.get(0), false).getHostText());
+    return "Master Server" + (masters.size() == 0 ? "" : ":" + AddressUtil.parseAddress(masters.get(0), false).getHost());
   }
 
   @Override
@@ -150,7 +150,7 @@ public class MasterServlet extends BasicServlet {
       masterStatus.addSortableColumn("OS&nbsp;Load", new NumberType<>(0., guessHighLoad * 1., 0., guessHighLoad * 3.),
           "The one-minute load average on the computer that runs the monitor web server.");
       TableRow row = masterStatus.prepareRow();
-      row.add(masters.size() == 0 ? "<div class='error'>Down</div>" : AddressUtil.parseAddress(masters.get(0), false).getHostText());
+      row.add(masters.size() == 0 ? "<div class='error'>Down</div>" : AddressUtil.parseAddress(masters.get(0), false).getHost());
       row.add(Monitor.getMmi().tServerInfo.size());
       row.add(slaves.size());
       row.add("<a href='/gc'>" + gcStatus + "</a>");
@@ -183,7 +183,7 @@ public class MasterServlet extends BasicServlet {
         if (server.logSorts != null) {
           for (RecoveryStatus recovery : server.logSorts) {
             TableRow row = recoveryTable.prepareRow();
-            row.add(AddressUtil.parseAddress(server.name, false).getHostText());
+            row.add(AddressUtil.parseAddress(server.name, false).getHost());
             row.add(recovery.name);
             row.add((long) recovery.runtime);
             row.add(recovery.progress);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/ScanServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/ScanServlet.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.monitor.Monitor.ScanStats;
 import org.apache.accumulo.monitor.util.Table;
@@ -30,8 +31,6 @@ import org.apache.accumulo.monitor.util.TableRow;
 import org.apache.accumulo.monitor.util.celltypes.DurationType;
 import org.apache.accumulo.monitor.util.celltypes.PreciseNumberType;
 import org.apache.accumulo.monitor.util.celltypes.TServerLinkType;
-
-import com.google.common.net.HostAndPort;
 
 public class ScanServlet extends BasicServlet {
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TServersServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/TServersServlet.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.Base64;
 import org.apache.accumulo.core.util.Duration;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.monitor.util.Table;
 import org.apache.accumulo.monitor.util.TableRow;
@@ -53,8 +54,6 @@ import org.apache.accumulo.monitor.util.celltypes.TableLinkType;
 import org.apache.accumulo.server.master.state.TabletServerState;
 import org.apache.accumulo.server.util.ActionStatsUpdator;
 import org.apache.accumulo.server.util.TableInfoUtil;
-
-import com.google.common.net.HostAndPort;
 
 public class TServersServlet extends BasicServlet {
 
@@ -252,7 +251,7 @@ public class TServersServlet extends BasicServlet {
 
   private void doDetailTable(HttpServletRequest req, StringBuilder sb, HostAndPort address, int numTablets, TabletStats total, TabletStats historical) {
     Table detailTable = new Table("tServerDetail", "Details");
-    detailTable.setSubCaption(address.getHostText() + ":" + address.getPort());
+    detailTable.setSubCaption(address.getHost() + ":" + address.getPort());
     detailTable.addSortableColumn("Hosted&nbsp;Tablets", new NumberType<Integer>(), null);
     detailTable.addSortableColumn("Entries", new NumberType<Long>(), null);
     detailTable.addSortableColumn("Minor&nbsp;Compacting", new NumberType<Integer>(), null);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -131,6 +131,7 @@ import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.core.util.Daemon;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.ServerServices;
@@ -245,8 +246,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class TabletServer extends AccumuloServerContext implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(TabletServer.class);
@@ -2338,7 +2337,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     } else {
       processor = new Processor<>(rpcProxy);
     }
-    HostAndPort address = startServer(getServerConfigurationFactory().getConfiguration(), clientAddress.getHostText(), Property.TSERV_CLIENTPORT, processor,
+    HostAndPort address = startServer(getServerConfigurationFactory().getConfiguration(), clientAddress.getHost(), Property.TSERV_CLIENTPORT, processor,
         "Thrift Client Server");
     log.info("address = " + address);
     return address;
@@ -2351,7 +2350,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     ReplicationServicer.Processor<ReplicationServicer.Iface> processor = new ReplicationServicer.Processor<>(repl);
     AccumuloConfiguration conf = getServerConfigurationFactory().getConfiguration();
     Property maxMessageSizeProperty = (conf.get(Property.TSERV_MAX_MESSAGE_SIZE) != null ? Property.TSERV_MAX_MESSAGE_SIZE : Property.GENERAL_MAX_MESSAGE_SIZE);
-    ServerAddress sp = TServerUtils.startServer(this, clientAddress.getHostText(), Property.REPLICATION_RECEIPT_SERVICE_PORT, processor,
+    ServerAddress sp = TServerUtils.startServer(this, clientAddress.getHost(), Property.REPLICATION_RECEIPT_SERVICE_PORT, processor,
         "ReplicationServicerHandler", "Replication Servicer", null, Property.REPLICATION_MIN_THREADS, Property.REPLICATION_THREADCHECK, maxMessageSizeProperty);
     this.replServer = sp.server;
     log.info("Started replication service on " + sp.address);
@@ -2773,14 +2772,14 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
   public String getClientAddressString() {
     if (clientAddress == null)
       return null;
-    return clientAddress.getHostText() + ":" + clientAddress.getPort();
+    return clientAddress.getHost() + ":" + clientAddress.getPort();
   }
 
   public String getReplicationAddressSTring() {
     if (null == replicationAddress) {
       return null;
     }
-    return replicationAddress.getHostText() + ":" + replicationAddress.getPort();
+    return replicationAddress.getHost() + ":" + replicationAddress.getPort();
   }
 
   public TServerInstance getTabletSession() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -60,6 +60,7 @@ import org.apache.accumulo.core.security.thrift.TCredentials;
 import org.apache.accumulo.core.trace.ProbabilitySampler;
 import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.server.client.HdfsZooInstance;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
@@ -80,8 +81,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class AccumuloReplicaSystem implements ReplicaSystem {
   private static final Logger log = LoggerFactory.getLogger(AccumuloReplicaSystem.class);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.tserver.tablet;
 
+import java.util.Collections;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -32,8 +33,6 @@ import org.apache.hadoop.fs.Path;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.collect.Iterators;
 
 /**
  *
@@ -60,7 +59,7 @@ public class TabletTest {
     int replication = 5;
     String compressType = "snappy";
 
-    EasyMock.expect(tableConf.iterator()).andReturn(Iterators.<Entry<String,String>> emptyIterator());
+    EasyMock.expect(tableConf.iterator()).andReturn(Collections.<Entry<String,String>> emptyIterator());
     EasyMock.expect(writeParams.getHdfsBlockSize()).andReturn(hdfsBlockSize).times(2);
     EasyMock.expect(writeParams.getBlockSize()).andReturn(blockSize).times(2);
     EasyMock.expect(writeParams.getIndexBlockSize()).andReturn(indexBlockSize).times(2);

--- a/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/WrongTabletTest.java
@@ -26,13 +26,13 @@ import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.tabletserver.thrift.TDurability;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.AccumuloServerContext;
 import org.apache.accumulo.server.cli.ClientOpts;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
-import com.google.common.net.HostAndPort;
 
 public class WrongTabletTest {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Iface;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Processor;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.trace.thrift.TInfo;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
 import org.apache.accumulo.core.util.UtilWaitThread;
@@ -48,8 +49,6 @@ import org.apache.accumulo.server.zookeeper.ZooReaderWriter;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * Tablet server that creates a lock in zookeeper, responds to one status request, and then hangs on subsequent requests. Exits with code zero if halted.

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.Stat;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.hadoop.io.Text;
@@ -50,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterators;
-import com.google.common.net.HostAndPort;
 
 /**
  * This little program can be used to write a lot of metadata entries and measure the performance of varying numbers of threads doing metadata lookups using the

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -62,6 +62,7 @@ import org.apache.accumulo.core.iterators.system.MultiIterator;
 import org.apache.accumulo.core.iterators.system.VisibilityFilter;
 import org.apache.accumulo.core.metadata.MetadataServicer;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.Stat;
 import org.apache.accumulo.server.cli.ClientOnRequiredTable;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
@@ -79,7 +80,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.Parameter;
-import com.google.common.net.HostAndPort;
 
 public class CollectTabletStats {
   private static final Logger log = LoggerFactory.getLogger(CollectTabletStats.class);
@@ -359,7 +359,7 @@ public class CollectTabletStats {
     for (Entry<KeyExtent,String> entry : tabletLocations.entrySet()) {
       String loc = entry.getValue();
       if (loc != null) {
-        boolean isLocal = HostAndPort.fromString(entry.getValue()).getHostText().equals(localaddress.getHostName());
+        boolean isLocal = HostAndPort.fromString(entry.getValue()).getHost().equals(localaddress.getHostName());
 
         if (selectLocalTablets && isLocal) {
           candidates.add(entry.getKey());

--- a/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/thrift/NullTserver.java
@@ -76,7 +76,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 
 import com.beust.jcommander.Parameter;
-import com.google.common.net.HostAndPort;
+import org.apache.accumulo.core.util.HostAndPort;
 
 /**
  * The purpose of this class is to server as fake tserver that is a data sink like /dev/null. NullTserver modifies the metadata location entries for a table to

--- a/test/src/test/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
@@ -37,8 +38,6 @@ import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.test.functional.ConfigurableMacIT;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 // see ACCUMULO-1950
 public class TotalQueuedIT extends ConfigurableMacIT {

--- a/test/src/test/java/org/apache/accumulo/test/functional/WatchTheWatchCountIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/WatchTheWatchCountIT.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.net.Socket;
 
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
@@ -28,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Range;
-import com.google.common.net.HostAndPort;
 
 // ACCUMULO-2757 - make sure we don't make too many more watchers
 public class WatchTheWatchCountIT extends ConfigurableMacIT {
@@ -56,7 +56,7 @@ public class WatchTheWatchCountIT extends ConfigurableMacIT {
     long total = 0;
     final HostAndPort hostAndPort = HostAndPort.fromString(zooKeepers);
     for (int i = 0; i < 5; i++) {
-      Socket socket = new Socket(hostAndPort.getHostText(), hostAndPort.getPort());
+      Socket socket = new Socket(hostAndPort.getHost(), hostAndPort.getPort());
       try {
         socket.getOutputStream().write("wchs\n".getBytes(), 0, 5);
         byte[] buffer = new byte[1024];

--- a/test/src/test/java/org/apache/accumulo/test/proxy/ProxyDurabilityIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/ProxyDurabilityIT.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
@@ -57,7 +58,6 @@ import org.apache.thrift.server.TServer;
 import org.junit.Test;
 
 import com.google.common.collect.Iterators;
-import com.google.common.net.HostAndPort;
 
 public class ProxyDurabilityIT extends ConfigurableMacIT {
 

--- a/test/src/test/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/SimpleProxyBase.java
@@ -59,6 +59,7 @@ import org.apache.accumulo.core.iterators.user.VersioningIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.UtilWaitThread;
 import org.apache.accumulo.examples.simple.constraints.NumericValueConstraint;
 import org.apache.accumulo.harness.MiniClusterHarness;
@@ -124,7 +125,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterators;
-import com.google.common.net.HostAndPort;
 
 /**
  * Call every method on the proxy and try to verify that it works.

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TestProxyInstanceOperations.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TestProxyInstanceOperations.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.proxy.Proxy;
 import org.apache.accumulo.proxy.TestProxyClient;
 import org.apache.thrift.TException;
@@ -35,8 +36,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 public class TestProxyInstanceOperations {
   private static final Logger log = LoggerFactory.getLogger(TestProxyInstanceOperations.class);

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TestProxyReadWrite.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TestProxyReadWrite.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.proxy.Proxy;
 import org.apache.accumulo.proxy.TestProxyClient;
 import org.apache.accumulo.proxy.Util;
@@ -49,8 +50,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class TestProxyReadWrite {
   protected static TServer proxy;

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TestProxySecurityOperations.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TestProxySecurityOperations.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.proxy.Proxy;
 import org.apache.accumulo.proxy.TestProxyClient;
 import org.apache.accumulo.proxy.thrift.SystemPermission;
@@ -43,8 +44,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class TestProxySecurityOperations {
   protected static TServer proxy;

--- a/test/src/test/java/org/apache/accumulo/test/proxy/TestProxyTableOperations.java
+++ b/test/src/test/java/org/apache/accumulo/test/proxy/TestProxyTableOperations.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.proxy.Proxy;
 import org.apache.accumulo.proxy.TestProxyClient;
 import org.apache.accumulo.proxy.thrift.ColumnUpdate;
@@ -43,8 +44,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.google.common.net.HostAndPort;
 
 public class TestProxyTableOperations {
 

--- a/test/src/test/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Client;
 import org.apache.accumulo.core.trace.Tracer;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.test.functional.ConfigurableMacIT;
@@ -58,8 +59,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.net.HostAndPort;
 
 /**
  * ACCUMULO-3302 series of tests which ensure that a WAL is prematurely closed when a TServer may still continue to use it. Checking that no tablet references a

--- a/test/src/test/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
@@ -38,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
-import com.google.common.net.HostAndPort;
 
 /**
  *


### PR DESCRIPTION
* Remove the dependency on Beta-annotated Guava classes and methods
* Pulled in HostAndPort from Guava 23
* Replaced usage of HostAndPort getHostText with getHost
* Replaced Iterators.emptyIterator with one from Collections
* Kept the same Guava 14 dependency