### PR TITLE
ACCUMULO-2968: Axe TabletServer.majorCompactorDisabled

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1924,7 +1924,6 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
     @Override
     public void run() {
-      // ACCUMULO-2968: Removed <em>if</em> condition that always returned <em>false</em>.
       splitTablet(tablet);
     }
   }
@@ -1953,9 +1952,6 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
     @Override
     public void run() {
-      // ACCUMULO-2968: While loop previously checked for value of <em>!majorCompactionDisabled</em>.
-      // This always resolved to <em>true</em>. Removing reference to <em>majorCompactionDisabled</em>
-      // in class.
       while (true) {
         try {
           sleepUninterruptibly(getConfiguration().getTimeInMillis(Property.TSERV_MAJC_DELAY), TimeUnit.MILLISECONDS);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -330,7 +330,6 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
   private HostAndPort clientAddress;
 
   private volatile boolean serverStopRequested = false;
-  private volatile boolean majorCompactorDisabled = false;
   private volatile boolean shutdownComplete = false;
 
   private ZooLock tabletServerLock;
@@ -1925,18 +1924,9 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
     @Override
     public void run() {
-      if (majorCompactorDisabled) {
-        // this will make split task that were queued when shutdown was
-        // initiated exit
-        return;
-      }
-
+      // ACCUMULO-2968: Removed <em>if</em> condition that always returned <em>false</em>.
       splitTablet(tablet);
     }
-  }
-
-  public boolean isMajorCompactionDisabled() {
-    return majorCompactorDisabled;
   }
 
   public long updateTotalQueuedMutationSize(long additionalMutationSize) {
@@ -1963,7 +1953,10 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
 
     @Override
     public void run() {
-      while (!majorCompactorDisabled) {
+      // ACCUMULO-2968: While loop previously checked for value of <em>!majorCompactionDisabled</em>.
+      // This always resolved to <em>true</em>. Removing reference to <em>majorCompactionDisabled</em>
+      // in class.
+      while (true) {
         try {
           sleepUninterruptibly(getConfiguration().getTimeInMillis(Property.TSERV_MAJC_DELAY), TimeUnit.MILLISECONDS);
 
@@ -1980,7 +1973,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
           Iterator<Entry<KeyExtent,Tablet>> iter = copyOnlineTablets.entrySet().iterator();
 
           // bail early now if we're shutting down
-          while (iter.hasNext() && !majorCompactorDisabled) {
+          while (iter.hasNext()) {
 
             Entry<KeyExtent,Tablet> entry = iter.next();
 
@@ -2015,7 +2008,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
             // idle compactions
             iter = copyOnlineTablets.entrySet().iterator();
 
-            while (iter.hasNext() && !majorCompactorDisabled && numMajorCompactionsInProgress < idleCompactionsToStart) {
+            while (iter.hasNext() && numMajorCompactionsInProgress < idleCompactionsToStart) {
               Entry<KeyExtent,Tablet> entry = iter.next();
               Tablet tablet = entry.getValue();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionRunner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionRunner.java
@@ -34,9 +34,6 @@ final class CompactionRunner implements Runnable, Comparable<CompactionRunner> {
 
   @Override
   public void run() {
-    // ACCUMULO-2968: isMajorCompactionDisabled() previously always returned false.
-    // Removed <em>if</em> condition that would never be executed (would have called
-    // tablet.removeMajorCompactionQueuedReason(reason) and then returned).
 
     tablet.majorCompact(reason, queued);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionRunner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionRunner.java
@@ -34,12 +34,9 @@ final class CompactionRunner implements Runnable, Comparable<CompactionRunner> {
 
   @Override
   public void run() {
-    if (tablet.getTabletServer().isMajorCompactionDisabled()) {
-      // this will make compaction tasks that were queued when shutdown was
-      // initiated exit
-      tablet.removeMajorCompactionQueuedReason(reason);
-      return;
-    }
+    // ACCUMULO-2968: isMajorCompactionDisabled() previously always returned false.
+    // Removed <em>if</em> condition that would never be executed (would have called
+    // tablet.removeMajorCompactionQueuedReason(reason) and then returned).
 
     tablet.majorCompact(reason, queued);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1686,7 +1686,9 @@ public class Tablet implements TabletCommitter {
   // BEGIN PRIVATE METHODS RELATED TO MAJOR COMPACTION
 
   private boolean isCompactionEnabled() {
-    return !isClosing() && !getTabletServer().isMajorCompactionDisabled();
+    // ACCUMULO-2968: Removed reference to <em>!isMajorCompactionDisabled</em> in return
+    // statement which always equated to <em>true</em>.
+    return !isClosing();
   }
 
   private CompactionStats _majorCompact(MajorCompactionReason reason) throws IOException, CompactionCanceledException {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1686,8 +1686,6 @@ public class Tablet implements TabletCommitter {
   // BEGIN PRIVATE METHODS RELATED TO MAJOR COMPACTION
 
   private boolean isCompactionEnabled() {
-    // ACCUMULO-2968: Removed reference to <em>!isMajorCompactionDisabled</em> in return
-    // statement which always equated to <em>true</em>.
     return !isClosing();
   }
 


### PR DESCRIPTION
ACCUMULO-2968: Axe TabletServer.majorCompactorDisabled

Removed references to majorCompatorDisabled variable defined in
accumulo/tserver/TabletServer.java.  This private variable was
defined as 'false' and never modified in source and additionally
no means were provided to alter the value in the code.

Several locations within TabletServer.java where updated. This
included a couple of 'if' statement that would never be executed as well
as some return statement where a constant value of true was
unnecessarily included.

There was one reference each within CompationRunner.java and Tablet.java
which were removed also.

The change of most note is probably the while loop within the run method
of TableServer. Previously the while check read:
   while(!majorCompatorDisabled)....

whereas now it reads:
   while(true)...

which was what it would always equate too. This could be seen to be a
loss of information perhaps. A comment was added to describe what
existed prior to the update.

After update all unit tests continued to pass as well as the 'sunny-day' integration tests.
