### PR TITLE
Improve info given in visibility exceptions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityFilter.java
@@ -73,10 +73,10 @@ public class VisibilityFilter extends Filter {
       cache.put(testVis, bb);
       return bb;
     } catch (VisibilityParseException e) {
-      log.error("Parse Error", e);
+      log.error("VisibilityParseException with visibility of Key {}: {}", k, e.getMessage());
       return false;
     } catch (BadArgumentException e) {
-      log.error("Parse Error", e);
+      log.error("BadArgumentException with visibility of Key {}: {}", k, e.getMessage());
       return false;
     }
   }


### PR DESCRIPTION
User was unable to debug bad visibility because error didn't have any key information.