### PR TITLE
Initial ideas for new Encryption interface

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -45,78 +45,14 @@ public enum Property {
   // Crypto-related properties
   @Experimental
   CRYPTO_PREFIX("crypto.", null, PropertyType.PREFIX,
-      "Properties in this category related to the configuration of both default and custom crypto"
-          + " modules."),
+      "Properties related to encryption."),
   @Experimental
-  CRYPTO_MODULE_CLASS("crypto.module.class", "NullCryptoModule", PropertyType.STRING,
-      "Fully qualified class name of the class that implements the CryptoModule"
-          + " interface, to be used in setting up encryption at rest for the WAL and"
-          + " (future) other parts of the code."),
+  CRYPTO_STRATEGY("crypto.strategy", "org.apache.accumulo.core.security.crypto.DefaultEncryptionStrategy", PropertyType.CLASSNAME, "Encryption strategy"),
   @Experimental
-  CRYPTO_CIPHER_SUITE("crypto.cipher.suite", "NullCipher", PropertyType.STRING,
-      "Describes the cipher suite to use for rfile encryption. The value must"
-          + " be either NullCipher or in the form of algorithm/mode/padding, e.g."
-          + " AES/CBC/NoPadding"),
+  CRYPTO_WAL_ENABLED("crypto.wal.enabled", "false", PropertyType.BOOLEAN, "Enable encryption for Write Ahead Logs."),
   @Experimental
