### PR TITLE
Only requeue compaction when there was activity

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionRunner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionRunner.java
@@ -41,12 +41,18 @@ final class CompactionRunner implements Runnable, Comparable<CompactionRunner> {
       return;
     }
 
-    tablet.majorCompact(reason, queued);
+    CompactionStats stats = tablet.majorCompact(reason, queued);
 
-    // if there is more work to be done, queue another major compaction
-    synchronized (tablet) {
-      if (reason == MajorCompactionReason.NORMAL && tablet.needsMajorCompaction(reason))
-        tablet.initiateMajorCompaction(reason);
+    // Some compaction strategies may always return true for shouldCompact() because they need to
+    // make blocking calls to gather information. Without the following check these strategies would
+    // endlessly requeue. So only check if a subsequent compaction is needed if the previous
+    // compaction actually did something.
+    if (stats != null && stats.getEntriesRead() > 0) {
+      // if there is more work to be done, queue another major compaction
+      synchronized (tablet) {
+        if (reason == MajorCompactionReason.NORMAL && tablet.needsMajorCompaction(reason))
+          tablet.initiateMajorCompaction(reason);
+      }
     }
   }
 


### PR DESCRIPTION
While working on an experimental compaction strategy for Fluo for apache/fluo#1054 I ran into a situation where Accumulo was calling my compaction strategy hundreds of thousands of times per second.  I tracked down the problem and fixed it in this PR. 