### PR TITLE
ACCUMULO-4818 Upgrade to checkstyle 8.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1213,7 +1213,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.12</version>
+            <version>8.13</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
ACCUMULO-4818 is about upgrading to checkstyle 8+. Since the current version is upgraded to 8.12 in the meantime this change might be insignificant.  