### PR TITLE
Fixes #561 - Be explicit about aliases in shell

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteTableCommand.java
@@ -47,7 +47,7 @@ public class DeleteTableCommand extends TableOperation {
 
   @Override
   public String description() {
-    return "deletes a table";
+    return "deletes a table (Same as droptable)";
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DropTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DropTableCommand.java
@@ -16,4 +16,10 @@
  */
 package org.apache.accumulo.shell.commands;
 
-public class DropTableCommand extends DeleteTableCommand {}
+public class DropTableCommand extends DeleteTableCommand {
+
+  @Override
+  public String description (){
+    return "deletes a table (Same as deletetable)";
+  }
+}


### PR DESCRIPTION
- Explicitly state that deletetable and droptable are the same

Screenshot from running in uno.
![screenshot 2018-10-03 10 12 21](https://user-images.githubusercontent.com/20524292/46416443-8aa29c80-c6f5-11e8-8d4d-64f90928a25b.png)
