### PR TITLE
Fix WAL race condition between zookeeper and metadata table

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2458,11 +2458,22 @@ public class Tablet implements TabletCommitter {
 
   private Set<DfsLogger> currentLogs = new HashSet<>();
 
-  public synchronized void removeInUseLogs(Set<DfsLogger> candidates) {
-    // remove logs related to minor compacting data
-    candidates.removeAll(otherLogs);
-    // remove logs related to tablets in memory data
-    candidates.removeAll(currentLogs);
+  public void removeInUseLogs(Set<DfsLogger> candidates) {
+    // This lock is held while clearing otherLogs and adding a minc file to metadata table. Not
+    // holding this lock leads to a small chance of data loss if tserver dies between clearing
+    // otherLogs and adding file to metadata table AND this method was called in the time between.
+    logLock.lock();
+    try {
+      // acquire locks in same order as other places in code to avoid deadlock
+      synchronized (this) {
+        // remove logs related to minor compacting data
+        candidates.removeAll(otherLogs);
+        // remove logs related to tablets in memory data
+        candidates.removeAll(currentLogs);
+      }
+    } finally {
+      logLock.unlock();
+    }
   }
 
   Set<String> beginClearingUnusedLogs() {


### PR DESCRIPTION
I noticed this race condition while looking in to #535.  This seems like a very low probability event because multiple conditions would need to be met in a small time window for data loss to occur as a result of this race.

 * Only tablet A references WAL_X in its otherLogs set
 * Thread T1 one clears otherLogs for tablet A 
 * Thread T2 calls markUnusedWALs() removing WAL_X from zookeeper
 * Tablet server dies (tablet data that was in WAL_X is not in metadata table or recovery data)
 * Thread T1 would have updated the metadata table with a new file if tserver had not died

This change acquires a lock so that the call to markUnusedWALs() will block until the file is added to metadata table.  This lock prevents zookeeper updates from happening before metadata table updates.

This bug only affects Accumulo 1.8.0 and later.