### PR TITLE
Correct display of BulkImport duration in monitor

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Duration.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Duration.java
@@ -19,11 +19,7 @@ package org.apache.accumulo.core.util;
 public class Duration {
 
   public static String format(long time) {
-    return format(time, "&nbsp;");
-  }
-
-  public static String format(long time, String space) {
-    return format(time, space, "&mdash;");
+    return format(time, "&nbsp;", "&mdash;");
   }
 
   public static String format(long time, String space, String zero) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/BulkImportServlet.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/servlets/BulkImportServlet.java
@@ -42,7 +42,7 @@ public class BulkImportServlet extends BasicServlet {
   }
 
   static private long duration(long start) {
-    return (System.currentTimeMillis() - start) / 1000L;
+    return System.currentTimeMillis() - start;
   }
 
   @Override

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/util/celltypes/DurationType.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/util/celltypes/DurationType.java
@@ -37,16 +37,13 @@ public class DurationType extends NumberType<Long> {
     if (obj == null)
       return "-";
     Long millis = (Long) obj;
-    if (errMin != null && errMax != null)
-      return seconds(millis, errMin, errMax);
+    if (errMin != null && errMax != null) {
+      String numbers = Duration.format(millis);
+      if (millis < errMin || millis > errMax)
+        return "<span class='error'>" + numbers + "</span>";
+      return numbers;
+    }
     return Duration.format(millis);
-  }
-
-  private static String seconds(long secs, long errMin, long errMax) {
-    String numbers = Duration.format(secs);
-    if (secs < errMin || secs > errMax)
-      return "<span class='error'>" + numbers + "</span>";
-    return numbers;
   }
 
 }


### PR DESCRIPTION
The formatting for monitor display accepts milliseconds. This
fix corrects issue where seconds (duration / 1000) were used,
causing the duration displayed by the monitor to format and display
incorrectly.