### PR TITLE
Rename link on Monitor to Rest

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -61,7 +61,7 @@
             </li>
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                Rest <span class="caret"></span>
+                REST <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
                 <li><a href="/rest/xml">XML</a></li>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -61,7 +61,7 @@
             </li>
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-                API <span class="caret"></span>
+                Rest <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
                 <li><a href="/rest/xml">XML</a></li>


### PR DESCRIPTION
I am not sure what to call this link but it shouldn't be API.  This is for the top far right link in the navigation bar.  It is a drop down of two links, one to generate the XML and one for JSON.