### PR TITLE
ACCUMULO-4779 Improved performance get by prefix in config

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ClientContext.java
@@ -176,11 +176,6 @@ public class ClientContext {
     return new AccumuloConfiguration() {
 
       @Override
-      protected String getArbitrarySystemPropertyImpl(String property) {
-        return config.getString(property, null);
-      }
-
-      @Override
       public String get(Property property) {
         final String key = property.getKey();
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mock/MockConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mock/MockConfiguration.java
@@ -40,11 +40,6 @@ class MockConfiguration extends AccumuloConfiguration {
   }
 
   @Override
-  protected String getArbitrarySystemPropertyImpl(String property) {
-    return map.get(property);
-  }
-
-  @Override
   public String get(Property property) {
     return map.get(property.getKey());
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
@@ -58,9 +58,4 @@ public class DefaultConfiguration extends AccumuloConfiguration {
       if (filter.apply(entry.getKey()))
         props.put(entry.getKey(), entry.getValue());
   }
-
-  @Override
-  protected String getArbitrarySystemPropertyImpl(String property) {
-    return null;
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -129,15 +129,6 @@ public class SiteConfiguration extends AccumuloConfiguration {
   }
 
   @Override
-  protected String getArbitrarySystemPropertyImpl(String property) {
-    String val = staticConfigs.get(property);
-    if (val == null) {
-      val = parent.getArbitrarySystemPropertyImpl(property);
-    }
-    return val;
-  }
-
-  @Override
   public void getProperties(Map<String,String> props, Predicate<String> filter) {
     parent.getProperties(props, filter);
 

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoModuleFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoModuleFactory.java
@@ -257,7 +257,7 @@ public class CryptoModuleFactory {
 
   public static CryptoModuleParameters fillParamsObjectFromConfiguration(CryptoModuleParameters params, AccumuloConfiguration conf) {
     // Get all the options from the configuration
-    Map<String,String> cryptoOpts = conf.getAllPropertiesWithPrefix(Property.CRYPTO_PREFIX);
+    Map<String,String> cryptoOpts = new HashMap<>(conf.getAllPropertiesWithPrefix(Property.CRYPTO_PREFIX));
     cryptoOpts.putAll(conf.getAllPropertiesWithPrefix(Property.INSTANCE_PREFIX));
     cryptoOpts.remove(Property.INSTANCE_SECRET.getKey());
     cryptoOpts.put(Property.CRYPTO_BLOCK_STREAM_SIZE.getKey(), Integer.toString((int) conf.getMemoryInBytes(Property.CRYPTO_BLOCK_STREAM_SIZE)));

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -17,11 +17,25 @@
 package org.apache.accumulo.core.conf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
 
 public class AccumuloConfigurationTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testGetMemoryInBytes() throws Exception {
@@ -147,4 +161,142 @@ public class AccumuloConfigurationTest {
     cc.getPort(Property.TSERV_CLIENTPORT);
   }
 
+  private static class TestConfiguration extends AccumuloConfiguration {
+
+    private HashMap<String,String> props = new HashMap<>();
+    private int upCount = 0;
+
+    public void set(String p, String v) {
+      props.put(p, v);
+      upCount++;
+    }
+
+    @Override
+    public long getUpdateCount() {
+      return upCount;
+    }
+
+    @Override
+    public String get(Property property) {
+      return props.get(property.getKey());
+    }
+
+    @Override
+    public void getProperties(Map<String,String> output, Predicate<String> filter) {
+      for (Entry<String,String> entry : props.entrySet()) {
+        if (filter.apply(entry.getKey())) {
+          output.put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+
+  }
+
+  @Test
+  public void testMutatePrefixMap() {
+    TestConfiguration tc = new TestConfiguration();
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
+
+    Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+
+    Map<String,String> expected1 = new HashMap<>();
+    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
+    assertEquals(expected1, pm1);
+
+    thrown.expect(UnsupportedOperationException.class);
+    pm1.put("k9", "v3");
+  }
+
+  @Test
+  public void testGetByPrefix() {
+    // This test checks that when anything changes that all prefix maps are regenerated. However when there are not changes the test expects all the exact same
+    // map to always be returned.
+
+    TestConfiguration tc = new TestConfiguration();
+
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    tc.set(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
+
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+
+    Map<String,String> pm1 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    Map<String,String> pm2 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+
+    assertSame(pm1, pm2);
+    Map<String,String> expected1 = new HashMap<>();
+    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a1", "325");
+    expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
+    assertEquals(expected1, pm1);
+
+    Map<String,String> pm3 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    Map<String,String> pm4 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+
+    assertSame(pm3, pm4);
+    Map<String,String> expected2 = new HashMap<>();
+    expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1", "class34");
+    expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i1.opt", "o99");
+    assertEquals(expected2, pm3);
+
+    Map<String,String> pm5 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+    Map<String,String> pm6 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+    assertSame(pm5, pm6);
+    assertEquals(0, pm5.size());
+
+    // ensure getting one prefix does not cause others to unnecessarily regenerate
+    Map<String,String> pm7 = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    assertSame(pm1, pm7);
+
+    Map<String,String> pm8 = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    assertSame(pm3, pm8);
+
+    Map<String,String> pm9 = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+    assertSame(pm5, pm9);
+
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    tc.set(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+
+    expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2", "class42");
+    expected2.put(Property.TABLE_ITERATOR_SCAN_PREFIX.getKey() + "i2.opt", "o78234");
+
+    Map<String,String> pmA = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    Map<String,String> pmB = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    assertNotSame(pm3, pmA);
+    assertSame(pmA, pmB);
+    assertEquals(expected2, pmA);
+
+    Map<String,String> pmC = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    Map<String,String> pmD = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    assertNotSame(pm1, pmC);
+    assertSame(pmC, pmD);
+    assertEquals(expected1, pmC);
+
+    tc.set(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1");
+
+    Map<String,String> pmE = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+    Map<String,String> pmF = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+    assertSame(pmE, pmF);
+    assertNotSame(pm5, pmE);
+    assertEquals(ImmutableMap.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1"), pmE);
+
+    Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    Map<String,String> pmH = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    assertNotSame(pmA, pmG);
+    assertSame(pmG, pmH);
+    assertEquals(expected2, pmG);
+
+    Map<String,String> pmI = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    Map<String,String> pmJ = tc.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
+    assertNotSame(pmC, pmI);
+    assertSame(pmI, pmJ);
+    assertEquals(expected1, pmI);
+
+    Map<String,String> pmK = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
+    assertSame(pmE, pmK);
+
+    Map<String,String> pmL = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
+    assertSame(pmG, pmL);
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
@@ -167,4 +167,9 @@ public class NamespaceConfiguration extends ObservableConfiguration {
     // to see if it happened to be created so we could invalidate its cache
     // but I don't see much benefit coming from that extra check.
   }
+
+  @Override
+  public long getUpdateCount() {
+    return parent.getUpdateCount() + getPropCacheAccessor().getZooCache().getUpdateCount();
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -139,4 +139,9 @@ public class TableConfiguration extends ObservableConfiguration {
   public String toString() {
     return this.getClass().getSimpleName();
   }
+
+  @Override
+  public long getUpdateCount() {
+    return parent.getUpdateCount() + getPropCacheAccessor().getZooCache().getUpdateCount();
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
@@ -79,15 +79,6 @@ public class ZooConfiguration extends AccumuloConfiguration {
   }
 
   @Override
-  protected String getArbitrarySystemPropertyImpl(String property) {
-    String val = getRaw(property);
-    if (val == null) {
-      val = getArbitrarySystemPropertyImpl(parent, property);
-    }
-    return val;
-  }
-
-  @Override
   public String get(Property property) {
     if (Property.isFixedZooPropertyKey(property)) {
       if (fixedProps.containsKey(property.getKey())) {
@@ -128,5 +119,10 @@ public class ZooConfiguration extends AccumuloConfiguration {
         }
       }
     }
+  }
+
+  @Override
+  public long getUpdateCount() {
+    return parent.getUpdateCount() + propCache.getUpdateCount();
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ZooConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ZooConfigurationFactoryTest.java
@@ -17,8 +17,10 @@
 package org.apache.accumulo.server.conf;
 
 import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertNotNull;
@@ -28,6 +30,7 @@ import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
+import org.apache.zookeeper.Watcher;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,7 +57,7 @@ public class ZooConfigurationFactoryTest {
     expect(instance.getZooKeepers()).andReturn("localhost");
     expect(instance.getZooKeepersSessionTimeOut()).andReturn(120000);
     replay(instance);
-    expect(zcf.getZooCache("localhost", 120000)).andReturn(zc);
+    expect(zcf.getZooCache(eq("localhost"), eq(120000), isA(Watcher.class))).andReturn(zc);
     replay(zcf);
 
     ZooConfiguration c = zconff.getInstance(instance, zcf, parent);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -177,6 +177,11 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
             }
           }
         }
+
+        @Override
+        public long getUpdateCount() {
+          return 0;
+        }
       };
     }
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
@@ -185,6 +185,11 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
               }
             }
           }
+
+          @Override
+          public long getUpdateCount() {
+            return 0;
+          }
         };
       }
     });
@@ -255,6 +260,11 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
                 props.put(e.getKey(), e.getValue());
               }
             }
+          }
+
+          @Override
+          public long getUpdateCount() {
+            return 0;
           }
         };
       }

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandlerTest.java
@@ -61,6 +61,11 @@ public class TCredentialsUpdatingInvocationHandlerTest {
       public void getProperties(Map<String,String> props, Predicate<String> filter) {
         cc.getProperties(props, filter);
       }
+
+      @Override
+      public long getUpdateCount() {
+        return cc.getUpdateCount();
+      }
     };
 
     proxy = new TCredentialsUpdatingInvocationHandler<>(new Object(), conf);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -610,8 +610,8 @@ public class Master extends AccumuloServerContext implements LiveTServerSet.List
     try {
       AccumuloVFSClassLoader.getContextManager().setContextConfig(new ContextManager.DefaultContextsConfig() {
         @Override
-        public String getVfsContextClasspathProperty(String key) {
-          return getConfiguration().getArbitrarySystemProperty(Property.VFS_CONTEXT_CLASSPATH_PROPERTY, key);
+        public Map<String,String> getVfsContextClasspathProperties() {
+          return getConfiguration().getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
         }
       });
     } catch (IOException e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2806,8 +2806,8 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     try {
       AccumuloVFSClassLoader.getContextManager().setContextConfig(new ContextManager.DefaultContextsConfig() {
         @Override
-        public String getVfsContextClasspathProperty(String key) {
-          return getConfiguration().getArbitrarySystemProperty(Property.VFS_CONTEXT_CLASSPATH_PROPERTY, key);
+        public Map<String,String> getVfsContextClasspathProperties() {
+          return getConfiguration().getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
         }
       });
     } catch (IOException e) {

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -563,10 +563,15 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
         AccumuloVFSClassLoader.getContextManager().setContextConfig(new ContextManager.DefaultContextsConfig() {
           @Override
-          public String getVfsContextClasspathProperty(String key) {
-            return systemConfig.get(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + key);
+          public Map<String,String> getVfsContextClasspathProperties() {
+            Map<String,String> filteredMap = new HashMap<>();
+            for (Entry<String,String> entry : systemConfig.entrySet()) {
+              if (entry.getKey().startsWith(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey())) {
+                filteredMap.put(entry.getKey(), entry.getValue());
+              }
+            }
+            return filteredMap;
           }
-
         });
       } catch (IllegalStateException ise) {}
 

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/ContextManager.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/ContextManager.java
@@ -99,21 +99,21 @@ public class ContextManager {
 
   public static abstract class DefaultContextsConfig implements ContextsConfig {
 
-    /**
-     * Implementations should prepend {@link AccumuloVFSClassLoader#VFS_CONTEXT_CLASSPATH_PROPERTY} to the given key.
-     */
-    public abstract String getVfsContextClasspathProperty(String key);
+    public abstract Map<String,String> getVfsContextClasspathProperties();
 
     @Override
     public ContextConfig getContextConfig(String context) {
 
-      String uris = getVfsContextClasspathProperty(context);
+      String prop = AccumuloVFSClassLoader.VFS_CONTEXT_CLASSPATH_PROPERTY + context;
+      Map<String,String> props = getVfsContextClasspathProperties();
+
+      String uris = props.get(prop);
 
       if (uris == null) {
         return null;
       }
 
-      String delegate = getVfsContextClasspathProperty(context + ".delegation");
+      String delegate = props.get(prop + ".delegation");
 
       boolean preDelegate = true;
 


### PR DESCRIPTION
This change will improve the performance of creating iterators.

Also removed custom method to get VFS config.  Now that getting
config by prefixes is fast, it can used for VFS.