### PR TITLE
ACCUMULO-3389 Iterator Names can't contain dots

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
@@ -85,10 +85,12 @@ public class IteratorSetting implements Writable {
   }
 
   /**
-   * Set the iterator's name. Must be a simple alphanumeric identifier.
+   * Set the iterator's name. Must be a simple alphanumeric identifier. The iterator name
+   * also may not contain a dot/period.
    */
   public void setName(String name) {
     checkArgument(name != null, "name is null");
+    checkArgument(!name.contains("."), "Iterator name cannot contain a dot/period");
     this.name = name;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
@@ -85,8 +85,7 @@ public class IteratorSetting implements Writable {
   }
 
   /**
-   * Set the iterator's name. Must be a simple alphanumeric identifier. The iterator name
-   * also may not contain a dot/period.
+   * Set the iterator's name. Must be a simple alphanumeric identifier. The iterator name also may not contain a dot/period.
    */
   public void setName(String name) {
     checkArgument(name != null, "name is null");

--- a/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
@@ -177,7 +177,7 @@ public class IteratorUtil {
         options.put(optName, entry.getValue());
 
       } else {
-        log.warn("Unrecognizable option: " + entry.getKey());
+        throw new IllegalArgumentException("Invalid iterator format: " + entry.getKey());
       }
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/client/IteratorSettingTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/IteratorSettingTest.java
@@ -110,4 +110,13 @@ public class IteratorSettingTest {
 
     assertNotEquals(setting1, notEquals2);
   }
+
+  /**
+   * Iterator names cannot contain dots. Throw IllegalArgumentException is invalid name is used.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testIteratorNameCannotContainDot() {
+    new IteratorSetting(500, "iterator.name.with.dots", Combiner.class.getName());
+  }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -316,10 +316,10 @@ public class IteratorUtilTest {
   }
 
   /**
-   * Iterators should not contain dots in the name. Also, if the split size on "." is greater than
-   * one, it should be 3, i.e., itername.opt.optname
+   * Iterators should not contain dots in the name. Also, if the split size on "." is greater than one, it should be 3, i.e., itername.opt.optname
    */
-  @Test public void testInvalidIteratorFormats() {
+  @Test
+  public void testInvalidIteratorFormats() {
 
     Map<String,String> data = new HashMap<>();
     List<IterInfo> iterators = new ArrayList<>();
@@ -328,8 +328,7 @@ public class IteratorUtilTest {
 
     // create iterator with 'dot' in name
     try {
-      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foo.bar",
-          "50," + SummingCombiner.class.getName());
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foo.bar", "50," + SummingCombiner.class.getName());
       conf = new ConfigurationCopy(data);
       IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
     } catch (IllegalArgumentException ex) {
@@ -342,8 +341,7 @@ public class IteratorUtilTest {
     // create iterator with 'dot' in name and with split size of 3. If split size of three, then
     // second part must be 'opt'.
     try {
-      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foo.bar.baz",
-          "49," + SummingCombiner.class.getName());
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foo.bar.baz", "49," + SummingCombiner.class.getName());
       conf = new ConfigurationCopy(data);
       IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
     } catch (IllegalArgumentException ex) {
@@ -355,8 +353,7 @@ public class IteratorUtilTest {
 
     // create iterator with invalid option format
     try {
-      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobar",
-          "48," + SummingCombiner.class.getName());
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobar", "48," + SummingCombiner.class.getName());
       data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobar.opt", "fakevalue");
       conf = new ConfigurationCopy(data);
       IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
@@ -372,8 +369,7 @@ public class IteratorUtilTest {
 
     // create iterator with 'opt' in incorrect position
     try {
-      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobaz",
-          "47," + SummingCombiner.class.getName());
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobaz", "47," + SummingCombiner.class.getName());
       data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobaz.fake.opt", "fakevalue");
       conf = new ConfigurationCopy(data);
       IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/IteratorUtilTest.java
@@ -42,9 +42,12 @@ import org.apache.accumulo.core.iterators.user.AgeOffFilter;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IteratorUtilTest {
 
+  private static final Logger log = LoggerFactory.getLogger(IteratorUtilTest.class);
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
   static class WrappedIter implements SortedKeyValueIterator<Key,Value> {
@@ -311,4 +314,75 @@ public class IteratorUtilTest {
     IterInfo ii = iterators.get(0);
     Assert.assertEquals(new IterInfo(50, SummingCombiner.class.getName(), "foo"), ii);
   }
+
+  /**
+   * Iterators should not contain dots in the name. Also, if the split size on "." is greater than
+   * one, it should be 3, i.e., itername.opt.optname
+   */
+  @Test public void testInvalidIteratorFormats() {
+
+    Map<String,String> data = new HashMap<>();
+    List<IterInfo> iterators = new ArrayList<>();
+    Map<String,Map<String,String>> options = new HashMap<>();
+    AccumuloConfiguration conf;
+
+    // create iterator with 'dot' in name
+    try {
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foo.bar",
+          "50," + SummingCombiner.class.getName());
+      conf = new ConfigurationCopy(data);
+      IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
+    } catch (IllegalArgumentException ex) {
+      log.debug("caught expected exception: " + ex.getMessage());
+    }
+    data.clear();
+    iterators.clear();
+    options.clear();
+
+    // create iterator with 'dot' in name and with split size of 3. If split size of three, then
+    // second part must be 'opt'.
+    try {
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foo.bar.baz",
+          "49," + SummingCombiner.class.getName());
+      conf = new ConfigurationCopy(data);
+      IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
+    } catch (IllegalArgumentException ex) {
+      log.debug("caught expected exception: " + ex.getMessage());
+    }
+    data.clear();
+    iterators.clear();
+    options.clear();
+
+    // create iterator with invalid option format
+    try {
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobar",
+          "48," + SummingCombiner.class.getName());
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobar.opt", "fakevalue");
+      conf = new ConfigurationCopy(data);
+      IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
+      Assert.assertEquals(1, iterators.size());
+      IterInfo ii = iterators.get(0);
+      Assert.assertEquals(new IterInfo(48, SummingCombiner.class.getName(), "foobar"), ii);
+    } catch (IllegalArgumentException ex) {
+      log.debug("caught expected exception: " + ex.getMessage());
+    }
+    data.clear();
+    iterators.clear();
+    options.clear();
+
+    // create iterator with 'opt' in incorrect position
+    try {
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobaz",
+          "47," + SummingCombiner.class.getName());
+      data.put(Property.TABLE_ITERATOR_SCAN_PREFIX + "foobaz.fake.opt", "fakevalue");
+      conf = new ConfigurationCopy(data);
+      IteratorUtil.parseIterConf(IteratorScope.scan, iterators, options, conf);
+      Assert.assertEquals(1, iterators.size());
+      IterInfo ii = iterators.get(0);
+      Assert.assertEquals(new IterInfo(47, SummingCombiner.class.getName(), "foobaz"), ii);
+    } catch (IllegalArgumentException ex) {
+      log.debug("caught expected exception: " + ex.getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
ACCUMULO-3389 Iterator Names can't contain dots
    
Updated code to check iterator names for the presence of dots. If name is found to contain a  dot then an IllegalArgumentException is thrown. Wrote unit/IT tests also.