### PR TITLE
Include commons-configuration in our convenience binaries for Hadoop 2.

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -48,6 +48,10 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <optional>true</optional>
@@ -331,7 +335,7 @@
         </property>
       </activation>
       <properties>
-        <artifactList>commons-math3,commons-vfs2,gson,guava,htrace-core,javax.servlet-api,jcommander,jetty-http,jetty-io,jetty-security,jetty-server,jetty-servlet,jetty-util,jline,libthrift,protobuf-java,slf4j-api,slf4j-log4j12</artifactList>
+        <artifactList>commons-configuration,commons-math3,commons-vfs2,gson,guava,htrace-core,javax.servlet-api,jcommander,jetty-http,jetty-io,jetty-security,jetty-server,jetty-servlet,jetty-util,jline,libthrift,protobuf-java,slf4j-api,slf4j-log4j12</artifactList>
         <assemblyDescriptor>src/main/assemblies/binary-release.xml</assemblyDescriptor>
         <hadoop.profile>2</hadoop.profile>
       </properties>
@@ -345,7 +349,7 @@
         </property>
       </activation>
       <properties>
-        <artifactList>commons-math3,commons-vfs2,gson,guava,htrace-core,javax.servlet-api,jcommander,jetty-http,jetty-io,jetty-security,jetty-server,jetty-servlet,jetty-util,jline,libthrift,protobuf-java,slf4j-api,slf4j-log4j12</artifactList>
+        <artifactList>commons-configuration,commons-math3,commons-vfs2,gson,guava,htrace-core,javax.servlet-api,jcommander,jetty-http,jetty-io,jetty-security,jetty-server,jetty-servlet,jetty-util,jline,libthrift,protobuf-java,slf4j-api,slf4j-log4j12</artifactList>
         <assemblyDescriptor>src/main/assemblies/binary-release.xml</assemblyDescriptor>
       </properties>
     </profile>
@@ -375,10 +379,6 @@
         <dependency>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>commons-configuration</groupId>
-          <artifactId>commons-configuration</artifactId>
         </dependency>
         <dependency>
           <groupId>commons-io</groupId>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -36,6 +36,7 @@
         <include>com.google.protobuf:protobuf-java</include>
         <include>javax.servlet:javax.servlet-api</include>
         <include>jline:jline</include>
+        <include>commons-configuration:commons-configuration</include>
         <include>org.apache.commons:commons-math3</include>
         <include>org.apache.commons:commons-vfs2</include>
         <include>org.apache.thrift:libthrift</include>


### PR DESCRIPTION
We need newer than Hadoop 2.y releases provide now, so bring our own along.

Closes #757 

Tested by using Apache Fluo Unos to stand up a cluster on top of Apache Hadoop 2.8.4. Setup failed right off the bat before change. After change was able to stand up a cluster, go through YCSB Workload A load and run, and use shell to flush, compact, scan, etc.