### PR TITLE
Remove httpclient dependency.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,11 +108,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/examples/simple/pom.xml
+++ b/examples/simple/pom.xml
@@ -77,11 +77,6 @@
       <artifactId>htrace-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>accumulo-minicluster</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
     </dependency>

--- a/maven-plugin/src/it/plugin-test/pom.xml
+++ b/maven-plugin/src/it/plugin-test/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>commons-configuration</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/maven-plugin/src/main/java/org/apache/accumulo/maven/plugin/StartMojo.java
+++ b/maven-plugin/src/main/java/org/apache/accumulo/maven/plugin/StartMojo.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
 import org.apache.commons.io.FileUtils;
-import org.apache.http.annotation.ThreadSafe;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -36,7 +35,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Goal which starts an instance of {@link MiniAccumuloCluster}.
  */
-@ThreadSafe
 @Mojo(name = "start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST,
     requiresDependencyResolution = ResolutionScope.TEST)
 public class StartMojo extends AbstractAccumuloMojo {

--- a/maven-plugin/src/main/java/org/apache/accumulo/maven/plugin/StopMojo.java
+++ b/maven-plugin/src/main/java/org/apache/accumulo/maven/plugin/StopMojo.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.maven.plugin;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.minicluster.impl.MiniAccumuloClusterImpl.LogWriter;
-import org.apache.http.annotation.ThreadSafe;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -28,7 +27,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Goal which stops all instances of {@link MiniAccumuloCluster} started with the start mojo.
  */
-@ThreadSafe
 @Mojo(name = "stop", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST,
     requiresDependencyResolution = ResolutionScope.TEST)
 public class StopMojo extends AbstractAccumuloMojo {

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
     <hadoop.version>2.6.4</hadoop.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.1.0-incubating</htrace.version>
-    <httpclient.version>3.1</httpclient.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <!-- jetty 9.2 is the last version to support jdk less than 1.8 -->
     <jetty.version>9.2.17.v20160517</jetty.version>
@@ -200,11 +199,6 @@
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
         <version>1.6</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-httpclient</groupId>
-        <artifactId>commons-httpclient</artifactId>
-        <version>${httpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -436,11 +430,6 @@
         <version>${htrace.hadoop.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${maven.plugin-version}</version>
@@ -469,16 +458,6 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>${thrift.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>commons-configuration</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>


### PR DESCRIPTION
* was present for Hadoop 1, which we don't support anymore
* was present for ThreadSafe note on our maven-plugin mojo, but that annotation is gone in current releases

Tested via running ITs locally and against standalone hadoop clusters