### PR TITLE
ACCUMULO-4740 Enable GCM mode for crypto

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -81,6 +81,8 @@ public class ConfigSanityCheck {
 
       if (key.equals(Property.CRYPTO_CIPHER_SUITE.getKey())) {
         cipherSuite = Objects.requireNonNull(value);
+        Preconditions.checkArgument(cipherSuite.equals("NullCipher") || cipherSuite.split("/").length == 3,
+            "Cipher suite must be NullCipher or in the form algorithm/mode/padding. Suite: " + cipherSuite + " is invalid.");
       }
 
       if (key.equals(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey())) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -49,14 +49,13 @@ public enum Property {
           + "(future) other parts of the code."),
   @Experimental
   CRYPTO_CIPHER_SUITE("crypto.cipher.suite", "NullCipher", PropertyType.STRING,
-      "Describes the cipher suite to use for rfile encryption. If a WAL cipher suite is not set, it will default to this value. The suite should be in the "
-          + "form of algorithm/mode/padding, e.g. AES/CBC/NoPadding"),
+      "Describes the cipher suite to use for rfile encryption. The value must be either NullCipher or in the form of algorithm/mode/padding, "
+          + "e.g. AES/CBC/NoPadding"),
   @Experimental
-  CRYPTO_WAL_CIPHER_SUITE(
-      "crypto.wal.cipher.suite",
-      "NullCipher",
-      PropertyType.STRING,
-      "Describes the cipher suite to use for the write-ahead log. Defaults to 'cyrpto.cipher.suite' and will use that value for WAL encryption unless otherwise specified."),
+  CRYPTO_WAL_CIPHER_SUITE("crypto.wal.cipher.suite", "", PropertyType.STRING,
+      "Describes the cipher suite to use for the write-ahead log. Defaults to 'cyrpto.cipher.suite' "
+          + "and will use that value for WAL encryption unless otherwise specified. Valid suite values include: an empty string, NullCipher, or a string the "
+          + "form of algorithm/mode/padding, e.g. AES/CBC/NOPadding"),
   @Experimental
   CRYPTO_CIPHER_KEY_ALGORITHM_NAME("crypto.cipher.key.algorithm.name", "NullCipher", PropertyType.STRING,
       "States the name of the algorithm used for the key for the corresponding cipher suite. The key type must be compatible with the cipher suite."),

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
@@ -160,9 +160,12 @@ public final class BCFile {
         // *This* is also very important. We don't want the underlying stream messed with.
         cryptoParams.setRecordParametersToStream(false);
 
-        // It is also important to make sure we get a new initialization vector on every call in here,
-        // so set any existing one to null, in case we're reusing a parameters object for its RNG or other bits
-        cryptoParams.setInitializationVector(null);
+        // It is also important to make sure we get a new initialization vector on every call in here.
+        // This was originally done by setting any existing one to null, in case we were reusing a parameters object.
+        // We are also now keeping track of the IV across the use of a specific file key, because if the encryption
+        // mode is GCM, it's important to guarantee unique IVs. The updateInitializationVector will increment the vector if it
+        // already exists for GCM, or it will set the IV to null in other cases.
+        cryptoParams.updateInitializationVector();
 
         // Initialize the cipher including generating a new IV
         cryptoParams = cryptoModule.initializeCipher(cryptoParams);

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
@@ -160,11 +160,7 @@ public final class BCFile {
         // *This* is also very important. We don't want the underlying stream messed with.
         cryptoParams.setRecordParametersToStream(false);
 
-        // It is also important to make sure we get a new initialization vector on every call in here.
-        // This was originally done by setting any existing one to null, in case we were reusing a parameters object.
-        // We are also now keeping track of the IV across the use of a specific file key, because if the encryption
-        // mode is GCM, it's important to guarantee unique IVs. The updateInitializationVector will increment the vector if it
-        // already exists for GCM, or it will set the IV to null in other cases.
+        // Create a new IV for the block or update an existing one in the case of GCM
         cryptoParams.updateInitializationVector();
 
         // Initialize the cipher including generating a new IV

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoModuleParameters.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoModuleParameters.java
@@ -604,7 +604,7 @@ public class CryptoModuleParameters {
    * @param i
    *          The current byte being incremented
    */
-  private static void incrementIV(byte[] iv, int i) {
+  static void incrementIV(byte[] iv, int i) {
     iv[i]++;
     if (iv[i] == 0) {
       if (i != 0) {

--- a/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -400,117 +401,96 @@ public class CryptoTest {
   public void testIVIncrements() {
     // One byte
     byte[] testIv1 = new byte[1];
-    testIv1[0] = (byte) 0xFE;
     // 11111110
-
-    CryptoModuleParameters.incrementIV(testIv1, 0);
+    testIv1[0] = (byte) 0xFE;
+    
     // 11111111
+    CryptoModuleParameters.incrementIV(testIv1, testIv1.length - 1);
+    Assert.assertArrayEquals(testIv1, new byte[] {(byte)0xff} );
 
-    assertEquals(testIv1[0], (byte) 0xFF);
-    CryptoModuleParameters.incrementIV(testIv1, 0);
     // 00000000
-    assertEquals(testIv1[0], (byte) 0x00);
+    CryptoModuleParameters.incrementIV(testIv1, testIv1.length - 1);
+    Assert.assertArrayEquals(testIv1, new byte[] {(byte)0x00});
 
     // Two bytes
     byte[] testIv2 = new byte[2];
+    // 00000000 11111110
     testIv2[0] = (byte) 0x00;
     testIv2[1] = (byte) 0xFE;
-    // 00000000 11111110
 
-    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
     // 00000000 11111111
-    assertEquals(testIv2[0], (byte) 0x00);
-    assertEquals(testIv2[1], (byte) 0xFF);
-
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x00, (byte)0xFF});
+
     // 00000001 00000000
-    assertEquals(testIv2[0], (byte) 0x01);
-    assertEquals(testIv2[1], (byte) 0x00);
-
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    // 00000001 00000001
-    assertEquals(testIv2[0], (byte) 0x01);
-    assertEquals(testIv2[1], (byte) 0x01);
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x01, (byte)0x00});
 
+    // 00000001 00000001
+    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x01, (byte)0x01});
+    
+    // 11111111 11111111
     testIv2[0] = (byte) 0xFF;
     testIv2[1] = (byte) 0xFF;
-    // 11111111 11111111
 
-    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
     // 00000000 00000000
-    assertEquals(testIv2[0], (byte) 0x00);
-    assertEquals(testIv2[1], (byte) 0x00);
+    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x00, (byte)0x00});
+    
 
     // Three bytes
     byte[] testIv3 = new byte[3];
+    // 00000000 00000000 11111110
     testIv3[0] = (byte) 0x00;
     testIv3[1] = (byte) 0x00;
     testIv3[2] = (byte) 0xFE;
-    // 00000000 00000000 11111110
 
-    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
     // 00000000 00000000 11111111
-    assertEquals(testIv3[0], (byte) 0x00);
-    assertEquals(testIv3[1], (byte) 0x00);
-    assertEquals(testIv3[2], (byte) 0xFF);
-
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x00, (byte)0xFF});
+
     // 00000000 00000001 00000000
