### PR TITLE
Update Shell bulk import command. Closes #470

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ImportDirectoryCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ImportDirectoryCommand.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.commons.cli.CommandLine;
@@ -30,7 +31,9 @@ public class ImportDirectoryCommand extends Command {
   @Override
   public String description() {
     return "bulk imports an entire directory of data files to the current"
-        + " table. The boolean argument determines if accumulo sets the time.";
+        + " table. The boolean argument determines if accumulo sets the time. "
+        + "Passing 3 arguments will use the old bulk import.  The new bulk import only takes 2 "
+        + "arguments: <directory> true|false";
   }
 
   @Override
@@ -38,23 +41,47 @@ public class ImportDirectoryCommand extends Command {
       throws IOException, AccumuloException, AccumuloSecurityException, TableNotFoundException {
     shellState.checkTableState();
 
-    String dir = cl.getArgs()[0];
-    String failureDir = cl.getArgs()[1];
-    final boolean setTime = Boolean.parseBoolean(cl.getArgs()[2]);
+    String[] args = cl.getArgs();
+    String dir = args[0];
+    boolean setTime;
 
-    shellState.getConnector().tableOperations().importDirectory(shellState.getTableName(), dir,
-        failureDir, setTime);
+    // new bulk import only takes 2 args
+    if (args.length == 2) {
+      setTime = Boolean.parseBoolean(cl.getArgs()[1]);
+      TableOperations.ImportExecutorOptions bulk = shellState.getConnector().tableOperations()
+          .addFilesTo(shellState.getTableName()).from(dir);
+      if (setTime)
+        bulk.settingLogicalTime().load();
+      else
+        bulk.load();
+    } else if (args.length == 3) {
+      // warn using deprecated bulk import
+      Shell.log.warn(
+          "Deprecated since 2.0.0. New bulk import technique does not take a failure directory "
+              + "as an argument.");
+      String failureDir = args[1];
+      setTime = Boolean.parseBoolean(cl.getArgs()[2]);
+      shellState.getConnector().tableOperations().importDirectory(shellState.getTableName(), dir,
+          failureDir, setTime);
+      return 0;
+    } else {
+      shellState.printException(
+          new IllegalArgumentException(String.format("Expected 2 or 3 arguments. There %s %d.",
+              args.length == 1 ? "was" : "were", args.length)));
+      printHelp(shellState);
+    }
+
     return 0;
   }
 
   @Override
   public int numArgs() {
-    return 3;
+    return Shell.NO_FIXED_ARG_LENGTH_CHECK;
   }
 
   @Override
   public String usage() {
-    return getName() + " <directory> <failureDirectory> true|false";
+    return getName() + " <directory> [failureDirectory] true|false";
   }
 
 }


### PR DESCRIPTION
The shell importdirectory command will now support both the old and new
versions of bulk import, based on the number of arguments provided.