### PR TITLE
Make durability propertyType case insensitive

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -116,7 +116,7 @@ public enum PropertyType {
       "A list of fully qualified java class names representing classes on the classpath.\n"
           + "An example is 'java.lang.String', rather than 'String'"),
 
-  DURABILITY("durability", in(true, null, "default", "none", "log", "flush", "sync"),
+  DURABILITY("durability", in(false, null, "default", "none", "log", "flush", "sync"),
       "One of 'none', 'log', 'flush' or 'sync'."),
 
   STRING("string", x -> true,


### PR DESCRIPTION
* Durability has uppercase values but the PropertyType.isValidFromat check fails if the
enum is set as a value.

This will fix the currently failing AccumuloOutputFormatIT