### PR TITLE
 #582 - Pass ServerContext to VolumeChoosers

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
@@ -23,7 +23,6 @@ import org.apache.accumulo.core.client.impl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironment.ChooserScope;
@@ -77,9 +76,9 @@ public class PerTableVolumeChooser implements VolumeChooser {
             ChooserScope.INIT, RandomVolumeChooser.class.getName());
         return randomChooser;
       case TABLE:
-        return getVolumeChooserForTable(env, loadConfFactory());
+        return getVolumeChooserForTable(env, loadConfFactory(env));
       default:
-        return getVolumeChooserForScope(env, loadConfFactory());
+        return getVolumeChooserForScope(env, loadConfFactory(env));
     }
   }
 
@@ -181,12 +180,12 @@ public class PerTableVolumeChooser implements VolumeChooser {
   }
 
   // visible (not private) for testing
-  ServerConfigurationFactory loadConfFactory() {
+  ServerConfigurationFactory loadConfFactory(VolumeChooserEnvironment env) {
     // This local variable is an intentional component of the single-check idiom.
     ServerConfigurationFactory localConf = lazyConfFactory;
     if (localConf == null) {
       // If we're under contention when first getting here we'll throw away some initializations.
-      localConf = ServerContext.getInstance().getServerConfFactory();
+      localConf = env.getServerContext().getServerConfFactory();
       lazyConfFactory = localConf;
     }
     return localConf;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PreferredVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PreferredVolumeChooser.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.volume.Volume;
-import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironment.ChooserScope;
@@ -75,9 +74,9 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
             ChooserScope.INIT);
         return options;
       case TABLE:
-        return getPreferredVolumesForTable(env, loadConfFactory(), options);
+        return getPreferredVolumesForTable(env, loadConfFactory(env), options);
       default:
-        return getPreferredVolumesForScope(env, loadConfFactory(), options);
+        return getPreferredVolumesForScope(env, loadConfFactory(env), options);
     }
   }
 
@@ -158,13 +157,13 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
   }
 
   // visible (not private) for testing
