### PR TITLE
ACCUMULO-4170 Clarify ClientConfiguration javadocs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -41,6 +41,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Contains a list of property keys recognized by the Accumulo client and convenience methods for setting them.
+ * <p>
+ * When loading a configuration file from the system, Accumulo uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
+ * <em>File.pathSeparator</em>, for a list of target files.
+ * <p>
+ * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, uses the following in this order:
+ * <ul>
+ *   <li>~/.accumulo/config
+ *   <li><em>$ACCUMULO_CONF_DIR</em>/client.conf, if <em>$ACCUMULO_CONF_DIR</em> is defined.
+ *   <li>/etc/accumulo/client.conf
+ *   <li>/etc/accumulo/conf/client.conf
+ * </ul>
+ * <p>
  *
  * @since 1.6.0
  */
@@ -184,12 +196,13 @@ public class ClientConfiguration extends CompositeConfiguration {
   }
 
   /**
-   * Attempts to load a configuration file from the system. Uses the "ACCUMULO_CLIENT_CONF_PATH" environment variable, split on File.pathSeparator, for a list
-   * of target files. If not set, uses the following in this order- ~/.accumulo/config $ACCUMULO_CONF_DIR/client.conf -OR- /etc/accumulo/client.conf -OR-
-   * /etc/accumulo/conf/client.conf
-   *
-   * A client configuration will then be read from each location using PropertiesConfiguration to construct a configuration. That means the latest item will be
-   * the one in the configuration.
+   * Attempts to load a configuration file from the system. Uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
+   * <em>File.pathSeparator</em>, for a list of target files.
+   * <p>
+   * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, see class comments above for default search path.
+   * <p>
+   * A client configuration will then be read from each location using <em>PropertiesConfiguration</em> to construct a configuration. That means the latest item
+   * will be the one in the configuration.
    *
    * @see PropertiesConfiguration
    * @see File#pathSeparator

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -41,18 +41,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Contains a list of property keys recognized by the Accumulo client and convenience methods for setting them.
- * <p>
- * When loading a configuration file from the system, Accumulo uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
- * <em>File.pathSeparator</em>, for a list of target files.
- * <p>
- * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, uses the following in this order:
- * <ul>
- *   <li>~/.accumulo/config
- *   <li><em>$ACCUMULO_CONF_DIR</em>/client.conf, if <em>$ACCUMULO_CONF_DIR</em> is defined.
- *   <li>/etc/accumulo/client.conf
- *   <li>/etc/accumulo/conf/client.conf
- * </ul>
- * <p>
  *
  * @since 1.6.0
  */
@@ -196,17 +184,23 @@ public class ClientConfiguration extends CompositeConfiguration {
   }
 
   /**
-   * Attempts to load a configuration file from the system. Uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable, split on
-   * <em>File.pathSeparator</em>, for a list of target files.
-   * <p>
-   * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, see class comments above for default search path.
-   * <p>
-   * A client configuration will then be read from each location using <em>PropertiesConfiguration</em> to construct a configuration. That means the latest item
-   * will be the one in the configuration.
-   *
-   * @see PropertiesConfiguration
-   * @see File#pathSeparator
-   */
+  * Attempts to load a configuration file from the system using the default search paths. Uses the <em>ACCUMULO_CLIENT_CONF_PATH</em> environment variable,
+  * split on <em>File.pathSeparator</em>, for a list of target files.
+  * <p>
+  * If <em>ACCUMULO_CLIENT_CONF_PATH</em> is not set, uses the following in this order:
+  * <ul>
+  *   <li> ~/.accumulo/config
+  *   <li> <em>$ACCUMULO_CONF_DIR</em>/client.conf, if <em>$ACCUMULO_CONF_DIR</em> is defined.
+  *   <li> /etc/accumulo/client.conf
+  *   <li> /etc/accumulo/conf/client.conf
+  * </ul>
+  * <p>
+  * A client configuration will then be read from each location using <em>PropertiesConfiguration</em> to construct a configuration.
+  * That means the latest item will be the one in the configuration.
+  *<p>
+  * @see PropertiesConfiguration
+  * @see File#pathSeparator
+  */
   public static ClientConfiguration loadDefault() {
     return loadFromSearchPath(getDefaultSearchPath());
   }


### PR DESCRIPTION
ACCUMULO-4170 Clarify ClientConfiguration javadocs

Updated the javadoc information with the ClientConfiguration class.
Specifically reworked the default search path information to be
displayed as a list rather than inline, thereby easing readability.
Additionally moved the search path list to the class level vice the
method level.

![classv2](https://user-images.githubusercontent.com/31573345/31499040-9479f3de-af31-11e7-93b0-10d7d3fd5447.png)

![methodv2](https://user-images.githubusercontent.com/31573345/31499043-978f5456-af31-11e7-8c7d-caff1e2b23f2.png)


