### PR TITLE
Revert commons-vfs2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
+        <!-- commons-vfs2 version 2.2 has defects that impacts changing Accumulo classpath contexts. -->
         <version>2.1</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
-        <version>2.2</version>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
Roll back to commons-vfs2 version 2.1 due to bugs with 2.2.  See dev mailing list thread: "commons-vfs2.jar 2.2 buggy"