### PR TITLE
Fix performance of crypto

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/impl/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/impl/AESCryptoService.java
@@ -448,13 +448,7 @@ public class AESCryptoService implements CryptoService {
           throw new CryptoException("Unable to initialize cipher", e);
         }
 
-        CipherOutputStream cos = new CipherOutputStream(new DiscardCloseOutputStream(outputStream),
-            cipher);
-        // Prevent underlying stream from being closed with DiscardCloseOutputStream
-        // Without this, when the crypto stream is closed (in order to flush its last bytes)
-        // the underlying RFile stream will *also* be closed, and that's undesirable as the
-        // cipher
-        // stream is closed for every block written.
+        CipherOutputStream cos = new CipherOutputStream(outputStream, cipher);
         return new BlockedOutputStream(cos, cipher.getBlockSize(), 1024);
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/DiscardCloseOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/DiscardCloseOutputStream.java
@@ -32,6 +32,16 @@ public class DiscardCloseOutputStream extends FilterOutputStream {
     super(out);
   }
 
+  /**
+   * It is very important to override this method!! The underlying method from FilterOutputStream
+   * calls write a single byte at a time and will kill performance.
+   *
+   */
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    out.write(b, off, len);
+  }
+
   @Override
   public void close() throws IOException {
     // Discard

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/DiscardCloseOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/DiscardCloseOutputStream.java
@@ -35,7 +35,6 @@ public class DiscardCloseOutputStream extends FilterOutputStream {
   /**
    * It is very important to override this method!! The underlying method from FilterOutputStream
    * calls write a single byte at a time and will kill performance.
-   *
    */
   @Override
   public void write(byte[] b, int off, int len) throws IOException {

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/NoFlushOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/NoFlushOutputStream.java
@@ -29,7 +29,6 @@ public class NoFlushOutputStream extends FilterOutputStream {
   /**
    * It is very important to override this method!! The underlying method from FilterOutputStream
    * calls write a single byte at a time and will kill performance.
-   *
    */
   @Override
   public void write(byte[] b, int off, int len) throws IOException {

--- a/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/NoFlushOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/crypto/streams/NoFlushOutputStream.java
@@ -16,13 +16,24 @@
  */
 package org.apache.accumulo.core.security.crypto.streams;
 
-import java.io.DataOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 
-public class NoFlushOutputStream extends DataOutputStream {
+public class NoFlushOutputStream extends FilterOutputStream {
 
   public NoFlushOutputStream(OutputStream out) {
     super(out);
+  }
+
+  /**
+   * It is very important to override this method!! The underlying method from FilterOutputStream
+   * calls write a single byte at a time and will kill performance.
+   *
+   */
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    out.write(b, off, len);
   }
 
   @Override


### PR DESCRIPTION
* Remove use of DiscardCloseOutputStream from WAL encryption
* Override inefficient write method in DiscardCloseOutputStream and NoFlushOutputStream
* Changed NoFlushOutputStream to extend FilterOutputStream, which doesn't have synchronized methods like DataOutputStream does