### PR TITLE
Multi table input for new MR. Closes #749

### DIFF
--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormat.java
@@ -54,7 +54,7 @@ public class AccumuloInputFormat implements InputFormat<Key,Value> {
    */
   @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
-    return AbstractInputFormat.getSplits(job, numSplits);
+    return AbstractInputFormat.getSplits(job);
   }
 
   @Override
@@ -96,6 +96,6 @@ public class AccumuloInputFormat implements InputFormat<Key,Value> {
    * Sets all the information required for this map reduce job.
    */
   public static InputFormatBuilder.ClientParams<JobConf> configure() {
-    return new InputFormatBuilderImpl<JobConf>(CLASS);
+    return new InputFormatBuilderImpl<>(CLASS);
   }
 }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapred/AccumuloRowInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapred/AccumuloRowInputFormat.java
@@ -53,7 +53,7 @@ public class AccumuloRowInputFormat implements InputFormat<Text,PeekingIterator<
    */
   @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
-    return AbstractInputFormat.getSplits(job, numSplits);
+    return AbstractInputFormat.getSplits(job);
   }
 
   @Override

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormat.java
@@ -49,6 +49,17 @@ import org.slf4j.LoggerFactory;
  *     .store(job);
  * </pre>
  *
+ * Multiple tables can be set by configuring clientProperties once and then calling .table() for
+ * each table. The methods following a call to .table() apply only to that table. For Example:
+ *
+ * <pre>
+ * AccumuloInputFormat.configure().clientProperties(props) // set client props once
+ *     .table(table1).auths(auths1).fetchColumns(cols1).batchScan(true) // options for table1
+ *     .table(table2).ranges(range2).auths(auths2).addIterator(iter2) // options for table2
+ *     .table(table3).ranges(range3).auths(auths3).addIterator(iter3) // options for table3
+ *     .store(job); // store all tables in the job when finished
+ * </pre>
+ *
  * For descriptions of all options see
  * {@link org.apache.accumulo.hadoop.mapreduce.InputFormatBuilder.InputFormatOptions}
  *

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/InputFormatBuilder.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/InputFormatBuilder.java
@@ -62,12 +62,18 @@ public interface InputFormatBuilder {
    */
   interface TableParams<T> {
     /**
-     * Sets the name of the input table, over which this job will scan.
+     * Sets the name of the input table, over which this job will scan. At least one table is
+     * required before calling store(Job)
      *
      * @param tableName
      *          the table to use when the tablename is null in the write call
      */
     InputFormatOptions<T> table(String tableName);
+
+    /**
+     * Finish configuring, verify and serialize options into the JobConf or Job
+     */
+    void store(T j) throws AccumuloException, AccumuloSecurityException;
   }
 
   /**
@@ -75,7 +81,7 @@ public interface InputFormatBuilder {
    *
    * @since 2.0
    */
-  interface InputFormatOptions<T> {
+  interface InputFormatOptions<T> extends TableParams<T> {
     /**
      * Sets the {@link Authorizations} used to scan. Must be a subset of the user's authorizations.
      * By Default, all of the users auths are set.
@@ -217,10 +223,5 @@ public interface InputFormatBuilder {
      * By default, this feature is <b>disabled</b>.
      */
     InputFormatOptions<T> batchScan(boolean value);
-
-    /**
-     * Finish configuring, verify and serialize options into the JobConf or Job
-     */
-    void store(T j) throws AccumuloException, AccumuloSecurityException;
   }
 }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AbstractInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AbstractInputFormat.java
@@ -449,7 +449,7 @@ public abstract class AbstractInputFormat {
     LinkedList<InputSplit> splits = new LinkedList<>();
     try (AccumuloClient client = createClient(context)) {
       Map<String,InputTableConfig> tableConfigs = InputConfigurator.getInputTableConfigs(CLASS,
-        context.getConfiguration());
+          context.getConfiguration());
       for (Map.Entry<String,InputTableConfig> tableConfigEntry : tableConfigs.entrySet()) {
 
         String tableName = tableConfigEntry.getKey();

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AbstractInputFormat.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AbstractInputFormat.java
@@ -182,35 +182,6 @@ public abstract class AbstractInputFormat {
     return InputConfigurator.getScanAuthorizations(CLASS, context.getConfiguration());
   }
 
-  /**
-   * Fetches all {@link InputTableConfig}s that have been set on the given job.
-   *
-   * @param context
-   *          the Hadoop job instance to be configured
-   * @return the {@link InputTableConfig} objects for the job
-   * @since 1.6.0
-   */
-  public static Map<String,InputTableConfig> getInputTableConfigs(JobContext context) {
-    return InputConfigurator.getInputTableConfigs(CLASS, context.getConfiguration());
-  }
-
-  /**
-   * Fetches a {@link InputTableConfig} that has been set on the configuration for a specific table.
-   *
-   * <p>
-   * null is returned in the event that the table doesn't exist.
-   *
-   * @param context
-   *          the Hadoop job instance to be configured
-   * @param tableName
-   *          the table name for which to grab the config object
-   * @return the {@link InputTableConfig} for the given table
-   * @since 1.6.0
-   */
-  protected static InputTableConfig getInputTableConfig(JobContext context, String tableName) {
-    return InputConfigurator.getInputTableConfig(CLASS, context.getConfiguration(), tableName);
-  }
-
   // InputFormat doesn't have the equivalent of OutputFormat's checkOutputSpecs(JobContext job)
   /**
    * Check whether a configuration is fully configured to be used with an Accumulo
@@ -310,7 +281,8 @@ public abstract class AbstractInputFormat {
       // in case the table name changed, we can still use the previous name for terms of
       // configuration,
       // but the scanner will use the table id resolved at job setup time
-      InputTableConfig tableConfig = getInputTableConfig(attempt, split.getTableName());
+      InputTableConfig tableConfig = InputConfigurator.getInputTableConfig(CLASS,
+          attempt.getConfiguration(), split.getTableName());
 
       log.debug("Creating client with user: " + client.whoami());
       log.debug("Creating scanner for table: " + table);
@@ -476,7 +448,8 @@ public abstract class AbstractInputFormat {
     Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     try (AccumuloClient client = createClient(context)) {
-      Map<String,InputTableConfig> tableConfigs = getInputTableConfigs(context);
+      Map<String,InputTableConfig> tableConfigs = InputConfigurator.getInputTableConfigs(CLASS,
+        context.getConfiguration());
       for (Map.Entry<String,InputTableConfig> tableConfigEntry : tableConfigs.entrySet()) {
 
         String tableName = tableConfigEntry.getKey();

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.apache.accumulo.hadoopImpl.mapreduce;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -50,7 +49,6 @@ public class InputFormatBuilderImpl<T>
   ClientInfo clientInfo;
 
   String currentTable;
-  Map<String,IteratorSetting> iterators = Collections.emptyMap();
   Map<String,InputTableConfig> tableConfigMap = Collections.emptyMap();
 
   public InputFormatBuilderImpl(Class<?> callingClass) {
@@ -69,7 +67,6 @@ public class InputFormatBuilderImpl<T>
     this.currentTable = Objects.requireNonNull(tableName, "Table name must not be null");
     if (tableConfigMap.isEmpty())
       tableConfigMap = new LinkedHashMap<>();
-    this.iterators = new LinkedHashMap<>();
     tableConfigMap.put(currentTable, new InputTableConfig());
     return this;
   }
@@ -112,8 +109,7 @@ public class InputFormatBuilderImpl<T>
   public InputFormatBuilder.InputFormatOptions<T> addIterator(IteratorSetting cfg) {
     // store iterators by name to prevent duplicates
     Objects.requireNonNull(cfg, "IteratorSetting must not be null.");
-    this.iterators.put(cfg.getName(), cfg);
-    tableConfigMap.get(currentTable).setIterators(new ArrayList<>(this.iterators.values()));
+    tableConfigMap.get(currentTable).addIterator(cfg);
     return this;
   }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -16,12 +16,13 @@
  */
 package org.apache.accumulo.hadoopImpl.mapreduce;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -46,17 +47,11 @@ public class InputFormatBuilderImpl<T>
     InputFormatBuilder.TableParams<T>, InputFormatBuilder.InputFormatOptions<T> {
 
   Class<?> callingClass;
-  String tableName;
   ClientInfo clientInfo;
-  Authorizations scanAuths;
 
-  Optional<String> context = Optional.empty();
-  Collection<Range> ranges = Collections.emptyList();
-  Collection<IteratorSetting.Column> fetchColumns = Collections.emptyList();
+  String currentTable;
   Map<String,IteratorSetting> iterators = Collections.emptyMap();
-  Optional<SamplerConfiguration> samplerConfig = Optional.empty();
-  Map<String,String> hints = Collections.emptyMap();
-  BuilderBooleans bools = new BuilderBooleans();
+  Map<String,InputTableConfig> tableConfigMap = Collections.emptyMap();
 
   public InputFormatBuilderImpl(Class<?> callingClass) {
     this.callingClass = callingClass;
@@ -71,38 +66,45 @@ public class InputFormatBuilderImpl<T>
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> table(String tableName) {
-    this.tableName = Objects.requireNonNull(tableName, "Table name must not be null");
+    this.currentTable = Objects.requireNonNull(tableName, "Table name must not be null");
+    if (tableConfigMap.isEmpty())
+      tableConfigMap = new LinkedHashMap<>();
+    this.iterators = new LinkedHashMap<>();
+    tableConfigMap.put(currentTable, new InputTableConfig());
     return this;
   }
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> auths(Authorizations auths) {
-    this.scanAuths = Objects.requireNonNull(auths, "Authorizations must not be null");
+    tableConfigMap.get(currentTable)
+        .setScanAuths(Objects.requireNonNull(auths, "Authorizations must not be null"));
     return this;
   }
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> classLoaderContext(String context) {
-    this.context = Optional.of(context);
+    tableConfigMap.get(currentTable).setContext(context);
     return this;
   }
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> ranges(Collection<Range> ranges) {
-    this.ranges = ImmutableList
+    List<Range> newRanges = ImmutableList
         .copyOf(Objects.requireNonNull(ranges, "Collection of ranges is null"));
-    if (this.ranges.size() == 0)
+    if (newRanges.size() == 0)
       throw new IllegalArgumentException("Specified collection of ranges is empty.");
+    tableConfigMap.get(currentTable).setRanges(newRanges);
     return this;
   }
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> fetchColumns(
       Collection<IteratorSetting.Column> fetchColumns) {
-    this.fetchColumns = ImmutableList
+    Collection<IteratorSetting.Column> newFetchColumns = ImmutableList
         .copyOf(Objects.requireNonNull(fetchColumns, "Collection of fetch columns is null"));
-    if (this.fetchColumns.size() == 0)
+    if (newFetchColumns.size() == 0)
       throw new IllegalArgumentException("Specified collection of fetch columns is empty.");
+    tableConfigMap.get(currentTable).fetchColumns(newFetchColumns);
     return this;
   }
 
@@ -110,57 +112,57 @@ public class InputFormatBuilderImpl<T>
   public InputFormatBuilder.InputFormatOptions<T> addIterator(IteratorSetting cfg) {
     // store iterators by name to prevent duplicates
     Objects.requireNonNull(cfg, "IteratorSetting must not be null.");
-    if (this.iterators.size() == 0)
-      this.iterators = new LinkedHashMap<>();
     this.iterators.put(cfg.getName(), cfg);
+    tableConfigMap.get(currentTable).setIterators(new ArrayList<>(this.iterators.values()));
     return this;
   }
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> executionHints(Map<String,String> hints) {
-    this.hints = ImmutableMap
+    Map<String,String> newHints = ImmutableMap
         .copyOf(Objects.requireNonNull(hints, "Map of execution hints must not be null."));
-    if (hints.size() == 0)
+    if (newHints.size() == 0)
       throw new IllegalArgumentException("Specified map of execution hints is empty.");
+    tableConfigMap.get(currentTable).setExecutionHints(newHints);
     return this;
   }
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> samplerConfiguration(
       SamplerConfiguration samplerConfig) {
-    this.samplerConfig = Optional.of(samplerConfig);
+    tableConfigMap.get(currentTable).setSamplerConfiguration(samplerConfig);
     return this;
   }
 
   @Override
   public InputFormatOptions<T> autoAdjustRanges(boolean value) {
-    bools.autoAdjustRanges = value;
+    tableConfigMap.get(currentTable).setAutoAdjustRanges(value);
     return this;
   }
 
   @Override
   public InputFormatOptions<T> scanIsolation(boolean value) {
-    bools.scanIsolation = value;
+    tableConfigMap.get(currentTable).setUseIsolatedScanners(value);
     return this;
   }
 
   @Override
   public InputFormatOptions<T> localIterators(boolean value) {
-    bools.localIters = value;
+    tableConfigMap.get(currentTable).setUseLocalIterators(value);
     return this;
   }
 
   @Override
   public InputFormatOptions<T> offlineScan(boolean value) {
-    bools.offlineScan = value;
+    tableConfigMap.get(currentTable).setOfflineScan(value);
     return this;
   }
 
   @Override
   public InputFormatOptions<T> batchScan(boolean value) {
-    bools.batchScan = value;
+    tableConfigMap.get(currentTable).setUseBatchScan(value);
     if (value)
-      bools.autoAdjustRanges = true;
+      tableConfigMap.get(currentTable).setAutoAdjustRanges(true);
     return this;
   }
 
@@ -180,30 +182,40 @@ public class InputFormatBuilderImpl<T>
    */
   private void store(Job job) throws AccumuloException, AccumuloSecurityException {
     AbstractInputFormat.setClientInfo(job, clientInfo);
-    InputFormatBase.setInputTableName(job, tableName);
-
-    scanAuths = getUserAuths(scanAuths, clientInfo);
-    AbstractInputFormat.setScanAuthorizations(job, scanAuths);
-
-    // all optional values
-    if (context.isPresent())
-      AbstractInputFormat.setClassLoaderContext(job, context.get());
-    if (ranges.size() > 0)
-      InputFormatBase.setRanges(job, ranges);
-    if (iterators.size() > 0)
-      InputConfigurator.writeIteratorsToConf(callingClass, job.getConfiguration(),
-          iterators.values());
-    if (fetchColumns.size() > 0)
-      InputConfigurator.fetchColumns(callingClass, job.getConfiguration(), fetchColumns);
-    if (samplerConfig.isPresent())
-      InputFormatBase.setSamplerConfiguration(job, samplerConfig.get());
-    if (hints.size() > 0)
-      InputFormatBase.setExecutionHints(job, hints);
-    InputFormatBase.setAutoAdjustRanges(job, bools.autoAdjustRanges);
-    InputFormatBase.setScanIsolation(job, bools.scanIsolation);
-    InputFormatBase.setLocalIterators(job, bools.localIters);
-    InputFormatBase.setOfflineTableScan(job, bools.offlineScan);
-    InputFormatBase.setBatchScan(job, bools.batchScan);
+    if (tableConfigMap.size() == 0) {
+      throw new IllegalArgumentException("At least one Table must be configured for job.");
+    }
+    // if only one table use the single table configuration method
+    if (tableConfigMap.size() == 1) {
+      Map.Entry<String,InputTableConfig> entry = tableConfigMap.entrySet().iterator().next();
+      InputFormatBase.setInputTableName(job, entry.getKey());
+      InputTableConfig config = entry.getValue();
+      if (!config.getScanAuths().isPresent())
+        config.setScanAuths(getUserAuths(clientInfo));
+      AbstractInputFormat.setScanAuthorizations(job, config.getScanAuths().get());
+      // all optional values
+      if (config.getContext().isPresent())
+        AbstractInputFormat.setClassLoaderContext(job, config.getContext().get());
+      if (config.getRanges().size() > 0)
+        InputFormatBase.setRanges(job, config.getRanges());
+      if (config.getIterators().size() > 0)
+        InputConfigurator.writeIteratorsToConf(callingClass, job.getConfiguration(),
+            config.getIterators());
+      if (config.getFetchedColumns().size() > 0)
+        InputConfigurator.fetchColumns(callingClass, job.getConfiguration(),
+            config.getFetchedColumns());
+      if (config.getSamplerConfiguration() != null)
+        InputFormatBase.setSamplerConfiguration(job, config.getSamplerConfiguration());
+      if (config.getExecutionHints().size() > 0)
+        InputFormatBase.setExecutionHints(job, config.getExecutionHints());
+      InputFormatBase.setAutoAdjustRanges(job, config.shouldAutoAdjustRanges());
+      InputFormatBase.setScanIsolation(job, config.shouldUseIsolatedScanners());
+      InputFormatBase.setLocalIterators(job, config.shouldUseLocalIterators());
+      InputFormatBase.setOfflineTableScan(job, config.isOfflineScan());
+      InputFormatBase.setBatchScan(job, config.shouldBatchScan());
+    } else {
+      InputConfigurator.setInputTableConfigs(callingClass, job.getConfiguration(), tableConfigMap);
+    }
   }
 
   /**
@@ -211,52 +223,56 @@ public class InputFormatBuilderImpl<T>
    */
   private void store(JobConf jobConf) throws AccumuloException, AccumuloSecurityException {
     org.apache.accumulo.hadoopImpl.mapred.AbstractInputFormat.setClientInfo(jobConf, clientInfo);
-    org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setInputTableName(jobConf, tableName);
-
-    scanAuths = getUserAuths(scanAuths, clientInfo);
-    org.apache.accumulo.hadoopImpl.mapred.AbstractInputFormat.setScanAuthorizations(jobConf,
-        scanAuths);
-
-    // all optional values
-    if (context.isPresent())
-      org.apache.accumulo.hadoopImpl.mapred.AbstractInputFormat.setClassLoaderContext(jobConf,
-          context.get());
-    if (ranges.size() > 0)
-      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setRanges(jobConf, ranges);
-    if (iterators.size() > 0)
-      InputConfigurator.writeIteratorsToConf(callingClass, jobConf, iterators.values());
-    if (fetchColumns.size() > 0)
-      InputConfigurator.fetchColumns(callingClass, jobConf, fetchColumns);
-    if (samplerConfig.isPresent())
-      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setSamplerConfiguration(jobConf,
-          samplerConfig.get());
-    if (hints.size() > 0)
-      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setExecutionHints(jobConf, hints);
-    org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setAutoAdjustRanges(jobConf,
-        bools.autoAdjustRanges);
-    org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setScanIsolation(jobConf,
-        bools.scanIsolation);
-    org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setLocalIterators(jobConf,
-        bools.localIters);
-    org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setOfflineTableScan(jobConf,
-        bools.offlineScan);
-    org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setBatchScan(jobConf, bools.batchScan);
+    if (tableConfigMap.size() == 0) {
+      throw new IllegalArgumentException("At least one Table must be configured for job.");
+    }
+    // if only one table use the single table configuration method
+    if (tableConfigMap.size() == 1) {
+      Map.Entry<String,InputTableConfig> entry = tableConfigMap.entrySet().iterator().next();
+      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setInputTableName(jobConf,
+          entry.getKey());
+      InputTableConfig config = entry.getValue();
+      if (!config.getScanAuths().isPresent())
+        config.setScanAuths(getUserAuths(clientInfo));
+      org.apache.accumulo.hadoopImpl.mapred.AbstractInputFormat.setScanAuthorizations(jobConf,
+          config.getScanAuths().get());
+      // all optional values
+      if (config.getContext().isPresent())
+        org.apache.accumulo.hadoopImpl.mapred.AbstractInputFormat.setClassLoaderContext(jobConf,
+            config.getContext().get());
+      if (config.getRanges().size() > 0)
+        org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setRanges(jobConf,
+            config.getRanges());
+      if (config.getIterators().size() > 0)
+        InputConfigurator.writeIteratorsToConf(callingClass, jobConf, config.getIterators());
+      if (config.getFetchedColumns().size() > 0)
+        InputConfigurator.fetchColumns(callingClass, jobConf, config.getFetchedColumns());
+      if (config.getSamplerConfiguration() != null)
+        org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setSamplerConfiguration(jobConf,
+            config.getSamplerConfiguration());
+      if (config.getExecutionHints().size() > 0)
+        org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setExecutionHints(jobConf,
+            config.getExecutionHints());
+      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setAutoAdjustRanges(jobConf,
+          config.shouldAutoAdjustRanges());
+      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setScanIsolation(jobConf,
+          config.shouldUseIsolatedScanners());
+      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setLocalIterators(jobConf,
+          config.shouldUseLocalIterators());
+      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setOfflineTableScan(jobConf,
+          config.isOfflineScan());
+      org.apache.accumulo.hadoopImpl.mapred.InputFormatBase.setBatchScan(jobConf,
+          config.shouldBatchScan());
+    } else {
+      InputConfigurator.setInputTableConfigs(callingClass, jobConf, tableConfigMap);
+    }
   }
 
-  private Authorizations getUserAuths(Authorizations scanAuths, ClientInfo clientInfo)
+  private Authorizations getUserAuths(ClientInfo clientInfo)
       throws AccumuloSecurityException, AccumuloException {
-    if (scanAuths != null)
-      return scanAuths;
     try (AccumuloClient c = Accumulo.newClient().from(clientInfo.getProperties()).build()) {
       return c.securityOperations().getUserAuthorizations(clientInfo.getPrincipal());
     }
   }
 
-  private static class BuilderBooleans {
-    boolean autoAdjustRanges = true;
-    boolean scanIsolation = false;
-    boolean offlineScan = false;
-    boolean localIters = false;
-    boolean batchScan = false;
-  }
 }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -780,7 +780,7 @@ public class InputConfigurator extends ConfiguratorBase {
       InputTableConfig queryConfig = new InputTableConfig();
       List<IteratorSetting> itrs = getIterators(implementingClass, conf);
       if (itrs != null)
-        queryConfig.setIterators(itrs);
+        itrs.forEach(itr -> queryConfig.addIterator(itr));
       Set<IteratorSetting.Column> columns = getFetchedColumns(implementingClass, conf);
       if (columns != null)
         queryConfig.fetchColumns(columns);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/MultiTableInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/MultiTableInputFormatIT.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.hadoop.its.mapred;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.hadoop.mapred.AccumuloInputFormat;
+import org.apache.accumulo.hadoopImpl.mapred.RangeInputSplit;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobClient;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Mapper;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.lib.NullOutputFormat;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.Test;
+
+public class MultiTableInputFormatIT extends AccumuloClusterHarness {
+
+  private static AssertionError e1 = null;
+  private static AssertionError e2 = null;
+
+  private static class MRTester extends Configured implements Tool {
+    private static class TestMapper implements Mapper<Key,Value,Key,Value> {
+      Key key = null;
+      int count = 0;
+
+      @Override
+      public void map(Key k, Value v, OutputCollector<Key,Value> output, Reporter reporter)
+          throws IOException {
+        try {
+          String tableName = ((RangeInputSplit) reporter.getInputSplit()).getTableName();
+          if (key != null)
+            assertEquals(key.getRow().toString(), new String(v.get()));
+          assertEquals(new Text(String.format("%s_%09x", tableName, count + 1)), k.getRow());
+          assertEquals(String.format("%s_%09x", tableName, count), new String(v.get()));
+        } catch (AssertionError e) {
+          e1 = e;
+        }
+        key = new Key(k);
+        count++;
+      }
+
+      @Override
+      public void configure(JobConf job) {}
+
+      @Override
+      public void close() throws IOException {
+        try {
+          assertEquals(100, count);
+        } catch (AssertionError e) {
+          e2 = e;
+        }
+      }
+
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+
+      if (args.length != 2) {
+        throw new IllegalArgumentException(
+            "Usage : " + MRTester.class.getName() + " <table1> <table2>");
+      }
+
+      String table1 = args[0];
+      String table2 = args[1];
+
+      JobConf job = new JobConf(getConf());
+      job.setJarByClass(this.getClass());
+
+      job.setInputFormat(AccumuloInputFormat.class);
+
+      AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties())
+          .table(table1).table(table2).store(job);
+
+      job.setMapperClass(TestMapper.class);
+      job.setMapOutputKeyClass(Key.class);
+      job.setMapOutputValueClass(Value.class);
+      job.setOutputFormat(NullOutputFormat.class);
+
+      job.setNumReduceTasks(0);
+
+      return JobClient.runJob(job).isSuccessful() ? 0 : 1;
+    }
+
+    public static void main(String[] args) throws Exception {
+      Configuration conf = new Configuration();
+      conf.set("mapreduce.framework.name", "local");
+      conf.set("mapreduce.cluster.local.dir",
+          new File(System.getProperty("user.dir"), "target/mapreduce-tmp").getAbsolutePath());
+      assertEquals(0, ToolRunner.run(conf, new MRTester(), args));
+    }
+  }
+
+  @Test
+  public void testMap() throws Exception {
+    String[] tableNames = getUniqueNames(2);
+    String table1 = tableNames[0];
+    String table2 = tableNames[1];
+    try (AccumuloClient c = getAccumuloClient()) {
+      c.tableOperations().create(table1);
+      c.tableOperations().create(table2);
+      BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());
+      BatchWriter bw2 = c.createBatchWriter(table2, new BatchWriterConfig());
+      for (int i = 0; i < 100; i++) {
+        Mutation t1m = new Mutation(new Text(String.format("%s_%09x", table1, i + 1)));
+        t1m.put(new Text(), new Text(), new Value(String.format("%s_%09x", table1, i).getBytes()));
+        bw.addMutation(t1m);
+        Mutation t2m = new Mutation(new Text(String.format("%s_%09x", table2, i + 1)));
+        t2m.put(new Text(), new Text(), new Value(String.format("%s_%09x", table2, i).getBytes()));
+        bw2.addMutation(t2m);
+      }
+      bw.close();
+      bw2.close();
+
+      MRTester.main(new String[] {table1, table2});
+      assertNull(e1);
+      assertNull(e2);
+    }
+  }
+
+}

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/MultiTableInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/MultiTableInputFormatIT.java
@@ -127,7 +127,7 @@ public class MultiTableInputFormatIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MultiTableInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MultiTableInputFormatIT.java
@@ -127,7 +127,7 @@ public class MultiTableInputFormatIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MultiTableInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/MultiTableInputFormatIT.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.hadoop.its.mapreduce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.hadoopImpl.mapreduce.RangeInputSplit;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.Test;
+
+public class MultiTableInputFormatIT extends AccumuloClusterHarness {
+
+  private static AssertionError e1 = null;
+  private static AssertionError e2 = null;
+
+  private static class MRTester extends Configured implements Tool {
+
+    private static class TestMapper extends Mapper<Key,Value,Key,Value> {
+      Key key = null;
+      int count = 0;
+
+      @Override
+      protected void map(Key k, Value v, Context context) throws IOException, InterruptedException {
+        try {
+          String tableName = ((RangeInputSplit) context.getInputSplit()).getTableName();
+          if (key != null)
+            assertEquals(key.getRow().toString(), new String(v.get()));
+          assertEquals(new Text(String.format("%s_%09x", tableName, count + 1)), k.getRow());
+          assertEquals(String.format("%s_%09x", tableName, count), new String(v.get()));
+        } catch (AssertionError e) {
+          e1 = e;
+        }
+        key = new Key(k);
+        count++;
+      }
+
+      @Override
+      protected void cleanup(Context context) throws IOException, InterruptedException {
+        try {
+          assertEquals(100, count);
+        } catch (AssertionError e) {
+          e2 = e;
+        }
+      }
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+
+      if (args.length != 2) {
+        throw new IllegalArgumentException(
+            "Usage : " + MRTester.class.getName() + " <table1> <table2>");
+      }
+
+      String table1 = args[0];
+      String table2 = args[1];
+
+      Job job = Job.getInstance(getConf(),
+          this.getClass().getSimpleName() + "_" + System.currentTimeMillis());
+      job.setJarByClass(this.getClass());
+
+      job.setInputFormatClass(AccumuloInputFormat.class);
+
+      AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties())
+          .table(table1).table(table2).store(job);
+
+      job.setMapperClass(TestMapper.class);
+      job.setMapOutputKeyClass(Key.class);
+      job.setMapOutputValueClass(Value.class);
+      job.setOutputFormatClass(NullOutputFormat.class);
+
+      job.setNumReduceTasks(0);
+
+      job.waitForCompletion(true);
+
+      return job.isSuccessful() ? 0 : 1;
+    }
+
+    public static void main(String[] args) throws Exception {
+      Configuration conf = new Configuration();
+      conf.set("mapreduce.framework.name", "local");
+      conf.set("mapreduce.cluster.local.dir",
+          new File(System.getProperty("user.dir"), "target/mapreduce-tmp").getAbsolutePath());
+      assertEquals(0, ToolRunner.run(conf, new MRTester(), args));
+    }
+  }
+
+  /**
+   * Generate incrementing counts and attach table name to the key/value so that order and
+   * multi-table data can be verified.
+   */
+  @Test
+  public void testMap() throws Exception {
+    String[] tableNames = getUniqueNames(2);
+    String table1 = tableNames[0];
+    String table2 = tableNames[1];
+    try (AccumuloClient c = getAccumuloClient()) {
+      c.tableOperations().create(table1);
+      c.tableOperations().create(table2);
+      BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());
+      BatchWriter bw2 = c.createBatchWriter(table2, new BatchWriterConfig());
+      for (int i = 0; i < 100; i++) {
+        Mutation t1m = new Mutation(new Text(String.format("%s_%09x", table1, i + 1)));
+        t1m.put(new Text(), new Text(), new Value(String.format("%s_%09x", table1, i).getBytes()));
+        bw.addMutation(t1m);
+        Mutation t2m = new Mutation(new Text(String.format("%s_%09x", table2, i + 1)));
+        t2m.put(new Text(), new Text(), new Value(String.format("%s_%09x", table2, i).getBytes()));
+        bw2.addMutation(t2m);
+      }
+      bw.close();
+      bw2.close();
+
+      MRTester.main(new String[] {table1, table2});
+      assertNull(e1);
+      assertNull(e2);
+    }
+  }
+
+}

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 
 public class AccumuloInputFormatTest {
@@ -49,6 +50,8 @@ public class AccumuloInputFormatTest {
 
   @Rule
   public TestName test = new TestName();
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
 
   @Before
   public void createJob() {
@@ -59,6 +62,14 @@ public class AccumuloInputFormatTest {
   public static void setupClientInfo() {
     clientProperties = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
         .setupClientProperties();
+  }
+
+  @Test
+  public void testMissingTable() throws Exception {
+    Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
+        .setupClientProperties();
+    exception.expect(IllegalArgumentException.class);
+    AccumuloInputFormat.configure().clientProperties(clientProps).store(new JobConf());
   }
 
   /**

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/MultiTableInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/MultiTableInputFormatTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.hadoop.mapred;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.IteratorSetting.Column;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.hadoop.mapreduce.InputFormatBuilder;
+import org.apache.accumulo.hadoopImpl.mapreduce.InputTableConfig;
+import org.apache.accumulo.hadoopImpl.mapreduce.lib.InputConfigurator;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class MultiTableInputFormatTest {
+  public static final Class<AccumuloInputFormat> CLASS = AccumuloInputFormat.class;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  /**
+   * Verify {@link InputTableConfig} objects get correctly serialized in the JobContext.
+   */
+  @Test
+  public void testStoreTables() throws Exception {
+    String table1Name = testName.getMethodName() + "1";
+    String table2Name = testName.getMethodName() + "2";
+    JobConf job = new JobConf();
+    Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
+        .setupClientProperties();
+    List<Range> ranges = singletonList(new Range("a", "b"));
+    Set<IteratorSetting.Column> cols = singleton(
+        new IteratorSetting.Column(new Text("CF1"), new Text("CQ1")));
+    IteratorSetting iter1 = new IteratorSetting(50, "iter1", "iterclass1");
+    IteratorSetting iter2 = new IteratorSetting(60, "iter2", "iterclass2");
+    List<IteratorSetting> allIters = new ArrayList<>();
+    allIters.add(iter1);
+    allIters.add(iter2);
+
+    // if auths are not set client will try to get from server, we dont want that here
+    Authorizations auths = Authorizations.EMPTY;
+
+    // @formatter:off
+    AccumuloInputFormat.configure().clientProperties(clientProps)
+        .table(table1Name).auths(auths).ranges(ranges).fetchColumns(cols).addIterator(iter1)
+        .addIterator(iter2).localIterators(true).offlineScan(true) // end table 1
+        .table(table2Name).auths(auths).ranges(ranges).fetchColumns(cols).addIterator(iter2) // end
+        .store(job);
+    // @formatter:on
+
+    InputTableConfig table1 = new InputTableConfig();
+    table1.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(allIters)
+        .setUseLocalIterators(true).setOfflineScan(true);
+    InputTableConfig table2 = new InputTableConfig();
+    table2.setScanAuths(auths).setRanges(ranges).fetchColumns(cols)
+        .setIterators(singletonList(iter2));
+
+    assertEquals(table1, InputConfigurator.getInputTableConfig(CLASS, job, table1Name));
+    assertEquals(table2, InputConfigurator.getInputTableConfig(CLASS, job, table2Name));
+  }
+
+  @Test
+  public void testManyTables() throws Exception {
+    JobConf job = new JobConf();
+    Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
+        .setupClientProperties();
+
+    // if auths are not set client will try to get from server, we dont want that here
+    Authorizations auths = Authorizations.EMPTY;
+
+    // set the client properties once then loop over tables
+    InputFormatBuilder.TableParams<JobConf> opts = AccumuloInputFormat.configure()
+        .clientProperties(clientProps);
+    for (int i = 0; i < 10_000; i++) {
+      List<Range> ranges = singletonList(new Range("a" + i, "b" + i));
+      Set<Column> cols = singleton(new Column(new Text("CF" + i), new Text("CQ" + i)));
+      IteratorSetting iter = new IteratorSetting(50, "iter" + i, "iterclass" + i);
+      opts.table("table" + i).auths(auths).ranges(ranges).fetchColumns(cols).addIterator(iter);
+    }
+    opts.store(job);
+
+    // verify
+    Map<String,InputTableConfig> configs = InputConfigurator.getInputTableConfigs(CLASS, job);
+    assertEquals(10_000, configs.size());
+
+    // create objects to test against
+    for (int i = 0; i < 10_000; i++) {
+      InputTableConfig t = new InputTableConfig();
+      List<Range> ranges = singletonList(new Range("a" + i, "b" + i));
+      Set<Column> cols = singleton(new Column(new Text("CF" + i), new Text("CQ" + i)));
+      IteratorSetting iter = new IteratorSetting(50, "iter" + i, "iterclass" + i);
+      t.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(singletonList(iter));
+      assertEquals(t, configs.get("table" + i));
+    }
+  }
+}

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/MultiTableInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/MultiTableInputFormatTest.java
@@ -76,11 +76,11 @@ public class MultiTableInputFormatTest {
     // @formatter:on
 
     InputTableConfig table1 = new InputTableConfig();
-    table1.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(allIters)
-        .setUseLocalIterators(true).setOfflineScan(true);
+    table1.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setUseLocalIterators(true)
+        .setOfflineScan(true);
+    allIters.forEach(itr -> table1.addIterator(itr));
     InputTableConfig table2 = new InputTableConfig();
-    table2.setScanAuths(auths).setRanges(ranges).fetchColumns(cols)
-        .setIterators(singletonList(iter2));
+    table2.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).addIterator(iter2);
 
     assertEquals(table1, InputConfigurator.getInputTableConfig(CLASS, job, table1Name));
     assertEquals(table2, InputConfigurator.getInputTableConfig(CLASS, job, table2Name));
@@ -116,7 +116,7 @@ public class MultiTableInputFormatTest {
       List<Range> ranges = singletonList(new Range("a" + i, "b" + i));
       Set<Column> cols = singleton(new Column(new Text("CF" + i), new Text("CQ" + i)));
       IteratorSetting iter = new IteratorSetting(50, "iter" + i, "iterclass" + i);
-      t.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(singletonList(iter));
+      t.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).addIterator(iter);
       assertEquals(t, configs.get("table" + i));
     }
   }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
@@ -39,9 +39,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AccumuloInputFormatTest {
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
   static Properties clientProperties;
 
   @BeforeClass
@@ -57,6 +62,14 @@ public class AccumuloInputFormatTest {
     cp.setProperty(ClientProperty.AUTH_PRINCIPAL.getKey(), "test-principal");
     cp.setProperty(ClientProperty.AUTH_TOKEN.getKey(), "test-token");
     return cp;
+  }
+
+  @Test
+  public void testMissingTable() throws Exception {
+    Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
+        .setupClientProperties();
+    exception.expect(IllegalArgumentException.class);
+    AccumuloInputFormat.configure().clientProperties(clientProps).store(new Job());
   }
 
   /**

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
@@ -69,7 +69,7 @@ public class AccumuloInputFormatTest {
     Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
         .setupClientProperties();
     exception.expect(IllegalArgumentException.class);
-    AccumuloInputFormat.configure().clientProperties(clientProps).store(new Job());
+    AccumuloInputFormat.configure().clientProperties(clientProps).store(Job.getInstance());
   }
 
   /**

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/MultiTableInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/MultiTableInputFormatTest.java
@@ -52,7 +52,7 @@ public class MultiTableInputFormatTest {
   public void testStoreTables() throws Exception {
     String table1Name = testName.getMethodName() + "1";
     String table2Name = testName.getMethodName() + "2";
-    Job job = new Job();
+    Job job = Job.getInstance();
     Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
         .setupClientProperties();
     List<Range> ranges = singletonList(new Range("a", "b"));
@@ -76,11 +76,11 @@ public class MultiTableInputFormatTest {
     // @formatter:on
 
     InputTableConfig table1 = new InputTableConfig();
-    table1.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(allIters)
-        .setUseLocalIterators(true).setOfflineScan(true);
+    table1.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setUseLocalIterators(true)
+        .setOfflineScan(true);
+    allIters.forEach(itr -> table1.addIterator(itr));
     InputTableConfig table2 = new InputTableConfig();
-    table2.setScanAuths(auths).setRanges(ranges).fetchColumns(cols)
-        .setIterators(singletonList(iter2));
+    table2.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).addIterator(iter2);
 
     Configuration jc = job.getConfiguration();
     assertEquals(table1, InputConfigurator.getInputTableConfig(CLASS, jc, table1Name));
@@ -89,7 +89,7 @@ public class MultiTableInputFormatTest {
 
   @Test
   public void testManyTables() throws Exception {
-    Job job = new Job();
+    Job job = Job.getInstance();
     Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
         .setupClientProperties();
 
@@ -118,7 +118,7 @@ public class MultiTableInputFormatTest {
       List<Range> ranges = singletonList(new Range("a" + i, "b" + i));
       Set<Column> cols = singleton(new Column(new Text("CF" + i), new Text("CQ" + i)));
       IteratorSetting iter = new IteratorSetting(50, "iter" + i, "iterclass" + i);
-      t.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(singletonList(iter));
+      t.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).addIterator(iter);
       assertEquals(t, configs.get("table" + i));
     }
   }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/MultiTableInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/MultiTableInputFormatTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.hadoop.mapreduce;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.IteratorSetting.Column;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.hadoopImpl.mapreduce.InputTableConfig;
+import org.apache.accumulo.hadoopImpl.mapreduce.lib.InputConfigurator;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class MultiTableInputFormatTest {
+  public static final Class<AccumuloInputFormat> CLASS = AccumuloInputFormat.class;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  /**
+   * Verify {@link InputTableConfig} objects get correctly serialized in the JobContext.
+   */
+  @Test
+  public void testStoreTables() throws Exception {
+    String table1Name = testName.getMethodName() + "1";
+    String table2Name = testName.getMethodName() + "2";
+    Job job = new Job();
+    Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
+        .setupClientProperties();
+    List<Range> ranges = singletonList(new Range("a", "b"));
+    Set<IteratorSetting.Column> cols = singleton(
+        new IteratorSetting.Column(new Text("CF1"), new Text("CQ1")));
+    IteratorSetting iter1 = new IteratorSetting(50, "iter1", "iterclass1");
+    IteratorSetting iter2 = new IteratorSetting(60, "iter2", "iterclass2");
+    List<IteratorSetting> allIters = new ArrayList<>();
+    allIters.add(iter1);
+    allIters.add(iter2);
+
+    // if auths are not set client will try to get from server, we dont want that here
+    Authorizations auths = Authorizations.EMPTY;
+
+    // @formatter:off
+    AccumuloInputFormat.configure().clientProperties(clientProps)
+        .table(table1Name).auths(auths).ranges(ranges).fetchColumns(cols).addIterator(iter1)
+        .addIterator(iter2).localIterators(true).offlineScan(true) // end table 1
+        .table(table2Name).auths(auths).ranges(ranges).fetchColumns(cols).addIterator(iter2) // end
+        .store(job);
+    // @formatter:on
+
+    InputTableConfig table1 = new InputTableConfig();
+    table1.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(allIters)
+        .setUseLocalIterators(true).setOfflineScan(true);
+    InputTableConfig table2 = new InputTableConfig();
+    table2.setScanAuths(auths).setRanges(ranges).fetchColumns(cols)
+        .setIterators(singletonList(iter2));
+
+    Configuration jc = job.getConfiguration();
+    assertEquals(table1, InputConfigurator.getInputTableConfig(CLASS, jc, table1Name));
+    assertEquals(table2, InputConfigurator.getInputTableConfig(CLASS, jc, table2Name));
+  }
+
+  @Test
+  public void testManyTables() throws Exception {
+    Job job = new Job();
+    Properties clientProps = org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest
+        .setupClientProperties();
+
+    // if auths are not set client will try to get from server, we dont want that here
+    Authorizations auths = Authorizations.EMPTY;
+
+    // set the client properties once then loop over tables
+    InputFormatBuilder.TableParams<Job> opts = AccumuloInputFormat.configure()
+        .clientProperties(clientProps);
+    for (int i = 0; i < 10_000; i++) {
+      List<Range> ranges = singletonList(new Range("a" + i, "b" + i));
+      Set<Column> cols = singleton(new Column(new Text("CF" + i), new Text("CQ" + i)));
+      IteratorSetting iter = new IteratorSetting(50, "iter" + i, "iterclass" + i);
+      opts.table("table" + i).auths(auths).ranges(ranges).fetchColumns(cols).addIterator(iter);
+    }
+    opts.store(job);
+
+    // verify
+    Map<String,InputTableConfig> configs = InputConfigurator.getInputTableConfigs(CLASS,
+        job.getConfiguration());
+    assertEquals(10_000, configs.size());
+
+    // create objects to test against
+    for (int i = 0; i < 10_000; i++) {
+      InputTableConfig t = new InputTableConfig();
+      List<Range> ranges = singletonList(new Range("a" + i, "b" + i));
+      Set<Column> cols = singleton(new Column(new Text("CF" + i), new Text("CQ" + i)));
+      IteratorSetting iter = new IteratorSetting(50, "iter" + i, "iterclass" + i);
+      t.setScanAuths(auths).setRanges(ranges).fetchColumns(cols).setIterators(singletonList(iter));
+      assertEquals(t, configs.get("table" + i));
+    }
+  }
+}

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/InputTableConfigTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/InputTableConfigTest.java
@@ -97,7 +97,7 @@ public class InputTableConfigTest {
     List<IteratorSetting> settings = new ArrayList<>();
     settings.add(new IteratorSetting(50, "iter", "iterclass"));
     settings.add(new IteratorSetting(55, "iter2", "iterclass2"));
-    tableQueryConfig.setIterators(settings);
+    settings.forEach(itr -> tableQueryConfig.addIterator(itr));
     byte[] serialized = serialize(tableQueryConfig);
     InputTableConfig actualConfig = deserialize(serialized);
     assertEquals(actualConfig.getIterators(), settings);


### PR DESCRIPTION
* Modified new MapReduce builder and implemention to allow multiple
tables through the same fluent API as AccumuloInputFormat
* Removed redundant getInputTableConfig methods, replacing with InputConfigurator