### PR TITLE
Update travis-ci settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# requiring sudo forces Travis to build in an environment with more RAM
+sudo: required
 language: java
-# speed up builds; don't use with default install step
+# speed up builds; don't use cache with default install step
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
     - $HOME/.m2
 install: echo NOOP Skipping pre-fetch of Maven dependencies
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_script:
   - unset _JAVA_OPTIONS
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 language: java
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#accumulo"
-    use_notice: true
-    on_success: change
-    on_failure: always
-    template:
-      - "%{result} %{repository_slug} %{branch} (%{build_url}): %{message}"
 # speed up builds; don't use with default install step
 cache:
   directories:
@@ -29,8 +20,10 @@ cache:
 install: echo NOOP Skipping pre-fetch of Maven dependencies
 jdk:
   - oraclejdk8
+before_script:
+  - unset _JAVA_OPTIONS
 env:
-  - BUILD_ARGS="clean verify javadoc:jar -DskipITs -DforkCount=1C"  # main build of unit tests and javadoc
+  - BUILD_ARGS="clean verify javadoc:jar -DskipITs"  # main build of unit tests and javadoc
   - BUILD_ARGS="clean compile -Dhadoop.version=3.0.3 -Dzookeeper.version=3.4.12"  # quick compile to verify older API
 script:
   - mvn $BUILD_ARGS


### PR DESCRIPTION
* Remove IRC notifications (nobody lurks in IRC anymore, so this isn't useful)
* Unset _JAVA_OPTIONS to restore default Java options, so plugins don't
  run out of memory and cause the container to get killed
* Remove forking for unit tests; the container doesn't have a lot of CPU
  to fork anyway, and removing this helps with excessive memory utilization