### PR TITLE
AccumuloFileOutputFormatITs need to look on local filesystem for results written into JUnit provided temp dir.

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
@@ -198,8 +198,9 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
       Configuration conf = CachedConfiguration.getInstance();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
       FileSKVIterator sample = RFileOperations.getInstance().newReaderBuilder()
-          .forFile(files[0].toString(), FileSystem.get(conf), conf).withTableConfiguration(acuconf)
-          .build().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
+          .forFile(files[0].toString(), FileSystem.getLocal(conf), conf)
+          .withTableConfiguration(acuconf).build()
+          .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);
     } else {
       assertEquals(0, files.length);

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
@@ -212,8 +212,9 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
       Configuration conf = CachedConfiguration.getInstance();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
       FileSKVIterator sample = RFileOperations.getInstance().newReaderBuilder()
-          .forFile(files[0].toString(), FileSystem.get(conf), conf).withTableConfiguration(acuconf)
-          .build().getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
+          .forFile(files[0].toString(), FileSystem.getLocal(conf), conf)
+          .withTableConfiguration(acuconf).build()
+          .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);
     } else {
       assertEquals(0, files.length);


### PR DESCRIPTION
Before this change the {mapred,mapreduce}.AccumuloFileOutputFormatITs would work against a minicluster backed by
Hadoop's LocalFileSystem, but fail if one followed the instructions for testing against a stand alone cluster.

The failure is because in the cluster case the FileSystem we get is for the HDFS instance underlying the
Accumulo cluster, which can't find the folder JUnit created for our test.