### PR TITLE
Remove hard coded values from BatchWriterConfig

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
@@ -231,15 +231,15 @@ public class BatchWriterConfig implements Writable {
     // write this out in a human-readable way
     ArrayList<String> fields = new ArrayList<>();
     if (maxMemory != null)
-      addField(fields, MAX_MEM.getKey(), maxMemory);
+      addField(fields, "maxMemory", maxMemory);
     if (maxLatency != null)
-      addField(fields, MAX_LATENCY.getKey(), maxLatency);
+      addField(fields, "maxLatency", maxLatency);
     if (maxWriteThreads != null)
-      addField(fields, MAX_WRITE_THREADS.getKey(), maxWriteThreads);
+      addField(fields, "maxWriteThreads", maxWriteThreads);
     if (timeout != null)
-      addField(fields, MAX_TIMEOUT.getKey(), timeout);
+      addField(fields, "timeout", timeout);
     if (durability != Durability.DEFAULT)
-      addField(fields, DURABILITY.getKey(), durability);
+      addField(fields, "durability", durability);
     String output = StringUtils.join(",", fields);
 
     byte[] bytes = output.getBytes(UTF_8);
@@ -273,15 +273,15 @@ public class BatchWriterConfig implements Writable {
       String[] keyValue = StringUtils.split(field, '\\', '=');
       String key = keyValue[0];
       String value = keyValue[1];
-      if (MAX_MEM.getKey().equals(key)) {
+      if ("maxMemory".equals(key)) {
         maxMemory = Long.valueOf(value);
-      } else if (MAX_LATENCY.getKey().equals(key)) {
+      } else if ("maxLatency".equals(key)) {
         maxLatency = Long.valueOf(value);
-      } else if (MAX_WRITE_THREADS.getKey().equals(key)) {
+      } else if ("maxWriteThreads".equals(key)) {
         maxWriteThreads = Integer.valueOf(value);
-      } else if (MAX_TIMEOUT.getKey().equals(key)) {
+      } else if ("timeout".equals(key)) {
         timeout = Long.valueOf(value);
-      } else if (DURABILITY.getKey().equals(key)) {
+      } else if ("durability".equals(key)) {
         durability = DurabilityImpl.fromString(value);
       } else {
         /* ignore any other properties */

--- a/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
@@ -45,25 +45,20 @@ public class BatchWriterConfig implements Writable {
 
   private static final Long DEFAULT_MAX_MEMORY = Long
       .parseLong(BATCH_WRITER_MAX_MEMORY_BYTES.getDefaultValue());
-  private static final ClientProperty MAX_MEM = BATCH_WRITER_MAX_MEMORY_BYTES;
   private Long maxMemory = null;
 
   private static final Long DEFAULT_MAX_LATENCY = TimeUnit.MILLISECONDS
       .convert(Long.parseLong(BATCH_WRITER_MAX_LATENCY_SEC.getDefaultValue()), TimeUnit.SECONDS);
-  private static final ClientProperty MAX_LATENCY = BATCH_WRITER_MAX_LATENCY_SEC;
   private Long maxLatency = null;
 
   private static final Long DEFAULT_TIMEOUT = getDefaultTimeout();
-  private static final ClientProperty MAX_TIMEOUT = BATCH_WRITER_MAX_TIMEOUT_SEC;
   private Long timeout = null;
 
   private static final Integer DEFAULT_MAX_WRITE_THREADS = Integer
       .parseInt(BATCH_WRITER_MAX_WRITE_THREADS.getDefaultValue());
-  private static final ClientProperty MAX_WRITE_THREADS = BATCH_WRITER_MAX_WRITE_THREADS;
   private Integer maxWriteThreads = null;
 
   private Durability durability = Durability.DEFAULT;
-  private static final ClientProperty DURABILITY = BATCH_WRITER_DURABILITY;
   private boolean isDurabilitySet = false;
 
   private static Long getDefaultTimeout() {

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -56,13 +56,14 @@ public enum ClientProperty {
   BATCH_WRITER_MAX_LATENCY_SEC("batch.writer.max.latency.sec", "120",
       "Max amount of time (in seconds) to hold data in memory before flushing it"),
   BATCH_WRITER_MAX_TIMEOUT_SEC("batch.writer.max.timeout.sec", "0",
-      "Max amount" + " of time (in seconds) an unresponsive server will be re-tried. An"
+      "Max amount of time (in seconds) an unresponsive server will be re-tried. An"
           + " exception is thrown when this timeout is exceeded. Set to zero for no timeout."),
   BATCH_WRITER_MAX_WRITE_THREADS("batch.writer.max.write.threads", "3",
       "Maximum number of threads to use for writing data to tablet servers."),
-  BATCH_WRITER_DURABILITY("batch.writer.durability", "default",
-      "Change the" + " durability for the BatchWriter session. To use the table's durability"
-          + " setting. use \"default\" which is the table's durability setting."),
+  BATCH_WRITER_DURABILITY("batch.writer.durability", "default", Property.TABLE_DURABILITY
+      .getDescription() + " Setting this property will "
+      + "change the durability for the BatchWriter session. A value of \"default\" will use the "
+      + "table's durability setting. "),
 
   // Scanner
   SCANNER_BATCH_SIZE("scanner.batch.size", "1000",

--- a/core/src/test/java/org/apache/accumulo/core/client/BatchWriterConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/BatchWriterConfigTest.java
@@ -152,7 +152,7 @@ public class BatchWriterConfigTest {
     bwConfig = new BatchWriterConfig();
     bwConfig.setMaxWriteThreads(42);
     bytes = createBytes(bwConfig);
-    assertEquals("     x#batch.writer.max.write.threads=42", new String(bytes, UTF_8));
+    assertEquals("     i#maxWriteThreads=42", new String(bytes, UTF_8));
     checkBytes(bwConfig, bytes);
 
     // test human-readable with 2 fields
@@ -160,15 +160,14 @@ public class BatchWriterConfigTest {
     bwConfig.setMaxWriteThreads(24);
     bwConfig.setTimeout(3, TimeUnit.SECONDS);
     bytes = createBytes(bwConfig);
-    assertEquals("    1v#batch.writer.max.write.threads=24,batch.writer.max.timeout.sec=3000",
-        new String(bytes, UTF_8));
+    assertEquals("     v#maxWriteThreads=24,timeout=3000", new String(bytes, UTF_8));
     checkBytes(bwConfig, bytes);
 
     // test human-readable durability
     bwConfig = new BatchWriterConfig();
     bwConfig.setDurability(Durability.LOG);
     bytes = createBytes(bwConfig);
-    assertEquals("     r#batch.writer.durability=LOG", new String(bytes, UTF_8));
+    assertEquals("     e#durability=LOG", new String(bytes, UTF_8));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/client/BatchWriterConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/BatchWriterConfigTest.java
@@ -25,8 +25,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.accumulo.core.conf.ClientProperty;
 import org.junit.Test;
 
 public class BatchWriterConfigTest {
@@ -150,7 +152,7 @@ public class BatchWriterConfigTest {
     bwConfig = new BatchWriterConfig();
     bwConfig.setMaxWriteThreads(42);
     bytes = createBytes(bwConfig);
-    assertEquals("     i#maxWriteThreads=42", new String(bytes, UTF_8));
+    assertEquals("     x#batch.writer.max.write.threads=42", new String(bytes, UTF_8));
     checkBytes(bwConfig, bytes);
 
     // test human-readable with 2 fields
@@ -158,14 +160,15 @@ public class BatchWriterConfigTest {
     bwConfig.setMaxWriteThreads(24);
     bwConfig.setTimeout(3, TimeUnit.SECONDS);
     bytes = createBytes(bwConfig);
-    assertEquals("     v#maxWriteThreads=24,timeout=3000", new String(bytes, UTF_8));
+    assertEquals("    1v#batch.writer.max.write.threads=24,batch.writer.max.timeout.sec=3000",
+        new String(bytes, UTF_8));
     checkBytes(bwConfig, bytes);
 
     // test human-readable durability
     bwConfig = new BatchWriterConfig();
     bwConfig.setDurability(Durability.LOG);
     bytes = createBytes(bwConfig);
-    assertEquals("     e#durability=LOG", new String(bytes, UTF_8));
+    assertEquals("     r#batch.writer.durability=LOG", new String(bytes, UTF_8));
   }
 
   @Test
@@ -233,6 +236,14 @@ public class BatchWriterConfigTest {
     assertEquals(bwConfig.getTimeout(TimeUnit.MILLISECONDS),
         createdConfig.getTimeout(TimeUnit.MILLISECONDS));
     assertEquals(bwConfig.getMaxWriteThreads(), createdConfig.getMaxWriteThreads());
+  }
+
+  @Test
+  public void countClientProps() {
+    // count the number in case one gets added to in one place but not the other
+    ClientProperty[] bwProps = Arrays.stream(ClientProperty.values())
+        .filter(c -> c.name().startsWith("BATCH_WRITER")).toArray(ClientProperty[]::new);
+    assertEquals(5, bwProps.length);
   }
 
 }


### PR DESCRIPTION
Replace hard coded defaults and key names in BatchWriterConfig with values in ClientProperty.
Also improved BATCH_WRITER_DURABILITY javadoc.