### PR TITLE
ACCUMULO-4792 Improve crypto configuration checks

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -114,13 +114,9 @@ public class ConfigSanityCheck {
       fatal(Property.CRYPTO_CIPHER_SUITE.getKey() + " and " + Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME + " must both be configured.");
     }
 
-    if (cryptoModule.equals(NULL_CRYPTO_MODULE) && !secretKeyEncryptionStrategy.equals(NULL_SECRET_KEY_ENCRYPTION_STRATEGY)) {
-      fatal(Property.CRYPTO_MODULE_CLASS.getKey() + " should be configured when " + Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey() + " is set.");
+    if (cryptoModule.equals(NULL_CRYPTO_MODULE) ^ secretKeyEncryptionStrategy.equals(NULL_SECRET_KEY_ENCRYPTION_STRATEGY)) {
+      fatal(Property.CRYPTO_MODULE_CLASS.getKey() + " and " + Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey() + " must both be configured.");
     }
-    if (!cryptoModule.equals(NULL_CRYPTO_MODULE) && secretKeyEncryptionStrategy.equals(NULL_SECRET_KEY_ENCRYPTION_STRATEGY)) {
-      fatal(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey() + " should be configured when " + Property.CRYPTO_MODULE_CLASS.getKey() + " is set.");
-    }
-
   }
 
   private interface CheckTimeDuration {

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -52,10 +52,10 @@ public class ConfigSanityCheck {
   public static void validate(Iterable<Entry<String,String>> entries) {
     String instanceZkTimeoutValue = null;
     boolean usingVolumes = false;
-    String cipherSuite = null;
-    String keyAlgorithm = null;
-    String secretKeyEncryptionStrategy = null;
-    String cryptoModule = null;
+    String cipherSuite = NULL_CIPHER;
+    String keyAlgorithm = NULL_CIPHER;
+    String secretKeyEncryptionStrategy = NULL_SECRET_KEY_ENCRYPTION_STRATEGY;
+    String cryptoModule = NULL_CRYPTO_MODULE;
     for (Entry<String,String> entry : entries) {
       String key = entry.getKey();
       String value = entry.getValue();
@@ -110,12 +110,8 @@ public class ConfigSanityCheck {
       log.warn("Use of {} and {} are deprecated. Consider using {} instead.", INSTANCE_DFS_URI, INSTANCE_DFS_DIR, Property.INSTANCE_VOLUMES);
     }
 
-    if (cipherSuite.equals(NULL_CIPHER) && !keyAlgorithm.equals(NULL_CIPHER)) {
-      fatal(Property.CRYPTO_CIPHER_SUITE.getKey() + " should be configured when " + Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey() + " is set.");
-    }
-
-    if (!cipherSuite.equals(NULL_CIPHER) && keyAlgorithm.equals(NULL_CIPHER)) {
-      fatal(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey() + " should be configured when " + Property.CRYPTO_CIPHER_SUITE.getKey() + " is set.");
+    if ((cipherSuite.equals(NULL_CIPHER) || keyAlgorithm.equals(NULL_CIPHER)) && !cipherSuite.equals(keyAlgorithm)) {
+      fatal(Property.CRYPTO_CIPHER_SUITE.getKey() + " and " + Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME + " must both be configured.");
     }
 
     if (cryptoModule.equals(NULL_CRYPTO_MODULE) && !secretKeyEncryptionStrategy.equals(NULL_SECRET_KEY_ENCRYPTION_STRATEGY)) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -31,6 +31,9 @@ public class ConfigSanityCheck {
 
   private static final Logger log = LoggerFactory.getLogger(ConfigSanityCheck.class);
   private static final String PREFIX = "BAD CONFIG ";
+  private static final String NULL_CIPHER = "NullCipher";
+  private static final String NULL_CRYPTO_MODULE = "NullCryptoModule";
+  private static final String NULL_SECRET_KEY_ENCRYPTION_STRATEGY = "NullSecretKeyEncryptionStrategy";
   @SuppressWarnings("deprecation")
   private static final Property INSTANCE_DFS_URI = Property.INSTANCE_DFS_URI;
   @SuppressWarnings("deprecation")
@@ -51,6 +54,8 @@ public class ConfigSanityCheck {
     boolean usingVolumes = false;
     String cipherSuite = null;
     String keyAlgorithm = null;
+    String secretKeyEncryptionStrategy = null;
+    String cryptoModule = null;
     for (Entry<String,String> entry : entries) {
       String key = entry.getKey();
       String value = entry.getValue();
@@ -81,12 +86,19 @@ public class ConfigSanityCheck {
 
       if (key.equals(Property.CRYPTO_CIPHER_SUITE.getKey())) {
         cipherSuite = Objects.requireNonNull(value);
-        Preconditions.checkArgument(cipherSuite.equals("NullCipher") || cipherSuite.split("/").length == 3,
+        Preconditions.checkArgument(cipherSuite.equals(NULL_CIPHER) || cipherSuite.split("/").length == 3,
             "Cipher suite must be NullCipher or in the form algorithm/mode/padding. Suite: " + cipherSuite + " is invalid.");
       }
 
       if (key.equals(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey())) {
         keyAlgorithm = Objects.requireNonNull(value);
+      }
+
+      if (key.equals(Property.CRYPTO_MODULE_CLASS.getKey())) {
+        cryptoModule = Objects.requireNonNull(value);
+      }
+      if (key.equals(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey())) {
+        secretKeyEncryptionStrategy = Objects.requireNonNull(value);
       }
     }
 
@@ -98,13 +110,21 @@ public class ConfigSanityCheck {
       log.warn("Use of {} and {} are deprecated. Consider using {} instead.", INSTANCE_DFS_URI, INSTANCE_DFS_DIR, Property.INSTANCE_VOLUMES);
     }
 
-    if (cipherSuite.equals("NullCipher") && !keyAlgorithm.equals("NullCipher")) {
+    if (cipherSuite.equals(NULL_CIPHER) && !keyAlgorithm.equals(NULL_CIPHER)) {
       fatal(Property.CRYPTO_CIPHER_SUITE.getKey() + " should be configured when " + Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey() + " is set.");
     }
 
-    if (!cipherSuite.equals("NullCipher") && keyAlgorithm.equals("NullCipher")) {
+    if (!cipherSuite.equals(NULL_CIPHER) && keyAlgorithm.equals(NULL_CIPHER)) {
       fatal(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey() + " should be configured when " + Property.CRYPTO_CIPHER_SUITE.getKey() + " is set.");
     }
+
+    if (cryptoModule.equals(NULL_CRYPTO_MODULE) && !secretKeyEncryptionStrategy.equals(NULL_SECRET_KEY_ENCRYPTION_STRATEGY)) {
+      fatal(Property.CRYPTO_MODULE_CLASS.getKey() + " should be configured when " + Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey() + " is set.");
+    }
+    if (!cryptoModule.equals(NULL_CRYPTO_MODULE) && secretKeyEncryptionStrategy.equals(NULL_SECRET_KEY_ENCRYPTION_STRATEGY)) {
+      fatal(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey() + " should be configured when " + Property.CRYPTO_MODULE_CLASS.getKey() + " is set.");
+    }
+
   }
 
   private interface CheckTimeDuration {

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigSanityCheckTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigSanityCheckTest.java
@@ -28,10 +28,6 @@ public class ConfigSanityCheckTest {
   @Before
   public void setUp() {
     m = new java.util.HashMap<>();
-    m.put(Property.CRYPTO_CIPHER_SUITE.getKey(), "NullCipher");
-    m.put(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey(), "NullCipher");
-    m.put(Property.CRYPTO_MODULE_CLASS.getKey(), "NullCryptoModule");
-    m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "NullSecretKeyEncryptionStrategy");
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigSanityCheckTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigSanityCheckTest.java
@@ -30,6 +30,8 @@ public class ConfigSanityCheckTest {
     m = new java.util.HashMap<>();
     m.put(Property.CRYPTO_CIPHER_SUITE.getKey(), "NullCipher");
     m.put(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey(), "NullCipher");
+    m.put(Property.CRYPTO_MODULE_CLASS.getKey(), "NullCryptoModule");
+    m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "NullSecretKeyEncryptionStrategy");
   }
 
   @Test
@@ -91,6 +93,20 @@ public class ConfigSanityCheckTest {
   public void testFail_cipherSuiteNotSetKeyAlgorithmSet() {
     m.put(Property.CRYPTO_CIPHER_SUITE.getKey(), "NullCipher");
     m.put(Property.CRYPTO_CIPHER_KEY_ALGORITHM_NAME.getKey(), "AES");
+    ConfigSanityCheck.validate(m.entrySet());
+  }
+
+  @Test(expected = SanityCheckException.class)
+  public void testFail_cryptoModuleSetSecretKeyEncryptionStrategyNotSet() {
+    m.put(Property.CRYPTO_MODULE_CLASS.getKey(), "DefaultCryptoModule");
+    m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "NullSecretKeyEncryptionStrategy");
+    ConfigSanityCheck.validate(m.entrySet());
+  }
+
+  @Test(expected = SanityCheckException.class)
+  public void testFail_cryptoModuleNotSetSecretKeyEncryptionStrategySet() {
+    m.put(Property.CRYPTO_MODULE_CLASS.getKey(), "NullCryptoModule");
+    m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "SecretKeyEncryptionStrategy");
     ConfigSanityCheck.validate(m.entrySet());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigSanityCheckTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigSanityCheckTest.java
@@ -105,4 +105,18 @@ public class ConfigSanityCheckTest {
     m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "SecretKeyEncryptionStrategy");
     ConfigSanityCheck.validate(m.entrySet());
   }
+
+  @Test
+  public void testPass_cryptoModuleAndSecretKeyEncryptionStrategyBothNull() {
+    m.put(Property.CRYPTO_MODULE_CLASS.getKey(), "NullCryptoModule");
+    m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "NullSecretKeyEncryptionStrategy");
+    ConfigSanityCheck.validate(m.entrySet());
+  }
+
+  @Test
+  public void testPass_cryptoModuleAndSecretKeyEncryptionStrategyBothSet() {
+    m.put(Property.CRYPTO_MODULE_CLASS.getKey(), "DefaultCryptoModule");
+    m.put(Property.CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS.getKey(), "SecretKeyEncryptionStrategy");
+    ConfigSanityCheck.validate(m.entrySet());
+  }
 }


### PR DESCRIPTION
Added a check to the configuration sanity checker to ensure that, if a crypto module other than NullCryptoModule was selected, a
SecretKeyEncryptionStrategy other than NullSecretKeyEncryptionStrategy must also be selected (and vice versa).