### PR TITLE
ACCUMULO-4170 Clarify ClientConfiguration javadocs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -209,8 +209,12 @@ public class ClientConfiguration extends CompositeConfiguration {
    * <li>/etc/accumulo/client.conf
    * <li>/etc/accumulo/conf/client.conf
    * </ul>
-   *
-   * @since 1.6.0
+   * <p>
+   * A client configuration will then be read from each location using <em>PropertiesConfiguration</em> to construct a configuration.
+   * That means the latest item will be the one in the configuration.
+   *<p>
+   * @see PropertiesConfiguration
+   * @see File#pathSeparator
    */
   public static ClientConfiguration loadDefault() {
     return loadFromSearchPath(getDefaultSearchPath());

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -41,18 +41,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Contains a list of property keys recognized by the Accumulo client and convenience methods for setting them.
- * <p>
- * When loading a configuration file from the system, Accumulo uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
- * <em>File.pathSeparator</em>, for a list of target files.
- * <p>
- * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, uses the following in this order:
- * <ul>
- *   <li>~/.accumulo/config
- *   <li><em>$ACCUMULO_CONF_DIR</em>/client.conf, if <em>$ACCUMULO_CONF_DIR</em> is defined.
- *   <li>/etc/accumulo/client.conf
- *   <li>/etc/accumulo/conf/client.conf
- * </ul>
- * <p>
+ *
  * @since 1.6.0
  */
 public class ClientConfiguration extends CompositeConfiguration {
@@ -210,16 +199,18 @@ public class ClientConfiguration extends CompositeConfiguration {
   }
 
   /**
-   * Attempts to load a configuration file from the system. Uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
-   * <em>File.pathSeparator</em>, for a list of target files.
+   * Attempts to load a configuration file from the system using the default search paths. Uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable,
+   * split on <em>File.pathSeparator</em>, for a list of target files.
    * <p>
-   * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, see class comments above for default search path.
-   * <p>
-   * A client configuration will then be read from each location using <em>PropertiesConfiguration</em> to construct a configuration. That means the latest item
-   * will be the one in the configuration.
+   * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, uses the following in this order:
+   * <ul>
+   * <li>~/.accumulo/config
+   * <li><em>$ACCUMULO_CONF_DIR</em>/client.conf, if <em>$ACCUMULO_CONF_DIR</em> is defined.
+   * <li>/etc/accumulo/client.conf
+   * <li>/etc/accumulo/conf/client.conf
+   * </ul>
    *
-   * @see PropertiesConfiguration
-   * @see File#pathSeparator
+   * @since 1.6.0
    */
   public static ClientConfiguration loadDefault() {
     return loadFromSearchPath(getDefaultSearchPath());

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -41,7 +41,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Contains a list of property keys recognized by the Accumulo client and convenience methods for setting them.
- *
+ * <p>
+ * When loading a configuration file from the system, Accumulo uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
+ * <em>File.pathSeparator</em>, for a list of target files.
+ * <p>
+ * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, uses the following in this order:
+ * <ul>
+ *   <li>~/.accumulo/config
+ *   <li><em>$ACCUMULO_CONF_DIR</em>/client.conf, if <em>$ACCUMULO_CONF_DIR</em> is defined.
+ *   <li>/etc/accumulo/client.conf
+ *   <li>/etc/accumulo/conf/client.conf
+ * </ul>
+ * <p>
  * @since 1.6.0
  */
 public class ClientConfiguration extends CompositeConfiguration {
@@ -199,12 +210,13 @@ public class ClientConfiguration extends CompositeConfiguration {
   }
 
   /**
-   * Attempts to load a configuration file from the system. Uses the "ACCUMULO_CLIENT_CONF_PATH" environment variable, split on File.pathSeparator, for a list
-   * of target files. If not set, uses the following in this order- ~/.accumulo/config $ACCUMULO_CONF_DIR/client.conf -OR- $ACCUMULO_HOME/conf/client.conf
-   * (depending on whether $ACCUMULO_CONF_DIR is set) /etc/accumulo/client.conf
-   *
-   * A client configuration will then be read from each location using PropertiesConfiguration to construct a configuration. That means the latest item will be
-   * the one in the configuration.
+   * Attempts to load a configuration file from the system. Uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
+   * <em>File.pathSeparator</em>, for a list of target files.
+   * <p>
+   * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, see class comments above for default search path.
+   * <p>
+   * A client configuration will then be read from each location using <em>PropertiesConfiguration</em> to construct a configuration. That means the latest item
+   * will be the one in the configuration.
    *
    * @see PropertiesConfiguration
    * @see File#pathSeparator


### PR DESCRIPTION
ACCUMULO-4170 Clarify ClientConfiguration javadocs

Updated the javadoc information with the ClientConfiguration class.
Specifically reworked the default search path information to be
displayed as a list rather than inline, thereby easing readability.

Reworded a few of the sentences and moved the path order up to the class
level rather than the method level.

![classv18](https://user-images.githubusercontent.com/31573345/31498872-21324e30-af31-11e7-9f82-a63ed0a5609f.png)

![methodv18](https://user-images.githubusercontent.com/31573345/31498873-25908910-af31-11e7-9664-6f9243e14665.png)
