### PR TITLE
Assign all TabletServers to default pool if empty

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -148,7 +148,16 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
         np.put(e.getKey(), e.getValue());
       }
     }
+
+    if (newPools.get(DEFAULT_POOL) == null) {
+      LOG.warn("Default pool is empty; assigning all tablet servers to the default pool");
+      SortedMap<TServerInstance,TabletServerStatus> dp = new TreeMap<>(current.comparator());
+      dp.putAll(current);
+      newPools.put(DEFAULT_POOL, dp);
+    }
+
     pools = newPools;
+
     LOG.trace("Pool to TabletServer mapping:");
     if (LOG.isTraceEnabled()) {
       for (Entry<String,SortedMap<TServerInstance,TabletServerStatus>> e : pools.entrySet()) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
@@ -209,25 +209,31 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     });
     Map<String,SortedMap<TServerInstance,TabletServerStatus>> groups = this
         .splitCurrentByRegex(createCurrent(15));
-    assertEquals(2, groups.size());
+
+    // Groups foo, bar, and the default pool which contains all known hosts
+    assertEquals(3, groups.size());
     assertTrue(groups.containsKey(FOO.getTableName()));
-    SortedMap<TServerInstance,TabletServerStatus> fooHosts = groups.get(FOO.getTableName());
-    assertEquals(15, fooHosts.size());
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.1:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.2:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.3:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.4:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.5:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.6:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.7:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.8:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.9:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.10:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.11:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.12:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.13:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.14:9997", 1)));
-    assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.15:9997", 1)));
+    assertTrue(groups.containsKey(DEFAULT_POOL));
+    for (String pool : new String[] {FOO.getTableName(), DEFAULT_POOL}) {
+      SortedMap<TServerInstance,TabletServerStatus> fooHosts = groups.get(pool);
+      assertEquals(15, fooHosts.size());
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.1:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.2:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.3:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.4:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.5:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.6:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.7:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.8:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.9:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.10:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.11:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.12:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.13:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.14:9997", 1)));
+      assertTrue(fooHosts.containsKey(new TServerInstance("192.168.0.15:9997", 1)));
+    }
+
     assertTrue(groups.containsKey(BAR.getTableName()));
     SortedMap<TServerInstance,TabletServerStatus> barHosts = groups.get(BAR.getTableName());
     assertEquals(10, barHosts.size());
@@ -417,13 +423,52 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     for (TServerInstance r : removals) {
       current.remove(r);
     }
-    this.getAssignments(Collections.unmodifiableSortedMap(allTabletServers),
+    this.getAssignments(Collections.unmodifiableSortedMap(current),
         Collections.unmodifiableMap(unassigned), assignments);
     assertEquals(unassigned.size(), assignments.size());
     // Ensure assignments are correct
+    // Ensure tablets are assigned in default pool
     for (Entry<KeyExtent,TServerInstance> e : assignments.entrySet()) {
-      if (!tabletInBounds(e.getKey(), e.getValue())) {
-        fail("tablet not in bounds: " + e.getKey() + " -> " + e.getValue().host());
+      if (tabletInBounds(e.getKey(), e.getValue())) {
+        fail("tablet unexpectedly in bounds: " + e.getKey() + " -> " + e.getValue().host());
+      }
+    }
+  }
+
+  @Test
+  public void testUnassignedWithNoDefaultPool() {
+    init(factory);
+    Map<KeyExtent,TServerInstance> assignments = new HashMap<>();
+    Map<KeyExtent,TServerInstance> unassigned = new HashMap<>();
+    for (KeyExtent ke : tableExtents.get(BAR.getTableName())) {
+      unassigned.put(ke, null);
+    }
+
+    SortedMap<TServerInstance,TabletServerStatus> current = createCurrent(15);
+    // Remove the BAR tablet servers and default pool from current
+    List<TServerInstance> removals = new ArrayList<>();
+    for (Entry<TServerInstance,TabletServerStatus> e : current.entrySet()) {
+      if (e.getKey().host().equals("192.168.0.6") || e.getKey().host().equals("192.168.0.7")
+          || e.getKey().host().equals("192.168.0.8") || e.getKey().host().equals("192.168.0.9")
+          || e.getKey().host().equals("192.168.0.10") || e.getKey().host().equals("192.168.0.11")
+          || e.getKey().host().equals("192.168.0.12") || e.getKey().host().equals("192.168.0.13")
+          || e.getKey().host().equals("192.168.0.14") || e.getKey().host().equals("192.168.0.15")) {
+        removals.add(e.getKey());
+      }
+    }
+
+    for (TServerInstance r : removals) {
+      current.remove(r);
+    }
+
+    this.getAssignments(Collections.unmodifiableSortedMap(current),
+        Collections.unmodifiableMap(unassigned), assignments);
+    assertEquals(unassigned.size(), assignments.size());
+
+    // Ensure tablets are assigned in default pool
+    for (Entry<KeyExtent,TServerInstance> e : assignments.entrySet()) {
+      if (tabletInBounds(e.getKey(), e.getValue())) {
+        fail("tablet unexpectedly in bounds: " + e.getKey() + " -> " + e.getValue().host());
       }
     }
   }


### PR DESCRIPTION
Backported from master.  See #691.  Only necessary change was the call to `init` in the test.