### PR TITLE
Add sec-bugs plugin. Closes #618

### DIFF
--- a/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
+++ b/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
@@ -20,6 +20,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -646,7 +647,7 @@ public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
     log.setLevel(logLevel);
     validateOptions(job);
 
-    Random random = new Random();
+    Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     Map<String,InputTableConfig> tableConfigs = getInputTableConfigs(job);
     for (Map.Entry<String,InputTableConfig> tableConfigEntry : tableConfigs.entrySet()) {

--- a/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
+++ b/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
@@ -20,6 +20,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -671,7 +672,7 @@ public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
     Level logLevel = getLogLevel(context);
     log.setLevel(logLevel);
     validateOptions(context);
-    Random random = new Random();
+    Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     Map<String,InputTableConfig> tableConfigs = getInputTableConfigs(context);
     for (Map.Entry<String,InputTableConfig> tableConfigEntry : tableConfigs.entrySet()) {

--- a/client/mapreduce/src/main/spotbugs/exclude-filter.xml
+++ b/client/mapreduce/src/main/spotbugs/exclude-filter.xml
@@ -26,4 +26,10 @@
       <Bug code="NM" pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE" />
     </Or>
   </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.client.mapreduce.lib.partition.RangePartitioner" />
+    <Method name="getCutPoints" />
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
 </FindBugsFilter>

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -1538,11 +1538,11 @@ public class TableOperationsImpl extends TableOperationsHelper {
   }
 
   /**
-   * Prevent potential CRLF injection into logs from read in user data
-   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   * Prevent potential CRLF injection into logs from read in user data See
+   * https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
    */
   private String sanitize(String msg) {
-    return msg.replaceAll("[\r\n]","");
+    return msg.replaceAll("[\r\n]", "");
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -29,6 +29,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1077,7 +1078,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     if (maxSplits == 1)
       return Collections.singleton(range);
 
-    Random random = new Random();
+    Random random = new SecureRandom();
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<>();
     Table.ID tableId = Tables.getTableId(context, tableName);
     TabletLocator tl = TabletLocator.getLocator(context, tableId);
@@ -1511,7 +1512,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
             && !entry.getValue().contains(Constants.CORE_PACKAGE_NAME)) {
           LoggerFactory.getLogger(this.getClass()).info(
               "Imported table sets '{}' to '{}'.  Ensure this class is on Accumulo classpath.",
-              entry.getKey(), entry.getValue());
+              sanitize(entry.getKey()), sanitize(entry.getValue()));
         }
       }
 
@@ -1534,6 +1535,14 @@ public class TableOperationsImpl extends TableOperationsHelper {
       throw new AssertionError(e);
     }
 
