### PR TITLE
fixes #587 Wait for tablets assigned to dead servers before deleting table

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/impl/InputConfigurator.java
@@ -671,7 +671,8 @@ public class InputConfigurator extends ConfiguratorBase {
    */
   public static Map<String,InputTableConfig> getInputTableConfigs(Class<?> implementingClass,
       Configuration conf) {
-    return getInputTableConfigs(implementingClass, conf, getInputTableName(implementingClass, conf));
+    return getInputTableConfigs(implementingClass, conf,
+        getInputTableName(implementingClass, conf));
   }
 
   /**
@@ -726,7 +727,8 @@ public class InputConfigurator extends ConfiguratorBase {
    */
   public static InputTableConfig getInputTableConfig(Class<?> implementingClass, Configuration conf,
       String tableName) {
-    Map<String,InputTableConfig> queryConfigs = getInputTableConfigs(implementingClass, conf, tableName);
+    Map<String,InputTableConfig> queryConfigs = getInputTableConfigs(implementingClass, conf,
+        tableName);
     return queryConfigs.get(tableName);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -207,18 +207,6 @@ public class TableManager {
               return newState.name().getBytes(UTF_8);
             }
           });
-
-      if (newState == TableState.DELETING) {
-        // Updating the cache of table states in this method is very tricky because of distributed
-        // race conditions and should be avoided. However in the case of the deleting table state,
-        // its a terminal state so its ok to update as long as the cache currently has some value.
-        // If the cache has no value it may have already transitioned from deleting to deleted.
-        synchronized (tableStateCache) {
-          if (tableStateCache.containsKey(tableId)) {
-            tableStateCache.put(tableId, TableState.DELETING);
-          }
-        }
-      }
     } catch (Exception e) {
       // ACCUMULO-3651 Changed level to error and added FATAL to message for slf4j compatibility
       log.error("FATAL Failed to transition table to state " + newState);

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -204,7 +204,8 @@ abstract class TabletGroupWatcher extends Daemon {
           }
           Master.log.debug(store.name() + " location State: " + tls);
           // ignore entries for tables that do not exist in zookeeper
-          if (TableManager.getInstance().getTableState(tls.extent.getTableId()) == null)
+          TableState tableState = TableManager.getInstance().getTableState(tls.extent.getTableId());
+          if (tableState == null || tableState == TableState.DELETING)
             continue;
 
           if (Master.log.isTraceEnabled())

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -204,8 +204,7 @@ abstract class TabletGroupWatcher extends Daemon {
           }
           Master.log.debug(store.name() + " location State: " + tls);
           // ignore entries for tables that do not exist in zookeeper
-          TableState tableState = TableManager.getInstance().getTableState(tls.extent.getTableId());
-          if (tableState == null || tableState == TableState.DELETING)
+          if (TableManager.getInstance().getTableState(tls.extent.getTableId()) == null)
             continue;
 
           if (Master.log.isTraceEnabled())

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/CleanUp.java
@@ -99,7 +99,9 @@ class CleanUp extends MasterRepo {
       TabletLocationState locationState = MetaDataTableScanner
           .createTabletLocationState(entry.getKey(), entry.getValue());
       TabletState state = locationState.getState(master.onlineTabletServers());
-      if (state.equals(TabletState.ASSIGNED) || state.equals(TabletState.HOSTED)) {
+      if (!state.equals(TabletState.UNASSIGNED)) {
+        // This code will even wait on tablets that are assigned to dead tablets servers. This is
+        // intentional because the master may make metadata writes for these tablets. See #587
         log.debug("Still waiting for table to be deleted: " + tableId + " locationState: "
             + locationState);
         done = false;


### PR DESCRIPTION
The tableOps.CleanUp.isReady() operation was not waiting on tablets that were
assigned to dead tablet servers.  The master will attempt to write logs and
delete the location for these tablets.  Therefore its best to wait for the
Master to make its metadata update before proceeding to clean up a deleted
table.