### PR TITLE
ACCUMULO-4611 Deprecate commons config in api

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo</artifactId>
   <packaging>pom</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-core</artifactId>
   <name>Apache Accumulo Core</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -194,13 +194,6 @@
                 <!--Allow API data types to reference thrift types, but do not
 		     analyze thrift types -->
                 <allow>org[.]apache[.]accumulo[.].*[.]thrift[.].*</allow>
-                <!--ClientConfiguration indirectly extends
-		     AbstractConfiguration and EventSource.  These two types
-		     bring in many types from apache commons.  Added these two
-		     types instead of all of the types they reference.-->
-                <allow>org[.]apache[.]commons[.]configuration[.]Configuration</allow>
-                <allow>org[.]apache[.]commons[.]configuration[.]AbstractConfiguration</allow>
-                <allow>org[.]apache[.]commons[.]configuration[.]event[.]EventSource</allow>
                 <!--Type from hadoop used in API.  If adding a new type from
 		     Hadoop to the Accumulo API ensure its annotated as
 		     stable.-->
@@ -212,6 +205,12 @@
                 <allow>org[.]apache[.]hadoop[.]util[.]Progressable</allow>
                 <!--ugghhh-->
                 <allow>org[.]apache[.]log4j[.](Level|Logger)</allow>
+                <!-- allow javax security exceptions for Authentication tokens -->
+                <allow>javax[.]security[.]auth[.]DestroyFailedException</allow>
+                <!-- allow questionable Hadoop exceptions for mapreduce -->
+                <allow>org[.]apache[.]hadoop[.]mapred[.](FileAlreadyExistsException|InvalidJobConfException)</allow>
+                <!-- allow lexicoders to throw iterator exceptions -->
+                <allow>org[.]apache[.]accumulo[.]core[.]iterators[.]ValueFormatException</allow>
               </allows>
             </configuration>
           </execution>

--- a/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
@@ -234,7 +234,7 @@ public class ClientOpts extends Help {
       if (clientConfigFile == null)
         clientConfig = ClientConfiguration.loadDefault();
       else
-        clientConfig = new ClientConfiguration(clientConfigFile);
+        clientConfig = ClientConfiguration.fromFile(new File(clientConfigFile));
     } catch (Exception e) {
       throw new IllegalArgumentException(e);
     }
@@ -347,7 +347,7 @@ public class ClientOpts extends Help {
       if (clientConfigFile == null)
         clientConfig = ClientConfiguration.loadDefault();
       else
-        clientConfig = new ClientConfiguration(clientConfigFile);
+        clientConfig = ClientConfiguration.fromFile(new File(clientConfigFile));
     } catch (Exception e) {
       throw new IllegalArgumentException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -21,12 +21,17 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.File;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 
 import org.apache.accumulo.core.conf.Property;
@@ -35,7 +40,15 @@ import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.event.ConfigurationErrorEvent;
+import org.apache.commons.configuration.event.ConfigurationErrorListener;
+import org.apache.commons.configuration.event.ConfigurationEvent;
+import org.apache.commons.configuration.event.ConfigurationListener;
+import org.apache.commons.configuration.interpol.ConfigurationInterpolator;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.logging.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,30 +160,46 @@ public class ClientConfiguration extends CompositeConfiguration {
     }
   }
 
