### PR TITLE
Upgrade the Curator Framework from version 2.11.0 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.59</bouncycastle.version>
     <!-- Curator version -->
-    <curator.version>2.11.0</curator.version>
+    <curator.version>2.12.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <!-- extra release args for testing -->


### PR DESCRIPTION
This PR upgrades the Curator Framework from version 2.11.0 to 2.12.0.

I ran mvn verify and it fails but it did before I made this change, and there were no new failures. Perhaps that is best handled in another issue (did not see it in the current 29 that exist). 

This is my first pull for this project and I'd just like to also say hello!