### PR TITLE
 #820 Fix ITs by using createAccumuloClient

### DIFF
--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
@@ -82,7 +82,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void testEmptyWrite() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(EMPTY_TABLE);
       handleWriteTests(false);
     }
@@ -90,7 +90,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void testRealWrite() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE);
       BatchWriter bw = c.createBatchWriter(TEST_TABLE, new BatchWriterConfig());
       Mutation m = new Mutation("Key");
@@ -206,7 +206,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void writeBadVisibility() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(BAD_TABLE);
       BatchWriter bw = c.createBatchWriter(BAD_TABLE, new BatchWriterConfig());
       Mutation m = new Mutation("r1");

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloInputFormatIT.java
@@ -153,7 +153,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   @Test
   public void testMap() throws Exception {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table);
       BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig());
       for (int i = 0; i < 100; i++) {
@@ -179,7 +179,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   public void testSample() throws Exception {
     final String TEST_TABLE_3 = getUniqueNames(1)[0];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE_3,
           new NewTableConfiguration().enableSampling(SAMPLER_CONFIG));
       BatchWriter bw = c.createBatchWriter(TEST_TABLE_3, new BatchWriterConfig());
@@ -215,7 +215,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     Collection<IteratorSetting.Column> fetchColumns = Collections
         .singleton(new IteratorSetting.Column(new Text("foo"), new Text("bar")));
 
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       accumuloClient.tableOperations().create(table);
 
       AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties()).table(table)

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloRowInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloRowInputFormatIT.java
@@ -188,7 +188,7 @@ public class AccumuloRowInputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
       BatchWriter writer = null;

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
@@ -150,7 +150,7 @@ public class TokenFileIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
@@ -83,7 +83,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
     TEST_TABLE = PREFIX + "_mapreduce_test_table";
     EMPTY_TABLE = PREFIX + "_mapreduce_empty_table";
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(EMPTY_TABLE);
       c.tableOperations().create(TEST_TABLE);
       c.tableOperations().create(BAD_TABLE);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
@@ -127,7 +127,7 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloRowInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloRowInputFormatIT.java
@@ -183,7 +183,7 @@ public class AccumuloRowInputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
       BatchWriter writer = null;

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
@@ -144,7 +144,7 @@ public class TokenFileIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -78,7 +78,6 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
   private static boolean initialized = false;
 
   protected static AccumuloCluster cluster;
-  protected static AccumuloClient client;
   protected static ClusterType type;
   protected static AccumuloClusterPropertyConfiguration clusterConf;
   protected static TestingKdc krb;
@@ -102,9 +101,6 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
   public static void tearDownHarness() throws Exception {
     if (null != krb) {
       krb.stop();
-    }
-    if (client != null) {
-      client.close();
     }
   }
 
@@ -188,26 +184,28 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
           // permissions to)
           UserGroupInformation.loginUserFromKeytab(systemUser.getPrincipal(),
               systemUser.getKeytab().getAbsolutePath());
-          AccumuloClient client = cluster.createAccumuloClient(systemUser.getPrincipal(),
+          AccumuloClient c = cluster.createAccumuloClient(systemUser.getPrincipal(),
               new KerberosToken());
+          c.close();
 
           // Then, log back in as the "root" user and do the grant
           UserGroupInformation.loginUserFromKeytab(rootUser.getPrincipal(),
               rootUser.getKeytab().getAbsolutePath());
-          client = getAccumuloClient();
 
-          // Create the trace table
-          client.tableOperations().create(traceTable);
+          try (AccumuloClient client = createAccumuloClient()) {
+            // Create the trace table
+            client.tableOperations().create(traceTable);
 
-          // Trace user (which is the same kerberos principal as the system user, but using a normal
-          // KerberosToken) needs
-          // to have the ability to read, write and alter the trace table
-          client.securityOperations().grantTablePermission(systemUser.getPrincipal(), traceTable,
-              TablePermission.READ);
-          client.securityOperations().grantTablePermission(systemUser.getPrincipal(), traceTable,
-              TablePermission.WRITE);
-          client.securityOperations().grantTablePermission(systemUser.getPrincipal(), traceTable,
-              TablePermission.ALTER_TABLE);
+            // Trace user (which is the same kerberos principal as the system user, but using a normal
+            // KerberosToken) needs
+            // to have the ability to read, write and alter the trace table
+            client.securityOperations()
+                .grantTablePermission(systemUser.getPrincipal(), traceTable, TablePermission.READ);
+            client.securityOperations()
+                .grantTablePermission(systemUser.getPrincipal(), traceTable, TablePermission.WRITE);
+            client.securityOperations().grantTablePermission(systemUser.getPrincipal(), traceTable,
+                TablePermission.ALTER_TABLE);
+          }
         }
         break;
       default:
