### PR TITLE
Remove warnings

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -124,7 +124,6 @@ public abstract class FileOperations {
    *     .build();
    * </pre>
    */
-  @SuppressWarnings("unchecked")
   public ScanReaderBuilder newScanReaderBuilder() {
     return new ScanReaderBuilder();
   }
@@ -350,6 +349,7 @@ public abstract class FileOperations {
       return this;
     }
 
+    @Override
     public WriterBuilder withTableConfiguration(AccumuloConfiguration tableConfiguration) {
       tableConfiguration(tableConfiguration);
       return this;
@@ -398,6 +398,7 @@ public abstract class FileOperations {
       return this;
     }
 
+    @Override
     public ReaderBuilder withTableConfiguration(AccumuloConfiguration tableConfiguration) {
       tableConfiguration(tableConfiguration);
       return this;
@@ -489,6 +490,7 @@ public abstract class FileOperations {
       return this;
     }
 
+    @Override
     public IndexReaderBuilder withTableConfiguration(AccumuloConfiguration tableConfiguration) {
       tableConfiguration(tableConfiguration);
       return this;
@@ -515,6 +517,7 @@ public abstract class FileOperations {
       return this;
     }
 
+    @Override
     public ScanReaderBuilder withTableConfiguration(AccumuloConfiguration tableConfiguration) {
       tableConfiguration(tableConfiguration);
       return this;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
@@ -17,8 +17,6 @@
 
 package org.apache.accumulo.core.file.rfile.bcfile;
 
-import static org.apache.accumulo.core.security.crypto.impl.CryptoEnvironmentImpl.Scope;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -46,6 +44,7 @@ import org.apache.accumulo.core.security.crypto.CryptoUtils;
 import org.apache.accumulo.core.security.crypto.impl.CryptoEnvironmentImpl;
 import org.apache.accumulo.core.security.crypto.impl.NoFileDecrypter;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
+import org.apache.accumulo.core.spi.crypto.CryptoEnvironment.Scope;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.spi.crypto.FileDecrypter;
 import org.apache.accumulo.core.spi.crypto.FileEncrypter;
@@ -487,10 +486,10 @@ public final class BCFile {
 
         BoundedRangeFileInputStream boundedRangeFileInputStream = new BoundedRangeFileInputStream(
             fsin, this.region.getOffset(), this.region.getCompressedSize());
-        InputStream inputStreamToBeCompressed = boundedRangeFileInputStream;
 
         try {
-          inputStreamToBeCompressed = decrypter.decryptStream(inputStreamToBeCompressed);
+          InputStream inputStreamToBeCompressed = decrypter
+              .decryptStream(boundedRangeFileInputStream);
           this.in = compressAlgo.createDecompressionStream(inputStreamToBeCompressed, decompressor,
               getFSInputBufferSize(conf));
         } catch (IOException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
@@ -71,7 +71,6 @@ public class AuditedSecurityOperation extends SecurityOperation {
   public static synchronized SecurityOperation getInstance(ServerContext context,
       boolean initialize) {
     if (instance == null) {
-      String instanceId = context.getInstanceID();
       instance = new AuditedSecurityOperation(context, getAuthorizor(context, initialize),
           getAuthenticator(context, initialize), getPermHandler(context, initialize));
     }

--- a/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
@@ -52,7 +52,10 @@ import com.google.common.collect.Iterators;
 // It would be useful to have an IT that will test this situation.
 public class UnusedWALIT extends ConfigurableMacBase {
 
-  private ZooReaderWriter zk;
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 120;
+  }
 
   @Override
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
@@ -65,7 +68,7 @@ public class UnusedWALIT extends ConfigurableMacBase {
     hadoopCoreSite.set("fs.namenode.fs-limits.min-block-size", Long.toString(logSize));
   }
 
-  @Test(timeout = 2 * 60 * 1000)
+  @Test
   public void test() throws Exception {
     // don't want this bad boy cleaning up walog entries
     getCluster().getClusterControl().stop(ServerType.GARBAGE_COLLECTOR);
@@ -79,7 +82,7 @@ public class UnusedWALIT extends ConfigurableMacBase {
     c.tableOperations().create(lilTable);
 
     ServerContext context = getServerContext();
-    zk = new ZooReaderWriter(c.info().getZooKeepers(), c.info().getZooKeepersSessionTimeOut(), "");
+    new ZooReaderWriter(c.info().getZooKeepers(), c.info().getZooKeepersSessionTimeOut(), "");
 
     // put some data in a log that should be replayed for both tables
     writeSomeData(c, bigTable, 0, 10, 0, 10);


### PR DESCRIPTION
* Remove unnecessary warnings suppression in FileOperations (also add
  missing overrides annotations here)
* Remove potential resource leak in BCFile due to reusing a variable for
  a potentially new resource allocation without closing the previous one
  assigned to that variable; this wasn't really a problem because of the
  way we were passing the input stream into the decryptor to get a new
  input stream, but it could happen if that code were to change slightly
* Remove unused instanceId from AuditedSecurityOperation
* Remove unused zk variable from UnusedWALIT (also make the timeout
  scalable, like other ITs, in case of testing on a resource-limited
  machine)