### PR TITLE
Make RFileScanner use table props throughout

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -181,7 +181,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
     }
 
     this.opts = opts;
-    if (null != opts.tableConfig) {
+    if (null != opts.tableConfig && opts.tableConfig.size() > 0) {
       ConfigurationCopy tableCC = new ConfigurationCopy(DefaultConfiguration.getInstance());
       opts.tableConfig.forEach(tableCC::set);
       this.tableConf = tableCC;

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -190,7 +190,8 @@ class RFileScanner extends ScannerOptions implements Scanner {
     }
 
     if (opts.indexCacheSize > 0 || opts.dataCacheSize > 0) {
-      ConfigurationCopy cc = new ConfigurationCopy(this.tableConf);
+      ConfigurationCopy cc = tableConf instanceof ConfigurationCopy ? (ConfigurationCopy) tableConf
+          : new ConfigurationCopy(tableConf);
       try {
         blockCacheManager = BlockCacheManagerFactory.getClientInstance(cc);
         if (opts.indexCacheSize > 0) {

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.client.impl.BaseIteratorEnvironment;
 import org.apache.accumulo.core.client.impl.ScannerOptions;
 import org.apache.accumulo.core.client.rfile.RFileScannerBuilder.InputArgs;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -78,7 +79,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
   private Opts opts;
   private int batchSize = 1000;
   private long readaheadThreshold = 3;
-  private ConfigurationCopy tableConf;
+  private AccumuloConfiguration tableConf;
 
   static class Opts {
     InputArgs in;
@@ -180,11 +181,13 @@ class RFileScanner extends ScannerOptions implements Scanner {
     }
 
     this.opts = opts;
-    ConfigurationCopy tableConf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     if (null != opts.tableConfig) {
-      opts.tableConfig.forEach(tableConf::set);
+      ConfigurationCopy tableCC = new ConfigurationCopy(DefaultConfiguration.getInstance());
+      opts.tableConfig.forEach(tableCC::set);
+      this.tableConf = tableCC;
+    } else {
+      this.tableConf = DefaultConfiguration.getInstance();
     }
-    this.tableConf = tableConf;
 
     if (opts.indexCacheSize > 0 || opts.dataCacheSize > 0) {
       ConfigurationCopy cc = new ConfigurationCopy(this.tableConf);


### PR DESCRIPTION
Ran into an issue with the crypto work i've been doing... the RFileScanner was only passing the default configuration to the BCFile constructor so the configured properties weren't visible.  This PR changes RFileScanner to set the table configured properties once and reuse throughout the iteration.