### PR TITLE
Restore deprecated instance methods removed in 0ba6c49

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/Instance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/Instance.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -70,6 +71,69 @@ public interface Instance {
    * @return the configured timeout to connect to zookeeper
    */
   int getZooKeepersSessionTimeOut();
+
+  /**
+   * Returns a connection to accumulo.
+   *
+   * @param user
+   *          a valid accumulo user
+   * @param pass
+   *          A UTF-8 encoded password. The password may be cleared after making this call.
+   * @return the accumulo Connector
+   * @throws AccumuloException
+   *           when a generic exception occurs
+   * @throws AccumuloSecurityException
+   *           when a user's credentials are invalid
+   * @deprecated since 1.5, use {@link #getConnector(String, AuthenticationToken)} with
+   *             {@link PasswordToken}
+   */
+  @Deprecated
+  default Connector getConnector(String user, byte[] pass)
+      throws AccumuloException, AccumuloSecurityException {
+    return getConnector(user, new PasswordToken(pass));
+  }
+
+  /**
+   * Returns a connection to accumulo.
+   *
+   * @param user
+   *          a valid accumulo user
+   * @param pass
+   *          A UTF-8 encoded password. The password may be cleared after making this call.
+   * @return the accumulo Connector
+   * @throws AccumuloException
+   *           when a generic exception occurs
+   * @throws AccumuloSecurityException
+   *           when a user's credentials are invalid
+   * @deprecated since 1.5, use {@link #getConnector(String, AuthenticationToken)} with
+   *             {@link PasswordToken}
+   */
+  @Deprecated
+  default Connector getConnector(String user, ByteBuffer pass)
+      throws AccumuloException, AccumuloSecurityException {
+    return getConnector(user, new PasswordToken(pass));
+  }
+
+  /**
+   * Returns a connection to this instance of accumulo.
+   *
+   * @param user
+   *          a valid accumulo user
+   * @param pass
+   *          If a mutable CharSequence is passed in, it may be cleared after this call.
+   * @return the accumulo Connector
+   * @throws AccumuloException
+   *           when a generic exception occurs
+   * @throws AccumuloSecurityException
+   *           when a user's credentials are invalid
+   * @deprecated since 1.5, use {@link #getConnector(String, AuthenticationToken)} with
+   *             {@link PasswordToken}
+   */
+  @Deprecated
+  default Connector getConnector(String user, CharSequence pass)
+      throws AccumuloException, AccumuloSecurityException {
+    return getConnector(user, new PasswordToken(pass));
+  }
 
   /**
    * Returns a connection to this instance of accumulo.


### PR DESCRIPTION
Restoring these for following reasons :

 * Any project that implemented Instance still had to implement deprecated
   methods.
 * Multiple projects currently have code that call these methods.
 * All of Instance is now deprecated.
 * Use of Java 8 default methods makes restoration trivial with single line
   implementations that have negligible maintenance burden.