### PR TITLE
ACCUMULO-4777 Removed the unused sequence generator.

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -95,8 +95,6 @@ public class TabletServerLogger {
   // Use a ReadWriteLock to allow multiple threads to use the log set, but obtain a write lock to change them
   private final ReentrantReadWriteLock logIdLock = new ReentrantReadWriteLock();
 
-  private final AtomicInteger seqGen = new AtomicInteger();
-
   private final AtomicLong syncCounter;
   private final AtomicLong flushCounter;
 
@@ -348,19 +346,18 @@ public class TabletServerLogger {
   }
 
   interface Writer {
-    LoggerOperation write(DfsLogger logger, int seq) throws Exception;
+    LoggerOperation write(DfsLogger logger) throws Exception;
   }
 
-  private int write(CommitSession commitSession, boolean mincFinish, Writer writer) throws IOException {
+  private void write(CommitSession commitSession, boolean mincFinish, Writer writer) throws IOException {
     List<CommitSession> sessions = Collections.singletonList(commitSession);
-    return write(sessions, mincFinish, writer);
+    write(sessions, mincFinish, writer);
   }
 
-  private int write(final Collection<CommitSession> sessions, boolean mincFinish, Writer writer) throws IOException {
+  private void write(final Collection<CommitSession> sessions, boolean mincFinish, Writer writer) throws IOException {
     // Work very hard not to lock this during calls to the outside world
     int currentLogId = logId.get();
 
-    int seq = -1;
     int attempt = 1;
     boolean success = false;
     while (!success) {
@@ -400,10 +397,7 @@ public class TabletServerLogger {
         if (currentLogId == logId.get()) {
 
           // write the mutation to the logs
-          seq = seqGen.incrementAndGet();
-          if (seq < 0)
-            throw new RuntimeException("Logger sequence generator wrapped!  Onos!!!11!eleven");
-          LoggerOperation lop = writer.write(copy, seq);
+          LoggerOperation lop = writer.write(copy);
           lop.await();
 
           // double-check: did the log set change?
@@ -453,42 +447,40 @@ public class TabletServerLogger {
         closeForReplication(sessions);
       }
     });
-    return seq;
   }
 
   protected void closeForReplication(Collection<CommitSession> sessions) {
     // TODO We can close the WAL here for replication purposes
   }
 
-  public int defineTablet(final CommitSession commitSession) throws IOException {
+  public void defineTablet(final CommitSession commitSession) throws IOException {
     // scribble this into the metadata tablet, too.
-    return write(commitSession, false, new Writer() {
+    write(commitSession, false, new Writer() {
       @Override
-      public LoggerOperation write(DfsLogger logger, int ignored) throws Exception {
+      public LoggerOperation write(DfsLogger logger) throws Exception {
         logger.defineTablet(commitSession.getWALogSeq(), commitSession.getLogId(), commitSession.getExtent());
         return DfsLogger.NO_WAIT_LOGGER_OP;
       }
     });
   }
 
-  public int log(final CommitSession commitSession, final int tabletSeq, final Mutation m, final Durability durability) throws IOException {
+  public void log(final CommitSession commitSession, final int tabletSeq, final Mutation m, final Durability durability) throws IOException {
     if (durability == Durability.NONE) {
-      return -1;
+      return;
     }
     if (durability == Durability.DEFAULT) {
       throw new IllegalArgumentException("Unexpected durability " + durability);
     }
-    int seq = write(commitSession, false, new Writer() {
+    write(commitSession, false, new Writer() {
       @Override
-      public LoggerOperation write(DfsLogger logger, int ignored) throws Exception {
+      public LoggerOperation write(DfsLogger logger) throws Exception {
         return logger.log(tabletSeq, commitSession.getLogId(), m, durability);
       }
     });
     logSizeEstimate.addAndGet(m.numBytes());
-    return seq;
   }
 
-  public int logManyTablets(Map<CommitSession,Mutations> mutations) throws IOException {
+  public void logManyTablets(Map<CommitSession,Mutations> mutations) throws IOException {
 
     final Map<CommitSession,Mutations> loggables = new HashMap<>(mutations);
     for (Entry<CommitSession,Mutations> entry : mutations.entrySet()) {
@@ -497,11 +489,11 @@ public class TabletServerLogger {
       }
     }
     if (loggables.size() == 0)
-      return -1;
+      return;
 
-    int seq = write(loggables.keySet(), false, new Writer() {
+    write(loggables.keySet(), false, new Writer() {
       @Override
-      public LoggerOperation write(DfsLogger logger, int ignored) throws Exception {
+      public LoggerOperation write(DfsLogger logger) throws Exception {
         List<TabletMutations> copy = new ArrayList<>(loggables.size());
         for (Entry<CommitSession,Mutations> entry : loggables.entrySet()) {
           CommitSession cs = entry.getKey();
@@ -519,7 +511,6 @@ public class TabletServerLogger {
         logSizeEstimate.addAndGet(m.numBytes());
       }
     }
-    return seq;
   }
 
   public void minorCompactionFinished(final CommitSession commitSession, final String fullyQualifiedFileName, final int walogSeq, final Durability durability)
@@ -527,23 +518,23 @@ public class TabletServerLogger {
 
     long t1 = System.currentTimeMillis();
 
-    int seq = write(commitSession, true, new Writer() {
+    write(commitSession, true, new Writer() {
       @Override
-      public LoggerOperation write(DfsLogger logger, int ignored) throws Exception {
+      public LoggerOperation write(DfsLogger logger) throws Exception {
         return logger.minorCompactionFinished(walogSeq, commitSession.getLogId(), fullyQualifiedFileName, durability);
       }
     });
 
     long t2 = System.currentTimeMillis();
 
-    log.debug(" wrote MinC finish  {}: writeTime:{}ms  durability:{}", seq, (t2 - t1), durability);
+    log.debug(" wrote MinC finish: writeTime:{}ms  durability:{}", (t2 - t1), durability);
   }
 
   public int minorCompactionStarted(final CommitSession commitSession, final int seq, final String fullyQualifiedFileName, final Durability durability)
       throws IOException {
     write(commitSession, false, new Writer() {
       @Override
-      public LoggerOperation write(DfsLogger logger, int ignored) throws Exception {
+      public LoggerOperation write(DfsLogger logger) throws Exception {
         return logger.minorCompactionStarted(seq, commitSession.getLogId(), fullyQualifiedFileName, durability);
       }
     });


### PR DESCRIPTION
This commit removed the unused sequence generator.  Yet to come is adding a retry backoff strategy to the WAL writing mechanism.