-    assertEquals(testIv3[0], (byte) 0x00);
-    assertEquals(testIv3[1], (byte) 0x01);
-    assertEquals(testIv3[2], (byte) 0x00);
-
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    // 00000000 00000001 00000001
-    assertEquals(testIv3[0], (byte) 0x00);
-    assertEquals(testIv3[1], (byte) 0x01);
-    assertEquals(testIv3[2], (byte) 0x01);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x01, (byte)0x00});
 
+    // 00000000 00000001 00000001
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x01, (byte)0x01});
+
+    // 00000000 11111111 11111110
     testIv3[0] = (byte) 0x00;
     testIv3[1] = (byte) 0xFF;
     testIv3[2] = (byte) 0xFE;
-    // 00000000 11111111 11111110
 
-    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
     // 00000000 11111111 11111111
-    assertEquals(testIv3[0], (byte) 0x00);
-    assertEquals(testIv3[1], (byte) 0xFF);
-    assertEquals(testIv3[2], (byte) 0xFF);
-
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0xFF, (byte)0xFF});
+
     // 00000001 00000000 00000000
-    assertEquals(testIv3[0], (byte) 0x01);
-    assertEquals(testIv3[1], (byte) 0x00);
-    assertEquals(testIv3[2], (byte) 0x00);
-
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    // 00000001 00000000 00000001
-    assertEquals(testIv3[0], (byte) 0x01);
-    assertEquals(testIv3[1], (byte) 0x00);
-    assertEquals(testIv3[2], (byte) 0x01);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x01, (byte)0x00, (byte)0x00});
 
