### PR TITLE
Updated Accumulo dependencies and classpath

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -51,14 +51,7 @@ if [ ! -d "$HADOOP_PREFIX" ]; then
 fi
 
 ## Add external Hadoop & Zookeeper dependencies to CLASSPATH.
-CLASSPATH="$(find "$ZOOKEEPER_HOME"/ "$HADOOP_PREFIX"/share/hadoop/{common,common/lib,hdfs,mapreduce,yarn} -maxdepth 1 -name '*.jar' \
-  -and -not -name '*slf4j*' \
-  -and -not -name '*fatjar*' \
-  -and -not -name '*-javadoc*' \
-  -and -not -name '*-sources*.jar' \
-  -and -not -name '*-test*.jar' \
-  -print0 | tr '\0' ':')$CLASSPATH"
-CLASSPATH="${conf}:${lib}/*:${HADOOP_CONF_DIR}:${CLASSPATH}"
+CLASSPATH="${conf}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${HADOOP_PREFIX}/share/hadoop/client/*"
 export CLASSPATH
 
 ##################################################################

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -296,10 +296,6 @@
       <artifactId>javax.inject</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-      <artifactId>jersey-guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
     </dependency>
@@ -338,6 +334,10 @@
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>
       <artifactId>jersey-mvc-freemarker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -78,7 +78,6 @@
         <include>org.glassfish.hk2:hk2-locator</include>
         <include>org.glassfish.hk2:hk2-utils</include>
         <include>org.glassfish.hk2:osgi-resource-locator</include>
-        <include>org.glassfish.jersey.bundles.repackaged:jersey-guava</include>
         <include>org.glassfish.jersey.containers:jersey-container-jetty-http</include>
         <include>org.glassfish.jersey.containers:jersey-container-servlet-core</include>
         <include>org.glassfish.jersey.containers:jersey-container-servlet</include>
@@ -89,6 +88,7 @@
         <include>org.glassfish.jersey.ext:jersey-entity-filtering</include>
         <include>org.glassfish.jersey.ext:jersey-mvc-freemarker</include>
         <include>org.glassfish.jersey.ext:jersey-mvc</include>
