### PR TITLE
ACCUMULO-4772 Update shell to use NewTableConfiguration methods

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -242,8 +242,7 @@ public class CreateTableCommand extends Command {
   }
 
   /**
-   * Validate that the provided scope arguments are valid iterator scope settings.
-   * Checking for duplicate entries and invalid scope values.
+   * Validate that the provided scope arguments are valid iterator scope settings. Checking for duplicate entries and invalid scope values.
    *
    * Returns an EnumSet of scopes to be set.
    */

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.constraints.VisibilityConstraint;
 import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.accumulo.shell.ShellUtil;
@@ -198,7 +199,7 @@ public class CreateTableCommand extends Command {
    * Used in conjunction with createtable shell command to allow an iterator to be configured upon table creation.
    */
   private NewTableConfiguration attachIteratorToNewTable(final CommandLine cl, final Shell shellState, NewTableConfiguration ntc) {
-    EnumSet<IteratorUtil.IteratorScope> scopeEnumSet = null;
+    EnumSet<IteratorScope> scopeEnumSet = null;
     IteratorSetting iteratorSetting = null;
     if (shellState.iteratorProfiles.size() == 0)
       throw new IllegalArgumentException("No shell iterator profiles have been created.");
@@ -217,7 +218,7 @@ public class CreateTableCommand extends Command {
       // handle case where only the profile is supplied. Use all scopes by default if no scope args are provided.
       if (parts.length == 1) {
         // add all scopes to enum set
-        scopeEnumSet = EnumSet.allOf(IteratorUtil.IteratorScope.class);
+        scopeEnumSet = EnumSet.allOf(IteratorScope.class);
       } else {
         // user provided scope arguments exist, parse them
         List<String> scopeArgs = Arrays.asList(parts[1].split(","));
@@ -229,7 +230,7 @@ public class CreateTableCommand extends Command {
         if (scopeArgs.contains("all")) {
           if (scopeArgs.size() > 1)
             throw new IllegalArgumentException("Cannot use 'all' in conjunction with other scopes");
-          scopeEnumSet = EnumSet.allOf(IteratorUtil.IteratorScope.class);
+          scopeEnumSet = EnumSet.allOf(IteratorScope.class);
         } else {
           // 'all' is not involved, examine the scope arguments and populate iterator scope EnumSet
           validateScopes(scopeArgs);
@@ -251,7 +252,7 @@ public class CreateTableCommand extends Command {
         throw new IllegalArgumentException("duplicate scope argument provided.");
       dupes.add(scope);
       try {
-        IteratorUtil.IteratorScope.valueOf(scope);
+        IteratorScope.valueOf(scope);
       } catch (IllegalArgumentException ex) {
         throw new IllegalArgumentException("iterator scope value is invalid/missing or contains spaces.", ex);
       }
@@ -261,14 +262,14 @@ public class CreateTableCommand extends Command {
   /**
    * Assign iterator scope arguments to an IteratorUntil.IteratorScope EnumSet for use with NewTableConfiguration object.
    */
-  private EnumSet<IteratorUtil.IteratorScope> addScopeArgsToIteratorEnumSet(final List<String> scopeList) {
-    EnumSet<IteratorUtil.IteratorScope> scopes = EnumSet.noneOf(IteratorUtil.IteratorScope.class);
+  private EnumSet<IteratorScope> addScopeArgsToIteratorEnumSet(final List<String> scopeList) {
+    EnumSet<IteratorScope> scopes = EnumSet.noneOf(IteratorScope.class);
     if (scopeList.contains("scan"))
-      scopes.add(IteratorUtil.IteratorScope.scan);
+      scopes.add(IteratorScope.scan);
     if (scopeList.contains("minc"))
-      scopes.add(IteratorUtil.IteratorScope.minc);
+      scopes.add(IteratorScope.minc);
     if (scopeList.contains("majc"))
-      scopes.add(IteratorUtil.IteratorScope.majc);
+      scopes.add(IteratorScope.majc);
     if (scopes.isEmpty())
       throw new IllegalArgumentException("supplied scope values are invalid.");
     return scopes;

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -2063,6 +2063,8 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("createtable " + table + "-l", false);
     ts.exec("createtable " + table + " -l locg1 = fam1,fam2", false);
     ts.exec("createtable " + table + " -l locg1=fam1 ,fam2", false);
+    ts.exec("createtable " + table + " -l locg1=fam1,fam2 locg1=fam3,fam4", false);
+    ts.exec("createtable " + table + " -l locg1=fam1,fam2 locg2=fam1", false);
     ts.exec("createtable " + table + " -l locg1", false);
     ts.exec("createtable " + table + " group=fam1", false);
     ts.exec("createtable " + table + "-l fam1,fam2", false);
@@ -2154,6 +2156,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     Assert.assertTrue(output.contains("Profile : profile1"));
     ts.exec("createtable " + table + " -i noprofile:scan,minc", false);
     ts.exec("createtable " + table + " -i profile1:scan,minc,all,majc", false);
+    ts.exec("createtable " + table + " -i profile1:scan,min,majc", false);
     ts.exec("createtable " + table + " -i profile1", false);
     ts.exec("createtable " + table + " profile1:-scan", false);
     ts.exec("createtable " + table + " -i profile1: all", false);

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -2154,14 +2154,28 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("setshelliter -n itname -p 10 -pn profile1 -ageoff -t " + tmpTable, true);
     output = ts.exec("listshelliter");
     Assert.assertTrue(output.contains("Profile : profile1"));
+    // test various bad argument calls
     ts.exec("createtable " + table + " -i noprofile:scan,minc", false);
     ts.exec("createtable " + table + " -i profile1:scan,minc,all,majc", false);
+    ts.exec("createtable " + table + " -i profile1:scan,all,majc", false);
     ts.exec("createtable " + table + " -i profile1:scan,min,majc", false);
-    ts.exec("createtable " + table + " -i profile1", false);
-    ts.exec("createtable " + table + " profile1:-scan", false);
+    ts.exec("createtable " + table + " -i profile1:scan,max,all", false);
+    ts.exec("createtable " + table + " -i profile1:", false);
+    ts.exec("createtable " + table + " -i profile1: ", false);
+    ts.exec("createtable " + table + " -i profile1:-scan", false);
+    ts.exec("createtable " + table + " profile1:majc", false);
     ts.exec("createtable " + table + " -i profile1: all", false);
+    ts.exec("createtable " + table + " -i profile1: All", false);
+    ts.exec("createtable " + table + " -i profile1: scan", false);
     ts.exec("createtable " + table + " -i profile1:minc scan", false);
+    ts.exec("createtable " + table + " -i profile1:minc,Scan", false);
     ts.exec("createtable " + table + " -i profile1:minc, scan", false);
+    ts.exec("createtable " + table + " -i profile1:minc,,scan", false);
+    ts.exec("createtable " + table + " -i profile1:minc,minc", false);
+    ts.exec("createtable " + table + " -i profile1:minc,Minc", false);
+    ts.exec("createtable " + table + " -i profile1:minc, ,scan", false);
+    ts.exec("createtable " + table + "-i", false);
+    ts.exec("createtable " + table + "-i ", false);
     ts.exec("deletetable -f " + tmpTable);
   }
 }


### PR DESCRIPTION
ACCUMULO-4772 Update Accumulo shell to utilize new NewTableConfiguration methods

Added capability to pre-configure iterators and locality groups when creating
new tables via the Accumulo shell. Updated CreateTableCommand.java to accept locality group
and iterator data. Updated ShellServerIT.java to test the new capabilities.