+    // 00000001 00000000 00000001
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x01, (byte)0x00, (byte)0x01});
+
+    // 11111111 11111111 11111110
     testIv3[0] = (byte) 0xFF;
     testIv3[1] = (byte) 0xFF;
     testIv3[2] = (byte) 0xFE;
-    // 11111111 11111111 11111110
 
-    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
     // 11111111 11111111 11111111
-    assertEquals(testIv3[0], (byte) 0xFF);
-    assertEquals(testIv3[1], (byte) 0xFF);
-    assertEquals(testIv3[2], (byte) 0xFF);
-
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0xFF, (byte)0xFF, (byte)0xFF});
+
     // 00000000 00000000 00000000
-    assertEquals(testIv3[0], (byte) 0x00);
-    assertEquals(testIv3[1], (byte) 0x00);
-    assertEquals(testIv3[2], (byte) 0x00);
-
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x00, (byte)0x00});
+
     // 00000000 00000000 00000001
-    assertEquals(testIv3[0], (byte) 0x00);
-    assertEquals(testIv3[1], (byte) 0x00);
-    assertEquals(testIv3[2], (byte) 0x01);
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x00, (byte)0x01});
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
@@ -17,8 +17,11 @@
 
 package org.apache.accumulo.core.security.crypto;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -47,7 +50,6 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -199,7 +201,7 @@ public class CryptoTest {
     InputStream plaintextIn = params.getPlaintextInputStream();
 
     assertNotNull(plaintextIn);
-    assertTrue(plaintextIn != in);
+    assertNotSame(plaintextIn, in);
     DataInputStream dataIn = new DataInputStream(plaintextIn);
     String markerString = dataIn.readUTF();
     int markerInt = dataIn.readInt();
@@ -216,7 +218,7 @@ public class CryptoTest {
     params = cryptoModule.getEncryptingOutputStream(params);
 
     assertNotNull(params.getEncryptedOutputStream());
-    assertTrue(params.getEncryptedOutputStream() != out);
+    assertNotSame(params.getEncryptedOutputStream(), out);
 
     DataOutputStream dataOut = new DataOutputStream(params.getEncryptedOutputStream());
     dataOut.writeUTF(MARKER_STRING);
@@ -230,8 +232,8 @@ public class CryptoTest {
     String stringifiedOtherBytes = getStringifiedBytes(MARKER_INT);
 
     // OK, let's make sure it's encrypted
-    assertTrue(!stringifiedBytes.contains(stringifiedMarkerBytes));
-    assertTrue(!stringifiedBytes.contains(stringifiedOtherBytes));
+    assertFalse(stringifiedBytes.contains(stringifiedMarkerBytes));
+    assertFalse(stringifiedBytes.contains(stringifiedOtherBytes));
     return resultingBytes;
   }
 
@@ -362,16 +364,16 @@ public class CryptoTest {
 
     byte[] wrappedKey = keyWrapCipher.wrap(randKey);
 
-    Assert.assertTrue(wrappedKey != null);
+    assertNotNull(wrappedKey);
     // AESWrap will produce 24 bytes given 128 bits of key data with a 128-bit KEK
-    Assert.assertTrue(wrappedKey.length == randomKey.length + 8);
+    assertEquals(wrappedKey.length, randomKey.length + 8);
 
     Cipher keyUnwrapCipher = Cipher.getInstance("AESWrap/ECB/NoPadding");
     keyUnwrapCipher.init(Cipher.UNWRAP_MODE, new SecretKeySpec(kek, "AES"));
     Key unwrappedKey = keyUnwrapCipher.unwrap(wrappedKey, "AES", Cipher.SECRET_KEY);
 
     byte[] unwrappedKeyBytes = unwrappedKey.getEncoded();
-    Assert.assertTrue(Arrays.equals(unwrappedKeyBytes, randomKey));
+    assertArrayEquals(unwrappedKeyBytes, randomKey);
 
   }
 
@@ -380,7 +382,7 @@ public class CryptoTest {
     AccumuloConfiguration conf = setAndGetAccumuloConfig(CRYPTO_ON_CONF);
     byte[] encryptedBytes = testEncryption(conf, new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20});
     Integer result = testDecryption(conf, encryptedBytes);
-    Assert.assertTrue(result.equals(1));
+    assertEquals(result, Integer.valueOf(1));
   }
 
   @Test
@@ -406,11 +408,11 @@ public class CryptoTest {
 
     // 11111111
     CryptoModuleParameters.incrementIV(testIv1, testIv1.length - 1);
-    Assert.assertArrayEquals(testIv1, new byte[] {(byte) 0xff});
+    assertArrayEquals(testIv1, new byte[] {(byte) 0xff});
 
     // 00000000
     CryptoModuleParameters.incrementIV(testIv1, testIv1.length - 1);
-    Assert.assertArrayEquals(testIv1, new byte[] {(byte) 0x00});
+    assertArrayEquals(testIv1, new byte[] {(byte) 0x00});
 
     // Two bytes
     byte[] testIv2 = new byte[2];
@@ -420,15 +422,15 @@ public class CryptoTest {
 
     // 00000000 11111111
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x00, (byte) 0xFF});
+    assertArrayEquals(testIv2, new byte[] {(byte) 0x00, (byte) 0xFF});
 
     // 00000001 00000000
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x01, (byte) 0x00});
+    assertArrayEquals(testIv2, new byte[] {(byte) 0x01, (byte) 0x00});
 
     // 00000001 00000001
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x01, (byte) 0x01});
+    assertArrayEquals(testIv2, new byte[] {(byte) 0x01, (byte) 0x01});
 
     // 11111111 11111111
     testIv2[0] = (byte) 0xFF;
