### PR TITLE
ACCUMULO-4629 Add table option to fail when deletes seen.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/OfflineIterator.java
@@ -383,7 +383,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     defaultSecurityLabel = cv.getExpression();
 
     SortedKeyValueIterator<Key,Value> visFilter = IteratorUtil.setupSystemScanIterators(multiIter,
-        new HashSet<>(options.fetchedColumns), authorizations, defaultSecurityLabel);
+        new HashSet<>(options.fetchedColumns), authorizations, defaultSecurityLabel, acuTableConf);
 
     return iterEnv.getTopLevelIterator(
         IteratorUtil.loadIterators(IteratorScope.scan, visFilter, extent, acuTableConf,

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -382,7 +382,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
         SortedSet<Column> cols = this.getFetchedColumns();
         families = LocalityGroupUtil.families(cols);
         iterator = IteratorUtil.setupSystemScanIterators(iterator, cols, getAuthorizations(),
-            EMPTY_BYTES);
+            EMPTY_BYTES, tableConf);
       }
 
       try {

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -489,5 +489,4 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
    * this configuration.
    */
   public void invalidateCache() {}
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.constraints.NoDeleteConstraint;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.system.DeletingIterator;
@@ -811,13 +812,14 @@ public enum Property {
           + "`table.summarizer.<unique id>=<summarizer class name>.` If the summarizer has options"
           + ", then for each option set" + " `table.summarizer.<unique id>.opt.<key>=<value>`."),
   @Experimental
-  TABLE_DELETE_BEHAVIOR("table.delete.behavior", DeletingIterator.Behavior.PROCESS.name(),
-      PropertyType.STRING,
+  TABLE_DELETE_BEHAVIOR("table.delete.behavior",
+      DeletingIterator.Behavior.PROCESS.name().toLowerCase(), PropertyType.STRING,
       "This determines what action to take when a delete marker is seen."
-          + " Valid actions are PROCESS and FAIL with PROCESS being the default.  When set to "
-          + "PROCESS, deletes will supress data.  When set to FAIL, any deletes seen will cause an"
-          + " exception. The purpose of FAIL is to support tables that never delete data and need "
-          + "fast seeks within the timestamp range of a column."),
+          + " Valid values are `process` and `fail` with `process` being the default.  When set to "
+          + "`process`, deletes will supress data.  When set to `fail`, any deletes seen will cause an"
+          + " exception. The purpose of `fail` is to support tables that never delete data and need "
+          + "fast seeks within the timestamp range of a column. When setting this to fail, also "
+          + "consider configuring the `" + NoDeleteConstraint.class.getName() + "` constraint."),
 
   // VFS ClassLoader properties
   VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY(

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.system.DeletingIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.spi.scan.ScanDispatcher;
 import org.apache.accumulo.core.spi.scan.ScanPrioritizer;
@@ -809,6 +810,14 @@ public enum Property {
           + " To add a summarizer set "
           + "`table.summarizer.<unique id>=<summarizer class name>.` If the summarizer has options"
           + ", then for each option set" + " `table.summarizer.<unique id>.opt.<key>=<value>`."),
+  @Experimental
+  TABLE_DELETE_BEHAVIOR("table.delete.behavior", DeletingIterator.Behavior.PROCESS.name(),
+      PropertyType.STRING,
+      "This determines what action to take when a delete marker is seen."
+          + " Valid actions are PROCESS and FAIL with PROCESS being the default.  When set to "
+          + "PROCESS, deletes will supress data.  When set to FAIL, any deletes seen will cause an"
+          + " exception. The purpose of FAIL is to support tables that never delete data and need "
+          + "fast seeks within the timestamp range of a column."),
 
   // VFS ClassLoader properties
   VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY(
@@ -884,9 +893,7 @@ public enum Property {
       "The sampling percentage to use for replication traces"),
   REPLICATION_RPC_TIMEOUT("replication.rpc.timeout", "2m", PropertyType.TIMEDURATION,
       "Amount of time for a single replication RPC call to last before failing"
-          + " the attempt. See replication.work.attempts."),
-
-  ;
+          + " the attempt. See replication.work.attempts.");
 
   private String key;
   private String defaultValue;
@@ -1141,7 +1148,7 @@ public enum Property {
       Property.TSERV_MAJC_MAXCONCURRENT, Property.REPLICATION_WORKER_THREADS,
       Property.TABLE_DURABILITY, Property.INSTANCE_ZK_TIMEOUT, Property.TABLE_CLASSPATH,
       Property.MASTER_METADATA_SUSPENDABLE, Property.TABLE_FAILURES_IGNORE,
-      Property.TABLE_SCAN_MAXMEM, Property.INSTANCE_CRYPTO_SERVICE);
+      Property.TABLE_SCAN_MAXMEM, Property.INSTANCE_CRYPTO_SERVICE, Property.TABLE_DELETE_BEHAVIOR);
 
   private static final EnumSet<Property> fixedProperties = EnumSet.of(Property.TSERV_CLIENTPORT,
       Property.TSERV_NATIVEMAP_ENABLED, Property.TSERV_SCAN_MAX_OPENFILES,

--- a/core/src/main/java/org/apache/accumulo/core/constraints/NoDeleteConstraint.java
+++ b/core/src/main/java/org/apache/accumulo/core/constraints/NoDeleteConstraint.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.accumulo.core.constraints;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.accumulo.core.data.ColumnUpdate;
+import org.apache.accumulo.core.data.Mutation;
+
+/**
+ * This constraint ensures mutations do not have deletes.
+ *
+ * @since 2.0.0
+ */
+public class NoDeleteConstraint implements Constraint {
+
+  @Override
+  public String getViolationDescription(short violationCode) {
+    if (violationCode == 1) {
+      return "Deletes are not allowed";
+    }
+    return null;
+  }
+
+  @Override
+  public List<Short> check(Environment env, Mutation mutation) {
+    List<ColumnUpdate> updates = mutation.getUpdates();
+    for (ColumnUpdate update : updates) {
+      if (update.isDeleted()) {
+        return Collections.singletonList((short) 1);
+      }
+    }
+
+    return null;
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -954,8 +954,8 @@ public class Mutation implements Writable {
   }
 
   /**
-   * Fluent API for putting or deleting to a Mutation that makes it easy use different types
-   * (i.e byte[], CharSequence, etc) when specifying the family, qualifier, value, etc.
+   * Fluent API for putting or deleting to a Mutation that makes it easy use different types (i.e
+   * byte[], CharSequence, etc) when specifying the family, qualifier, value, etc.
    *
    * <p>
    * Methods are optional but must follow this order: family, qualifier, visibility, timestamp.

--- a/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/IteratorUtil.java
@@ -449,8 +449,9 @@ public class IteratorUtil {
 
   public static SortedKeyValueIterator<Key,Value> setupSystemScanIterators(
       SortedKeyValueIterator<Key,Value> source, Set<Column> cols, Authorizations auths,
-      byte[] defaultVisibility) throws IOException {
-    DeletingIterator delIter = new DeletingIterator(source, false);
+      byte[] defaultVisibility, AccumuloConfiguration conf) throws IOException {
+    SortedKeyValueIterator<Key,Value> delIter = DeletingIterator.wrap(source, false,
+        DeletingIterator.getBehavior(conf));
     ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
     SortedKeyValueIterator<Key,Value> colFilter = ColumnQualifierFilter.wrap(cfsi, cols);
     return VisibilityFilter.wrap(colFilter, auths, defaultVisibility);

--- a/core/src/test/java/org/apache/accumulo/core/constraints/NoDeleteConstraintTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/constraints/NoDeleteConstraintTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.constraints;
+
+import java.util.List;
+
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NoDeleteConstraintTest {
+
+  @Test
+  public void testConstraint() {
+    Mutation m1 = new Mutation("r1");
+    m1.putDelete("f1", "q1");
+
+    NoDeleteConstraint ndc = new NoDeleteConstraint();
+
+    List<Short> results = ndc.check(null, m1);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(1, results.get(0).intValue());
+
+    Mutation m2 = new Mutation("r1");
+    m2.put("f1", "q1", new Value("v1"));
+
+    results = ndc.check(null, m2);
+    Assert.assertNull(results);
+  }
+}

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -344,7 +344,8 @@ public class Compactor implements Callable<CompactionStats> {
 
       CountingIterator citr = new CountingIterator(new MultiIterator(iters, extent.toDataRange()),
           entriesRead);
-      DeletingIterator delIter = new DeletingIterator(citr, propogateDeletes);
+      SortedKeyValueIterator<Key,Value> delIter = DeletingIterator.wrap(citr, propogateDeletes,
+          DeletingIterator.getBehavior(acuTableConf));
       ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
 
       // if(env.getIteratorScope() )

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -200,7 +200,7 @@ class ScanDataSource implements DataSource {
 
     SortedKeyValueIterator<Key,Value> visFilter = IteratorUtil.setupSystemScanIterators(
         statsIterator, options.getColumnSet(), options.getAuthorizations(),
-        options.getDefaultLabels());
+        options.getDefaultLabels(), tablet.getTableConfiguration());
 
     if (!loadIters) {
       return visFilter;

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import java.util.Collections;
+
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.iterators.system.DeletingIterator.Behavior;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeleteFailIT extends AccumuloClusterHarness {
+
+  @Test
+  public void testFail() throws Exception {
+    Connector c = getConnector();
+    String tableName = getUniqueNames(1)[0];
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    ntc.setProperties(
+        Collections.singletonMap(Property.TABLE_DELETE_BEHAVIOR.getKey(), Behavior.FAIL.name()));
+    c.tableOperations().create(tableName, ntc);
+
+    try (BatchWriter writer = c.createBatchWriter(tableName)) {
+      Mutation m = new Mutation("1234");
+      m.putDelete("f1", "q1", 2L);
+      writer.addMutation(m);
+    }
+
+    Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY);
+
+    try {
+      scanner.forEach(e -> {});
+      Assert.fail();
+    } catch (RuntimeException e) {}
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
@@ -51,7 +51,7 @@ public class DeleteFailIT extends AccumuloClusterHarness {
 
     try {
       scanner.forEach(e -> {});
-      Assert.fail();
+      Assert.fail("Expected scan to fail because  deletes are present.");
     } catch (RuntimeException e) {}
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -57,6 +57,7 @@ import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.iterators.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.iterators.system.ColumnQualifierFilter;
 import org.apache.accumulo.core.iterators.system.DeletingIterator;
+import org.apache.accumulo.core.iterators.system.DeletingIterator.Behavior;
 import org.apache.accumulo.core.iterators.system.MultiIterator;
 import org.apache.accumulo.core.iterators.system.VisibilityFilter;
 import org.apache.accumulo.core.metadata.MetadataServicer;
@@ -439,7 +440,8 @@ public class CollectTabletStats {
     iters.add(smi);
 
     MultiIterator multiIter = new MultiIterator(iters, ke);
-    DeletingIterator delIter = new DeletingIterator(multiIter, false);
+    SortedKeyValueIterator<Key,Value> delIter = DeletingIterator.wrap(multiIter, false,
+        Behavior.PROCESS);
     ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
     SortedKeyValueIterator<Key,Value> colFilter = ColumnQualifierFilter.wrap(cfsi, columnSet);
     SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(colFilter, authorizations,


### PR DESCRIPTION
This experimental option allows for tables that do not use
deletes to have fast seeks within the timestamp range.