### PR TITLE
ACCUMULO-4730 Created EntryLengthSummarizer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.client.summary.summarizers;
 
 import java.math.RoundingMode;
+import java.util.Map;
 
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
@@ -32,298 +33,103 @@ import com.google.common.math.IntMath;
  */
 public class EntryLengthSummarizer implements Summarizer {
 
-  public static final String MIN_KEY_STAT = "minKey";
-  public static final String MAX_KEY_STAT = "maxKey";
-  public static final String SUM_KEYS_STAT = "sumKeys";
+  /* Helper function that calculates the various statistics that is used for the Collector methods.*/
+  private static class LengthStats {
+    private long min = Long.MAX_VALUE;
+    private long max = Long.MIN_VALUE;
+    private long sum = 0;
+    private long[] counts = new long[32];
 
-  public static final String MIN_ROW_STAT = "minRow";
-  public static final String MAX_ROW_STAT = "maxRow";
-  public static final String SUM_ROWS_STAT = "sumRows";
+    private void accept(int length) {
+      int idx;
 
-  public static final String MIN_FAMILY_STAT = "minFamily";
-  public static final String MAX_FAMILY_STAT = "maxFamily";
-  public static final String SUM_FAMILIES_STAT = "sumFamilies";
+      if (length < min) {
+        min = length;
+      }
 
-  public static final String MIN_QUALIFIER_STAT = "minQualifier";
-  public static final String MAX_QUALIFIER_STAT = "maxQualifier";
-  public static final String SUM_QUALIFIERS_STAT = "sumQualifiers";
+      if (length > max) {
+        max = length;
+      }
 
-  public static final String MIN_VISIBILITY_STAT = "minVisibility";
-  public static final String MAX_VISIBILITY_STAT = "maxVisibility";
-  public static final String SUM_VISIBILITIES_STAT = "sumVisibilities";
+      sum += length;
 
-  public static final String MIN_VALUE_STAT = "minValue";
-  public static final String MAX_VALUE_STAT = "maxValue";
-  public static final String SUM_VALUES_STAT = "sumValues";
+      if (length == 0) {
+        idx = 0;
+      } else {
+        idx = IntMath.log2(length, RoundingMode.HALF_UP);
+      }
 
-  public static final String TOTAL_STAT = "total";// Total number of Keys
+      counts[idx]++;
+    }
+
+    void summarize (String prefix, StatisticConsumer sc) {
+      sc.accept(prefix+".min", (min != Long.MAX_VALUE ? min:0));
+      sc.accept(prefix+".max", (max != Long.MIN_VALUE ? max:0));
+      sc.accept(prefix+".sum", sum);
+
+      for (int i = 0; i < counts.length; i++) {
+        if (counts[i] > 0) {
+          sc.accept(prefix+".logHist."+i, counts[i]);
+        }
+      }
+    }
+
+  }
+
+  /* Helper function for merging that is used by the Combiner. */
+  private static void merge(String prefix, Map<String, Long> stats1, Map<String,Long> stats2 ) {
+    stats1.merge(prefix+".min", stats2.get(prefix+".min"), Long::max);
+    stats1.merge(prefix+".max", stats2.get(prefix+".max"), Long::max);
+    stats1.merge(prefix+".sum", stats2.get(prefix+".sum"), Long::sum);
+    stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
+  }
 
   @Override
   public Collector collector(SummarizerConfiguration sc) {
     return new Collector() {
-
-      private long minKey = Long.MAX_VALUE;
-      private long maxKey = Long.MIN_VALUE;
-      private long sumKeys = 0;
-      private long[] keyCounts = new long[32];
-
-      private long minRow = Long.MAX_VALUE;
-      private long maxRow = Long.MIN_VALUE;
-      private long sumRows = 0;
-      private long[] rowCounts = new long[32];
-
-      private long minFamily = Long.MAX_VALUE;
-      private long maxFamily = Long.MIN_VALUE;
-      private long sumFamilies = 0;
-      private long[] familyCounts = new long[32];
-
-      private long minQualifier = Long.MAX_VALUE;
-      private long maxQualifier = Long.MIN_VALUE;
-      private long sumQualifiers = 0;
-      private long[] qualifierCounts = new long[32];
-
-      private long minVisibility = Long.MAX_VALUE;
-      private long maxVisibility = Long.MIN_VALUE;
-      private long sumVisibilities = 0;
-      private long[] visibilityCounts = new long[32];
-
-      private long minValue = Long.MAX_VALUE;
-      private long maxValue = Long.MIN_VALUE;
-      private long sumValues = 0;
-      private long[] valueCounts = new long[32];
-
+      
+      private LengthStats keyStats = new LengthStats();
+      private LengthStats rowStats = new LengthStats();
+      private LengthStats familyStats = new LengthStats();
+      private LengthStats qualifierStats = new LengthStats();
+      private LengthStats visibilityStats = new LengthStats();
+      private LengthStats valueStats = new LengthStats();
       private long total = 0;
 
       @Override
       public void accept(Key k, Value v) {
-        int idx;
-
-        // KEYS
-        if (k.getLength() < minKey) {
-          minKey = k.getLength();
-        }
-
-        if (k.getLength() > maxKey) {
-          maxKey = k.getLength();
-        }
-
-        sumKeys += k.getLength();
-
-        if (k.getLength() == 0) {
-          idx = 0;
-        } else {
-          idx = IntMath.log2(k.getLength(), RoundingMode.HALF_UP);
-        }
-
-        keyCounts[idx]++;
-
-        // ROWS
-        if (k.getRowData().length() < minRow) {
-          minRow = k.getRowData().length();
-        }
-
-        if (k.getRowData().length() > maxRow) {
-          maxRow = k.getRowData().length();
-        }
-
-        sumRows += k.getRowData().length();
-
-        if (k.getRowData().length() == 0) {
-          idx = 0;
-        } else {
-          idx = IntMath.log2(k.getRowData().length(), RoundingMode.HALF_UP);
-        }
-
-        rowCounts[idx]++;
-
-        // FAMILIES
-        if (k.getColumnFamilyData().length() < minFamily) {
-          minFamily = k.getColumnFamilyData().length();
-        }
-
-        if (k.getColumnFamilyData().length() > maxFamily) {
-          maxFamily = k.getColumnFamilyData().length();
-        }
-
-        sumFamilies += k.getColumnFamilyData().length();
-
-        if (k.getColumnFamilyData().length() == 0) {
-          idx = 0;
-        } else {
-          idx = IntMath.log2(k.getColumnFamilyData().length(), RoundingMode.HALF_UP);
-        }
-
-        familyCounts[idx]++;
-
-        // QUALIFIERS
-        if (k.getColumnQualifierData().length() < minQualifier) {
-          minQualifier = k.getColumnQualifierData().length();
-        }
-
-        if (k.getColumnQualifierData().length() > maxQualifier) {
-          maxQualifier = k.getColumnQualifierData().length();
-        }
-
-        sumQualifiers += k.getColumnQualifierData().length();
-
-        if (k.getColumnQualifierData().length() == 0) {
-          idx = 0;
-        } else {
-          idx = IntMath.log2(k.getColumnQualifierData().length(), RoundingMode.HALF_UP);
-        }
-
-        qualifierCounts[idx]++;
-
-        // VISIBILITIES
-        if (k.getColumnVisibilityData().length() < minVisibility) {
-          minVisibility = k.getColumnVisibilityData().length();
-        }
-
-        if (k.getColumnVisibilityData().length() > maxVisibility) {
-          maxVisibility = k.getColumnVisibilityData().length();
-        }
-
-        sumVisibilities += k.getColumnVisibilityData().length();
-
-        if (k.getColumnVisibilityData().length() == 0) {
-          idx = 0;
-        } else {
-          idx = IntMath.log2(k.getColumnVisibilityData().length(), RoundingMode.HALF_UP);
-        }
-
-        visibilityCounts[idx]++;
-
-        // VALUES
-        if (v.getSize() < minValue) {
-          minValue = v.getSize();
-        }
-
-        if (v.getSize() > maxValue) {
-          maxValue = v.getSize();
-        }
-
-        sumValues += v.getSize();
-
-        if (v.getSize() == 0) {
-          idx = 0;
-        } else {
-          idx = IntMath.log2(v.getSize(), RoundingMode.HALF_UP);
-        }
-
-        valueCounts[idx]++;
-
-        // TOTAL
-        total++;
+       keyStats.accept(k.getLength());
+       rowStats.accept(k.getRowData().length());
+       familyStats.accept(k.getColumnFamilyData().length());
+       qualifierStats.accept(k.getColumnQualifierData().length());
+       visibilityStats.accept(k.getColumnVisibilityData().length());
+       valueStats.accept(v.getSize());
+       total++;
       }
 
       @Override
       public void summarize(StatisticConsumer sc) {
-        sc.accept(MIN_KEY_STAT, (minKey != Long.MAX_VALUE ? minKey:0));
-        sc.accept(MAX_KEY_STAT, (maxKey != Long.MIN_VALUE ? maxKey:0));
-        sc.accept(SUM_KEYS_STAT, sumKeys);
-
-        for (int i = 0;i < keyCounts.length;i++) {
-          if(keyCounts[i] > 0) {
-            sc.accept("key.logHist."+i, keyCounts[i]);
-          }
-        }
-
-        sc.accept(MIN_ROW_STAT, (minRow != Long.MAX_VALUE ? minRow:0));
-        sc.accept(MAX_ROW_STAT, (maxRow != Long.MIN_VALUE ? maxRow:0));
-        sc.accept(SUM_ROWS_STAT, sumRows);
-
-        for (int i = 0;i < rowCounts.length;i++) {
-          if(rowCounts[i] > 0) {
-            sc.accept("row.logHist."+i, rowCounts[i]);
-          }
-        }
-
-        sc.accept(MIN_FAMILY_STAT, (minFamily != Long.MAX_VALUE ? minFamily:0));
-        sc.accept(MAX_FAMILY_STAT, (maxFamily != Long.MIN_VALUE ? maxFamily:0));
-        sc.accept(SUM_FAMILIES_STAT, sumFamilies);
-
-        for (int i = 0;i < familyCounts.length;i++) {
-          if(familyCounts[i] > 0) {
-            sc.accept("family.logHist."+i, familyCounts[i]);
-          }
-        }
-
-        sc.accept(MIN_QUALIFIER_STAT, (minQualifier != Long.MAX_VALUE ? minQualifier:0));
-        sc.accept(MAX_QUALIFIER_STAT, (maxQualifier != Long.MIN_VALUE ? maxQualifier:0));
-        sc.accept(SUM_QUALIFIERS_STAT, sumQualifiers);
-
-        for (int i = 0;i < qualifierCounts.length;i++) {
-          if(qualifierCounts[i] > 0) {
-            sc.accept("qualifier.logHist."+i, qualifierCounts[i]);
-          }
-        }
-
-        sc.accept(MIN_VISIBILITY_STAT, (minVisibility != Long.MAX_VALUE ? minVisibility:0));
-        sc.accept(MAX_VISIBILITY_STAT, (maxVisibility != Long.MIN_VALUE ? maxVisibility:0));
-        sc.accept(SUM_VISIBILITIES_STAT, sumVisibilities);
-
-        for (int i = 0;i < visibilityCounts.length;i++) {
-          if(visibilityCounts[i] > 0) {
-            sc.accept("visibility.logHist."+i, visibilityCounts[i]);
-          }
-        }
-
-        sc.accept(MIN_VALUE_STAT, (minValue != Long.MAX_VALUE ? minValue:0));
-        sc.accept(MAX_VALUE_STAT, (maxValue != Long.MIN_VALUE ? maxValue:0));
-        sc.accept(SUM_VALUES_STAT, sumValues);
-
-        for (int i = 0;i < valueCounts.length;i++) {
-          if(valueCounts[i] > 0) {
-            sc.accept("value.logHist."+i, valueCounts[i]);
-          }
-        }
-
-        sc.accept(TOTAL_STAT, total);
+        keyStats.summarize("key", sc);
+        rowStats.summarize("row", sc);
+        familyStats.summarize("family", sc);
+        qualifierStats.summarize("qualifier", sc);
+        visibilityStats.summarize("visibility", sc);
+        valueStats.summarize("value", sc);
+        sc.accept("total", total);
       }
-
     };
   }
 
   @Override
   public Combiner combiner(SummarizerConfiguration sc) {
     return (stats1, stats2) -> {
-      stats1.merge(MIN_KEY_STAT, stats2.get(MIN_KEY_STAT), Long::max);
-      stats1.merge(MAX_KEY_STAT, stats2.get(MAX_KEY_STAT), Long::max);
-      stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
-      // Log2 Histogram for Keys
-      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-
-      stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::max);
-      stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
-      stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
-      // Log2 Histogram for Rows
-      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-
-      stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::max);
-      stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
-      stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
-      // Log2 Histogram for Families
-      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-
-      stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::max);
-      stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
-      stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
-      // Log2 Histogram for Qualifiers
-      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-
-      stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::max);
-      stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
-      stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
-      // Log2 Histogram for Visibilities
-      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-
-      stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::max);
-      stats1.merge(MAX_VALUE_STAT, stats2.get(MAX_VALUE_STAT), Long::max);
-      stats1.merge(SUM_VALUES_STAT, stats2.get(SUM_VALUES_STAT), Long::sum);
-      // Log2 Histogram for Values
-      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-
-      stats1.merge(TOTAL_STAT, stats2.get(TOTAL_STAT), Long::sum);
+      merge("key", stats1, stats2);
+      merge("row", stats1, stats2);
+      merge("family", stats1, stats2);
+      merge("qualifier", stats1, stats2);
+      merge("visibility", stats1, stats2);
+      merge("value", stats1, stats2);
+      stats1.merge("total", stats2.get("total"), Long::sum);
     };
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.summary.summarizers;
+
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.summary.Summarizer;
+import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+/**
+ * Summarizer that computes summary information about field lengths. 
+ * Specifically key length, row length, family length, qualifier length, visibility length, and value length.
+ * Incrementally computes minimum, maximum, count, sum, and log2 histogram of the lengths.
+ */
+public class EntryLengthSummarizer implements Summarizer {
+
+  public static final String MIN_KEY_STAT = "minKey";
+  public static final String MAX_KEY_STAT = "maxKey";
+  public static final String SUM_KEYS_STAT = "sumKeys";
+  //Log2 Histogram for Keys
+  
+  public static final String MIN_ROW_STAT = "minRow";
+  public static final String MAX_ROW_STAT = "maxRow";
+  public static final String SUM_ROWS_STAT = "sumRows";
+  //Log2 Histogram for Rows
+  
+  public static final String MIN_FAMILY_STAT = "minFamily";
+  public static final String MAX_FAMILY_STAT = "maxFamily";
+  public static final String SUM_FAMILIES_STAT = "sumFamilies";
+  //Log2 Histogram for Families
+  
+  public static final String MIN_QUALIFIER_STAT = "minQualifier";
+  public static final String MAX_QUALIFIER_STAT = "maxQualifier";
+  public static final String SUM_QUALIFIERS_STAT = "sumQualifiers";
+  //Log2 Histogram for Qualifiers
+  
+  public static final String MIN_VISIBILITY_STAT = "minVisbility";
+  public static final String MAX_VISIBILITY_STAT = "maxVisibility";
+  public static final String SUM_VISIBILITIES_STAT = "sumVisibilities";
+  //Log2 Histogram for Visibilities
+  
+  public static final String MIN_VALUE_STAT = "minValue";
+  public static final String MAX_VALUE_STAT = "maxValue";
+  public static final String SUM_VALUES_STAT = "sumValues";
+  //Log2 Histogram for Values
+  
+  public static final String TOTAL_STAT = "total"; //Count
+  
+  @Override
+  public Collector collector(SummarizerConfiguration sc) {
+    return new Collector() {
+
+      private long minKey = Long.MIN_VALUE;
+      private long maxKey = Long.MAX_VALUE;
+      private long sumKeys = 0;
+      
+      private long minRow = Long.MIN_VALUE;
+      private long maxRow = Long.MAX_VALUE;
+      private long sumRows = 0;
+      
+      private long minFamily = Long.MIN_VALUE;
+      private long maxFamily = Long.MAX_VALUE;
+      private long sumFamilies = 0;
+      
+      private long minQualifier = Long.MIN_VALUE;
+      private long maxQualifier = Long.MAX_VALUE;
+      private long sumQualifiers = 0;
+      
+      private long minVisibility = Long.MIN_VALUE;
+      private long maxVisibility = Long.MAX_VALUE;
+      private long sumVisibilities = 0;
+      
+      private long minValue = Long.MIN_VALUE;
+      private long maxValue = Long.MAX_VALUE;
+      private long sumValues = 0;
+      
+      private long total = 0;
+      
+      @Override
+      public void accept(Key k, Value v) {
+        // Keys
+        if (k.getLength() < minKey) {
+          minKey = k.getLength();
+        }
+        
+        if (k.getLength() > maxKey) {
+          maxKey = k.getLength();
+        }
+        
+        sumKeys += k.getLength();
+        
+        // Rows
+        if (k.getRowData().length() < minRow) {
+          minRow = k.getRowData().length();
+        }
+        
+        if (k.getRowData().length() > maxRow) {
+          maxRow = k.getRowData().length();
+        }
+        
+        sumRows += k.getRowData().length();
+        
+        // Families
+        if (k.getColumnFamilyData().length() < minFamily) {
+          minFamily = k.getColumnFamilyData().length();
+        }
+        
+        if (k.getColumnFamilyData().length() > maxFamily) {
+          maxFamily = k.getColumnFamilyData().length();
+        }
+        
+        sumFamilies += k.getColumnFamilyData().length();
+        
+        // Qualifiers
+        if (k.getColumnQualifierData().length() < minQualifier) {
+          minQualifier = k.getColumnQualifierData().length();
+        }
+        
+        if (k.getColumnQualifierData().length() > maxQualifier) {
+          maxQualifier = k.getColumnQualifierData().length();
+        }
+        
+        sumQualifiers += k.getColumnQualifierData().length();
+        
+        // Visibilities
+        if (k.getColumnVisibilityData().length() < minVisibility) {
+          minVisibility = k.getColumnVisibilityData().length();
+        }
+        
+        if (k.getColumnVisibilityData().length() > maxVisibility) {
+          maxVisibility = k.getColumnVisibilityData().length();
+        }
+        
+        sumVisibilities += k.getColumnVisibilityData().length();
+        
+        // Values
+        if (v.getSize() < minValue) {
+          minValue = v.getSize();
+        }
+        
+        if (v.getSize() > maxValue) {
+          maxValue = v.getSize();
+        }
+        
+        sumValues += v.getSize();
+        
+        // Count
+        total++;
+      }
+
+      @Override
+      public void summarize(StatisticConsumer sc) {
+        sc.accept(MIN_KEY_STAT, minKey);
+        sc.accept(MAX_KEY_STAT, maxKey);
+        sc.accept(SUM_KEYS_STAT, sumKeys);
+        
+        sc.accept(MIN_ROW_STAT, minRow);
+        sc.accept(MAX_ROW_STAT, maxRow);
+        sc.accept(SUM_KEYS_STAT, sumRows);
+        
+        sc.accept(MIN_FAMILY_STAT, minFamily);
+        sc.accept(MAX_FAMILY_STAT, minFamily);
+        sc.accept(SUM_FAMILIES_STAT, sumFamilies);
+        
+        sc.accept(MIN_QUALIFIER_STAT, minQualifier);
+        sc.accept(MAX_QUALIFIER_STAT, maxQualifier);
+        sc.accept(SUM_QUALIFIERS_STAT, sumQualifiers);
+        
+        sc.accept(MIN_VISIBILITY_STAT, minVisibility);
+        sc.accept(MAX_VISIBILITY_STAT, maxVisibility);
+        sc.accept(SUM_VISIBILITIES_STAT, sumVisibilities);
+        
+        sc.accept(MIN_VALUE_STAT, minValue);
+        sc.accept(MAX_VALUE_STAT, maxValue);
+        sc.accept(SUM_VALUES_STAT, sumValues);
+        
+        sc.accept(TOTAL_STAT, total);
+      }
+      
+    };
+  }
+
+  @Override
+  public Combiner combiner(SummarizerConfiguration sc) {
+    return (stats1, stats2) -> {
+      stats1.merge(MIN_KEY_STAT, stats2.get(MIN_KEY_STAT), Long::min);
+      stats1.merge(MAX_KEY_STAT, stats2.get(MAX_KEY_STAT), Long::max);
+      stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
+      
+      stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::min);
+      stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
+      stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
+      
+      stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::min);
+      stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
+      stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
+      
+      stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::min);
+      stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
+      stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
+      
+      stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::min);
+      stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
+      stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
+      
+      stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::min);
+      stats1.merge(MAX_VALUE_STAT, stats2.get(MAX_VALUE_STAT), Long::max);
+      stats1.merge(SUM_VALUES_STAT, stats2.get(SUM_VALUES_STAT), Long::sum);
+      
+      stats1.merge(TOTAL_STAT, stats2.get(TOTAL_STAT), Long::sum);
+    };
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -289,43 +289,37 @@ public class EntryLengthSummarizer implements Summarizer {
     return (stats1, stats2) -> {
       stats1.merge(MIN_KEY_STAT, stats2.get(MIN_KEY_STAT), Long::max);
       stats1.merge(MAX_KEY_STAT, stats2.get(MAX_KEY_STAT), Long::max);
-      stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
-      
+      stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);      
       // Log2 Histogram for Keys
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::max);
       stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
