### PR TITLE
Correct how Continuous Ingest specifies the debug log file

### DIFF
--- a/test/system/continuous/start-ingest.sh
+++ b/test/system/continuous/start-ingest.sh
@@ -32,7 +32,7 @@ CONTINUOUS_CONF_DIR=${CONTINUOUS_CONF_DIR:-${bin}}
 
 DEBUG_OPT=''
 if [[ $DEBUG_INGEST == on ]] ; then
-	DEBUG_OPT="--debug $CONTINUOUS_LOG_DIR/\`date +%Y%m%d%H%M%S\`_\`hostname\`_ingest.log";
+	DEBUG_OPT="--debugLog $CONTINUOUS_LOG_DIR/\`date +%Y%m%d%H%M%S\`_\`hostname\`_ingest.log";
 fi
 
 VIS_OPT=''


### PR DESCRIPTION
I was trying to run continuous ingest test, but run into an error:

In start-ingest.sh, DEBUG_OPT is set to use -debug, but that is to turn logs on-off.
When calling pssh command, we use it to set where to log. It will not run, and in the .out log it will just write the usage:

```
Usage: org.apache.accumulo.test.continuous.ContinuousIngest [options]
Options:
[..]
--debug
turn on TRACE-level log messages
Default: false
--debugLog
file to write debugging output
```