### PR TITLE
ACCUMULO-4791 fix setshelliter usage

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.server.security.handler;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +34,7 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.security.thrift.TCredentials;
+import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -163,11 +163,19 @@ public class ZKAuthorizor implements Authorizor {
 
   @Override
   public boolean isValidAuthorizations(String user, List<ByteBuffer> auths) throws AccumuloSecurityException {
-    Collection<ByteBuffer> userauths = getCachedUserAuthorizations(user).getAuthorizationsBB();
-    for (ByteBuffer auth : auths)
-      if (!userauths.contains(auth))
+    if (auths.isEmpty()) {
+      // avoid deserializing auths from ZK cache
+      return true;
+    }
+
+    Authorizations userauths = getCachedUserAuthorizations(user);
+
+    for (ByteBuffer auth : auths) {
+      if (!userauths.contains(ByteBufferUtil.toBytes(auth))) {
         return false;
+      }
+    }
+
     return true;
   }
-
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -363,23 +363,54 @@ public class SetIterCommand extends Command {
     return "sets a table-specific or namespace-specific iterator";
   }
 
-  @Override
-  public Options getOptions() {
+  // Set all options common to both iterators and shell iterators
+  public void setBaseOptions(Options options) {
+    setPriorityOptions(options);
+    setNameOptions(options);
+    setIteratorTypeOptions(options);
+  }
 
-    final Options o = new Options();
+  private void setNameOptions(Options options) {
+    nameOpt = new Option("n", "name", true, "iterator to set");
+    nameOpt.setArgName("itername");
+    options.addOption(nameOpt);
+  }
 
+  private void setPriorityOptions(Options options) {
     priorityOpt = new Option("p", "priority", true, "the order in which the iterator is applied");
     priorityOpt.setArgName("pri");
     priorityOpt.setRequired(true);
+    options.addOption(priorityOpt);
+  }
 
-    nameOpt = new Option("n", "name", true, "iterator to set");
-    nameOpt.setArgName("itername");
+  @Override
+  public Options getOptions() {
+    final Options o = new Options();
+    setBaseOptions(o);
+    setScopeOptions(o);
+    setTableOptions(o);
+    return o;
+  }
 
+  private void setScopeOptions(Options o) {
     allScopeOpt = new Option("all", "all-scopes", false, "applied at scan time, minor and major compactions");
     mincScopeOpt = new Option(IteratorScope.minc.name(), "minor-compaction", false, "applied at minor compaction");
     majcScopeOpt = new Option(IteratorScope.majc.name(), "major-compaction", false, "applied at major compaction");
     scanScopeOpt = new Option(IteratorScope.scan.name(), "scan-time", false, "applied at scan time");
+    o.addOption(allScopeOpt);
+    o.addOption(mincScopeOpt);
+    o.addOption(majcScopeOpt);
+    o.addOption(scanScopeOpt);
+  }
 
+  private void setTableOptions(Options o) {
+    final OptionGroup tableGroup = new OptionGroup();
+    tableGroup.addOption(OptUtil.tableOpt("table to configure iterators on"));
+    tableGroup.addOption(OptUtil.namespaceOpt("namespace to configure iterators on"));
+    o.addOptionGroup(tableGroup);
+  }
+
+  private void setIteratorTypeOptions(Options o) {
     final OptionGroup typeGroup = new OptionGroup();
     classnameTypeOpt = new Option("class", "class-name", true, "a java class that implements SortedKeyValueIterator");
     classnameTypeOpt.setArgName("name");
@@ -396,20 +427,7 @@ public class SetIterCommand extends Command {
     typeGroup.addOption(reqvisTypeOpt);
     typeGroup.addOption(ageoffTypeOpt);
     typeGroup.setRequired(true);
-
-    final OptionGroup tableGroup = new OptionGroup();
-    tableGroup.addOption(OptUtil.tableOpt("table to configure iterators on"));
-    tableGroup.addOption(OptUtil.namespaceOpt("namespace to configure iterators on"));
-
-    o.addOption(priorityOpt);
-    o.addOption(nameOpt);
-    o.addOption(allScopeOpt);
-    o.addOption(mincScopeOpt);
-    o.addOption(majcScopeOpt);
-    o.addOption(scanScopeOpt);
     o.addOptionGroup(typeGroup);
-    o.addOptionGroup(tableGroup);
-    return o;
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -364,7 +364,7 @@ public class SetIterCommand extends Command {
   }
 
   // Set all options common to both iterators and shell iterators
-  public void setBaseOptions(Options options) {
+  protected void setBaseOptions(Options options) {
     setPriorityOptions(options);
     setNameOptions(options);
     setIteratorTypeOptions(options);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -108,7 +108,7 @@ public class SetIterCommand extends Command {
       configuredName = setUpOptions(classloader, shellState.getReader(), classname, options);
     } finally {
       // ACCUMULO-4792: reset table name and continue
-      if (profileOpt != null && tmpTable != null) {
+      if (tmpTable != null) {
         shellState.setTableName(currentTableName);
       }
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetShellIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetShellIterCommand.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.ShellCommandException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +74,6 @@ public class SetShellIterCommand extends SetIterCommand {
         iter.remove();
       }
     }
-
     tableScanIterators.add(setting);
   }
 
@@ -86,43 +84,17 @@ public class SetShellIterCommand extends SetIterCommand {
 
   @Override
   public Options getOptions() {
-
     final Options o = new Options();
+    setBaseOptions(o);
+    setProfileOptions(o);
+    return o;
+  }
 
+  private void setProfileOptions(Options o) {
     profileOpt = new Option("pn", "profile", true, "iterator profile name");
     profileOpt.setRequired(true);
     profileOpt.setArgName("profile");
-
-    priorityOpt = new Option("p", "priority", true, "the order in which the iterator is applied");
-    priorityOpt.setArgName("pri");
-    priorityOpt.setRequired(true);
-
-    final OptionGroup typeGroup = new OptionGroup();
-    classnameTypeOpt = new Option("class", "class-name", true, "a java class that implements SortedKeyValueIterator");
-    classnameTypeOpt.setArgName("name");
-    aggTypeOpt = new Option("agg", "aggregator", false, "an aggregating type");
-    regexTypeOpt = new Option("regex", "regular-expression", false, "a regex matching iterator");
-    versionTypeOpt = new Option("vers", "version", false, "a versioning iterator");
-    reqvisTypeOpt = new Option("reqvis", "require-visibility", false, "an iterator that omits entries with empty visibilities");
-    ageoffTypeOpt = new Option("ageoff", "ageoff", false, "an aging off iterator");
-
-    typeGroup.addOption(classnameTypeOpt);
-    typeGroup.addOption(aggTypeOpt);
-    typeGroup.addOption(regexTypeOpt);
-    typeGroup.addOption(versionTypeOpt);
-    typeGroup.addOption(reqvisTypeOpt);
-    typeGroup.addOption(ageoffTypeOpt);
-    typeGroup.setRequired(true);
-
-    nameOpt = new Option("n", "name", true, "iterator to set");
-    nameOpt.setArgName("itername");
-
     o.addOption(profileOpt);
-    o.addOptionGroup(typeGroup);
-    o.addOption(priorityOpt);
-    o.addOption(nameOpt);
-
-    return o;
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1729,7 +1729,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
   @Test
   public void scansWithClassLoaderContext() throws Exception {
     try {
-      Class.forName("org.apache.accumulo.test.functional.ValueReversingIterator");
+      Class.forName(VALUE_REVERSING_ITERATOR);
       fail("ValueReversingIterator already on the classpath");
     } catch (Exception e) {
       // Do nothing here, This is success. The following line is here
@@ -1738,7 +1738,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     }
     ts.exec("createtable t");
     // Assert that the TabletServer does not know anything about our class
-    String result = ts.exec("setiter -scan -n reverse -t t -p 21 -class org.apache.accumulo.test.functional.ValueReversingIterator");
+    String result = ts.exec("setiter -scan -n reverse -t t -p 21 -class " + VALUE_REVERSING_ITERATOR);
     assertTrue(result.contains("class not found"));
     make10();
     setupFakeContextPath();
@@ -1749,7 +1749,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     result = ts.exec("config -t t -s table.classpath.context=" + FAKE_CONTEXT);
     assertEquals("root@miniInstance t> config -t t -s table.classpath.context=" + FAKE_CONTEXT + "\n", result);
 
-    result = ts.exec("setshelliter -pn baz -n reverse -p 21 -class org.apache.accumulo.test" + ".functional.ValueReversingIterator");
+    result = ts.exec("setshelliter -pn baz -n reverse -p 21 -class " + VALUE_REVERSING_ITERATOR);
     assertTrue(result.contains("The iterator class does not implement OptionDescriber"));
 
     // The implementation of ValueReversingIterator in the FAKE context does nothing, the value is not reversed.
@@ -1849,6 +1849,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
   private static final String REAL_CONTEXT = "REAL";
   private static final String REAL_CONTEXT_CLASSPATH = "file://" + System.getProperty("user.dir") + "/target/" + ShellServerIT.class.getSimpleName()
       + "-real-iterators.jar";
+  private static final String VALUE_REVERSING_ITERATOR = "org.apache.accumulo.test.functional.ValueReversingIterator";
 
   private void setupRealContextPath() throws Exception {
     // Copy the test iterators jar to tmp

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1802,8 +1802,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
   }
 
   /**
-   * The purpose of this test is to verify that you can successfully scan a table that has an iterator set but not via the shellIter capability. Purpose is to
-   * verify that the scansWithClassLoaderContext test can handle situations with both normal iterators and shell iterators.
+   * The purpose of this test is to verify that you can successfully scan a table with a regular iterator. It was written to verify that the changes made while
+   * updating the setshelliter command did not break the existing setiter capabilities. It tests that a table can be scanned with an iterator both while within
+   * a table context and also while in the 'notable' context.
    */
   @Test
   public void testScanTableWithIterSetWithoutProfile() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -405,7 +405,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("insert a cf cq 1");
     ts.exec("insert a cf cq 1");
     ts.input.set("true\n\n\n\nSTRING");
-    ts.exec("setscaniter -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 10 -n name", true);
+    ts.exec("setscaniter -class " + SUMMING_COMBINER_ITERATOR + " -p 10 -n name", true);
     ts.exec("scan", true, "3", true);
     ts.exec("deletescaniter -n name", true);
     ts.exec("scan", true, "1", true);
@@ -533,11 +533,11 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("insert a cf cq 1");
     ts.exec("insert a cf cq 1");
     ts.input.set("true\n\n\n\nSTRING\n");
-    ts.exec("setshelliter -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 10 -pn sum -n name", true);
-    ts.exec("setshelliter -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 11 -pn sum -n name", false);
-    ts.exec("setshelliter -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 10 -pn sum -n other", false);
+    ts.exec("setshelliter -class " + SUMMING_COMBINER_ITERATOR + " -p 10 -pn sum -n name", true);
+    ts.exec("setshelliter -class " + SUMMING_COMBINER_ITERATOR + " -p 11 -pn sum -n name", false);
+    ts.exec("setshelliter -class " + SUMMING_COMBINER_ITERATOR + " -p 10 -pn sum -n other", false);
     ts.input.set("true\n\n\n\nSTRING\n");
-    ts.exec("setshelliter -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 11 -pn sum -n xyzzy", true);
+    ts.exec("setshelliter -class " + SUMMING_COMBINER_ITERATOR + " -p 11 -pn sum -n xyzzy", true);
     ts.exec("scan -pn sum", true, "3", true);
     ts.exec("listshelliter", true, "Iterator name", true);
     ts.exec("listshelliter", true, "Iterator xyzzy", true);
@@ -555,11 +555,11 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("insert a cf cq 1");
     ts.exec("insert a cf cq 1");
     ts.input.set("true\n\n\n\nSTRING\n");
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 10 -n name", true);
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 11 -n name", false);
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 10 -n other", false);
+    ts.exec("setiter -scan -class " + SUMMING_COMBINER_ITERATOR + " -p 10 -n name", true);
+    ts.exec("setiter -scan -class " + SUMMING_COMBINER_ITERATOR + " -p 11 -n name", false);
+    ts.exec("setiter -scan -class " + SUMMING_COMBINER_ITERATOR + " -p 10 -n other", false);
     ts.input.set("true\n\n\n\nSTRING\n");
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 11 -n xyzzy", true);
+    ts.exec("setiter -scan -class " + SUMMING_COMBINER_ITERATOR + " -p 11 -n xyzzy", true);
     ts.exec("scan", true, "3", true);
     ts.exec("listiter -scan", true, "Iterator name", true);
     ts.exec("listiter -scan", true, "Iterator xyzzy", true);
@@ -580,13 +580,13 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("createtable " + tableName);
     ts.input.set("\n\n");
     // Setting a non-optiondescriber with no name should fail
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.ColumnFamilyCounter -p 30", false);
+    ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30", false);
 
     // Name as option will work
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.ColumnFamilyCounter -p 30 -name cfcounter", true);
+    ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30 -name cfcounter", true);
 
     String expectedKey = "table.iterator.scan.cfcounter";
-    String expectedValue = "30,org.apache.accumulo.core.iterators.ColumnFamilyCounter";
+    String expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
     TableOperations tops = conn.tableOperations();
     checkTableForProperty(tops, tableName, expectedKey, expectedValue);
 
@@ -598,9 +598,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.input.set("customcfcounter\n\n");
 
     // Name on the CLI should override OptionDescriber (or user input name, in this case)
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.ColumnFamilyCounter -p 30", true);
+    ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30", true);
     expectedKey = "table.iterator.scan.customcfcounter";
-    expectedValue = "30,org.apache.accumulo.core.iterators.ColumnFamilyCounter";
+    expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
     checkTableForProperty(tops, tableName, expectedKey, expectedValue);
 
     ts.exec("deletetable " + tableName, true);
@@ -611,9 +611,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.input.set("customcfcounter\nname1 value1\nname2 value2\n\n");
 
     // Name on the CLI should override OptionDescriber (or user input name, in this case)
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.ColumnFamilyCounter -p 30", true);
+    ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30", true);
     expectedKey = "table.iterator.scan.customcfcounter";
-    expectedValue = "30,org.apache.accumulo.core.iterators.ColumnFamilyCounter";
+    expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
     checkTableForProperty(tops, tableName, expectedKey, expectedValue);
     expectedKey = "table.iterator.scan.customcfcounter.opt.name1";
     expectedValue = "value1";
@@ -630,9 +630,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.input.set("\nname1 value1.1,value1.2,value1.3\nname2 value2\n\n");
 
     // Name on the CLI should override OptionDescriber (or user input name, in this case)
-    ts.exec("setiter -scan -class org.apache.accumulo.core.iterators.ColumnFamilyCounter -p 30 -name cfcounter", true);
+    ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30 -name cfcounter", true);
     expectedKey = "table.iterator.scan.cfcounter";
-    expectedValue = "30,org.apache.accumulo.core.iterators.ColumnFamilyCounter";
+    expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
     checkTableForProperty(tops, tableName, expectedKey, expectedValue);
     expectedKey = "table.iterator.scan.cfcounter.opt.name1";
     expectedValue = "value1.1,value1.2,value1.3";
@@ -1665,7 +1665,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("namespaces", true, "testers3", true);
     ts.exec("deletenamespace testers3 -f", true);
     ts.input.set("true\n\n\n\nSTRING\n");
-    ts.exec("setiter -ns thing2 -scan -class org.apache.accumulo.core.iterators.user.SummingCombiner -p 10 -n name", true);
+    ts.exec("setiter -ns thing2 -scan -class " + SUMMING_COMBINER_ITERATOR + " -p 10 -n name", true);
     ts.exec("listiter -ns thing2 -scan", true, "Summing", true);
     ts.exec("deleteiter -ns thing2 -n name -scan", true);
     ts.exec("createuser dude");
@@ -1851,6 +1851,8 @@ public class ShellServerIT extends SharedMiniClusterBase {
   private static final String REAL_CONTEXT_CLASSPATH = "file://" + System.getProperty("user.dir") + "/target/" + ShellServerIT.class.getSimpleName()
       + "-real-iterators.jar";
   private static final String VALUE_REVERSING_ITERATOR = "org.apache.accumulo.test.functional.ValueReversingIterator";
+  private static final String SUMMING_COMBINER_ITERATOR = "org.apache.accumulo.core.iterators.user.SummingCombiner";
+  private static final String COLUMN_FAMILY_COUNTER_ITERATOR = "org.apache.accumulo.core.iterators" + ".ColumnFamilyCounter";
 
   private void setupRealContextPath() throws Exception {
     // Copy the test iterators jar to tmp

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1817,10 +1817,10 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("scan", true, "foo a:b []    c");
 
     // create a normal iterator while in current table context
-    ts.input.set("\n5000\n\n");
+    ts.input.set("\n1000\n\n");
     ts.exec("setiter -scan -n itname -p 10 -ageoff", true);
 
-    ts.exec("sleep 6", true);
+    ts.exec("sleep 2", true);
     // scan the created table.
     ts.exec("scan", true, "", true);
     ts.exec("deletetable -f " + table);

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1835,9 +1835,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("scan -t " + table, true, "foo a:b []    c");
 
     // create a normal iterator which in current table context
-    ts.input.set("\n5000\n\n");
+    ts.input.set("\n1000\n\n");
     ts.exec("setiter -scan -n itname -p 10 -ageoff -t " + table, true);
-    ts.exec("sleep 6", true);
+    ts.exec("sleep 2", true);
     // re-scan the table. Should not see data.
     ts.exec("scan -t " + table, true, "", true);
     ts.exec("deletetable -f " + table);


### PR DESCRIPTION
The setshelliter command has incorrect usage statement. Update code to no longer require a table name in order for the command to execute.

The setshelliter command allows a user to set an iterator profile that can be used within a shell session without having to continuously having to input all the iterator related arguments each time it is used. There is no need to use a table or namespace argument, yet one of those arguments were required in order to create a shell iterator. This was due to the fact that the setshelliter command inherited from both the setitercommand and shell classes, both of which require a table or namespace. 

This update removes the need to supply the table/namespace arguments in order to create a shell iterator. Note that if the setshelliter command is used while within a table context the table argument was implied and the command would execute without issue. But if attempting to create a shell iterator when within the 'notable' context it would fail. To get around this issue, if the shell iterator command is called while not within a table context, the context is temporarily set to an existing table context and then reset once the shell iterator is created. 