### PR TITLE
Verifying whether JAVA_HOME is set or not

### DIFF
--- a/start/src/test/shell/makeHelloWorldJars.sh
+++ b/start/src/test/shell/makeHelloWorldJars.sh
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 if [ -z "$JAVA_HOME" ]; then
    echo "JAVA_HOME is not set. Java is required to proceed"
    exit 1

--- a/start/src/test/shell/makeHelloWorldJars.sh
+++ b/start/src/test/shell/makeHelloWorldJars.sh
@@ -14,7 +14,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+if [ -z "$JAVA_HOME" ]; then
+   echo "JAVA_HOME is not set. Java is required to proceed"
+   exit 1
+fi
 mkdir -p target/generated-sources/HelloWorld/test
 sed "s/%%/Hello World\!/" < src/test/java/test/HelloWorldTemplate > target/generated-sources/HelloWorld/test/HelloWorld.java
 $JAVA_HOME/bin/javac target/generated-sources/HelloWorld/test/HelloWorld.java -d target/generated-sources/HelloWorld

--- a/start/src/test/shell/makeTestJars.sh
+++ b/start/src/test/shell/makeTestJars.sh
@@ -14,6 +14,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if [ -z "$JAVA_HOME" ]; then
+   echo "JAVA_HOME is not set. Java is required to proceed"
+   exit 1
+fi
 
 for x in A B C
 do


### PR DESCRIPTION
PATCH:  Asserting whether JAVA_HOME is set or not when running "mvn package". When the JAVA_HOME is not set, we are seeing an error that says "bin/javac" not found, "bin/java" not found.
Adding the Assertion that checks for JAVA_HOME is set or not and Errors out with a more intuitive Error Message