### PR TITLE
ACCUMULO-4805 Obtain filemanager lock once when opening files

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -275,7 +275,6 @@ public class FileManager {
 
     List<String> filesToOpen = null;
     List<FileSKVIterator> filesToClose = Collections.emptyList();
-    // List<FileSKVIterator> reservedFiles = new ArrayList<>();
     Map<FileSKVIterator,String> readersReserved = new HashMap<>();
 
     if (!tablet.isMeta()) {


### PR DESCRIPTION
Before this change the lock on the file manager was obtained F+1 times, where
F is the number of files.  When there are lots of threads this is a lot of
contention.  In this change, the lock is only obtained once.

Also in this change the file managers semaphore was switched to non-fair.  The
fair semaphore is expensive and can cause contention.