@@ -436,7 +438,7 @@ public class CryptoTest {
 
     // 00000000 00000000
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x00, (byte) 0x00});
+    assertArrayEquals(testIv2, new byte[] {(byte) 0x00, (byte) 0x00});
 
     // Three bytes
     byte[] testIv3 = new byte[3];
@@ -447,15 +449,15 @@ public class CryptoTest {
 
     // 00000000 00000000 11111111
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0xFF});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0xFF});
 
     // 00000000 00000001 00000000
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x01, (byte) 0x00});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x01, (byte) 0x00});
 
     // 00000000 00000001 00000001
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x01, (byte) 0x01});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x01, (byte) 0x01});
 
     // 00000000 11111111 11111110
     testIv3[0] = (byte) 0x00;
@@ -464,15 +466,15 @@ public class CryptoTest {
 
     // 00000000 11111111 11111111
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0xFF, (byte) 0xFF});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0xFF, (byte) 0xFF});
 
     // 00000001 00000000 00000000
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x01, (byte) 0x00, (byte) 0x00});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x01, (byte) 0x00, (byte) 0x00});
 
     // 00000001 00000000 00000001
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x01, (byte) 0x00, (byte) 0x01});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x01, (byte) 0x00, (byte) 0x01});
 
     // 11111111 11111111 11111110
     testIv3[0] = (byte) 0xFF;
@@ -481,15 +483,15 @@ public class CryptoTest {
 
     // 11111111 11111111 11111111
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
 
     // 00000000 00000000 00000000
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0x00});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0x00});
 
     // 00000000 00000000 00000001
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0x01});
+    assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0x01});
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
@@ -396,6 +396,124 @@ public class CryptoTest {
     testDecryption(conf, encryptedBytes);
   }
 
