### PR TITLE
fixes #449 fix two bugs with WAL recovery

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -3276,12 +3276,12 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     logger.recover(fs, extent, tconf, recoveryLogs, tabletFiles, mutationReceiver);
   }
 
-  public int createLogId(KeyExtent tablet) {
-    AccumuloConfiguration acuTableConf = getTableConfiguration(tablet);
-    if (DurabilityImpl.fromString(acuTableConf.get(Property.TABLE_DURABILITY)) != Durability.NONE) {
-      return logIdGenerator.incrementAndGet();
+  public int createLogId() {
+    int logId = logIdGenerator.incrementAndGet();
+    if (logId < 0) {
+      throw new IllegalStateException("Log Id rolled");
     }
-    return -1;
+    return logId;
   }
 
   public TableConfiguration getTableConfiguration(KeyExtent extent) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/CloseableIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/CloseableIterator.java
@@ -14,9 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.tserver.logger;
+package org.apache.accumulo.tserver.log;
 
-public enum LogEvents {
-  // DO NOT CHANGE ORDER OF ENUMS, ORDER IS USED IN SERIALIZATION
-  OPEN, DEFINE_TABLET, MUTATION, MANY_MUTATIONS, COMPACTION_START, COMPACTION_FINISH;
+import java.io.IOException;
+import java.util.Iterator;
+
+public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
+  @Override
+  public void close() throws IOException;
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -601,7 +601,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     final LogFileKey key = new LogFileKey();
     key.event = DEFINE_TABLET;
     key.seq = seq;
-    key.tid = tid;
+    key.tabletId = tid;
     key.tablet = tablet;
     try {
       write(key, EMPTY);
@@ -662,7 +662,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
       LogFileKey key = new LogFileKey();
       key.event = MANY_MUTATIONS;
       key.seq = tabletMutations.getSeq();
-      key.tid = tabletMutations.getTid();
+      key.tabletId = tabletMutations.getTid();
       LogFileValue value = new LogFileValue();
       value.mutations = tabletMutations.getMutations();
       data.add(new Pair<>(key, value));
@@ -688,7 +688,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     LogFileKey key = new LogFileKey();
     key.event = COMPACTION_FINISH;
     key.seq = seq;
-    key.tid = tid;
+    key.tabletId = tid;
     return logFileData(Collections.singletonList(new Pair<>(key, EMPTY)), durability);
   }
 
@@ -697,7 +697,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     LogFileKey key = new LogFileKey();
     key.event = COMPACTION_START;
     key.seq = seq;
-    key.tid = tid;
+    key.tabletId = tid;
     key.filename = fqfn;
     return logFileData(Collections.singletonList(new Pair<>(key, EMPTY)), durability);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.tserver.log;
+
+import static org.apache.accumulo.tserver.logger.LogEvents.OPEN;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.tserver.logger.LogEvents;
+import org.apache.accumulo.tserver.logger.LogFileKey;
+import org.apache.accumulo.tserver.logger.LogFileValue;
+import org.apache.hadoop.fs.Path;
+import org.mortbay.log.Log;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+import com.google.common.collect.UnmodifiableIterator;
+
+/**
+ * Iterates over multiple recovery logs merging them into a single sorted stream.
+ */
+public class RecoveryLogsIterator
+    implements Iterator<Entry<LogFileKey,LogFileValue>>, AutoCloseable {
+
+  private List<MultiReader> readers;
+  private UnmodifiableIterator<Entry<LogFileKey,LogFileValue>> iter;
+
+  private static class MultiReaderIterator implements Iterator<Entry<LogFileKey,LogFileValue>> {
+
+    private MultiReader reader;
+    private LogFileKey key = new LogFileKey();
+    private LogFileValue value = new LogFileValue();
+    private boolean hasNext;
+    private LogFileKey end;
+
+    MultiReaderIterator(MultiReader reader, LogFileKey start, LogFileKey end) throws IOException {
+      this.reader = reader;
+      this.end = end;
+
+      reader.seek(start);
+
+      hasNext = reader.next(key, value);
+
+      if (hasNext && key.compareTo(start) < 0) {
+        throw new IllegalStateException("First key is less than start " + key + " " + start);
+      }
+
+      if (hasNext && key.compareTo(end) > 0) {
+        hasNext = false;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return hasNext;
+    }
+
+    @Override
+    public Entry<LogFileKey,LogFileValue> next() {
+      Preconditions.checkState(hasNext);
+      Entry<LogFileKey,LogFileValue> entry = new AbstractMap.SimpleImmutableEntry<>(key, value);
+
+      key = new LogFileKey();
+      value = new LogFileValue();
+      try {
+        hasNext = reader.next(key, value);
+        if (hasNext && key.compareTo(end) > 0) {
+          hasNext = false;
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+
+      return entry;
+    }
+  }
+
+  static class SortCheckIterator implements Iterator<Entry<LogFileKey,LogFileValue>> {
+
+    private PeekingIterator<Entry<LogFileKey,LogFileValue>> source;
+    private String sourceName;
+
+    SortCheckIterator(String sourceName, Iterator<Entry<LogFileKey,LogFileValue>> source) {
+      this.source = Iterators.peekingIterator(source);
+      this.sourceName = sourceName;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return source.hasNext();
+    }
+
+    @Override
+    public Entry<LogFileKey,LogFileValue> next() {
+      Entry<LogFileKey,LogFileValue> next = source.next();
+      if (source.hasNext()) {
+        Preconditions.checkState(next.getKey().compareTo(source.peek().getKey()) <= 0,
+            "Data source %s keys not in order %s %s", sourceName, next.getKey(),
+            source.peek().getKey());
+      }
+      return next;
+    }
+  }
+
+  private MultiReader open(VolumeManager fs, Path log) throws IOException {
+    MultiReader reader = new MultiReader(fs, log);
+    LogFileKey key = new LogFileKey();
+    LogFileValue value = new LogFileValue();
+    if (!reader.next(key, value)) {
+      reader.close();
+      return null;
+    }
+    if (key.event != OPEN) {
+      reader.close();
+      throw new RuntimeException("First log entry value is not OPEN");
+    }
+
+    return reader;
+  }
+
+  static LogFileKey maxKey(LogEvents event) {
+    LogFileKey key = new LogFileKey();
+    key.event = event;
+    key.tid = Integer.MAX_VALUE;
+    key.seq = Long.MAX_VALUE;
+    return key;
+  }
+
+  static LogFileKey maxKey(LogEvents event, int tid) {
+    LogFileKey key = maxKey(event);
+    key.tid = tid;
+    return key;
+  }
+
+  static LogFileKey minKey(LogEvents event) {
+    LogFileKey key = new LogFileKey();
+    key.event = event;
+    key.tid = 0;
+    key.seq = 0;
+    return key;
+  }
+
+  static LogFileKey minKey(LogEvents event, int tid) {
+    LogFileKey key = minKey(event);
+    key.tid = tid;
+    return key;
+  }
+
+  /**
+   * Iterates only over keys with the specified event (some events are equivalent for sorting) and
+   * tid type.
+   */
+  RecoveryLogsIterator(VolumeManager fs, List<Path> recoveryLogPaths, LogEvents event, int tid)
+      throws IOException {
+    this(fs, recoveryLogPaths, minKey(event, tid), maxKey(event, tid));
+  }
+
+  /**
+   * Iterates only over keys with the specified event (some events are equivalent for sorting).
+   */
+  RecoveryLogsIterator(VolumeManager fs, List<Path> recoveryLogPaths, LogEvents event)
+      throws IOException {
+    this(fs, recoveryLogPaths, minKey(event), maxKey(event));
+  }
+
+  /**
+   * Iterates only over keys between [start,end].
+   */
+  RecoveryLogsIterator(VolumeManager fs, List<Path> recoveryLogPaths, LogFileKey start,
+      LogFileKey end) throws IOException {
+    readers = new ArrayList<>(recoveryLogPaths.size());
+
+    ArrayList<Iterator<Entry<LogFileKey,LogFileValue>>> iterators = new ArrayList<>();
+
+    try {
+      for (Path log : recoveryLogPaths) {
+        MultiReader reader = open(fs, log);
+        if (reader != null) {
+          readers.add(reader);
+          iterators.add(
+              new SortCheckIterator(log.getName(), new MultiReaderIterator(reader, start, end)));
+        }
+      }
+
+      iter = Iterators.mergeSorted(iterators, new Comparator<Entry<LogFileKey,LogFileValue>>() {
+        @Override
+        public int compare(Entry<LogFileKey,LogFileValue> o1, Entry<LogFileKey,LogFileValue> o2) {
+          return o1.getKey().compareTo(o2.getKey());
+        }
+      });
+
+    } catch (RuntimeException | IOException e) {
+      close();
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iter.hasNext();
+  }
+
+  @Override
+  public Entry<LogFileKey,LogFileValue> next() {
+    return iter.next();
+  }
+
+  @Override
+  public void close() {
+    for (MultiReader reader : readers) {
+      try {
+        reader.close();
+      } catch (IOException e) {
+        Log.debug("Failed to close reader", e);
+      }
+    }
+  }
+}

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -16,12 +16,9 @@
  */
 package org.apache.accumulo.tserver.log;
 
-import static org.apache.accumulo.tserver.logger.LogEvents.OPEN;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -32,94 +29,30 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.UnmodifiableIterator;
 
 /**
  * Iterates over multiple sorted recovery logs merging them into a single sorted stream.
  */
-public class RecoveryLogsIterator
-    implements Iterator<Entry<LogFileKey,LogFileValue>>, AutoCloseable {
+public class RecoveryLogsIterator implements CloseableIterator<Entry<LogFileKey,LogFileValue>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryLogsIterator.class);
 
-  private List<RecoveryLogReader> readers;
+  List<CloseableIterator<Entry<LogFileKey,LogFileValue>>> iterators;
   private UnmodifiableIterator<Entry<LogFileKey,LogFileValue>> iter;
 
   /**
-   * Ensures source iterator provides data in sorted order
-   */
-  // TODO add unit test and move to RecoveryLogReader
-  @VisibleForTesting
-  static class SortCheckIterator implements Iterator<Entry<LogFileKey,LogFileValue>> {
-
-    private PeekingIterator<Entry<LogFileKey,LogFileValue>> source;
-    private String sourceName;
-
-    SortCheckIterator(String sourceName, Iterator<Entry<LogFileKey,LogFileValue>> source) {
-      this.source = Iterators.peekingIterator(source);
-      this.sourceName = sourceName;
-    }
-
-    @Override
-    public boolean hasNext() {
-      return source.hasNext();
-    }
-
-    @Override
-    public Entry<LogFileKey,LogFileValue> next() {
-      Entry<LogFileKey,LogFileValue> next = source.next();
-      if (source.hasNext()) {
-        Preconditions.checkState(next.getKey().compareTo(source.peek().getKey()) <= 0,
-            "Data source %s keys not in order %s %s", sourceName, next.getKey(),
-            source.peek().getKey());
-      }
-      return next;
-    }
-  }
-
-  // TODO get rid of this (push down into iterator in RecoveryLogReader)
-  private RecoveryLogReader open(VolumeManager fs, Path log) throws IOException {
-    RecoveryLogReader reader = new RecoveryLogReader(fs, log);
-    LogFileKey key = new LogFileKey();
-    LogFileValue value = new LogFileValue();
-    if (!reader.next(key, value)) {
-      reader.close();
-      return null;
-    }
-    if (key.event != OPEN) {
-      RuntimeException e = new IllegalStateException(
-          "First log entry value is not OPEN (" + log + ")");
-      try {
-        reader.close();
-      } catch (Exception e2) {
-        e.addSuppressed(e2);
-      }
-      throw e;
-    }
-
-    return reader;
-  }
-
-  /**
-   * Iterates only over keys between [start,end].
+   * Iterates only over keys in the range [start,end].
    */
   RecoveryLogsIterator(VolumeManager fs, List<Path> recoveryLogPaths, LogFileKey start,
       LogFileKey end) throws IOException {
-    readers = new ArrayList<>(recoveryLogPaths.size());
 
-    ArrayList<Iterator<Entry<LogFileKey,LogFileValue>>> iterators = new ArrayList<>();
+    iterators = new ArrayList<>(recoveryLogPaths.size());
 
     try {
       for (Path log : recoveryLogPaths) {
-        RecoveryLogReader reader = open(fs, log);
-        if (reader != null) {
-          readers.add(reader);
-          iterators.add(new SortCheckIterator(log.getName(), reader.getIterator(start, end)));
-        }
+        iterators.add(new RecoveryLogReader(fs, log, start, end));
       }
 
       iter = Iterators.mergeSorted(iterators, new Comparator<Entry<LogFileKey,LogFileValue>>() {
@@ -150,8 +83,13 @@ public class RecoveryLogsIterator
   }
 
   @Override
+  public void remove() {
+    throw new UnsupportedOperationException("remove");
+  }
+
+  @Override
   public void close() {
-    for (RecoveryLogReader reader : readers) {
+    for (CloseableIterator<?> reader : iterators) {
       try {
         reader.close();
       } catch (IOException e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -78,7 +78,10 @@ public class SortedLogRecovery {
   static LogFileKey minKey(LogEvents event) {
     LogFileKey key = new LogFileKey();
     key.event = event;
-    key.tabletId = 0;
+    // see GitHub issue #477. There was a bug that caused -1 to end up in tabletId. If this happens
+    // want to detect it and fail since recovery is dubious in this situation . Other code should
+    // fail if the id is actually -1 in data.
+    key.tabletId = -1;
     key.seq = 0;
     return key;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -64,28 +64,28 @@ public class SortedLogRecovery {
   static LogFileKey maxKey(LogEvents event) {
     LogFileKey key = new LogFileKey();
     key.event = event;
-    key.tid = Integer.MAX_VALUE;
+    key.tabletId = Integer.MAX_VALUE;
     key.seq = Long.MAX_VALUE;
     return key;
   }
 
   static LogFileKey maxKey(LogEvents event, int tabletId) {
     LogFileKey key = maxKey(event);
-    key.tid = tabletId;
+    key.tabletId = tabletId;
     return key;
   }
 
   static LogFileKey minKey(LogEvents event) {
     LogFileKey key = new LogFileKey();
     key.event = event;
-    key.tid = 0;
+    key.tabletId = 0;
     key.seq = 0;
     return key;
   }
 
   static LogFileKey minKey(LogEvents event, int tabletId) {
     LogFileKey key = minKey(event);
-    key.tid = tabletId;
+    key.tabletId = tabletId;
     return key;
   }
 
@@ -106,12 +106,12 @@ public class SortedLogRecovery {
         checkState(key.event == DEFINE_TABLET); // should only fail if bug elsewhere
 
         if (key.tablet.equals(extent) || key.tablet.equals(alternative)) {
-          checkState(key.tid >= 0, "Tid %s for %s is negative", key.tid, extent);
-          checkState(tabletId == -1 || key.tid >= tabletId); // should only fail if bug in
+          checkState(key.tabletId >= 0, "tabletId %s for %s is negative", key.tabletId, extent);
+          checkState(tabletId == -1 || key.tabletId >= tabletId); // should only fail if bug in
           // RecoveryLogsIterator
 
-          if (tabletId != key.tid) {
-            tabletId = key.tid;
+          if (tabletId != key.tabletId) {
+            tabletId = key.tabletId;
           }
         }
       }
@@ -175,7 +175,7 @@ public class SortedLogRecovery {
         LogFileKey key = ddi.next().getKey();
 
         checkState(key.seq >= 0, "Unexpected negative seq %s for tabletId %s", key.seq, tabletId);
-        checkState(key.tid == tabletId); // should only fail if bug elsewhere
+        checkState(key.tabletId == tabletId); // should only fail if bug elsewhere
 
         if (key.event == COMPACTION_START) {
           checkState(key.seq >= lastStart); // should only fail if bug elsewhere
@@ -186,7 +186,7 @@ public class SortedLogRecovery {
             firstEventWasFinish = true;
           } else if (lastEvent == COMPACTION_FINISH) {
             throw new IllegalStateException(
-                "Saw consecutive COMPACTION_FINISH events " + key.tid + " " + key.seq);
+                "Saw consecutive COMPACTION_FINISH events " + key.tabletId + " " + key.seq);
           } else {
             if (key.seq <= lastStart) {
               throw new IllegalStateException(
@@ -230,7 +230,7 @@ public class SortedLogRecovery {
       while (rli.hasNext()) {
         Entry<LogFileKey,LogFileValue> entry = rli.next();
 
-        checkState(entry.getKey().tid == tabletId); // should only fail if bug elsewhere
+        checkState(entry.getKey().tabletId == tabletId); // should only fail if bug elsewhere
         checkState(entry.getKey().seq >= recoverySeq); // should only fail if bug elsewhere
 
         if (entry.getKey().event == MUTATION) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogEvents.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogEvents.java
@@ -17,6 +17,9 @@
 package org.apache.accumulo.tserver.logger;
 
 public enum LogEvents {
+  // TODO add unit test to verify ordinals, rather than rely on dubious comments
+  // TODO if possible, rename COMPACTION to "FLUSH" (or at least "MINC") without changing
+  // serialization
   // DO NOT CHANGE ORDER OF ENUMS, ORDER IS USED IN SERIALIZATION
   OPEN, DEFINE_TABLET, MUTATION, MANY_MUTATIONS, COMPACTION_START, COMPACTION_FINISH;
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -34,7 +34,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
   public String filename = null;
   public KeyExtent tablet = null;
   public long seq = -1;
-  public int tid = -1;
+  public int tid = -1; // TODO rename to tabletId
   public static final int VERSION = 2;
   public String tserverSession;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -34,7 +34,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
   public String filename = null;
   public KeyExtent tablet = null;
   public long seq = -1;
-  public int tid = -1; // TODO rename to tabletId
+  public int tabletId = -1;
   public static final int VERSION = 2;
   public String tserverSession;
 
@@ -48,35 +48,35 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
     event = LogEvents.values()[value];
     switch (event) {
       case OPEN:
-        tid = in.readInt();
+        tabletId = in.readInt();
         tserverSession = in.readUTF();
-        if (tid != VERSION) {
-          throw new RuntimeException(String
-              .format("Bad version number for log file: expected %d, but saw %d", VERSION, tid));
+        if (tabletId != VERSION) {
+          throw new RuntimeException(String.format(
+              "Bad version number for log file: expected %d, but saw %d", VERSION, tabletId));
         }
         break;
       case COMPACTION_FINISH:
         seq = in.readLong();
-        tid = in.readInt();
+        tabletId = in.readInt();
         break;
       case COMPACTION_START:
         seq = in.readLong();
-        tid = in.readInt();
+        tabletId = in.readInt();
         filename = in.readUTF();
         break;
       case DEFINE_TABLET:
         seq = in.readLong();
-        tid = in.readInt();
+        tabletId = in.readInt();
         tablet = new KeyExtent();
         tablet.readFields(in);
         break;
       case MANY_MUTATIONS:
         seq = in.readLong();
-        tid = in.readInt();
+        tabletId = in.readInt();
         break;
       case MUTATION:
         seq = in.readLong();
-        tid = in.readInt();
+        tabletId = in.readInt();
         break;
       default:
         throw new RuntimeException("Unknown log event type: " + event);
@@ -90,32 +90,32 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
     switch (event) {
       case OPEN:
         seq = -1;
-        tid = -1;
+        tabletId = -1;
         out.writeInt(VERSION);
         out.writeUTF(tserverSession);
         // out.writeUTF(Accumulo.getInstanceID());
         break;
       case COMPACTION_FINISH:
         out.writeLong(seq);
-        out.writeInt(tid);
+        out.writeInt(tabletId);
         break;
       case COMPACTION_START:
         out.writeLong(seq);
-        out.writeInt(tid);
+        out.writeInt(tabletId);
         out.writeUTF(filename);
         break;
       case DEFINE_TABLET:
         out.writeLong(seq);
-        out.writeInt(tid);
+        out.writeInt(tabletId);
         tablet.write(out);
         break;
       case MANY_MUTATIONS:
         out.writeLong(seq);
-        out.writeInt(tid);
+        out.writeInt(tabletId);
         break;
       case MUTATION:
         out.writeLong(seq);
-        out.writeInt(tid);
+        out.writeInt(tabletId);
         break;
       default:
         throw new IllegalArgumentException("Bad value for LogFileEntry type");
@@ -151,8 +151,8 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
     }
     if (this.event == OPEN)
       return 0;
-    if (this.tid != o.tid) {
-      return this.tid - o.tid;
+    if (this.tabletId != o.tabletId) {
+      return this.tabletId - o.tabletId;
     }
     return sign(this.seq - o.seq);
   }
@@ -176,15 +176,15 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
       case OPEN:
         return String.format("OPEN %s", tserverSession);
       case COMPACTION_FINISH:
-        return String.format("COMPACTION_FINISH %d %d", tid, seq);
+        return String.format("COMPACTION_FINISH %d %d", tabletId, seq);
       case COMPACTION_START:
-        return String.format("COMPACTION_START %d %d %s", tid, seq, filename);
+        return String.format("COMPACTION_START %d %d %s", tabletId, seq, filename);
       case MUTATION:
-        return String.format("MUTATION %d %d", tid, seq);
+        return String.format("MUTATION %d %d", tabletId, seq);
       case MANY_MUTATIONS:
-        return String.format("MANY_MUTATIONS %d %d", tid, seq);
+        return String.format("MANY_MUTATIONS %d %d", tabletId, seq);
       case DEFINE_TABLET:
-        return String.format("DEFINE_TABLET %d %d %s", tid, seq, tablet);
+        return String.format("DEFINE_TABLET %d %d %s", tabletId, seq, tablet);
     }
     throw new RuntimeException("Unknown type of entry: " + event);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.accumulo.tserver.log.DfsLogger;
 import org.apache.accumulo.tserver.log.DfsLogger.DFSLoggerInputStreams;
 import org.apache.accumulo.tserver.log.DfsLogger.LogHeaderIncompleteException;
-import org.apache.accumulo.tserver.log.MultiReader;
+import org.apache.accumulo.tserver.log.RecoveryLogReader;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
@@ -129,7 +129,7 @@ public class LogReader {
         }
       } else {
         // read the log entries sorted in a map file
-        MultiReader input = new MultiReader(fs, path);
+        RecoveryLogReader input = new RecoveryLogReader(fs, path);
         while (input.next(key, value)) {
           printLogEvent(key, value, row, rowMatcher, ke, tabletIds, opts.maxMutations);
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -720,7 +720,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
       switch (key.event) {
         case DEFINE_TABLET:
           if (target.getSourceTableId().equals(key.tablet.getTableId())) {
-            desiredTids.add(key.tid);
+            desiredTids.add(key.tabletId);
           }
           break;
         default:
@@ -772,13 +772,13 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
         case DEFINE_TABLET:
           // For new DEFINE_TABLETs, we also need to record the new tids we see
           if (target.getSourceTableId().equals(key.tablet.getTableId())) {
-            desiredTids.add(key.tid);
+            desiredTids.add(key.tabletId);
           }
           break;
         case MUTATION:
         case MANY_MUTATIONS:
           // Only write out mutations for tids that are for the desired tablet
-          if (desiredTids.contains(key.tid)) {
+          if (desiredTids.contains(key.tabletId)) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             DataOutputStream out = new DataOutputStream(baos);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -330,7 +330,7 @@ public class Tablet implements TabletCommitter {
     this.splitCreationTime = data.getSplitTime();
     this.tabletTime = TabletTime.getInstance(data.getTime());
     this.persistedTime = tabletTime.getTime();
-    this.logId = tabletServer.createLogId(extent);
+    this.logId = tabletServer.createLogId();
 
     TableConfiguration tblConf = tabletServer.getTableConfiguration(extent);
     if (null == tblConf) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEventsTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogEventsTest.java
@@ -14,9 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.tserver.logger;
+package org.apache.accumulo.tserver.log;
 
-public enum LogEvents {
-  // DO NOT CHANGE ORDER OF ENUMS, ORDER IS USED IN SERIALIZATION
-  OPEN, DEFINE_TABLET, MUTATION, MANY_MUTATIONS, COMPACTION_START, COMPACTION_FINISH;
+import org.apache.accumulo.tserver.logger.LogEvents;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogEventsTest {
+  @Test
+  public void testOrdinals() {
+    // Ordinals are used for persistence, so its important they are stable.
+
+    LogEvents[] expectedOrder = new LogEvents[] {LogEvents.OPEN, LogEvents.DEFINE_TABLET,
+        LogEvents.MUTATION, LogEvents.MANY_MUTATIONS, LogEvents.COMPACTION_START,
+        LogEvents.COMPACTION_FINISH};
+
+    for (int i = 0; i < expectedOrder.length; i++) {
+      Assert.assertEquals(i, expectedOrder[i].ordinal());
+    }
+  }
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
@@ -57,6 +57,8 @@ public class LogFileKeyTest {
     // add keys in expected sort order
     keys.add(nk(LogEvents.OPEN, 0, 0));
 
+    // there was a bug that was putting -1 in WAL for tabletId, ensure this data sorts as expected
+    keys.add(nk(LogEvents.DEFINE_TABLET, -1, 0));
     keys.add(nk(LogEvents.DEFINE_TABLET, 3, 6));
     keys.add(nk(LogEvents.DEFINE_TABLET, 3, 7));
     keys.add(nk(LogEvents.DEFINE_TABLET, 4, 2));

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.tserver.log;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.accumulo.tserver.logger.LogEvents;
+import org.apache.accumulo.tserver.logger.LogFileKey;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogFileKeyTest {
+
+  private static LogFileKey nk(LogEvents e, int tabletId, long seq) {
+    LogFileKey k = new LogFileKey();
+    k.event = e;
+    k.tabletId = tabletId;
+    k.seq = seq;
+    return k;
+  }
+
+  @Test
+  public void testEquivalence() {
+
+    LogFileKey start = nk(LogEvents.COMPACTION_START, 1, 3);
+    LogFileKey finish = nk(LogEvents.COMPACTION_FINISH, 1, 3);
+    LogFileKey mut = nk(LogEvents.MUTATION, 1, 3);
+    LogFileKey mmut = nk(LogEvents.MANY_MUTATIONS, 1, 3);
+
+    Assert.assertTrue(start.compareTo(finish) == 0);
+    Assert.assertTrue(finish.compareTo(start) == 0);
+
+    Assert.assertTrue(mut.compareTo(mmut) == 0);
+    Assert.assertTrue(mmut.compareTo(mut) == 0);
+  }
+
+  @Test
+  public void testSortOrder() {
+    List<LogFileKey> keys = new ArrayList<>();
+
+    // add keys in expected sort order
+    keys.add(nk(LogEvents.OPEN, 0, 0));
+
+    keys.add(nk(LogEvents.DEFINE_TABLET, 3, 6));
+    keys.add(nk(LogEvents.DEFINE_TABLET, 3, 7));
+    keys.add(nk(LogEvents.DEFINE_TABLET, 4, 2));
+    keys.add(nk(LogEvents.DEFINE_TABLET, 4, 9));
+
+    keys.add(nk(LogEvents.COMPACTION_START, 3, 3));
+    keys.add(nk(LogEvents.COMPACTION_FINISH, 3, 5));
+    keys.add(nk(LogEvents.COMPACTION_START, 3, 7));
+    keys.add(nk(LogEvents.COMPACTION_FINISH, 3, 9));
+
+    keys.add(nk(LogEvents.COMPACTION_START, 4, 1));
+    keys.add(nk(LogEvents.COMPACTION_FINISH, 4, 3));
+    keys.add(nk(LogEvents.COMPACTION_START, 4, 11));
+    keys.add(nk(LogEvents.COMPACTION_FINISH, 4, 13));
+
+    keys.add(nk(LogEvents.MUTATION, 3, 1));
+    keys.add(nk(LogEvents.MUTATION, 3, 2));
+    keys.add(nk(LogEvents.MUTATION, 3, 3));
+    keys.add(nk(LogEvents.MUTATION, 3, 3));
+    keys.add(nk(LogEvents.MANY_MUTATIONS, 3, 11));
+
+    keys.add(nk(LogEvents.MANY_MUTATIONS, 4, 2));
+    keys.add(nk(LogEvents.MUTATION, 4, 3));
+    keys.add(nk(LogEvents.MUTATION, 4, 5));
+    keys.add(nk(LogEvents.MUTATION, 4, 7));
+    keys.add(nk(LogEvents.MANY_MUTATIONS, 4, 15));
+
+    for (int i = 0; i < 10; i++) {
+      List<LogFileKey> testList = new ArrayList<>(keys);
+      Collections.shuffle(testList);
+      Collections.sort(testList);
+
+      Assert.assertEquals(keys, testList);
+    }
+
+  }
+}

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsReaderTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsReaderTest.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class MultiReaderTest {
+public class RecoveryLogsReaderTest {
 
   VolumeManager fs;
   TemporaryFolder root = new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
@@ -73,7 +73,7 @@ public class MultiReaderTest {
     root.create();
   }
 
-  private void scan(MultiReader reader, int start) throws IOException {
+  private void scan(RecoveryLogReader reader, int start) throws IOException {
     IntWritable key = new IntWritable();
     BytesWritable value = new BytesWritable();
 
@@ -85,7 +85,7 @@ public class MultiReaderTest {
     }
   }
 
-  private void scanOdd(MultiReader reader, int start) throws IOException {
+  private void scanOdd(RecoveryLogReader reader, int start) throws IOException {
     IntWritable key = new IntWritable();
     BytesWritable value = new BytesWritable();
 
@@ -98,7 +98,7 @@ public class MultiReaderTest {
   @Test
   public void testMultiReader() throws IOException {
     Path manyMaps = new Path("file://" + root.getRoot().getAbsolutePath() + "/manyMaps");
-    MultiReader reader = new MultiReader(fs, manyMaps);
+    RecoveryLogReader reader = new RecoveryLogReader(fs, manyMaps);
     IntWritable key = new IntWritable();
     BytesWritable value = new BytesWritable();
 
@@ -128,7 +128,7 @@ public class MultiReaderTest {
     reader.close();
 
     fs.deleteRecursively(new Path(manyMaps, "even"));
-    reader = new MultiReader(fs, manyMaps);
+    reader = new RecoveryLogReader(fs, manyMaps);
     key.set(501);
     assertTrue(reader.seek(key));
     scanOdd(reader, 501);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsReaderTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsReaderTest.java
@@ -22,9 +22,17 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
 
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.tserver.log.RecoveryLogReader.SortCheckIterator;
+import org.apache.accumulo.tserver.logger.LogEvents;
+import org.apache.accumulo.tserver.logger.LogFileKey;
+import org.apache.accumulo.tserver.logger.LogFileValue;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
@@ -142,6 +150,31 @@ public class RecoveryLogsReaderTest {
     assertEquals(1, key.get());
     reader.close();
 
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testSortCheck() {
+
+    List<Entry<LogFileKey,LogFileValue>> unsorted = new ArrayList<>();
+
+    LogFileKey k1 = new LogFileKey();
+    k1.event = LogEvents.MANY_MUTATIONS;
+    k1.tabletId = 2;
+    k1.seq = 55;
+
+    LogFileKey k2 = new LogFileKey();
+    k2.event = LogEvents.MANY_MUTATIONS;
+    k2.tabletId = 9;
+    k2.seq = 9;
+
+    unsorted.add(new AbstractMap.SimpleEntry<>(k2, (LogFileValue) null));
+    unsorted.add(new AbstractMap.SimpleEntry<>(k1, (LogFileValue) null));
+
+    SortCheckIterator iter = new SortCheckIterator(unsorted.iterator());
+
+    while (iter.hasNext()) {
+      iter.next();
+    }
   }
 
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -46,7 +46,7 @@ public class LogFileTest {
     LogFileKey key = new LogFileKey();
     key.event = event;
     key.seq = seq;
-    key.tid = tid;
+    key.tabletId = tid;
     key.filename = filename;
     key.tablet = tablet;
     key.tserverSession = keyResult.tserverSession;
@@ -75,24 +75,24 @@ public class LogFileTest {
     readWrite(COMPACTION_FINISH, 1, 2, null, null, null, key, value);
     assertEquals(key.event, COMPACTION_FINISH);
     assertEquals(key.seq, 1);
-    assertEquals(key.tid, 2);
+    assertEquals(key.tabletId, 2);
     readWrite(COMPACTION_START, 3, 4, "some file", null, null, key, value);
     assertEquals(key.event, COMPACTION_START);
     assertEquals(key.seq, 3);
-    assertEquals(key.tid, 4);
+    assertEquals(key.tabletId, 4);
     assertEquals(key.filename, "some file");
     KeyExtent tablet = new KeyExtent("table", new Text("bbbb"), new Text("aaaa"));
     readWrite(DEFINE_TABLET, 5, 6, null, tablet, null, key, value);
     assertEquals(key.event, DEFINE_TABLET);
     assertEquals(key.seq, 5);
-    assertEquals(key.tid, 6);
+    assertEquals(key.tabletId, 6);
     assertEquals(key.tablet, tablet);
     Mutation m = new ServerMutation(new Text("row"));
     m.put(new Text("cf"), new Text("cq"), new Value("value".getBytes()));
     readWrite(MUTATION, 7, 8, null, null, new Mutation[] {m}, key, value);
     assertEquals(key.event, MUTATION);
     assertEquals(key.seq, 7);
-    assertEquals(key.tid, 8);
+    assertEquals(key.tabletId, 8);
     assertEquals(value.mutations, Arrays.asList(m));
     m = new ServerMutation(new Text("row"));
     m.put(new Text("cf"), new Text("cq"), new ColumnVisibility("vis"), 12345,
@@ -103,12 +103,12 @@ public class LogFileTest {
     readWrite(MUTATION, 8, 9, null, null, new Mutation[] {m}, key, value);
     assertEquals(key.event, MUTATION);
     assertEquals(key.seq, 8);
-    assertEquals(key.tid, 9);
+    assertEquals(key.tabletId, 9);
     assertEquals(value.mutations, Arrays.asList(m));
     readWrite(MANY_MUTATIONS, 9, 10, null, null, new Mutation[] {m, m}, key, value);
     assertEquals(key.event, MANY_MUTATIONS);
     assertEquals(key.seq, 9);
-    assertEquals(key.tid, 10);
+    assertEquals(key.tabletId, 10);
     assertEquals(value.mutations, Arrays.asList(m, m));
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
@@ -79,7 +79,7 @@ public class AccumuloReplicaSystemTest {
      */
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("1", null, null);
-    key.tid = 1;
+    key.tabletId = 1;
 
     key.write(dos);
     value.write(dos);
@@ -94,14 +94,14 @@ public class AccumuloReplicaSystemTest {
 
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("2", null, null);
-    key.tid = 2;
+    key.tabletId = 2;
     value.mutations = Collections.emptyList();
 
     key.write(dos);
     value.write(dos);
 
     key.event = LogEvents.OPEN;
-    key.tid = LogFileKey.VERSION;
+    key.tabletId = LogFileKey.VERSION;
     key.tserverSession = "foobar";
 
     key.write(dos);
@@ -116,7 +116,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.COMPACTION_START;
-    key.tid = 2;
+    key.tabletId = 2;
     key.filename = "/accumulo/tables/1/t-000001/A000001.rf";
     value.mutations = Collections.emptyList();
 
@@ -125,14 +125,14 @@ public class AccumuloReplicaSystemTest {
 
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("1", null, null);
-    key.tid = 3;
+    key.tabletId = 3;
     value.mutations = Collections.emptyList();
 
     key.write(dos);
     value.write(dos);
 
     key.event = LogEvents.COMPACTION_FINISH;
-    key.tid = 6;
+    key.tabletId = 6;
     value.mutations = Collections.emptyList();
 
     key.write(dos);
@@ -140,7 +140,7 @@ public class AccumuloReplicaSystemTest {
 
     key.tablet = null;
     key.event = LogEvents.MUTATION;
-    key.tid = 3;
+    key.tabletId = 3;
     key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     value.mutations = Arrays.<Mutation> asList(new ServerMutation(new Text("row")));
 
@@ -188,7 +188,7 @@ public class AccumuloReplicaSystemTest {
      */
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("1", null, null);
-    key.tid = 1;
+    key.tabletId = 1;
 
     key.write(dos);
     value.write(dos);
@@ -203,14 +203,14 @@ public class AccumuloReplicaSystemTest {
 
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("2", null, null);
-    key.tid = 2;
+    key.tabletId = 2;
     value.mutations = Collections.emptyList();
 
     key.write(dos);
     value.write(dos);
 
     key.event = LogEvents.OPEN;
-    key.tid = LogFileKey.VERSION;
+    key.tabletId = LogFileKey.VERSION;
     key.tserverSession = "foobar";
 
     key.write(dos);
@@ -225,7 +225,7 @@ public class AccumuloReplicaSystemTest {
     value.write(dos);
 
     key.event = LogEvents.COMPACTION_START;
-    key.tid = 2;
+    key.tabletId = 2;
     key.filename = "/accumulo/tables/1/t-000001/A000001.rf";
     value.mutations = Collections.emptyList();
 
@@ -234,14 +234,14 @@ public class AccumuloReplicaSystemTest {
 
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("1", null, null);
-    key.tid = 3;
+    key.tabletId = 3;
     value.mutations = Collections.emptyList();
 
     key.write(dos);
     value.write(dos);
 
     key.event = LogEvents.COMPACTION_FINISH;
-    key.tid = 6;
+    key.tabletId = 6;
     value.mutations = Collections.emptyList();
 
     key.write(dos);
@@ -249,7 +249,7 @@ public class AccumuloReplicaSystemTest {
 
     key.tablet = null;
     key.event = LogEvents.MUTATION;
-    key.tid = 3;
+    key.tabletId = 3;
     key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     value.mutations = Arrays.<Mutation> asList(new ServerMutation(new Text("row")));
 
@@ -396,7 +396,7 @@ public class AccumuloReplicaSystemTest {
      */
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent("1", null, null);
-    key.tid = 1;
+    key.tabletId = 1;
 
     key.write(dos);
     value.write(dos);
@@ -411,7 +411,7 @@ public class AccumuloReplicaSystemTest {
 
     key.tablet = null;
     key.event = LogEvents.MUTATION;
-    key.tid = 1;
+    key.tabletId = 1;
     key.filename = "/accumulo/wals/tserver+port/" + UUID.randomUUID();
     value.mutations = Arrays.<Mutation> asList(new ServerMutation(new Text("row")));
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayerTest.java
@@ -83,7 +83,7 @@ public class BatchWriterReplicationReplayerTest {
     LogFileKey key = new LogFileKey();
     key.event = LogEvents.MANY_MUTATIONS;
     key.seq = 1;
-    key.tid = 1;
+    key.tabletId = 1;
 
     WalEdits edits = new WalEdits();
 
@@ -149,7 +149,7 @@ public class BatchWriterReplicationReplayerTest {
     LogFileKey key = new LogFileKey();
     key.event = LogEvents.MANY_MUTATIONS;
     key.seq = 1;
-    key.tid = 1;
+    key.tabletId = 1;
 
     WalEdits edits = new WalEdits();
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
@@ -118,7 +118,7 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     key.event = LogEvents.DEFINE_TABLET;
     key.tablet = new KeyExtent(Integer.toString(fakeTableId), null, null);
     key.seq = 1l;
-    key.tid = 1;
+    key.tabletId = 1;
 
     key.write(dos);
     value.write(dos);


### PR DESCRIPTION
 * Fix bug where tablet is unloaded, reloaded on tserver, and then tserver dies
 * Fix bug with out of order logs.  Recovery code assumed logs were passed in
   time order.  However, since 1.8.0 they have been passed in random order. Rewrote
   recovery code to handle out of order logs.  The fix was to read all logs in
   a sorted merged way.