### PR TITLE
Avoid ZK watch when checking if property is set

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -386,7 +386,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
     }
   }
 
-  public boolean isPropertySet(Property prop) {
+  public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
     throw new UnsupportedOperationException();
   }
 
@@ -409,14 +409,14 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
       return null;
     }
 
-    if (!isPropertySet(prop) && isPropertySet(deprecatedProp)) {
+    if (!isPropertySet(prop, true) && isPropertySet(deprecatedProp, true)) {
       if (!depPropWarned) {
         depPropWarned = true;
         log.warn("Property {} is deprecated, use {} instead.", deprecatedProp.getKey(),
             prop.getKey());
       }
       return Integer.valueOf(get(deprecatedProp));
-    } else if (isPropertySet(prop) && isPropertySet(deprecatedProp) && !depPropWarned) {
+    } else if (isPropertySet(prop, true) && isPropertySet(deprecatedProp, true) && !depPropWarned) {
       depPropWarned = true;
       log.warn("Deprecated property {} ignored because {} is set", deprecatedProp.getKey(),
           prop.getKey());

--- a/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
@@ -54,7 +54,7 @@ public class DefaultConfiguration extends AccumuloConfiguration {
   }
 
   @Override
-  public boolean isPropertySet(Property prop) {
+  public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
     return false;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -221,7 +221,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
   }
 
   @Override
-  public boolean isPropertySet(Property prop) {
+  public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
     if (prop.isSensitive()) {
       String hadoopVal = getSensitiveFromHadoop(prop);
       if (hadoopVal != null) {
@@ -229,7 +229,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
       }
     }
     return overrides.containsKey(prop.getKey()) || staticConfigs.containsKey(prop.getKey())
-        || getConfiguration().containsKey(prop.getKey()) || parent.isPropertySet(prop);
+        || getConfiguration().containsKey(prop.getKey()) || parent.isPropertySet(prop, cacheAndWatch);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -239,7 +239,7 @@ public class ZooCache {
     this.externalWatcher = watcher;
   }
 
-  private abstract class ZooRunnable<T> {
+  public abstract class ZooRunnable<T> {
     /**
      * Runs an operation against ZooKeeper. Retries are performed by the retry method when
      * KeeperExceptions occur.
@@ -252,7 +252,7 @@ public class ZooCache {
      *
      * @return T the result of the runnable
      */
-    abstract T run() throws KeeperException, InterruptedException;
+    protected abstract T run() throws KeeperException, InterruptedException;
 
     /**
      * Retry will attempt to call the run method. Run should make a call to {@link #getZooKeeper()}

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -239,7 +239,7 @@ public class ZooCache {
     this.externalWatcher = watcher;
   }
 
-  public abstract class ZooRunnable<T> {
+  private abstract class ZooRunnable<T> {
     /**
      * Runs an operation against ZooKeeper. Retries are performed by the retry method when
      * KeeperExceptions occur.
@@ -252,7 +252,7 @@ public class ZooCache {
      *
      * @return T the result of the runnable
      */
-    protected abstract T run() throws KeeperException, InterruptedException;
+    abstract T run() throws KeeperException, InterruptedException;
 
     /**
      * Retry will attempt to call the run method. Run should make a call to {@link #getZooKeeper()}

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -151,7 +151,7 @@ public class AccumuloConfigurationTest {
     }
 
     @Override
-    public boolean isPropertySet(Property prop) {
+    public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
       return props.containsKey(prop.getKey());
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerUtil.java
@@ -126,7 +126,7 @@ public class ServerUtil {
       String key = entry.getKey();
       log.info("{} = {}", key, (Property.isSensitive(key) ? "<hidden>" : entry.getValue()));
       Property prop = Property.getPropertyByKey(key);
-      if (prop != null && conf.isPropertySet(prop)) {
+      if (prop != null && conf.isPropertySet(prop, false)) {
         if (prop.isDeprecated()) {
           Property replacedBy = prop.replacedBy();
           if (replacedBy != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
@@ -115,7 +115,7 @@ public class ZooConfiguration extends AccumuloConfiguration {
       ZooReader zr = context.getZooReaderWriter();
       String zPath = propPathPrefix + "/" + prop.getKey();
       try {
-        if (zr.exists(zPath) && zr.getData(zPath, null) != null) {
+        if (zr.exists(zPath)) {
           return true;
         }
       } catch (KeeperException|InterruptedException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
@@ -28,22 +28,26 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooUtil;
+import org.apache.accumulo.fate.zookeeper.ZooReader;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ZooConfiguration extends AccumuloConfiguration {
   private static final Logger log = LoggerFactory.getLogger(ZooConfiguration.class);
 
+  private final ServerContext context;
   private final ZooCache propCache;
   private final AccumuloConfiguration parent;
   private final Map<String,String> fixedProps = Collections.synchronizedMap(new HashMap<>());
   private final String propPathPrefix;
 
-  protected ZooConfiguration(String instanceId, ZooCache propCache, AccumuloConfiguration parent) {
+  protected ZooConfiguration(ServerContext context, ZooCache propCache, AccumuloConfiguration parent) {
+    this.context = context;
     this.propCache = propCache;
     this.parent = parent;
-    this.propPathPrefix = ZooUtil.getRoot(instanceId) + Constants.ZCONFIG;
+    this.propPathPrefix = context.getZooKeeperRoot() + Constants.ZCONFIG;
   }
 
   @Override
@@ -98,9 +102,26 @@ public class ZooConfiguration extends AccumuloConfiguration {
   }
 
   @Override
-  public boolean isPropertySet(Property prop) {
-    return fixedProps.containsKey(prop.getKey()) || getRaw(prop.getKey()) != null
-        || parent.isPropertySet(prop);
+  public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
+    if (fixedProps.containsKey(prop.getKey())) {
+      return true;
+    }
+    if (cacheAndWatch) {
+      if (getRaw(prop.getKey()) != null) {
+        return true;
+      }
+    } else {
+      ZooReader zr = context.getZooReaderWriter();
+      String zPath = propPathPrefix + "/" + prop.getKey();
+      try {
+        if (zr.exists(zPath) && zr.getData(zPath, null) != null) {
+          return true;
+        }
+      } catch (KeeperException|InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return parent.isPropertySet(prop, cacheAndWatch);
   }
 
   private String getRaw(String key) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ZooConfiguration extends AccumuloConfiguration {
+
   private static final Logger log = LoggerFactory.getLogger(ZooConfiguration.class);
 
   private final ServerContext context;
@@ -118,7 +119,7 @@ public class ZooConfiguration extends AccumuloConfiguration {
           return true;
         }
       } catch (KeeperException|InterruptedException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
     return parent.isPropertySet(prop, cacheAndWatch);

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfigurationFactory.java
@@ -61,7 +61,7 @@ class ZooConfigurationFactory {
         };
         propCache = zcf.getZooCache(context.getZooKeepers(), context.getZooKeepersSessionTimeOut(),
             watcher);
-        config = new ZooConfiguration(context.getInstanceID(), propCache, parent);
+        config = new ZooConfiguration(context, propCache, parent);
         instances.put(context.getInstanceID(), config);
       }
     }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ZooConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ZooConfigurationFactoryTest.java
@@ -52,6 +52,7 @@ public class ZooConfigurationFactoryTest {
 
   @Test
   public void testGetInstance() {
+    expect(context.getZooKeeperRoot()).andReturn("zkroot").anyTimes();
     expect(context.getInstanceID()).andReturn("iid").anyTimes();
     expect(context.getZooKeepers()).andReturn("localhost").anyTimes();
     expect(context.getZooKeepersSessionTimeOut()).andReturn(120000).anyTimes();


### PR DESCRIPTION
* Updated AccumuloConfig.isPropertySet() method optionally cache and
  watch for changes in the property