### PR TITLE
Monitor 2.0: Eliminate use of async:false for ajax requests

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -26,15 +26,10 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshBulkImport() {
-  $.ajaxSetup({
-    async: false
+  getBulkImports().then(function() {
+    refreshBulkImportTable();
+    refreshServerBulkTable();
   });
-  getBulkImports();
-  $.ajaxSetup({
-    async: true
-  });
-  refreshBulkImportTable();
-  refreshServerBulkTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -317,7 +317,7 @@ function makePlot(id, inData, type) {
  * stores it on a sessionStorage variable
  */
 function getMaster() {
-  $.getJSON('/rest/master', function(data) {
+  return $.getJSON('/rest/master', function(data) {
     sessionStorage.master = JSON.stringify(data);
   });
 }
@@ -327,7 +327,7 @@ function getMaster() {
  * stores it on a sessionStorage variable
  */
 function getZK() {
-  $.getJSON('/rest/zk', function(data) {
+  return $.getJSON('/rest/zk', function(data) {
     sessionStorage.zk = JSON.stringify(data);
   });
 }
@@ -336,7 +336,7 @@ function getZK() {
  * REST GET call for the namespaces, stores it on a global variable
  */
 function getNamespaces() {
-  $.getJSON('/rest/tables/namespaces', function(data) {
+  return $.getJSON('/rest/tables/namespaces', function(data) {
     NAMESPACES = JSON.stringify(data);
   });
 }
@@ -357,13 +357,13 @@ function getNamespaceTables(namespaces) {
    * get tables from specific namespaces
    */
   if (namespaces.indexOf('*') != -1) {
-    getTables();
+    return getTables();
   } else {
     // Convert the list to a string for the REST call
     namespaceList = namespaces.toString();
 
     var call = '/rest/tables/namespaces/' + namespaceList;
-    $.getJSON(call, function(data) {
+    return $.getJSON(call, function(data) {
       sessionStorage.tables = JSON.stringify(data);
     });
   }
@@ -373,7 +373,7 @@ function getNamespaceTables(namespaces) {
  * REST GET call for the tables, stores it on a sessionStorage variable
  */
 function getTables() {
-  $.getJSON('/rest/tables', function(data) {
+  return $.getJSON('/rest/tables', function(data) {
     sessionStorage.tables = JSON.stringify(data);
   });
 }
@@ -392,7 +392,7 @@ function clearDeadServers(server) {
  * REST GET call for the tservers, stores it on a sessionStorage variable
  */
 function getTServers() {
-  $.getJSON('/rest/tservers', function(data) {
+  return $.getJSON('/rest/tservers', function(data) {
     sessionStorage.tservers = JSON.stringify(data);
   });
 }
@@ -404,7 +404,7 @@ function getTServers() {
  */
 function getTServer(server) {
   var call = '/rest/tservers/' + server;
-  $.getJSON(call, function(data) {
+  return $.getJSON(call, function(data) {
     sessionStorage.server = JSON.stringify(data);
   });
 }
@@ -413,7 +413,7 @@ function getTServer(server) {
  * REST GET call for the scans, stores it on a sessionStorage variable
  */
 function getScans() {
-  $.getJSON('/rest/scans', function(data) {
+  return $.getJSON('/rest/scans', function(data) {
     sessionStorage.scans = JSON.stringify(data);
   });
 }
@@ -422,7 +422,7 @@ function getScans() {
  * REST GET call for the bulk imports, stores it on a sessionStorage variable
  */
 function getBulkImports() {
-  $.getJSON('/rest/bulkImports', function(data) {
+  return $.getJSON('/rest/bulkImports', function(data) {
     sessionStorage.bulkImports = JSON.stringify(data);
   });
 }
@@ -432,7 +432,7 @@ function getBulkImports() {
  * stores it on a sessionStorage variable
  */
 function getGarbageCollector() {
-  $.getJSON('/rest/gc', function(data) {
+  return $.getJSON('/rest/gc', function(data) {
     sessionStorage.gc = JSON.stringify(data);
   });
 }
@@ -441,7 +441,7 @@ function getGarbageCollector() {
  * REST GET call for the server stats, stores it on a sessionStorage variable
  */
 function getServerStats() {
-  $.getJSON('/rest/tservers/serverStats', function(data) {
+  return $.getJSON('/rest/tservers/serverStats', function(data) {
     sessionStorage.serverStats = JSON.stringify(data);
   });
 }
@@ -450,7 +450,7 @@ function getServerStats() {
  * REST GET call for the recovery list, stores it on a sessionStorage variable
  */
 function getRecoveryList() {
-  $.getJSON('/rest/tservers/recovery', function(data) {
+  return $.getJSON('/rest/tservers/recovery', function(data) {
     sessionStorage.recoveryList = JSON.stringify(data);
   });
 }
@@ -463,7 +463,7 @@ function getRecoveryList() {
  */
 function getTableServers(tableID) {
   var call = '/rest/tables/' + tableID;
-  $.getJSON(call, function(data) {
+  return $.getJSON(call, function(data) {
     sessionStorage.tableServers = JSON.stringify(data);
   });
 }
@@ -475,7 +475,7 @@ function getTableServers(tableID) {
  */
 function getTraceSummary(minutes) {
   var call = '/rest/trace/summary/' + minutes;
-  $.getJSON(call, function(data) {
+  return $.getJSON(call, function(data) {
     sessionStorage.traceSummary = JSON.stringify(data);
   });
 }
@@ -488,7 +488,7 @@ function getTraceSummary(minutes) {
  */
 function getTraceOfType(type, minutes) {
   var call = '/rest/trace/listType/' + type + '/' + minutes;
-  $.getJSON(call, function(data) {
+  return $.getJSON(call, function(data) {
     sessionStorage.traceType = JSON.stringify(data);
   });
 }
@@ -500,7 +500,7 @@ function getTraceOfType(type, minutes) {
  */
 function getTraceShow(id) {
   var call = '/rest/trace/show/' + id;
-  $.getJSON(call, function(data) {
+  return $.getJSON(call, function(data) {
     sessionStorage.traceShow = JSON.stringify(data);
   });
 }
@@ -509,7 +509,7 @@ function getTraceShow(id) {
  * REST GET call for the logs, stores it on a sessionStorage variable
  */
 function getLogs() {
-  $.getJSON('/rest/logs', function(data) {
+  return $.getJSON('/rest/logs', function(data) {
     sessionStorage.logs = JSON.stringify(data);
   });
 }
@@ -519,14 +519,6 @@ function getLogs() {
  */
 function clearLogs() {
   $.post('/rest/logs');
-}
-
-/**
- * REST GET call for the problems
- */
-function getProblems() {
-  getProblemSummary();
-  getProblemDetails();
 }
 
 /**
@@ -561,7 +553,7 @@ function clearDetailsProblems(table, resource, type) {
  * stores it on a sessionStorage variable
  */
 function getProblemSummary() {
-  $.getJSON('/rest/problems/summary', function(data) {
+  return $.getJSON('/rest/problems/summary', function(data) {
     sessionStorage.problemSummary = JSON.stringify(data);
   });
 }
@@ -571,7 +563,7 @@ function getProblemSummary() {
  * stores it on a sessionStorage variable
  */
 function getProblemDetails() {
-  $.getJSON('/rest/problems/details', function(data) {
+  return $.getJSON('/rest/problems/details', function(data) {
     sessionStorage.problemDetails = JSON.stringify(data);
   });
 }
@@ -581,7 +573,7 @@ function getProblemDetails() {
  * stores it on a sessionStorage variable
  */
 function getReplication() {
-  $.getJSON('/rest/replication', function(data) {
+  return $.getJSON('/rest/replication', function(data) {
     sessionStorage.replication = JSON.stringify(data);
   });
 }
@@ -593,7 +585,7 @@ function getReplication() {
  * stores it on a sessionStorage variable
  */
 function getIngestRate() {
-  $.getJSON('/rest/statistics/time/ingestRate', function(data) {
+  return $.getJSON('/rest/statistics/time/ingestRate', function(data) {
     sessionStorage.ingestRate = JSON.stringify(data);
   });
 }
@@ -603,7 +595,7 @@ function getIngestRate() {
  * stores it on a sessionStorage variable
  */
 function getScanEntries() {
-  $.getJSON('/rest/statistics/time/scanEntries', function(data) {
+  return $.getJSON('/rest/statistics/time/scanEntries', function(data) {
     sessionStorage.scanEntries = JSON.stringify(data);
   });
 }
@@ -613,7 +605,7 @@ function getScanEntries() {
  * stores it on a sessionStorage variable
  */
 function getIngestByteRate() {
-  $.getJSON('/rest/statistics/time/ingestByteRate', function(data) {
+  return $.getJSON('/rest/statistics/time/ingestByteRate', function(data) {
     sessionStorage.ingestMB = JSON.stringify(data);
   });
 }
@@ -622,7 +614,7 @@ function getIngestByteRate() {
  * REST GET call for the query byte rate, stores it on a sessionStorage variable
  */
 function getQueryByteRate() {
-  $.getJSON('/rest/statistics/time/queryByteRate', function(data) {
+  return $.getJSON('/rest/statistics/time/queryByteRate', function(data) {
     sessionStorage.queryMB = JSON.stringify(data);
   });
 }
@@ -631,7 +623,7 @@ function getQueryByteRate() {
  * REST GET call for the load average, stores it on a sessionStorage variable
  */
 function getLoadAverage() {
-  $.getJSON('/rest/statistics/time/load', function(data) {
+  return $.getJSON('/rest/statistics/time/load', function(data) {
     sessionStorage.loadAvg = JSON.stringify(data);
   });
 }
@@ -640,7 +632,7 @@ function getLoadAverage() {
  * REST GET call for the lookups, stores it on a sessionStorage variable
  */
 function getLookups() {
-  $.getJSON('/rest/statistics/time/lookups', function(data) {
+  return $.getJSON('/rest/statistics/time/lookups', function(data) {
     sessionStorage.lookups = JSON.stringify(data);
   });
 }
@@ -650,7 +642,7 @@ function getLookups() {
  * stores it on a sessionStorage variable
  */
 function getMinorCompactions() {
-  $.getJSON('/rest/statistics/time/minorCompactions', function(data) {
+  return $.getJSON('/rest/statistics/time/minorCompactions', function(data) {
     sessionStorage.minorCompactions = JSON.stringify(data);
   });
 }
@@ -660,7 +652,7 @@ function getMinorCompactions() {
  * stores it on a sessionStorage variable
  */
 function getMajorCompactions() {
-  $.getJSON('/rest/statistics/time/majorCompactions', function(data) {
+  return $.getJSON('/rest/statistics/time/majorCompactions', function(data) {
     sessionStorage.majorCompactions = JSON.stringify(data);
   });
 }
@@ -670,7 +662,7 @@ function getMajorCompactions() {
  * stores it on a sessionStorage variable
  */
 function getIndexCacheHitRate() {
-  $.getJSON('/rest/statistics/time/indexCacheHitRate', function(data) {
+  return $.getJSON('/rest/statistics/time/indexCacheHitRate', function(data) {
     sessionStorage.indexCache = JSON.stringify(data);
   });
 }
@@ -680,7 +672,7 @@ function getIndexCacheHitRate() {
  * stores it on a sessionStorage variable
  */
 function getDataCacheHitRate() {
-  $.getJSON('/rest/statistics/time/dataCacheHitRate', function(data) {
+  return $.getJSON('/rest/statistics/time/dataCacheHitRate', function(data) {
     sessionStorage.dataCache = JSON.stringify(data);
   });
 }
@@ -689,7 +681,7 @@ function getDataCacheHitRate() {
  * REST GET call for the server status, stores it on a sessionStorage variable
  */
 function getStatus() {
-  $.getJSON('/rest/status', function(data) {
+  return $.getJSON('/rest/status', function(data) {
     sessionStorage.status = JSON.stringify(data);
   });
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
@@ -26,14 +26,9 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshGC() {
-  $.ajaxSetup({
-    async: false
+  getGarbageCollector().then(function() {
+    refreshGCTable();
   });
-  getGarbageCollector();
-  $.ajaxSetup({
-    async: true
-  });
-  refreshGCTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/listType.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/listType.js
@@ -20,14 +20,9 @@ var type, minutes;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshListType() {
-  $.ajaxSetup({
-    async: false
+  getTraceOfType(type, minutes).then(function() {
+    refreshTypeTraceTable(minutes);
   });
-  getTraceOfType(type, minutes);
-  $.ajaxSetup({
-    async: true
-  });
-  refreshTypeTraceTable(minutes);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/master.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/master.js
@@ -26,16 +26,12 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshMaster() {
-  $.ajaxSetup({
-    async: false
+  getMaster().then(function() {
+    refreshMasterTable();
   });
-  getMaster();
-  getRecoveryList();
-  $.ajaxSetup({
-    async: true
+  getRecoveryList().then(function() {
+    recoveryList();
   });
-  refreshMasterTable();
-  recoveryList();
 }
 
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -26,14 +26,9 @@ $(document).ready(function() {
  * Makes the REST calls, generates the sidebar with the new information
  */
 function refreshSidebar() {
-  $.ajaxSetup({
-    async: false
+  getStatus().then(function() {
+    refreshSideBarNotifications();
   });
-  getStatus();
-  $.ajaxSetup({
-    async: true
-  });
-  refreshSideBarNotifications();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -26,27 +26,27 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshOverview() {
-  $.ajaxSetup({
-    async: false
+  getMaster().then(function() {
+    refreshMasterTable();
   });
-  getMaster();
-  getZK();
-  getIngestRate();
-  getScanEntries();
-  getIngestByteRate();
-  getQueryByteRate();
-  getLoadAverage();
-  getLookups();
-  getMinorCompactions();
-  getMajorCompactions();
-  getIndexCacheHitRate();
-  getDataCacheHitRate();
-  $.ajaxSetup({
-    async: true
+  getZK().then(function() {
+    refreshZKTable();
   });
-  refreshMasterTable();
-  refreshZKTable();
-  makePlots();
+  var requests = [
+    getIngestRate(),
+    getScanEntries(),
+    getIngestByteRate(),
+    getQueryByteRate(),
+    getLoadAverage(),
+    getLookups(),
+    getMinorCompactions(),
+    getMajorCompactions(),
+    getIndexCacheHitRate(),
+    getDataCacheHitRate()
+  ];
+  $.when(...requests).always(function() {
+    makePlots();
+  });
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
@@ -20,15 +20,12 @@ var tableID;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshProblems() {
-  $.ajaxSetup({
-    async: false
+  getProblemSummary().then(function() {
+    refreshProblemSummaryTable();
   });
-  getProblems();
-  $.ajaxSetup({
-    async: true
+  getProblemDetails().then(function() {
+    refreshProblemDetailsTable();
   });
-  refreshProblemSummaryTable();
-  refreshProblemDetailsTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
@@ -26,14 +26,9 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshReplication() {
-  $.ajaxSetup({
-    async: false
+  getReplication().then(function() {
+    refreshReplicationsTable();
   });
-  getReplication();
-  $.ajaxSetup({
-    async: true
-  });
-  refreshReplicationsTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -26,14 +26,9 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshScans() {
-  $.ajaxSetup({
-    async: false
+  getScans().then(function() {
+    refreshScansTable();
   });
-  getScans();
-  $.ajaxSetup({
-    async: true
-  });
-  refreshScansTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
@@ -21,17 +21,12 @@ var tabletResults;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshServer() {
-  $.ajaxSetup({
-    async: false
+  getTServer(serv).then(function() {;
+    refreshDetailTable();
+    refreshHistoryTable();
+    refreshCurrentTable();
+    refreshResultsTable();
   });
-  getTServer(serv);
-  $.ajaxSetup({
-    async: true
-  });
-  refreshDetailTable();
-  refreshHistoryTable();
-  refreshCurrentTable();
-  refreshResultsTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/show.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/show.js
@@ -19,14 +19,9 @@ var id;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTraceShow() {
-  $.ajaxSetup({
-    async: false
+  getTraceShow(id).then(function() {
+    refreshTraceShowTable();
   });
-  getTraceShow(id);
-  $.ajaxSetup({
-    async: true
-  });
-  refreshTraceShowTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/summary.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/summary.js
@@ -19,14 +19,9 @@ var minutes;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshSummary() {
-  $.ajaxSetup({
-    async: false
+  getTraceSummary(minutes).then(function() {
+    refreshTraceSummaryTable(minutes);
   });
-  getTraceSummary(minutes);
-  $.ajaxSetup({
-    async: true
-  });
-  refreshTraceSummaryTable(minutes);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -20,14 +20,9 @@ var tableID;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTable() {
-  $.ajaxSetup({
-    async: false
+  getTableServers(tableID).then(function() {
+    refreshTableServersTable();
   });
-  getTableServers(tableID);
-  $.ajaxSetup({
-    async: true
-  });
-  refreshTableServersTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -76,16 +76,11 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTServers() {
-  $.ajaxSetup({
-    async: false
+  getTServers().then(function() {
+    refreshBadTServersTable();
+    refreshDeadTServersTable();
+    refreshTServersTable();
   });
-  getTServers();
-  $.ajaxSetup({
-    async: true
-  });
-  refreshBadTServersTable();
-  refreshDeadTServersTable();
-  refreshTServersTable();
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/vis.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/vis.ftl
@@ -41,22 +41,16 @@
          * Creates initial visualization table, passes the shape, size, motion, and color from the template
          */
         $(document).ready(function() {
-          $.ajaxSetup({
-            async: false
-          });
-          getServerStats();
-          $.ajaxSetup({
-            async: true
-          });
+          getServerStats().then(function() {
+            setStats();
+            setOptions('${shape}', '${size}', '${motion}', '${color}');
+            setState();
 
-          setStats();
-          setOptions('${shape}', '${size}', '${motion}', '${color}');
-          setState();
-
-          drawGrid();
-          getXML();
-          refresh();
-          drawDots();
+            drawGrid();
+            getXML();
+            refresh();
+            drawDots();
+          });
         });
         // Populates variables to be used in the visualization
         var numCores = 8;


### PR DESCRIPTION
Forcing ajax queries to be synchronous isn't advisable for the reasons described in the links below.  I've improved the code to work asynchronously.
I'm also working on some other improvements but I wanted to submit them as smaller PR's to make them easier to review.

[jQuery.ajax(): Setting async to false is strongly discouraged as it can cause the browser to become unresponsive.](http://api.jquery.com/jquery.ajax/)
[MDN: Synchronous requests on the main thread have been deprecated due to the negative effects to the user experience.](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#Synchronous_request)

The functions that use .getJSON() in functions.js now return the jqXHR (jQuery XML HTTP Request) object.
This object implements the Promise interface, so it's possible to provide a callback for when one or more requests complete.

In most cases there was only one request to wait for so .then(handler) can be chained directly onto the request.

In some cases, there were several requests issued synchronously.
Where possible, the individual handlers were chained onto their respective request function if there were no dependencies between the requests.  (Eg. problems.js)

The overview page is the only case where many requests must all be completed before the plots can be updated.  In this case $.always() is used to wait for all requests to finish.  Using $.always() will ignore any failures and continue to update the plots.  This isn't a great solution but there are no adverse effects and I intend to improve it further in another pull request.