### PR TITLE
ACCUMULO-4722 Use Objects.equals in Pairs class"

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Pair.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Pair.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.core.util;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 public class Pair<A,B> {
   A first;
@@ -28,29 +29,16 @@ public class Pair<A,B> {
     this.second = s;
   }
 
-  private int hashCode(Object o) {
-    if (o == null)
-      return 0;
-    return o.hashCode();
-  }
-
   @Override
   public int hashCode() {
-    return hashCode(first) + hashCode(second);
-  }
-
-  private boolean equals(Object o1, Object o2) {
-    if (o1 == null || o2 == null)
-      return o1 == o2;
-
-    return o1.equals(o2);
+    return Objects.hashCode(first) + Objects.hashCode(second);
   }
 
   @Override
   public boolean equals(Object o) {
     if (o instanceof Pair<?,?>) {
-      Pair<?,?> op = (Pair<?,?>) o;
-      return equals(first, op.first) && equals(second, op.second);
+      Pair<?,?> other = (Pair<?,?>) o;
+      return Objects.equals(first, other.first) && Objects.equals(second, other.second);
     }
     return false;
   }

--- a/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
@@ -17,6 +17,10 @@
 package org.apache.accumulo.core.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map.Entry;
@@ -26,13 +30,42 @@ import org.junit.Test;
 public class PairTest {
 
   /**
+   * Test method for {@link org.apache.accumulo.core.util.Pair#hashCode()}.
+   */
+  @Test
+  public void testHashMethod() {
+    Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
+    Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
+    Pair<Integer,String> pair3 = new Pair<>(null, null);
+    assertNotSame(pair1, pair2);
+    assertEquals(pair1.hashCode(), pair2.hashCode());
+    assertNotSame(pair2, pair3);
+    assertNotEquals(pair2.hashCode(), pair3.hashCode());
+  }
+
+  /**
    * Test method for {@link org.apache.accumulo.core.util.Pair#equals(java.lang.Object)}.
    */
   @Test
   public void testEqualsObject() {
-    Pair<Integer,String> pair = new Pair<>(25, "twenty-five");
+    Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
-    assertEquals(pair, pair2);
+    Pair<Integer,String> pair3 = new Pair<>(25, "twentyfive");
+    Pair<Integer,String> null1 = null;
+
+    assertEquals(pair1, pair1);
+    assertEquals(pair2, pair1);
+    assertNotEquals(pair1, pair3);
+
+    // verify direct calls
+    assertTrue(pair1.equals(pair2));
+    assertTrue(pair2.equals(pair1));
+    assertFalse(pair1.equals(pair3));
+
+    // check null
+    assertEquals(null1, null1);
+    assertEquals(null1, null);
+    assertNotEquals(pair1, null1);
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PairTest.java
@@ -37,10 +37,13 @@ public class PairTest {
     Pair<Integer,String> pair1 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair2 = new Pair<>(25, "twenty-five");
     Pair<Integer,String> pair3 = new Pair<>(null, null);
+    Pair<Integer,String> pair4 = new Pair<>(25, "twentyfive");
+    Pair<Integer,String> pair5 = new Pair<>(225, "twenty-five");
     assertNotSame(pair1, pair2);
     assertEquals(pair1.hashCode(), pair2.hashCode());
     assertNotSame(pair2, pair3);
-    assertNotEquals(pair2.hashCode(), pair3.hashCode());
+    assertNotEquals(pair1.hashCode(), pair4.hashCode());
+    assertNotEquals(pair1.hashCode(), pair5.hashCode());
   }
 
   /**


### PR DESCRIPTION
ACCUMULO-4722 Use Objects.equals() in Pair equals method

Removed private equals method in Pairs class and instead made use of the
java.util.Objects.equals method. Updated the test class to verify
several variations of the equals method.