+        <include>org.glassfish.jersey.inject:jersey-hk2</include>
         <include>org.glassfish.jersey.media:jersey-media-jaxb</include>
         <include>org.glassfish.jersey.media:jersey-media-json-jackson</include>
         <include>org.glassfish.web:javax.el</include>

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client.summary;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,10 +52,10 @@ public class SummarizerConfiguration {
       ArrayList<String> keys = new ArrayList<>(this.options.keySet());
       Collections.sort(keys);
       Hasher hasher = Hashing.murmur3_32().newHasher();
-      hasher.putString(className);
+      hasher.putString(className, StandardCharsets.UTF_8);
       for (String key : keys) {
-        hasher.putString(key);
-        hasher.putString(options.get(key));
+        hasher.putString(key, StandardCharsets.UTF_8);
+        hasher.putString(options.get(key), StandardCharsets.UTF_8);
       }
 
       this.configId = hasher.hash().toString();

--- a/core/src/main/java/org/apache/accumulo/core/sample/impl/DataoutputHasher.java
+++ b/core/src/main/java/org/apache/accumulo/core/sample/impl/DataoutputHasher.java
@@ -96,7 +96,7 @@ public class DataoutputHasher implements DataOutput {
 
   @Override
   public void writeChars(String s) throws IOException {
-    hasher.putString(s);
+    hasher.putString(s, StandardCharsets.UTF_8);
 
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -17,6 +17,7 @@
 
 package org.apache.accumulo.core.summary;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -207,7 +208,8 @@ public class Gatherer {
 
         // When no location, the approach below will consistently choose the same tserver for the
         // same file (as long as the set of tservers is stable).
-        int idx = Math.abs(Hashing.murmur3_32().hashString(entry.getKey()).asInt())
+        int idx = Math
+            .abs(Hashing.murmur3_32().hashString(entry.getKey(), StandardCharsets.UTF_8).asInt())
             % tservers.size();
         location = tservers.get(idx);
       }
@@ -357,7 +359,8 @@ public class Gatherer {
     private synchronized void initiateProcessing(ProcessedFiles previousWork) {
       try {
         Predicate<String> fileSelector = file -> Math
-            .abs(Hashing.murmur3_32().hashString(file).asInt()) % modulus == remainder;
+            .abs(Hashing.murmur3_32().hashString(file, StandardCharsets.UTF_8).asInt())
+            % modulus == remainder;
         if (previousWork != null) {
           fileSelector = fileSelector.and(previousWork.failedFiles::contains);
         }

--- a/core/src/main/spotbugs/exclude-filter.xml
+++ b/core/src/main/spotbugs/exclude-filter.xml
@@ -104,4 +104,8 @@
     <Class name="org.apache.accumulo.core.client.impl.ScannerOptionsTest" />
     <Bug code="NP" pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS" />
   </Match>
+  <Match>
+    <Class name="org.apache.accumulo.core.util.HostAndPort" />
+    <Bug code="NP" pattern="NP_NULL_PARAM_DEREF" />
+  </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
     <!-- bouncycastle version for test dependencies -->
-    <bouncycastle.version>1.59</bouncycastle.version>
+    <bouncycastle.version>1.60</bouncycastle.version>
     <!-- Curator version -->
     <curator.version>2.12.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
@@ -125,15 +125,15 @@
     <!-- surefire/failsafe plugin option -->
     <forkCount>1</forkCount>
     <hadoop.version>3.0.2</hadoop.version>
-    <hk2.version>2.4.0-b27</hk2.version>
+    <hk2.version>2.5.0-b62</hk2.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.1.0-incubating</htrace.version>
     <httpclient.version>4.3.1</httpclient.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <jackson.version>2.9.6</jackson.version>
     <javax.el.version>2.2.4</javax.el.version>
-    <jersey.version>2.25.1</jersey.version>
-    <jetty.version>9.3.21.v20170918</jetty.version>
+    <jersey.version>2.27</jersey.version>
+    <jetty.version>9.4.11.v20180605</jetty.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.plugin-version>3.2.5</maven.plugin-version>
@@ -152,7 +152,7 @@
     <thrift.version>0.11.0</thrift.version>
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
     <!-- ZooKeeper version -->
-    <zookeeper.version>3.4.10</zookeeper.version>
+    <zookeeper.version>3.4.13</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -164,7 +164,7 @@
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>classmate</artifactId>
-        <version>1.0.0</version>
+        <version>1.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -199,7 +199,7 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>2.3.3</version>
+        <version>2.6.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -209,14 +209,12 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.7</version>
+        <version>2.8.5</version>
       </dependency>
-      <!-- Hadoop-2.4.0 MiniDFSCluster uses classes dropped in Guava 15 -->
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <!-- Hadoop-2.4.0 MiniDFSCluster uses classes from <Guava-15.0; fixed in 2.6.0 and later -->
-        <version>14.0.1</version>
+        <version>26.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -226,12 +224,12 @@
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.2</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.4</version>
+        <version>1.11</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -241,22 +239,22 @@
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
-        <version>1.6</version>
+        <version>1.10</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.1</version>
+        <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>
@@ -281,7 +279,7 @@
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -600,7 +598,7 @@
       <dependency>
         <groupId>org.freemarker</groupId>
         <artifactId>freemarker</artifactId>
-        <version>2.3.23</version>
+        <version>2.3.28</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
@@ -631,11 +629,6 @@
         <groupId>org.glassfish.hk2.external</groupId>
         <artifactId>javax.inject</artifactId>
         <version>${hk2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-        <artifactId>jersey-guava</artifactId>
-        <version>${jersey.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
@@ -685,6 +678,11 @@
       <dependency>
         <groupId>org.glassfish.jersey.ext</groupId>
         <artifactId>jersey-mvc-freemarker</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
@@ -1097,6 +1095,7 @@
                 <unusedDeclaredDependency>org.apache.httpcomponents:httpclient:jar:${httpclient.version}</unusedDeclaredDependency>
                 <unusedDeclaredDependency>org.glassfish.jersey.containers:jersey-container-jetty-http:jar:${jersey.version}</unusedDeclaredDependency>
                 <unusedDeclaredDependency>org.glassfish.jersey.ext:jersey-bean-validation:jar:${jersey.version}</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2:jar:${jersey.version}</unusedDeclaredDependency>
                 <unusedDeclaredDependency>org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:jar:${jersey.version}</unusedDeclaredDependency>
                 <unusedDeclaredDependency>org.powermock:powermock-api-easymock:jar:${powermock.version}</unusedDeclaredDependency>
                 <unusedDeclaredDependency>org.slf4j:slf4j-log4j12:jar:${slf4j.version}</unusedDeclaredDependency>

--- a/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
@@ -84,7 +84,7 @@ public class CloseWriteAheadLogReferences implements Runnable {
     // As long as we depend on a newer Guava than Hadoop uses, we have to make sure we're compatible
     // with
     // what the version they bundle uses.
-    Stopwatch sw = new Stopwatch();
+    Stopwatch sw = Stopwatch.createUnstarted();
 
     Connector conn;
     try {

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/RemoveCompleteReplicationRecords.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/RemoveCompleteReplicationRecords.java
@@ -86,7 +86,7 @@ public class RemoveCompleteReplicationRecords implements Runnable {
     WorkSection.limit(bs);
     bs.addScanIterator(cfg);
 
-    Stopwatch sw = new Stopwatch();
+    Stopwatch sw = Stopwatch.createUnstarted();
     long recordsRemoved = 0;
     try {
       sw.start();

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -117,6 +117,10 @@
       <artifactId>jersey-mvc-freemarker</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -44,7 +44,7 @@ public class EmbeddedWebServer {
 
     handler = new ServletContextHandler(
         ServletContextHandler.SESSIONS | ServletContextHandler.SECURITY);
-    handler.getSessionHandler().getSessionManager().getSessionCookieConfig().setHttpOnly(true);
+    handler.getSessionHandler().getSessionCookieConfig().setHttpOnly(true);
     handler.setContextPath("/");
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -75,7 +75,7 @@ public class ScannerIT extends AccumuloClusterHarness {
       s.setBatchSize(1);
       s.setRange(new Range());
 
-      sw = new Stopwatch();
+      sw = Stopwatch.createUnstarted();
       iterator = s.iterator();
 
       sw.start();
@@ -98,7 +98,7 @@ public class ScannerIT extends AccumuloClusterHarness {
       s.setBatchSize(1);
       s.setReadaheadThreshold(0L);
 
-      sw = new Stopwatch();
+      sw = Stopwatch.createUnstarted();
       iterator = s.iterator();
 
       sw.start();


### PR DESCRIPTION
* Limited the number of dependencies from Hadoop
* Upgraded several dependencies including ZooKeeper,
  Jetty, Guava, Gson, Jersey, Bouncy Castle, ClassMate,
  FreeMarker, Caffeine, commons-cli, commons-codec,
  commons-configuration, commons-io, commons-lang,
  commons-logging, javax.ws-rs-api, HK2