### PR TITLE
Fix summarizer bug with empty loc group

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -433,6 +433,10 @@ class SummarySerializer {
 
     boolean exceedsRange(Text startRow, Text endRow) {
 
+      if (summaries.length == 0) {
+        return false;
+      }
+
       Text lastRow = summaries[summaries.length - 1].lastRow;
       if (startRow != null && firstRow.compareTo(startRow) <= 0
           && startRow.compareTo(lastRow) < 0) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -717,13 +717,15 @@ public class SummaryIT extends AccumuloClusterHarness {
     SummarizerConfiguration sc1 = SummarizerConfiguration.builder(FamilySummarizer.class).build();
     SummarizerConfiguration sc2 = SummarizerConfiguration.builder(BasicSummarizer.class).build();
     ntc.enableSummarization(sc1, sc2);
-    c.tableOperations().create(table, ntc);
 
     Map<String,Set<Text>> lgroups = new HashMap<>();
     lgroups.put("lg1", ImmutableSet.of(new Text("chocolate"), new Text("coffee")));
     lgroups.put("lg2", ImmutableSet.of(new Text(" broccoli "), new Text("cabbage")));
+    // create a locality group that will not have data in it
+    lgroups.put("lg3", ImmutableSet.of(new Text(" apple "), new Text("orange")));
 
-    c.tableOperations().setLocalityGroups(table, lgroups);
+    ntc.setLocalityGroups(lgroups);
+    c.tableOperations().create(table, ntc);
 
     Map<Key,Value> expected = new HashMap<>();
     try (BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig())) {


### PR DESCRIPTION
For a table with multiple locality groups and a locality group with no data,
feching summaries would fail.  Found this while working on apache/fluo#1054