### PR TITLE
Fix #713 Monitor 2.0 overview plots overlap when resizing browser window

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -32,6 +32,7 @@
       <script src="/resources/external/datatables/js/dataTables.bootstrap.js"></script>
       <script src="/resources/external/flot/jquery.flot.js"></script>
       <script src="/resources/external/flot/jquery.flot.time.js"></script>
+      <script src="/resources/external/flot/jquery.flot.resize.js"></script>
       <script src="/resources/external/ellipsis.js"></script>
       <link rel="stylesheet" href="/resources/external/bootstrap/css/bootstrap.css" />
       <link rel="stylesheet" href="/resources/external/bootstrap/css/bootstrap-theme.css" />


### PR DESCRIPTION
Included Flot's resize plugin to properly handle window resize.