+  @Test
+  public void testIVIncrements() {
+    // One byte
+    byte[] testIv1 = new byte[1];
+    testIv1[0] = (byte) 0xFE;
+    // 11111110
+
+    CryptoModuleParameters.incrementIV(testIv1, 0);
+    // 11111111
+
+    assertEquals(testIv1[0], (byte) 0xFF);
+    CryptoModuleParameters.incrementIV(testIv1, 0);
+    // 00000000
+    assertEquals(testIv1[0], (byte) 0x00);
+
+    // Two bytes
+    byte[] testIv2 = new byte[2];
+    testIv2[0] = (byte) 0x00;
+    testIv2[1] = (byte) 0xFE;
+    // 00000000 11111110
+
+    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    // 00000000 11111111
+    assertEquals(testIv2[0], (byte) 0x00);
+    assertEquals(testIv2[1], (byte) 0xFF);
+
+    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    // 00000001 00000000
+    assertEquals(testIv2[0], (byte) 0x01);
+    assertEquals(testIv2[1], (byte) 0x00);
+
+    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    // 00000001 00000001
+    assertEquals(testIv2[0], (byte) 0x01);
+    assertEquals(testIv2[1], (byte) 0x01);
+
+    testIv2[0] = (byte) 0xFF;
+    testIv2[1] = (byte) 0xFF;
+    // 11111111 11111111
+
+    CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
+    // 00000000 00000000
+    assertEquals(testIv2[0], (byte) 0x00);
+    assertEquals(testIv2[1], (byte) 0x00);
+
+    // Three bytes
+    byte[] testIv3 = new byte[3];
+    testIv3[0] = (byte) 0x00;
+    testIv3[1] = (byte) 0x00;
+    testIv3[2] = (byte) 0xFE;
+    // 00000000 00000000 11111110
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000000 00000000 11111111
+    assertEquals(testIv3[0], (byte) 0x00);
+    assertEquals(testIv3[1], (byte) 0x00);
+    assertEquals(testIv3[2], (byte) 0xFF);
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000000 00000001 00000000
+    assertEquals(testIv3[0], (byte) 0x00);
+    assertEquals(testIv3[1], (byte) 0x01);
+    assertEquals(testIv3[2], (byte) 0x00);
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000000 00000001 00000001
+    assertEquals(testIv3[0], (byte) 0x00);
+    assertEquals(testIv3[1], (byte) 0x01);
+    assertEquals(testIv3[2], (byte) 0x01);
+
+    testIv3[0] = (byte) 0x00;
+    testIv3[1] = (byte) 0xFF;
+    testIv3[2] = (byte) 0xFE;
+    // 00000000 11111111 11111110
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000000 11111111 11111111
+    assertEquals(testIv3[0], (byte) 0x00);
+    assertEquals(testIv3[1], (byte) 0xFF);
+    assertEquals(testIv3[2], (byte) 0xFF);
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000001 00000000 00000000
+    assertEquals(testIv3[0], (byte) 0x01);
+    assertEquals(testIv3[1], (byte) 0x00);
+    assertEquals(testIv3[2], (byte) 0x00);
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000001 00000000 00000001
+    assertEquals(testIv3[0], (byte) 0x01);
+    assertEquals(testIv3[1], (byte) 0x00);
+    assertEquals(testIv3[2], (byte) 0x01);
+
+    testIv3[0] = (byte) 0xFF;
+    testIv3[1] = (byte) 0xFF;
+    testIv3[2] = (byte) 0xFE;
+    // 11111111 11111111 11111110
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 11111111 11111111 11111111
+    assertEquals(testIv3[0], (byte) 0xFF);
+    assertEquals(testIv3[1], (byte) 0xFF);
+    assertEquals(testIv3[2], (byte) 0xFF);
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000000 00000000 00000000
+    assertEquals(testIv3[0], (byte) 0x00);
+    assertEquals(testIv3[1], (byte) 0x00);
+    assertEquals(testIv3[2], (byte) 0x00);
+
+    CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
+    // 00000000 00000000 00000001
+    assertEquals(testIv3[0], (byte) 0x00);
+    assertEquals(testIv3[1], (byte) 0x00);
+    assertEquals(testIv3[2], (byte) 0x01);
+
+  }
+
   /**
    * Used in AESGCM unit tests to encrypt data. Uses MARKER_STRING and MARKER_INT
    *

--- a/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
@@ -362,16 +362,16 @@ public class CryptoTest {
 
     byte[] wrappedKey = keyWrapCipher.wrap(randKey);
 
-    assert (wrappedKey != null);
+    Assert.assertTrue(wrappedKey != null);
     // AESWrap will produce 24 bytes given 128 bits of key data with a 128-bit KEK
-    assert (wrappedKey.length == randomKey.length + 8);
+    Assert.assertTrue(wrappedKey.length == randomKey.length + 8);
 
     Cipher keyUnwrapCipher = Cipher.getInstance("AESWrap/ECB/NoPadding");
     keyUnwrapCipher.init(Cipher.UNWRAP_MODE, new SecretKeySpec(kek, "AES"));
     Key unwrappedKey = keyUnwrapCipher.unwrap(wrappedKey, "AES", Cipher.SECRET_KEY);
 
     byte[] unwrappedKeyBytes = unwrappedKey.getEncoded();
-    assert (Arrays.equals(unwrappedKeyBytes, randomKey));
+    Assert.assertTrue(Arrays.equals(unwrappedKeyBytes, randomKey));
 
   }
 
@@ -380,7 +380,7 @@ public class CryptoTest {
     AccumuloConfiguration conf = setAndGetAccumuloConfig(CRYPTO_ON_CONF);
     byte[] encryptedBytes = testEncryption(conf, new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20});
     Integer result = testDecryption(conf, encryptedBytes);
-    assert (result.equals(1));
+    Assert.assertTrue(result.equals(1));
   }
 
   @Test
@@ -403,14 +403,14 @@ public class CryptoTest {
     byte[] testIv1 = new byte[1];
     // 11111110
     testIv1[0] = (byte) 0xFE;
-    
+
     // 11111111
     CryptoModuleParameters.incrementIV(testIv1, testIv1.length - 1);
-    Assert.assertArrayEquals(testIv1, new byte[] {(byte)0xff} );
+    Assert.assertArrayEquals(testIv1, new byte[] {(byte) 0xff});
 
     // 00000000
     CryptoModuleParameters.incrementIV(testIv1, testIv1.length - 1);
-    Assert.assertArrayEquals(testIv1, new byte[] {(byte)0x00});
+    Assert.assertArrayEquals(testIv1, new byte[] {(byte) 0x00});
 
     // Two bytes
     byte[] testIv2 = new byte[2];
@@ -420,24 +420,23 @@ public class CryptoTest {
 
     // 00000000 11111111
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x00, (byte)0xFF});
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x00, (byte) 0xFF});
 
     // 00000001 00000000
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x01, (byte)0x00});
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x01, (byte) 0x00});
 
     // 00000001 00000001
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x01, (byte)0x01});
-    
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x01, (byte) 0x01});
+
     // 11111111 11111111
     testIv2[0] = (byte) 0xFF;
     testIv2[1] = (byte) 0xFF;
 
     // 00000000 00000000
     CryptoModuleParameters.incrementIV(testIv2, testIv2.length - 1);
-    Assert.assertArrayEquals(testIv2, new byte[] {(byte)0x00, (byte)0x00});
-    
+    Assert.assertArrayEquals(testIv2, new byte[] {(byte) 0x00, (byte) 0x00});
 
     // Three bytes
     byte[] testIv3 = new byte[3];
@@ -448,15 +447,15 @@ public class CryptoTest {
 
     // 00000000 00000000 11111111
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x00, (byte)0xFF});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0xFF});
 
     // 00000000 00000001 00000000
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x01, (byte)0x00});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x01, (byte) 0x00});
 
     // 00000000 00000001 00000001
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x01, (byte)0x01});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x01, (byte) 0x01});
 
     // 00000000 11111111 11111110
     testIv3[0] = (byte) 0x00;
@@ -465,15 +464,15 @@ public class CryptoTest {
 
     // 00000000 11111111 11111111
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0xFF, (byte)0xFF});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0xFF, (byte) 0xFF});
 
     // 00000001 00000000 00000000
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x01, (byte)0x00, (byte)0x00});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x01, (byte) 0x00, (byte) 0x00});
 
     // 00000001 00000000 00000001
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x01, (byte)0x00, (byte)0x01});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x01, (byte) 0x00, (byte) 0x01});
 
     // 11111111 11111111 11111110
     testIv3[0] = (byte) 0xFF;
@@ -482,15 +481,15 @@ public class CryptoTest {
 
     // 11111111 11111111 11111111
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0xFF, (byte)0xFF, (byte)0xFF});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
 
     // 00000000 00000000 00000000
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x00, (byte)0x00});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0x00});
 
     // 00000000 00000000 00000001
     CryptoModuleParameters.incrementIV(testIv3, testIv3.length - 1);
-    Assert.assertArrayEquals(testIv3, new byte[] {(byte)0x00, (byte)0x00, (byte)0x01});
+    Assert.assertArrayEquals(testIv3, new byte[] {(byte) 0x00, (byte) 0x00, (byte) 0x01});
 
   }
 
@@ -532,7 +531,7 @@ public class CryptoTest {
    *          The accumulo configuration
    * @param encryptedBytes
    *          The encrypted bytes
-   * @return 0 if data is incorrectly decrypted, 1 if decrypted data matches input, 2 if data integrity was compromised
+   * @return 0 if data is incorrectly decrypted, 1 if decrypted data matches input
    * @throws IOException
    *           if DataInputStream fails
    * @throws AEADBadTagException
@@ -552,8 +551,7 @@ public class CryptoTest {
       utf = decryptedDataStream.readUTF();
       in = decryptedDataStream.readInt();
     } catch (IOException e) {
-      final String message = "javax.crypto.AEADBadTagException:";
-      if (e.getMessage().substring(0, message.length()).equals(message)) {
+      if (e.getCause().getClass().equals(AEADBadTagException.class)) {
         throw new AEADBadTagException();
       } else {
         throw e;

--- a/core/src/test/resources/crypto-on-accumulo-site.xml
+++ b/core/src/test/resources/crypto-on-accumulo-site.xml
@@ -76,8 +76,12 @@
       <value>org.apache.accumulo.core.security.crypto.DefaultCryptoModule</value>
     </property>
     <property>
+      <name>crypto.security.provider</name>
+      <value>SunJCE</value>
+    </property>
+    <property>
       <name>crypto.cipher.suite</name>
-      <value>AES/CFB/NoPadding</value>
+      <value>AES/GCM/NoPadding</value>
     </property>
     <property>
       <name>crypto.wal.cipher.suite</name>
@@ -127,7 +131,7 @@
     
     <property>
     	<name>crypto.default.key.strategy.cipher.suite</name>
-    	<value>AES/ECB/NoPadding</value>
+    	<value>AESWrap/ECB/NoPadding</value>
     </property>
 
 </configuration>

--- a/core/src/test/resources/crypto-on-no-key-encryption-accumulo-site.xml
+++ b/core/src/test/resources/crypto-on-no-key-encryption-accumulo-site.xml
@@ -80,6 +80,10 @@
       <value>AES/CFB/NoPadding</value>
     </property>
     <property>
+      <name>crypto.wal.cipher.suite</name>
+      <value>AES/CBC/NoPadding</value>
+    </property>
+    <property>
       <name>crypto.cipher.key.algorithm.name</name>
       <value>AES</value>
     </property>

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -468,7 +468,8 @@ public class DfsLogger implements Comparable<DfsLogger> {
 
       CryptoModuleParameters params = CryptoModuleFactory.createParamsObjectFromAccumuloConfiguration(conf.getConfiguration());
       // Immediately update to the correct cipher. Doing this here keeps the CryptoModule independent of the writers using it
-      if (params.getAllOptions().get(Property.CRYPTO_WAL_CIPHER_SUITE.getKey()) != null) {
+      if (params.getAllOptions().get(Property.CRYPTO_WAL_CIPHER_SUITE.getKey()) != null
+          && !params.getAllOptions().get(Property.CRYPTO_WAL_CIPHER_SUITE.getKey()).equals("")) {
         params.setCipherSuite(params.getAllOptions().get(Property.CRYPTO_WAL_CIPHER_SUITE.getKey()));
       }
 


### PR DESCRIPTION
Introduced the GCMParameterSpec constructor required by cipher
Updated IV management for AES-GCM (see Appendix A of NIST SP 800-38D)