### PR TITLE
Fix bug with GC not scanning root table for file refs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataScanner.java
@@ -315,14 +315,12 @@ public class MetadataScanner implements Iterable<TabletMetadata>, AutoCloseable 
 
     @Override
     public RangeOptions scanMetadataTable() {
-      this.table = MetadataTable.NAME;
-      return this;
+      return scanTable(MetadataTable.NAME);
     }
 
     @Override
     public RangeOptions scanRootTable() {
-      this.table = RootTable.NAME;
-      return this;
+      return scanTable(RootTable.NAME);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataScanner.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.core.client.impl.Table.ID;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ClonedColumnFamily;
@@ -62,10 +63,11 @@ public class MetadataScanner implements Iterable<TabletMetadata>, AutoCloseable 
     TableOptions from(Connector conn);
   }
 
-  public interface TableOptions extends RangeOptions {
-    /**
-     * Optionally set a table name, defaults to {@value MetadataTable#NAME}
-     */
+  public interface TableOptions {
+    RangeOptions scanRootTable();
+
+    RangeOptions scanMetadataTable();
+
     RangeOptions scanTable(String tableName);
   }
 
@@ -308,6 +310,18 @@ public class MetadataScanner implements Iterable<TabletMetadata>, AutoCloseable 
     @Override
     public RangeOptions scanTable(String tableName) {
       this.table = tableName;
+      return this;
+    }
+
+    @Override
+    public RangeOptions scanMetadataTable() {
+      this.table = MetadataTable.NAME;
+      return this;
+    }
+
+    @Override
+    public RangeOptions scanRootTable() {
+      this.table = RootTable.NAME;
       return this;
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -160,7 +160,7 @@ public class Gatherer {
       Predicate<String> fileSelector)
       throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
 
-    Iterable<TabletMetadata> tmi = MetadataScanner.builder().from(ctx)
+    Iterable<TabletMetadata> tmi = MetadataScanner.builder().from(ctx).scanMetadataTable()
         .overRange(tableId, startRow, endRow).fetchFiles().fetchLocation().fetchLast().fetchPrev()
         .build();
 
@@ -522,8 +522,9 @@ public class Gatherer {
   private int countFiles()
       throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
     // TODO use a batch scanner + iterator to parallelize counting files
-    return MetadataScanner.builder().from(ctx).overRange(tableId, startRow, endRow).fetchFiles()
-        .fetchPrev().build().stream().mapToInt(tm -> tm.getFiles().size()).sum();
+    return MetadataScanner.builder().from(ctx).scanMetadataTable()
+        .overRange(tableId, startRow, endRow).fetchFiles().fetchPrev().build().stream()
+        .mapToInt(tm -> tm.getFiles().size()).sum();
   }
 
   private class GatherRequest implements Supplier<SummaryCollection> {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -300,8 +300,8 @@ public class SimpleGarbageCollector extends AccumuloServerContext implements Ifa
         throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
 
       Stream<TabletMetadata> tabletStream = MetadataScanner.builder().from(getConnector())
-          .overTabletRange().checkConsistency().fetchDir().fetchFiles().fetchScans().build()
-          .stream();
+          .scanTable(tableName).overTabletRange().checkConsistency().fetchDir().fetchFiles()
+          .fetchScans().build().stream();
 
       Stream<Reference> refStream = tabletStream.flatMap(tm -> {
         Stream<Reference> refs = Stream.concat(tm.getFiles().stream(), tm.getScans().stream())

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -108,7 +108,7 @@ class LoadFiles extends MasterRepo {
     Text startRow = loadMapEntry.getKey().getPrevEndRow();
 
     long timeInMillis = master.getConfiguration().getTimeInMillis(Property.MASTER_BULK_TIMEOUT);
-    Iterator<TabletMetadata> tabletIter = MetadataScanner.builder().from(master)
+    Iterator<TabletMetadata> tabletIter = MetadataScanner.builder().from(master).scanMetadataTable()
         .overRange(tableId, startRow, null).checkConsistency().fetchPrev().fetchLocation()
         .fetchLoaded().build().iterator();
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
@@ -166,9 +166,9 @@ public class PrepBulkImport extends MasterRepo {
       Iterators.transform(lmi, entry -> entry.getKey());
 
       TabletIterFactory tabletIterFactory = startRow -> {
-        return MetadataScanner.builder().from(master).overRange(bulkInfo.tableId, startRow, null)
-            .checkConsistency().fetchPrev().build().stream().map(TabletMetadata::getExtent)
-            .iterator();
+        return MetadataScanner.builder().from(master).scanMetadataTable()
+            .overRange(bulkInfo.tableId, startRow, null).checkConsistency().fetchPrev().build()
+            .stream().map(TabletMetadata::getExtent).iterator();
       };
 
       checkForMerge(bulkInfo.tableId.canonicalID(),


### PR DESCRIPTION
This bug was introduced in 9feb5e1. In addition to fixing the bug,
specifying the table was made mandatory for the metadata scanner
builder.

The bug was found by MetadataMaxFilesIT