### PR TITLE
Set props path in ConfigOpts. Fixes #676

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.cli;
 
 import java.io.File;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,8 +41,7 @@ public class ConfigOpts extends Help {
 
   public synchronized String getPropertiesPath() {
     if (propsPath == null) {
-      URL propLocation = SiteConfiguration.getAccumuloPropsLocation();
-      propsPath = propLocation.getFile();
+      propsPath = SiteConfiguration.getAccumuloPropsLocation().getFile();
     }
     return propsPath;
   }

--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.cli;
 
 import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +41,10 @@ public class ConfigOpts extends Help {
   private String propsPath;
 
   public String getPropertiesPath() {
+    if (propsPath == null) {
+      URL propLocation = SiteConfiguration.getAccumuloPropsLocation();
+      propsPath = propLocation.getFile();
+    }
     return propsPath;
   }
 
@@ -59,12 +64,7 @@ public class ConfigOpts extends Help {
 
   public synchronized SiteConfiguration getSiteConfiguration() {
     if (siteConfig == null) {
-      if (propsPath != null) {
-        siteConfig = new SiteConfiguration(new File(propsPath), getOverrides());
-      } else {
-        siteConfig = new SiteConfiguration(SiteConfiguration.getAccumuloPropsLocation(),
-            getOverrides());
-      }
+      siteConfig = new SiteConfiguration(new File(getPropertiesPath()), getOverrides());
     }
     return siteConfig;
   }

--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -40,7 +40,7 @@ public class ConfigOpts extends Help {
       + "The classpath will be searched if this property is not set")
   private String propsPath;
 
-  public String getPropertiesPath() {
+  public synchronized String getPropertiesPath() {
     if (propsPath == null) {
       URL propLocation = SiteConfiguration.getAccumuloPropsLocation();
       propsPath = propLocation.getFile();


### PR DESCRIPTION
We are getting the properties path after calling getSiteconfiguration but it was never set so a null is getting passed to JCommander.