### PR TITLE
Allows configuration of the "key password" in addition to keystore password for Monitor

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -566,6 +566,10 @@ public enum Property {
       "The keystore password for enabling monitor SSL."),
   MONITOR_SSL_KEYSTORETYPE("monitor.ssl.keyStoreType", "jks", PropertyType.STRING,
       "Type of SSL keystore"),
+  @Sensitive
+  MONITOR_SSL_KEYPASS("monitor.ssl.keyPassword", "", PropertyType.STRING,
+      "Optional: the password for the private key in the keyStore. When not provided, this "
+          + "defaults to the keystore password."),
   MONITOR_SSL_TRUSTSTORE("monitor.ssl.trustStore", "", PropertyType.PATH,
       "The truststore for enabling monitor SSL."),
   @Sensitive

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -30,11 +30,8 @@ import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class EmbeddedWebServer {
-  private static final Logger LOG = LoggerFactory.getLogger(EmbeddedWebServer.class);
   private static String EMPTY = "";
 
   Server server = null;
@@ -51,20 +48,17 @@ public class EmbeddedWebServer {
     final AccumuloConfiguration conf = Monitor.getContext().getConfiguration();
     if (EMPTY.equals(conf.get(Property.MONITOR_SSL_KEYSTORE))
         || EMPTY.equals(conf.get(Property.MONITOR_SSL_KEYSTOREPASS))
-        || EMPTY.equals(conf.get(Property.MONITOR_SSL_TRUSTSTORE))) {
+        || EMPTY.equals(conf.get(Property.MONITOR_SSL_TRUSTSTORE))
+        || EMPTY.equals(conf.get(Property.MONITOR_SSL_TRUSTSTOREPASS))) {
       connector = new ServerConnector(server, new HttpConnectionFactory());
       usingSsl = false;
     } else {
-      final String trustStorePass = conf.get(Property.MONITOR_SSL_TRUSTSTOREPASS);
-      if (trustStorePass.isEmpty()) {
-        LOG.warn("Truststore JKS file has an empty password which prevents any integrity checks.");
-      }
       SslContextFactory sslContextFactory = new SslContextFactory();
       sslContextFactory.setKeyStorePath(conf.get(Property.MONITOR_SSL_KEYSTORE));
       sslContextFactory.setKeyStorePassword(conf.get(Property.MONITOR_SSL_KEYSTOREPASS));
       sslContextFactory.setKeyStoreType(conf.get(Property.MONITOR_SSL_KEYSTORETYPE));
       sslContextFactory.setTrustStorePath(conf.get(Property.MONITOR_SSL_TRUSTSTORE));
-      sslContextFactory.setTrustStorePassword(trustStorePass);
+      sslContextFactory.setTrustStorePassword(conf.get(Property.MONITOR_SSL_TRUSTSTOREPASS));
       sslContextFactory.setTrustStoreType(conf.get(Property.MONITOR_SSL_TRUSTSTORETYPE));
 
       final String includedCiphers = conf.get(Property.MONITOR_SSL_INCLUDE_CIPHERS);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -58,20 +58,20 @@ public class EmbeddedWebServer {
       usingSsl = false;
     } else {
       LOG.debug("Configuring Jetty to use TLS");
-      // The password for the private key inside of the keystore Convention is that when one is not
-      // provided, it's set to be the same as they keystore's password. Use that same logic here.
-      String keyPass = conf.get(Property.MONITOR_SSL_KEYPASS);
-      if (Property.MONITOR_SSL_KEYPASS.getDefaultValue().equals(keyPass)) {
-        keyPass = conf.get(Property.MONITOR_SSL_KEYSTOREPASS);
+      final SslContextFactory sslContextFactory = new SslContextFactory();
+      // If the key password is the same as the keystore password, we don't
+      // have to explicitly set it. Thus, if the user doesn't provide a key
+      // password, don't set anything.
+      final String keyPass = conf.get(Property.MONITOR_SSL_KEYPASS);
+      if (!Property.MONITOR_SSL_KEYPASS.getDefaultValue().equals(keyPass)) {
+        sslContextFactory.setKeyManagerPassword(keyPass);
       }
-      SslContextFactory sslContextFactory = new SslContextFactory();
       sslContextFactory.setKeyStorePath(conf.get(Property.MONITOR_SSL_KEYSTORE));
       sslContextFactory.setKeyStorePassword(conf.get(Property.MONITOR_SSL_KEYSTOREPASS));
       sslContextFactory.setKeyStoreType(conf.get(Property.MONITOR_SSL_KEYSTORETYPE));
       sslContextFactory.setTrustStorePath(conf.get(Property.MONITOR_SSL_TRUSTSTORE));
       sslContextFactory.setTrustStorePassword(conf.get(Property.MONITOR_SSL_TRUSTSTOREPASS));
       sslContextFactory.setTrustStoreType(conf.get(Property.MONITOR_SSL_TRUSTSTORETYPE));
-      sslContextFactory.setKeyManagerPassword(keyPass);
 
       final String includedCiphers = conf.get(Property.MONITOR_SSL_INCLUDE_CIPHERS);
       if (!Property.MONITOR_SSL_INCLUDE_CIPHERS.getDefaultValue().equals(includedCiphers)) {


### PR DESCRIPTION
Java keystores can have a keystore password as well as a password on the private key contained inside of that keystore (when that keystore may contain multiple keys). Usually, but not always, the "key password" is the same as the keystore password. This commit introduces a new property to allow this configuration, but fall back to the keystore password when unset.

This also includes a revert of #646 as that "fix" didn't actually address the problem I was seeing.

```
2018-09-21 14:00:17,659 [component.AbstractLifeCycle] WARN :  FAILED SslContextFactory@fa4e1e0(/Users/jelser/keystore.jks,/Users/jelser/truststore.jks): java.security.UnrecoverableKeyException: Cannot recover key
java.security.UnrecoverableKeyException: Cannot recover key
        at sun.security.provider.KeyProtector.recover(KeyProtector.java:328)
        at sun.security.provider.JavaKeyStore.engineGetKey(JavaKeyStore.java:146)
        at sun.security.provider.JavaKeyStore$JKS.engineGetKey(JavaKeyStore.java:56)
        at sun.security.provider.KeyStoreDelegator.engineGetKey(KeyStoreDelegator.java:96)
        at sun.security.provider.JavaKeyStore$DualFormatJKS.engineGetKey(JavaKeyStore.java:70)
        at java.security.KeyStore.getKey(KeyStore.java:1023)
        at sun.security.ssl.SunX509KeyManagerImpl.<init>(SunX509KeyManagerImpl.java:133)
        at sun.security.ssl.KeyManagerFactoryImpl$SunX509.engineInit(KeyManagerFactoryImpl.java:70)
        at javax.net.ssl.KeyManagerFactory.init(KeyManagerFactory.java:256)
        at org.eclipse.jetty.util.ssl.SslContextFactory.getKeyManagers(SslContextFactory.java:904)
        at org.eclipse.jetty.util.ssl.SslContextFactory.doStart(SslContextFactory.java:297)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:125)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:107)
        at org.eclipse.jetty.server.SslConnectionFactory.doStart(SslConnectionFactory.java:64)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:125)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:107)
        at org.eclipse.jetty.server.AbstractConnector.doStart(AbstractConnector.java:260)
        at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:81)
        at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:218)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
        at org.eclipse.jetty.server.Server.doStart(Server.java:337)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
        at org.apache.accumulo.monitor.EmbeddedWebServer.start(EmbeddedWebServer.java:109)
        at org.apache.accumulo.monitor.Monitor.run(Monitor.java:455)
        at org.apache.accumulo.monitor.Monitor.main(Monitor.java:418)
        at org.apache.accumulo.monitor.MonitorExecutable.execute(MonitorExecutable.java:33)
        at org.apache.accumulo.start.Main$1.run(Main.java:93)
        at java.lang.Thread.run(Thread.java:748)
```

This is what happens when a key password is set which is different than the keystore password.