### PR TITLE
ACCUMULO-2537 Add @Override Annotations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsHelper.java
@@ -175,6 +175,7 @@ public abstract class TableOperationsHelper implements TableOperations {
     checkIteratorConflicts(iteratorProps, setting, scopes);
   }
 
+  @Override
   public int addConstraint(String tableName, String constraintClassName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     TreeSet<Integer> constraintNumbers = new TreeSet<>();

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
@@ -77,6 +77,7 @@ public abstract class SeekingFilter extends WrappingIterator {
       return accept ? PASSES.get(advance) : FAILS.get(advance);
     }
 
+    @Override
     public String toString() {
       return "Acc: " + accept + " Adv: " + advance;
     }

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -656,6 +656,7 @@ public class Gatherer {
       return endRow;
     }
 
+    @Override
     public String toString() {
       return startRow + " " + endRow;
     }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/InstantiationTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/InstantiationTestCase.java
@@ -43,6 +43,7 @@ public class InstantiationTestCase implements IteratorTestCase {
     return new IteratorTestOutput(TestOutcome.PASSED);
   }
 
+  @Override
   public boolean verify(IteratorTestOutput expected, IteratorTestOutput actual) {
     // Ignore what the user provided as expected output, just check that we instantiated the
     // iterator successfully.

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/OutputVerifyingTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/OutputVerifyingTestCase.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.iteratortest.IteratorTestOutput;
  */
 public abstract class OutputVerifyingTestCase implements IteratorTestCase {
 
+  @Override
   public boolean verify(IteratorTestOutput expected, IteratorTestOutput actual) {
     return expected.equals(actual);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -1776,6 +1776,41 @@
         <findbugs.excludeFilterFile>src/main/findbugs/exclude-filter.xml</findbugs.excludeFilterFile>
       </properties>
     </profile>
+    <profile>
+      <id>overrides</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerId>javac-with-errorprone</compilerId>
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <source>1.8</source>
+              <target>1.8</target>
+              <compilerArgs>
+                <arg>-XepDisableAllChecks</arg>
+                <arg>-Xep:MissingOverride:ERROR</arg>
+                <arg>-XepExcludedPaths:.*/(proto|thrift|generated-sources)/.*</arg>
+              </compilerArgs>
+              <showWarnings>true</showWarnings>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>2.3.1</version>
+              </dependency>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                <version>2.8</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- Active by default, build against Hadoop 2 -->
     <profile>
       <id>hadoop-default</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1777,7 +1777,9 @@
       </properties>
     </profile>
     <profile>
-      <id>overrides</id>
+      <!-- This profile uses the google errorprone compiler to enforce use of the Override
+      annotation where needed. Auto-generated code is not checked. -->
+      <id>use-errorprone</id>
       <build>
         <plugins>
           <plugin>
@@ -1786,14 +1788,11 @@
             <configuration>
               <compilerId>javac-with-errorprone</compilerId>
               <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <source>1.8</source>
-              <target>1.8</target>
               <compilerArgs>
                 <arg>-XepDisableAllChecks</arg>
                 <arg>-Xep:MissingOverride:ERROR</arg>
                 <arg>-XepExcludedPaths:.*/(proto|thrift|generated-sources)/.*</arg>
               </compilerArgs>
-              <showWarnings>true</showWarnings>
             </configuration>
             <dependencies>
               <dependency>

--- a/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
@@ -53,6 +53,7 @@ public class GenerateSequentialRFile implements Runnable {
     long valuesPerRow = 42000;
   }
 
+  @Override
   public void run() {
     try {
       final Configuration conf = new Configuration();

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -125,6 +125,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
       this.cdl = cdl;
     }
 
+    @Override
     public void run() {
       try {
         cdl.countDown();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
@@ -80,6 +80,7 @@ public class SessionBlockVerifyIT extends ScanSessionTimeOutIT {
   ExecutorService service = Executors.newFixedThreadPool(10);
 
   @Test
+  @Override
   public void run() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -446,6 +446,7 @@ public class SummaryIT extends AccumuloClusterHarness {
       return true;
     }
 
+    @Override
     public void gatherInformation(MajorCompactionRequest request) throws IOException {
       List<Summary> summaries = request.getSummaries(request.getFiles().keySet(),
           conf -> conf.getClassName().contains("FooCounter"));


### PR DESCRIPTION
Added a profile 'overrides' to enforce use of the override annotation on
required methods. Uses google errorprone to handle enforcement. It
ignores the generated code in the project (i,e, thrift/proto/generated-sources).
 Findbugs/Spotbugs do not currently enable enforcement of the annotation,
 thus the use of errorprone. Initially setup as a profile to verify it works as expected
and satisfies the goal of the annotation enforcement. Can be incorporated into 
standard build in the future if desired. 

Added the annotation to the necessary files in the process. Ignoring the generated
code, there were not a huge number of missing annotations. There are currently 
432 locations in the generated code that are missing the annotation.

All other errorprone checks are disabled. There is a related ticket to examine 
possible use of errorprone as a general error detecting tool.

This pull request replaces Jira ticket ACCUMULO-2537.