### PR TITLE
Fix ChaoticBalancerIT

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.server.conf.ServerConfiguration;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.thrift.TException;
@@ -160,4 +161,11 @@ public class ChaoticLoadBalancer extends TabletBalancer {
 
     return 100;
   }
+
+  @Deprecated
+  @Override
+  public void init(ServerConfiguration conf) {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -31,11 +31,8 @@ import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
-import org.apache.accumulo.server.conf.ServerConfiguration;
-import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletMigration;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,14 +160,4 @@ public class ChaoticLoadBalancer extends TabletBalancer {
 
     return 100;
   }
-
-  @Deprecated
-  @Override
-  public void init(ServerConfiguration conf) {
-    throw new NotImplementedException();
-  }
-
-  @Override
-  public void init(ServerConfigurationFactory conf) {}
-
 }

--- a/test/src/test/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
@@ -42,6 +42,7 @@ public class ChaoticBalancerIT extends AccumuloClusterIT {
     Map<String,String> siteConfig = cfg.getSiteConfig();
     siteConfig.put(Property.TSERV_MAXMEM.getKey(), "10K");
     siteConfig.put(Property.TSERV_MAJC_DELAY.getKey(), "0");
+    siteConfig.put(Property.TABLE_LOAD_BALANCER.getKey(), ChaoticLoadBalancer.class.getName());
     cfg.setSiteConfig(siteConfig);
   }
 
@@ -56,7 +57,6 @@ public class ChaoticBalancerIT extends AccumuloClusterIT {
     String[] names = getUniqueNames(2);
     String tableName = names[0], unused = names[1];
     c.tableOperations().create(tableName);
-    c.tableOperations().setProperty(tableName, Property.TABLE_LOAD_BALANCER.getKey(), ChaoticLoadBalancer.class.getName());
     c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "10K");
     SortedSet<Text> splits = new TreeSet<>();
     for (int i = 0; i < 100; i++) {

--- a/test/src/test/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
@@ -42,6 +42,7 @@ public class ChaoticBalancerIT extends AccumuloClusterIT {
     Map<String,String> siteConfig = cfg.getSiteConfig();
     siteConfig.put(Property.TSERV_MAXMEM.getKey(), "10K");
     siteConfig.put(Property.TSERV_MAJC_DELAY.getKey(), "0");
+    // ChaoticLoadBalancer balances across all tables
     siteConfig.put(Property.TABLE_LOAD_BALANCER.getKey(), ChaoticLoadBalancer.class.getName());
     cfg.setSiteConfig(siteConfig);
   }


### PR DESCRIPTION
First fixed the NPE by removing the overloaded init methods.  Then fixed the test (I think) by changing the configuration back to what it was originally intended, a balancer for all tables not just one.