### PR TITLE
ACCUMULO-4780 Add overflow check to seq num in CommitSession

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/AccumuloTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/AccumuloTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileNotFoundException;
 
-import com.google.common.collect.Sets;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.commons.io.FileUtils;
@@ -35,6 +34,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.Sets;
 
 public class AccumuloTest {
   private FileSystem fs;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
@@ -23,11 +23,11 @@ import org.apache.accumulo.core.data.Mutation;
 
 public class TabletMutations {
   private final int tid;
-  private final int seq;
+  private final long seq;
   private final List<Mutation> mutations;
   private final Durability durability;
 
-  public TabletMutations(int tid, int seq, List<Mutation> mutations, Durability durability) {
+  public TabletMutations(int tid, long seq, List<Mutation> mutations, Durability durability) {
     this.tid = tid;
     this.seq = seq;
     this.mutations = mutations;
@@ -42,7 +42,7 @@ public class TabletMutations {
     return tid;
   }
 
-  public int getSeq() {
+  public long getSeq() {
     return seq;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2998,13 +2998,13 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     return durability;
   }
 
-  public void minorCompactionFinished(CommitSession tablet, String newDatafile, int walogSeq) throws IOException {
+  public void minorCompactionFinished(CommitSession tablet, String newDatafile, long walogSeq) throws IOException {
     Durability durability = getMincEventDurability(tablet.getExtent());
     totalMinorCompactions.incrementAndGet();
     logger.minorCompactionFinished(tablet, newDatafile, walogSeq, durability);
   }
 
-  public void minorCompactionStarted(CommitSession tablet, int lastUpdateSequence, String newMapfileLocation) throws IOException {
+  public void minorCompactionStarted(CommitSession tablet, long lastUpdateSequence, String newMapfileLocation) throws IOException {
     Durability durability = getMincEventDurability(tablet.getExtent());
     logger.minorCompactionStarted(tablet, lastUpdateSequence, newMapfileLocation, durability);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -518,7 +518,7 @@ public class DfsLogger {
       }
   }
 
-  public synchronized void defineTablet(int seq, int tid, KeyExtent tablet) throws IOException {
+  public synchronized void defineTablet(long seq, int tid, KeyExtent tablet) throws IOException {
     // write this log to the METADATA table
     final LogFileKey key = new LogFileKey();
     key.event = DEFINE_TABLET;
@@ -539,7 +539,7 @@ public class DfsLogger {
     encryptingLogFile.flush();
   }
 
-  public LoggerOperation log(int seq, int tid, Mutation mutation, Durability durability) throws IOException {
+  public LoggerOperation log(long seq, int tid, Mutation mutation, Durability durability) throws IOException {
     return logManyTablets(Collections.singletonList(new TabletMutations(tid, seq, Collections.singletonList(mutation), durability)));
   }
 
@@ -601,7 +601,7 @@ public class DfsLogger {
     return result;
   }
 
-  public LoggerOperation minorCompactionFinished(int seq, int tid, String fqfn, Durability durability) throws IOException {
+  public LoggerOperation minorCompactionFinished(long seq, int tid, String fqfn, Durability durability) throws IOException {
     LogFileKey key = new LogFileKey();
     key.event = COMPACTION_FINISH;
     key.seq = seq;
@@ -609,7 +609,7 @@ public class DfsLogger {
     return logFileData(Collections.singletonList(new Pair<>(key, EMPTY)), durability);
   }
 
-  public LoggerOperation minorCompactionStarted(int seq, int tid, String fqfn, Durability durability) throws IOException {
+  public LoggerOperation minorCompactionStarted(long seq, int tid, String fqfn, Durability durability) throws IOException {
     LogFileKey key = new LogFileKey();
     key.event = COMPACTION_START;
     key.seq = seq;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -395,7 +395,7 @@ public class TabletServerLogger {
     });
   }
 
-  public int log(final CommitSession commitSession, final int tabletSeq, final Mutation m, final Durability durability) throws IOException {
+  public int log(final CommitSession commitSession, final long tabletSeq, final Mutation m, final Durability durability) throws IOException {
     if (durability == Durability.NONE) {
       return -1;
     }
@@ -446,7 +446,7 @@ public class TabletServerLogger {
     return seq;
   }
 
-  public void minorCompactionFinished(final CommitSession commitSession, final String fullyQualifiedFileName, final int walogSeq, final Durability durability)
+  public void minorCompactionFinished(final CommitSession commitSession, final String fullyQualifiedFileName, final long walogSeq, final Durability durability)
       throws IOException {
 
     long t1 = System.currentTimeMillis();
@@ -464,7 +464,7 @@ public class TabletServerLogger {
     log.debug(" wrote MinC finish  {}: writeTime:{}ms  durability:{}", seq, (t2 - t1), durability);
   }
 
-  public int minorCompactionStarted(final CommitSession commitSession, final int seq, final String fullyQualifiedFileName, final Durability durability)
+  public long minorCompactionStarted(final CommitSession commitSession, final long seq, final String fullyQualifiedFileName, final Durability durability)
       throws IOException {
     write(commitSession, false, new Writer() {
       @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CommitSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CommitSession.java
@@ -30,21 +30,21 @@ public class CommitSession {
 
   private static final Logger log = LoggerFactory.getLogger(CommitSession.class);
 
-  private final int seq;
+  private final long seq;
   private final InMemoryMap memTable;
   private final TabletCommitter committer;
 
   private int commitsInProgress;
   private long maxCommittedTime = Long.MIN_VALUE;
 
-  CommitSession(TabletCommitter committer, int seq, InMemoryMap imm) {
+  CommitSession(TabletCommitter committer, long seq, InMemoryMap imm) {
     this.seq = seq;
     this.memTable = imm;
     this.committer = committer;
     commitsInProgress = 0;
   }
 
-  public int getWALogSeq() {
+  public long getWALogSeq() {
     return seq;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -35,7 +35,7 @@ class TabletMemory implements Closeable {
   private InMemoryMap memTable;
   private InMemoryMap otherMemTable;
   private InMemoryMap deletingMemTable;
-  private int nextSeq = 1;
+  private long nextSeq = 1L;
   private CommitSession commitSession;
 
   TabletMemory(TabletCommitter tablet) {


### PR DESCRIPTION
ACCUMULO-4780 Add overflow check to sequence number in CommitSession

Ticket suggested adding overflow check to sequence number or converting to long.
This PR converted the sequence number from an int to long to prevent fear of future
overflow. The change propagated to several other files that made use of or called
methods that utilized the sequence number.

Updated the affected files and re-ran uni and integration (sunnyday) tests to verify all tests still passed. All tests still passed.