### PR TITLE
ACCUMULO-4697 tablet server could kick off too many idle compactions

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1531,18 +1531,16 @@ public class Tablet implements TabletCommitter {
     return location;
   }
 
-  public synchronized boolean initiateMajorCompaction(MajorCompactionReason reason) {
+  public synchronized void initiateMajorCompaction(MajorCompactionReason reason) {
 
     if (isClosing() || isClosed() || !needsMajorCompaction(reason) || isMajorCompactionRunning()
         || majorCompactionQueued.contains(reason)) {
-      return false;
+      return;
     }
 
     majorCompactionQueued.add(reason);
 
     getTabletResources().executeMajorCompaction(getExtent(), new CompactionRunner(this, reason));
-
-    return false;
   }
 
   /**


### PR DESCRIPTION
ACCUMULO-4697 tablet server could kick off too many idle compactions

Tablet.initiateMajorCompaction() always returns false, but we check the return value when accounting for the number of idle major compactions started in TabletServer.MajorCompactor.run() and continue to kick off idle compactions on every tablet.

DefaultCompactionStrategy doesn't do anything special for idle compactions, so this will only be an issue with a custom CompactionStrategy.

My guess would be the best thing to do would be to get rid of idle compactions and get rid of the return value on initiateMajorCompaction().

This update follows the reporters suggestion and removes the idle compaction code and refactors the  initiateMajorCompaction() method to return void.

This ticket references Jira ticket  [ACCUMULO-4697](https://issues.apache.org/jira/browse/ACCUMULO-4697)
