### PR TITLE
Add createIfNotExists method to table/namespace operations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NamespaceOperations.java
@@ -100,6 +100,22 @@ public interface NamespaceOperations {
       throws AccumuloException, AccumuloSecurityException, NamespaceExistsException;
 
   /**
+   * Create an empty namespace with no initial configuration, if namespace with given name doesn't
+   * exists. Valid names for a namespace contain letters, numbers, and the underscore character.
+   *
+   * @param namespace
+   *          the name of the namespace
+   * @throws AccumuloException
+   *           if a general error occurs
+   * @throws AccumuloSecurityException
+   *           if the user does not have permission
+   * @return true if a new namespace was created, false otherwise
+   * @since 2.0.0
+   */
+  boolean createIfNotExists(String namespace)
+      throws AccumuloException, AccumuloSecurityException, NamespaceExistsException;
+
+  /**
    * Delete an empty namespace
    *
    * @param namespace

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -138,6 +138,38 @@ public interface TableOperations {
       throws AccumuloSecurityException, AccumuloException, TableExistsException;
 
   /**
+   * Create a table with no special configuration if no table with the given table name exists
+   *
+   * @param tableName
+   *          the name of the table
+   * @throws AccumuloException
+   *           if a general error occurs
+   * @throws AccumuloSecurityException
+   *           if the user does not have permission
+   * @return true if a new namespace was created, false otherwise
+   * @since 2.0.0
+   */
+  boolean createIfNotExists(String tableName) throws AccumuloException, AccumuloSecurityException;
+
+  /**
+   * @param tableName
+   *          the name of the table
+   * @param ntc
+   *          specifies the new table's configuration variable, which are: 1. enable/disable the
+   *          versioning iterator, which will limit the number of Key versions kept; 2. specifies
+   *          logical or real-time based time recording for entries in the table; 3. user defined
+   *          properties to be merged into the initial properties of the table
+   * @throws AccumuloException
+   *           if a general error occurs
+   * @throws AccumuloSecurityException
+   *           if the user does not have permission
+   * @return true if a new namespace was created, false otherwise
+   * @since 2.0.0
+   */
+  boolean createIfNotExists(String tableName, NewTableConfiguration ntc)
+      throws AccumuloSecurityException, AccumuloException;
+
+  /**
    * Imports a table exported via exportTable and copied via hadoop distcp.
    *
    * @param tableName

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
@@ -126,6 +126,17 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
   }
 
   @Override
+  public boolean createIfNotExists(String namespace)
+      throws AccumuloException, AccumuloSecurityException {
+    try {
+      create(namespace);
+      return true;
+    } catch (NamespaceExistsException e) {
+      return false;
+    }
+  }
+
+  @Override
   public void delete(String namespace) throws AccumuloException, AccumuloSecurityException,
       NamespaceNotFoundException, NamespaceNotEmptyException {
     checkArgument(namespace != null, "namespace is null");

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -262,6 +262,23 @@ public class TableOperationsImpl extends TableOperationsHelper {
     }
   }
 
+  @Override
+  public boolean createIfNotExists(String tableName)
+      throws AccumuloException, AccumuloSecurityException {
+    return createIfNotExists(tableName, new NewTableConfiguration());
+  }
+
+  @Override
+  public boolean createIfNotExists(String tableName, NewTableConfiguration ntc)
+      throws AccumuloException, AccumuloSecurityException {
+    try {
+      create(tableName, ntc);
+      return true;
+    } catch (TableExistsException e) {
+      return false;
+    }
+  }
+
   private long beginFateOperation() throws ThriftSecurityException, TException {
     while (true) {
       MasterClientService.Iface client = null;

--- a/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/impl/TableOperationsHelperTest.java
@@ -89,6 +89,16 @@ public class TableOperationsHelperTest {
         throws AccumuloException, AccumuloSecurityException, TableExistsException {}
 
     @Override
+    public boolean createIfNotExists(String tableName) {
+      return true;
+    }
+
+    @Override
+    public boolean createIfNotExists(String tableName, NewTableConfiguration ntc) {
+      return true;
+    }
+
+    @Override
     public void addSplits(String tableName, SortedSet<Text> partitionKeys)
         throws TableNotFoundException, AccumuloException, AccumuloSecurityException {}
 

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -221,6 +221,39 @@ public class NamespacesIT extends AccumuloClusterHarness {
     assertFalse(c.tableOperations().exists(t2));
   }
 
+  @Test
+  public void createNamespaceAndTableIfNotExists() throws Exception {
+    String t = namespace + ".1";
+    assertFalse(c.namespaceOperations().exists(namespace));
+    assertFalse(c.tableOperations().exists(t));
+    try {
+      c.namespaceOperations().delete(namespace);
+    } catch (NamespaceNotFoundException e) {}
+    try {
+      c.tableOperations().delete(t);
+    } catch (TableNotFoundException e) {
+      assertEquals(NamespaceNotFoundException.class.getName(), e.getCause().getClass().getName());
+    }
+
+    boolean namespaceCreated = c.namespaceOperations().createIfNotExists(namespace);
+    assertTrue(namespaceCreated);
+    assertTrue(c.namespaceOperations().exists(namespace));
+
+    namespaceCreated = c.namespaceOperations().createIfNotExists(namespace);
+    assertFalse(namespaceCreated);
+    assertTrue(c.namespaceOperations().exists(namespace));
+
+    boolean tableCreated = c.tableOperations().createIfNotExists(t);
+    assertTrue(tableCreated);
+    assertTrue(c.namespaceOperations().exists(namespace));
+    assertTrue(c.tableOperations().exists(t));
+
+    tableCreated = c.tableOperations().createIfNotExists(t);
+    assertFalse(tableCreated);
+    assertTrue(c.namespaceOperations().exists(namespace));
+    assertTrue(c.tableOperations().exists(t));
+  }
+
   @Test(expected = NamespaceNotEmptyException.class)
   public void deleteNonEmptyNamespace() throws Exception {
     String tableName1 = namespace + ".1";


### PR DESCRIPTION
Methods will create a namespace or table if one didn't exist otherwise
it does nothing. Both methods return a boolean to indicate whether a
table/namespace was created.

Closes #418