+  // helper for the constructor which takes a String file name
+  private static PropertiesConfiguration newPropsFile(String file) throws ConfigurationException {
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    props.setListDelimiter('\0');
+    props.load(file);
+    return props;
+  }
+
+  // helper for the constructor which takes a File
+  private static PropertiesConfiguration newPropsFile(File file) throws ConfigurationException {
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    props.setListDelimiter('\0');
+    props.load(file);
+    return props;
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API; use {@link #fromFile(File)} instead.
+   */
+  @Deprecated
   public ClientConfiguration(String configFile) throws ConfigurationException {
-    this(new PropertiesConfiguration(), configFile);
+    this(Collections.singletonList(newPropsFile(configFile)));
   }
 
-  private ClientConfiguration(PropertiesConfiguration propertiesConfiguration, String configFile) throws ConfigurationException {
-    super(propertiesConfiguration);
-    // Don't do list interpolation
-    this.setListDelimiter('\0');
-    propertiesConfiguration.setListDelimiter('\0');
-    propertiesConfiguration.load(configFile);
-  }
-
+  /**
+   * Load a client configuration from the provided configuration properties file
+   *
+   * @param configFile
+   *          the path to the properties file
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API; use {@link #fromFile(File)} instead.
+   */
+  @Deprecated
   public ClientConfiguration(File configFile) throws ConfigurationException {
-    this(new PropertiesConfiguration(), configFile);
+    this(Collections.singletonList(newPropsFile(configFile)));
   }
 
-  private ClientConfiguration(PropertiesConfiguration propertiesConfiguration, File configFile) throws ConfigurationException {
-    super(propertiesConfiguration);
-    // Don't do list interpolation
-    this.setListDelimiter('\0');
-    propertiesConfiguration.setListDelimiter('\0');
-    propertiesConfiguration.load(configFile);
-  }
-
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
   public ClientConfiguration(List<? extends Configuration> configs) {
     super(configs);
     // Don't do list interpolation
@@ -192,8 +221,9 @@ public class ClientConfiguration extends CompositeConfiguration {
    *
    * @see PropertiesConfiguration
    * @see #loadDefault()
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
    */
-
+  @Deprecated
   public ClientConfiguration(Configuration... configs) {
     this(Arrays.asList(configs));
   }
@@ -221,23 +251,66 @@ public class ClientConfiguration extends CompositeConfiguration {
     return loadFromSearchPath(getDefaultSearchPath());
   }
 
-  private static ClientConfiguration loadFromSearchPath(List<String> paths) {
+  /**
+   * Initializes an empty configuration object to be further configured with other methods on the class.
+   *
+   * @since 1.9.0
+   */
+  public static ClientConfiguration create() {
+    return new ClientConfiguration(Collections.<Configuration> emptyList());
+  }
+
+  /**
+   * Initializes a configuration object from the contents of a configuration file. Currently supports Java "properties" files. The returned object can be
+   * further configured with subsequent calls to other methods on this class.
+   *
+   * @param file
+   *          the path to the configuration file
+   * @since 1.9.0
+   */
+  public static ClientConfiguration fromFile(File file) {
     try {
-      List<Configuration> configs = new LinkedList<>();
-      for (String path : paths) {
-        File conf = new File(path);
-        if (conf.isFile() && conf.canRead()) {
-          configs.add(new ClientConfiguration(conf));
-        }
-      }
-      // We couldn't find the client configuration anywhere
-      if (configs.isEmpty()) {
-        log.warn("Found no client.conf in default paths. Using default client configuration values.");
-      }
-      return new ClientConfiguration(configs);
+      return new ClientConfiguration(file);
     } catch (ConfigurationException e) {
-      throw new IllegalStateException("Error loading client configuration", e);
+      throw new IllegalArgumentException("Bad configuration file: " + file, e);
     }
+  }
+
+  /**
+   * Initializes a configuration object from the contents of a map. The returned object can be further configured with subsequent calls to other methods on this
+   * class.
+   *
+   * @param properties
+   *          a map containing the configuration properties to use
+   * @since 1.9.0
+   */
+  public static ClientConfiguration fromMap(Map<String,String> properties) {
+    MapConfiguration mapConf = new MapConfiguration(properties);
+    mapConf.setListDelimiter('\0');
+    return new ClientConfiguration(Collections.singletonList(mapConf));
+  }
+
+  private static ClientConfiguration loadFromSearchPath(List<String> paths) {
+    List<Configuration> configs = new LinkedList<>();
+    for (String path : paths) {
+      File conf = new File(path);
+      if (conf.isFile() && conf.canRead()) {
+        PropertiesConfiguration props = new PropertiesConfiguration();
+        props.setListDelimiter('\0');
+        try {
+          props.load(conf);
+          log.info("Loaded client configuration file {}", conf);
+        } catch (ConfigurationException e) {
+          throw new IllegalStateException("Error loading client configuration file " + conf, e);
+        }
+        configs.add(props);
+      }
+    }
+    // We couldn't find the client configuration anywhere
+    if (configs.isEmpty()) {
+      log.warn("Found no client.conf in default paths. Using default client configuration values.");
+    }
+    return new ClientConfiguration(configs);
   }
 
   public static ClientConfiguration deserialize(String serializedConfig) {
@@ -354,14 +427,32 @@ public class ClientConfiguration extends CompositeConfiguration {
    *
    */
   public void setProperty(ClientProperty prop, String value) {
-    this.setProperty(prop.getKey(), value);
+    with(prop, value);
   }
 
   /**
    * Same as {@link #setProperty(ClientProperty, String)} but returns the ClientConfiguration for chaining purposes
    */
   public ClientConfiguration with(ClientProperty prop, String value) {
-    this.setProperty(prop.getKey(), value);
+    return with(prop.getKey(), value);
+  }
+
+  /**
+   * Sets the value of property to value
+   *
+   * @since 1.9.0
+   */
+  public void setProperty(String prop, String value) {
+    with(prop, value);
+  }
+
+  /**
+   * Same as {@link #setProperty(String, String)} but returns the ClientConfiguration for chaining purposes
+   *
+   * @since 1.9.0
+   */
+  public ClientConfiguration with(String prop, String value) {
+    super.setProperty(prop, value);
     return this;
   }
 
@@ -473,6 +564,15 @@ public class ClientConfiguration extends CompositeConfiguration {
   }
 
   /**
+   * Show whether SASL has been set on this configuration.
+   *
+   * @since 1.9.0
+   */
+  public boolean hasSasl() {
+    return getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), Boolean.parseBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getDefaultValue()));
+  }
+
+  /**
    * Same as {@link #with(ClientProperty, String)} for ClientProperty.INSTANCE_RPC_SASL_ENABLED and ClientProperty.GENERAL_KERBEROS_PRINCIPAL.
    *
    * @param saslEnabled
@@ -484,4 +584,747 @@ public class ClientConfiguration extends CompositeConfiguration {
   public ClientConfiguration withSasl(boolean saslEnabled, String kerberosServerPrimary) {
     return withSasl(saslEnabled).with(ClientProperty.KERBEROS_SERVER_PRIMARY, kerberosServerPrimary);
   }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Configuration getConfiguration(int index) {
+    return super.getConfiguration(index);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Configuration getSource(String key) {
+    return super.getSource(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void removeConfiguration(Configuration config) {
+    super.removeConfiguration(config);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void addConfiguration(Configuration config) {
+    super.addConfiguration(config);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Configuration getInMemoryConfiguration() {
+    return super.getInMemoryConfiguration();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Log getLogger() {
+    return super.getLogger();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Configuration subset(String prefix) {
+    return super.subset(prefix);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Configuration interpolatedConfiguration() {
+    return super.interpolatedConfiguration();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void setLogger(Log log) {
+    super.setLogger(log);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public ConfigurationInterpolator getInterpolator() {
+    return super.getInterpolator();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public synchronized StrSubstitutor getSubstitutor() {
+    return super.getSubstitutor();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void append(Configuration c) {
+    super.append(c);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void copy(Configuration c) {
+    super.copy(c);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void addConfigurationListener(ConfigurationListener l) {
+    super.addConfigurationListener(l);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean removeConfigurationListener(ConfigurationListener l) {
+    return super.removeConfigurationListener(l);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean removeErrorListener(ConfigurationErrorListener l) {
+    return super.removeErrorListener(l);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void addErrorListener(ConfigurationErrorListener l) {
+    super.addErrorListener(l);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void addErrorLogListener() {
+    super.addErrorLogListener();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void addProperty(String key, Object value) {
+    super.addProperty(key, value);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected void addPropertyDirect(String key, Object token) {
+    super.addPropertyDirect(key, token);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void clear() {
+    super.clear();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void clearConfigurationListeners() {
+    super.clearConfigurationListeners();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void clearErrorListeners() {
+    super.clearErrorListeners();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void clearProperty(String key) {
+    super.clearProperty(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected void clearPropertyDirect(String key) {
+    super.clearPropertyDirect(key);
+  }
+
+  @Override
+  public boolean containsKey(String key) {
+    return super.containsKey(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected ConfigurationErrorEvent createErrorEvent(int type, String propName, Object propValue, Throwable ex) {
+    return super.createErrorEvent(type, propName, propValue, ex);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected ConfigurationEvent createEvent(int type, String propName, Object propValue, boolean before) {
+    return super.createEvent(type, propName, propValue, before);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected ConfigurationInterpolator createInterpolator() {
+    return super.createInterpolator();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected void fireError(int type, String propName, Object propValue, Throwable ex) {
+    super.fireError(type, propName, propValue, ex);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected void fireEvent(int type, String propName, Object propValue, boolean before) {
+    super.fireEvent(type, propName, propValue, before);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public BigDecimal getBigDecimal(String key) {
+    return super.getBigDecimal(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public BigDecimal getBigDecimal(String key, BigDecimal defaultValue) {
+    return super.getBigDecimal(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public BigInteger getBigInteger(String key) {
+    return super.getBigInteger(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public BigInteger getBigInteger(String key, BigInteger defaultValue) {
+    return super.getBigInteger(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean getBoolean(String key) {
+    return super.getBoolean(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean getBoolean(String key, boolean defaultValue) {
+    return super.getBoolean(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Boolean getBoolean(String key, Boolean defaultValue) {
+    return super.getBoolean(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public byte getByte(String key) {
+    return super.getByte(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public byte getByte(String key, byte defaultValue) {
+    return super.getByte(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Byte getByte(String key, Byte defaultValue) {
+    return super.getByte(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Collection getConfigurationListeners() {
+    return super.getConfigurationListeners();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public double getDouble(String key) {
+    return super.getDouble(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Double getDouble(String key, Double defaultValue) {
+    return super.getDouble(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public double getDouble(String key, double defaultValue) {
+    return super.getDouble(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Collection getErrorListeners() {
+    return super.getErrorListeners();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public float getFloat(String key) {
+    return super.getFloat(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Float getFloat(String key, Float defaultValue) {
+    return super.getFloat(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public float getFloat(String key, float defaultValue) {
+    return super.getFloat(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public int getInt(String key) {
+    return super.getInt(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public int getInt(String key, int defaultValue) {
+    return super.getInt(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Integer getInteger(String key, Integer defaultValue) {
+    return super.getInteger(key, defaultValue);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Iterator<String> getKeys() {
+    return super.getKeys();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  @Override
+  public Iterator<String> getKeys(String key) {
+    return super.getKeys(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @SuppressWarnings("rawtypes")
+  @Override
+  public List getList(String key) {
+    return super.getList(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @SuppressWarnings("rawtypes")
+  @Override
+  public List getList(String key, List defaultValue) {
+    return super.getList(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public char getListDelimiter() {
+    return super.getListDelimiter();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public long getLong(String key) {
+    return super.getLong(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public long getLong(String key, long defaultValue) {
+    return super.getLong(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Long getLong(String key, Long defaultValue) {
+    return super.getLong(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public int getNumberOfConfigurations() {
+    return super.getNumberOfConfigurations();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Properties getProperties(String key) {
+    return super.getProperties(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Properties getProperties(String key, Properties defaults) {
+    return super.getProperties(key, defaults);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Object getProperty(String key) {
+    return super.getProperty(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public short getShort(String key) {
+    return super.getShort(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public short getShort(String key, short defaultValue) {
+    return super.getShort(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public Short getShort(String key, Short defaultValue) {
+    return super.getShort(key, defaultValue);
+  }
+
+  @Override
+  public String getString(String key) {
+    return super.getString(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public String getString(String key, String defaultValue) {
+    return super.getString(key, defaultValue);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public String[] getStringArray(String key) {
+    return super.getStringArray(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected Object interpolate(Object value) {
+    return super.interpolate(value);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected String interpolate(String base) {
+    return super.interpolate(base);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @SuppressWarnings("rawtypes")
+  @Override
+  protected String interpolateHelper(String base, List priorVariables) {
+    return super.interpolateHelper(base, priorVariables);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean isDelimiterParsingDisabled() {
+    return super.isDelimiterParsingDisabled();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean isDetailEvents() {
+    return super.isDetailEvents();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean isEmpty() {
+    return super.isEmpty();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public boolean isThrowExceptionOnMissing() {
+    return super.isThrowExceptionOnMissing();
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  protected Object resolveContainerStore(String key) {
+    return super.resolveContainerStore(key);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void setDelimiterParsingDisabled(boolean delimiterParsingDisabled) {
+    super.setDelimiterParsingDisabled(delimiterParsingDisabled);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void setDetailEvents(boolean enable) {
+    super.setDetailEvents(enable);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void setListDelimiter(char listDelimiter) {
+    super.setListDelimiter(listDelimiter);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void setProperty(String key, Object value) {
+    super.setProperty(key, value);
+  }
+
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
+  @Override
+  public void setThrowExceptionOnMissing(boolean throwExceptionOnMissing) {
+    super.setThrowExceptionOnMissing(throwExceptionOnMissing);
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
@@ -95,7 +95,7 @@ public class ZooKeeperInstance implements Instance {
    *          A comma separated list of zoo keeper server locations. Each location can contain an optional port, of the format host:port.
    * @param sessionTimeout
    *          zoo keeper session time out in milliseconds.
-   * @deprecated since 1.6.0; Use {@link #ZooKeeperInstance(Configuration)} instead.
+   * @deprecated since 1.6.0; Use {@link #ZooKeeperInstance(ClientConfiguration)} instead.
    */
   @Deprecated
   public ZooKeeperInstance(String instanceName, String zooKeepers, int sessionTimeout) {
@@ -108,7 +108,7 @@ public class ZooKeeperInstance implements Instance {
    *          The UUID that identifies the accumulo instance you want to connect to.
    * @param zooKeepers
    *          A comma separated list of zoo keeper server locations. Each location can contain an optional port, of the format host:port.
-   * @deprecated since 1.6.0; Use {@link #ZooKeeperInstance(Configuration)} instead.
+   * @deprecated since 1.6.0; Use {@link #ZooKeeperInstance(ClientConfiguration)} instead.
    */
   @Deprecated
   public ZooKeeperInstance(UUID instanceId, String zooKeepers) {
@@ -123,7 +123,7 @@ public class ZooKeeperInstance implements Instance {
    *          A comma separated list of zoo keeper server locations. Each location can contain an optional port, of the format host:port.
    * @param sessionTimeout
    *          zoo keeper session time out in milliseconds.
-   * @deprecated since 1.6.0; Use {@link #ZooKeeperInstance(Configuration)} instead.
+   * @deprecated since 1.6.0; Use {@link #ZooKeeperInstance(ClientConfiguration)} instead.
    */
   @Deprecated
   public ZooKeeperInstance(UUID instanceId, String zooKeepers, int sessionTimeout) {
@@ -135,7 +135,10 @@ public class ZooKeeperInstance implements Instance {
    *          Client configuration for specifying connection options. See {@link ClientConfiguration} which extends Configuration with convenience methods
    *          specific to Accumulo.
    * @since 1.6.0
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API; use
+   *             {@link #ZooKeeperInstance(ClientConfiguration)} instead.
    */
+  @Deprecated
   public ZooKeeperInstance(Configuration config) {
     this(config, new ZooCacheFactory());
   }
@@ -145,7 +148,9 @@ public class ZooKeeperInstance implements Instance {
     if (config instanceof ClientConfiguration) {
       this.clientConf = (ClientConfiguration) config;
     } else {
-      this.clientConf = new ClientConfiguration(config);
+      @SuppressWarnings("deprecation")
+      ClientConfiguration cliConf = new ClientConfiguration(config);
+      this.clientConf = cliConf;
     }
     this.instanceId = clientConf.get(ClientProperty.INSTANCE_ID);
     this.instanceName = clientConf.get(ClientProperty.INSTANCE_NAME);
@@ -158,6 +163,16 @@ public class ZooKeeperInstance implements Instance {
       // Validates that the provided instanceName actually exists
       getInstanceID();
     }
+  }
+
+  /**
+   * @param config
+   *          Client configuration for specifying connection options. See {@link ClientConfiguration} which extends Configuration with convenience methods
+   *          specific to Accumulo.
+   * @since 1.9.0
+   */
+  public ZooKeeperInstance(ClientConfiguration config) {
+    this(config, new ZooCacheFactory());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ClientContext.java
@@ -124,11 +124,9 @@ public class ClientContext {
    * Retrieve SASL configuration to initiate an RPC connection to a server
    */
   public SaslConnectionParams getSaslParams() {
-    final boolean defaultVal = Boolean.parseBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getDefaultValue());
-
     // Use the clientConf if we have it
     if (null != clientConf) {
-      if (!clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), defaultVal)) {
+      if (!clientConf.hasSasl()) {
         return null;
       }
       return new SaslConnectionParams(clientConf, getCredentials().getToken());

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.util.KerberosName;
@@ -130,13 +129,7 @@ public class SaslConnectionParams {
   protected final Map<String,String> saslProperties;
 
   public SaslConnectionParams(AccumuloConfiguration conf, AuthenticationToken token) {
-    this(new ClientConfiguration(createMapConfiguration(conf)), token);
-  }
-
-  private static MapConfiguration createMapConfiguration(AccumuloConfiguration conf) {
-    MapConfiguration mapConf = new MapConfiguration(getProperties(conf));
-    mapConf.setListDelimiter('\0');
-    return mapConf;
+    this(ClientConfiguration.fromMap(getProperties(conf)), token);
   }
 
   public SaslConnectionParams(ClientConfiguration conf, AuthenticationToken token) {

--- a/core/src/test/java/org/apache/accumulo/core/client/ClientConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/ClientConfigurationTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -65,7 +64,9 @@ public class ClientConfigurationTest {
     third.addProperty(ClientProperty.INSTANCE_ZK_HOST.getKey(), "thirdZkHosts");
     third.addProperty(ClientProperty.INSTANCE_NAME.getKey(), "thirdInstanceName");
     third.addProperty(ClientProperty.INSTANCE_ZK_TIMEOUT.getKey(), "123s");
-    return new ClientConfiguration(Arrays.asList(first, second, third));
+    @SuppressWarnings("deprecation")
+    ClientConfiguration clientConf = new ClientConfiguration(Arrays.asList(first, second, third));
+    return clientConf;
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/ClientContextTest.java
@@ -69,8 +69,7 @@ public class ClientContextTest {
     }
 
     String absPath = getKeyStoreUrl(keystore);
-    ClientConfiguration clientConf = new ClientConfiguration();
-    clientConf.addProperty(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), absPath);
+    ClientConfiguration clientConf = ClientConfiguration.create().with(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), absPath);
 
     AccumuloConfiguration accClientConf = ClientContext.convertClientConfig(clientConf);
     Assert.assertEquals("mysecret", accClientConf.get(Property.INSTANCE_SECRET));
@@ -82,7 +81,7 @@ public class ClientContextTest {
       return;
     }
 
-    ClientConfiguration clientConf = new ClientConfiguration();
+    ClientConfiguration clientConf = ClientConfiguration.create();
 
     AccumuloConfiguration accClientConf = ClientContext.convertClientConfig(clientConf);
     Assert.assertEquals(Property.INSTANCE_SECRET.getDefaultValue(), accClientConf.get(Property.INSTANCE_SECRET));
@@ -95,8 +94,7 @@ public class ClientContextTest {
     }
 
     String absPath = getKeyStoreUrl(keystore);
-    ClientConfiguration clientConf = new ClientConfiguration();
-    clientConf.addProperty(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), absPath);
+    ClientConfiguration clientConf = ClientConfiguration.create().with(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), absPath);
 
     AccumuloConfiguration accClientConf = ClientContext.convertClientConfig(clientConf);
     Map<String,String> props = new HashMap<>();

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsImplTest.java
@@ -38,7 +38,7 @@ public class TableOperationsImplTest {
     Instance instance = EasyMock.createMock(Instance.class);
     Credentials credentials = EasyMock.createMock(Credentials.class);
 
-    ClientContext context = new ClientContext(instance, credentials, new ClientConfiguration());
+    ClientContext context = new ClientContext(instance, credentials, ClientConfiguration.create());
     TableOperationsImpl topsImpl = new TableOperationsImpl(context);
 
     Connector connector = EasyMock.createMock(Connector.class);

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TabletLocatorImplTest.java
@@ -171,7 +171,7 @@ public class TabletLocatorImplTest {
   @Before
   public void setUp() {
     testInstance = new TestInstance("instance1", "tserver1");
-    context = new ClientContext(testInstance, new Credentials("test", null), new ClientConfiguration());
+    context = new ClientContext(testInstance, new Credentials("test", null), ClientConfiguration.create());
   }
 
   private void runTest(Text tableName, List<Range> ranges, TabletLocatorImpl tab1TabletCache, Map<String,Map<KeyExtent,List<Range>>> expected) throws Exception {

--- a/core/src/test/java/org/apache/accumulo/core/client/mapreduce/lib/impl/ConfiguratorBaseTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/mapreduce/lib/impl/ConfiguratorBaseTest.java
@@ -80,7 +80,7 @@ public class ConfiguratorBaseTest {
   @Test
   public void testSetZooKeeperInstance() {
     Configuration conf = new Configuration();
-    ConfiguratorBase.setZooKeeperInstance(this.getClass(), conf, new ClientConfiguration().withInstance("testInstanceName").withZkHosts("testZooKeepers")
+    ConfiguratorBase.setZooKeeperInstance(this.getClass(), conf, ClientConfiguration.create().withInstance("testInstanceName").withZkHosts("testZooKeepers")
         .withSsl(true).withZkTimeout(1234));
     ClientConfiguration clientConf = ClientConfiguration.deserialize(conf.get(ConfiguratorBase.enumToConfKey(this.getClass(),
         ConfiguratorBase.InstanceOpts.CLIENT_CONFIG)));

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-docs</artifactId>
   <packaging>pom</packaging>

--- a/examples/simple/pom.xml
+++ b/examples/simple/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-examples-simple</artifactId>

--- a/examples/simple/src/main/java/org/apache/accumulo/examples/simple/reservations/ARS.java
+++ b/examples/simple/src/main/java/org/apache/accumulo/examples/simple/reservations/ARS.java
@@ -281,7 +281,7 @@ public class ARS {
       } else if (tokens[0].equals("quit") && tokens.length == 1) {
         break;
       } else if (tokens[0].equals("connect") && tokens.length == 6 && ars == null) {
-        ZooKeeperInstance zki = new ZooKeeperInstance(new ClientConfiguration().withInstance(tokens[1]).withZkHosts(tokens[2]));
+        ZooKeeperInstance zki = new ZooKeeperInstance(ClientConfiguration.create().withInstance(tokens[1]).withZkHosts(tokens[2]));
         Connector conn = zki.getConnector(tokens[3], new PasswordToken(tokens[4]));
         if (conn.tableOperations().exists(tokens[5])) {
           ars = new ARS(conn, tokens[5]);

--- a/fate/pom.xml
+++ b/fate/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-fate</artifactId>
   <name>Apache Accumulo Fate</name>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-iterator-test-harness</artifactId>
   <name>Apache Accumulo Iterator Test Harness</name>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -147,7 +147,6 @@
               </excludes>
               <allows>
                 <allow>org[.]apache[.]accumulo[.]core[.](client|data|security)[.](?!.*(impl|thrift|crypto).*).*</allow>
-                <allow>org.apache.commons.configuration.PropertiesConfiguration</allow>
               </allows>
             </configuration>
           </execution>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-minicluster</artifactId>
   <name>Apache Accumulo MiniCluster</name>

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloInstance.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloInstance.java
@@ -38,9 +38,14 @@ public class MiniAccumuloInstance extends ZooKeeperInstance {
    * Construct an {@link Instance} entry point to Accumulo using a {@link MiniAccumuloCluster} directory
    */
   public MiniAccumuloInstance(String instanceName, File directory) throws FileNotFoundException {
-    super(new ClientConfiguration(getConfigProperties(directory)).withInstance(instanceName).withZkHosts(getZooKeepersFromDir(directory)));
+    super(ClientConfiguration.fromFile(new File(new File(directory, "conf"), "client.conf")).withInstance(instanceName)
+        .withZkHosts(getZooKeepersFromDir(directory)));
   }
 
+  /**
+   * @deprecated since 1.9.0; will be removed in 2.0.0 to eliminate commons config leakage into Accumulo API
+   */
+  @Deprecated
   public static PropertiesConfiguration getConfigProperties(File directory) {
     try {
       PropertiesConfiguration conf = new PropertiesConfiguration();

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
@@ -92,8 +92,6 @@ import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriterFactory;
 import org.apache.accumulo.start.Main;
 import org.apache.accumulo.start.classloader.vfs.MiniDFSUtil;
-import org.apache.commons.configuration.AbstractConfiguration;
-import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.impl.VFSClassLoader;
@@ -751,13 +749,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
 
   @Override
   public ClientConfiguration getClientConfig() {
-    return new ClientConfiguration(getConfigs(config)).withInstance(this.getInstanceName()).withZkHosts(this.getZooKeepers());
-  }
-
-  private static List<AbstractConfiguration> getConfigs(MiniAccumuloConfigImpl config) {
-    MapConfiguration cfg = new MapConfiguration(config.getSiteConfig());
-    cfg.setListDelimiter('\0');
-    return Collections.<AbstractConfiguration> singletonList(cfg);
+    return ClientConfiguration.fromMap(config.getSiteConfig()).withInstance(this.getInstanceName()).withZkHosts(this.getZooKeepers());
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>
-  <version>1.8.2-SNAPSHOT</version>
+  <version>1.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Accumulo Project</name>
   <description>Apache Accumulo is a sorted, distributed key/value store based

--- a/pom.xml
+++ b/pom.xml
@@ -797,7 +797,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>apilyzer-maven-plugin</artifactId>
-          <version>1.0.1</version>
+          <version>1.2.0</version>
         </plugin>
         <plugin>
           <groupId>com.googlecode.maven-java-formatter-plugin</groupId>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-proxy</artifactId>
   <name>Apache Accumulo Proxy</name>

--- a/proxy/src/main/java/org/apache/accumulo/proxy/Proxy.java
+++ b/proxy/src/main/java/org/apache/accumulo/proxy/Proxy.java
@@ -220,7 +220,7 @@ public class Proxy implements KeywordExecutable {
         sslParams = SslConnectionParams.forClient(ClientContext.convertClientConfig(clientConf));
         break;
       case SASL:
-        if (!clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+        if (!clientConf.hasSasl()) {
           // ACCUMULO-3651 Changed level to error and added FATAL to message for slf4j capability
           log.error("FATAL: SASL thrift server was requested but it is disabled in client configuration");
           throw new RuntimeException("SASL is not enabled in configuration");

--- a/proxy/src/main/java/org/apache/accumulo/proxy/ProxyServer.java
+++ b/proxy/src/main/java/org/apache/accumulo/proxy/ProxyServer.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.proxy;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -112,7 +113,6 @@ import org.apache.accumulo.proxy.thrift.UnknownWriter;
 import org.apache.accumulo.proxy.thrift.WriterOptions;
 import org.apache.accumulo.server.rpc.ThriftServerType;
 import org.apache.accumulo.server.rpc.UGIAssumingProcessor;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -197,11 +197,7 @@ public class ProxyServer implements AccumuloProxy.Iface {
       ClientConfiguration clientConf;
       if (props.containsKey("clientConfigurationFile")) {
         String clientConfFile = props.getProperty("clientConfigurationFile");
-        try {
-          clientConf = new ClientConfiguration(clientConfFile);
-        } catch (ConfigurationException e) {
-          throw new RuntimeException(e);
-        }
+        clientConf = ClientConfiguration.fromFile(new File(clientConfFile));
       } else {
         clientConf = ClientConfiguration.loadDefault();
       }

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-server-base</artifactId>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-gc</artifactId>

--- a/server/master/pom.xml
+++ b/server/master/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-master</artifactId>

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-monitor</artifactId>

--- a/server/native/pom.xml
+++ b/server/native/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-native</artifactId>

--- a/server/tracer/pom.xml
+++ b/server/tracer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-tracer</artifactId>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>accumulo-tserver</artifactId>

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
@@ -46,7 +46,7 @@ public class ReplicationProcessorTest {
     Instance inst = EasyMock.createMock(Instance.class);
     VolumeManager fs = EasyMock.createMock(VolumeManager.class);
     Credentials creds = new Credentials("foo", new PasswordToken("bar"));
-    ClientContext context = new ClientContext(inst, creds, new ClientConfiguration());
+    ClientContext context = new ClientContext(inst, creds, ClientConfiguration.create());
 
     Map<String,String> data = new HashMap<>();
 
@@ -65,7 +65,7 @@ public class ReplicationProcessorTest {
     Instance inst = EasyMock.createMock(Instance.class);
     VolumeManager fs = EasyMock.createMock(VolumeManager.class);
     Credentials creds = new Credentials("foo", new PasswordToken("bar"));
-    ClientContext context = new ClientContext(inst, creds, new ClientConfiguration());
+    ClientContext context = new ClientContext(inst, creds, ClientConfiguration.create());
 
     Map<String,String> data = new HashMap<>();
     ConfigurationCopy conf = new ConfigurationCopy(data);

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-shell</artifactId>
   <name>Apache Accumulo Shell</name>

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
@@ -303,7 +303,8 @@ public class ShellOptionsJC {
   }
 
   public ClientConfiguration getClientConfiguration() throws ConfigurationException, FileNotFoundException {
-    ClientConfiguration clientConfig = clientConfigFile == null ? ClientConfiguration.loadDefault() : new ClientConfiguration(getClientConfigFile());
+    ClientConfiguration clientConfig = clientConfigFile == null ? ClientConfiguration.loadDefault() : ClientConfiguration.fromFile(new File(
+        getClientConfigFile()));
     if (useSsl()) {
       clientConfig.setProperty(ClientProperty.INSTANCE_RPC_SSL_ENABLED, "true");
     }

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellConfigTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellConfigTest.java
@@ -120,21 +120,21 @@ public class ShellConfigTest {
    */
   @Test
   public void testZooKeeperHostFallBackToSite() throws Exception {
-    ClientConfiguration clientConfig = new ClientConfiguration();
+    ClientConfiguration clientConfig = ClientConfiguration.create();
     assertFalse("Client config contains zk hosts", clientConfig.containsKey(ClientConfiguration.ClientProperty.INSTANCE_ZK_HOST.getKey()));
     assertEquals("ShellConfigTestZKHostValue", Shell.getZooKeepers(null, clientConfig));
   }
 
   @Test
   public void testZooKeeperHostFromClientConfig() throws Exception {
-    ClientConfiguration clientConfig = new ClientConfiguration();
+    ClientConfiguration clientConfig = ClientConfiguration.create();
     clientConfig.withZkHosts("cc_hostname");
     assertEquals("cc_hostname", Shell.getZooKeepers(null, clientConfig));
   }
 
   @Test
   public void testZooKeeperHostFromOption() throws Exception {
-    ClientConfiguration clientConfig = new ClientConfiguration();
+    ClientConfiguration clientConfig = ClientConfiguration.create();
     clientConfig.withZkHosts("cc_hostname");
     assertEquals("opt_hostname", Shell.getZooKeepers("opt_hostname", clientConfig));
   }

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellSetInstanceTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellSetInstanceTest.java
@@ -213,7 +213,7 @@ public class ShellSetInstanceTest {
 
     ZooKeeperInstance theInstance = createMock(ZooKeeperInstance.class);
 
-    expectNew(ZooKeeperInstance.class, clientConf).andReturn(theInstance);
+    expectNew(ZooKeeperInstance.class, new Class<?>[] {ClientConfiguration.class}, clientConf).andReturn(theInstance);
     replay(theInstance, ZooKeeperInstance.class);
 
     shell.setInstance(opts);
@@ -261,7 +261,7 @@ public class ShellSetInstanceTest {
     replay(opts);
 
     ZooKeeperInstance theInstance = createMock(ZooKeeperInstance.class);
-    expectNew(ZooKeeperInstance.class, clientConf).andReturn(theInstance);
+    expectNew(ZooKeeperInstance.class, new Class<?>[] {ClientConfiguration.class}, clientConf).andReturn(theInstance);
     replay(theInstance, ZooKeeperInstance.class);
 
     shell.setInstance(opts);

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-start</artifactId>
   <name>Apache Accumulo Start</name>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-test</artifactId>
   <name>Apache Accumulo Testing</name>

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.cluster.ClusterUsers;
 import org.apache.accumulo.cluster.standalone.StandaloneAccumuloCluster;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.admin.TableOperations;
@@ -141,7 +140,7 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase implements M
 
         // For SASL, we need to get the Hadoop configuration files as well otherwise UGI will log in as SIMPLE instead of KERBEROS
         Configuration hadoopConfiguration = standaloneCluster.getHadoopConfiguration();
-        if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+        if (clientConf.hasSasl()) {
           UserGroupInformation.setConfiguration(hadoopConfiguration);
           // Login as the admin user to start the tests
           UserGroupInformation.loginUserFromKeytab(conf.getAdminPrincipal(), conf.getAdminKeytab().getAbsolutePath());

--- a/test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.harness.AccumuloClusterHarness.ClusterType;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
@@ -87,11 +86,7 @@ public class StandaloneAccumuloClusterConfiguration extends AccumuloClusterPrope
 
     this.conf = getConfiguration(type);
     this.clientConfFile = clientConfFile;
-    try {
-      this.clientConf = new ClientConfiguration(clientConfFile);
-    } catch (ConfigurationException e) {
-      throw new RuntimeException("Failed to load client configuration from " + clientConfFile);
-    }
+    this.clientConf = ClientConfiguration.fromFile(clientConfFile);
     // Update instance name if not already set
     if (!clientConf.containsKey(ClientProperty.INSTANCE_NAME.getKey())) {
       clientConf.withInstance(getInstanceName());
@@ -160,7 +155,7 @@ public class StandaloneAccumuloClusterConfiguration extends AccumuloClusterPrope
 
   @Override
   public AuthenticationToken getAdminToken() {
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       File keytab = getAdminKeytab();
       try {
         UserGroupInformation.loginUserFromKeytab(getAdminPrincipal(), keytab.getAbsolutePath());

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.ConditionalWriter.Result;
 import org.apache.accumulo.core.client.ConditionalWriter.Status;
@@ -235,7 +234,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
 
     String user = null;
     ClientConfiguration clientConf = cluster.getClientConfig();
-    final boolean saslEnabled = clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false);
+    final boolean saslEnabled = clientConf.hasSasl();
 
     ClusterUser user1 = getUser(0);
     user = user1.getPrincipal();
@@ -1202,7 +1201,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
     Connector conn = getConnector();
     String user = null;
     ClientConfiguration clientConf = cluster.getClientConfig();
-    final boolean saslEnabled = clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false);
+    final boolean saslEnabled = clientConf.hasSasl();
 
     // Create a new user
     ClusterUser user1 = getUser(0);

--- a/test/src/main/java/org/apache/accumulo/test/IMMLGBenchmark.java
+++ b/test/src/main/java/org/apache/accumulo/test/IMMLGBenchmark.java
@@ -54,7 +54,7 @@ import com.google.common.collect.Iterators;
  */
 public class IMMLGBenchmark {
   public static void main(String[] args) throws Exception {
-    ZooKeeperInstance zki = new ZooKeeperInstance(new ClientConfiguration().withInstance("test16").withZkHosts("localhost"));
+    ZooKeeperInstance zki = new ZooKeeperInstance(ClientConfiguration.create().withInstance("test16").withZkHosts("localhost"));
     Connector conn = zki.getConnector("root", new PasswordToken("secret"));
 
     int numlg = Integer.parseInt(args[0]);

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -43,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
@@ -72,7 +71,6 @@ import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.accumulo.test.categories.SunnyDayTests;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.accumulo.tracer.TraceServer;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -158,17 +156,13 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
     TestShell(String user, String rootPass, String instanceName, String zookeepers, File configFile) throws IOException {
       ClientConfiguration clientConf;
-      try {
-        clientConf = new ClientConfiguration(configFile);
-      } catch (ConfigurationException e) {
-        throw new IOException(e);
-      }
+      clientConf = ClientConfiguration.fromFile(configFile);
       // start the shell
       output = new TestOutputStream();
       input = new StringInputStream();
       shell = new Shell(new ConsoleReader(input, output));
       shell.setLogErrorsToConsole();
-      if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+      if (clientConf.hasSasl()) {
         // Pull the kerberos principal out when we're using SASL
         shell.config("-u", user, "-z", instanceName, zookeepers, "--config-file", configFile.getAbsolutePath());
       } else {
@@ -343,7 +337,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("exporttable -t " + table + " " + exportUri, true);
     DistCp cp = newDistCp(new Configuration(false));
     String import_ = "file://" + new File(rootPath, "ShellServerIT.import").toString();
-    if (getCluster().getClientConfig().getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (getCluster().getClientConfig().hasSasl()) {
       // DistCp bugs out trying to get a fs delegation token to perform the cp. Just copy it ourselves by hand.
       FileSystem fs = getCluster().getFileSystem();
       FileSystem localFs = FileSystem.getLocal(new Configuration(false));

--- a/test/src/main/java/org/apache/accumulo/test/UsersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UsersIT.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -41,7 +40,7 @@ public class UsersIT extends AccumuloClusterHarness {
     // Ensure that the user exists
     if (!currentUsers.contains(user0.getPrincipal())) {
       PasswordToken token = null;
-      if (!getCluster().getClientConfig().getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+      if (!getCluster().getClientConfig().hasSasl()) {
         token = new PasswordToken(user0.getPassword());
       }
       conn.securityOperations().createLocalUser(user0.getPrincipal(), token);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableExistsException;
@@ -123,7 +122,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
     TestIngest.Opts opts = new TestIngest.Opts();
     VerifyIngest.Opts vopts = new VerifyIngest.Opts();
     ClientConfiguration conf = cluster.getClientConfig();
-    if (conf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (conf.hasSasl()) {
       opts.updateKerberosCredentials(cluster.getClientConfig());
       vopts.updateKerberosCredentials(cluster.getClientConfig());
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
@@ -23,7 +23,6 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -70,7 +69,7 @@ public class ChaoticBalancerIT extends AccumuloClusterHarness {
     opts.setTableName(tableName);
     vopts.setTableName(tableName);
     ClientConfiguration clientConfig = getCluster().getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
       vopts.updateKerberosCredentials(clientConfig);
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.accumulo.core.cli.ClientOpts.Password;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
@@ -141,7 +140,7 @@ public class CompactionIT extends AccumuloClusterHarness {
               opts.dataSize = 50;
               opts.cols = 1;
               opts.setTableName(tableName);
-              if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+              if (clientConf.hasSasl()) {
                 opts.updateKerberosCredentials(clientConf);
               } else {
                 opts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
@@ -182,7 +182,7 @@ public class ConfigurableMacBase extends AccumuloITBase {
   }
 
   protected ClientConfiguration getClientConfig() throws Exception {
-    return new ClientConfiguration(getCluster().getConfig().getClientConfFile());
+    return ClientConfiguration.fromFile(getCluster().getConfig().getClientConfFile());
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
@@ -65,7 +64,7 @@ public class CredentialsIT extends AccumuloClusterHarness {
     ClientConfiguration clientConf = cluster.getClientConfig();
     ClusterUser user = getUser(0);
     username = user.getPrincipal();
-    saslEnabled = clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false);
+    saslEnabled = clientConf.hasSasl();
     // Create the user if it doesn't exist
     Set<String> users = conn.securityOperations().listLocalUsers();
     if (!users.contains(username)) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/DynamicThreadPoolsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DynamicThreadPoolsIT.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
@@ -88,7 +87,7 @@ public class DynamicThreadPoolsIT extends AccumuloClusterHarness {
     opts.createTable = true;
     opts.setTableName(firstTable);
     ClientConfiguration clientConf = cluster.getClientConfig();
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       opts.updateKerberosCredentials(clientConf);
     } else {
       opts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -22,7 +22,6 @@ import java.util.Random;
 
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.TestIngest;
@@ -55,7 +54,7 @@ public class FateStarvationIT extends AccumuloClusterHarness {
     opts.cols = 1;
     opts.setTableName(tableName);
     ClientConfiguration clientConf = cluster.getClientConfig();
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       opts.updateKerberosCredentials(clientConf);
     } else {
       opts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterFailoverIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterFailoverIT.java
@@ -22,7 +22,6 @@ import org.apache.accumulo.cluster.ClusterControl;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -55,7 +54,7 @@ public class MasterFailoverIT extends AccumuloClusterHarness {
     TestIngest.Opts opts = new TestIngest.Opts();
     opts.setTableName(names[0]);
     ClientConfiguration clientConf = cluster.getClientConfig();
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       opts.updateKerberosCredentials(clientConf);
     } else {
       opts.setPrincipal(getAdminPrincipal());
@@ -70,7 +69,7 @@ public class MasterFailoverIT extends AccumuloClusterHarness {
     c.tableOperations().rename(names[0], names[1]);
     VerifyIngest.Opts vopts = new VerifyIngest.Opts();
     vopts.setTableName(names[1]);
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       vopts.updateKerberosCredentials(clientConf);
     } else {
       vopts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
@@ -25,7 +25,6 @@ import java.util.Random;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.conf.Property;
@@ -107,7 +106,7 @@ public class MaxOpenIT extends AccumuloClusterHarness {
       opts.cols = 1;
       opts.random = i;
       opts.setTableName(tableName);
-      if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+      if (clientConf.hasSasl()) {
         opts.updateKerberosCredentials(clientConf);
       } else {
         opts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
@@ -321,7 +320,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
         break;
       case OBTAIN_DELEGATION_TOKEN:
         ClientConfiguration clientConf = cluster.getClientConfig();
-        if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+        if (clientConf.hasSasl()) {
           // TODO Try to obtain a delegation token without the permission
         }
         break;
@@ -464,7 +463,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
         break;
       case OBTAIN_DELEGATION_TOKEN:
         ClientConfiguration clientConf = cluster.getClientConfig();
-        if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+        if (clientConf.hasSasl()) {
           // TODO Try to obtain a delegation token with the permission
         }
         break;

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -62,7 +62,6 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
@@ -207,7 +206,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     opts.columnFamily = colf;
     opts.createTable = true;
     opts.setTableName(tableName);
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
     } else {
       opts.setPrincipal(principal);
@@ -231,7 +230,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     opts.startRow = offset;
     opts.columnFamily = colf;
     opts.setTableName(tableName);
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
     } else {
       opts.setPrincipal(principal);
@@ -259,7 +258,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
           ClientConfiguration clientConf = cluster.getClientConfig();
           // Invocation is different for SASL. We're only logged in via this processes memory (not via some credentials cache on disk)
           // Need to pass along the keytab because of that.
-          if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+          if (clientConf.hasSasl()) {
             String principal = getAdminPrincipal();
             AuthenticationToken token = getAdminToken();
             assertTrue("Expected KerberosToken, but was " + token.getClass(), token instanceof KerberosToken);
@@ -288,7 +287,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
           ClientConfiguration clientConf = cluster.getClientConfig();
           // Invocation is different for SASL. We're only logged in via this processes memory (not via some credentials cache on disk)
           // Need to pass along the keytab because of that.
-          if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+          if (clientConf.hasSasl()) {
             String principal = getAdminPrincipal();
             AuthenticationToken token = getAdminToken();
             assertTrue("Expected KerberosToken, but was " + token.getClass(), token instanceof KerberosToken);
@@ -423,7 +422,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
           System.setOut(newOut);
           List<String> args = new ArrayList<>();
           args.add(entry.getKey().getColumnQualifier().toString());
-          if (ClusterType.STANDALONE == getClusterType() && cluster.getClientConfig().getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+          if (ClusterType.STANDALONE == getClusterType() && cluster.getClientConfig().hasSasl()) {
             args.add("--config");
             StandaloneAccumuloCluster sac = (StandaloneAccumuloCluster) cluster;
             String hadoopConfDir = sac.getHadoopConfDir();

--- a/test/src/main/java/org/apache/accumulo/test/functional/RenameIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RenameIT.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.test.functional;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.TestIngest;
@@ -45,7 +44,7 @@ public class RenameIT extends AccumuloClusterHarness {
     opts.setTableName(name1);
 
     final ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
     } else {
       opts.setPrincipal(getAdminPrincipal());
@@ -57,7 +56,7 @@ public class RenameIT extends AccumuloClusterHarness {
     TestIngest.ingest(c, opts, bwOpts);
     VerifyIngest.Opts vopts = new VerifyIngest.Opts();
 
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       vopts.updateKerberosCredentials(clientConfig);
     } else {
       vopts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
@@ -159,7 +158,7 @@ public class RestartIT extends AccumuloClusterHarness {
     OPTS.setTableName(tableName);
     VOPTS.setTableName(tableName);
     ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       OPTS.updateKerberosCredentials(clientConfig);
       VOPTS.updateKerberosCredentials(clientConfig);
     } else {
@@ -270,7 +269,7 @@ public class RestartIT extends AccumuloClusterHarness {
     OPTS.setTableName(tableName);
     VOPTS.setTableName(tableName);
     ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       OPTS.updateKerberosCredentials(clientConfig);
       VOPTS.updateKerberosCredentials(clientConfig);
     } else {
@@ -306,7 +305,7 @@ public class RestartIT extends AccumuloClusterHarness {
     c.tableOperations().create(tableName);
     OPTS.setTableName(tableName);
     ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       OPTS.updateKerberosCredentials(clientConfig);
     } else {
       OPTS.setPrincipal(getAdminPrincipal());
@@ -326,7 +325,7 @@ public class RestartIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     VOPTS.setTableName(tableName);
     ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       OPTS.updateKerberosCredentials(clientConfig);
       VOPTS.updateKerberosCredentials(clientConfig);
     } else {
@@ -347,7 +346,7 @@ public class RestartIT extends AccumuloClusterHarness {
       c.tableOperations().setProperty(MetadataTable.NAME, Property.TABLE_SPLIT_THRESHOLD.getKey(), "20K");
       TestIngest.Opts opts = new TestIngest.Opts();
       opts.setTableName(tableName);
-      if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+      if (clientConfig.hasSasl()) {
         opts.updateKerberosCredentials(clientConfig);
       } else {
         opts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIteratorIT.java
@@ -32,7 +32,6 @@ import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
@@ -47,7 +46,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
-import org.apache.accumulo.test.functional.AuthsIterator;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.After;
@@ -79,7 +77,7 @@ public class ScanIteratorIT extends AccumuloClusterHarness {
     ClusterUser clusterUser = getUser(0);
     user = clusterUser.getPrincipal();
     PasswordToken userToken;
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       userToken = null;
       saslEnabled = true;
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -29,7 +29,6 @@ import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
@@ -132,7 +131,7 @@ public class SplitIT extends AccumuloClusterHarness {
     opts.setTableName(table);
 
     ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
       vopts.updateKerberosCredentials(clientConfig);
     } else {
@@ -165,7 +164,7 @@ public class SplitIT extends AccumuloClusterHarness {
     assertTrue("Count should be cgreater than 10: " + count, count > 10);
 
     String[] args;
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       ClusterUser rootUser = getAdminUser();
       args = new String[] {"-i", cluster.getInstanceName(), "-u", rootUser.getPrincipal(), "--keytab", rootUser.getKeytab().getAbsolutePath(), "-z",
           cluster.getZooKeepers()};
@@ -204,7 +203,7 @@ public class SplitIT extends AccumuloClusterHarness {
     c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "10K");
     ClientConfiguration clientConfig = getCluster().getClientConfig();
     String password = null, keytab = null;
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       keytab = getAdminUser().getKeytab().getAbsolutePath();
     } else {
       password = new String(((PasswordToken) getAdminToken()).getPassword(), UTF_8);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.cluster.AccumuloCluster;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.TableOperations;
@@ -72,7 +71,7 @@ public class TableIT extends AccumuloClusterHarness {
     TestIngest.Opts opts = new TestIngest.Opts();
     VerifyIngest.Opts vopts = new VerifyIngest.Opts();
     ClientConfiguration clientConfig = getCluster().getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
       vopts.updateKerberosCredentials(clientConfig);
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogIT.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.test.functional;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -60,7 +59,7 @@ public class WriteAheadLogIT extends AccumuloClusterHarness {
     opts.setTableName(tableName);
 
     ClientConfiguration clientConfig = cluster.getClientConfig();
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       opts.updateKerberosCredentials(clientConfig);
       vopts.updateKerberosCredentials(clientConfig);
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/WriteLotsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WriteLotsIT.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.accumulo.core.cli.BatchWriterOpts;
 import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.TestIngest;
@@ -57,7 +56,7 @@ public class WriteLotsIT extends AccumuloClusterHarness {
             opts.startRow = index * 10000;
             opts.rows = 10000;
             opts.setTableName(tableName);
-            if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+            if (clientConfig.hasSasl()) {
               opts.updateKerberosCredentials(clientConfig);
             } else {
               opts.setPrincipal(getAdminPrincipal());
@@ -81,7 +80,7 @@ public class WriteLotsIT extends AccumuloClusterHarness {
     VerifyIngest.Opts vopts = new VerifyIngest.Opts();
     vopts.rows = 10000 * THREADS;
     vopts.setTableName(tableName);
-    if (clientConfig.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConfig.hasSasl()) {
       vopts.updateKerberosCredentials(clientConfig);
     } else {
       vopts.setPrincipal(getAdminPrincipal());

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
@@ -167,7 +167,7 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
 
       job.setInputFormat(AccumuloInputFormat.class);
 
-      ClientConfiguration clientConfig = new ClientConfiguration().withInstance(instanceName).withZkHosts(zooKeepers);
+      ClientConfiguration clientConfig = ClientConfiguration.create().withInstance(instanceName).withZkHosts(zooKeepers);
 
       AccumuloInputFormat.setConnectorInfo(job, user, new PasswordToken(pass));
       AccumuloInputFormat.setInputTableName(job, table1);

--- a/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/metadata/MetadataBatchScanTest.java
@@ -67,7 +67,7 @@ public class MetadataBatchScanTest {
 
     ClientOpts opts = new ClientOpts();
     opts.parseArgs(MetadataBatchScanTest.class.getName(), args);
-    Instance inst = new ZooKeeperInstance(new ClientConfiguration().withInstance("acu14").withZkHosts("localhost"));
+    Instance inst = new ZooKeeperInstance(ClientConfiguration.create().withInstance("acu14").withZkHosts("localhost"));
     final Connector connector = inst.getConnector(opts.getPrincipal(), opts.getToken());
 
     TreeSet<Long> splits = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/multitable/CopyTool.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/multitable/CopyTool.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.test.randomwalk.multitable;
 import java.io.IOException;
 
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
@@ -63,7 +62,7 @@ public class CopyTool extends Configured implements Tool {
       return 1;
     }
 
-    ClientConfiguration clientConf = new ClientConfiguration().withInstance(args[3]).withZkHosts(args[4]);
+    ClientConfiguration clientConf = ClientConfiguration.create().withInstance(args[3]).withZkHosts(args[4]);
 
     job.setInputFormatClass(AccumuloInputFormat.class);
     AccumuloInputFormat.setInputTableName(job, args[2]);
@@ -72,7 +71,7 @@ public class CopyTool extends Configured implements Tool {
 
     final String principal;
     final AuthenticationToken token;
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       // Use the Kerberos creds to request a DelegationToken for MapReduce to use
       // We could use the specified keytab (args[1]), but we're already logged in and don't need to, so we can just use the current user
       KerberosToken kt = new KerberosToken();

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/security/SecurityFixture.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/security/SecurityFixture.java
@@ -20,7 +20,6 @@ import java.net.InetAddress;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.security.Authorizations;
@@ -37,7 +36,7 @@ public class SecurityFixture extends Fixture {
     String secTableName, systemUserName, tableUserName, secNamespaceName;
     // A best-effort sanity check to guard against not password-based auth
     ClientConfiguration clientConf = ClientConfiguration.loadDefault();
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       throw new IllegalStateException("Security module currently cannot support Kerberos/SASL instances");
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/sequential/MapRedVerifyTool.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/sequential/MapRedVerifyTool.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import org.apache.accumulo.core.client.ClientConfiguration;
-import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
@@ -102,7 +101,7 @@ public class MapRedVerifyTool extends Configured implements Tool {
     AccumuloOutputFormat.setZooKeeperInstance(job, clientConf);
 
     job.setInputFormatClass(AccumuloInputFormat.class);
-    if (clientConf.getBoolean(ClientProperty.INSTANCE_RPC_SASL_ENABLED.getKey(), false)) {
+    if (clientConf.hasSasl()) {
       // Better be logged in
       KerberosToken token = new KerberosToken();
       try {

--- a/test/src/main/java/org/apache/accumulo/test/scalability/ScaleTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/scalability/ScaleTest.java
@@ -48,7 +48,8 @@ public abstract class ScaleTest {
     String password = this.scaleProps.getProperty("PASSWORD");
     System.out.println(password);
 
-    conn = new ZooKeeperInstance(new ClientConfiguration().withInstance(instanceName).withZkHosts(zookeepers)).getConnector(user, new PasswordToken(password));
+    conn = new ZooKeeperInstance(ClientConfiguration.create().withInstance(instanceName).withZkHosts(zookeepers)).getConnector(user,
+        new PasswordToken(password));
   }
 
   protected void startTimer() {

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.accumulo</groupId>
     <artifactId>accumulo-project</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-trace</artifactId>
   <name>Apache Accumulo Trace</name>


### PR DESCRIPTION
In 3 commits:

1. Bump to version 1.9.0 as required by semver for API additions, and so we can deprecate and remove the offending API in 2.0.0 as discussed on the mailing list
2. Update apilyzer rules to find offending APIs with respect to commons-config
3. Fix

The third "fix" commit is the most interesting one. If necessary, I can push the first two to a branch, and then then do a pull request with just the last commit against that branch, so it's easier to review on its own. Reviewers, let me know if you want me to do that.

@joshelser Tagging you here for review, b/c GitHub won't show your GitHub user name in the "Request reviewers" dialog. Probably b/c you haven't sync'd with GitBox to be added to the repo? Not sure.