### PR TITLE
Fix warnings and jar sealing issues with ITs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ConnectorImpl.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.ConditionalWriterConfig;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MultiTableBatchWriter;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -44,7 +43,7 @@ import org.apache.accumulo.core.singletons.SingletonManager.Mode;
  * copied over to that.
  */
 @Deprecated
-public class ConnectorImpl extends Connector {
+public class ConnectorImpl extends org.apache.accumulo.core.client.Connector {
 
   private final AccumuloClientImpl impl;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -1137,6 +1137,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
   }
 
   @Override
+  @Deprecated
   public void importDirectory(String tableName, String dir, String failureDir, boolean setTime)
       throws IOException, AccumuloSecurityException, TableNotFoundException, AccumuloException {
     checkArgument(tableName != null, "tableName is null");

--- a/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/crypto/CryptoTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -101,7 +102,10 @@ public class CryptoTest {
     try (FSDataOutputStream out = fs.create(aesPath)) {
       out.writeUTF("sixteenbytekey"); // 14 + 2 from writeUTF
     }
-    FSDataOutputStream out = fs.create(new Path(emptyKeyPath));
+    try (FSDataOutputStream out = fs.create(new Path(emptyKeyPath))) {
+      // auto close after creating
+      assertNotNull(out);
+    }
   }
 
   @Test
@@ -322,6 +326,7 @@ public class CryptoTest {
     byte[] wrapped = AESKeyUtils.wrapKey(fek, kek);
     exception.expect(CryptoException.class);
     java.security.Key unwrapped = AESKeyUtils.unwrapKey(wrapped, wrongKek);
+    fail("creation of " + unwrapped + " should fail");
   }
 
   @Test
@@ -339,13 +344,14 @@ public class CryptoTest {
     exception.expect(CryptoException.class);
     SecretKeySpec fileKey = AESKeyUtils.loadKekFromUri(
         System.getProperty("user.dir") + "/target/CryptoTest-testkeyfile-doesnt-exist");
+    fail("creation of " + fileKey + " should fail");
   }
 
   @Test
   public void testAESKeyUtilsLoadKekFromEmptyFile() {
     exception.expect(CryptoException.class);
     SecretKeySpec fileKey = AESKeyUtils.loadKekFromUri(emptyKeyPath);
-
+    fail("creation of " + fileKey + " should fail");
   }
 
   private ArrayList<Key> testData() {

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormat.java
@@ -63,8 +63,8 @@ import org.slf4j.LoggerFactory;
  * @since 2.0
  */
 public class AccumuloInputFormat implements InputFormat<Key,Value> {
-  private static Class CLASS = AccumuloInputFormat.class;
-  private static Logger log = LoggerFactory.getLogger(CLASS);
+  private static final Class<AccumuloInputFormat> CLASS = AccumuloInputFormat.class;
+  private static final Logger log = LoggerFactory.getLogger(CLASS);
 
   /**
    * Gets the splits of the tables that have been set on the job by reading the metadata table for

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormat.java
@@ -63,8 +63,8 @@ import org.slf4j.LoggerFactory;
  * @since 2.0
  */
 public class AccumuloInputFormat extends InputFormat<Key,Value> {
-  private static Class CLASS = AccumuloInputFormat.class;
-  private static Logger log = LoggerFactory.getLogger(CLASS);
+  private static final Class<AccumuloInputFormat> CLASS = AccumuloInputFormat.class;
+  private static final Logger log = LoggerFactory.getLogger(CLASS);
 
   /**
    * Gets the splits of the tables that have been set on the job by reading the metadata table for

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/AccumuloRowInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/AccumuloRowInputFormat.java
@@ -65,7 +65,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
  * @since 2.0
  */
 public class AccumuloRowInputFormat extends InputFormat<Text,PeekingIterator<Entry<Key,Value>>> {
-  private static Class CLASS = AccumuloRowInputFormat.class;
+  private static final Class<AccumuloRowInputFormat> CLASS = AccumuloRowInputFormat.class;
 
   @Override
   public RecordReader<Text,PeekingIterator<Entry<Key,Value>>> createRecordReader(InputSplit split,

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/NewAccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/NewAccumuloInputFormatIT.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.hadoop.mapreduce;
+package org.apache.accumulo.hadoop.its.mapreduce;
 
 import static java.lang.System.currentTimeMillis;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
@@ -47,6 +47,8 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.hadoop.mapreduce.InputInfo;
 import org.apache.accumulo.hadoopImpl.mapreduce.BatchInputSplit;
 import org.apache.accumulo.hadoopImpl.mapreduce.RangeInputSplit;
 import org.apache.accumulo.harness.AccumuloClusterHarness;

--- a/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
@@ -18,6 +18,7 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -71,8 +72,9 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
   @After
   public void checkForDanglingFateLocks() {
-    // create an accumulo client even though its not used inorder to enable static stuff
+    // create an accumulo client even though it's not used in order to enable static stuff
     try (AccumuloClient c = getAccumuloClient()) {
+      assertNotNull(c);
       FunctionalTestUtils.assertNoDanglingFateLocks(getClientContext(), getCluster());
     }
   }


### PR DESCRIPTION
* Fix compiler warnings
  * Add missing Deprecated annotation in class method which overrides
    deprecated interface method
  * Add trivial notNull checks in test try-with-resources methods which
    didn't otherwise reference the resource inside the try block
  * Add fail() methods to fail after a test method is called which is
    expected to throw an exception, in order to ensure the exception is
    thrown in the correct line, and to add a reference to the assigned
    variable
  * Add generic parameters and final keyword to CLASS constants in new
    hadoop-mapreduce module
  * Remove import statement for deprecated class
* Rename packages for ITs in new hadoop-mapreduce module to avoid jar
sealing conflicts between the module's main jar and the IT classes
* Fix trivial typos in a comment seen in UserCompactionStrategyIT