### PR TITLE
ACCUMULO-551 Correct display of BulkImport duration in monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/BulkImportServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/BulkImportServlet.java
@@ -42,7 +42,7 @@ public class BulkImportServlet extends BasicServlet {
   }
 
   static private long duration(long start) {
-    return (System.currentTimeMillis() - start) / 1000L;
+    return System.currentTimeMillis() - start;
   }
 
   @Override


### PR DESCRIPTION
The formatting for monitor display accepts milliseconds. This
fix corrects issue where seconds (duration / 1000) were used,
causing the duration displayed by the monitor to format and display
incorrectly.