@@ -217,22 +215,26 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
 
   public void cleanupTables() throws Exception {
     final String tablePrefix = this.getClass().getSimpleName() + "_";
-    final TableOperations tops = getAccumuloClient().tableOperations();
-    for (String table : tops.list()) {
-      if (table.startsWith(tablePrefix)) {
-        log.debug("Removing table {}", table);
-        tops.delete(table);
+    try (AccumuloClient client = createAccumuloClient()) {
+      final TableOperations tops = client.tableOperations();
+      for (String table : tops.list()) {
+        if (table.startsWith(tablePrefix)) {
+          log.debug("Removing table {}", table);
+          tops.delete(table);
+        }
       }
     }
   }
 
   public void cleanupUsers() throws Exception {
     final String userPrefix = this.getClass().getSimpleName();
-    final SecurityOperations secOps = getAccumuloClient().securityOperations();
-    for (String user : secOps.listLocalUsers()) {
-      if (user.startsWith(userPrefix)) {
-        log.info("Dropping local user {}", user);
-        secOps.dropLocalUser(user);
+    try (AccumuloClient client = createAccumuloClient()) {
+      final SecurityOperations secOps = client.securityOperations();
+      for (String user : secOps.listLocalUsers()) {
+        if (user.startsWith(userPrefix)) {
+          log.info("Dropping local user {}", user);
+          secOps.dropLocalUser(user);
+        }
       }
     }
   }
@@ -363,13 +365,6 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
       fail("Could not connect to Accumulo: " + e.getMessage());
       throw new RuntimeException("Could not connect to Accumulo", e);
     }
-  }
-
-  public AccumuloClient getAccumuloClient() {
-    if (client == null) {
-      client = createAccumuloClient();
-    }
-    return client;
   }
 
   // TODO Really don't want this here. Will ultimately need to abstract configuration method away

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -84,7 +84,7 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
   protected static TestingKdc krb;
 
   @BeforeClass
-  public static void setUp() throws Exception {
+  public static void setUpHarness() throws Exception {
     clusterConf = AccumuloClusterPropertyConfiguration.get();
     type = clusterConf.getClusterType();
 
@@ -99,7 +99,7 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
   }
 
   @AfterClass
-  public static void tearDownKdc() throws Exception {
+  public static void tearDownHarness() throws Exception {
     if (null != krb) {
       krb.stop();
     }
@@ -352,18 +352,22 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
     return clusterConf;
   }
 
+  public AccumuloClient createAccumuloClient() {
+    try {
+      String princ = getAdminPrincipal();
+      AuthenticationToken token = getAdminToken();
+      log.debug("Creating client as {} with {}", princ, token);
+      return cluster.createAccumuloClient(princ, token);
+    } catch (Exception e) {
+      log.error("Could not connect to Accumulo", e);
+      fail("Could not connect to Accumulo: " + e.getMessage());
+      throw new RuntimeException("Could not connect to Accumulo", e);
+    }
+  }
+
   public AccumuloClient getAccumuloClient() {
     if (client == null) {
-      try {
-        String princ = getAdminPrincipal();
-        AuthenticationToken token = getAdminToken();
-        log.debug("Creating client as {} with {}", princ, token);
-        client = cluster.createAccumuloClient(princ, token);
-      } catch (Exception e) {
-        log.error("Could not connect to Accumulo", e);
-        fail("Could not connect to Accumulo: " + e.getMessage());
-        throw new RuntimeException("Could not connect to Accumulo", e);
-      }
+      client = createAccumuloClient();
     }
     return client;
   }

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -85,7 +85,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
 
   @Before
   public void alterConfig() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       InstanceOperations iops = client.instanceOperations();
       Map<String,String> config = iops.getSystemConfiguration();
       gcCycleDelay = config.get(Property.GC_CYCLE_DELAY.getKey());
@@ -96,7 +96,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
     }
     getCluster().getClusterControl().stopAllServers(ServerType.GARBAGE_COLLECTOR);
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       ClientInfo info = ClientInfo.from(client.properties());
       ZooCache zcache = new ZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       zcache.clear();
@@ -130,7 +130,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
 
   @After
   public void restoreConfig() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       InstanceOperations iops = c.instanceOperations();
       if (null != gcCycleDelay) {
         iops.setProperty(Property.GC_CYCLE_DELAY.getKey(), gcCycleDelay);
@@ -149,7 +149,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     // make a table
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       log.info("Creating table to be deleted");
       c.tableOperations().create(tableName);
       final String tableId = c.tableOperations().tableIdMap().get(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/BalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BalanceIT.java
@@ -37,7 +37,7 @@ public class BalanceIT extends AccumuloClusterHarness {
   @Test
   public void testBalance() throws Exception {
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       log.info("Creating table");
       c.tableOperations().create(tableName);
       SortedSet<Text> splits = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/BatchWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BatchWriterIT.java
@@ -35,7 +35,7 @@ public class BatchWriterIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     // call the batchwriter with buffer of size zero
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table);
       BatchWriterConfig config = new BatchWriterConfig();
       config.setMaxMemory(0);

--- a/test/src/main/java/org/apache/accumulo/test/BatchWriterInTabletServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BatchWriterInTabletServerIT.java
@@ -60,7 +60,7 @@ public class BatchWriterInTabletServerIT extends AccumuloClusterHarness {
   public void testNormalWrite() throws Exception {
     String[] uniqueNames = getUniqueNames(2);
     String t1 = uniqueNames[0], t2 = uniqueNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       int numEntriesToWritePerEntry = 50;
       IteratorSetting itset = BatchWriterIterator.iteratorSetting(6, 0, 15, 1000,
           numEntriesToWritePerEntry, t2, c, getAdminToken(), false, false);
@@ -80,7 +80,7 @@ public class BatchWriterInTabletServerIT extends AccumuloClusterHarness {
   public void testClearLocatorAndSplitWrite() throws Exception {
     String[] uniqueNames = getUniqueNames(2);
     String t1 = uniqueNames[0], t2 = uniqueNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       int numEntriesToWritePerEntry = 50;
       IteratorSetting itset = BatchWriterIterator.iteratorSetting(6, 0, 15, 1000,
           numEntriesToWritePerEntry, t2, c, getAdminToken(), true, true);

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportSequentialRowsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportSequentialRowsIT.java
@@ -62,7 +62,7 @@ public class BulkImportSequentialRowsIT extends AccumuloClusterHarness {
   @Test
   public void testBulkImportFailure() throws Exception {
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       TableOperations to = client.tableOperations();
       to.create(tableName);
       FileSystem fs = getFileSystem();

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
@@ -66,7 +66,7 @@ public class BulkImportVolumeIT extends AccumuloClusterHarness {
   @Test
   public void testBulkImportFailure() throws Exception {
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.tableOperations().create(tableName);
       FileSystem fs = getFileSystem();
       Path rootPath = new Path(cluster.getTemporaryPath(), getClass().getName());

--- a/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
@@ -68,7 +68,7 @@ public class CleanWalIT extends AccumuloClusterHarness {
 
   @Before
   public void offlineTraceTable() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String traceTable = client.instanceOperations().getSystemConfiguration()
           .get(Property.TRACE_TABLE.getKey());
       if (client.tableOperations().exists(traceTable)) {
@@ -80,7 +80,7 @@ public class CleanWalIT extends AccumuloClusterHarness {
   @After
   public void onlineTraceTable() throws Exception {
     if (null != cluster) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         String traceTable = client.instanceOperations().getSystemConfiguration()
             .get(Property.TRACE_TABLE.getKey());
         if (client.tableOperations().exists(traceTable)) {
@@ -93,7 +93,7 @@ public class CleanWalIT extends AccumuloClusterHarness {
   // test for ACCUMULO-1830
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
       BatchWriter bw = client.createBatchWriter(tableName, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/ClientSideIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ClientSideIteratorIT.java
@@ -77,7 +77,7 @@ public class ClientSideIteratorIT extends AccumuloClusterHarness {
 
   @Before
   public void setupInstance() throws Exception {
-    client = getAccumuloClient();
+    client = createAccumuloClient();
     tableName = getUniqueNames(1)[0];
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -46,7 +46,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
   @Test
   public void testNoFiles() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -75,7 +75,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
   @Test
   public void testFilesChange() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -133,7 +133,7 @@ public class CloneIT extends AccumuloClusterHarness {
   // test split where files of children are the same
   @Test
   public void testSplit1() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -177,7 +177,7 @@ public class CloneIT extends AccumuloClusterHarness {
   // test split where files of children differ... like majc and split occurred
   @Test
   public void testSplit2() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -255,7 +255,7 @@ public class CloneIT extends AccumuloClusterHarness {
   // test two tablets splitting into four
   @Test
   public void testSplit3() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -304,7 +304,7 @@ public class CloneIT extends AccumuloClusterHarness {
   // test cloned marker
   @Test
   public void testClonedMarker() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -371,7 +371,7 @@ public class CloneIT extends AccumuloClusterHarness {
   // test two tablets splitting into four
   @Test
   public void testMerge() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -136,7 +136,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
 
   @Before
   public void deleteUsers() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       Set<String> users = client.securityOperations().listLocalUsers();
       ClusterUser user = getUser(0);
       if (users.contains(user.getPrincipal())) {
@@ -148,7 +148,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testBasic() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -243,7 +243,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testFields() throws Exception {
 
-    try (AccumuloClient client1 = getAccumuloClient()) {
+    try (AccumuloClient client1 = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       String user = null;
@@ -351,7 +351,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   public void testBadColVis() throws Exception {
     // test when a user sets a col vis in a condition that can never be seen
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -464,7 +464,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   public void testConstraints() throws Exception {
     // ensure constraint violations are properly reported
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -497,7 +497,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testIterators() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName,
@@ -647,7 +647,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   public void testTableAndConditionIterators() throws Exception {
 
     // test w/ table that has iterators configured
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       IteratorSetting aiConfig1 = new IteratorSetting(30, "AI1", AddingIterator.class);
@@ -746,7 +746,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testBatch() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -864,7 +864,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testBigBatch() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -939,7 +939,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testBatchErrors() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -1026,7 +1026,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   public void testSameRow() throws Exception {
     // test multiple mutations for same row in same batch
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);
@@ -1214,7 +1214,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
     // test multiple threads using a single conditional writer
 
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       client.tableOperations().create(tableName);
 
@@ -1295,7 +1295,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testSecurity() throws Exception {
     // test against table user does not have read and/or write permissions for
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String user = null;
 
       // Create a new user
@@ -1361,7 +1361,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
 
   @Test
   public void testTimeout() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       String table = getUniqueNames(1)[0];
 
@@ -1414,7 +1414,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testDeleteTable() throws Exception {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       try {
         client.createConditionalWriter(table, new ConditionalWriterConfig());
@@ -1448,7 +1448,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testOffline() throws Exception {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       client.tableOperations().create(table);
 
@@ -1482,7 +1482,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   @Test
   public void testError() throws Exception {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       client.tableOperations().create(table);
 
@@ -1513,7 +1513,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
   public void testNoConditions() throws AccumuloException, AccumuloSecurityException,
       TableExistsException, TableNotFoundException {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       client.tableOperations().create(table);
 
@@ -1534,7 +1534,7 @@ public class ConditionalWriterIT extends AccumuloClusterHarness {
     // Need to add a getClientConfig() to AccumuloCluster
     Assume.assumeTrue(getClusterType() == ClusterType.MINI);
     Process tracer = null;
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       AccumuloCluster cluster = getCluster();
       MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;
       if (!client.tableOperations().exists("trace")) {

--- a/test/src/main/java/org/apache/accumulo/test/FindMaxIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/FindMaxIT.java
@@ -50,7 +50,7 @@ public class FindMaxIT extends AccumuloClusterHarness {
 
   @Test
   public void test1() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -69,7 +69,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
   @Test
   public void testExportImportThenScan() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       String[] tableNames = getUniqueNames(2);
       String srcTable = tableNames[0], destTable = tableNames[1];

--- a/test/src/main/java/org/apache/accumulo/test/InterruptibleScannersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InterruptibleScannersIT.java
@@ -51,7 +51,7 @@ public class InterruptibleScannersIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     // make a table
     final String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.tableOperations().create(tableName);
 
       // make the world's slowest scanner

--- a/test/src/main/java/org/apache/accumulo/test/IsolationAndDeepCopyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/IsolationAndDeepCopyIT.java
@@ -45,7 +45,7 @@ public class IsolationAndDeepCopyIT extends AccumuloClusterHarness {
     // test bug fox for ACCUMULO-3977
 
     String table = super.getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       client.tableOperations().create(table);
 

--- a/test/src/main/java/org/apache/accumulo/test/KeyValueEqualityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/KeyValueEqualityIT.java
@@ -42,7 +42,7 @@ public class KeyValueEqualityIT extends AccumuloClusterHarness {
 
   @Test
   public void testEquality() throws Exception {
-    try (AccumuloClient client = this.getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final BatchWriterConfig config = new BatchWriterConfig();
 
       final String[] tables = getUniqueNames(2);

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -86,7 +86,7 @@ public class LocatorIT extends AccumuloClusterHarness {
 
   @Test
   public void testBasic() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
 
       client.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -40,7 +40,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
   // a test for ACCUMULO-3096
   @Test(expected = ConstraintViolationException.class)
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.securityOperations().grantTablePermission(getAdminPrincipal(), MetadataTable.NAME,
           TablePermission.WRITE);
 

--- a/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
@@ -52,7 +52,7 @@ public class MetaSplitIT extends AccumuloClusterHarness {
   @Before
   public void saveMetadataSplits() throws Exception {
     if (ClusterType.STANDALONE == getClusterType()) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         Collection<Text> splits = client.tableOperations().listSplits(MetadataTable.NAME);
         // We expect a single split
         if (!splits.equals(Arrays.asList(new Text("~")))) {
@@ -71,7 +71,7 @@ public class MetaSplitIT extends AccumuloClusterHarness {
   public void restoreMetadataSplits() throws Exception {
     if (null != metadataSplits) {
       log.info("Restoring split on metadata table");
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         client.tableOperations().merge(MetadataTable.NAME, null, null);
         client.tableOperations().addSplits(MetadataTable.NAME, new TreeSet<>(metadataSplits));
       }
@@ -80,7 +80,7 @@ public class MetaSplitIT extends AccumuloClusterHarness {
 
   @Test(expected = AccumuloException.class)
   public void testRootTableSplit() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       SortedSet<Text> splits = new TreeSet<>();
       splits.add(new Text("5"));
       client.tableOperations().addSplits(RootTable.NAME, splits);
@@ -89,7 +89,7 @@ public class MetaSplitIT extends AccumuloClusterHarness {
 
   @Test
   public void testRootTableMerge() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.tableOperations().merge(RootTable.NAME, null, null);
     }
   }
@@ -104,7 +104,7 @@ public class MetaSplitIT extends AccumuloClusterHarness {
 
   @Test
   public void testMetadataTableSplit() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       TableOperations opts = client.tableOperations();
       for (int i = 1; i <= 10; i++) {
         opts.create(Integer.toString(i));

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableBatchWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableBatchWriterIT.java
@@ -58,7 +58,7 @@ public class MultiTableBatchWriterIT extends AccumuloClusterHarness {
 
   @Before
   public void setUpArgs() throws AccumuloException, AccumuloSecurityException {
-    accumuloClient = getAccumuloClient();
+    accumuloClient = createAccumuloClient();
     mtbw = getMultiTableBatchWriter();
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -106,7 +106,7 @@ public class NamespacesIT extends AccumuloClusterHarness {
     Assume.assumeTrue(ClusterType.MINI == getClusterType());
 
     // prepare a unique namespace and get a new root client for each test
-    c = getAccumuloClient();
+    c = createAccumuloClient();
     namespace = "ns_" + getUniqueNames(1)[0];
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/OrIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/OrIteratorIT.java
@@ -59,7 +59,7 @@ public class OrIteratorIT extends AccumuloClusterHarness {
 
   @Test
   public void testMultipleRowsInTablet() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -101,7 +101,7 @@ public class OrIteratorIT extends AccumuloClusterHarness {
 
   @Test
   public void testMultipleTablets() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -153,7 +153,7 @@ public class OrIteratorIT extends AccumuloClusterHarness {
 
   @Test
   public void testSingleLargeRow() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
       client.tableOperations().setProperty(tableName, Property.TABLE_SCAN_MAXMEM.getKey(), "1");
@@ -201,7 +201,7 @@ public class OrIteratorIT extends AccumuloClusterHarness {
 
   @Test
   public void testNoMatchesForTable() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -242,7 +242,7 @@ public class OrIteratorIT extends AccumuloClusterHarness {
 
   @Test
   public void testNoMatchesInSingleTablet() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 
@@ -297,7 +297,7 @@ public class OrIteratorIT extends AccumuloClusterHarness {
 
   @Test
   public void testResultOrder() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
@@ -61,7 +61,7 @@ public class RecoveryCompactionsAreFlushesIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     // create a table
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "100");
       c.tableOperations().setProperty(tableName, Property.TABLE_FILE_MAX.getKey(), "3");

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -124,7 +124,7 @@ public class SampleIT extends AccumuloClusterHarness {
   @Test
   public void testBasic() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       String clone = tableName + "_clone";
 
@@ -308,7 +308,7 @@ public class SampleIT extends AccumuloClusterHarness {
 
   @Test
   public void testIterator() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       String clone = tableName + "_clone";
 
@@ -421,7 +421,7 @@ public class SampleIT extends AccumuloClusterHarness {
   @Test
   public void testSampleNotPresent() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       String clone = tableName + "_clone";
 

--- a/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
@@ -49,7 +49,7 @@ public class ScanFlushWithTimeIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     log.info("Creating table");
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(tableName);
       log.info("Adding slow iterator");
       IteratorSetting setting = new IteratorSetting(50, SlowIterator.class);

--- a/test/src/main/java/org/apache/accumulo/test/ShellConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellConfigIT.java
@@ -48,7 +48,7 @@ public class ShellConfigIT extends AccumuloClusterHarness {
 
   @Before
   public void checkProperty() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       // TABLE_VOLUME_CHOOSER is a valid property that can be updated in ZK, whereas the crypto
       // properties are not.
       // This lets us run this test more generically rather than forcibly needing to update some
@@ -63,7 +63,7 @@ public class ShellConfigIT extends AccumuloClusterHarness {
   @After
   public void resetProperty() throws Exception {
     if (null != origPropValue) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         client.instanceOperations().setProperty(PerTableVolumeChooser.TABLE_VOLUME_CHOOSER,
             origPropValue);
       }

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -71,7 +71,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
 
     String tableName = getUniqueNames(1)[0];
 
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       for (int tn = 0; tn < 2; tn++) {
         // create a table and put some data in it
         accumuloClient.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -53,7 +53,7 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       ServerContext context = getCluster().getServerContext();
 
       String table = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -81,7 +81,7 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
   @Before
   public void setup() throws Exception {
-    accumuloClient = getAccumuloClient();
+    accumuloClient = createAccumuloClient();
   }
 
   @After

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -132,7 +132,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   @Test
   public void testMasterService() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       final String instanceID = client.getInstanceID();
 
       // Wait for the Master to grab its lock
@@ -200,7 +200,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   @Test
   public void testGarbageCollectorPorts() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String instanceID = client.getInstanceID();
 
       // Wait for the Master to grab its lock

--- a/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
@@ -73,7 +73,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   @After
   public void checkForDanglingFateLocks() {
     // create an accumulo client even though it's not used in order to enable static stuff
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       assertNotNull(c);
       FunctionalTestUtils.assertNoDanglingFateLocks(getClientContext(), getCluster());
     }
@@ -81,7 +81,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
   @Test
   public void testDropA() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
@@ -113,7 +113,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
   private void testDropNone(Map<String,String> options) throws Exception {
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
@@ -155,7 +155,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
     // test per-table classpath + user specified compaction strategy
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       File target = new File(System.getProperty("user.dir"), "target");
       assertTrue(target.mkdirs() || target.isDirectory());
@@ -202,7 +202,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   public void testIterators() throws Exception {
     // test compaction strategy + iterators
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
@@ -246,7 +246,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
   @Test
   public void testFileSize() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
@@ -283,7 +283,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   public void testConcurrent() throws Exception {
     // two compactions without iterators or strategy should be able to run concurrently
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/UsersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UsersIT.java
@@ -35,7 +35,7 @@ public class UsersIT extends AccumuloClusterHarness {
   @Test
   public void testCreateExistingUser() throws Exception {
     ClusterUser user0 = getUser(0);
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       Set<String> currentUsers = client.securityOperations().listLocalUsers();
 
       // Ensure that the user exists

--- a/test/src/main/java/org/apache/accumulo/test/YieldScannersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/YieldScannersIT.java
@@ -62,7 +62,7 @@ public class YieldScannersIT extends AccumuloClusterHarness {
   public void testScan() throws Exception {
     // make a table
     final String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.tableOperations().create(tableName);
       final BatchWriter writer = client.createBatchWriter(tableName, new BatchWriterConfig());
       for (int i = 0; i < 10; i++) {
@@ -117,7 +117,7 @@ public class YieldScannersIT extends AccumuloClusterHarness {
   public void testBatchScan() throws Exception {
     // make a table
     final String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.tableOperations().create(tableName);
       final BatchWriter writer = client.createBatchWriter(tableName, new BatchWriterConfig());
       for (int i = 0; i < 10; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
@@ -26,7 +26,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
 
   @Test(expected = AccumuloException.class)
   public void testNoFiles() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       // Should throw an error as this property can't be changed in ZooKeeper
       client.instanceOperations().setProperty(Property.GENERAL_RPC_TIMEOUT.getKey(), "60s");
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -62,7 +62,7 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
   @SuppressWarnings("deprecation")
   @Test
   public void testGetConnectorFromAccumuloClient() throws Exception {
-    AccumuloClient client = getAccumuloClient();
+    AccumuloClient client = createAccumuloClient();
     org.apache.accumulo.core.client.Connector c = org.apache.accumulo.core.client.Connector
         .from(client);
     assertEquals(client.whoami(), c.whoami());
@@ -75,7 +75,7 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
 
   @Test
   public void testAccumuloClientBuilder() throws Exception {
-    AccumuloClient c = getAccumuloClient();
+    AccumuloClient c = createAccumuloClient();
     String instanceName = getClientInfo().getInstanceName();
     String zookeepers = getClientInfo().getZooKeepers();
     final String user = "testuser";

--- a/test/src/main/java/org/apache/accumulo/test/functional/AddSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AddSplitIT.java
@@ -51,7 +51,7 @@ public class AddSplitIT extends AccumuloClusterHarness {
   public void addSplitTest() throws Exception {
 
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(tableName);
 
       insertData(c, tableName, 1L);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BadIteratorMincIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BadIteratorMincIT.java
@@ -47,7 +47,7 @@ public class BadIteratorMincIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -90,7 +90,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
   @Before
   public void setupTables() throws AccumuloException, AccumuloSecurityException,
       TableExistsException, TableNotFoundException {
-    accumuloClient = getAccumuloClient();
+    accumuloClient = createAccumuloClient();
     // Need at least two tservers
     Assume.assumeTrue("Not enough tservers to run test",
         accumuloClient.instanceOperations().getTabletServers().size() >= 2);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
@@ -60,7 +60,7 @@ public class BatchScanSplitIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -67,7 +67,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tableNames = getUniqueNames(2);
       String bwft = tableNames[0];
       c.tableOperations().create(bwft);
@@ -183,7 +183,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
 
   @Test
   public void runMultiThreadedBinningTest() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tableNames = getUniqueNames(1);
       String tableName = tableNames[0];
       c.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -81,7 +81,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
   private void runLatencyTest(AccumuloClient client, String tableName) throws Exception {
     // should automatically flush after 2 seconds
     try (
-        BatchWriter bw = getAccumuloClient().createBatchWriter(tableName,
+        BatchWriter bw = client.createBatchWriter(tableName,
             new BatchWriterConfig().setMaxLatency(1000, TimeUnit.MILLISECONDS));
         Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
@@ -51,7 +51,7 @@ public class BigRootTabletIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().addSplits(MetadataTable.NAME,
           FunctionalTestUtils.splits("0 1 2 3 4 5 6 7 8 9 a".split(" ")));
       String[] names = getUniqueNames(10);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BinaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BinaryIT.java
@@ -36,7 +36,7 @@ public class BinaryIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       runTest(c, tableName);
@@ -46,7 +46,7 @@ public class BinaryIT extends AccumuloClusterHarness {
   @Test
   public void testPreSplit() throws Exception {
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(tableName);
       SortedSet<Text> splits = new TreeSet<>();
       splits.add(new Text("8"));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BinaryStressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BinaryStressIT.java
@@ -62,7 +62,7 @@ public class BinaryStressIT extends AccumuloClusterHarness {
     if (ClusterType.MINI == getClusterType()) {
       return;
     }
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       InstanceOperations iops = client.instanceOperations();
       Map<String,String> conf = iops.getSystemConfiguration();
       majcDelay = conf.get(Property.TSERV_MAJC_DELAY.getKey());
@@ -79,7 +79,7 @@ public class BinaryStressIT extends AccumuloClusterHarness {
   @After
   public void resetConfig() throws Exception {
     if (null != majcDelay) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         InstanceOperations iops = client.instanceOperations();
         iops.setProperty(Property.TSERV_MAJC_DELAY.getKey(), majcDelay);
         iops.setProperty(Property.TSERV_MAXMEM.getKey(), maxMem);
@@ -91,7 +91,7 @@ public class BinaryStressIT extends AccumuloClusterHarness {
 
   @Test
   public void binaryStressTest() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "10K");

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -70,7 +70,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String readAhead = c.instanceOperations().getSystemConfiguration()
           .get(Property.TSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getKey());
       c.instanceOperations().setProperty(Property.TSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getKey(),

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
@@ -63,7 +63,7 @@ public class BulkFileIT extends AccumuloClusterHarness {
   @SuppressWarnings("deprecation")
   @Test
   public void testBulkFile() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       SortedSet<Text> splits = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
@@ -65,7 +65,7 @@ public class BulkIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       runTest(client, getClientInfo(), getCluster().getFileSystem(),
           getCluster().getTemporaryPath(), getUniqueNames(1)[0], this.getClass().getName(),
           testName.getMethodName(), false);
@@ -74,7 +74,7 @@ public class BulkIT extends AccumuloClusterHarness {
 
   @Test
   public void testOld() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       runTest(client, getClientInfo(), getCluster().getFileSystem(),
           getCluster().getTemporaryPath(), getUniqueNames(1)[0], this.getClass().getName(),
           testName.getMethodName(), true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
@@ -102,7 +102,7 @@ public class BulkLoadIT extends AccumuloClusterHarness {
 
   @Before
   public void setupBulkTest() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       aconf = getCluster().getServerContext().getConfiguration();
@@ -139,14 +139,14 @@ public class BulkLoadIT extends AccumuloClusterHarness {
 
   @Test
   public void testSingleTabletSingleFile() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       testSingleTabletSingleFile(client, false);
     }
   }
 
   @Test
   public void testSingleTabletSingleFileOffline() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       testSingleTabletSingleFile(client, true);
     }
   }
@@ -171,21 +171,21 @@ public class BulkLoadIT extends AccumuloClusterHarness {
 
   @Test
   public void testSingleTabletSingleFileNoSplits() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       testSingleTabletSingleFileNoSplits(client, false);
     }
   }
 
   @Test
   public void testSingleTabletSingleFileNoSplitsOffline() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       testSingleTabletSingleFileNoSplits(client, true);
     }
   }
 
   @Test
   public void testBadPermissions() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       addSplits(c, tableName, "0333");
 
       String dir = getDir("/testBadPermissions-");
@@ -220,7 +220,7 @@ public class BulkLoadIT extends AccumuloClusterHarness {
   }
 
   private void testBulkFile(boolean offline, boolean usePlan) throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       addSplits(c, tableName, "0333 0666 0999 1333 1666");
 
       if (offline)
@@ -297,7 +297,7 @@ public class BulkLoadIT extends AccumuloClusterHarness {
 
   @Test
   public void testBadLoadPlans() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       addSplits(c, tableName, "0333 0666 0999 1333 1666");
 
       String dir = getDir("/testBulkFile-");

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
@@ -55,7 +55,7 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
 
   @Before
   public void alterConfig() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       majcDelay = client.instanceOperations().getSystemConfiguration()
           .get(Property.TSERV_MAJC_DELAY.getKey());
       if (!"1s".equals(majcDelay)) {
@@ -69,7 +69,7 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
   @After
   public void resetConfig() throws Exception {
     if (null != majcDelay) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         client.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), majcDelay);
         getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
         getClusterControl().startAllServers(ServerType.TABLET_SERVER);
@@ -82,7 +82,7 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
 
   @Test
   public void testBulkSplitOptimization() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1000");

--- a/test/src/main/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ChaoticBalancerIT.java
@@ -53,7 +53,7 @@ public class ChaoticBalancerIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] names = getUniqueNames(1);
       String tableName = names[0];
       NewTableConfiguration ntc = new NewTableConfiguration();

--- a/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
@@ -88,7 +88,7 @@ public class ClassLoaderIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       BatchWriter bw = c.createBatchWriter(tableName, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -71,7 +71,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
     String table1 = tableNames[0];
     String table2 = tableNames[1];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       c.tableOperations().create(table1);
 
@@ -205,7 +205,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
     String table2 = tableNames[1];
     String table3 = tableNames[2];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       AccumuloCluster cluster = getCluster();
       Assume.assumeTrue(cluster instanceof MiniAccumuloClusterImpl);
       MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;
@@ -266,7 +266,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
 
   @Test
   public void testCloneWithSplits() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       List<Mutation> mutations = new ArrayList<>();
       TreeSet<Text> splits = new TreeSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
@@ -57,7 +57,7 @@ public class CombinerIT extends AccumuloClusterHarness {
 
   @Test
   public void aggregationTest() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       IteratorSetting setting = new IteratorSetting(10, SummingCombiner.class);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -73,7 +73,7 @@ public class CompactionIT extends AccumuloClusterHarness {
   @Before
   public void alterConfig() throws Exception {
     if (ClusterType.STANDALONE == getClusterType()) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         InstanceOperations iops = client.instanceOperations();
         Map<String,String> config = iops.getSystemConfiguration();
         majcThreadMaxOpen = config.get(Property.TSERV_MAJC_THREAD_MAXOPEN.getKey());
@@ -94,7 +94,7 @@ public class CompactionIT extends AccumuloClusterHarness {
   public void resetConfig() throws Exception {
     // We set the values..
     if (null != majcThreadMaxOpen) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         InstanceOperations iops = client.instanceOperations();
 
         iops.setProperty(Property.TSERV_MAJC_THREAD_MAXOPEN.getKey(), majcThreadMaxOpen);
@@ -109,7 +109,7 @@ public class CompactionIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
@@ -98,7 +98,7 @@ public class ConcurrencyIT extends AccumuloClusterHarness {
   // @formatter:on
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       runTest(c, getUniqueNames(1)[0]);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -52,7 +52,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
 
   @Test
   public void testConcurrentDeleteTablesOps() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tables = getUniqueNames(2);
 
       TreeSet<Text> splits = createSplits();
@@ -150,7 +150,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
 
   @Test
   public void testConcurrentFateOpsWithDelete() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tables = getUniqueNames(2);
 
       TreeSet<Text> splits = createSplits();

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConstraintIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConstraintIT.java
@@ -57,7 +57,7 @@ public class ConstraintIT extends AccumuloClusterHarness {
   @Test
   public void run() throws Exception {
     String[] tableNames = getUniqueNames(3);
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       for (String table : tableNames) {
         c.tableOperations().create(table);
         c.tableOperations().addConstraint(table, NumericValueConstraint.class.getName());

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateAndUseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateAndUseIT.java
@@ -63,7 +63,7 @@ public class CreateAndUseIT extends AccumuloClusterHarness {
   @Test
   public void verifyDataIsPresent() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       Text cf = new Text("cf1");
       Text cq = new Text("cq1");
@@ -98,7 +98,7 @@ public class CreateAndUseIT extends AccumuloClusterHarness {
 
   @Test
   public void createTableAndScan() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String table2 = getUniqueNames(1)[0];
       client.tableOperations().create(table2);
       client.tableOperations().addSplits(table2, splits);
@@ -118,7 +118,7 @@ public class CreateAndUseIT extends AccumuloClusterHarness {
 
   @Test
   public void createTableAndBatchScan() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       ArrayList<Range> ranges = new ArrayList<>();
       for (int i = 1; i < 257; i++) {
         ranges.add(new Range(new Text(String.format("%08x", (i << 8) - 16))));

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
@@ -67,7 +67,7 @@ public class CreateInitialSplitsIT extends AccumuloClusterHarness {
 
   @Before
   public void setupInitialSplits() {
-    client = getAccumuloClient();
+    client = createAccumuloClient();
   }
 
   @After

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateManyScannersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateManyScannersIT.java
@@ -30,7 +30,7 @@ public class CreateManyScannersIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       for (int i = 0; i < 100000; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
@@ -57,7 +57,7 @@ public class CredentialsIT extends AccumuloClusterHarness {
 
   @Before
   public void createLocalUser() throws AccumuloException, AccumuloSecurityException {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       ClusterUser user = getUser(0);
       username = user.getPrincipal();
       saslEnabled = saslEnabled();
@@ -81,7 +81,7 @@ public class CredentialsIT extends AccumuloClusterHarness {
       UserGroupInformation.loginUserFromKeytab(root.getPrincipal(),
           root.getKeytab().getAbsolutePath());
     }
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.securityOperations().dropLocalUser(username);
     }
   }
@@ -102,7 +102,7 @@ public class CredentialsIT extends AccumuloClusterHarness {
 
   @Test
   public void testDestroyTokenBeforeRPC() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       AuthenticationToken token = getUser(0).getToken();
       try (
           AccumuloClient userAccumuloClient = Accumulo.newClient().from(client.properties())

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteEverythingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteEverythingIT.java
@@ -62,7 +62,7 @@ public class DeleteEverythingIT extends AccumuloClusterHarness {
 
   @Before
   public void updateMajcDelay() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       majcDelay = c.instanceOperations().getSystemConfiguration()
           .get(Property.TSERV_MAJC_DELAY.getKey());
       c.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), "1s");
@@ -75,14 +75,14 @@ public class DeleteEverythingIT extends AccumuloClusterHarness {
 
   @After
   public void resetMajcDelay() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), majcDelay);
     }
   }
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       BatchWriter bw = c.createBatchWriter(tableName, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
@@ -35,7 +35,7 @@ public class DeleteFailIT extends AccumuloClusterHarness {
 
   @Test
   public void testFail() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       NewTableConfiguration ntc = new NewTableConfiguration();
       ntc.setProperties(

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteIT.java
@@ -43,7 +43,7 @@ public class DeleteIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       AuthenticationToken token = getAdminToken();

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
@@ -69,7 +69,7 @@ public class DeleteRowsIT extends AccumuloClusterHarness {
 
   @Test(timeout = 5 * 60 * 1000)
   public void testDeleteAllRows() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tableNames = this.getUniqueNames(20);
       for (String tableName : tableNames) {
         c.tableOperations().create(tableName);
@@ -83,7 +83,7 @@ public class DeleteRowsIT extends AccumuloClusterHarness {
 
   @Test
   public void testManyRows() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       // Delete ranges of rows, and verify the tablets are removed.
       int i = 0;
       // Eliminate whole tablets

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsSplitIT.java
@@ -67,7 +67,7 @@ public class DeleteRowsSplitIT extends AccumuloClusterHarness {
     // Delete ranges of rows, and verify the are removed
     // Do this while adding many splits
     final String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       // Eliminate whole tablets
       for (int test = 0; test < 10; test++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteTableDuringSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteTableDuringSplitIT.java
@@ -49,7 +49,7 @@ public class DeleteTableDuringSplitIT extends AccumuloClusterHarness {
   @Test
   public void test() throws Exception {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       // 96 invocations, 8 at a time
       int batches = 12, batchSize = 8;

--- a/test/src/main/java/org/apache/accumulo/test/functional/DynamicThreadPoolsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DynamicThreadPoolsIT.java
@@ -61,7 +61,7 @@ public class DynamicThreadPoolsIT extends AccumuloClusterHarness {
 
   @Before
   public void updateMajcDelay() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       majcDelay = c.instanceOperations().getSystemConfiguration()
           .get(Property.TSERV_MAJC_DELAY.getKey());
       c.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), "100ms");
@@ -73,7 +73,7 @@ public class DynamicThreadPoolsIT extends AccumuloClusterHarness {
 
   @After
   public void resetMajcDelay() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), majcDelay);
     }
   }
@@ -82,7 +82,7 @@ public class DynamicThreadPoolsIT extends AccumuloClusterHarness {
   public void test() throws Exception {
     final String[] tables = getUniqueNames(15);
     String firstTable = tables[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.instanceOperations().setProperty(Property.TSERV_MAJC_MAXCONCURRENT.getKey(), "5");
       TestIngest.Opts opts = new TestIngest.Opts();
       opts.rows = 500 * 1000;

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -41,7 +41,7 @@ public class FateStarvationIT extends AccumuloClusterHarness {
   @Test
   public void run() throws Exception {
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(tableName);
 
       c.tableOperations().addSplits(tableName, TestIngest.getSplitPoints(0, 100000, 50));

--- a/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
@@ -94,7 +94,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
     REG_TABLE_NAME = names[0];
     PRE_SPLIT_TABLE_NAME = names[1];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       tservMajcDelay = c.instanceOperations().getSystemConfiguration()
           .get(Property.TSERV_MAJC_DELAY.getKey());
       c.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), "10ms");
@@ -104,7 +104,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
   @After
   public void resetMajcDelay() throws Exception {
     if (null != tservMajcDelay) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         client.instanceOperations().setProperty(Property.TSERV_MAJC_DELAY.getKey(), tservMajcDelay);
       }
     }
@@ -123,7 +123,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
       TestIngest.toPrintableChars(rowData);
       splitPoints.add(new Text(rowData));
     }
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(REG_TABLE_NAME);
       c.tableOperations().create(PRE_SPLIT_TABLE_NAME);
       c.tableOperations().setProperty(PRE_SPLIT_TABLE_NAME,

--- a/test/src/main/java/org/apache/accumulo/test/functional/LogicalTimeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LogicalTimeIT.java
@@ -45,7 +45,7 @@ public class LogicalTimeIT extends AccumuloClusterHarness {
   public void run() throws Exception {
     int tc = 0;
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       runMergeTest(c, tableName + tc++, new String[] {"m"}, new String[] {"a"}, null, null, "b",
           2L);
       runMergeTest(c, tableName + tc++, new String[] {"m"}, new String[] {"z"}, null, null, "b",

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
@@ -46,7 +46,7 @@ public class MasterAssignmentIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = super.getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       String tableId = c.tableOperations().tableIdMap().get(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterFailoverIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterFailoverIT.java
@@ -49,7 +49,7 @@ public class MasterFailoverIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] names = getUniqueNames(2);
       c.tableOperations().create(names[0]);
       TestIngest.Opts opts = new TestIngest.Opts();

--- a/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
@@ -65,7 +65,7 @@ public class MaxOpenIT extends AccumuloClusterHarness {
 
   @Before
   public void alterConfig() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       InstanceOperations iops = client.instanceOperations();
       Map<String,String> sysConfig = iops.getSystemConfiguration();
       scanMaxOpenFiles = sysConfig.get(Property.TSERV_SCAN_MAX_OPENFILES.getKey());
@@ -76,7 +76,7 @@ public class MaxOpenIT extends AccumuloClusterHarness {
 
   @After
   public void restoreConfig() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       InstanceOperations iops = client.instanceOperations();
       if (null != scanMaxOpenFiles) {
         iops.setProperty(Property.TSERV_SCAN_MAX_OPENFILES.getKey(), scanMaxOpenFiles);
@@ -95,7 +95,7 @@ public class MaxOpenIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "10");

--- a/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MergeIT.java
@@ -56,7 +56,7 @@ public class MergeIT extends AccumuloClusterHarness {
 
   @Test
   public void merge() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().addSplits(tableName, splits("a b c d e f g h i j k".split(" ")));
@@ -75,7 +75,7 @@ public class MergeIT extends AccumuloClusterHarness {
 
   @Test
   public void mergeSize() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().addSplits(tableName,
@@ -113,7 +113,7 @@ public class MergeIT extends AccumuloClusterHarness {
   @Test
   public void mergeTest() throws Exception {
     int tc = 0;
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       runMergeTest(c, tableName + tc++, ns(), ns(), ns("l", "m", "n"), ns(null, "l"),
           ns(null, "n"));

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -61,7 +61,7 @@ public class MetadataIT extends AccumuloClusterHarness {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableNames[] = getUniqueNames(2);
 
       // create a table to write some data to metadata table
@@ -100,7 +100,7 @@ public class MetadataIT extends AccumuloClusterHarness {
 
   @Test
   public void mergeMeta() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] names = getUniqueNames(5);
       SortedSet<Text> splits = new TreeSet<>();
       for (String id : "1 2 3 4 5".split(" ")) {
@@ -123,7 +123,7 @@ public class MetadataIT extends AccumuloClusterHarness {
 
   @Test
   public void batchScanTest() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -78,7 +78,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
   @Before
   public void limitToMini() throws Exception {
     Assume.assumeTrue(ClusterType.MINI == getClusterType());
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       Set<String> users = c.securityOperations().listLocalUsers();
       ClusterUser user = getUser(0);
       if (users.contains(user.getPrincipal())) {
@@ -97,7 +97,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
     ClusterUser testUser = getUser(0), rootUser = getAdminUser();
 
     // verify that the test is being run by root
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       verifyHasOnlyTheseSystemPermissions(c, c.whoami(), SystemPermission.values());
 
       // create the test user
@@ -569,7 +569,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
       passwordToken = (PasswordToken) token;
     }
     loginAs(rootUser);
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.securityOperations().createLocalUser(principal, passwordToken);
       loginAs(testUser);
       try (AccumuloClient test_user_client = Accumulo.newClient().from(c.properties())

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -139,7 +139,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     // Shutdown cleanly.
     log.debug("Starting Monitor");
     cluster.getClusterControl().startAllServers(ServerType.MONITOR);
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       ingest(accumuloClient, getClientInfo(), ROWS, COLS, 50, 0, tableName);
       verify(accumuloClient, getClientInfo(), ROWS, COLS, 50, 0, tableName);
@@ -323,7 +323,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   @Test
   public void largeTest() throws Exception {
     // write a few large values
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       String table = getUniqueNames(1)[0];
       ingest(accumuloClient, getClientInfo(), 2, 1, 500000, 0, table);
       verify(accumuloClient, getClientInfo(), 2, 1, 500000, 0, table);
@@ -333,7 +333,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   @Test
   public void interleaved() throws Exception {
     // read and write concurrently
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       interleaveTest(accumuloClient, tableName);
     }
@@ -378,7 +378,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   @Test
   public void localityGroupPerf() throws Exception {
     // verify that locality groups can make look-ups faster
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       accumuloClient.tableOperations().create(tableName);
       accumuloClient.tableOperations().setProperty(tableName, "table.group.g1", "colf");
@@ -411,7 +411,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
    */
   @Test
   public void sunnyLG() throws Exception {
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       accumuloClient.tableOperations().create(tableName);
       Map<String,Set<Text>> groups = new TreeMap<>();
@@ -428,7 +428,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   @Test
   public void sunnyLGUsingNewTableConfiguration() throws Exception {
     // create a locality group, write to it and ensure it exists in the RFiles that result
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       NewTableConfiguration ntc = new NewTableConfiguration();
       Map<String,Set<Text>> groups = new HashMap<>();
@@ -486,7 +486,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
   @Test
   public void localityGroupChange() throws Exception {
     // Make changes to locality groups and ensure nothing is lost
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       String table = getUniqueNames(1)[0];
       TableOperations to = accumuloClient.tableOperations();
       to.create(table);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RenameIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RenameIT.java
@@ -43,7 +43,7 @@ public class RenameIT extends AccumuloClusterHarness {
     opts.setTableName(name1);
     opts.setClientProperties(cluster.getClientProperties());
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       TestIngest.ingest(c, opts, bwOpts);
       c.tableOperations().rename(name1, name2);
       TestIngest.ingest(c, opts, bwOpts);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -107,7 +107,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void restartMaster() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       OPTS.setTableName(tableName);
       VOPTS.setTableName(tableName);
@@ -149,7 +149,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void restartMasterRecovery() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       OPTS.setTableName(tableName);
@@ -200,7 +200,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void restartMasterSplit() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       final AuthenticationToken token = getAdminToken();
       final ClusterControl control = getCluster().getClusterControl();
@@ -257,7 +257,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void killedTabletServer() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       OPTS.setTableName(tableName);
@@ -274,7 +274,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void killedTabletServer2() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String[] names = getUniqueNames(2);
       final String tableName = names[0];
       final ClusterControl control = getCluster().getClusterControl();
@@ -290,7 +290,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void killedTabletServerDuringShutdown() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       OPTS.setTableName(tableName);
@@ -307,7 +307,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
   @Test
   public void shutdownDuringCompactingSplitting() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       VOPTS.setTableName(tableName);
       OPTS.setClientProperties(getClientProperties());

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartStressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartStressIT.java
@@ -98,7 +98,7 @@ public class RestartStressIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       final AuthenticationToken token = getAdminToken();
       c.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
@@ -59,7 +59,7 @@ public class RowDeleteIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       Map<String,Set<Text>> groups = new HashMap<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -109,7 +109,7 @@ public class ScanIdIT extends AccumuloClusterHarness {
   public void testScanId() throws Exception {
 
     final String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       client.tableOperations().create(tableName);
 
       addSplits(client, tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIteratorIT.java
@@ -110,7 +110,7 @@ public class ScanIteratorIT extends AccumuloClusterHarness {
   @Test
   public void run() throws Exception {
     String tableName = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       BatchWriter bw = c.createBatchWriter(tableName, new BatchWriterConfig());
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIteratorIT.java
@@ -68,7 +68,7 @@ public class ScanIteratorIT extends AccumuloClusterHarness {
 
   @Before
   public void setup() throws Exception {
-    accumuloClient = getAccumuloClient();
+    accumuloClient = createAccumuloClient();
     tableName = getUniqueNames(1)[0];
 
     accumuloClient.tableOperations().create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanRangeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanRangeIT.java
@@ -48,7 +48,7 @@ public class ScanRangeIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tableNames = getUniqueNames(2);
       String table1 = tableNames[0];
       c.tableOperations().create(table1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanSessionTimeOutIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanSessionTimeOutIT.java
@@ -64,7 +64,7 @@ public class ScanSessionTimeOutIT extends AccumuloClusterHarness {
 
   @Before
   public void reduceSessionIdle() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       InstanceOperations ops = client.instanceOperations();
       sessionIdle = ops.getSystemConfiguration().get(Property.TSERV_SESSION_MAXIDLE.getKey());
       ops.setProperty(Property.TSERV_SESSION_MAXIDLE.getKey(), getMaxIdleTimeString());
@@ -86,7 +86,7 @@ public class ScanSessionTimeOutIT extends AccumuloClusterHarness {
   @After
   public void resetSessionIdle() throws Exception {
     if (null != sessionIdle) {
-      try (AccumuloClient client = getAccumuloClient()) {
+      try (AccumuloClient client = createAccumuloClient()) {
         client.instanceOperations().setProperty(Property.TSERV_SESSION_MAXIDLE.getKey(),
             sessionIdle);
       }
@@ -95,7 +95,7 @@ public class ScanSessionTimeOutIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
@@ -87,7 +87,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
   @Test
   public void test() throws Exception {
     Path dstPath = copyTestIteratorsJarToTmp();
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       // Set the classloader context property on the table to point to the test iterators jar file.
       c.instanceOperations().setProperty(CONTEXT_PROPERTY, CONTEXT_CLASSPATH);
 
@@ -136,7 +136,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
   @Test
   public void testScanContextOverridesTableContext() throws Exception {
     Path dstPath = copyTestIteratorsJarToTmp();
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       // Create two contexts FOO and ScanContextIT. The FOO context will point to a classpath
       // that contains nothing. The ScanContextIT context will point to the test iterators jar
       String tableContext = "FOO";
@@ -192,7 +192,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
   @Test
   public void testOneScannerDoesntInterfereWithAnother() throws Exception {
     Path dstPath = copyTestIteratorsJarToTmp();
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       // Set the classloader context property on the table to point to the test iterators jar file.
       c.instanceOperations().setProperty(CONTEXT_PROPERTY, CONTEXT_CLASSPATH);
 
@@ -238,7 +238,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
   @Test
   public void testClearContext() throws Exception {
     Path dstPath = copyTestIteratorsJarToTmp();
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       // Set the classloader context property on the table to point to the test iterators jar file.
       c.instanceOperations().setProperty(CONTEXT_PROPERTY, CONTEXT_CLASSPATH);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerIT.java
@@ -48,7 +48,7 @@ public class ScannerIT extends AccumuloClusterHarness {
   @Test
   public void testScannerReadaheadConfiguration() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table);
 
       BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ServerSideErrorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ServerSideErrorIT.java
@@ -48,7 +48,7 @@ public class ServerSideErrorIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       IteratorSetting is = new IteratorSetting(5, "Bad Aggregator", BadCombiner.class);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
@@ -82,7 +82,7 @@ public class SessionBlockVerifyIT extends ScanSessionTimeOutIT {
   @Test
   @Override
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SparseColumnFamilyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SparseColumnFamilyIT.java
@@ -45,7 +45,7 @@ public class SparseColumnFamilyIT extends AccumuloClusterHarness {
   @Test
   public void sparceColumnFamily() throws Exception {
     String scftt = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(scftt);
 
       BatchWriter bw = c.createBatchWriter(scftt, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -74,7 +74,7 @@ public class SplitIT extends AccumuloClusterHarness {
   @Before
   public void alterConfig() throws Exception {
     Assume.assumeTrue(ClusterType.MINI == getClusterType());
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       InstanceOperations iops = client.instanceOperations();
       Map<String,String> config = iops.getSystemConfiguration();
       tservMaxMem = config.get(Property.TSERV_MAXMEM.getKey());
@@ -105,7 +105,7 @@ public class SplitIT extends AccumuloClusterHarness {
 
   @After
   public void resetConfig() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       if (null != tservMaxMem) {
         log.info("Resetting {}={}", Property.TSERV_MAXMEM.getKey(), tservMaxMem);
         client.instanceOperations().setProperty(Property.TSERV_MAXMEM.getKey(), tservMaxMem);
@@ -123,7 +123,7 @@ public class SplitIT extends AccumuloClusterHarness {
 
   @Test
   public void tabletShouldSplit() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String table = getUniqueNames(1)[0];
       c.tableOperations().create(table);
       c.tableOperations().setProperty(table, Property.TABLE_SPLIT_THRESHOLD.getKey(), "256K");
@@ -178,7 +178,7 @@ public class SplitIT extends AccumuloClusterHarness {
 
   @Test
   public void interleaveSplit() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "10K");
@@ -199,7 +199,7 @@ public class SplitIT extends AccumuloClusterHarness {
 
   @Test
   public void deleteSplit() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "10K");

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -139,7 +139,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void basicSummaryTest() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(BasicSummarizer.class.getName())
           .build();
@@ -316,7 +316,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void selectionTest() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(BasicSummarizer.class).build();
       SummarizerConfiguration sc2 = SummarizerConfiguration.builder(KeySizeSummarizer.class)
@@ -480,7 +480,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void compactionTest() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(FooCounter.class.getName())
           .build();
@@ -550,7 +550,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void testBuggySummarizer() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(BuggySummarizer.class).build();
       ntc.enableSummarization(sc1);
@@ -577,7 +577,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void testPermissions() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(FooCounter.class).build();
       ntc.enableSummarization(sc1);
@@ -653,7 +653,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void tooLargeTest() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(BigSummarizer.class).build();
       ntc.enableSummarization(sc1);
@@ -724,7 +724,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void testLocalityGroups() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       SummarizerConfiguration sc1 = SummarizerConfiguration.builder(FamilySummarizer.class).build();
       SummarizerConfiguration sc2 = SummarizerConfiguration.builder(BasicSummarizer.class).build();
@@ -787,7 +787,7 @@ public class SummaryIT extends AccumuloClusterHarness {
 
   @Test
   public void testExceptions() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       try {
         c.tableOperations().summaries("foo").retrieve();
@@ -845,7 +845,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   @Test
   public void testManyFiles() throws Exception {
     final String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       NewTableConfiguration ntc = new NewTableConfiguration();
       ntc.enableSummarization(SummarizerConfiguration.builder(FamilySummarizer.class).build());
       c.tableOperations().create(table, ntc);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
@@ -80,7 +80,7 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
 
   @Before
   public void setup() {
-    accumuloClient = getAccumuloClient();
+    accumuloClient = createAccumuloClient();
     context = new ClientContext(accumuloClient);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -63,7 +63,7 @@ public class TableIT extends AccumuloClusterHarness {
     MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;
     String rootPath = mac.getConfig().getDir().getAbsolutePath();
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       TableOperations to = c.tableOperations();
       String tableName = getUniqueNames(1)[0];
       to.create(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
@@ -58,7 +58,7 @@ public class TabletIT extends AccumuloClusterHarness {
 
   @Test
   public void createTableTest() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       createTableTest(client, tableName, false);
       createTableTest(client, tableName, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -81,7 +81,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
   public void test() throws AccumuloException, AccumuloSecurityException, TableExistsException,
       TableNotFoundException {
 
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
 
       String[] tables = getUniqueNames(4);
       final String t1 = tables[0];

--- a/test/src/main/java/org/apache/accumulo/test/functional/TimeoutIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TimeoutIT.java
@@ -47,7 +47,7 @@ public class TimeoutIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String[] tableNames = getUniqueNames(2);
       testBatchWriterTimeout(client, tableNames[0]);
       testBatchScannerTimeout(client, tableNames[1]);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TooManyDeletesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TooManyDeletesIT.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class TooManyDeletesIT extends AccumuloClusterHarness {
   @Test
   public void tooManyDeletesCompactionStrategyIT() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
 
       String table = getUniqueNames(1)[0];
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/VisibilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/VisibilityIT.java
@@ -62,14 +62,14 @@ public class VisibilityIT extends AccumuloClusterHarness {
 
   @Before
   public void emptyAuths() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       origAuths = c.securityOperations().getUserAuthorizations(getAdminPrincipal());
     }
   }
 
   @After
   public void resetAuths() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       if (null != origAuths) {
         c.securityOperations().changeUserAuthorizations(getAdminPrincipal(), origAuths);
       }
@@ -78,7 +78,7 @@ public class VisibilityIT extends AccumuloClusterHarness {
 
   @Test
   public void run() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String[] tableNames = getUniqueNames(2);
       String table = tableNames[0];
       c.tableOperations().create(table);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogEncryptedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogEncryptedIT.java
@@ -82,7 +82,7 @@ public class WriteAheadLogEncryptedIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "750K");

--- a/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogIT.java
@@ -49,7 +49,7 @@ public class WriteAheadLogIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "750K");

--- a/test/src/main/java/org/apache/accumulo/test/functional/WriteLotsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WriteLotsIT.java
@@ -38,7 +38,7 @@ public class WriteLotsIT extends AccumuloClusterHarness {
 
   @Test
   public void writeLots() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       final String tableName = getUniqueNames(1)[0];
       c.tableOperations().create(tableName);
       final AtomicReference<Exception> ref = new AtomicReference<>();

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloFileOutputFormatIT.java
@@ -82,7 +82,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void testEmptyWrite() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(EMPTY_TABLE);
       handleWriteTests(false);
     }
@@ -90,7 +90,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void testRealWrite() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE);
       BatchWriter bw = c.createBatchWriter(TEST_TABLE, new BatchWriterConfig());
       Mutation m = new Mutation("Key");
@@ -207,7 +207,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void writeBadVisibility() throws Exception {
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(BAD_TABLE);
       BatchWriter bw = c.createBatchWriter(BAD_TABLE, new BatchWriterConfig());
       Mutation m = new Mutation("r1");

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloInputFormatIT.java
@@ -152,7 +152,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   @Test
   public void testMap() throws Exception {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table);
       BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig());
       for (int i = 0; i < 100; i++) {
@@ -178,7 +178,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   public void testSample() throws Exception {
     final String TEST_TABLE_3 = getUniqueNames(1)[0];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE_3,
           new NewTableConfiguration().enableSampling(SAMPLER_CONFIG));
       BatchWriter bw = c.createBatchWriter(TEST_TABLE_3, new BatchWriterConfig());
@@ -216,7 +216,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     boolean isolated = true, localIters = true;
     Level level = Level.WARN;
 
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       accumuloClient.tableOperations().create(table);
 
       AccumuloInputFormat.setClientProperties(job, getClientProperties());

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloMultiTableInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloMultiTableInputFormatIT.java
@@ -139,7 +139,7 @@ public class AccumuloMultiTableInputFormatIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloRowInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloRowInputFormatIT.java
@@ -183,7 +183,7 @@ public class AccumuloRowInputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
       BatchWriter writer = null;

--- a/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
@@ -150,7 +150,7 @@ public class TokenFileIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloFileOutputFormatIT.java
@@ -83,7 +83,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
     TEST_TABLE = PREFIX + "_mapreduce_test_table";
     EMPTY_TABLE = PREFIX + "_mapreduce_empty_table";
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(EMPTY_TABLE);
       c.tableOperations().create(TEST_TABLE);
       c.tableOperations().create(BAD_TABLE);

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
@@ -94,7 +94,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
    */
   @Test
   public void testGetSplits() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String table = getUniqueNames(1)[0];
       client.tableOperations().create(table);
       insertData(client, table, currentTimeMillis());
@@ -315,7 +315,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   public void testMap() throws Exception {
     final String TEST_TABLE_1 = getUniqueNames(1)[0];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE_1);
       BatchWriter bw = c.createBatchWriter(TEST_TABLE_1, new BatchWriterConfig());
       for (int i = 0; i < 100; i++) {
@@ -339,7 +339,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   public void testSample() throws Exception {
     final String TEST_TABLE_3 = getUniqueNames(1)[0];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE_3,
           new NewTableConfiguration().enableSampling(SAMPLER_CONFIG));
       BatchWriter bw = c.createBatchWriter(TEST_TABLE_3, new BatchWriterConfig());
@@ -373,7 +373,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   public void testMapWithBatchScanner() throws Exception {
     final String TEST_TABLE_2 = getUniqueNames(1)[0];
 
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(TEST_TABLE_2);
       BatchWriter bw = c.createBatchWriter(TEST_TABLE_2, new BatchWriterConfig());
       for (int i = 0; i < 100; i++) {
@@ -401,7 +401,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     boolean isolated = true, localIters = true;
     Level level = Level.WARN;
 
-    try (AccumuloClient accumuloClient = getAccumuloClient()) {
+    try (AccumuloClient accumuloClient = createAccumuloClient()) {
       accumuloClient.tableOperations().create(table);
 
       AccumuloInputFormat.setClientProperties(job, getClientProperties());
@@ -435,7 +435,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
   @Test
   public void testPartialInputSplitDelegationToConfiguration() throws Exception {
     String table = getUniqueNames(1)[0];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table);
       BatchWriter bw = c.createBatchWriter(table, new BatchWriterConfig());
       for (int i = 0; i < 100; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloMultiTableInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloMultiTableInputFormatIT.java
@@ -138,7 +138,7 @@ public class AccumuloMultiTableInputFormatIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloOutputFormatIT.java
@@ -128,7 +128,7 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloRowInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloRowInputFormatIT.java
@@ -180,7 +180,7 @@ public class AccumuloRowInputFormatIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    try (AccumuloClient client = getAccumuloClient()) {
+    try (AccumuloClient client = createAccumuloClient()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
       BatchWriter writer = null;

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
@@ -143,7 +143,7 @@ public class TokenFileIT extends AccumuloClusterHarness {
     String[] tableNames = getUniqueNames(2);
     String table1 = tableNames[0];
     String table2 = tableNames[1];
-    try (AccumuloClient c = getAccumuloClient()) {
+    try (AccumuloClient c = createAccumuloClient()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
       BatchWriter bw = c.createBatchWriter(table1, new BatchWriterConfig());


### PR DESCRIPTION
* ITs were failing as they tried to use clients
  that were previously closed due to obtaining client
  using getAccumuloClient and closing it in try-with-resources
* This can be fixed by switch method to createAccumuloClient
* This problem was exposed after clients were managed
  better within code in #825