-      stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
-      
+      stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);      
       // Log2 Histogram for Rows
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::max);
       stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
-      stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
-      
+      stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);     
       // Log2 Histogram for Families
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::max);
       stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
-      stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
-      
+      stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);      
       // Log2 Histogram for Qualifiers
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::max);
       stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
-      stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
-      
+      stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);     
       // Log2 Histogram for Visibilities
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::max);
       stats1.merge(MAX_VALUE_STAT, stats2.get(MAX_VALUE_STAT), Long::max);
       stats1.merge(SUM_VALUES_STAT, stats2.get(SUM_VALUES_STAT), Long::sum);
-      
       // Log2 Histogram for Values
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
 

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.core.client.summary.summarizers;
 
 import java.math.RoundingMode;
 
-import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.data.Key;
@@ -57,7 +56,7 @@ public class EntryLengthSummarizer implements Summarizer {
   public static final String MAX_VALUE_STAT = "maxValue";
   public static final String SUM_VALUES_STAT = "sumValues";
   
-  public static final String TOTAL_STAT = "total"; //Count
+  public static final String TOTAL_STAT = "total"; // Total number of Keys
   
   @Override
   public Collector collector(SummarizerConfiguration sc) {
@@ -213,7 +212,7 @@ public class EntryLengthSummarizer implements Summarizer {
         
         valueCounts[idx]++;
         
-        // COUNT
+        // TOTAL
         total++;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -26,7 +26,7 @@ import org.apache.accumulo.core.data.Value;
 import com.google.common.math.IntMath;
 
 /**
- * Summarizer that computes summary information about field lengths. 
+ * Summarizer that computes summary information about field lengths.
  * Specifically key length, row length, family length, qualifier length, visibility length, and value length.
  * Incrementally computes minimum, maximum, count, sum, and log2 histogram of the lengths.
  */
@@ -35,29 +35,29 @@ public class EntryLengthSummarizer implements Summarizer {
   public static final String MIN_KEY_STAT = "minKey";
   public static final String MAX_KEY_STAT = "maxKey";
   public static final String SUM_KEYS_STAT = "sumKeys";
-  
+
   public static final String MIN_ROW_STAT = "minRow";
   public static final String MAX_ROW_STAT = "maxRow";
   public static final String SUM_ROWS_STAT = "sumRows";
-  
+
   public static final String MIN_FAMILY_STAT = "minFamily";
   public static final String MAX_FAMILY_STAT = "maxFamily";
   public static final String SUM_FAMILIES_STAT = "sumFamilies";
-  
+
   public static final String MIN_QUALIFIER_STAT = "minQualifier";
   public static final String MAX_QUALIFIER_STAT = "maxQualifier";
   public static final String SUM_QUALIFIERS_STAT = "sumQualifiers";
-  
+
   public static final String MIN_VISIBILITY_STAT = "minVisibility";
   public static final String MAX_VISIBILITY_STAT = "maxVisibility";
   public static final String SUM_VISIBILITIES_STAT = "sumVisibilities";
-  
+
   public static final String MIN_VALUE_STAT = "minValue";
   public static final String MAX_VALUE_STAT = "maxValue";
   public static final String SUM_VALUES_STAT = "sumValues";
-  
+
   public static final String TOTAL_STAT = "total";// Total number of Keys
-  
+
   @Override
   public Collector collector(SummarizerConfiguration sc) {
     return new Collector() {
@@ -66,152 +66,152 @@ public class EntryLengthSummarizer implements Summarizer {
       private long maxKey = Long.MIN_VALUE;
       private long sumKeys = 0;
       private long[] keyCounts = new long[32];
-      
+
       private long minRow = Long.MAX_VALUE;
       private long maxRow = Long.MIN_VALUE;
       private long sumRows = 0;
       private long[] rowCounts = new long[32];
-      
+
       private long minFamily = Long.MAX_VALUE;
       private long maxFamily = Long.MIN_VALUE;
       private long sumFamilies = 0;
       private long[] familyCounts = new long[32];
-      
+
       private long minQualifier = Long.MAX_VALUE;
       private long maxQualifier = Long.MIN_VALUE;
       private long sumQualifiers = 0;
       private long[] qualifierCounts = new long[32];
-      
+
       private long minVisibility = Long.MAX_VALUE;
       private long maxVisibility = Long.MIN_VALUE;
       private long sumVisibilities = 0;
       private long[] visibilityCounts = new long[32];
-      
+
       private long minValue = Long.MAX_VALUE;
       private long maxValue = Long.MIN_VALUE;
       private long sumValues = 0;
       private long[] valueCounts = new long[32];
-      
+
       private long total = 0;
-      
+
       @Override
       public void accept(Key k, Value v) {
         int idx;
-        
+
         // KEYS
         if (k.getLength() < minKey) {
           minKey = k.getLength();
         }
-        
+
         if (k.getLength() > maxKey) {
           maxKey = k.getLength();
         }
-        
+
         sumKeys += k.getLength();
-        
+
         if (k.getLength() == 0) {
           idx = 0;
         } else {
           idx = IntMath.log2(k.getLength(), RoundingMode.HALF_UP);
         }
-        
+
         keyCounts[idx]++;
-        
+
         // ROWS
         if (k.getRowData().length() < minRow) {
           minRow = k.getRowData().length();
         }
-        
+
         if (k.getRowData().length() > maxRow) {
           maxRow = k.getRowData().length();
         }
-        
+
         sumRows += k.getRowData().length();
-        
+
         if (k.getRowData().length() == 0) {
           idx = 0;
         } else {
           idx = IntMath.log2(k.getRowData().length(), RoundingMode.HALF_UP);
         }
-        
+
         rowCounts[idx]++;
-        
+
         // FAMILIES
         if (k.getColumnFamilyData().length() < minFamily) {
           minFamily = k.getColumnFamilyData().length();
         }
-        
+
         if (k.getColumnFamilyData().length() > maxFamily) {
           maxFamily = k.getColumnFamilyData().length();
         }
-        
+
         sumFamilies += k.getColumnFamilyData().length();
-        
+
         if (k.getColumnFamilyData().length() == 0) {
           idx = 0;
         } else {
           idx = IntMath.log2(k.getColumnFamilyData().length(), RoundingMode.HALF_UP);
         }
-        
+
         familyCounts[idx]++;
-        
+
         // QUALIFIERS
         if (k.getColumnQualifierData().length() < minQualifier) {
           minQualifier = k.getColumnQualifierData().length();
         }
-        
+
         if (k.getColumnQualifierData().length() > maxQualifier) {
           maxQualifier = k.getColumnQualifierData().length();
         }
-        
+
         sumQualifiers += k.getColumnQualifierData().length();
-        
+
         if (k.getColumnQualifierData().length() == 0) {
           idx = 0;
         } else {
           idx = IntMath.log2(k.getColumnQualifierData().length(), RoundingMode.HALF_UP);
         }
-        
+
         qualifierCounts[idx]++;
-        
+
         // VISIBILITIES
         if (k.getColumnVisibilityData().length() < minVisibility) {
           minVisibility = k.getColumnVisibilityData().length();
         }
-        
+
         if (k.getColumnVisibilityData().length() > maxVisibility) {
           maxVisibility = k.getColumnVisibilityData().length();
         }
-        
+
         sumVisibilities += k.getColumnVisibilityData().length();
-        
+
         if (k.getColumnVisibilityData().length() == 0) {
           idx = 0;
         } else {
           idx = IntMath.log2(k.getColumnVisibilityData().length(), RoundingMode.HALF_UP);
         }
-        
+
         visibilityCounts[idx]++;
-        
+
         // VALUES
         if (v.getSize() < minValue) {
           minValue = v.getSize();
         }
-        
+
         if (v.getSize() > maxValue) {
           maxValue = v.getSize();
         }
-        
+
         sumValues += v.getSize();
-          
+
         if (v.getSize() == 0) {
           idx = 0;
         } else {
           idx = IntMath.log2(v.getSize(), RoundingMode.HALF_UP);
         }
-        
+
         valueCounts[idx]++;
-        
+
         // TOTAL
         total++;
       }
@@ -221,66 +221,66 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MIN_KEY_STAT, (minKey != Long.MAX_VALUE ? minKey:0));
         sc.accept(MAX_KEY_STAT, (maxKey != Long.MIN_VALUE ? maxKey:0));
         sc.accept(SUM_KEYS_STAT, sumKeys);
-        
+
         for (int i = 0;i < keyCounts.length;i++) {
           if(keyCounts[i] > 0) {
             sc.accept("key.logHist."+i, keyCounts[i]);
           }
         }
-        
+
         sc.accept(MIN_ROW_STAT, (minRow != Long.MAX_VALUE ? minRow:0));
         sc.accept(MAX_ROW_STAT, (maxRow != Long.MIN_VALUE ? maxRow:0));
         sc.accept(SUM_ROWS_STAT, sumRows);
-        
+
         for (int i = 0;i < rowCounts.length;i++) {
           if(rowCounts[i] > 0) {
             sc.accept("row.logHist."+i, rowCounts[i]);
           }
         }
-        
+
         sc.accept(MIN_FAMILY_STAT, (minFamily != Long.MAX_VALUE ? minFamily:0));
         sc.accept(MAX_FAMILY_STAT, (maxFamily != Long.MIN_VALUE ? maxFamily:0));
         sc.accept(SUM_FAMILIES_STAT, sumFamilies);
-        
+
         for (int i = 0;i < familyCounts.length;i++) {
           if(familyCounts[i] > 0) {
             sc.accept("family.logHist."+i, familyCounts[i]);
           }
         }
-        
+
         sc.accept(MIN_QUALIFIER_STAT, (minQualifier != Long.MAX_VALUE ? minQualifier:0));
         sc.accept(MAX_QUALIFIER_STAT, (maxQualifier != Long.MIN_VALUE ? maxQualifier:0));
         sc.accept(SUM_QUALIFIERS_STAT, sumQualifiers);
-        
+
         for (int i = 0;i < qualifierCounts.length;i++) {
           if(qualifierCounts[i] > 0) {
             sc.accept("qualifier.logHist."+i, qualifierCounts[i]);
           }
         }
-        
+
         sc.accept(MIN_VISIBILITY_STAT, (minVisibility != Long.MAX_VALUE ? minVisibility:0));
         sc.accept(MAX_VISIBILITY_STAT, (maxVisibility != Long.MIN_VALUE ? maxVisibility:0));
         sc.accept(SUM_VISIBILITIES_STAT, sumVisibilities);
-        
+
         for (int i = 0;i < visibilityCounts.length;i++) {
           if(visibilityCounts[i] > 0) {
             sc.accept("visibility.logHist."+i, visibilityCounts[i]);
           }
         }
-        
+
         sc.accept(MIN_VALUE_STAT, (minValue != Long.MAX_VALUE ? minValue:0));
         sc.accept(MAX_VALUE_STAT, (maxValue != Long.MIN_VALUE ? maxValue:0));
         sc.accept(SUM_VALUES_STAT, sumValues);
-        
+
         for (int i = 0;i < valueCounts.length;i++) {
           if(valueCounts[i] > 0) {
             sc.accept("value.logHist."+i, valueCounts[i]);
           }
         }
-        
+
         sc.accept(TOTAL_STAT, total);
       }
-      
+
     };
   }
 
@@ -292,31 +292,31 @@ public class EntryLengthSummarizer implements Summarizer {
       stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
       // Log2 Histogram for Keys
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-      
+
       stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::max);
       stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
       stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
       // Log2 Histogram for Rows
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-      
+
       stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::max);
       stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
       stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
       // Log2 Histogram for Families
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-      
+
       stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::max);
       stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
       stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
       // Log2 Histogram for Qualifiers
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-      
+
       stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::max);
       stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
       stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
       // Log2 Histogram for Visibilities
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
-      
+
       stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::max);
       stats1.merge(MAX_VALUE_STAT, stats2.get(MAX_VALUE_STAT), Long::max);
       stats1.merge(SUM_VALUES_STAT, stats2.get(SUM_VALUES_STAT), Long::sum);

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -79,10 +79,10 @@ public class EntryLengthSummarizer implements Summarizer {
 
   /* Helper functions for merging that is used by the Combiner. */
   private static void merge(String key, BiFunction<Long,Long,Long> mergeFunc, Map<String, Long> stats1, Map<String,Long> stats2) {
-    if (stats2.containsKey(key) && (stats1.containsKey(key) == false)) {
-      stats1.put(key, stats2.get(key));
-    } else if (stats2.containsKey(key) && stats1.containsKey(key)){
-      stats1.merge(key, stats2.get(key), mergeFunc);
+    Long mergeVal = stats2.get(key);
+    
+    if(mergeVal != null) {
+      stats1.merge(key, mergeVal, mergeFunc);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -16,11 +16,15 @@
  */
 package org.apache.accumulo.core.client.summary.summarizers;
 
+import java.math.RoundingMode;
+
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+
+import com.google.common.math.IntMath;
 
 /**
  * Summarizer that computes summary information about field lengths. 
@@ -32,32 +36,26 @@ public class EntryLengthSummarizer implements Summarizer {
   public static final String MIN_KEY_STAT = "minKey";
   public static final String MAX_KEY_STAT = "maxKey";
   public static final String SUM_KEYS_STAT = "sumKeys";
-  //Log2 Histogram for Keys
   
   public static final String MIN_ROW_STAT = "minRow";
   public static final String MAX_ROW_STAT = "maxRow";
   public static final String SUM_ROWS_STAT = "sumRows";
-  //Log2 Histogram for Rows
   
   public static final String MIN_FAMILY_STAT = "minFamily";
   public static final String MAX_FAMILY_STAT = "maxFamily";
   public static final String SUM_FAMILIES_STAT = "sumFamilies";
-  //Log2 Histogram for Families
   
   public static final String MIN_QUALIFIER_STAT = "minQualifier";
   public static final String MAX_QUALIFIER_STAT = "maxQualifier";
   public static final String SUM_QUALIFIERS_STAT = "sumQualifiers";
-  //Log2 Histogram for Qualifiers
   
   public static final String MIN_VISIBILITY_STAT = "minVisibility";
   public static final String MAX_VISIBILITY_STAT = "maxVisibility";
   public static final String SUM_VISIBILITIES_STAT = "sumVisibilities";
-  //Log2 Histogram for Visibilities
   
   public static final String MIN_VALUE_STAT = "minValue";
   public static final String MAX_VALUE_STAT = "maxValue";
   public static final String SUM_VALUES_STAT = "sumValues";
-  //Log2 Histogram for Values
   
   public static final String TOTAL_STAT = "total"; //Count
   
@@ -68,32 +66,40 @@ public class EntryLengthSummarizer implements Summarizer {
       private long minKey = Long.MAX_VALUE;
       private long maxKey = Long.MIN_VALUE;
       private long sumKeys = 0;
+      private long[] keyCounts = new long[32];
       
       private long minRow = Long.MAX_VALUE;
       private long maxRow = Long.MIN_VALUE;
       private long sumRows = 0;
+      private long[] rowCounts = new long[32];
       
       private long minFamily = Long.MAX_VALUE;
       private long maxFamily = Long.MIN_VALUE;
       private long sumFamilies = 0;
+      private long[] familyCounts = new long[32];
       
       private long minQualifier = Long.MAX_VALUE;
       private long maxQualifier = Long.MIN_VALUE;
       private long sumQualifiers = 0;
+      private long[] qualifierCounts = new long[32];
       
       private long minVisibility = Long.MAX_VALUE;
       private long maxVisibility = Long.MIN_VALUE;
       private long sumVisibilities = 0;
+      private long[] visibilityCounts = new long[32];
       
       private long minValue = Long.MAX_VALUE;
       private long maxValue = Long.MIN_VALUE;
       private long sumValues = 0;
+      private long[] valueCounts = new long[32];
       
       private long total = 0;
       
       @Override
       public void accept(Key k, Value v) {
-        // Keys
+        int idx;
+        
+        // KEYS
         if (k.getLength() < minKey) {
           minKey = k.getLength();
         }
@@ -104,7 +110,15 @@ public class EntryLengthSummarizer implements Summarizer {
         
         sumKeys += k.getLength();
         
-        // Rows
+        if (k.getLength() == 0) {
+          idx = 0;
+        } else {
+          idx = IntMath.log2(k.getLength(), RoundingMode.HALF_UP);
+        }
+        
+        keyCounts[idx]++;
+        
+        // ROWS
         if (k.getRowData().length() < minRow) {
           minRow = k.getRowData().length();
         }
@@ -115,7 +129,15 @@ public class EntryLengthSummarizer implements Summarizer {
         
         sumRows += k.getRowData().length();
         
-        // Families
+        if (k.getRowData().length() == 0) {
+          idx = 0;
+        } else {
+          idx = IntMath.log2(k.getRowData().length(), RoundingMode.HALF_UP);
+        }
+        
+        rowCounts[idx]++;
+        
+        // FAMILIES
         if (k.getColumnFamilyData().length() < minFamily) {
           minFamily = k.getColumnFamilyData().length();
         }
@@ -126,7 +148,15 @@ public class EntryLengthSummarizer implements Summarizer {
         
         sumFamilies += k.getColumnFamilyData().length();
         
-        // Qualifiers
+        if (k.getColumnFamilyData().length() == 0) {
+          idx = 0;
+        } else {
+          idx = IntMath.log2(k.getColumnFamilyData().length(), RoundingMode.HALF_UP);
+        }
+        
+        familyCounts[idx]++;
+        
+        // QUALIFIERS
         if (k.getColumnQualifierData().length() < minQualifier) {
           minQualifier = k.getColumnQualifierData().length();
         }
@@ -137,7 +167,15 @@ public class EntryLengthSummarizer implements Summarizer {
         
         sumQualifiers += k.getColumnQualifierData().length();
         
-        // Visibilities
+        if (k.getColumnQualifierData().length() == 0) {
+          idx = 0;
+        } else {
+          idx = IntMath.log2(k.getColumnQualifierData().length(), RoundingMode.HALF_UP);
+        }
+        
+        qualifierCounts[idx]++;
+        
+        // VISIBILITIES
         if (k.getColumnVisibilityData().length() < minVisibility) {
           minVisibility = k.getColumnVisibilityData().length();
         }
@@ -148,7 +186,15 @@ public class EntryLengthSummarizer implements Summarizer {
         
         sumVisibilities += k.getColumnVisibilityData().length();
         
-        // Values
+        if (k.getColumnVisibilityData().length() == 0) {
+          idx = 0;
+        } else {
+          idx = IntMath.log2(k.getColumnVisibilityData().length(), RoundingMode.HALF_UP);
+        }
+        
+        visibilityCounts[idx]++;
+        
+        // VALUES
         if (v.getSize() < minValue) {
           minValue = v.getSize();
         }
@@ -158,8 +204,16 @@ public class EntryLengthSummarizer implements Summarizer {
         }
         
         sumValues += v.getSize();
+          
+        if (v.getSize() == 0) {
+          idx = 0;
+        } else {
+          idx = IntMath.log2(v.getSize(), RoundingMode.HALF_UP);
+        }
         
-        // Count
+        valueCounts[idx]++;
+        
+        // COUNT
         total++;
       }
 
@@ -169,25 +223,61 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_KEY_STAT, (maxKey != Long.MIN_VALUE ? maxKey:0));
         sc.accept(SUM_KEYS_STAT, sumKeys);
         
+        for (int i = 0; i < keyCounts.length; i++) {
+          if(keyCounts[i] > 0) {
+            sc.accept("key.logHist."+i, keyCounts[i]);
+          }
+        }
+        
         sc.accept(MIN_ROW_STAT, (minRow != Long.MAX_VALUE ? minRow:0));
         sc.accept(MAX_ROW_STAT, (maxRow != Long.MIN_VALUE ? maxRow:0));
         sc.accept(SUM_ROWS_STAT, sumRows);
+        
+        for (int i = 0; i < rowCounts.length; i++) {
+          if(rowCounts[i] > 0) {
+            sc.accept("row.logHist."+i, rowCounts[i]);
+          }
+        }
         
         sc.accept(MIN_FAMILY_STAT, (minFamily != Long.MAX_VALUE ? minFamily:0));
         sc.accept(MAX_FAMILY_STAT, (maxFamily != Long.MIN_VALUE ? maxFamily:0));
         sc.accept(SUM_FAMILIES_STAT, sumFamilies);
         
+        for (int i = 0; i < familyCounts.length; i++) {
+          if(familyCounts[i] > 0) {
+            sc.accept("family.logHist."+i, familyCounts[i]);
+          }
+        }
+        
         sc.accept(MIN_QUALIFIER_STAT, (minQualifier != Long.MAX_VALUE ? minQualifier:0));
         sc.accept(MAX_QUALIFIER_STAT, (maxQualifier != Long.MIN_VALUE ? maxQualifier:0));
         sc.accept(SUM_QUALIFIERS_STAT, sumQualifiers);
+        
+        for (int i = 0; i < qualifierCounts.length; i++) {
+          if(qualifierCounts[i] > 0) {
+            sc.accept("qualifier.logHist."+i, qualifierCounts[i]);
+          }
+        }
         
         sc.accept(MIN_VISIBILITY_STAT, (minVisibility != Long.MAX_VALUE ? minVisibility:0));
         sc.accept(MAX_VISIBILITY_STAT, (maxVisibility != Long.MIN_VALUE ? maxVisibility:0));
         sc.accept(SUM_VISIBILITIES_STAT, sumVisibilities);
         
+        for (int i = 0; i < visibilityCounts.length; i++) {
+          if(visibilityCounts[i] > 0) {
+            sc.accept("visibility.logHist."+i, visibilityCounts[i]);
+          }
+        }
+        
         sc.accept(MIN_VALUE_STAT, (minValue != Long.MAX_VALUE ? minValue:0));
         sc.accept(MAX_VALUE_STAT, (maxValue != Long.MIN_VALUE ? maxValue:0));
         sc.accept(SUM_VALUES_STAT, sumValues);
+        
+        for (int i = 0; i < valueCounts.length; i++) {
+          if(valueCounts[i] > 0) {
+            sc.accept("value.logHist."+i, valueCounts[i]);
+          }
+        }
         
         sc.accept(TOTAL_STAT, total);
       }
@@ -202,26 +292,44 @@ public class EntryLengthSummarizer implements Summarizer {
       stats1.merge(MAX_KEY_STAT, stats2.get(MAX_KEY_STAT), Long::max);
       stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
       
+      // Log2 Histogram for Keys
+      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
+      
       stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::max);
       stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
       stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
+      
+      // Log2 Histogram for Rows
+      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::max);
       stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
       stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
       
+      // Log2 Histogram for Families
+      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
+      
       stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::max);
       stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
       stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
+      
+      // Log2 Histogram for Qualifiers
+      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::max);
       stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
       stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
       
+      // Log2 Histogram for Visibilities
+      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
+      
       stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::max);
       stats1.merge(MAX_VALUE_STAT, stats2.get(MAX_VALUE_STAT), Long::max);
       stats1.merge(SUM_VALUES_STAT, stats2.get(SUM_VALUES_STAT), Long::sum);
       
+      // Log2 Histogram for Values
+      stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
+
       stats1.merge(TOTAL_STAT, stats2.get(TOTAL_STAT), Long::sum);
     };
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -49,7 +49,7 @@ public class EntryLengthSummarizer implements Summarizer {
   public static final String SUM_QUALIFIERS_STAT = "sumQualifiers";
   //Log2 Histogram for Qualifiers
   
-  public static final String MIN_VISIBILITY_STAT = "minVisbility";
+  public static final String MIN_VISIBILITY_STAT = "minVisibility";
   public static final String MAX_VISIBILITY_STAT = "maxVisibility";
   public static final String SUM_VISIBILITIES_STAT = "sumVisibilities";
   //Log2 Histogram for Visibilities
@@ -65,28 +65,28 @@ public class EntryLengthSummarizer implements Summarizer {
   public Collector collector(SummarizerConfiguration sc) {
     return new Collector() {
 
-      private long minKey = Long.MIN_VALUE;
-      private long maxKey = Long.MAX_VALUE;
+      private long minKey = Long.MAX_VALUE;
+      private long maxKey = Long.MIN_VALUE;
       private long sumKeys = 0;
       
-      private long minRow = Long.MIN_VALUE;
-      private long maxRow = Long.MAX_VALUE;
+      private long minRow = Long.MAX_VALUE;
+      private long maxRow = Long.MIN_VALUE;
       private long sumRows = 0;
       
-      private long minFamily = Long.MIN_VALUE;
-      private long maxFamily = Long.MAX_VALUE;
+      private long minFamily = Long.MAX_VALUE;
+      private long maxFamily = Long.MIN_VALUE;
       private long sumFamilies = 0;
       
-      private long minQualifier = Long.MIN_VALUE;
-      private long maxQualifier = Long.MAX_VALUE;
+      private long minQualifier = Long.MAX_VALUE;
+      private long maxQualifier = Long.MIN_VALUE;
       private long sumQualifiers = 0;
       
-      private long minVisibility = Long.MIN_VALUE;
-      private long maxVisibility = Long.MAX_VALUE;
+      private long minVisibility = Long.MAX_VALUE;
+      private long maxVisibility = Long.MIN_VALUE;
       private long sumVisibilities = 0;
       
-      private long minValue = Long.MIN_VALUE;
-      private long maxValue = Long.MAX_VALUE;
+      private long minValue = Long.MAX_VALUE;
+      private long maxValue = Long.MIN_VALUE;
       private long sumValues = 0;
       
       private long total = 0;
@@ -165,28 +165,28 @@ public class EntryLengthSummarizer implements Summarizer {
 
       @Override
       public void summarize(StatisticConsumer sc) {
-        sc.accept(MIN_KEY_STAT, minKey);
-        sc.accept(MAX_KEY_STAT, maxKey);
+        sc.accept(MIN_KEY_STAT, (minKey != Long.MAX_VALUE ? minKey:0));
+        sc.accept(MAX_KEY_STAT, (maxKey != Long.MIN_VALUE ? maxKey:0));
         sc.accept(SUM_KEYS_STAT, sumKeys);
         
-        sc.accept(MIN_ROW_STAT, minRow);
-        sc.accept(MAX_ROW_STAT, maxRow);
-        sc.accept(SUM_KEYS_STAT, sumRows);
+        sc.accept(MIN_ROW_STAT, (minRow != Long.MAX_VALUE ? minRow:0));
+        sc.accept(MAX_ROW_STAT, (maxRow != Long.MIN_VALUE ? maxRow:0));
+        sc.accept(SUM_ROWS_STAT, sumRows);
         
-        sc.accept(MIN_FAMILY_STAT, minFamily);
-        sc.accept(MAX_FAMILY_STAT, minFamily);
+        sc.accept(MIN_FAMILY_STAT, (minFamily != Long.MAX_VALUE ? minFamily:0));
+        sc.accept(MAX_FAMILY_STAT, (maxFamily != Long.MIN_VALUE ? maxFamily:0));
         sc.accept(SUM_FAMILIES_STAT, sumFamilies);
         
-        sc.accept(MIN_QUALIFIER_STAT, minQualifier);
-        sc.accept(MAX_QUALIFIER_STAT, maxQualifier);
+        sc.accept(MIN_QUALIFIER_STAT, (minQualifier != Long.MAX_VALUE ? minQualifier:0));
+        sc.accept(MAX_QUALIFIER_STAT, (maxQualifier != Long.MIN_VALUE ? maxQualifier:0));
         sc.accept(SUM_QUALIFIERS_STAT, sumQualifiers);
         
-        sc.accept(MIN_VISIBILITY_STAT, minVisibility);
-        sc.accept(MAX_VISIBILITY_STAT, maxVisibility);
+        sc.accept(MIN_VISIBILITY_STAT, (minVisibility != Long.MAX_VALUE ? minVisibility:0));
+        sc.accept(MAX_VISIBILITY_STAT, (maxVisibility != Long.MIN_VALUE ? maxVisibility:0));
         sc.accept(SUM_VISIBILITIES_STAT, sumVisibilities);
         
-        sc.accept(MIN_VALUE_STAT, minValue);
-        sc.accept(MAX_VALUE_STAT, maxValue);
+        sc.accept(MIN_VALUE_STAT, (minValue != Long.MAX_VALUE ? minValue:0));
+        sc.accept(MAX_VALUE_STAT, (maxValue != Long.MIN_VALUE ? maxValue:0));
         sc.accept(SUM_VALUES_STAT, sumValues);
         
         sc.accept(TOTAL_STAT, total);
@@ -198,27 +198,27 @@ public class EntryLengthSummarizer implements Summarizer {
   @Override
   public Combiner combiner(SummarizerConfiguration sc) {
     return (stats1, stats2) -> {
-      stats1.merge(MIN_KEY_STAT, stats2.get(MIN_KEY_STAT), Long::min);
+      stats1.merge(MIN_KEY_STAT, stats2.get(MIN_KEY_STAT), Long::max);
       stats1.merge(MAX_KEY_STAT, stats2.get(MAX_KEY_STAT), Long::max);
       stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
       
-      stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::min);
+      stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::max);
       stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
       stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
       
-      stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::min);
+      stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::max);
       stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
       stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
       
-      stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::min);
+      stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::max);
       stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
       stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
       
-      stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::min);
+      stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::max);
       stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
       stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
       
-      stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::min);
+      stats1.merge(MIN_VALUE_STAT, stats2.get(MIN_VALUE_STAT), Long::max);
       stats1.merge(MAX_VALUE_STAT, stats2.get(MAX_VALUE_STAT), Long::max);
       stats1.merge(SUM_VALUES_STAT, stats2.get(SUM_VALUES_STAT), Long::sum);
       

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -31,6 +31,8 @@ import com.google.common.math.IntMath;
  * Summarizer that computes summary information about field lengths.
  * Specifically key length, row length, family length, qualifier length, visibility length, and value length.
  * Incrementally computes minimum, maximum, count, sum, and log2 histogram of the lengths.
+ *
+ * @since 2.0.0
  */
 public class EntryLengthSummarizer implements Summarizer {
 
@@ -80,7 +82,7 @@ public class EntryLengthSummarizer implements Summarizer {
   /* Helper functions for merging that is used by the Combiner. */
   private static void merge(String key, BiFunction<Long,Long,Long> mergeFunc, Map<String, Long> stats1, Map<String,Long> stats2) {
     Long mergeVal = stats2.get(key);
-    
+
     if(mergeVal != null) {
       stats1.merge(key, mergeVal, mergeFunc);
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -78,16 +78,30 @@ public class EntryLengthSummarizer implements Summarizer {
 
   /* Helper function for merging that is used by the Combiner. */
   private static void merge(String prefix, Map<String, Long> stats1, Map<String,Long> stats2 ) {
-    stats1.merge(prefix+".min", stats2.get(prefix+".min"), Long::min);
-    stats1.merge(prefix+".max", stats2.get(prefix+".max"), Long::max);
-    stats1.merge(prefix+".sum", stats2.get(prefix+".sum"), Long::sum);
-    
+    if (stats2.containsKey(prefix+".min") && (stats1.containsKey(prefix+".min") == false)) {
+      stats1.put(prefix+".min", stats2.get(prefix+".min"));
+    } else {
+      stats1.merge(prefix+".min", stats2.get(prefix+".min"), Long::min);
+    }
+
+    if (stats2.containsKey(prefix+".max") && (stats1.containsKey(prefix+".max") == false)) {
+      stats1.put(prefix+".max", stats2.get(prefix+".max"));
+    } else {
+      stats1.merge(prefix+".max", stats2.get(prefix+".max"), Long::max);
+    }
+
+    if (stats2.containsKey(prefix+".sum") && (stats1.containsKey(prefix+".sum") == false)) {
+      stats1.put(prefix+".sum", stats2.get(prefix+".sum"));
+    } else {
+      stats1.merge(prefix+".sum", stats2.get(prefix+".sum"), Long::sum);
+    }
+
     /* i must be less than 32 since counts[] size max is 32. */
     for (int i = 0; i < 32; i++) {
       if (stats1.containsKey(prefix+".logHist."+i) && stats2.containsKey(prefix+".logHist."+i)) {
         stats1.merge(prefix+".logHist."+i, stats2.get(prefix+".logHist."+i), Long::sum);
       }
-      
+
       if (stats2.containsKey(prefix+".logHist."+i) && (stats1.containsKey(prefix+".logHist."+i) == false)) {
         stats1.put(prefix+".logHist."+i, stats2.get(prefix+".logHist."+i));
       }
@@ -97,7 +111,7 @@ public class EntryLengthSummarizer implements Summarizer {
   @Override
   public Collector collector(SummarizerConfiguration sc) {
     return new Collector() {
-      
+
       private LengthStats keyStats = new LengthStats();
       private LengthStats rowStats = new LengthStats();
       private LengthStats familyStats = new LengthStats();

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizer.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
+ * (the "License");you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
@@ -56,7 +56,7 @@ public class EntryLengthSummarizer implements Summarizer {
   public static final String MAX_VALUE_STAT = "maxValue";
   public static final String SUM_VALUES_STAT = "sumValues";
   
-  public static final String TOTAL_STAT = "total"; // Total number of Keys
+  public static final String TOTAL_STAT = "total";// Total number of Keys
   
   @Override
   public Collector collector(SummarizerConfiguration sc) {
@@ -222,7 +222,7 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_KEY_STAT, (maxKey != Long.MIN_VALUE ? maxKey:0));
         sc.accept(SUM_KEYS_STAT, sumKeys);
         
-        for (int i = 0; i < keyCounts.length; i++) {
+        for (int i = 0;i < keyCounts.length;i++) {
           if(keyCounts[i] > 0) {
             sc.accept("key.logHist."+i, keyCounts[i]);
           }
@@ -232,7 +232,7 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_ROW_STAT, (maxRow != Long.MIN_VALUE ? maxRow:0));
         sc.accept(SUM_ROWS_STAT, sumRows);
         
-        for (int i = 0; i < rowCounts.length; i++) {
+        for (int i = 0;i < rowCounts.length;i++) {
           if(rowCounts[i] > 0) {
             sc.accept("row.logHist."+i, rowCounts[i]);
           }
@@ -242,7 +242,7 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_FAMILY_STAT, (maxFamily != Long.MIN_VALUE ? maxFamily:0));
         sc.accept(SUM_FAMILIES_STAT, sumFamilies);
         
-        for (int i = 0; i < familyCounts.length; i++) {
+        for (int i = 0;i < familyCounts.length;i++) {
           if(familyCounts[i] > 0) {
             sc.accept("family.logHist."+i, familyCounts[i]);
           }
@@ -252,7 +252,7 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_QUALIFIER_STAT, (maxQualifier != Long.MIN_VALUE ? maxQualifier:0));
         sc.accept(SUM_QUALIFIERS_STAT, sumQualifiers);
         
-        for (int i = 0; i < qualifierCounts.length; i++) {
+        for (int i = 0;i < qualifierCounts.length;i++) {
           if(qualifierCounts[i] > 0) {
             sc.accept("qualifier.logHist."+i, qualifierCounts[i]);
           }
@@ -262,7 +262,7 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_VISIBILITY_STAT, (maxVisibility != Long.MIN_VALUE ? maxVisibility:0));
         sc.accept(SUM_VISIBILITIES_STAT, sumVisibilities);
         
-        for (int i = 0; i < visibilityCounts.length; i++) {
+        for (int i = 0;i < visibilityCounts.length;i++) {
           if(visibilityCounts[i] > 0) {
             sc.accept("visibility.logHist."+i, visibilityCounts[i]);
           }
@@ -272,7 +272,7 @@ public class EntryLengthSummarizer implements Summarizer {
         sc.accept(MAX_VALUE_STAT, (maxValue != Long.MIN_VALUE ? maxValue:0));
         sc.accept(SUM_VALUES_STAT, sumValues);
         
-        for (int i = 0; i < valueCounts.length; i++) {
+        for (int i = 0;i < valueCounts.length;i++) {
           if(valueCounts[i] > 0) {
             sc.accept("value.logHist."+i, valueCounts[i]);
           }
@@ -289,31 +289,31 @@ public class EntryLengthSummarizer implements Summarizer {
     return (stats1, stats2) -> {
       stats1.merge(MIN_KEY_STAT, stats2.get(MIN_KEY_STAT), Long::max);
       stats1.merge(MAX_KEY_STAT, stats2.get(MAX_KEY_STAT), Long::max);
-      stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);      
+      stats1.merge(SUM_KEYS_STAT, stats2.get(SUM_KEYS_STAT), Long::sum);
       // Log2 Histogram for Keys
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_ROW_STAT, stats2.get(MIN_ROW_STAT), Long::max);
       stats1.merge(MAX_ROW_STAT, stats2.get(MAX_ROW_STAT), Long::max);
-      stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);      
+      stats1.merge(SUM_ROWS_STAT, stats2.get(SUM_ROWS_STAT), Long::sum);
       // Log2 Histogram for Rows
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_FAMILY_STAT, stats2.get(MIN_FAMILY_STAT), Long::max);
       stats1.merge(MAX_FAMILY_STAT, stats2.get(MAX_FAMILY_STAT), Long::max);
-      stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);     
+      stats1.merge(SUM_FAMILIES_STAT, stats2.get(SUM_FAMILIES_STAT), Long::sum);
       // Log2 Histogram for Families
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_QUALIFIER_STAT, stats2.get(MIN_QUALIFIER_STAT), Long::max);
       stats1.merge(MAX_QUALIFIER_STAT, stats2.get(MAX_QUALIFIER_STAT), Long::max);
-      stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);      
+      stats1.merge(SUM_QUALIFIERS_STAT, stats2.get(SUM_QUALIFIERS_STAT), Long::sum);
       // Log2 Histogram for Qualifiers
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       
       stats1.merge(MIN_VISIBILITY_STAT, stats2.get(MIN_VISIBILITY_STAT), Long::max);
       stats1.merge(MAX_VISIBILITY_STAT, stats2.get(MAX_VISIBILITY_STAT), Long::max);
-      stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);     
+      stats1.merge(SUM_VISIBILITIES_STAT, stats2.get(SUM_VISIBILITIES_STAT), Long::sum);
       // Log2 Histogram for Visibilities
       stats2.forEach((k,v) -> stats1.merge(k, v, Long::sum));
       

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.summary.summarizers;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import org.apache.accumulo.core.client.summary.CounterSummary;
+import org.apache.accumulo.core.client.summary.summarizers.EntryLengthSummarizer;
+import org.apache.accumulo.core.client.summary.Summarizer;
+import org.apache.accumulo.core.client.summary.Summarizer.Collector;
+import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
+import org.apache.accumulo.core.client.summary.summarizers.FamilySummarizer;
+import org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EntryLengthSummarizersTest {
+  
+  @Test
+  public void testMinMaxKey() {
+    
+  }
+  
+  @Test
+  public void testKeySum() {
+    
+  }
+  
+  @Test
+  public void testMinMaxRow() {
+    
+  }
+  
+  @Test
+  public void testRowSum() {
+    
+  }
+  
+  @Test
+  public void testMinMaxFamily() {
+    
+  }
+  
+  @Test
+  public void testFamilySum() {
+    
+  }
+  
+  @Test
+  public void testMinMaxQualifier() {
+    
+  }
+  
+  @Test
+  public void testQualifierSum() {
+    
+  }
+  
+  @Test
+  public void testMinMaxVisibility() {
+    
+  }
+  
+  @Test
+  public void testVisbilitySum() {
+    
+  }
+  
+  @Test
+  public void testMinMaxValue() {
+    
+  }
+  
+  @Test
+  public void testValueSum() {
+    
+  }
+  
+  @Test
+  public void testTotal() {
+    
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -933,20 +933,8 @@ public class EntryLengthSummarizersTest {
     HashMap<String, Long> stats2 = new HashMap<>();
     collector2.summarize(stats2::put);
 
-    /*
-    System.out.println("========= Stats 1");
-    stats1.entrySet().forEach(System.out::println);
-    System.out.println("========= Stats 2");
-    stats2.entrySet().forEach(System.out::println);
-    */
-
     Combiner combiner = entrySum.combiner(sc);
     combiner.merge(stats1, stats2);
-
-    /*
-    System.out.println("========= Merged");
-    stats1.entrySet().forEach(System.out::println);
-    */
 
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("key.min", 5L);
@@ -1029,11 +1017,6 @@ public class EntryLengthSummarizersTest {
     Combiner combiner = entrySum.combiner(sc);
     combiner.merge(stats1, stats2);
 
-    /*
-    System.out.println("========= Merged");
-    stats1.entrySet().forEach(System.out::println);
-    */
-
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("key.min", 10L);
     expected.put("key.max", 33L);
@@ -1110,11 +1093,6 @@ public class EntryLengthSummarizersTest {
 
     Combiner combiner = entrySum.combiner(sc);
     combiner.merge(stats1, stats2);
-
-    /*
-    System.out.println("========= Merged");
-    stats1.entrySet().forEach(System.out::println);
-    */
 
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("key.min", 4L);

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -16,16 +16,14 @@
  */
 package org.apache.accumulo.core.client.summary.summarizers;
 
+
 import java.util.Arrays;
 import java.util.HashMap;
 
-import org.apache.accumulo.core.client.summary.CounterSummary;
 import org.apache.accumulo.core.client.summary.summarizers.EntryLengthSummarizer;
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.Summarizer.Collector;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
-import org.apache.accumulo.core.client.summary.summarizers.FamilySummarizer;
-import org.apache.accumulo.core.client.summary.summarizers.VisibilitySummarizer;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.junit.Assert;
@@ -34,67 +32,204 @@ import org.junit.Test;
 public class EntryLengthSummarizersTest {
   
   @Test
-  public void testMinMaxKey() {
+  public void testKeyRowFamily() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
+    Key k1 = new Key("maximum","f1");
+    Key k2 = new Key("min","f2");
+    Key k3 = new Key("row3","f3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 5L);
+    expected.put("maxKey", 9L);
+    expected.put("sumKeys", 20L);
+    
+    expected.put("minRow", 3L);
+    expected.put("maxRow", 7L);
+    expected.put("sumRows", 14L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 2L);
+    expected.put("sumFamilies", 6L);
+    
+    expected.put("minQualifier", 0L);
+    expected.put("maxQualifier", 0L);
+    expected.put("sumQualifiers", 0L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
   }
   
   @Test
-  public void testKeySum() {
+  public void testPrevPlusQualifier() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
+    Key k1 = new Key("maximumnoqualifier","f1", "q");
+    Key k2 = new Key("minkey","fam2", "q2");
+    Key k3 = new Key("row3","f3", "qualifier3");
+    Key k4 = new Key("r4", "family4", "qual4");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    collector.accept(k4, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 12L);
+    expected.put("maxKey", 21L);
+    expected.put("sumKeys", 63L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 18L);
+    expected.put("sumRows", 30L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 7L);
+    expected.put("sumFamilies", 15L);
+    
+    expected.put("minQualifier", 1L);
+    expected.put("maxQualifier", 10L);
+    expected.put("sumQualifiers", 18L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    expected.put("total", 4L);
+    
+    Assert.assertEquals(expected, stats);
   }
   
   @Test
-  public void testMinMaxRow() {
+  public void testPrevPlusVisibility() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
+    Key k1 = new Key("maximumnoqualifier","f1", "q", "vis1");
+    Key k2 = new Key("minkey","fam2", "q2", "visibility2");
+    Key k3 = new Key("row3","f3", "qualifier3", "v3");
+    Key k4 = new Key("r4", "family4", "qual4", "vis4");
+    Key k5 = new Key("fifthrow", "thirdfamily", "q5", "v5");
+    Key k6 = new Key("r6", "sixthfamily", "qual6", "visibi6");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    collector.accept(k4, new Value(""));
+    collector.accept(k5, new Value(""));
+    collector.accept(k6, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 18L);
+    expected.put("maxKey", 25L);
+    expected.put("sumKeys", 132L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 18L);
+    expected.put("sumRows", 40L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 11L);
+    expected.put("sumFamilies", 37L);
+    
+    expected.put("minQualifier", 1L);
+    expected.put("maxQualifier", 10L);
+    expected.put("sumQualifiers", 25L);
+    
+    expected.put("minVisibility", 2L);
+    expected.put("maxVisibility", 11L);
+    expected.put("sumVisibilities", 30L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    expected.put("total", 6L);
+    
+    Assert.assertEquals(expected, stats);
   }
   
   @Test
-  public void testRowSum() {
+  public void testAll() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
-  }
-  
-  @Test
-  public void testMinMaxFamily() {
+    Key k1 = new Key("maximumnoqualifier","f1", "q", "vis1");
+    Key k2 = new Key("minkey","fam2", "q2", "visibility2");
+    Key k3 = new Key("row3","f3", "qualifier3", "v3");
+    Key k4 = new Key("r4", "family4", "qual4", "vis4");
+    Key k5 = new Key("fifthrow", "thirdfamily", "q5", "v5");
+    Key k6 = new Key("r6", "sixthfamily", "qual6", "visibi6");
     
-  }
-  
-  @Test
-  public void testFamilySum() {
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value("v1"));
+    collector.accept(k2, new Value("value2"));
+    collector.accept(k3, new Value("val3"));
+    collector.accept(k4, new Value("fourthvalue"));
+    collector.accept(k5, new Value(""));
+    collector.accept(k6, new Value("value6"));
     
-  }
-  
-  @Test
-  public void testMinMaxQualifier() {
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
     
-  }
-  
-  @Test
-  public void testQualifierSum() {
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 18L);
+    expected.put("maxKey", 25L);
+    expected.put("sumKeys", 132L);
     
-  }
-  
-  @Test
-  public void testMinMaxVisibility() {
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 18L);
+    expected.put("sumRows", 40L);
     
-  }
-  
-  @Test
-  public void testVisbilitySum() {
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 11L);
+    expected.put("sumFamilies", 37L);
     
-  }
-  
-  @Test
-  public void testMinMaxValue() {
+    expected.put("minQualifier", 1L);
+    expected.put("maxQualifier", 10L);
+    expected.put("sumQualifiers", 25L);
     
-  }
-  
-  @Test
-  public void testValueSum() {
+    expected.put("minVisibility", 2L);
+    expected.put("maxVisibility", 11L);
+    expected.put("sumVisibilities", 30L);
     
-  }
-  
-  @Test
-  public void testTotal() {
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 11L);
+    expected.put("sumValues", 29L);
     
+    expected.put("total", 6L);
+    
+    Assert.assertEquals(expected, stats);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -16,12 +16,8 @@
  */
 package org.apache.accumulo.core.client.summary.summarizers;
 
-
-import java.util.Arrays;
 import java.util.HashMap;
-
 import org.apache.accumulo.core.client.summary.summarizers.EntryLengthSummarizer;
-import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.Summarizer.Collector;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.data.Key;

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -26,708 +26,708 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class EntryLengthSummarizersTest {
-  
+
   /* Basic Test: Each test adds to the next, all are simple lengths. */
-  
+
   @Test
   public void testBasicRow() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1");
     Key k2 = new Key("r2");
     Key k3 = new Key("r3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 2L);
     expected.put("maxKey", 2L);
     expected.put("sumKeys", 6L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.1", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 2L);
     expected.put("sumRows", 6L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
-    
+
     expected.put("minFamily", 0L);
     expected.put("maxFamily", 0L);
     expected.put("sumFamilies", 0L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.0", 3L);
-    
+
     expected.put("minQualifier", 0L);
     expected.put("maxQualifier", 0L);
     expected.put("sumQualifiers", 0L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testBasicFamily() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "f1");
     Key k2 = new Key("r2", "f2");
     Key k3 = new Key("r3", "f3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 4L);
     expected.put("maxKey", 4L);
     expected.put("sumKeys", 12L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.2", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 2L);
     expected.put("sumRows", 6L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 2L);
     expected.put("sumFamilies", 6L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
-    
+
     expected.put("minQualifier", 0L);
     expected.put("maxQualifier", 0L);
     expected.put("sumQualifiers", 0L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testBasicQualifier() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "f1", "q1");
     Key k2 = new Key("r2", "f2", "q2");
     Key k3 = new Key("r3", "f3", "q3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 6L);
     expected.put("maxKey", 6L);
     expected.put("sumKeys", 18L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.3", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 2L);
     expected.put("sumRows", 6L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 2L);
     expected.put("sumFamilies", 6L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
-    
+
     expected.put("minQualifier", 2L);
     expected.put("maxQualifier", 2L);
     expected.put("sumQualifiers", 6L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 3L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testBasicVisibility() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "f1", "q1", "v1");
     Key k2 = new Key("r2", "f2", "q2", "v2");
     Key k3 = new Key("r3", "f3", "q3", "v3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 8L);
     expected.put("maxKey", 8L);
     expected.put("sumKeys", 24L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.3", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 2L);
     expected.put("sumRows", 6L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 2L);
     expected.put("sumFamilies", 6L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
-    
+
     expected.put("minQualifier", 2L);
     expected.put("maxQualifier", 2L);
     expected.put("sumQualifiers", 6L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 3L);
-    
+
     expected.put("minVisibility", 2L);
     expected.put("maxVisibility", 2L);
     expected.put("sumVisibilities", 6L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.1", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testBasicValue() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "f1", "q1", "v1");
     Key k2 = new Key("r2", "f2", "q2", "v2");
     Key k3 = new Key("r3", "f3", "q3", "v3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value("v1"));
     collector.accept(k2, new Value("v2"));
     collector.accept(k3, new Value("v3"));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 8L);
     expected.put("maxKey", 8L);
     expected.put("sumKeys", 24L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.3", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 2L);
     expected.put("sumRows", 6L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 2L);
     expected.put("sumFamilies", 6L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
-    
+
     expected.put("minQualifier", 2L);
     expected.put("maxQualifier", 2L);
     expected.put("sumQualifiers", 6L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 3L);
-    
+
     expected.put("minVisibility", 2L);
     expected.put("maxVisibility", 2L);
     expected.put("sumVisibilities", 6L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.1", 3L);
-    
+
     expected.put("minValue", 2L);
     expected.put("maxValue", 2L);
     expected.put("sumValues", 6L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.1", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   /* Complex Test: Each test adds to the next, all are mixed lengths. */
-  
+
   @Test
   public void testComplexRow() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1");
     Key k2 = new Key("row2");
     Key k3 = new Key("columnRow3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 2L);
     expected.put("maxKey", 10L);
     expected.put("sumKeys", 16L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.1", 1L);
     expected.put("key.logHist.2", 1L);
     expected.put("key.logHist.3", 1L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 10L);
     expected.put("sumRows", 16L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
-    
+
     expected.put("minFamily", 0L);
     expected.put("maxFamily", 0L);
     expected.put("sumFamilies", 0L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.0", 3L);
-    
+
     expected.put("minQualifier", 0L);
     expected.put("maxQualifier", 0L);
     expected.put("sumQualifiers", 0L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testComplexFamily() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "family1");
     Key k2 = new Key("row2", "columnFamily2");
     Key k3 = new Key("columnRow3", "f3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 9L);
     expected.put("maxKey", 17L);
     expected.put("sumKeys", 38L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.3", 1L);
     expected.put("key.logHist.4", 2L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 10L);
     expected.put("sumRows", 16L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 13L);
     expected.put("sumFamilies", 22L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
-    
+
     expected.put("minQualifier", 0L);
     expected.put("maxQualifier", 0L);
     expected.put("sumQualifiers", 0L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testComplexQualifier() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "family1", "columnQualifier1");
     Key k2 = new Key("row2", "columnFamily2", "q2");
     Key k3 = new Key("columnRow3", "f3", "qualifier3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 19L);
     expected.put("maxKey", 25L);
     expected.put("sumKeys", 66L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.4", 2L);
     expected.put("key.logHist.5", 1L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 10L);
     expected.put("sumRows", 16L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 13L);
     expected.put("sumFamilies", 22L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
-    
+
     expected.put("minQualifier", 2L);
     expected.put("maxQualifier", 16L);
     expected.put("sumQualifiers", 28L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 1L);
     expected.put("qualifier.logHist.3", 1L);
     expected.put("qualifier.logHist.4", 1L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testComplexVisibility() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "family1", "columnQualifier1", "v1");
     Key k2 = new Key("row2", "columnFamily2", "q2", "visibility2");
     Key k3 = new Key("columnRow3", "f3", "qualifier3", "columnVisibility3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 27L);
     expected.put("maxKey", 39L);
     expected.put("sumKeys", 96L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.5", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 10L);
     expected.put("sumRows", 16L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 13L);
     expected.put("sumFamilies", 22L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
-    
+
     expected.put("minQualifier", 2L);
     expected.put("maxQualifier", 16L);
     expected.put("sumQualifiers", 28L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 1L);
     expected.put("qualifier.logHist.3", 1L);
     expected.put("qualifier.logHist.4", 1L);
-    
+
     expected.put("minVisibility", 2L);
     expected.put("maxVisibility", 17L);
     expected.put("sumVisibilities", 30L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.1", 1L);
     expected.put("visibility.logHist.3", 1L);
     expected.put("visibility.logHist.4", 1L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testComplexValue() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("r1", "family1", "columnQualifier1", "v1");
     Key k2 = new Key("row2", "columnFamily2", "q2", "visibility2");
     Key k3 = new Key("columnRow3", "f3", "qualifier3", "columnVisibility3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value("v1"));
     collector.accept(k2, new Value("value2"));
     collector.accept(k3, new Value("keyValue3"));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 27L);
     expected.put("maxKey", 39L);
     expected.put("sumKeys", 96L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.5", 3L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 10L);
     expected.put("sumRows", 16L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 13L);
     expected.put("sumFamilies", 22L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
-    
+
     expected.put("minQualifier", 2L);
     expected.put("maxQualifier", 16L);
     expected.put("sumQualifiers", 28L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 1L);
     expected.put("qualifier.logHist.3", 1L);
     expected.put("qualifier.logHist.4", 1L);
-    
+
     expected.put("minVisibility", 2L);
     expected.put("maxVisibility", 17L);
     expected.put("sumVisibilities", 30L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.1", 1L);
     expected.put("visibility.logHist.3", 1L);
     expected.put("visibility.logHist.4", 1L);
-    
+
     expected.put("minValue", 2L);
     expected.put("maxValue", 9L);
     expected.put("sumValues", 17L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.1", 1L);
     expected.put("value.logHist.3", 2L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   /* Miscellaneous Test */
-  
+
   @Test
   public void testAll() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("maximumnoqualifier","f1", "q", "vis1");
     Key k2 = new Key("minkey","fam2", "q2", "visibility2");
     Key k3 = new Key("row3","f3", "qualifier3", "v3");
     Key k4 = new Key("r4", "family4", "qual4", "vis4");
     Key k5 = new Key("fifthrow", "thirdfamily", "q5", "v5");
     Key k6 = new Key("r6", "sixthfamily", "qual6", "visibi6");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value("v1"));
     collector.accept(k2, new Value("value2"));
@@ -735,135 +735,135 @@ public class EntryLengthSummarizersTest {
     collector.accept(k4, new Value("fourthvalue"));
     collector.accept(k5, new Value(""));
     collector.accept(k6, new Value("value6"));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 18L);
     expected.put("maxKey", 25L);
     expected.put("sumKeys", 132L);
-    
+
     // Log2 Histogram
     expected.put("key.logHist.4", 2L);
     expected.put("key.logHist.5", 4L);
-    
+
     expected.put("minRow", 2L);
     expected.put("maxRow", 18L);
     expected.put("sumRows", 40L);
-    
+
     // Log2 Histogram
     expected.put("row.logHist.1", 2L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 2L);
     expected.put("row.logHist.4", 1L);
-    
+
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 11L);
     expected.put("sumFamilies", 37L);
-    
+
     // Log2 Histogram
     expected.put("family.logHist.1", 2L);
     expected.put("family.logHist.2", 1L);
     expected.put("family.logHist.3", 3L);
-    
+
     expected.put("minQualifier", 1L);
     expected.put("maxQualifier", 10L);
     expected.put("sumQualifiers", 25L);
-    
+
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 1L);
     expected.put("qualifier.logHist.1", 2L);
     expected.put("qualifier.logHist.2", 2L);
     expected.put("qualifier.logHist.3", 1L);
-    
+
     expected.put("minVisibility", 2L);
     expected.put("maxVisibility", 11L);
     expected.put("sumVisibilities", 30L);
-    
+
     // Log2 Histogram
     expected.put("visibility.logHist.1", 2L);
     expected.put("visibility.logHist.2", 2L);
     expected.put("visibility.logHist.3", 2L);
-    
+
     expected.put("minValue", 0L);
     expected.put("maxValue", 11L);
     expected.put("sumValues", 29L);
-    
+
     // Log2 Histogram
     expected.put("value.logHist.0", 1L);
     expected.put("value.logHist.1", 1L);
     expected.put("value.logHist.2", 1L);
     expected.put("value.logHist.3", 3L);
-    
+
     expected.put("total", 6L);
-    
+
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testLog2Histogram() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
-    
+
     Key k1 = new Key("row1");
     Key k2 = new Key("row2");
     Key k3 = new Key("row3");
-    
+
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value("01"));
     collector.accept(k2, new Value("012345678"));
     collector.accept(k3, new Value("012345679"));
-    
+
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("minKey", 4L);
     expected.put("maxKey", 4L);
     expected.put("sumKeys", 12L);
-    
+
     // Log2 Histogram for Key
     expected.put("key.logHist.2", 3L);
-    
+
     expected.put("minRow", 4L);
     expected.put("maxRow", 4L);
     expected.put("sumRows", 12L);
-    
+
     // Log2 Histogram for Row
     expected.put("row.logHist.2", 3L);
-    
+
     expected.put("minFamily", 0L);
     expected.put("maxFamily", 0L);
     expected.put("sumFamilies", 0L);
-    
+
     // Log2 Histogram for Family
     expected.put("family.logHist.0", 3L);
-    
+
     expected.put("minQualifier", 0L);
     expected.put("maxQualifier", 0L);
     expected.put("sumQualifiers", 0L);
-    
+
     // Log2 Histogram for Qualifier
     expected.put("qualifier.logHist.0", 3L);
-    
+
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
-    
+
     // Log2 Histogram for Visibility
     expected.put("visibility.logHist.0", 3L);
-    
+
     expected.put("minValue", 2L);
     expected.put("maxValue", 9L);
     expected.put("sumValues", 20L);
-    
+
     // Log2 Histogram for Value
     expected.put("value.logHist.1", 1L);
     expected.put("value.logHist.3", 2L);
-    
+
     expected.put("total", 3L);
-    
+
     Assert.assertEquals(expected, stats);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -71,7 +71,7 @@ public class EntryLengthSummarizersTest {
 
     Assert.assertEquals(expected, stats);
   }
-  
+
   @Test
   public void testBasicRow() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
@@ -909,9 +909,9 @@ public class EntryLengthSummarizersTest {
 
     Assert.assertEquals(expected, stats);
   }
-  
+
   /* COMBINER TEST */
-  
+
   @Test
   public void testCombine() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
@@ -947,7 +947,7 @@ public class EntryLengthSummarizersTest {
     System.out.println("========= Merged");
     stats1.entrySet().forEach(System.out::println);
     */
-    
+
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("key.min", 5L);
     expected.put("key.max", 14L);
@@ -1003,6 +1003,166 @@ public class EntryLengthSummarizersTest {
     expected.put("value.logHist.3", 1L);
 
     expected.put("total", 6L);
+
+    Assert.assertEquals(expected, stats1);
+  }
+
+  @Test
+  public void testCombine2() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+
+    Collector collector1 = entrySum.collector(sc);
+    collector1.accept(new Key("12345678901234567890","f12345","q123456"), new Value("value1234567890"));
+
+    HashMap<String, Long> stats1 = new HashMap<>();
+    collector1.summarize(stats1::put);
+
+    Collector collector2 = entrySum.collector(sc);
+    collector2.accept(new Key("5432","f11","q12"), new Value("2"));
+    collector2.accept(new Key("12","f11","q1234"), new Value("12"));
+    collector2.accept(new Key("12","f11","q11234567"), new Value("4444"));
+
+    HashMap<String, Long> stats2 = new HashMap<>();
+    collector2.summarize(stats2::put);
+
+    Combiner combiner = entrySum.combiner(sc);
+    combiner.merge(stats1, stats2);
+
+    /*
+    System.out.println("========= Merged");
+    stats1.entrySet().forEach(System.out::println);
+    */
+
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("key.min", 10L);
+    expected.put("key.max", 33L);
+    expected.put("key.sum", 67L);
+
+    // Log2 Histogram for Key
+    expected.put("key.logHist.3", 2L);
+    expected.put("key.logHist.4", 1L);
+    expected.put("key.logHist.5", 1L);
+
+    expected.put("row.min", 2L);
+    expected.put("row.max", 20L);
+    expected.put("row.sum", 28L);
+
+    // Log2 Histogram for Row
+    expected.put("row.logHist.1", 2L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.4", 1L);
+
+    expected.put("family.min", 3L);
+    expected.put("family.max", 6L);
+    expected.put("family.sum", 15L);
+
+    // Log2 Histogram for Family
+    expected.put("family.logHist.2", 3L);
+    expected.put("family.logHist.3", 1L);
+
+    expected.put("qualifier.min", 3L);
+    expected.put("qualifier.max", 9L);
+    expected.put("qualifier.sum", 24L);
+
+    // Log2 Histogram for Qualifier
+    expected.put("qualifier.logHist.2", 2L);
+    expected.put("qualifier.logHist.3", 2L);
+
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
+
+    // Log2 Histogram for Visibility
+    expected.put("visibility.logHist.0", 4L);
+
+    expected.put("value.min", 1L);
+    expected.put("value.max", 15L);
+    expected.put("value.sum", 22L);
+
+    // Log2 Histogram for Value
+    expected.put("value.logHist.0", 1L);
+    expected.put("value.logHist.1", 1L);
+    expected.put("value.logHist.2", 1L);
+    expected.put("value.logHist.4", 1L);
+
+    expected.put("total", 4L);
+
+    Assert.assertEquals(expected, stats1);
+  }
+
+  @Test
+  public void testCombine3() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+
+    Collector collector1 = entrySum.collector(sc);
+    collector1.accept(new Key("r1","f1"), new Value("v1"));
+
+    HashMap<String, Long> stats1 = new HashMap<>();
+    collector1.summarize(stats1::put);
+
+    Collector collector2 = entrySum.collector(sc);
+    collector2.accept(new Key("row1","family1","q1"), new Value(""));
+
+    HashMap<String, Long> stats2 = new HashMap<>();
+    collector2.summarize(stats2::put);
+
+    Combiner combiner = entrySum.combiner(sc);
+    combiner.merge(stats1, stats2);
+
+    System.out.println("========= Merged");
+    stats1.entrySet().forEach(System.out::println);
+
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("key.min", 4L);
+    expected.put("key.max", 13L);
+    expected.put("key.sum", 17L);
+
+    // Log2 Histogram for Key
+    expected.put("key.logHist.2", 1L);
+    expected.put("key.logHist.4", 1L);
+
+    expected.put("row.min", 2L);
+    expected.put("row.max", 4L);
+    expected.put("row.sum", 6L);
+
+    // Log2 Histogram for Row
+    expected.put("row.logHist.1", 1L);
+    expected.put("row.logHist.2", 1L);
+
+    expected.put("family.min", 2L);
+    expected.put("family.max", 7L);
+    expected.put("family.sum", 9L);
+
+    // Log2 Histogram for Family
+    expected.put("family.logHist.1", 1L);
+    expected.put("family.logHist.3", 1L);
+
+    expected.put("qualifier.min", 0L);
+    expected.put("qualifier.max", 2L);
+    expected.put("qualifier.sum", 2L);
+
+    // Log2 Histogram for Qualifier
+    expected.put("qualifier.logHist.0", 1L);
+    expected.put("qualifier.logHist.1", 1L);
+
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
+
+    // Log2 Histogram for Visibility
+    expected.put("visibility.logHist.0", 2L);
+
+    expected.put("value.min", 0L);
+    expected.put("value.max", 2L);
+    expected.put("value.sum", 2L);
+
+    // Log2 Histogram for Value
+    expected.put("value.logHist.0", 1L);
+    expected.put("value.logHist.1", 1L);
+
+    expected.put("total", 2L);
 
     Assert.assertEquals(expected, stats1);
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -47,44 +47,44 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 2L);
-    expected.put("maxKey", 2L);
-    expected.put("sumKeys", 6L);
+    expected.put("key.min", 2L);
+    expected.put("key.max", 2L);
+    expected.put("key.sum", 6L);
 
     // Log2 Histogram
     expected.put("key.logHist.1", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 2L);
-    expected.put("sumRows", 6L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 2L);
+    expected.put("row.sum", 6L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
 
-    expected.put("minFamily", 0L);
-    expected.put("maxFamily", 0L);
-    expected.put("sumFamilies", 0L);
+    expected.put("family.min", 0L);
+    expected.put("family.max", 0L);
+    expected.put("family.sum", 0L);
 
     // Log2 Histogram
     expected.put("family.logHist.0", 3L);
 
-    expected.put("minQualifier", 0L);
-    expected.put("maxQualifier", 0L);
-    expected.put("sumQualifiers", 0L);
+    expected.put("qualifier.min", 0L);
+    expected.put("qualifier.max", 0L);
+    expected.put("qualifier.sum", 0L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -112,44 +112,44 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 4L);
-    expected.put("maxKey", 4L);
-    expected.put("sumKeys", 12L);
+    expected.put("key.min", 4L);
+    expected.put("key.max", 4L);
+    expected.put("key.sum", 12L);
 
     // Log2 Histogram
     expected.put("key.logHist.2", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 2L);
-    expected.put("sumRows", 6L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 2L);
+    expected.put("row.sum", 6L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 2L);
-    expected.put("sumFamilies", 6L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 2L);
+    expected.put("family.sum", 6L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
 
-    expected.put("minQualifier", 0L);
-    expected.put("maxQualifier", 0L);
-    expected.put("sumQualifiers", 0L);
+    expected.put("qualifier.min", 0L);
+    expected.put("qualifier.max", 0L);
+    expected.put("qualifier.sum", 0L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -177,44 +177,44 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 6L);
-    expected.put("maxKey", 6L);
-    expected.put("sumKeys", 18L);
+    expected.put("key.min", 6L);
+    expected.put("key.max", 6L);
+    expected.put("key.sum", 18L);
 
     // Log2 Histogram
     expected.put("key.logHist.3", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 2L);
-    expected.put("sumRows", 6L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 2L);
+    expected.put("row.sum", 6L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 2L);
-    expected.put("sumFamilies", 6L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 2L);
+    expected.put("family.sum", 6L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
 
-    expected.put("minQualifier", 2L);
-    expected.put("maxQualifier", 2L);
-    expected.put("sumQualifiers", 6L);
+    expected.put("qualifier.min", 2L);
+    expected.put("qualifier.max", 2L);
+    expected.put("qualifier.sum", 6L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 3L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -242,44 +242,44 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 8L);
-    expected.put("maxKey", 8L);
-    expected.put("sumKeys", 24L);
+    expected.put("key.min", 8L);
+    expected.put("key.max", 8L);
+    expected.put("key.sum", 24L);
 
     // Log2 Histogram
     expected.put("key.logHist.3", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 2L);
-    expected.put("sumRows", 6L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 2L);
+    expected.put("row.sum", 6L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 2L);
-    expected.put("sumFamilies", 6L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 2L);
+    expected.put("family.sum", 6L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
 
-    expected.put("minQualifier", 2L);
-    expected.put("maxQualifier", 2L);
-    expected.put("sumQualifiers", 6L);
+    expected.put("qualifier.min", 2L);
+    expected.put("qualifier.max", 2L);
+    expected.put("qualifier.sum", 6L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 3L);
 
-    expected.put("minVisibility", 2L);
-    expected.put("maxVisibility", 2L);
-    expected.put("sumVisibilities", 6L);
+    expected.put("visibility.min", 2L);
+    expected.put("visibility.max", 2L);
+    expected.put("visibility.sum", 6L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.1", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -307,44 +307,44 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 8L);
-    expected.put("maxKey", 8L);
-    expected.put("sumKeys", 24L);
+    expected.put("key.min", 8L);
+    expected.put("key.max", 8L);
+    expected.put("key.sum", 24L);
 
     // Log2 Histogram
     expected.put("key.logHist.3", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 2L);
-    expected.put("sumRows", 6L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 2L);
+    expected.put("row.sum", 6L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 3L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 2L);
-    expected.put("sumFamilies", 6L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 2L);
+    expected.put("family.sum", 6L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 3L);
 
-    expected.put("minQualifier", 2L);
-    expected.put("maxQualifier", 2L);
-    expected.put("sumQualifiers", 6L);
+    expected.put("qualifier.min", 2L);
+    expected.put("qualifier.max", 2L);
+    expected.put("qualifier.sum", 6L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 3L);
 
-    expected.put("minVisibility", 2L);
-    expected.put("maxVisibility", 2L);
-    expected.put("sumVisibilities", 6L);
+    expected.put("visibility.min", 2L);
+    expected.put("visibility.max", 2L);
+    expected.put("visibility.sum", 6L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.1", 3L);
 
-    expected.put("minValue", 2L);
-    expected.put("maxValue", 2L);
-    expected.put("sumValues", 6L);
+    expected.put("value.min", 2L);
+    expected.put("value.max", 2L);
+    expected.put("value.sum", 6L);
 
     // Log2 Histogram
     expected.put("value.logHist.1", 3L);
@@ -374,48 +374,48 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 2L);
-    expected.put("maxKey", 10L);
-    expected.put("sumKeys", 16L);
+    expected.put("key.min", 2L);
+    expected.put("key.max", 10L);
+    expected.put("key.sum", 16L);
 
     // Log2 Histogram
     expected.put("key.logHist.1", 1L);
     expected.put("key.logHist.2", 1L);
     expected.put("key.logHist.3", 1L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 10L);
-    expected.put("sumRows", 16L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 10L);
+    expected.put("row.sum", 16L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
 
-    expected.put("minFamily", 0L);
-    expected.put("maxFamily", 0L);
-    expected.put("sumFamilies", 0L);
+    expected.put("family.min", 0L);
+    expected.put("family.max", 0L);
+    expected.put("family.sum", 0L);
 
     // Log2 Histogram
     expected.put("family.logHist.0", 3L);
 
-    expected.put("minQualifier", 0L);
-    expected.put("maxQualifier", 0L);
-    expected.put("sumQualifiers", 0L);
+    expected.put("qualifier.min", 0L);
+    expected.put("qualifier.max", 0L);
+    expected.put("qualifier.sum", 0L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -443,49 +443,49 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 9L);
-    expected.put("maxKey", 17L);
-    expected.put("sumKeys", 38L);
+    expected.put("key.min", 9L);
+    expected.put("key.max", 17L);
+    expected.put("key.sum", 38L);
 
     // Log2 Histogram
     expected.put("key.logHist.3", 1L);
     expected.put("key.logHist.4", 2L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 10L);
-    expected.put("sumRows", 16L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 10L);
+    expected.put("row.sum", 16L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 13L);
-    expected.put("sumFamilies", 22L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 13L);
+    expected.put("family.sum", 22L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
 
-    expected.put("minQualifier", 0L);
-    expected.put("maxQualifier", 0L);
-    expected.put("sumQualifiers", 0L);
+    expected.put("qualifier.min", 0L);
+    expected.put("qualifier.max", 0L);
+    expected.put("qualifier.sum", 0L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 3L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -513,51 +513,51 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 19L);
-    expected.put("maxKey", 25L);
-    expected.put("sumKeys", 66L);
+    expected.put("key.min", 19L);
+    expected.put("key.max", 25L);
+    expected.put("key.sum", 66L);
 
     // Log2 Histogram
     expected.put("key.logHist.4", 2L);
     expected.put("key.logHist.5", 1L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 10L);
-    expected.put("sumRows", 16L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 10L);
+    expected.put("row.sum", 16L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 13L);
-    expected.put("sumFamilies", 22L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 13L);
+    expected.put("family.sum", 22L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
 
-    expected.put("minQualifier", 2L);
-    expected.put("maxQualifier", 16L);
-    expected.put("sumQualifiers", 28L);
+    expected.put("qualifier.min", 2L);
+    expected.put("qualifier.max", 16L);
+    expected.put("qualifier.sum", 28L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 1L);
     expected.put("qualifier.logHist.3", 1L);
     expected.put("qualifier.logHist.4", 1L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -585,52 +585,52 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 27L);
-    expected.put("maxKey", 39L);
-    expected.put("sumKeys", 96L);
+    expected.put("key.min", 27L);
+    expected.put("key.max", 39L);
+    expected.put("key.sum", 96L);
 
     // Log2 Histogram
     expected.put("key.logHist.5", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 10L);
-    expected.put("sumRows", 16L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 10L);
+    expected.put("row.sum", 16L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 13L);
-    expected.put("sumFamilies", 22L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 13L);
+    expected.put("family.sum", 22L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
 
-    expected.put("minQualifier", 2L);
-    expected.put("maxQualifier", 16L);
-    expected.put("sumQualifiers", 28L);
+    expected.put("qualifier.min", 2L);
+    expected.put("qualifier.max", 16L);
+    expected.put("qualifier.sum", 28L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 1L);
     expected.put("qualifier.logHist.3", 1L);
     expected.put("qualifier.logHist.4", 1L);
 
-    expected.put("minVisibility", 2L);
-    expected.put("maxVisibility", 17L);
-    expected.put("sumVisibilities", 30L);
+    expected.put("visibility.min", 2L);
+    expected.put("visibility.max", 17L);
+    expected.put("visibility.sum", 30L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.1", 1L);
     expected.put("visibility.logHist.3", 1L);
     expected.put("visibility.logHist.4", 1L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 0L);
-    expected.put("sumValues", 0L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 0L);
+    expected.put("value.sum", 0L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 3L);
@@ -658,52 +658,52 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 27L);
-    expected.put("maxKey", 39L);
-    expected.put("sumKeys", 96L);
+    expected.put("key.min", 27L);
+    expected.put("key.max", 39L);
+    expected.put("key.sum", 96L);
 
     // Log2 Histogram
     expected.put("key.logHist.5", 3L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 10L);
-    expected.put("sumRows", 16L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 10L);
+    expected.put("row.sum", 16L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 1L);
     expected.put("row.logHist.2", 1L);
     expected.put("row.logHist.3", 1L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 13L);
-    expected.put("sumFamilies", 22L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 13L);
+    expected.put("family.sum", 22L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 1L);
     expected.put("family.logHist.3", 1L);
     expected.put("family.logHist.4", 1L);
 
-    expected.put("minQualifier", 2L);
-    expected.put("maxQualifier", 16L);
-    expected.put("sumQualifiers", 28L);
+    expected.put("qualifier.min", 2L);
+    expected.put("qualifier.max", 16L);
+    expected.put("qualifier.sum", 28L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.1", 1L);
     expected.put("qualifier.logHist.3", 1L);
     expected.put("qualifier.logHist.4", 1L);
 
-    expected.put("minVisibility", 2L);
-    expected.put("maxVisibility", 17L);
-    expected.put("sumVisibilities", 30L);
+    expected.put("visibility.min", 2L);
+    expected.put("visibility.max", 17L);
+    expected.put("visibility.sum", 30L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.1", 1L);
     expected.put("visibility.logHist.3", 1L);
     expected.put("visibility.logHist.4", 1L);
 
-    expected.put("minValue", 2L);
-    expected.put("maxValue", 9L);
-    expected.put("sumValues", 17L);
+    expected.put("value.min", 2L);
+    expected.put("value.max", 9L);
+    expected.put("value.sum", 17L);
 
     // Log2 Histogram
     expected.put("value.logHist.1", 1L);
@@ -722,7 +722,7 @@ public class EntryLengthSummarizersTest {
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
 
     Key k1 = new Key("maximumnoqualifier","f1", "q", "vis1");
-    Key k2 = new Key("minkey","fam2", "q2", "visibility2");
+    Key k2 = new Key("minKey","fam2", "q2", "visibility2");
     Key k3 = new Key("row3","f3", "qualifier3", "v3");
     Key k4 = new Key("r4", "family4", "qual4", "vis4");
     Key k5 = new Key("fifthrow", "thirdfamily", "q5", "v5");
@@ -740,17 +740,17 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 18L);
-    expected.put("maxKey", 25L);
-    expected.put("sumKeys", 132L);
+    expected.put("key.min", 18L);
+    expected.put("key.max", 25L);
+    expected.put("key.sum", 132L);
 
     // Log2 Histogram
     expected.put("key.logHist.4", 2L);
     expected.put("key.logHist.5", 4L);
 
-    expected.put("minRow", 2L);
-    expected.put("maxRow", 18L);
-    expected.put("sumRows", 40L);
+    expected.put("row.min", 2L);
+    expected.put("row.max", 18L);
+    expected.put("row.sum", 40L);
 
     // Log2 Histogram
     expected.put("row.logHist.1", 2L);
@@ -758,18 +758,18 @@ public class EntryLengthSummarizersTest {
     expected.put("row.logHist.3", 2L);
     expected.put("row.logHist.4", 1L);
 
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 11L);
-    expected.put("sumFamilies", 37L);
+    expected.put("family.min", 2L);
+    expected.put("family.max", 11L);
+    expected.put("family.sum", 37L);
 
     // Log2 Histogram
     expected.put("family.logHist.1", 2L);
     expected.put("family.logHist.2", 1L);
     expected.put("family.logHist.3", 3L);
 
-    expected.put("minQualifier", 1L);
-    expected.put("maxQualifier", 10L);
-    expected.put("sumQualifiers", 25L);
+    expected.put("qualifier.min", 1L);
+    expected.put("qualifier.max", 10L);
+    expected.put("qualifier.sum", 25L);
 
     // Log2 Histogram
     expected.put("qualifier.logHist.0", 1L);
@@ -777,18 +777,18 @@ public class EntryLengthSummarizersTest {
     expected.put("qualifier.logHist.2", 2L);
     expected.put("qualifier.logHist.3", 1L);
 
-    expected.put("minVisibility", 2L);
-    expected.put("maxVisibility", 11L);
-    expected.put("sumVisibilities", 30L);
+    expected.put("visibility.min", 2L);
+    expected.put("visibility.max", 11L);
+    expected.put("visibility.sum", 30L);
 
     // Log2 Histogram
     expected.put("visibility.logHist.1", 2L);
     expected.put("visibility.logHist.2", 2L);
     expected.put("visibility.logHist.3", 2L);
 
-    expected.put("minValue", 0L);
-    expected.put("maxValue", 11L);
-    expected.put("sumValues", 29L);
+    expected.put("value.min", 0L);
+    expected.put("value.max", 11L);
+    expected.put("value.sum", 29L);
 
     // Log2 Histogram
     expected.put("value.logHist.0", 1L);
@@ -819,44 +819,44 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
 
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 4L);
-    expected.put("maxKey", 4L);
-    expected.put("sumKeys", 12L);
+    expected.put("key.min", 4L);
+    expected.put("key.max", 4L);
+    expected.put("key.sum", 12L);
 
     // Log2 Histogram for Key
     expected.put("key.logHist.2", 3L);
 
-    expected.put("minRow", 4L);
-    expected.put("maxRow", 4L);
-    expected.put("sumRows", 12L);
+    expected.put("row.min", 4L);
+    expected.put("row.max", 4L);
+    expected.put("row.sum", 12L);
 
     // Log2 Histogram for Row
     expected.put("row.logHist.2", 3L);
 
-    expected.put("minFamily", 0L);
-    expected.put("maxFamily", 0L);
-    expected.put("sumFamilies", 0L);
+    expected.put("family.min", 0L);
+    expected.put("family.max", 0L);
+    expected.put("family.sum", 0L);
 
     // Log2 Histogram for Family
     expected.put("family.logHist.0", 3L);
 
-    expected.put("minQualifier", 0L);
-    expected.put("maxQualifier", 0L);
-    expected.put("sumQualifiers", 0L);
+    expected.put("qualifier.min", 0L);
+    expected.put("qualifier.max", 0L);
+    expected.put("qualifier.sum", 0L);
 
     // Log2 Histogram for Qualifier
     expected.put("qualifier.logHist.0", 3L);
 
-    expected.put("minVisibility", 0L);
-    expected.put("maxVisibility", 0L);
-    expected.put("sumVisibilities", 0L);
+    expected.put("visibility.min", 0L);
+    expected.put("visibility.max", 0L);
+    expected.put("visibility.sum", 0L);
 
     // Log2 Histogram for Visibility
     expected.put("visibility.logHist.0", 3L);
 
-    expected.put("minValue", 2L);
-    expected.put("maxValue", 9L);
-    expected.put("sumValues", 20L);
+    expected.put("value.min", 2L);
+    expected.put("value.max", 9L);
+    expected.put("value.sum", 20L);
 
     // Log2 Histogram for Value
     expected.put("value.logHist.1", 1L);

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -31,14 +31,16 @@ import org.junit.Test;
 
 public class EntryLengthSummarizersTest {
   
+  /* Basic Test: Each test adds to the next, all are simple lengths. */
+  
   @Test
-  public void testKeyRowFamily() {
+  public void testBasicRow() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
-    Key k1 = new Key("maximum","f1");
-    Key k2 = new Key("min","f2");
-    Key k3 = new Key("row3","f3");
+    Key k1 = new Key("r1");
+    Key k2 = new Key("r2");
+    Key k3 = new Key("r3");
     
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
@@ -49,29 +51,47 @@ public class EntryLengthSummarizersTest {
     collector.summarize(stats::put);
     
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 5L);
-    expected.put("maxKey", 9L);
-    expected.put("sumKeys", 20L);
+    expected.put("minKey", 2L);
+    expected.put("maxKey", 2L);
+    expected.put("sumKeys", 6L);
     
-    expected.put("minRow", 3L);
-    expected.put("maxRow", 7L);
-    expected.put("sumRows", 14L);
+    // Log2 Histogram
+    expected.put("key.logHist.1", 3L);
     
-    expected.put("minFamily", 2L);
-    expected.put("maxFamily", 2L);
-    expected.put("sumFamilies", 6L);
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 2L);
+    expected.put("sumRows", 6L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 3L);
+    
+    expected.put("minFamily", 0L);
+    expected.put("maxFamily", 0L);
+    expected.put("sumFamilies", 0L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.0", 3L);
     
     expected.put("minQualifier", 0L);
     expected.put("maxQualifier", 0L);
     expected.put("sumQualifiers", 0L);
     
+    // Log2 Histogram
+    expected.put("qualifier.logHist.0", 3L);
+    
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
     
+    // Log2 Histogram
+    expected.put("visibility.logHist.0", 3L);
+    
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
     
     expected.put("total", 3L);
     
@@ -79,106 +99,626 @@ public class EntryLengthSummarizersTest {
   }
   
   @Test
-  public void testPrevPlusQualifier() {
+  public void testBasicFamily() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
-    Key k1 = new Key("maximumnoqualifier","f1", "q");
-    Key k2 = new Key("minkey","fam2", "q2");
-    Key k3 = new Key("row3","f3", "qualifier3");
-    Key k4 = new Key("r4", "family4", "qual4");
+    Key k1 = new Key("r1", "f1");
+    Key k2 = new Key("r2", "f2");
+    Key k3 = new Key("r3", "f3");
     
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    collector.accept(k4, new Value(""));
     
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
     
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 12L);
-    expected.put("maxKey", 21L);
-    expected.put("sumKeys", 63L);
+    expected.put("minKey", 4L);
+    expected.put("maxKey", 4L);
+    expected.put("sumKeys", 12L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.2", 3L);
     
     expected.put("minRow", 2L);
-    expected.put("maxRow", 18L);
-    expected.put("sumRows", 30L);
+    expected.put("maxRow", 2L);
+    expected.put("sumRows", 6L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 3L);
     
     expected.put("minFamily", 2L);
-    expected.put("maxFamily", 7L);
-    expected.put("sumFamilies", 15L);
+    expected.put("maxFamily", 2L);
+    expected.put("sumFamilies", 6L);
     
-    expected.put("minQualifier", 1L);
-    expected.put("maxQualifier", 10L);
-    expected.put("sumQualifiers", 18L);
+    // Log2 Histogram
+    expected.put("family.logHist.1", 3L);
+    
+    expected.put("minQualifier", 0L);
+    expected.put("maxQualifier", 0L);
+    expected.put("sumQualifiers", 0L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.0", 3L);
     
     expected.put("minVisibility", 0L);
     expected.put("maxVisibility", 0L);
     expected.put("sumVisibilities", 0L);
     
+    // Log2 Histogram
+    expected.put("visibility.logHist.0", 3L);
+    
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
     
-    expected.put("total", 4L);
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
     
     Assert.assertEquals(expected, stats);
   }
   
   @Test
-  public void testPrevPlusVisibility() {
+  public void testBasicQualifier() {
     SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
     EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
     
-    Key k1 = new Key("maximumnoqualifier","f1", "q", "vis1");
-    Key k2 = new Key("minkey","fam2", "q2", "visibility2");
-    Key k3 = new Key("row3","f3", "qualifier3", "v3");
-    Key k4 = new Key("r4", "family4", "qual4", "vis4");
-    Key k5 = new Key("fifthrow", "thirdfamily", "q5", "v5");
-    Key k6 = new Key("r6", "sixthfamily", "qual6", "visibi6");
+    Key k1 = new Key("r1", "f1", "q1");
+    Key k2 = new Key("r2", "f2", "q2");
+    Key k3 = new Key("r3", "f3", "q3");
     
     Collector collector = entrySum.collector(sc);
     collector.accept(k1, new Value(""));
     collector.accept(k2, new Value(""));
     collector.accept(k3, new Value(""));
-    collector.accept(k4, new Value(""));
-    collector.accept(k5, new Value(""));
-    collector.accept(k6, new Value(""));
     
     HashMap<String,Long> stats = new HashMap<>();
     collector.summarize(stats::put);
     
     HashMap<String,Long> expected = new HashMap<>();
-    expected.put("minKey", 18L);
-    expected.put("maxKey", 25L);
-    expected.put("sumKeys", 132L);
+    expected.put("minKey", 6L);
+    expected.put("maxKey", 6L);
+    expected.put("sumKeys", 18L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.3", 3L);
     
     expected.put("minRow", 2L);
-    expected.put("maxRow", 18L);
-    expected.put("sumRows", 40L);
+    expected.put("maxRow", 2L);
+    expected.put("sumRows", 6L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 3L);
     
     expected.put("minFamily", 2L);
-    expected.put("maxFamily", 11L);
-    expected.put("sumFamilies", 37L);
+    expected.put("maxFamily", 2L);
+    expected.put("sumFamilies", 6L);
     
-    expected.put("minQualifier", 1L);
-    expected.put("maxQualifier", 10L);
-    expected.put("sumQualifiers", 25L);
+    // Log2 Histogram
+    expected.put("family.logHist.1", 3L);
     
-    expected.put("minVisibility", 2L);
-    expected.put("maxVisibility", 11L);
-    expected.put("sumVisibilities", 30L);
+    expected.put("minQualifier", 2L);
+    expected.put("maxQualifier", 2L);
+    expected.put("sumQualifiers", 6L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.1", 3L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.0", 3L);
     
     expected.put("minValue", 0L);
     expected.put("maxValue", 0L);
     expected.put("sumValues", 0L);
     
-    expected.put("total", 6L);
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
     
     Assert.assertEquals(expected, stats);
   }
+  
+  @Test
+  public void testBasicVisibility() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1", "f1", "q1", "v1");
+    Key k2 = new Key("r2", "f2", "q2", "v2");
+    Key k3 = new Key("r3", "f3", "q3", "v3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 8L);
+    expected.put("maxKey", 8L);
+    expected.put("sumKeys", 24L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.3", 3L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 2L);
+    expected.put("sumRows", 6L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 3L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 2L);
+    expected.put("sumFamilies", 6L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.1", 3L);
+    
+    expected.put("minQualifier", 2L);
+    expected.put("maxQualifier", 2L);
+    expected.put("sumQualifiers", 6L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.1", 3L);
+    
+    expected.put("minVisibility", 2L);
+    expected.put("maxVisibility", 2L);
+    expected.put("sumVisibilities", 6L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.1", 3L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  @Test
+  public void testBasicValue() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1", "f1", "q1", "v1");
+    Key k2 = new Key("r2", "f2", "q2", "v2");
+    Key k3 = new Key("r3", "f3", "q3", "v3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value("v1"));
+    collector.accept(k2, new Value("v2"));
+    collector.accept(k3, new Value("v3"));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 8L);
+    expected.put("maxKey", 8L);
+    expected.put("sumKeys", 24L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.3", 3L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 2L);
+    expected.put("sumRows", 6L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 3L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 2L);
+    expected.put("sumFamilies", 6L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.1", 3L);
+    
+    expected.put("minQualifier", 2L);
+    expected.put("maxQualifier", 2L);
+    expected.put("sumQualifiers", 6L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.1", 3L);
+    
+    expected.put("minVisibility", 2L);
+    expected.put("maxVisibility", 2L);
+    expected.put("sumVisibilities", 6L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.1", 3L);
+    
+    expected.put("minValue", 2L);
+    expected.put("maxValue", 2L);
+    expected.put("sumValues", 6L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.1", 3L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  /* Complex Test: Each test adds to the next, all are mixed lengths. */
+  
+  @Test
+  public void testComplexRow() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1");
+    Key k2 = new Key("row2");
+    Key k3 = new Key("columnRow3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 2L);
+    expected.put("maxKey", 10L);
+    expected.put("sumKeys", 16L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.1", 1L);
+    expected.put("key.logHist.2", 1L);
+    expected.put("key.logHist.3", 1L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 10L);
+    expected.put("sumRows", 16L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 1L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.3", 1L);
+    
+    expected.put("minFamily", 0L);
+    expected.put("maxFamily", 0L);
+    expected.put("sumFamilies", 0L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.0", 3L);
+    
+    expected.put("minQualifier", 0L);
+    expected.put("maxQualifier", 0L);
+    expected.put("sumQualifiers", 0L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.0", 3L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.0", 3L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  @Test
+  public void testComplexFamily() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1", "family1");
+    Key k2 = new Key("row2", "columnFamily2");
+    Key k3 = new Key("columnRow3", "f3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 9L);
+    expected.put("maxKey", 17L);
+    expected.put("sumKeys", 38L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.3", 1L);
+    expected.put("key.logHist.4", 2L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 10L);
+    expected.put("sumRows", 16L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 1L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.3", 1L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 13L);
+    expected.put("sumFamilies", 22L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.1", 1L);
+    expected.put("family.logHist.3", 1L);
+    expected.put("family.logHist.4", 1L);
+    
+    expected.put("minQualifier", 0L);
+    expected.put("maxQualifier", 0L);
+    expected.put("sumQualifiers", 0L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.0", 3L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.0", 3L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  @Test
+  public void testComplexQualifier() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1", "family1", "columnQualifier1");
+    Key k2 = new Key("row2", "columnFamily2", "q2");
+    Key k3 = new Key("columnRow3", "f3", "qualifier3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 19L);
+    expected.put("maxKey", 25L);
+    expected.put("sumKeys", 66L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.4", 2L);
+    expected.put("key.logHist.5", 1L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 10L);
+    expected.put("sumRows", 16L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 1L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.3", 1L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 13L);
+    expected.put("sumFamilies", 22L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.1", 1L);
+    expected.put("family.logHist.3", 1L);
+    expected.put("family.logHist.4", 1L);
+    
+    expected.put("minQualifier", 2L);
+    expected.put("maxQualifier", 16L);
+    expected.put("sumQualifiers", 28L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.1", 1L);
+    expected.put("qualifier.logHist.3", 1L);
+    expected.put("qualifier.logHist.4", 1L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.0", 3L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  @Test
+  public void testComplexVisibility() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1", "family1", "columnQualifier1", "v1");
+    Key k2 = new Key("row2", "columnFamily2", "q2", "visibility2");
+    Key k3 = new Key("columnRow3", "f3", "qualifier3", "columnVisibility3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value(""));
+    collector.accept(k2, new Value(""));
+    collector.accept(k3, new Value(""));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 27L);
+    expected.put("maxKey", 39L);
+    expected.put("sumKeys", 96L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.5", 3L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 10L);
+    expected.put("sumRows", 16L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 1L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.3", 1L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 13L);
+    expected.put("sumFamilies", 22L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.1", 1L);
+    expected.put("family.logHist.3", 1L);
+    expected.put("family.logHist.4", 1L);
+    
+    expected.put("minQualifier", 2L);
+    expected.put("maxQualifier", 16L);
+    expected.put("sumQualifiers", 28L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.1", 1L);
+    expected.put("qualifier.logHist.3", 1L);
+    expected.put("qualifier.logHist.4", 1L);
+    
+    expected.put("minVisibility", 2L);
+    expected.put("maxVisibility", 17L);
+    expected.put("sumVisibilities", 30L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.1", 1L);
+    expected.put("visibility.logHist.3", 1L);
+    expected.put("visibility.logHist.4", 1L);
+    
+    expected.put("minValue", 0L);
+    expected.put("maxValue", 0L);
+    expected.put("sumValues", 0L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.0", 3L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  @Test
+  public void testComplexValue() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("r1", "family1", "columnQualifier1", "v1");
+    Key k2 = new Key("row2", "columnFamily2", "q2", "visibility2");
+    Key k3 = new Key("columnRow3", "f3", "qualifier3", "columnVisibility3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value("v1"));
+    collector.accept(k2, new Value("value2"));
+    collector.accept(k3, new Value("keyValue3"));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 27L);
+    expected.put("maxKey", 39L);
+    expected.put("sumKeys", 96L);
+    
+    // Log2 Histogram
+    expected.put("key.logHist.5", 3L);
+    
+    expected.put("minRow", 2L);
+    expected.put("maxRow", 10L);
+    expected.put("sumRows", 16L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 1L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.3", 1L);
+    
+    expected.put("minFamily", 2L);
+    expected.put("maxFamily", 13L);
+    expected.put("sumFamilies", 22L);
+    
+    // Log2 Histogram
+    expected.put("family.logHist.1", 1L);
+    expected.put("family.logHist.3", 1L);
+    expected.put("family.logHist.4", 1L);
+    
+    expected.put("minQualifier", 2L);
+    expected.put("maxQualifier", 16L);
+    expected.put("sumQualifiers", 28L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.1", 1L);
+    expected.put("qualifier.logHist.3", 1L);
+    expected.put("qualifier.logHist.4", 1L);
+    
+    expected.put("minVisibility", 2L);
+    expected.put("maxVisibility", 17L);
+    expected.put("sumVisibilities", 30L);
+    
+    // Log2 Histogram
+    expected.put("visibility.logHist.1", 1L);
+    expected.put("visibility.logHist.3", 1L);
+    expected.put("visibility.logHist.4", 1L);
+    
+    expected.put("minValue", 2L);
+    expected.put("maxValue", 9L);
+    expected.put("sumValues", 17L);
+    
+    // Log2 Histogram
+    expected.put("value.logHist.1", 1L);
+    expected.put("value.logHist.3", 2L);
+    
+    expected.put("total", 3L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  /* Miscellaneous Test */
   
   @Test
   public void testAll() {
@@ -208,27 +748,125 @@ public class EntryLengthSummarizersTest {
     expected.put("maxKey", 25L);
     expected.put("sumKeys", 132L);
     
+    // Log2 Histogram
+    expected.put("key.logHist.4", 2L);
+    expected.put("key.logHist.5", 4L);
+    
     expected.put("minRow", 2L);
     expected.put("maxRow", 18L);
     expected.put("sumRows", 40L);
+    
+    // Log2 Histogram
+    expected.put("row.logHist.1", 2L);
+    expected.put("row.logHist.2", 1L);
+    expected.put("row.logHist.3", 2L);
+    expected.put("row.logHist.4", 1L);
     
     expected.put("minFamily", 2L);
     expected.put("maxFamily", 11L);
     expected.put("sumFamilies", 37L);
     
+    // Log2 Histogram
+    expected.put("family.logHist.1", 2L);
+    expected.put("family.logHist.2", 1L);
+    expected.put("family.logHist.3", 3L);
+    
     expected.put("minQualifier", 1L);
     expected.put("maxQualifier", 10L);
     expected.put("sumQualifiers", 25L);
+    
+    // Log2 Histogram
+    expected.put("qualifier.logHist.0", 1L);
+    expected.put("qualifier.logHist.1", 2L);
+    expected.put("qualifier.logHist.2", 2L);
+    expected.put("qualifier.logHist.3", 1L);
     
     expected.put("minVisibility", 2L);
     expected.put("maxVisibility", 11L);
     expected.put("sumVisibilities", 30L);
     
+    // Log2 Histogram
+    expected.put("visibility.logHist.1", 2L);
+    expected.put("visibility.logHist.2", 2L);
+    expected.put("visibility.logHist.3", 2L);
+    
     expected.put("minValue", 0L);
     expected.put("maxValue", 11L);
     expected.put("sumValues", 29L);
     
+    // Log2 Histogram
+    expected.put("value.logHist.0", 1L);
+    expected.put("value.logHist.1", 1L);
+    expected.put("value.logHist.2", 1L);
+    expected.put("value.logHist.3", 3L);
+    
     expected.put("total", 6L);
+    
+    Assert.assertEquals(expected, stats);
+  }
+  
+  @Test
+  public void testLog2Histogram() {
+    SummarizerConfiguration sc = SummarizerConfiguration.builder(EntryLengthSummarizer.class).build();
+    EntryLengthSummarizer entrySum = new EntryLengthSummarizer();
+    
+    Key k1 = new Key("row1");
+    Key k2 = new Key("row2");
+    Key k3 = new Key("row3");
+    
+    Collector collector = entrySum.collector(sc);
+    collector.accept(k1, new Value("01"));
+    collector.accept(k2, new Value("012345678"));
+    collector.accept(k3, new Value("012345679"));
+    
+    HashMap<String,Long> stats = new HashMap<>();
+    collector.summarize(stats::put);
+    
+    HashMap<String,Long> expected = new HashMap<>();
+    expected.put("minKey", 4L);
+    expected.put("maxKey", 4L);
+    expected.put("sumKeys", 12L);
+    
+    // Log2 Histogram for Key
+    expected.put("key.logHist.2", 3L);
+    
+    expected.put("minRow", 4L);
+    expected.put("maxRow", 4L);
+    expected.put("sumRows", 12L);
+    
+    // Log2 Histogram for Row
+    expected.put("row.logHist.2", 3L);
+    
+    expected.put("minFamily", 0L);
+    expected.put("maxFamily", 0L);
+    expected.put("sumFamilies", 0L);
+    
+    // Log2 Histogram for Family
+    expected.put("family.logHist.0", 3L);
+    
+    expected.put("minQualifier", 0L);
+    expected.put("maxQualifier", 0L);
+    expected.put("sumQualifiers", 0L);
+    
+    // Log2 Histogram for Qualifier
+    expected.put("qualifier.logHist.0", 3L);
+    
+    expected.put("minVisibility", 0L);
+    expected.put("maxVisibility", 0L);
+    expected.put("sumVisibilities", 0L);
+    
+    // Log2 Histogram for Visibility
+    expected.put("visibility.logHist.0", 3L);
+    
+    expected.put("minValue", 2L);
+    expected.put("maxValue", 9L);
+    expected.put("sumValues", 20L);
+    
+    // Log2 Histogram for Value
+    expected.put("value.logHist.1", 1L);
+    expected.put("value.logHist.3", 2L);
+    
+    expected.put("total", 3L);
     
     Assert.assertEquals(expected, stats);
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
+ * (the "License");you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0

--- a/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/summary/summarizers/EntryLengthSummarizersTest.java
@@ -1111,8 +1111,10 @@ public class EntryLengthSummarizersTest {
     Combiner combiner = entrySum.combiner(sc);
     combiner.merge(stats1, stats2);
 
+    /*
     System.out.println("========= Merged");
     stats1.entrySet().forEach(System.out::println);
+    */
 
     HashMap<String,Long> expected = new HashMap<>();
     expected.put("key.min", 4L);


### PR DESCRIPTION
Built in Summarizer that computes summary information about field lengths. Specifically key length, row length, family length, qualifier length, visibility length, and value length. Incrementally computes min, max, count, sum, and log2 histogram.