### PR TITLE
Handle RW unexpected table state

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/randomwalk/concurrent/OfflineTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/randomwalk/concurrent/OfflineTable.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.test.randomwalk.Environment;
@@ -50,7 +51,12 @@ public class OfflineTable extends Test {
       log.debug("Onlined " + tableName);
     } catch (TableNotFoundException tne) {
       log.debug("offline or online failed " + tableName + ", doesnt exist");
+    } catch (AccumuloException ae) {
+      if (ae.getMessage().startsWith("Unexpected table state")) {
+        log.debug("offline or online failed " + tableName + ", unexpected table state");
+      } else {
+        throw ae;
+      }
     }
-
   }
 }


### PR DESCRIPTION
Saw this error during randomwalk:

<pre>12:44:53,443 [randomwalk.Framework] ERROR: Error during random walk
java.lang.Exception: Error running node Concurrent.xml
        at org.apache.accumulo.test.randomwalk.Module.visit(Module.java:352)
        at org.apache.accumulo.test.randomwalk.Framework.run(Framework.java:59)
        at org.apache.accumulo.test.randomwalk.Framework.main(Framework.java:122)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.accumulo.start.Main$2.run(Main.java:170)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.Exception: Error running node ct.OfflineTable
        at org.apache.accumulo.test.randomwalk.Module.visit(Module.java:352)
        at org.apache.accumulo.test.randomwalk.Module$1.call(Module.java:286)
        at org.apache.accumulo.test.randomwalk.Module$1.call(Module.java:281)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.apache.accumulo.fate.util.LoggingRunnable.run(LoggingRunnable.java:35)
        ... 1 more
Caused by: org.apache.accumulo.core.client.AccumuloException: Unexpected table state 5un OFFLINE != ONLINE
        at org.apache.accumulo.core.client.impl.TableOperationsImpl.waitForTableStateTransition(TableOperationsImpl.java:1202)
        at org.apache.accumulo.core.client.impl.TableOperationsImpl.online(TableOperationsImpl.java:1381)
        at org.apache.accumulo.test.randomwalk.concurrent.OfflineTable.visit(OfflineTable.java:49)
</pre>