-  CRYPTO_WAL_CIPHER_SUITE("crypto.wal.cipher.suite", "", PropertyType.STRING,
-      "Describes the cipher suite to use for the write-ahead log. Defaults to"
-          + " 'cyrpto.cipher.suite' and will use that value for WAL encryption unless"
-          + " otherwise specified. Valid suite values include: an empty string,"
-          + " NullCipher, or a string the form of algorithm/mode/padding, e.g."
-          + " AES/CBC/NOPadding"),
-  @Experimental
-  CRYPTO_CIPHER_KEY_ALGORITHM_NAME("crypto.cipher.key.algorithm.name", "NullCipher",
-      PropertyType.STRING,
-      "States the name of the algorithm used for the key for the corresponding"
-          + " cipher suite. The key type must be compatible with the cipher suite."),
-  @Experimental
-  CRYPTO_BLOCK_STREAM_SIZE("crypto.block.stream.size", "1K", PropertyType.BYTES,
-      "The size of the buffer above the cipher stream. Used for reading files"
-          + " and padding walog entries."),
-  @Experimental
-  CRYPTO_CIPHER_KEY_LENGTH("crypto.cipher.key.length", "128", PropertyType.STRING,
-      "Specifies the key length *in bits* to use for the symmetric key, "
-          + "should probably be 128 or 256 unless you really know what you're doing"),
-  @Experimental
-  CRYPTO_SECURITY_PROVIDER("crypto.security.provider", "", PropertyType.STRING,
-      "States the security provider to use, and defaults to the system configured provider"),
-  @Experimental
-  CRYPTO_SECURE_RNG("crypto.secure.rng", "SHA1PRNG", PropertyType.STRING,
-      "States the secure random number generator to use, and defaults to the built-in SHA1PRNG"),
-  @Experimental
-  CRYPTO_SECURE_RNG_PROVIDER("crypto.secure.rng.provider", "SUN", PropertyType.STRING,
-      "States the secure random number generator provider to use."),
-  @Experimental
-  CRYPTO_SECRET_KEY_ENCRYPTION_STRATEGY_CLASS("crypto.secret.key.encryption.strategy.class",
-      "NullSecretKeyEncryptionStrategy", PropertyType.STRING,
-      "The class Accumulo should use for its key encryption strategy."),
-  @Experimental
-  CRYPTO_DEFAULT_KEY_STRATEGY_HDFS_URI("crypto.default.key.strategy.hdfs.uri", "",
-      PropertyType.STRING,
-      "The path relative to the top level instance directory (instance.dfs.dir) where to store"
-          + " the key encryption key within HDFS."),
-  @Experimental
-  CRYPTO_DEFAULT_KEY_STRATEGY_KEY_LOCATION("crypto.default.key.strategy.key.location",
-      "/crypto/secret/keyEncryptionKey", PropertyType.ABSOLUTEPATH,
-      "The path relative to the top level instance directory (instance.dfs.dir) where to store"
-          + " the key encryption key within HDFS."),
-  @Experimental
-  CRYPTO_DEFAULT_KEY_STRATEGY_CIPHER_SUITE("crypto.default.key.strategy.cipher.suite", "NullCipher",
-      PropertyType.STRING,
-      "The cipher suite to use when encrypting session keys with a key"
-          + " encryption keyThis should be set to match the overall encryption"
-          + " algorithm but with ECB mode and no padding unless you really know what"
-          + " you're doing and are sure you won't break internal file formats"),
-  @Experimental
-  CRYPTO_OVERRIDE_KEY_STRATEGY_WITH_CONFIGURED_STRATEGY(
-      "crypto.override.key.strategy.with.configured.strategy", "false", PropertyType.BOOLEAN,
-      "The default behavior is to record the key encryption strategy with the"
-          + " encrypted file, and continue to use that strategy for the life of that"
-          + " file. Sometimes, you change your strategy and want to use the new"
-          + " strategy, not the old one. (Most commonly, this will be because you have"
-          + " moved key material from one spot to another.) If you want to override"
-          + " the recorded key strategy with the one in the configuration file, set"
-          + " this property to true."),
+  CRYPTO_RFILE_ENABLED("crypto.rfile.enabled", "false", PropertyType.BOOLEAN, "Enable encryption for R-Files."),
+
   // SSL properties local to each node (see also instance.ssl.enabled which must be consistent
   // across all nodes in an instance)
   RPC_PREFIX("rpc.", null, PropertyType.PREFIX,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -45,13 +45,12 @@ public enum Property {
   // Crypto-related properties
   @Experimental
   CRYPTO_PREFIX("crypto.", null, PropertyType.PREFIX,
-      "Properties related to encryption."),
+      "Properties related to on-disk file encryption."),
   @Experimental
-  CRYPTO_STRATEGY("crypto.strategy", "org.apache.accumulo.core.security.crypto.DefaultEncryptionStrategy", PropertyType.CLASSNAME, "Encryption strategy"),
+  CRYPTO_STRATEGY("crypto.strategy", "org.apache.accumulo.core.security.crypto.DefaultEncryptionStrategy",
+          PropertyType.CLASSNAME, "Encryption strategy"),
   @Experimental
-  CRYPTO_WAL_ENABLED("crypto.wal.enabled", "false", PropertyType.BOOLEAN, "Enable encryption for Write Ahead Logs."),
-  @Experimental
-  CRYPTO_RFILE_ENABLED("crypto.rfile.enabled", "false", PropertyType.BOOLEAN, "Enable encryption for R-Files."),
+  CRYPTO_ENABLED("crypto.enabled", "false", PropertyType.BOOLEAN, "Enable on-disk file encryption."),
 
   // SSL properties local to each node (see also instance.ssl.enabled which must be consistent
   // across all nodes in an instance)

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/EncryptionStrategy.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/EncryptionStrategy.java
@@ -1,0 +1,30 @@
+package org.apache.accumulo.core.security.crypto;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
+
+public interface EncryptionStrategy {
+
+  public void encryptStream(OutputStream outputStream);
+
+  public void decryptStream(InputStream inputStream);
+
+  public Map<String,String> properties = new HashMap<>();
+
+  default void readProperties(AccumuloConfiguration conf) {
+    this.properties.putAll(conf.getAllPropertiesWithPrefix(Property.CRYPTO_PREFIX));
+  }
+
+  default void setProperties(Map<String, String> properties) {
+    this.properties.putAll(properties);
+  }
+
+  default Map<String,String> getProperties() {
+    return properties;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/EncryptionStrategy.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/EncryptionStrategy.java
@@ -2,29 +2,41 @@ package org.apache.accumulo.core.security.crypto;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.conf.Property;
 
 public interface EncryptionStrategy {
 
-  public void encryptStream(OutputStream outputStream);
-
-  public void decryptStream(InputStream inputStream);
-
-  public Map<String,String> properties = new HashMap<>();
-
-  default void readProperties(AccumuloConfiguration conf) {
-    this.properties.putAll(conf.getAllPropertiesWithPrefix(Property.CRYPTO_PREFIX));
+  /**
+   * Where in Accumulo the on-disk file encryption takes place.
+   */
+  enum Scope {
+    WAL, RFILE;
   }
 
-  default void setProperties(Map<String, String> properties) {
-    this.properties.putAll(properties);
-  }
+  /**
+   * Initialize the EncryptionStrategy.
+   *
+   * @param encryptionScope
+   *           where the encryption takes places
+   * @return true
+   *           if initialization was successful
+   * @since 2.0
+   */
+  boolean init(Scope encryptionScope);
 
-  default Map<String,String> getProperties() {
-    return properties;
-  }
+  /**
+   * Encrypts the OutputStream.
+   *
+   * @param outputStream
+   * @since 2.0
+   */
+  void encryptStream(OutputStream outputStream);
+
+  /**
+   * Decrypts the InputStream.
+   *
+   * @param inputStream
+   * @since 2.0
+   */
+  void decryptStream(InputStream inputStream);
+
 }


### PR DESCRIPTION
Looking for design feedback on a new encryption interface.  My thinking was to do something pluggable and seamless, similar to the way CompactionStrategy was done. 

If encryption is enabled call EncryptionStrategy.encryptStream() and EncryptionStrategy.decryptStream(), otherwise proceed normally. A DefaultEncryptionStrategy would be provided with basic encryption behavior.  Seems doable for BCFile, not so sure about the WALs.

Feedback PR only, not merging.