### PR TITLE
ACCUMULO-3807 Avoid Copy/Sort column on WAL recovery exceeds 100%

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -449,9 +449,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
       short replication = (short) conf.getConfiguration().getCount(Property.TSERV_WAL_REPLICATION);
       if (replication == 0)
         replication = fs.getDefaultReplication(new Path(logPath));
-      long blockSize = conf.getConfiguration().getAsBytes(Property.TSERV_WAL_BLOCKSIZE);
-      if (blockSize == 0)
-        blockSize = (long) (conf.getConfiguration().getAsBytes(Property.TSERV_WALOG_MAX_SIZE) * 1.1);
+      long blockSize = getWalBlockSize(conf.getConfiguration());
       if (conf.getConfiguration().getBoolean(Property.TSERV_WAL_SYNC))
         logFile = fs.createSyncable(new Path(logPath), 0, replication, blockSize);
       else
@@ -512,6 +510,13 @@ public class DfsLogger implements Comparable<DfsLogger> {
     syncThread.start();
     op.await();
     log.debug("Got new write-ahead log: {}", this);
+  }
+
+  static long getWalBlockSize(AccumuloConfiguration conf) {
+    long blockSize = conf.getAsBytes(Property.TSERV_WAL_BLOCKSIZE);
+    if (blockSize == 0)
+      blockSize = (long) (conf.getAsBytes(Property.TSERV_WALOG_MAX_SIZE) * 1.1);
+    return blockSize;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -221,6 +221,7 @@ public class LogSorter {
 
   ThreadPoolExecutor threadPool;
   private final Instance instance;
+  private double walBlockSize;
 
   public LogSorter(Instance instance, VolumeManager fs, AccumuloConfiguration conf) {
     this.instance = instance;
@@ -228,6 +229,7 @@ public class LogSorter {
     this.conf = conf;
     int threadPoolSize = conf.getCount(Property.TSERV_RECOVERY_MAX_CONCURRENT);
     this.threadPool = new SimpleThreadPool(threadPoolSize, this.getClass().getName());
+    this.walBlockSize = DfsLogger.getWalBlockSize(conf);
   }
 
   public void startWatchingForRecoveryLogs(ThreadPoolExecutor distWorkQThreadPool) throws KeeperException, InterruptedException {
@@ -242,7 +244,9 @@ public class LogSorter {
         RecoveryStatus status = new RecoveryStatus();
         status.name = entries.getKey();
         try {
-          status.progress = entries.getValue().getBytesCopied() / (0.0 + conf.getAsBytes(Property.TSERV_WALOG_MAX_SIZE));
+          double progress = entries.getValue().getBytesCopied() / walBlockSize;
+          // to be sure progress does not exceed 100%
+          status.progress = Math.max(progress, 99.0);
         } catch (IOException ex) {
           log.warn("Error getting bytes read");
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -246,7 +246,7 @@ public class LogSorter {
         try {
           double progress = entries.getValue().getBytesCopied() / walBlockSize;
           // to be sure progress does not exceed 100%
-          status.progress = Math.min(progress, 99.0);
+          status.progress = Math.min(progress, 99.9);
         } catch (IOException ex) {
           log.warn("Error getting bytes read");
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -246,7 +246,7 @@ public class LogSorter {
         try {
           double progress = entries.getValue().getBytesCopied() / walBlockSize;
           // to be sure progress does not exceed 100%
-          status.progress = Math.max(progress, 99.0);
+          status.progress = Math.min(progress, 99.0);
         } catch (IOException ex) {
           log.warn("Error getting bytes read");
         }


### PR DESCRIPTION
The Math.max() will solve the issue I hope.

I'm not sure what happens if `Property.TSERV_WAL_BLOCKSIZE` is not 0 and smaller than `Property.TSERV_WALOG_MAX_SIZE`. The problem is that `TabletServerLogger` still uses `Property.TSERV_WALOG_MAX_SIZE` [to check data size](https://github.com/apache/accumulo/blob/master/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java#L456) stored in one file. While file size  [is set to](https://github.com/apache/accumulo/blob/master/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java#L452) `Property.TSERV_WAL_BLOCKSIZE`.