### PR TITLE
Fix multiple concurrency bugs in Master.gatherTableInformation()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -340,6 +340,7 @@ public enum Property {
   MASTER_REPLICATION_COORDINATOR_THREADCHECK("master.replication.coordinator.threadcheck.time",
       "5s", PropertyType.TIMEDURATION,
       "The time between adjustments of the coordinator thread pool"),
+  @Deprecated
   MASTER_STATUS_THREAD_POOL_SIZE("master.status.threadpool.size", "1", PropertyType.COUNT,
       "The number of threads to use when fetching the tablet server status for balancing."),
   MASTER_METADATA_SUSPENDABLE("master.metadata.suspendable", "false", PropertyType.BOOLEAN,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -340,12 +340,9 @@ public enum Property {
   MASTER_REPLICATION_COORDINATOR_THREADCHECK("master.replication.coordinator.threadcheck.time",
       "5s", PropertyType.TIMEDURATION,
       "The time between adjustments of the coordinator thread pool"),
-  /**
-   * @deprecated since 1.9.1
-   */
   @Deprecated
   MASTER_STATUS_THREAD_POOL_SIZE("master.status.threadpool.size", "1", PropertyType.COUNT,
-      "The number of threads to use when fetching the tablet server status for balancing."),
+      "Deprecated since 1.9.2 and no longer used."),
   MASTER_METADATA_SUSPENDABLE("master.metadata.suspendable", "false", PropertyType.BOOLEAN,
       "Allow tablets for the " + MetadataTable.NAME
           + " table to be suspended via table.suspend.duration."),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -340,9 +340,9 @@ public enum Property {
   MASTER_REPLICATION_COORDINATOR_THREADCHECK("master.replication.coordinator.threadcheck.time",
       "5s", PropertyType.TIMEDURATION,
       "The time between adjustments of the coordinator thread pool"),
-  @Deprecated
-  MASTER_STATUS_THREAD_POOL_SIZE("master.status.threadpool.size", "1", PropertyType.COUNT,
-      "Deprecated since 1.9.2 and no longer used."),
+  MASTER_STATUS_THREAD_POOL_SIZE("master.status.threadpool.size", "0", PropertyType.COUNT,
+      "The number of threads to use when fetching the tablet server status for balancing.  Zero "
+          + "indicates an unlimited number of threads will be used."),
   MASTER_METADATA_SUSPENDABLE("master.metadata.suspendable", "false", PropertyType.BOOLEAN,
       "Allow tablets for the " + MetadataTable.NAME
           + " table to be suspended via table.suspend.duration."),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -340,6 +340,9 @@ public enum Property {
   MASTER_REPLICATION_COORDINATOR_THREADCHECK("master.replication.coordinator.threadcheck.time",
       "5s", PropertyType.TIMEDURATION,
       "The time between adjustments of the coordinator thread pool"),
+  /**
+   * @deprecated since 1.9.1
+   */
   @Deprecated
   MASTER_STATUS_THREAD_POOL_SIZE("master.status.threadpool.size", "1", PropertyType.COUNT,
       "The number of threads to use when fetching the tablet server status for balancing."),

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1149,7 +1149,7 @@ public class Master extends AccumuloServerContext
   private SortedMap<TServerInstance,TabletServerStatus> gatherTableInformation(
       Set<TServerInstance> currentServers) {
     final long rpcTimeout = getConfiguration().getTimeInMillis(Property.GENERAL_RPC_TIMEOUT);
-    int threads = Math.max(getConfiguration().getCount(Property.MASTER_STATUS_THREAD_POOL_SIZE), 0);
+    int threads = getConfiguration().getCount(Property.MASTER_STATUS_THREAD_POOL_SIZE);
     ExecutorService tp = threads == 0 ? Executors.newCachedThreadPool()
         : Executors.newFixedThreadPool(threads);
     long start = System.currentTimeMillis();

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -163,6 +164,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 
 /**
@@ -1065,7 +1067,7 @@ public class Master extends AccumuloServerContext
     private long updateStatus()
         throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
       Set<TServerInstance> currentServers = tserverSet.getCurrentServers();
-      tserverStatus = Collections.synchronizedSortedMap(gatherTableInformation(currentServers));
+      tserverStatus = gatherTableInformation(currentServers);
       checkForHeldServer(tserverStatus);
 
       if (!badServers.isEmpty()) {
@@ -1147,11 +1149,19 @@ public class Master extends AccumuloServerContext
   private SortedMap<TServerInstance,TabletServerStatus> gatherTableInformation(
       Set<TServerInstance> currentServers) {
     long start = System.currentTimeMillis();
-    int threads = Math.max(getConfiguration().getCount(Property.MASTER_STATUS_THREAD_POOL_SIZE), 1);
-    ExecutorService tp = Executors.newFixedThreadPool(threads);
-    final SortedMap<TServerInstance,TabletServerStatus> result = new TreeMap<>();
+    // TODO deprecate property
+    // int threads = Math.max(getConfiguration().getCount(Property.MASTER_STATUS_THREAD_POOL_SIZE),
+    // 8);
+    ExecutorService tp = Executors.newCachedThreadPool();
+    // use ConcurrentSkipListMap for two reasons. First, multiple threads may concurrently put.
+    // Second, its ok for one thread to iterate over map entries while another thread puts.
+    final SortedMap<TServerInstance,TabletServerStatus> result = new ConcurrentSkipListMap<>();
     for (TServerInstance serverInstance : currentServers) {
       final TServerInstance server = serverInstance;
+      // Since an unbounded thread pool is being used, rate limit how fast task are added to the
+      // executor. This prevents the threads from growing large unless there are lots of
+      // unresponsive tservers.
+      sleepUninterruptibly(5, TimeUnit.MILLISECONDS);
       tp.submit(new Runnable() {
         @Override
         public void run() {
@@ -1196,13 +1206,21 @@ public class Master extends AccumuloServerContext
     } catch (InterruptedException e) {
       log.debug("Interrupted while fetching status");
     }
+
+    tp.shutdownNow();
+
+    // Because result is a ConcurrentSkipListMap will not see a concurrent modification exception,
+    // even though background threads may still try to put.
+    SortedMap<TServerInstance,TabletServerStatus> info = ImmutableSortedMap.copyOf(result);
+
     synchronized (badServers) {
       badServers.keySet().retainAll(currentServers);
-      badServers.keySet().removeAll(result.keySet());
+      badServers.keySet().removeAll(info.keySet());
     }
-    log.debug(String.format("Finished gathering information from %d servers in %.2f seconds",
-        result.size(), (System.currentTimeMillis() - start) / 1000.));
-    return result;
+    log.debug(String.format("Finished gathering information from %d of %d servers in %.2f seconds",
+        info.size(), currentServers.size(), (System.currentTimeMillis() - start) / 1000.));
+
+    return info;
   }
 
   public void run() throws IOException, InterruptedException, KeeperException {

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1149,9 +1149,6 @@ public class Master extends AccumuloServerContext
   private SortedMap<TServerInstance,TabletServerStatus> gatherTableInformation(
       Set<TServerInstance> currentServers) {
     long start = System.currentTimeMillis();
-    // TODO deprecate property
-    // int threads = Math.max(getConfiguration().getCount(Property.MASTER_STATUS_THREAD_POOL_SIZE),
-    // 8);
     ExecutorService tp = Executors.newCachedThreadPool();
     // use ConcurrentSkipListMap for two reasons. First, multiple threads may concurrently put.
     // Second, its ok for one thread to iterate over map entries while another thread puts.


### PR DESCRIPTION
Master.gatherTableInformation() had the following problems :

 * If Property.MASTER_STATUS_THREAD_POOL_SIZE set > 1, then multiple threads
   would put into a TreeMap
 * Create a thread pool and never called shutdown now
 * Returns a reference to a treemap that threads in thread pool may still
   be adding to.

This patch also attempts to address the issues brought up in #402 by switching
to a cached thread pool.  This will allow the thread pool to expand so that
unresponsive tservers do not prevent gathering status from responsive tservers.