### PR TITLE
Cleanup deprecation stuffs

### DIFF
--- a/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
+++ b/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
@@ -361,7 +361,7 @@ public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
    *          The job
    * @return The client configuration for the job
    * @since 1.7.0
-   * @deprecated since 2.0.0, replaced by {{@link #getClientInfo(JobConf)}}
+   * @deprecated since 2.0.0, replaced by {@link #getClientInfo(JobConf)}
    */
   @Deprecated
   protected static org.apache.accumulo.core.client.ClientConfiguration getClientConfiguration(

--- a/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
+++ b/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
@@ -222,7 +222,7 @@ public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
    * @param tokenFile
    *          the path to the token file
    * @since 1.6.0
-   * @deprecated since 2.0.0, use {{@link #setClientPropertiesFile(Job, String)}}
+   * @deprecated since 2.0.0, use {@link #setClientPropertiesFile(Job, String)}
    */
   @Deprecated
   public static void setConnectorInfo(Job job, String principal, String tokenFile)
@@ -409,6 +409,7 @@ public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
    *          The Job
    * @return The ClientConfiguration
    * @since 1.7.0
+   * @deprecated since 2.0.0; use {@link #getClientInfo(JobContext)} instead
    */
   @Deprecated
   protected static org.apache.accumulo.core.client.ClientConfiguration getClientConfiguration(

--- a/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/ConfiguratorBase.java
+++ b/client/mapreduce/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/ConfiguratorBase.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ClientInfo;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.client.impl.AuthenticationTokenIdentifier;
 import org.apache.accumulo.core.client.impl.ClientConfConverter;
@@ -308,6 +307,7 @@ public class ConfiguratorBase {
    * @param clientConfig
    *          client configuration for specifying connection timeouts, SSL connection options, etc.
    * @since 1.6.0
+   * @deprecated since 2.0.0; use {@link #setClientInfo(Class, Configuration, ClientInfo)} instead
    */
   @Deprecated
   public static void setZooKeeperInstance(Class<?> implementingClass, Configuration conf,
@@ -337,7 +337,8 @@ public class ConfiguratorBase {
   @Deprecated
   public static org.apache.accumulo.core.client.Instance getInstance(Class<?> implementingClass,
       Configuration conf) {
-    return Connector.from(getClient(implementingClass, conf)).getInstance();
+    return org.apache.accumulo.core.client.Connector.from(getClient(implementingClass, conf))
+        .getInstance();
   }
 
   /**
@@ -368,6 +369,7 @@ public class ConfiguratorBase {
    *
    * @return A ClientConfiguration
    * @since 1.7.0
+   * @deprecated since 2.0.0; use {@link #getClientInfo(Class, Configuration)} instead
    */
   @Deprecated
   public static org.apache.accumulo.core.client.ClientConfiguration getClientConfiguration(

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/AccumuloClientImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/AccumuloClientImpl.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ClientInfo;
 import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.ConditionalWriterConfig;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MultiTableBatchWriter;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -54,7 +53,8 @@ import org.apache.accumulo.core.trace.Tracer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class AccumuloClientImpl extends Connector implements AccumuloClient {
+public class AccumuloClientImpl extends org.apache.accumulo.core.client.Connector
+    implements AccumuloClient {
   private static final String SYSTEM_TOKEN_NAME = "org.apache.accumulo.server.security."
       + "SystemCredentials$SystemToken";
   private final ClientContext context;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ClientContext.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ClientInfo;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -138,9 +137,10 @@ public class ClientContext {
       }
 
       @Override
-      public Connector getConnector(String principal, AuthenticationToken token)
-          throws AccumuloException, AccumuloSecurityException {
-        return Connector.from(context.getClient().changeUser(principal, token));
+      public org.apache.accumulo.core.client.Connector getConnector(String principal,
+          AuthenticationToken token) throws AccumuloException, AccumuloSecurityException {
+        return org.apache.accumulo.core.client.Connector
+            .from(context.getClient().changeUser(principal, token));
       }
     };
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/Summary.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/Summary.java
@@ -104,7 +104,7 @@ public class Summary {
     /**
      * @return The total number of files that had some kind of issue which would cause summary
      *         statistics to be inaccurate. This is the sum of {@link #getMissing()},
-     *         {@link #getExtra()}, {{@link #getLarge()}, and {@link #getDeleted()}.
+     *         {@link #getExtra()}, {@link #getLarge()}, and {@link #getDeleted()}.
      */
     public long getInaccurate() {
       return getMissing() + getExtra() + getLarge() + getDeleted();

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -98,7 +98,8 @@ public enum Property {
           + Integer.MAX_VALUE),
   @Deprecated
   INSTANCE_DFS_URI("instance.dfs.uri", "", PropertyType.URI,
-      "A url accumulo should use to connect to DFS. If this is empty, accumulo"
+      "This property is deprecated since 1.6.0. "
+          + "A url accumulo should use to connect to DFS. If this is empty, accumulo"
           + " will obtain this information from the hadoop configuration. This property"
           + " will only be used when creating new files if instance.volumes is empty."
           + " After an upgrade to 1.6.0 Accumulo will start using absolute paths to"
@@ -107,7 +108,8 @@ public enum Property {
           + " (if empty using the hadoop config)."),
   @Deprecated
   INSTANCE_DFS_DIR("instance.dfs.dir", "/accumulo", PropertyType.ABSOLUTEPATH,
-      "HDFS directory in which accumulo instance will run. "
+      "This property is deprecated since 1.6.0. "
+          + "HDFS directory in which accumulo instance will run. "
           + "Do not change after accumulo is initialized."),
   @Sensitive
   INSTANCE_SECRET("instance.secret", "DEFAULT", PropertyType.STRING,
@@ -193,7 +195,7 @@ public enum Property {
           + " do not have to be consistent throughout a cloud."),
   @Deprecated
   GENERAL_CLASSPATHS(AccumuloClassLoader.GENERAL_CLASSPATHS, "", PropertyType.STRING,
-      "This property is deprecated. The class path should instead be configured"
+      "This property is deprecated since 2.0.0. The class path should instead be configured"
           + " by the launch environment (for example, accumulo-env.sh). A list of all"
           + " of the places to look for a class. Order does matter, as it will look for"
           + " the jar starting in the first location to the last. Supports full regex"
@@ -484,7 +486,7 @@ public enum Property {
           + " problems recovering from sudden system resets."),
   @Deprecated
   TSERV_WAL_SYNC_METHOD("tserver.wal.sync.method", "hsync", PropertyType.STRING,
-      "This property is deprecated. Use table.durability instead."),
+      "This property is deprecated since 1.7.0. Use table.durability instead."),
   TSERV_ASSIGNMENT_DURATION_WARNING("tserver.assignment.duration.warning", "10m",
       PropertyType.TIMEDURATION,
       "The amount of time an assignment can run before the server will print a"
@@ -689,7 +691,7 @@ public enum Property {
           + " summary cache size."),
   @Deprecated
   TABLE_WALOG_ENABLED("table.walog.enabled", "true", PropertyType.BOOLEAN,
-      "This setting is deprecated.  Use table.durability=none instead."),
+      "This setting is deprecated since 1.7.0. Use table.durability=none instead."),
   TABLE_BLOOM_ENABLED("table.bloom.enabled", "false", PropertyType.BOOLEAN,
       "Use bloom filters on this table."),
   TABLE_BLOOM_LOAD_THRESHOLD("table.bloom.load.threshold", "1", PropertyType.COUNT,

--- a/core/src/main/java/org/apache/accumulo/core/util/format/BinaryFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/BinaryFormatter.java
@@ -23,8 +23,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
 
 /**
- * @deprecated Use {@link DefaultFormatter} providing showLength and printTimestamps via
- *             {@link FormatterConfig}.
+ * @deprecated since 1.8.0; Use {@link DefaultFormatter} providing showLength and printTimestamps
+ *             via {@link FormatterConfig}.
  */
 @Deprecated
 public class BinaryFormatter extends DefaultFormatter {

--- a/core/src/main/java/org/apache/accumulo/core/util/format/DateStringFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/DateStringFormatter.java
@@ -37,6 +37,8 @@ import org.apache.accumulo.core.data.Value;
  * final FormatterConfig config = new FormatterConfig().setPrintTimestamps(true)
  *     .setDateFormatSupplier(dfSupplier);
  * </pre>
+ *
+ * @deprecated since 1.8.0
  */
 @Deprecated
 public class DateStringFormatter implements Formatter {

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/AccumuloCluster.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/AccumuloCluster.java
@@ -63,7 +63,7 @@ public interface AccumuloCluster {
   /**
    * Get the client configuration for the cluster
    *
-   * @deprecated since 2.0.0, replaced by {{@link #getClientInfo()}}
+   * @deprecated since 2.0.0, replaced by {@link #getClientInfo()}
    */
   @Deprecated
   org.apache.accumulo.core.client.ClientConfiguration getClientConfig();

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloCluster.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloCluster.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ClientInfo;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.util.Pair;
@@ -121,9 +120,11 @@ public class MiniAccumuloCluster {
    * @since 1.6.0
    * @deprecated since 2.0.0, replaced by {@link #getAccumuloClient(String, AuthenticationToken)}
    */
-  public Connector getConnector(String user, String passwd)
+  @Deprecated
+  public org.apache.accumulo.core.client.Connector getConnector(String user, String passwd)
       throws AccumuloException, AccumuloSecurityException {
-    return Connector.from(impl.getAccumuloClient(user, new PasswordToken(passwd)));
+    return org.apache.accumulo.core.client.Connector
+        .from(impl.getAccumuloClient(user, new PasswordToken(passwd)));
   }
 
   /**
@@ -138,7 +139,7 @@ public class MiniAccumuloCluster {
 
   /**
    * @since 1.6.0
-   * @deprecated since 2.0.0, replaced by {{@link #getClientInfo()}}
+   * @deprecated since 2.0.0, replaced by {@link #getClientInfo()}
    */
   @Deprecated
   public org.apache.accumulo.core.client.ClientConfiguration getClientConfig() {

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -90,9 +89,10 @@ public class MiniAccumuloClusterExistingZooKeepersTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void canConnectViaExistingZooKeeper() throws Exception {
-    Connector conn = accumulo.getConnector("root", SECRET);
+    org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", SECRET);
     ClientContext context = new ClientContext(accumulo.getClientInfo());
     assertEquals(zooKeeper.getConnectString(), context.getZooKeepers());
 

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.accumulo.core.client.Connector;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -75,11 +74,12 @@ public class MiniAccumuloClusterStartStopTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void multipleStopsIsAllowed() throws Exception {
     accumulo.start();
 
-    Connector conn = accumulo.getConnector("root", "superSecret");
+    org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
     conn.tableOperations().create("foo");
 
     accumulo.stop();

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
@@ -87,9 +86,10 @@ public class MiniAccumuloClusterTest {
     assertEquals("dfs.replication", DFSConfigKeys.DFS_REPLICATION_KEY);
   }
 
+  @SuppressWarnings("deprecation")
   @Test(timeout = 30000)
   public void test() throws Exception {
-    Connector conn = accumulo.getConnector("root", "superSecret");
+    org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
 
     conn.tableOperations().create("table1", new NewTableConfiguration());
 
@@ -105,7 +105,7 @@ public class MiniAccumuloClusterTest {
 
     conn.tableOperations().attachIterator("table1", is);
 
-    Connector uconn = accumulo.getConnector("user1", "pass1");
+    org.apache.accumulo.core.client.Connector uconn = accumulo.getConnector("user1", "pass1");
 
     BatchWriter bw = uconn.createBatchWriter("table1", new BatchWriterConfig());
 
@@ -162,10 +162,11 @@ public class MiniAccumuloClusterTest {
   public TemporaryFolder folder = new TemporaryFolder(
       new File(System.getProperty("user.dir") + "/target"));
 
+  @SuppressWarnings("deprecation")
   @Test(timeout = 60000)
   public void testPerTableClasspath() throws Exception {
 
-    Connector conn = accumulo.getConnector("root", "superSecret");
+    org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
 
     conn.tableOperations().create("table2");
 


### PR DESCRIPTION
* Add missing since information for deprecations, including properties
* Fix various javadoc syntax
* Remove deprecated import statements and suppress deprecations in
  tests, to limit spam from compiler warnings