### PR TITLE
ACCUMULO-4716 Don't cache blks over max array size

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -156,6 +156,10 @@ public class CachableBlockFile {
     private boolean closed = false;
     private AccumuloConfiguration accumuloConfiguration = null;
 
+    // ACCUMULO-4716 - Define MAX_ARRAY_SIZE smaller than Integer.MAX_VALUE to prevent possible OutOfMemory
+    // errors when allocating arrays - described in stackoverflow post: https://stackoverflow.com/a/8381338
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
     private interface BlockLoader {
       BlockReader get() throws IOException;
 
@@ -342,7 +346,7 @@ public class CachableBlockFile {
 
     private BlockRead cacheBlock(String _lookup, BlockCache cache, BlockReader _currBlock, String block) throws IOException {
 
-      if ((cache == null) || (_currBlock.getRawSize() > cache.getMaxSize())) {
+      if ((cache == null) || (_currBlock.getRawSize() > Math.min(cache.getMaxSize(), MAX_ARRAY_SIZE))) {
         return new BlockRead(_currBlock, _currBlock.getRawSize());
       } else {
 


### PR DESCRIPTION
ACCUMULO-4716 Don't cache blocks over max array size

Prevents byte array from caching up to Integer.MAX_VALUE to prevent
possible OutofMemory error as described in StackOverflow post
https://stackoverflow.com/a/8381338