### PR TITLE
ACCUMULO-4496 Update user manual and error messages for FATE upgrade …

### DIFF
--- a/docs/src/main/asciidoc/chapters/troubleshooting.txt
+++ b/docs/src/main/asciidoc/chapters/troubleshooting.txt
@@ -815,6 +815,21 @@ overriden by using the +--local-wal-directories+ option on the tool. It can be i
 
     $ACCUMULO_HOME/bin/accumulo org.apache.accumulo.tserver.log.LocalWALRecovery
 
+*Q* Trying to start the master after upgrading, the upgrade is aborting with the aborting with the following message:
+
+    org.apache.accumulo.core.client.AccumuloException:
+    Aborting upgrade because there are outstanding FATE transactions from a previous Accumulo version.
+
+*A* You can use the shell to delete completed FATE transactions using the following:
+
+* Start tservers
+* Start shell
+* Run fate print to list all
+* If completed, just delete with fate delete
+* Start masters once there are no more fate operations
+
+If any of the operations are not complete, you should rollback the upgrade and troubleshoot completing them with your prior version.
+
 ### File Naming Conventions
 
 *Q*: Why are files named like they are? Why do some start with +C+ and others with +F+?

--- a/server/base/src/main/java/org/apache/accumulo/server/Accumulo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/Accumulo.java
@@ -343,8 +343,10 @@ public class Accumulo {
       if (!(fate.list().isEmpty())) {
         throw new AccumuloException("Aborting upgrade because there are"
             + " outstanding FATE transactions from a previous Accumulo version."
-            + " Please see the README document for instructions on what to do under"
-            + " your previous version.");
+            + " You can start the tservers and then use the shell to delete completed "
+            + " transactions. If there are uncomplete transactions, you will need to roll"
+            + " back and fix those issues. Please see the Accumulo User manual, "
+            + " Troubleshooting, Upgrade Issues for more information. ");
       }
     } catch (Exception exception) {
       log.fatal("Problem verifying Fate readiness", exception);


### PR DESCRIPTION
…failure.

Updated the user manual and the log message generated when outstanding
FATE transactions cause upgrade to fail.