### PR TITLE
ACCUMULO-3361 CryptoTest creates files in /tmp/tmp

### DIFF
--- a/core/src/test/resources/crypto-on-accumulo-site.xml
+++ b/core/src/test/resources/crypto-on-accumulo-site.xml
@@ -113,7 +113,7 @@
     </property>
     <property>
       <name>instance.dfs.dir</name>
-      <value>/tmp</value>
+      <value>target/dfs</value>
     </property>
     <property>
       <name>instance.dfs.uri</name>
@@ -126,7 +126,7 @@
     </property>
     <property>
       <name>crypto.default.key.strategy.key.location</name>
-      <value>/tmp/test.secret.key</value>
+      <value>test.secret.key</value>
     </property>
     
     <property>


### PR DESCRIPTION
ACCUMULO-3361 CryptoTest creates files in /tmp/tmp

Updated the crypto-on-accumulo-site.xml resource file to use target/dfs rather than /tmp for
location of instance.dfs.dir in cryptoTest. As a result the test.secret.key is now written
underneath the target directory rather than /tmp.