+  }
+
+  /**
+   * Prevent potential CRLF injection into logs from read in user data
+   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   */
+  private String sanitize(String msg) {
+    return msg.replaceAll("[\r\n]","");
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -17,12 +17,14 @@
 package org.apache.accumulo.core.client.impl;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -76,6 +78,7 @@ public class ThriftScanner {
 
   public static final Map<TabletType,Set<String>> serversWaitedForWrites = new EnumMap<>(
       TabletType.class);
+  private static Random secureRandom = new SecureRandom();
 
   static {
     for (TabletType ttype : TabletType.values()) {
@@ -225,7 +228,7 @@ public class ThriftScanner {
   static long pause(long millis, long maxSleep) throws InterruptedException {
     Thread.sleep(millis);
     // wait 2 * last time, with +-10% random jitter
-    return (long) (Math.min(millis * 2, maxSleep) * (.9 + Math.random() / 5));
+    return (long) (Math.min(millis * 2, maxSleep) * (.9 + secureRandom.nextDouble() / 5));
   }
 
   public static List<KeyValue> scan(ClientContext context, ScanState scanState, int timeOut)

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftTransportPool.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client.impl;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,7 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,7 +45,7 @@ import com.google.common.collect.Iterables;
 
 public class ThriftTransportPool {
 
-  private static final Random random = new Random();
+  private static final SecureRandom random = new SecureRandom();
   private long killTime = 1000 * 3;
 
   private static class CachedConnections {

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -293,11 +293,11 @@ public class BloomFilterLayer {
     }
 
     /**
-     * Prevent potential CRLF injection into logs from read in user data
-     * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+     * Prevent potential CRLF injection into logs from read in user data See
+     * https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
      */
     private String sanitize(String msg) {
-      return msg.replaceAll("[\r\n]","");
+      return msg.replaceAll("[\r\n]", "");
     }
 
     private synchronized void initiateLoad(int maxLoadThreads) {

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -24,12 +24,12 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -264,10 +264,10 @@ public class BloomFilterLayer {
 
           bloomFilter = null;
         } catch (ClassNotFoundException e) {
-          LOG.error("Failed to find KeyFunctor in config: " + ClassName, e);
+          LOG.error("Failed to find KeyFunctor in config: " + sanitize(ClassName), e);
           bloomFilter = null;
         } catch (InstantiationException e) {
-          LOG.error("Could not instantiate KeyFunctor: " + ClassName, e);
+          LOG.error("Could not instantiate KeyFunctor: " + sanitize(ClassName), e);
           bloomFilter = null;
         } catch (IllegalAccessException e) {
           LOG.error("Illegal acess exception", e);
@@ -290,6 +290,14 @@ public class BloomFilterLayer {
 
       initiateLoad(maxLoadThreads);
 
+    }
+
+    /**
+     * Prevent potential CRLF injection into logs from read in user data
+     * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+     */
+    private String sanitize(String msg) {
+      return msg.replaceAll("[\r\n]","");
     }
 
     private synchronized void initiateLoad(int maxLoadThreads) {
@@ -445,7 +453,7 @@ public class BloomFilterLayer {
   public static void main(String[] args) throws IOException {
     PrintStream out = System.out;
 
-    Random r = new Random();
+    SecureRandom r = new SecureRandom();
 
     HashSet<Integer> valsSet = new HashSet<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
@@ -138,7 +138,8 @@ public class VisMetricsGatherer
                 .digest(entry.getKey().getBytes(UTF_8));
             encodedKey = new String(encodedBytes, UTF_8);
           } catch (NoSuchAlgorithmException e) {
-            out.println("Failed to convert key to "+Constants.PW_HASH_ALGORITHM+" hash: " + e.getMessage());
+            out.println("Failed to convert key to " + Constants.PW_HASH_ALGORITHM + " hash: "
+                + e.getMessage());
           }
           out.printf("%-20s", encodedKey.substring(0, 8));
         } else

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -131,15 +132,15 @@ public class VisMetricsGatherer
           + "Percent of blocks");
       for (Entry<String,Long> entry : metric.get(lGName).asMap().entrySet()) {
         if (hash) {
-          String md5String = "";
+          String encodedKey = "";
           try {
-            byte[] md5Bytes = MessageDigest.getInstance("MD5")
+            byte[] encodedBytes = MessageDigest.getInstance(Constants.PW_HASH_ALGORITHM)
                 .digest(entry.getKey().getBytes(UTF_8));
-            md5String = new String(md5Bytes, UTF_8);
+            encodedKey = new String(encodedBytes, UTF_8);
           } catch (NoSuchAlgorithmException e) {
-            out.println("Failed to convert key to MD5 hash: " + e.getMessage());
+            out.println("Failed to convert key to "+Constants.PW_HASH_ALGORITHM+" hash: " + e.getMessage());
           }
-          out.printf("%-20s", md5String.substring(0, 8));
+          out.printf("%-20s", encodedKey.substring(0, 8));
         } else
           out.printf("%-20s", entry.getKey());
         out.print("\t\t" + entry.getValue() + "\t\t\t");

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.security.KeyStore;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -64,7 +65,7 @@ public class ThriftUtil {
 
   public static final String GSSAPI = "GSSAPI", DIGEST_MD5 = "DIGEST-MD5";
 
-  private static final Random SASL_BACKOFF_RAND = new Random();
+  private static final Random SASL_BACKOFF_RAND = new SecureRandom();
   private static final int RELOGIN_MAX_BACKOFF = 5000;
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoUtils.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoUtils.java
@@ -55,38 +55,6 @@ public class CryptoUtils {
     return secureRandom;
   }
 
-  public static Cipher getCipher(String cipherSuite, String securityProvider) {
-    Cipher cipher = null;
-
-    if (cipherSuite.equals("NullCipher")) {
-      cipher = new NullCipher();
-    } else {
-      try {
-        if (securityProvider == null || securityProvider.equals("")) {
-          cipher = Cipher.getInstance(cipherSuite);
-        } else {
-          cipher = Cipher.getInstance(cipherSuite, securityProvider);
-        }
-      } catch (NoSuchAlgorithmException e) {
-        log.error(String.format("Accumulo configuration file contained a cipher"
-            + " suite \"%s\" that was not recognized by any providers", cipherSuite));
-        throw new CryptoException(e);
-      } catch (NoSuchPaddingException e) {
-        log.error(String.format(
-            "Accumulo configuration file contained a"
-                + " cipher, \"%s\" with a padding that was not recognized by any" + " providers",
-            cipherSuite));
-        throw new CryptoException(e);
-      } catch (NoSuchProviderException e) {
-        log.error(String.format(
-            "Accumulo configuration file contained a provider, \"%s\" an unrecognized provider",
-            securityProvider));
-        throw new CryptoException(e);
-      }
-    }
-    return cipher;
-  }
-
   /**
    * Read the decryption parameters from the DataInputStream
    */

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoUtils.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/CryptoUtils.java
@@ -24,10 +24,6 @@ import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 import java.util.Objects;
 
-import javax.crypto.Cipher;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.NullCipher;
-
 import org.apache.accumulo.core.spi.crypto.CryptoService.CryptoException;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.fate.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -59,6 +60,7 @@ public class ZooCache {
   private final HashMap<String,List<String>> childrenCache;
 
   private final ZooReader zReader;
+  private final SecureRandom secureRandom = new SecureRandom();
 
   public static class ZcStat {
     private long ephemeralOwner;
@@ -287,7 +289,7 @@ public class ZooCache {
         }
         LockSupport.parkNanos(sleepTime);
         if (sleepTime < 10_000) {
-          sleepTime = (int) (sleepTime + sleepTime * Math.random());
+          sleepTime = (int) (sleepTime + sleepTime * secureRandom.nextDouble());
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooSession.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,6 +53,8 @@ public class ZooSession {
   }
 
   private static Map<String,ZooSessionInfo> sessions = new HashMap<>();
+
+  private static final SecureRandom secureRandom = new SecureRandom();
 
   private static String sessionKey(String keepers, int timeout, String scheme, byte[] auth) {
     return keepers + ":" + timeout + ":" + (scheme == null ? "" : scheme) + ":"
@@ -138,7 +141,7 @@ public class ZooSession {
         }
         UtilWaitThread.sleep(sleepTime);
         if (sleepTime < 10000)
-          sleepTime = sleepTime + (long) (sleepTime * Math.random());
+          sleepTime = sleepTime + (long) (sleepTime * secureRandom.nextDouble());
       }
     }
 

--- a/core/src/main/spotbugs/exclude-filter.xml
+++ b/core/src/main/spotbugs/exclude-filter.xml
@@ -16,6 +16,107 @@
 -->
 <FindBugsFilter>
   <Match>
+    <!-- TODO ticket for this and BloomFilter OBJECT_DESERIALIZATION - ACCUMULO-3591 could satisfy -->
+    <Class name="org.apache.accumulo.fate.ZooStore" />
+    <Bug code="OBJECT" pattern="OBJECT_DESERIALIZATION" />
+  </Match>
+  <Match>
+    <!-- Ignore security bugs in Tests -->
+    <Or>
+      <Class name="org.apache.accumulo.core.conf.SiteConfigurationTest"/>
+      <Class name="org.apache.accumulo.core.client.impl.ClientContextTest"/>
+      <Class name="org.apache.accumulo.core.client.rfile.RFileTest"/>
+      <Class name="org.apache.accumulo.core.client.security.tokens.CredentialProviderTokenTest"/>
+      <Class name="org.apache.accumulo.core.conf.CredentialProviderFactoryShimTest"/>
+      <Class name="org.apache.accumulo.core.file.BloomFilterLayerLookupTest"/>
+    </Or>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Using CBC mode for Write ahead log encryption so OK with no integrity -->
+    <Or>
+      <Class name="org.apache.accumulo.core.security.crypto.CryptoTest"/>
+      <Class name="org.apache.accumulo.core.security.crypto.impl.AESCryptoService$AESCBCCryptoModule$AESCBCFileEncrypter"/>
+      <Class name="org.apache.accumulo.core.security.crypto.impl.AESCryptoService$AESCBCCryptoModule$AESCBCFileDecrypter"/>
+      <Class name="org.apache.accumulo.core.security.crypto.impl.KeyManager"/>
+    </Or>
+    <Bug code="CIPHER" pattern="CIPHER_INTEGRITY" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.cli.ClientOpts" />
+    <Method name="getClientProperties" />
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.cli.ConfigOpts" />
+    <Method name="getSiteConfiguration" />
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.client.ClientConfiguration" />
+    <Or>
+      <Method name="getClientConfPath" params="java.lang.String"/>
+      <Method name="loadFromSearchPath" params="java.util.List" />
+    </Or>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.client.impl.ConnectorImpl$ConnectorBuilderImpl" />
+    <Method name="usingProperties" params="java.lang.String"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.conf.ClientProperty" />
+    <Method name="getAuthenticationToken" params="java.util.Properties"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.conf.Property" />
+    <Method name="precomputeDefaultValue" />
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.rpc.SslConnectionParams" />
+    <Method name="findKeystore" params="java.lang.String"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.rpc.ThriftUtil" />
+    <Method name="createSSLContext" params="org.apache.accumulo.core.rpc.SslConnectionParams"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.core.security.crypto.impl.KeyManager" />
+    <Method name="loadKekFromUri" params="java.lang.String"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Only hash function compared not actual hash here -->
+    <Class name="org.apache.accumulo.core.client.sample.AbstractHashSampler" />
+    <Method name="init" params="org.apache.accumulo.core.client.sample.SamplerConfiguration" />
+    <Bug code="UNSAFE" pattern="UNSAFE_HASH_EQUALS" />
+  </Match>
+  <Match>
+    <!-- Printing stack traces of errors in Test is OK -->
+    <Class name="org.apache.accumulo.core.file.rfile.MultiThreadedRFileTest" />
+    <Method name="testMultipleReaders"  />
+    <Bug code="INFORMATION" pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE" />
+  </Match>
+  <Match>
+    <Class name="org.apache.accumulo.core.conf.SiteConfiguration" />
+    <Method name="&lt;init&gt;" params="java.net.URL,java.util.Map" returns="void"/>
+    <Bug code="URLCONNECTION" pattern="URLCONNECTION_SSRF_FD"/>
+  </Match>
+  <Match>
     <!-- ignore thrift-generated files -->
     <Or>
       <Package name="org.apache.accumulo.core.client.impl.thrift" />
@@ -30,11 +131,12 @@
   </Match>
   <Match>
     <!-- ignore Writable false positives about closing wrapped DataInput stream -->
-    <Or>
-      <Class name="org.apache.accumulo.core.bloomfilter.BloomFilter" />
-    </Or>
+    <Class name="org.apache.accumulo.core.bloomfilter.BloomFilter" />
     <Method name="readFields" params="java.io.DataInput" returns="void" />
-    <Bug code="OS" pattern="OS_OPEN_STREAM" />
+    <Or>
+      <Bug code="OBJECT" pattern="OBJECT_DESERIALIZATION" />
+      <Bug code="OS" pattern="OS_OPEN_STREAM" />
+    </Or>
   </Match>
   <Match>
     <Class name="org.apache.accumulo.core.file.blockfile.impl.SeekableByteArrayInputStream" />
@@ -87,7 +189,6 @@
     <!-- CryptoTest shouldn't close the given I/O streams, because they are just wrapping them -->
     <Or>
       <Class name="org.apache.accumulo.core.security.crypto.CryptoTest" />
-      <Class name="org.apache.accumulo.core.security.crypto.DefaultCryptoModule" />
     </Or>
     <Bug code="OS" pattern="OS_OPEN_STREAM" />
   </Match>

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/ConcurrentKeyExtentCacheTest.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.client.impl;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -99,7 +100,7 @@ public class ConcurrentKeyExtentCacheTest {
 
   @Test
   public void testExactEndRows() {
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
     TestCache tc = new TestCache();
     rand.ints(10000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).sequential()
         .forEach(lookupRow -> testLookup(tc, lookupRow));
@@ -116,7 +117,7 @@ public class ConcurrentKeyExtentCacheTest {
   public void testRandom() throws Exception {
     TestCache tc = new TestCache();
 
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
     rand.ints(10000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
         .forEach(lookupRow -> testLookup(tc, lookupRow));
     Assert.assertEquals(256, tc.updates.get());

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -514,7 +515,7 @@ public class RFileTest {
     Scanner scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withIndexCache(1000000).withDataCache(10000000).build();
 
-    Random rand = new Random(5);
+    Random rand = new SecureRandom();
 
     for (int i = 0; i < 100; i++) {
       int r = rand.nextInt(10000);

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -48,7 +49,7 @@ import org.slf4j.LoggerFactory;
 public class BloomFilterLayerLookupTest {
 
   private static final Logger log = LoggerFactory.getLogger(BloomFilterLayerLookupTest.class);
-  private static Random random = new Random();
+  private static Random random = new SecureRandom();
 
   @Rule
   public TestName testName = new TestName();

--- a/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.accumulo.core.file.blockfile.cache;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -492,7 +493,7 @@ public class TestLruBlockCache extends TestCase {
 
   private Block[] generateRandomBlocks(int numBlocks, long maxSize) {
     Block[] blocks = new Block[numBlocks];
-    Random r = new Random();
+    Random r = new SecureRandom();
     for (int i = 0; i < numBlocks; i++) {
       blocks[i] = new Block("block" + i, r.nextInt((int) maxSize) + 1);
     }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.core.file.rfile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -108,7 +109,7 @@ public class MultiLevelIndexTest extends TestCase {
     liter = reader.lookup(new Key(String.format("%05d000", num + 1)));
     assertFalse(liter.hasNext());
 
-    Random rand = new Random();
+    Random rand = new SecureRandom();
     for (int i = 0; i < 100; i++) {
       int k = rand.nextInt(num * 1000);
       int expected;

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -287,7 +288,7 @@ public class MultiThreadedRFileTest {
   }
 
   private void validate(TestRFile trf) throws IOException {
-    Random random = new Random();
+    Random random = new SecureRandom();
     for (int iteration = 0; iteration < 10; iteration++) {
       int part = random.nextInt(4);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.SecureRandom;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -537,7 +538,7 @@ public class RFileTest {
 
     // test seeking to random location and reading all data from that point
     // there was an off by one bug with this in the transient index
-    Random rand = new Random();
+    Random rand = new SecureRandom();
     for (int i = 0; i < 12; i++) {
       index = rand.nextInt(expectedKeys.size());
       trf.seek(expectedKeys.get(index));
@@ -1659,7 +1660,7 @@ public class RFileTest {
 
     Set<ByteSequence> cfs = Collections.emptySet();
 
-    Random rand = new Random();
+    Random rand = new SecureRandom();
 
     for (int count = 0; count < 100; count++) {
 
@@ -1998,9 +1999,9 @@ public class RFileTest {
     sample.seek(new Range(), columnFamilies, inclusive);
     Assert.assertEquals(sampleData, toList(sample));
 
-    Random rand = new Random();
+    Random rand = new SecureRandom();
     long seed = rand.nextLong();
-    rand = new Random(seed);
+    rand.setSeed(seed);
 
     // randomly seek sample iterator and verify
     for (int i = 0; i < 33; i++) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RolllingStatsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RolllingStatsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.accumulo.core.file.rfile;
 
+import java.security.SecureRandom;
 import java.util.Random;
 import java.util.function.IntSupplier;
 
@@ -59,7 +60,7 @@ public class RolllingStatsTest {
 
   private static class StatTester {
 
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
     private DescriptiveStatistics ds;
     private RollingStats rs;
     private RollingStats rsp;
@@ -92,7 +93,7 @@ public class RolllingStatsTest {
   public void testFewSizes() {
     StatTester st = new StatTester(1019);
     int[] keySizes = {103, 113, 123, 2345};
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
     for (int i = 0; i < 10000; i++) {
       st.addValue(keySizes[rand.nextInt(keySizes.length)]);
     }
@@ -118,7 +119,7 @@ public class RolllingStatsTest {
 
       StatTester st = new StatTester(windowSize);
 
-      Random rand = new Random();
+      Random rand = new SecureRandom();
 
       for (int i = 0; i < 1000; i++) {
         int v = 200 + rand.nextInt(50);
@@ -173,7 +174,7 @@ public class RolllingStatsTest {
   @Test
   public void testSpikes() {
 
-    Random rand = new Random();
+    Random rand = new SecureRandom();
 
     StatTester st = new StatTester(3017);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.core.file.streams;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.hadoop.fs.Seekable;
@@ -28,7 +29,7 @@ public class RateLimitedInputStreamTest {
 
   @Test
   public void permitsAreProperlyAcquired() throws Exception {
-    Random randGen = new Random();
+    Random randGen = new SecureRandom();
     MockRateLimiter rateLimiter = new MockRateLimiter();
     long bytesRetrieved = 0;
     try (InputStream is = new RateLimitedInputStream(new RandomInputStream(), rateLimiter)) {
@@ -43,7 +44,7 @@ public class RateLimitedInputStreamTest {
   }
 
   private static class RandomInputStream extends InputStream implements Seekable {
-    private final Random r = new Random();
+    private final Random r = new SecureRandom();
 
     @Override
     public int read() throws IOException {

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.file.streams;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -30,7 +31,7 @@ public class RateLimitedOutputStreamTest {
 
   @Test
   public void permitsAreProperlyAcquired() throws Exception {
-    Random randGen = new Random();
+    Random randGen = new SecureRandom();
     MockRateLimiter rateLimiter = new MockRateLimiter();
     long bytesWritten = 0;
     try (RateLimitedOutputStream os = new RateLimitedOutputStream(new NullOutputStream(),

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.iterators.user;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -70,7 +71,7 @@ public class IndexedDocIteratorTest extends TestCase {
       Text[] columnFamilies, Text[] otherColumnFamilies, HashSet<Text> docs,
       Text[] negatedColumns) {
     StringBuilder sb = new StringBuilder();
-    Random r = new Random();
+    Random r = new SecureRandom();
     Value v = new Value(new byte[0]);
     TreeMap<Key,Value> map = new TreeMap<>();
     boolean[] negateMask = new boolean[columnFamilies.length];

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -59,7 +60,7 @@ public class IntersectingIteratorTest {
   private TreeMap<Key,Value> createSortedMap(float hitRatio, int numRows, int numDocsPerRow,
       Text[] columnFamilies, Text[] otherColumnFamilies, HashSet<Text> docs,
       Text[] negatedColumns) {
-    Random r = new Random();
+    Random r = new SecureRandom();
     Value v = new Value(new byte[0]);
     TreeMap<Key,Value> map = new TreeMap<>();
     boolean[] negateMask = new boolean[columnFamilies.length];

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -376,7 +377,7 @@ public abstract class TestCfCqSlice {
       skvi.init(parent, options, null);
       skvi.seek(range, EMPTY_CF_SET, false);
 
-      Random random = new Random();
+      Random random = new SecureRandom();
 
       while (skvi.hasTop()) {
         Key k = skvi.getTopKey();

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -33,7 +34,7 @@ import org.junit.Test;
 public class AuthenticationTokenTest {
   @Test
   public void testSerializeDeserializeToken() throws AccumuloSecurityException, IOException {
-    Random random = new Random();
+    Random random = new SecureRandom();
     byte[] randomBytes = new byte[12];
     random.nextBytes(randomBytes);
     boolean allZero = true;

--- a/core/src/test/java/org/apache/accumulo/core/security/crypto/BlockedIOStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/crypto/BlockedIOStreamTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -82,7 +83,7 @@ public class BlockedIOStreamTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     // buffer will be size 12
     BlockedOutputStream blockOut = new BlockedOutputStream(baos, 16, 16);
-    Random r = new Random(22);
+    Random r = new SecureRandom();
 
     byte[] undersized = new byte[11];
     byte[] perfectSized = new byte[12];
@@ -126,7 +127,7 @@ public class BlockedIOStreamTest {
     int blockSize = 16;
     // buffer will be size 12
     BlockedOutputStream blockOut = new BlockedOutputStream(baos, blockSize, blockSize);
-    Random r = new Random(22);
+    Random r = new SecureRandom();
 
     int size = 1024 * 1024 * 128;
     byte[] giant = new byte[size];

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public class IsolatedDeepCopiesTestCase extends OutputVerifyingTestCase {
   private static final Logger log = LoggerFactory.getLogger(IsolatedDeepCopiesTestCase.class);
 
-  private final Random random = new Random();
+  private final Random random = new SecureRandom();
 
   @Override
   public IteratorTestOutput test(IteratorTestInput testInput) {

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Random;
 import java.util.TreeMap;
 
@@ -41,7 +42,7 @@ public class MultipleHasTopCalls extends OutputVerifyingTestCase {
   private final Random random;
 
   public MultipleHasTopCalls() {
-    this.random = new Random();
+    this.random = new SecureRandom();
   }
 
   @Override

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Random;
 import java.util.TreeMap;
@@ -48,7 +49,7 @@ public class ReSeekTestCase extends OutputVerifyingTestCase {
   private final Random random;
 
   public ReSeekTestCase() {
-    this.random = new Random();
+    this.random = new SecureRandom();
   }
 
   @Override

--- a/maven-plugin/src/main/spotbugs/exclude-filter.xml
+++ b/maven-plugin/src/main/spotbugs/exclude-filter.xml
@@ -15,18 +15,15 @@
   limitations under the License.
 -->
 <FindBugsFilter>
-  <Match>
-    <!-- ignore thrift-generated classes -->
-    <Package name="org.apache.accumulo.proxy.thrift" />
-  </Match>
-  <Match>
-    <!-- admin classes can call System.exit -->
-    <Class name="org.apache.accumulo.proxy.Proxy" />
-    <Bug code="DM" pattern="DM_EXIT" />
-  </Match>
-  <Match>
-    <!-- Calling new File on input can be dangerous, but OK here -->
-    <Class name="org.apache.accumulo.proxy.Proxy$PropertiesConverter"/>
-    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
-  </Match>
+    <Match>
+        <!-- new file on user input can be dangerous but OK here -->
+        <Class name="org.apache.accumulo.maven.plugin.StartMojo"/>
+        <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+    </Match>
+    <Match>
+        <!-- dangerous on untrusted files but OK here -->
+        <Class name="org.apache.accumulo.maven.plugin.HelpMojo"/>
+        <Method name="build" params="" returns="org.w3c.dom.Document"/>
+        <Bug code="XXE" pattern="XXE_DOCUMENT"/>
+    </Match>
 </FindBugsFilter>

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
@@ -122,11 +122,11 @@ public class StandaloneClusterControl implements ClusterControl {
   }
 
   /**
-   * Prevent potential CRLF injection into logs from read in user data
-   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   * Prevent potential CRLF injection into logs from read in user data See
+   * https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
    */
   private String sanitize(String msg) {
-    return msg.replaceAll("[\r\n]","");
+    return msg.replaceAll("[\r\n]", "");
   }
 
   public Entry<Integer,String> execMapreduceWithStdout(Class<?> clz, String[] args)
@@ -288,7 +288,8 @@ public class StandaloneClusterControl implements ClusterControl {
     String pid = getPid(server, accumuloHome, hostname);
 
     if (pid.trim().isEmpty()) {
-      log.debug("Found no processes for {} on {}", sanitize(server.prettyPrint()), sanitize(hostname));
+      log.debug("Found no processes for {} on {}", sanitize(server.prettyPrint()),
+          sanitize(hostname));
       return;
     }
 

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
@@ -117,8 +117,16 @@ public class StandaloneClusterControl implements ClusterControl {
     for (String arg : args) {
       cmd.add("'" + arg + "'");
     }
-    log.info("Running: '{}' on {}", StringUtils.join(cmd, " "), master);
+    log.info("Running: '{}' on {}", sanitize(StringUtils.join(cmd, " ")), sanitize(master));
     return exec(master, cmd.toArray(new String[cmd.size()]));
+  }
+
+  /**
+   * Prevent potential CRLF injection into logs from read in user data
+   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   */
+  private String sanitize(String msg) {
+    return msg.replaceAll("[\r\n]","");
   }
 
   public Entry<Integer,String> execMapreduceWithStdout(Class<?> clz, String[] args)
@@ -280,7 +288,7 @@ public class StandaloneClusterControl implements ClusterControl {
     String pid = getPid(server, accumuloHome, hostname);
 
     if (pid.trim().isEmpty()) {
-      log.debug("Found no processes for {} on {}", server, hostname);
+      log.debug("Found no processes for {} on {}", sanitize(server.prettyPrint()), sanitize(hostname));
       return;
     }
 

--- a/minicluster/src/main/spotbugs/exclude-filter.xml
+++ b/minicluster/src/main/spotbugs/exclude-filter.xml
@@ -16,6 +16,11 @@
 -->
 <FindBugsFilter>
   <Match>
+    <!-- TODO Fix this in _exec? -->
+    <Class name="org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl" />
+    <Bug code="COMMAND" pattern="COMMAND_INJECTION" />
+  </Match>
+  <Match>
     <!-- locking is confusing, but probably correct -->
     <Class name="org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl" />
     <Method name="start" params="" returns="void" />
@@ -26,5 +31,32 @@
     <Class name="org.apache.accumulo.minicluster.impl.ProcessReference" />
     <Method name="equals" params="java.lang.Object" returns="boolean" />
     <Bug code="EQ" pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Or>
+      <Class name="org.apache.accumulo.cluster.RemoteShellOptions" />
+      <Class name="org.apache.accumulo.cluster.standalone.StandaloneAccumuloCluster" />
+      <Class name="org.apache.accumulo.cluster.standalone.StandaloneClusterControl"/>
+      <Class name="org.apache.accumulo.minicluster.MiniAccumuloClusterExistingZooKeepersTest"/>
+      <Class name="org.apache.accumulo.minicluster.MiniAccumuloClusterStartStopTest"/>
+      <Class name="org.apache.accumulo.minicluster.MiniAccumuloRunner"/>
+      <Class name="org.apache.accumulo.minicluster.MiniAccumuloRunner$PropertiesConverter"/>
+      <Class name="org.apache.accumulo.minicluster.impl.MiniAccumuloClusterControl"/>
+      <Class name="org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl"/>
+    </Or>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <!-- Socket just for shutdown -->
+    <Class name="org.apache.accumulo.minicluster.MiniAccumuloRunner" />
+    <Method name="main" params="java.lang.String[]" returns="void"/>
+    <Bug code="UNENCRYPTED" pattern="UNENCRYPTED_SERVER_SOCKET"/>
+  </Match>
+  <Match>
+    <!-- temp socket just for starting up -->
+    <Class name="org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl"/>
+    <Method name="start" params="" returns="void" />
+    <Bug code="UNENCRYPTED" pattern="UNENCRYPTED_SOCKET"/>
   </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -806,6 +806,11 @@
                 <artifactId>library-detectors</artifactId>
                 <version>1.2.0</version>
               </plugin>
+              <plugin>
+                <groupId>com.h3xstream.findsecbugs</groupId>
+                <artifactId>findsecbugs-plugin</artifactId>
+                <version>1.8.0</version>
+              </plugin>
             </plugins>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -800,16 +800,11 @@
             <includeTests>true</includeTests>
             <maxRank>16</maxRank>
             <jvmArgs>-Dcom.overstock.findbugs.ignore=com.google.common.util.concurrent.RateLimiter,com.google.common.hash.Hasher,com.google.common.hash.HashCode,com.google.common.hash.HashFunction,com.google.common.hash.Hashing,com.google.common.cache.Cache,com.google.common.io.CountingOutputStream,com.google.common.io.ByteStreams,com.google.common.cache.LoadingCache,com.google.common.base.Stopwatch,com.google.common.cache.RemovalNotification,com.google.common.util.concurrent.Uninterruptibles,com.google.common.reflect.ClassPath,com.google.common.reflect.ClassPath$ClassInfo,com.google.common.base.Throwables,com.google.common.collect.Iterators</jvmArgs>
-            <plugins>
+            <plugins combine.children="append">
               <plugin>
                 <groupId>com.overstock.findbugs</groupId>
                 <artifactId>library-detectors</artifactId>
                 <version>1.2.0</version>
-              </plugin>
-              <plugin>
-                <groupId>com.h3xstream.findsecbugs</groupId>
-                <artifactId>findsecbugs-plugin</artifactId>
-                <version>1.8.0</version>
               </plugin>
             </plugins>
           </configuration>
@@ -1740,6 +1735,26 @@
                 <version>2.8</version>
               </dependency>
             </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>sec-bugs</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <configuration>
+              <plugins>
+                <plugin>
+                  <groupId>com.h3xstream.findsecbugs</groupId>
+                  <artifactId>findsecbugs-plugin</artifactId>
+                  <version>1.8.0</version>
+                </plugin>
+              </plugins>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/proxy/src/main/java/org/apache/accumulo/proxy/Util.java
+++ b/proxy/src/main/java/org/apache/accumulo/proxy/Util.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.accumulo.proxy.thrift.IteratorSetting;
@@ -27,7 +28,7 @@ import org.apache.accumulo.proxy.thrift.Key;
 
 public class Util {
 
-  private static Random random = new Random(0);
+  private static Random random = new SecureRandom();
 
   public static String randString(int numbytes) {
     return new BigInteger(numbytes * 5, random).toString(32);

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/RandomVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/RandomVolumeChooser.java
@@ -16,10 +16,11 @@
  */
 package org.apache.accumulo.server.fs;
 
+import java.security.SecureRandom;
 import java.util.Random;
 
 public class RandomVolumeChooser implements VolumeChooser {
-  private final Random random = new Random();
+  private final Random random = new SecureRandom();
 
   @Override
   public String choose(VolumeChooserEnvironment env, String[] options)

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -373,7 +373,7 @@ public class VolumeUtil {
 
   private static String hash(FileSystem fs, Path dir, String name) throws IOException {
     try (FSDataInputStream in = fs.open(new Path(dir, name))) {
-      return DigestUtils.shaHex(in);
+      return DigestUtils.sha256Hex(in);
     }
 
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.server.master.balancer;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +62,7 @@ public class ChaoticLoadBalancer extends TabletBalancer {
     this.tableName = tableName;
   }
 
-  Random r = new Random();
+  Random r = new SecureRandom();
 
   @Override
   public void getAssignments(SortedMap<TServerInstance,TabletServerStatus> current,

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.master.balancer;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -377,7 +378,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
               if (null == outOfBoundsTablets) {
                 continue;
               }
-              Random random = new Random();
+              Random random = new SecureRandom();
               for (TabletStats ts : outOfBoundsTablets) {
                 KeyExtent ke = new KeyExtent(ts.getExtent());
                 if (migrations.contains(ke)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -73,7 +73,7 @@ class ZKSecurityTool {
       log.error("Count not create hashed password", e);
       return false;
     }
-    return java.util.Arrays.equals(passwordToCheck, zkData);
+    return MessageDigest.isEqual(passwordToCheck, zkData);
   }
 
   public static byte[] createPass(byte[] password) throws AccumuloException {

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.tablets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.accumulo.core.Constants;
@@ -43,7 +44,7 @@ public class UniqueNameAllocator {
   public UniqueNameAllocator(ServerContext context) {
     this.context = context;
     nextNamePath = Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNEXT_FILE;
-    rand = new Random();
+    rand = new SecureRandom();
   }
 
   public synchronized String getNextName() {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.util;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class FileUtil {
     Path result = null;
     while (result == null) {
       result = new Path(tabletDirectory + Path.SEPARATOR + "tmp/idxReduce_"
-          + String.format("%09d", new Random().nextInt(Integer.MAX_VALUE)));
+          + String.format("%09d", new SecureRandom().nextInt(Integer.MAX_VALUE)));
       try {
         fs.getFileStatus(result);
         result = null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.server.util;
 
+import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Random;
 
@@ -41,7 +42,7 @@ public class RandomWriter {
   public static class RandomMutationGenerator implements Iterable<Mutation>, Iterator<Mutation> {
     private long max_mutations;
     private int mutations_so_far = 0;
-    private Random r = new Random();
+    private Random r = new SecureRandom();
     private static final Logger log = LoggerFactory.getLogger(RandomMutationGenerator.class);
 
     public RandomMutationGenerator(long num_mutations) {

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.zookeeper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +66,7 @@ public class DistributedWorkQueue {
     if (numTask.get() >= threadPool.getCorePoolSize())
       return;
 
-    Random random = new Random();
+    Random random = new SecureRandom();
     Collections.shuffle(children, random);
     try {
       for (final String child : children) {
@@ -160,7 +161,7 @@ public class DistributedWorkQueue {
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config) {
     // Preserve the old delay and period
-    this(path, config, new Random().nextInt(60 * 1000), 60 * 1000);
+    this(path, config, new SecureRandom().nextInt(60 * 1000), 60 * 1000);
   }
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config, long timerInitialDelay,

--- a/server/base/src/main/spotbugs/exclude-filter.xml
+++ b/server/base/src/main/spotbugs/exclude-filter.xml
@@ -35,4 +35,34 @@
     </Or>
     <Bug code="DM" pattern="DM_EXIT" />
   </Match>
+  <Match>
+    <!-- Tests, Monitor or Proxy don't need SSL sockets -->
+    <Or>
+        <Class name="org.apache.accumulo.server.monitor.LogService$SocketServer"/>
+      <Class name="org.apache.accumulo.server.util.TServerUtilsTest"/>
+      <Class name="org.apache.accumulo.server.util.PortUtils" />
+    </Or>
+    <Bug code="UNENCRYPTED" pattern="UNENCRYPTED_SERVER_SOCKET" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.server.metrics.AbstractMetricsImpl" />
+    <Or>
+      <Method name="setupLogging"/>
+      <Method name="startNewLog"/>
+    </Or>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Or>
+      <Class name="org.apache.accumulo.server.security.SystemCredentialsTest"/>
+      <Class name="org.apache.accumulo.server.util.Admin"/>
+      <Class name="org.apache.accumulo.server.util.FileSystemMonitor" />
+      <Class name="org.apache.accumulo.server.util.RestoreZookeeper" />
+      <Class name="org.apache.accumulo.server.util.SendLogToChainsaw" />
+      <Class name="org.apache.accumulo.server.util.ConvertConfig"/>
+    </Or>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
 </FindBugsFilter>

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.accumulo.server.master.balancer;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -327,7 +328,7 @@ public class GroupBalancerTest {
   @Test
   public void bigTest() {
     TabletServers tservers = new TabletServers();
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
 
     for (int g = 1; g <= 60; g++) {
       for (int t = 1; t <= 241; t++) {
@@ -346,7 +347,7 @@ public class GroupBalancerTest {
   @Test
   public void bigTest2() {
     TabletServers tservers = new TabletServers();
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
 
     for (int g = 1; g <= 60; g++) {
       for (int t = 1; t <= rand.nextInt(1000); t++) {

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/MasterReplicationCoordinator.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/MasterReplicationCoordinator.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.master.replication;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
@@ -56,7 +57,8 @@ public class MasterReplicationCoordinator implements ReplicationCoordinator.Ifac
 
   protected MasterReplicationCoordinator(Master master, ZooReader reader) {
     this.master = master;
-    this.rand = new Random(358923462L);
+    this.rand = new SecureRandom();
+    this.rand.setSeed(358923462L);
     this.reader = reader;
     this.security = SecurityOperation.getInstance(master.getContext(), false);
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/LoadFiles.java
@@ -21,6 +21,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -136,7 +137,7 @@ class LoadFiles extends MasterRepo {
 
       // Use the threadpool to assign files one-at-a-time to the server
       final List<String> loaded = Collections.synchronizedList(new ArrayList<>());
-      final Random random = new Random();
+      final Random random = new SecureRandom();
       final TServerInstance[] servers;
       String prop = conf.get(Property.MASTER_BULK_TSERVER_REGEX);
       if (null == prop || "".equals(prop)) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -81,7 +81,6 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.mvc.MvcFeature;
 import org.glassfish.jersey.server.mvc.freemarker.FreemarkerMvcFeature;
 import org.glassfish.jersey.servlet.ServletContainer;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemsResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemsResource.java
@@ -105,7 +105,7 @@ public class ProblemsResource {
       ProblemReports.getInstance(Monitor.getContext()).deleteProblemReports(Table.ID.of(tableID));
     } catch (Exception e) {
       log.error("Failed to delete problem reports for table "
-          + (StringUtils.isEmpty(tableID) ? StringUtils.EMPTY : tableID), e);
+          + (StringUtils.isEmpty(tableID) ? StringUtils.EMPTY : sanitize(tableID)), e);
     }
   }
 
@@ -165,8 +165,16 @@ public class ProblemsResource {
           ProblemType.valueOf(ptype), resource);
     } catch (Exception e) {
       log.error("Failed to delete problem reports for table "
-          + (StringUtils.isBlank(tableID) ? "" : tableID), e);
+          + (StringUtils.isBlank(tableID) ? "" : sanitize(tableID)), e);
     }
+  }
+
+  /**
+   * Prevent potential CRLF injection into logs from read in user data.
+   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   */
+  private String sanitize(String msg) {
+    return msg.replaceAll("[\r\n]","");
   }
 
   @GET

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemsResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/problems/ProblemsResource.java
@@ -170,11 +170,11 @@ public class ProblemsResource {
   }
 
   /**
-   * Prevent potential CRLF injection into logs from read in user data.
-   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   * Prevent potential CRLF injection into logs from read in user data. See
+   * https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
    */
   private String sanitize(String msg) {
-    return msg.replaceAll("[\r\n]","");
+    return msg.replaceAll("[\r\n]", "");
   }
 
   @GET

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -16,7 +16,7 @@
  */
 package org.apache.accumulo.monitor.rest.tservers;
 
-import static org.apache.accumulo.monitor.util.ParameterValidator.SERVER_REGEX;
+import static org.apache.accumulo.monitor.util.ParameterValidator.HOSTNAME_PORT_REGEX;
 
 import java.lang.management.ManagementFactory;
 import java.security.MessageDigest;
@@ -101,7 +101,7 @@ public class TabletServerResource {
   @POST
   @Consumes(MediaType.TEXT_PLAIN)
   public void clearDeadServer(
-      @QueryParam("server") @NotNull @Pattern(regexp = SERVER_REGEX) String server) {
+      @QueryParam("server") @NotNull @Pattern(regexp = HOSTNAME_PORT_REGEX) String server) {
     DeadServerList obit = new DeadServerList(Monitor.getContext(),
         Monitor.getContext().getZooKeeperRoot() + Constants.ZDEADTSERVERS);
     obit.delete(server);
@@ -148,7 +148,7 @@ public class TabletServerResource {
   @Path("{address}")
   @GET
   public TabletServerSummary getTserverDetails(
-      @PathParam("address") @NotNull @Pattern(regexp = SERVER_REGEX) String tserverAddress)
+      @PathParam("address") @NotNull @Pattern(regexp = HOSTNAME_PORT_REGEX) String tserverAddress)
       throws Exception {
 
     boolean tserverExists = false;
@@ -316,7 +316,7 @@ public class TabletServerResource {
 
       KeyExtent extent = new KeyExtent(info.extent);
       Table.ID tableId = extent.getTableId();
-      MessageDigest digester = MessageDigest.getInstance("MD5");
+      MessageDigest digester = MessageDigest.getInstance(Constants.PW_HASH_ALGORITHM);
       if (extent.getEndRow() != null && extent.getEndRow().getLength() > 0) {
         digester.update(extent.getEndRow().getBytes(), 0, extent.getEndRow().getLength());
       }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/util/ParameterValidator.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/util/ParameterValidator.java
@@ -26,15 +26,8 @@ public interface ParameterValidator {
   String ALPHA_NUM_REGEX_TABLE_ID = "[!+]?\\w+";
   String ALPHA_NUM_REGEX_BLANK_OK = "\\w*";
 
-  String RESOURCE_REGEX = "(\\w|:)+";
-
-  // asterisk or - or blank or a namespace name
-  String NAMESPACE_REGEX = "[*-]?|\\w+";
-
-  // asterisk or blank or a comma-separated list of - or namespace names (optional trailing comma)
-  String NAMESPACE_LIST_REGEX = "[*]?|([-]|\\w+)(,([-]|\\w+))*,?";
+  String RESOURCE_REGEX = "(?:\\w|:)+";
 
   // host name and port
-  String SERVER_REGEX = "(\\w+[.-]*\\w*)+(:[0-9]{1,5})*";
-  String SERVER_REGEX_BLANK_OK = "(" + SERVER_REGEX + ")*";
+  String HOSTNAME_PORT_REGEX = "[a-zA-Z0-9.-]+:[0-9]{2,5}";
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -19,7 +19,7 @@ package org.apache.accumulo.monitor.view;
 import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX;
 import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_BLANK_OK;
 import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_TABLE_ID;
-import static org.apache.accumulo.monitor.util.ParameterValidator.SERVER_REGEX_BLANK_OK;
+import static org.apache.accumulo.monitor.util.ParameterValidator.HOSTNAME_PORT_REGEX;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
@@ -151,7 +151,7 @@ public class WebViews {
   @Path("tservers")
   @Template(name = "/default.ftl")
   public Map<String,Object> getTabletServers(
-      @QueryParam("s") @Pattern(regexp = SERVER_REGEX_BLANK_OK) String server) {
+      @QueryParam("s") @Pattern(regexp = HOSTNAME_PORT_REGEX) String server) {
 
     Map<String,Object> model = getModel();
     model.put("title", "Tablet Server Status");

--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/util/ParameterValidatorTest.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/util/ParameterValidatorTest.java
@@ -41,17 +41,17 @@ public class ParameterValidatorTest {
 
   @Test
   public void testServerRegex() throws Exception {
-    Pattern p = Pattern.compile(ParameterValidator.SERVER_REGEX);
+    Pattern p = Pattern.compile(ParameterValidator.HOSTNAME_PORT_REGEX);
     Assert.assertTrue("Did not match hostname with dots",
-        p.matcher("ab3cd.12d34.3xyz.net").matches());
+        p.matcher("ab3cd.12d34.3xyz.net:12").matches());
     Assert.assertTrue("Did not match hostname with dash",
-        p.matcher("abcd.123.server-foo.com").matches());
+        p.matcher("abcd.123.server-foo.com:56789").matches());
     Assert.assertTrue("Did not match hostname and port",
         p.matcher("abcd.123.server-foo.com:1234").matches());
-    Assert.assertTrue("Did not match all numeric", p.matcher("127.0.0.1").matches());
     Assert.assertTrue("Did not match all numeric and port", p.matcher("127.0.0.1:9999").matches());
     Assert.assertTrue("Did not match all numeric and port", p.matcher("ServerName:9999").matches());
 
+    Assert.assertFalse("Port number required", p.matcher("127.0.0.1").matches());
     Assert.assertFalse(p.matcher("abcd.1234.*.xyz").matches());
     Assert.assertFalse(p.matcher("abcd.1234.;xyz").matches());
     Assert.assertFalse(p.matcher("abcd.12{3}4.xyz").matches());
@@ -59,13 +59,6 @@ public class ParameterValidatorTest {
     Assert.assertFalse(p.matcher("abcd=4.xyz").matches());
     Assert.assertFalse(p.matcher("abcd=\"4.xyz\"").matches());
     Assert.assertFalse(p.matcher("abcd\"4.xyz\"").matches());
-
-    Pattern q = Pattern.compile(ParameterValidator.SERVER_REGEX_BLANK_OK);
-    Assert.assertTrue(q.matcher("abcd:9997").matches());
-    Assert.assertTrue(q.matcher("abcd.123:9997").matches());
-    Assert.assertTrue(q.matcher("abcd.123-xyz:9997").matches());
-    Assert.assertTrue(q.matcher("abcd.123-xyz").matches());
-    Assert.assertTrue(q.matcher("").matches());
   }
 
 }

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.tracer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class ZooTraceClient extends SendSpansViaThrift implements Watcher {
   ZooReader zoo = null;
   String path;
   boolean pathExists = false;
-  final Random random = new Random();
+  final Random random = new SecureRandom();
   final List<String> hosts = new ArrayList<>();
   long retryPause = 5000L;
 

--- a/server/tracer/src/main/spotbugs/exclude-filter.xml
+++ b/server/tracer/src/main/spotbugs/exclude-filter.xml
@@ -16,7 +16,20 @@
 -->
 <FindBugsFilter>
   <Match>
+    <!-- TODO open ticket to make this use thrift SSL -->
+    <Class name="org.apache.accumulo.tracer.SendSpansViaThrift" />
+    <Bug code="UNENCRYPTED" pattern="UNENCRYPTED_SOCKET" />
+  </Match>
+  <Match>
     <!-- ignore thrift-generated classes -->
     <Package name="org.apache.accumulo.tracer.thrift" />
+  </Match>
+  <Match>
+    <!-- Test doesn't need SSL -->
+    <Class name="org.apache.accumulo.tracer.TracerTest"/>
+    <Or>
+      <Bug code="UNENCRYPTED" pattern="UNENCRYPTED_SOCKET" />
+      <Bug code="UNENCRYPTED" pattern="UNENCRYPTED_SERVER_SOCKET" />
+    </Or>
   </Match>
 </FindBugsFilter>

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -27,6 +27,7 @@ import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.security.PrivilegedExceptionAction;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -460,7 +461,7 @@ public class TabletServer implements Runnable {
   }
 
   private static long jitter(long ms) {
-    Random r = new Random();
+    Random r = new SecureRandom();
     // add a random 10% wait
     return (long) ((1. + (r.nextDouble() / 10)) * ms);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.tserver.tablet;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
@@ -139,7 +140,7 @@ public class MinorCompactor extends Compactor {
           throw new IllegalStateException(e);
         }
 
-        Random random = new Random();
+        Random random = new SecureRandom();
 
         int sleep = sleepTime + random.nextInt(sleepTime);
         log.debug("MinC failed sleeping {} ms before retrying", sleep);

--- a/server/tserver/src/main/spotbugs/exclude-filter.xml
+++ b/server/tserver/src/main/spotbugs/exclude-filter.xml
@@ -27,4 +27,20 @@
     <Method name="&lt;init&gt;" params="org.apache.accumulo.tserver.TabletServer,org.apache.accumulo.server.fs.VolumeManager,org.apache.accumulo.server.ServerContext" returns="void" />
     <Bug code="DM" pattern="DM_GC" />
   </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.tserver.NativeMap" />
+    <Method name="loadNativeLib" params="java.util.List"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.tserver.replication.AccumuloReplicaSystem" />
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+  </Match>
+  <Match>
+    <!-- Calling new File on input can be dangerous, but OK here -->
+    <Class name="org.apache.accumulo.tserver.log.TestUpgradePathForWALogs" />
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
 </FindBugsFilter>

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -656,9 +656,17 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         + (getTableName().isEmpty() ? "" : " ") + getTableName() + "> ";
   }
 
+  /**
+   * Prevent potential CRLF injection into logs from read in user data
+   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   */
+  private String sanitize(String msg) {
+    return msg.replaceAll("[\r\n]","");
+  }
+
   public void execCommand(String input, boolean ignoreAuthTimeout, boolean echoPrompt)
       throws IOException {
-    audit.log(Level.INFO, getDefaultPrompt() + input);
+    audit.log(Level.INFO, sanitize(getDefaultPrompt() + input));
     if (echoPrompt) {
       reader.print(getDefaultPrompt());
       reader.println(input);

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -657,11 +657,11 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   }
 
   /**
-   * Prevent potential CRLF injection into logs from read in user data
-   * See https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
+   * Prevent potential CRLF injection into logs from read in user data See
+   * https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS
    */
   private String sanitize(String msg) {
-    return msg.replaceAll("[\r\n]","");
+    return msg.replaceAll("[\r\n]", "");
   }
 
   public void execCommand(String input, boolean ignoreAuthTimeout, boolean echoPrompt)

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -23,6 +23,7 @@ import java.util.Base64;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Scanner;
@@ -112,7 +113,7 @@ public class GetSplitsCommand extends Command {
   private static String obscuredTabletName(final KeyExtent extent) {
     MessageDigest digester;
     try {
-      digester = MessageDigest.getInstance("MD5");
+      digester = MessageDigest.getInstance(Constants.PW_HASH_ALGORITHM);
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/shell/src/main/spotbugs/exclude-filter.xml
+++ b/shell/src/main/spotbugs/exclude-filter.xml
@@ -20,4 +20,30 @@
     <Class name="org.apache.accumulo.shell.Shell" />
     <Bug code="DM" pattern="DM_EXIT" />
   </Match>
+  <Match>
+    <!-- output to anywhere OK here -->
+    <Class name="org.apache.accumulo.shell.Shell$PrintFile"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_OUT"/>
+  </Match>
+  <Match>
+    <!-- new file input stream OK here -->
+    <Class name="org.apache.accumulo.shell.ShellOptionsJC"/>
+    <Method name="getClientProperties" params="" returns="java.util.Properties"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <!-- new file input stream OK here -->
+    <Or>
+      <Class name="org.apache.accumulo.shell.commands.ExecfileCommand"/>
+      <Class name="org.apache.accumulo.shell.ShellOptionsJC$PasswordConverter$KeyType$2"/>
+      <Class name="org.apache.accumulo.shell.commands.ScriptCommand"/>
+    </Or>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
+  <Match>
+    <!-- new file input stream OK here -->
+    <Class name="org.apache.accumulo.shell.ShellUtil"/>
+    <Method name="scanFile" params="java.lang.String,boolean" returns="java.util.List"/>
+    <Bug code="PATH" pattern="PATH_TRAVERSAL_IN"/>
+  </Match>
 </FindBugsFilter>

--- a/shell/src/test/java/org/apache/accumulo/shell/PasswordConverterTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/PasswordConverterTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.security.SecureRandom;
 import java.util.Scanner;
 
 import org.apache.accumulo.shell.ShellOptionsJC.PasswordConverter;
@@ -74,7 +75,7 @@ public class PasswordConverterTest {
 
   @Test
   public void testPass() {
-    String expected = String.valueOf(Math.random());
+    String expected = String.valueOf(new SecureRandom().nextDouble());
     argv[1] = "pass:" + expected;
     new JCommander(password).parse(argv);
     assertEquals(expected, password.password);

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.xml.XMLConstants;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.XMLConstants;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/start/src/main/spotbugs/exclude-filter.xml
+++ b/start/src/main/spotbugs/exclude-filter.xml
@@ -1,0 +1,36 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+	<Match>
+		<!-- Calling new File on input can be dangerous, but OK here -->
+		<Class name="org.apache.accumulo.start.classloader.AccumuloClassLoader" />
+		<Method name="addUrl" params="java.lang.String, java.util.ArrayList"/>
+		<Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+	</Match>
+	<Match>
+		<!-- Calling new File on input can be dangerous, but OK here -->
+		<Class name="org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader" />
+		<Method name="computeTopCacheDir" />
+		<Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+	</Match>
+	<Match>
+		<!-- Calling new File on input can be dangerous, but OK here -->
+		<Class name="org.apache.accumulo.start.classloader.vfs.UniqueFileReplicator" />
+		<Method name="replicateFile" params="org.apache.commons.vfs2.FileObject, org.apache.commons.vfs2.FileSelector"/>
+		<Bug code="PATH" pattern="PATH_TRAVERSAL_IN" />
+	</Match>
+</FindBugsFilter>

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.accumulo.cluster.ClusterUser;
@@ -105,7 +106,7 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
     }
 
     cluster = harness.create(SharedMiniClusterBase.class.getName(),
-        System.currentTimeMillis() + "_" + new Random().nextInt(Short.MAX_VALUE), token,
+        System.currentTimeMillis() + "_" + new SecureRandom().nextInt(Short.MAX_VALUE), token,
         miniClusterCallback, krb);
     cluster.start();
 

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.util.Random;
 
 import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.cluster.ClusterUsers;

--- a/test/src/main/java/org/apache/accumulo/test/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CompactionRateLimitingIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test;
 
+import java.security.SecureRandom;
 import java.util.Random;
 
 import org.apache.accumulo.core.client.BatchWriter;
@@ -48,7 +49,7 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
     Connector conn = getCluster().getConnector("root", new PasswordToken(ROOT_PASSWORD));
     conn.tableOperations().create(tableName);
     try (BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig())) {
-      Random r = new Random();
+      Random r = new SecureRandom();
       while (bytesWritten < BYTES_TO_WRITE) {
         byte[] rowKey = new byte[32];
         r.nextBytes(rowKey);

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -22,6 +22,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -859,7 +860,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
     ArrayList<byte[]> rows = new ArrayList<>(num);
     ArrayList<ConditionalMutation> cml = new ArrayList<>(num);
 
-    Random r = new Random();
+    Random r = new SecureRandom();
     byte[] e = new byte[0];
 
     for (int i = 0; i < num; i++) {
@@ -934,7 +935,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
     ColumnVisibility cvaob = new ColumnVisibility("A|B");
     ColumnVisibility cvaab = new ColumnVisibility("A&B");
 
-    switch ((new Random()).nextInt(3)) {
+    switch ((new SecureRandom()).nextInt(3)) {
       case 1:
         conn.tableOperations().addSplits(tableName, nss("6"));
         break;
@@ -1151,7 +1152,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
     public void run() {
       try (Scanner scanner = new IsolatedScanner(
           conn.createScanner(tableName, Authorizations.EMPTY))) {
-        Random rand = new Random();
+        Random rand = new SecureRandom();
 
         for (int i = 0; i < 20; i++) {
           int numRows = rand.nextInt(10) + 1;
@@ -1197,7 +1198,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
 
     conn.tableOperations().create(tableName);
 
-    Random rand = new Random();
+    Random rand = new SecureRandom();
 
     switch (rand.nextInt(3)) {
       case 1:

--- a/test/src/main/java/org/apache/accumulo/test/CreateRandomRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/CreateRandomRFile.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.test;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -35,7 +36,8 @@ public class CreateRandomRFile {
   private static String file;
 
   public static byte[] createValue(long rowid, int dataSize) {
-    Random r = new Random(rowid);
+    Random r = new SecureRandom();
+    r.setSeed(rowid);
     byte value[] = new byte[dataSize];
 
     r.nextBytes(value);
@@ -57,7 +59,7 @@ public class CreateRandomRFile {
     num = Integer.parseInt(args[1]);
     long rands[] = new long[num];
 
-    Random r = new Random();
+    Random r = new SecureRandom();
 
     for (int i = 0; i < rands.length; i++) {
       rands[i] = (r.nextLong() & 0x7fffffffffffffffL) % 10000000000L;

--- a/test/src/main/java/org/apache/accumulo/test/FaultyConditionalWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/FaultyConditionalWriter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,7 +41,7 @@ public class FaultyConditionalWriter implements ConditionalWriter {
     this.cw = cw;
     this.up = unknownProbability;
     this.wp = writeProbability;
-    this.rand = new Random();
+    this.rand = new SecureRandom();
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/IMMLGBenchmark.java
+++ b/test/src/main/java/org/apache/accumulo/test/IMMLGBenchmark.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -134,7 +135,7 @@ public class IMMLGBenchmark {
 
   private static long write(Connector conn, ArrayList<byte[]> cfset, String table)
       throws TableNotFoundException, MutationsRejectedException {
-    Random rand = new Random();
+    Random rand = new SecureRandom();
 
     byte val[] = new byte[50];
 

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -21,6 +21,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -81,7 +82,7 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
     final String tableName = getUniqueNames(1)[0];
     final Connector c = getConnector();
     c.tableOperations().create(tableName);
-    Random random = new Random();
+    Random random = new SecureRandom();
     BatchWriter bw = c.createBatchWriter(tableName, null);
     for (int i = 0; i < 50000; i++) {
       byte[] row = new byte[100];

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -20,6 +20,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.security.SecureRandom;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +74,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
     final Thread agitator = agitator(stop);
     agitator.start();
     System.out.println("writing");
-    final Random random = new Random();
+    final Random random = new SecureRandom();
     for (i = 0; i < 1_000_000; i++) {
       // make non-negative avoiding Math.abs, because that can still be negative
       long randomRow = random.nextLong() & Long.MAX_VALUE;

--- a/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
+++ b/test/src/main/java/org/apache/accumulo/test/QueryMetadataTable.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map.Entry;
@@ -129,7 +130,7 @@ public class QueryMetadataTable {
 
     ArrayList<Text> rows = new ArrayList<>(rowSet);
 
-    Random r = new Random();
+    Random r = new SecureRandom();
 
     ExecutorService tp = Executors.newFixedThreadPool(opts.numThreads);
 

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -953,7 +954,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     assertEquals(2, countFiles(cloneId));
 
     // create two large files
-    Random rand = new Random();
+    Random rand = new SecureRandom();
     StringBuilder sb = new StringBuilder("insert b v q ");
     for (int i = 0; i < 10000; i++) {
       sb.append('a' + rand.nextInt(26));

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -107,7 +108,7 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
 
     @Override
     public Exception call() {
-      Random r = new Random();
+      Random r = new SecureRandom();
       countDown.countDown();
       try {
         countDown.await();

--- a/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -160,7 +161,7 @@ public class TestBinaryRows {
     } else if (opts.mode.equals("randomLookups")) {
       int numLookups = 1000;
 
-      Random r = new Random();
+      Random r = new SecureRandom();
 
       long t1 = System.currentTimeMillis();
 

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
@@ -214,7 +215,7 @@ public class TestIngest {
     byte[][] bytevals = generateValues(opts.dataSize);
 
     byte randomValue[] = new byte[opts.dataSize];
-    Random random = new Random();
+    Random random = new SecureRandom();
 
     long bytesWritten = 0;
 

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertTrue;
 
+import java.security.SecureRandom;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -54,7 +55,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
 
   @Test(timeout = 4 * 60 * 1000)
   public void test() throws Exception {
-    Random random = new Random();
+    Random random = new SecureRandom();
     Connector c = getConnector();
     c.instanceOperations().setProperty(Property.TSERV_TOTAL_MUTATION_QUEUE_MAX.getKey(),
         "" + SMALL_QUEUE_SIZE);

--- a/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -297,7 +298,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   }
 
   void writeRandomValue(Connector c, String tableName, int size) throws Exception {
-    Random rand = new Random();
+    Random rand = new SecureRandom();
 
     byte data1[] = new byte[size];
     rand.nextBytes(data1);

--- a/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -92,7 +93,7 @@ public class VerifyIngest {
     long t1 = System.currentTimeMillis();
 
     byte randomValue[] = new byte[opts.dataSize];
-    Random random = new Random();
+    Random random = new SecureRandom();
 
     Key endKey = new Key(new Text("row_" + String.format("%010d", opts.rows + opts.startRow)));
 

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.security.SecureRandom;
 import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -47,7 +48,7 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
 
   private final static byte[] HEXCHARS = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
       0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66};
-  private final static Random random = new Random();
+  private final static Random random = new SecureRandom();
 
   public static byte[] randomHex(int n) {
     byte[] binary = new byte[n];

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test.functional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -89,7 +90,7 @@ public class BatchScanSplitIT extends AccumuloClusterHarness {
 
     System.out.println("splits : " + splits);
 
-    Random random = new Random(19011230);
+    Random random = new SecureRandom();
     HashMap<Text,Value> expected = new HashMap<>();
     ArrayList<Range> ranges = new ArrayList<>();
     for (int i = 0; i < 100; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test.functional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -107,7 +108,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
       TableNotFoundException, MutationsRejectedException, Exception {
     BatchWriter bw = getConnector().createBatchWriter(tableName, new BatchWriterConfig());
     try (Scanner scanner = getConnector().createScanner(tableName, Authorizations.EMPTY)) {
-      Random r = new Random();
+      Random r = new SecureRandom();
 
       for (int i = 0; i < 4; i++) {
         for (int j = 0; j < NUM_TO_FLUSH; j++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -176,7 +177,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
 
   private long query(Connector c, String table, int depth, long start, long end, int num, int step)
       throws Exception {
-    Random r = new Random(42);
+    Random r = new SecureRandom();
 
     HashSet<Long> expected = new HashSet<>();
     List<Range> ranges = new ArrayList<>(num);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Random;
@@ -61,7 +62,7 @@ public class CacheTestWriter {
 
     ArrayList<String> children = new ArrayList<>();
 
-    Random r = new Random();
+    Random r = new SecureRandom();
 
     while (count++ < numVerifications) {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.accumulo.test.functional;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -258,7 +259,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
   private void writeData(Connector c, String table)
       throws TableNotFoundException, MutationsRejectedException {
     try (BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig())) {
-      Random rand = new Random();
+      Random rand = new SecureRandom();
       for (int i = 0; i < 1000; i++) {
         Mutation m = new Mutation(String.format("%09x", rand.nextInt(100000 * 1000)));
         m.put("m", "order", "" + i);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableCompactionIT.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -141,7 +142,7 @@ public class ConfigurableCompactionIT extends ConfigurableMacBase {
     conn.tableOperations().flush(tablename, null, null, true);
   }
 
-  final static Random r = new Random();
+  final static Random r = new SecureRandom();
 
   private void makeFile(Connector conn, String tablename) throws Exception {
     BatchWriter bw = conn.createBatchWriter(tablename, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -58,7 +59,7 @@ public class FateStarvationIT extends AccumuloClusterHarness {
     c.tableOperations().flush(tableName, null, null, true);
 
     List<Text> splits = new ArrayList<>(TestIngest.getSplitPoints(0, 100000, 67));
-    Random rand = new Random();
+    Random rand = new SecureRandom();
 
     for (int i = 0; i < 100; i++) {
       int idx1 = rand.nextInt(splits.size() - 1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test.functional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -108,7 +109,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    Random r = new Random();
+    Random r = new SecureRandom();
     byte rowData[] = new byte[ROW_SIZE];
     r.setSeed(SEED + 1);
     TreeSet<Text> splitPoints = new TreeSet<>();
@@ -149,7 +150,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
   private void basicTest(Connector c, String table, int expectedSplits) throws Exception {
     BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig());
 
-    Random r = new Random();
+    Random r = new SecureRandom();
     byte rowData[] = new byte[ROW_SIZE];
 
     r.setSeed(SEED);
@@ -188,7 +189,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
   }
 
   private void verify(Connector c, String table) throws Exception {
-    Random r = new Random();
+    Random r = new SecureRandom();
     byte rowData[] = new byte[ROW_SIZE];
 
     r.setSeed(SEED);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +140,7 @@ public class MaxOpenIT extends AccumuloClusterHarness {
       long t1 = System.currentTimeMillis();
 
       byte rval[] = new byte[50];
-      Random random = new Random();
+      Random random = new SecureRandom();
 
       for (Entry<Key,Value> entry : bs) {
         count++;

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -471,7 +472,7 @@ public class NativeMapIT {
     // insert things with varying field sizes and value sizes
 
     // generate random data
-    Random r = new Random(75);
+    Random r = new SecureRandom();
 
     ArrayList<Pair<Key,Value>> testData = new ArrayList<>();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.security.SecureRandom;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -87,7 +88,7 @@ public class ScanIdIT extends AccumuloClusterHarness {
 
   private static final int NUM_DATA_ROWS = 100;
 
-  private static final Random random = new Random();
+  private static final Random random = new SecureRandom();
 
   private static final ExecutorService pool = Executors.newFixedThreadPool(NUM_SCANNERS);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -31,6 +31,7 @@ import static org.apache.accumulo.test.functional.BasicSummarizer.MIN_TIMESTAMP_
 import static org.apache.accumulo.test.functional.BasicSummarizer.TOTAL_STAT;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -831,7 +832,7 @@ public class SummaryIT extends AccumuloClusterHarness {
     ntc.enableSummarization(SummarizerConfiguration.builder(FamilySummarizer.class).build());
     c.tableOperations().create(table, ntc);
 
-    Random rand = new Random(42);
+    Random rand = new SecureRandom();
     int q = 0;
 
     SortedSet<Text> partitionKeys = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -167,7 +168,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
   }
 
   private void writeSomeData(Connector conn, String tableName, int row, int col) throws Exception {
-    Random rand = new Random();
+    Random rand = new SecureRandom();
     BatchWriter bw = conn.createBatchWriter(tableName, null);
     byte[] rowData = new byte[10];
     byte[] cq = new byte[10];

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test.functional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -98,7 +99,8 @@ public class ZombieTServer {
   private static final Logger log = LoggerFactory.getLogger(ZombieTServer.class);
 
   public static void main(String[] args) throws Exception {
-    Random random = new Random(System.currentTimeMillis() % 1000);
+    Random random = new SecureRandom();
+    random.setSeed(System.currentTimeMillis() % 1000);
     int port = random.nextInt(30000) + 2000;
     ServerContext context = new ServerContext(new SiteConfiguration());
     TransactionWatcher watcher = new TransactionWatcher(context);

--- a/test/src/main/java/org/apache/accumulo/test/master/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/SuspendedTabletsIT.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ import com.google.common.collect.SetMultimap;
 
 public class SuspendedTabletsIT extends ConfigurableMacBase {
   private static final Logger log = LoggerFactory.getLogger(SuspendedTabletsIT.class);
-  private static final Random RANDOM = new Random();
+  private static final Random RANDOM = new SecureRandom();
   private static ExecutorService THREAD_POOL;
 
   public static final int TSERVERS = 5;

--- a/test/src/main/java/org/apache/accumulo/test/performance/ContinuousIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/ContinuousIngest.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -99,7 +100,7 @@ public class ContinuousIngest {
         bwOpts.getBatchWriterConfig());
     bw = Trace.wrapAll(bw, new CountSampler(1024));
 
-    Random r = new Random();
+    Random r = new SecureRandom();
 
     byte[] ingestInstanceId = UUID.randomUUID().toString().getBytes(UTF_8);
 

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test.performance.scan;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -381,7 +382,7 @@ public class CollectTabletStats {
   private static List<KeyExtent> selectRandomTablets(int numThreads, List<KeyExtent> candidates) {
     List<KeyExtent> tabletsToTest = new ArrayList<>();
 
-    Random rand = new Random();
+    Random rand = new SecureRandom();
     for (int i = 0; i < numThreads; i++) {
       int rindex = rand.nextInt(candidates.size());
       tabletsToTest.add(candidates.get(rindex));

--- a/test/src/main/java/org/apache/accumulo/test/util/metadata/MetadataBatchScan.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/metadata/MetadataBatchScan.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test.util.metadata;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -65,7 +66,7 @@ public class MetadataBatchScan {
     final Connector connector = opts.getConnector();
 
     TreeSet<Long> splits = new TreeSet<>();
-    Random r = new Random(42);
+    Random r = new SecureRandom();
 
     while (splits.size() < 99999) {
       splits.add((r.nextLong() & 0x7fffffffffffffffL) % 1000000000000L);

--- a/test/src/main/java/org/apache/accumulo/test/util/nativemap/NativeMapPerformance.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/nativemap/NativeMapPerformance.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test.util.nativemap;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -69,7 +70,7 @@ public class NativeMapPerformance {
     else
       throw new IllegalArgumentException(" map type must be SKIP_LIST, TREE_MAP, or NATIVE_MAP");
 
-    Random rand = new Random(19);
+    Random rand = new SecureRandom();
 
     // puts
     long tps = System.currentTimeMillis();
@@ -115,7 +116,7 @@ public class NativeMapPerformance {
 
     long tie = System.currentTimeMillis();
 
-    rand = new Random(19);
+    rand = new SecureRandom();
     int rowsToLookup[] = new int[numLookups];
     int colsToLookup[] = new int[numLookups];
     for (int i = 0; i < Math.min(numLookups, numRows); i++) {

--- a/test/src/main/java/org/apache/accumulo/test/util/nativemap/NativeMapStress.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/nativemap/NativeMapStress.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test.util.nativemap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -69,7 +70,7 @@ public class NativeMapStress {
         public void run() {
           NativeMap nm = new NativeMap();
 
-          Random r = new Random();
+          Random r = new SecureRandom();
 
           OpTimer timer = null;
           AtomicLong nextOpid = new AtomicLong();
@@ -258,7 +259,7 @@ public class NativeMapStress {
       Runnable r = new Runnable() {
         @Override
         public void run() {
-          Random r = new Random();
+          Random r = new SecureRandom();
           int inserts = 0;
 
           for (int i = 0; i < insertsPerThread / 100.0; i++) {

--- a/test/src/main/spotbugs/exclude-filter.xml
+++ b/test/src/main/spotbugs/exclude-filter.xml
@@ -16,6 +16,10 @@
 -->
 <FindBugsFilter>
   <Match>
+    <!-- ignore security bugs in tests -->
+    <Bug category="SECURITY" />
+  </Match>
+  <Match>
     <!-- ignore thrift-generated files -->
     <Or>
       <Package name="org.apache.accumulo.test.rpc.thrift" />


### PR DESCRIPTION
* Replaced Math.Random with SecureRandom
* Sanitize user input in log messages to prevent potential CRLF injection
* Use SHA-256 instead of MD5 or SHA-1
* Remove unused method in CryptoUtils
* Replace vulnerable regex in Monitor param validation