### PR TITLE
Fix plugin build with skipQA profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1352,7 +1352,6 @@
         <enforcer.skip>true</enforcer.skip>
         <formatter.skip>true</formatter.skip>
         <impsort.skip>true</impsort.skip>
-        <maven.plugin.skip>true</maven.plugin.skip>
         <mdep.analyze.skip>true</mdep.analyze.skip>
         <modernizer.skip>true</modernizer.skip>
         <rat.skip>true</rat.skip>


### PR DESCRIPTION
The command `mvn install -PskipQA` allows quick install for
testing.  However the accumulo maven plugin built by this
command was not working.  This change fixes that.