### PR TITLE
ACCUMULO-4854 Fix DfsLogger exceptions

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -553,13 +553,9 @@ public class DfsLogger implements Comparable<DfsLogger> {
   }
 
   private synchronized void write(LogFileKey key, LogFileValue value) throws IOException {
-    try {
-      key.write(encryptingLogFile);
-      value.write(encryptingLogFile);
-      encryptingLogFile.flush();
-    } catch (ClosedChannelException e) {
-      throw new LogClosedException();
-    }
+    key.write(encryptingLogFile);
+    value.write(encryptingLogFile);
+    encryptingLogFile.flush();
   }
 
   public LoggerOperation log(long seq, int tid, Mutation mutation, Durability durability)


### PR DESCRIPTION
   Removed translation of ClosedChannelException to a LogClosedException in the write method as that is done by callers of the method.