-  ServerConfigurationFactory loadConfFactory() {
+  ServerConfigurationFactory loadConfFactory(VolumeChooserEnvironment env) {
     // Get the current table's properties, and find the preferred volumes property
     // This local variable is an intentional component of the single-check idiom.
     ServerConfigurationFactory localConf = lazyConfFactory;
     if (localConf == null) {
       // If we're under contention when first getting here we'll throw away some initializations.
-      localConf = ServerContext.getInstance().getServerConfFactory();
+      localConf = env.getServerContext().getServerConfFactory();
       lazyConfFactory = localConf;
     }
     return localConf;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironment.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironment.java
@@ -19,6 +19,9 @@ package org.apache.accumulo.server.fs;
 import java.util.Objects;
 
 import org.apache.accumulo.core.client.impl.Table;
+import org.apache.accumulo.server.ServerContext;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class VolumeChooserEnvironment {
 
@@ -31,15 +34,29 @@ public class VolumeChooserEnvironment {
     DEFAULT, TABLE, INIT, LOGGER
   }
 
+  private final ServerContext context;
   private final ChooserScope scope;
   private final Table.ID tableId;
 
+  // Also for visible for initialization
+  @VisibleForTesting
   public VolumeChooserEnvironment(ChooserScope scope) {
+    this(scope, null);
+  }
+
+  public VolumeChooserEnvironment(ChooserScope scope, ServerContext context) {
+    this.context = context;
     this.scope = Objects.requireNonNull(scope);
     this.tableId = null;
   }
 
+  @VisibleForTesting
   public VolumeChooserEnvironment(Table.ID tableId) {
+    this(tableId, null);
+  }
+
+  public VolumeChooserEnvironment(Table.ID tableId, ServerContext context) {
+    this.context = context;
     this.scope = ChooserScope.TABLE;
     this.tableId = Objects.requireNonNull(tableId);
   }
@@ -50,6 +67,14 @@ public class VolumeChooserEnvironment {
 
   public ChooserScope getScope() {
     return this.scope;
+  }
+
+  public ServerContext getServerContext() {
+    if (context == null) {
+      throw new IllegalStateException(
+          "Requested ServerContext from VolumeChooseEnvironment that" + " was created without it");
+    }
+    return context;
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -272,7 +272,8 @@ public class VolumeUtil {
       throw new IllegalArgumentException("Unexpected table dir " + dir);
     }
 
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(extent.getTableId());
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(extent.getTableId(),
+        context);
     Path newDir = new Path(vm.choose(chooserEnv, ServerConstants.getBaseUris()) + Path.SEPARATOR
         + ServerConstants.TABLE_DIR + Path.SEPARATOR + dir.getParent().getName() + Path.SEPARATOR
         + dir.getName());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -927,7 +927,7 @@ public class MetadataTableUtil {
         Key k = entry.getKey();
         Mutation m = new Mutation(k.getRow());
         m.putDelete(k.getColumnFamily(), k.getColumnQualifier());
-        VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableId);
+        VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableId, context);
         String dir = volumeManager.choose(chooserEnv, ServerConstants.getBaseUris())
             + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + tableId + Path.SEPARATOR + new String(
                 FastFormat.toZeroPaddedString(dirCount++, 8, 16, Constants.CLONE_PREFIX_BYTES));
@@ -1036,7 +1036,8 @@ public class MetadataTableUtil {
    */
   public static void createReplicationTable(ServerContext context) throws IOException {
 
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(ReplicationTable.ID);
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(ReplicationTable.ID,
+        context);
     String dir = VolumeManagerImpl.get().choose(chooserEnv, ServerConstants.getBaseUris())
         + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + ReplicationTable.ID
         + Constants.DEFAULT_TABLET_LOCATION;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomizeVolumes.java
@@ -113,7 +113,7 @@ public class RandomizeVolumes {
       Key key = entry.getKey();
       Mutation m = new Mutation(key.getRow());
 
-      VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableId);
+      VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableId, context);
       final String newLocation = vm.choose(chooserEnv, ServerConstants.getBaseUris())
           + Path.SEPARATOR + ServerConstants.TABLE_DIR + Path.SEPARATOR + tableId + Path.SEPARATOR
           + directory;

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PerTableVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PerTableVolumeChooserTest.java
@@ -51,12 +51,12 @@ public class PerTableVolumeChooserTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     confFactory = createStrictMock(ServerConfigurationFactory.class);
 
     chooser = new PerTableVolumeChooser() {
       @Override
-      ServerConfigurationFactory loadConfFactory() {
+      ServerConfigurationFactory loadConfFactory(VolumeChooserEnvironment env) {
         return confFactory;
       }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
@@ -52,12 +52,12 @@ public class PreferredVolumeChooserTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     confFactory = createStrictMock(ServerConfigurationFactory.class);
 
     chooser = new PreferredVolumeChooser() {
       @Override
-      ServerConfigurationFactory loadConfFactory() {
+      ServerConfigurationFactory loadConfFactory(VolumeChooserEnvironment env) {
         return confFactory;
       }
     };

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -282,7 +282,7 @@ public class Master
     if (!zoo.exists(dirZPath)) {
       Path oldPath = fs.getFullPath(FileType.TABLE, "/" + MetadataTable.ID + "/root_tablet");
       if (fs.exists(oldPath)) {
-        VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(RootTable.ID);
+        VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(RootTable.ID, context);
         String newPath = fs.choose(chooserEnv, ServerConstants.getBaseUris())
             + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + RootTable.ID;
         fs.mkdirs(new Path(newPath));

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -669,7 +669,8 @@ abstract class TabletGroupWatcher extends Daemon {
       } else {
         // Recreate the default tablet to hold the end of the table
         Master.log.debug("Recreating the last tablet to point to {}", extent.getPrevEndRow());
-        VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(extent.getTableId());
+        VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(extent.getTableId(),
+            master.getContext());
         String tdir = master.getFileSystem().choose(chooserEnv, ServerConstants.getBaseUris())
             + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + extent.getTableId()
             + Constants.DEFAULT_TABLET_LOCATION;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/ChooseDir.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/ChooseDir.java
@@ -41,7 +41,8 @@ class ChooseDir extends MasterRepo {
   public Repo<Master> call(long tid, Master master) throws Exception {
     // Constants.DEFAULT_TABLET_LOCATION has a leading slash prepended to it so we don't need to add
     // one here
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableInfo.tableId);
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableInfo.tableId,
+        master.getContext());
     tableInfo.dir = master.getFileSystem().choose(chooserEnv, ServerConstants.getBaseUris())
         + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + tableInfo.tableId
         + Constants.DEFAULT_TABLET_LOCATION;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadataTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/PopulateMetadataTable.java
@@ -218,7 +218,8 @@ class PopulateMetadataTable extends MasterRepo {
    */
   protected String getClonedTabletDir(Master master, String[] tableDirs, String tabletDir) {
     // We can try to spread out the tablet dirs across all volumes
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableInfo.tableId);
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableInfo.tableId,
+        master.getContext());
     String tableDir = master.getFileSystem().choose(chooserEnv, tableDirs);
 
     // Build up a full hdfs://localhost:8020/accumulo/tables/$id/c-XXXXXXX

--- a/server/master/src/test/java/org/apache/accumulo/master/tableOps/ImportTableTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/tableOps/ImportTableTest.java
@@ -39,6 +39,7 @@ public class ImportTableTest {
     // This needs to be unique WRT the importtable command
     String tabletDir = "/c-00000001";
 
+    EasyMock.expect(master.getContext()).andReturn(null);
     EasyMock.expect(master.getFileSystem()).andReturn(volumeManager);
     // Choose the 2nd element
     VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(iti.tableId);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -280,7 +280,7 @@ public class TabletServerLogger {
           DfsLogger alog = null;
           try {
             log.debug("Creating next WAL");
-            alog = new DfsLogger(conf, syncCounter, flushCounter);
+            alog = new DfsLogger(tserver.getContext(), conf, syncCounter, flushCounter);
             alog.open(tserver.getClientAddressString());
             String fileName = alog.getFileName();
             log.debug("Created next WAL " + fileName);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -498,8 +498,8 @@ public class Tablet implements TabletCommitter {
       // make some closed references that represent the recovered logs
       currentLogs = new HashSet<>();
       for (LogEntry logEntry : logEntries) {
-        currentLogs.add(new DfsLogger(tabletServer.getServerConfig(), logEntry.filename,
-            logEntry.getColumnQualifier().toString()));
+        currentLogs.add(new DfsLogger(tabletServer.getContext(), tabletServer.getServerConfig(),
+            logEntry.filename, logEntry.getColumnQualifier().toString()));
       }
 
       rebuildReferencedLogs();
@@ -2847,7 +2847,7 @@ public class Tablet implements TabletCommitter {
     String lowDirectory;
 
     UniqueNameAllocator namer = context.getUniqueNameAllocator();
-    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableId);
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(tableId, context);
     String volume = fs.choose(chooserEnv, ServerConstants.getBaseUris()) + Constants.HDFS_TABLES_DIR
         + Path.SEPARATOR;
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/WalRemovalOrderTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/WalRemovalOrderTest.java
@@ -50,7 +50,7 @@ public class WalRemovalOrderTest {
     };
 
     try {
-      return new DfsLogger(conf, filename, null);
+      return new DfsLogger(null, conf, filename, null);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }


### PR DESCRIPTION
* Removed ServerContext.getInstance() from VolumeChoosers
* Passed ServerContext by modifying VolumeChooserEnvironment