### PR TITLE
When filtering in config, include values

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -189,10 +189,13 @@ public class ConfigCommand extends Command {
 
       for (Entry<String,String> propEntry : acuconf) {
         final String key = propEntry.getKey();
-        // only show properties with similar names to that
-        // specified, or all of them if none specified
+        final String value = propEntry.getValue();
+        // only show properties which names or values
+        // match the filter text
+
         if (cl.hasOption(filterOpt.getOpt())
-            && !key.contains(cl.getOptionValue(filterOpt.getOpt()))) {
+            && !(key.contains(cl.getOptionValue(filterOpt.getOpt()))
+                || value.contains(cl.getOptionValue(filterOpt.getOpt())))) {
           continue;
         }
         if ((tableName != null || namespace != null) && !Property.isValidTablePropertyKey(key)) {
@@ -206,11 +209,13 @@ public class ConfigCommand extends Command {
 
       for (Entry<String,String> propEntry : sortedConf.entrySet()) {
         final String key = propEntry.getKey();
+        final String value = propEntry.getValue();
+        // only show properties which names or values
+        // match the filter text
 
-        // only show properties with similar names to that
-        // specified, or all of them if none specified
         if (cl.hasOption(filterOpt.getOpt())
-            && !key.contains(cl.getOptionValue(filterOpt.getOpt()))) {
+            && !(key.contains(cl.getOptionValue(filterOpt.getOpt()))
+                || value.contains(cl.getOptionValue(filterOpt.getOpt())))) {
           continue;
         }
         if ((tableName != null || namespace != null) && !Property.isValidTablePropertyKey(key)) {


### PR DESCRIPTION
It is not uncommon that the value of a config setting is what I am looking for. I often end up searching through the code for the property name when the filter could just check the value as well. 

I thought about adding a seperate parameter, but the description for filter made it feel as though this was the expected behavior anyway. 