### PR TITLE
ACCUMULO-4726 Add Value.contentEquals(byte[]) method

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Value.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Value.java
@@ -242,14 +242,20 @@ public class Value implements WritableComparable<Object> {
 
   @Override
   public boolean equals(Object right_obj) {
-    // compare with byte[] for backwards compatibility, but this is generally a pretty bad practice
-    if (right_obj instanceof byte[]) {
-      return compareTo((byte[]) right_obj) == 0;
-    }
     if (right_obj instanceof Value) {
       return compareTo(right_obj) == 0;
     }
     return false;
+  }
+
+  /**
+   * Compares the bytes in this object to the specified byte array
+   *
+   * @return true if the contents of this Value is equivalent to the supplied byte array
+   * @since 2.0.0
+   */
+  public boolean contentEquals(byte[] right_obj) {
+    return compareTo(right_obj) == 0;
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
@@ -303,7 +303,7 @@ public class VersioningIteratorTest {
     it.seek(testRange, EMPTY_COL_FAMS, false);
 
     assertTrue(it.hasTop());
-    assertTrue(it.getTopValue().equals("00".getBytes()));
+    assertTrue(it.getTopValue().contentEquals("00".getBytes()));
     it.next();
     assertFalse(it.hasTop());
   }


### PR DESCRIPTION
(Note: This PR builds on #312; diffs of NullTServer may show up here, but are part of that PR, not this one.)

Add a method to compare Value objects with byte arrays, and stop
supporting the ability to compare Value objects with byte arrays using
the existing equals(Object) method, which is unsafe and should only be
used to compare with other Value instances.
