### PR TITLE
Monitor 2.0: HTML, CSS, and plot updates

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/css/screen.css
@@ -15,36 +15,15 @@
 * limitations under the License.
 */
 /* basic screen style for all pages */
-html,body {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  color: #333333;
-  font-size: 10pt;
+body {
   font-family: verdana, arial, sans-serif;
+  font-size: 10pt;
+  padding-top:50px; /* For fixed top navbar */
 }
 
 #banner {
   height: 1.5em;
   font-size: 1.0em;
-}
-
-#content-wrapper {
-  position: relative;
-  min-height: 95%;
-}
-
-* #content-wrapper {
-  height: 95%;
-}
-
-#content {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 1.5em;
-  padding-bottom: 0;
 }
 
 #header {
@@ -86,38 +65,9 @@ html,body {
 }
 
 #main {
-  position: absolute;
-  top: 5.0em;
-  /*left: 11em;*/
-  left: 0;
-  right: 0;
-  bottom: 0;
   padding: 0.6em;
   /*overflow: scroll;*/
-  margin-left: auto;
-  margin-right: auto;
   width: 90%;
-}
-
-#nav {
-  position: absolute;
-  top: 0.5em;
-  /*left: 0;*/
-  right: 0;
-  /*bottom: 0;*/
-  padding: 0.5em;
-  /*width: 10em;*/
-  /*color: #304065;*/
-  /*background-color: #c4c4c4;*/
-  /*text-align: left;*/
-  /*height: 3.0em;*/
-}
-
-#nav-title {
-  margin-left: auto;
-  margin-right: auto;
-  text-align: center;
-  font-size: 1.1em;
 }
 
 h1 {
@@ -439,10 +389,6 @@ pre.logevent {
   border-radius: 5px;
   width: 32px;
   height: 32px;
-}
-
-.center-block {
-  width: 100%;
 }
 
 .nav-pills > li > a {

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -116,44 +116,41 @@ function refreshZKTable() {
 /**
  * Create the plots for the overview page
  */
+var plotOptions = {
+  colors: ['#d9534f', '#337ab7'],
+  grid: {
+    backgroundColor: {colors: ['#fff', '#eee']},
+  },
+  lines: {
+    show: true
+  },
+  points: {
+    show: false,
+    radius: 1
+  },
+  xaxis: {
+    mode: 'time',
+    minTickSize: [1, 'minute'],
+    timeformat: '%H:%M',
+    ticks: 3
+  },
+  yaxis: {
+    min: 0
+  }
+};
+
+var cachePlotOptions = $.extend(true, {}, plotOptions, {
+  lines: { show: false },
+  points: { show: true },
+  yaxis: {
+    max: 1.1,
+    ticks: [0, 0.25, 0.5, 0.75, 1.0]
+  }
+});
+
 function makePlots() {
   var d = new Date();
   var n = d.getTimezoneOffset() * 60000; // Converts offset to milliseconds
-  var tz = d.toLocaleTimeString('en-us',
-      {timeZoneName: 'short'}).split(' ')[2]; // Short version of timezone
-  var tzFormat = '%H:%M<br>' + tz;
-
-  var plotOptions = {
-    colors: ['#d9534f', '#337ab7'],
-    grid: {
-      backgroundColor: {colors: ['#fff', '#eee']},
-    },
-    lines: {
-      show: true
-    },
-    points: {
-      show: false,
-      radius: 1
-    },
-    xaxis: {
-      mode: 'time',
-      minTickSize: [1, 'minute'],
-      timeformat: tzFormat,
-      ticks: 3
-    },
-    yaxis: {
-      min: 0
-    }
-  };
-
-  var cachePlotOptions = $.extend(true, {}, plotOptions, {
-    lines: { show: false },
-    points: { show: true },
-    yaxis: {
-      max: 1.1,
-      ticks: [0, 0.25, 0.5, 0.75, 1.0]
-    }
-  });
 
   // Create Ingest Rate plot
   var ingestRate = [{data:[]}];

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/bulkImport.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/bulkImport.ftl
@@ -14,25 +14,33 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="masterBulkImportStatus" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="masterBulkImportStatus" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">All Bulk Imports</span><br/></caption>
             <tbody>
-            <tr><th class="firstcell">Directory&nbsp;</th>
+              <tr><th class="firstcell">Directory&nbsp;</th>
                 <th title="The age of the import.">Age&nbsp;</th>
                 <th title="The current state of the bulk import">State&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>
 
-      <div class="center-block">
-        <table id="bulkImportStatus" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="bulkImportStatus" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Per TabletServer</span><br/></caption>
-            <tbody><tr><th class="firstcell">Server&nbsp;</th>
-                <th title="Number of imports presently running">#&nbsp;</th>
-                <th title="The age of the oldest import running on this server.">Oldest&nbsp;Age&nbsp;</th>
-            </tr>
+            <tbody>
+              <tr><th class="firstcell">Server</th>
+                <th title="Number of imports presently running">#</th>
+                <th title="The age of the oldest import running on this server.">Oldest&nbsp;Age</th>
+              </tr>
             </tbody>
         </table>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/default.ftl
@@ -60,18 +60,12 @@
   </head>
 
   <body>
-    <#include "modals.ftl">
-    <div id="content-wrapper">
-      <div id="content">
-        <div id="navbar" class="navbar navbar-inverse navbar-fixed-top">
-          <#include "navbar.ftl">
-        </div>
+    <#include "navbar.ftl">
 
-        <div id="main">
-          <#include "${template}">
+    <div id="main" class="container-fluid">
+      <#include "${template}">
 
-        </div>
-      </div>
     </div>
+    <#include "modals.ftl">
   </body>
 </html>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/listType.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/listType.ftl
@@ -25,14 +25,21 @@
         });
       </script>
 
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="trace" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="trace" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Traces for masterReplicationDriver</span><br/></caption>
-            <tbody><tr><th class="firstcell" title="Start Time of selected trace type">Start&nbsp;</th>
-                <th title="Span Time of selected trace type">ms&nbsp;</th>
-                <th title="Service and Location of selected trace type">Source&nbsp;</th>
-            </tr>
+            <tbody>
+              <tr><th class="firstcell" title="Start Time of selected trace type">Start</th>
+                <th title="Span Time of selected trace type">ms</th>
+                <th title="Service and Location of selected trace type">Source</th>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/master.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/master.ftl
@@ -14,10 +14,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-      <div><h3>${title}</h3></div>
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
       <div id="masterBanner" style="display: none;"><div class="alert alert-danger" role="alert">Master Server Not Running</div></div>
-      <div class="center-block">
-        <table id="masterStatus" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="masterStatus" class="table table-bordered table-striped table-condensed">
           <tbody>
             <tr><th class="firstcell" title="The hostname of the master server">Hostname</th>
                 <th title="Number of tablet servers currently available">Online TServers&nbsp;</th>
@@ -32,8 +37,8 @@
                 <th title="The maximum amount of time that ingest has been held across all servers due to a lack of memory to store the records">Hold&nbsp;Time</th>
                 <th title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load</th></tr>
           </tbody>
-        </table>
-        <table id="recoveryList" class="table table-bordered table-striped table-condensed">
+          </table>
+          <table id="recoveryList" class="table table-bordered table-striped table-condensed">
           <caption><span class="table-caption">Log&nbsp;Recovery</span><br/>
             <span class="table-subcaption">Some tablets were unloaded in an unsafe manner. Write-ahead logs are being recovered.</span><br/>
           </caption>
@@ -44,7 +49,8 @@
                 <th>Progress</th></tr>
             </thead>
             <tbody></tbody>
-        </table>
+          </table>
+        </div>
       </div>
       <br/>
       <#include "${tablesTemplate}">

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -14,6 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+    <div id="navbar" class="navbar navbar-inverse navbar-fixed-top">
       <div class="container-fluid">
         <!-- toggle -->
         <div class="navbar-header">
@@ -82,3 +83,4 @@
           </ul>
         </div>
       </div>
+    </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
@@ -14,99 +14,84 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-      <div class="center"><h3>${title}</h3></div>
-      <br>
-      <div class="center-block">
-        <div class="container">
-          <div class="row">
-            <div class="col-md-6" id="master">
-              <table class="table table-bordered table-striped table-condensed">
-                <tbody>
-                <tr><th colspan="2"><a href="/master">Accumulo Master</a></th></tr>
-                <tr><td colspan="2" class="center" ><span class="label label-danger">Master&nbsp;is&nbsp;Down</span></td></tr>
-                <tr><td class="left"><a href="/tables">Tables</a></td><td class="right"></td></tr>
-                <tr><td class="left"><a href="/tservers">Tablet&nbsp;Servers</a></td><td class="right"></td></tr>
-                <tr><td class="left"><a href="/tservers">Dead&nbsp;Tablet&nbsp;Servers</a></td><td class="right"></td></tr>
-                <tr><td class="left">Tablets</td><td class="right"></td></tr>
-                <tr><td class="left">Entries</td><td class="right"></td></tr>
-                <tr><td class="left">Lookups</td><td class="right"></td></tr>
-                <tr><td class="left">Uptime</td><td class="right"></td></tr>
-                </tbody>
-              </table>
-            </div>
-            <div class="col-md-6" id="zookeeper">
-                <table class="table table-bordered table-striped table-condensed">
-                  <tbody>
-                  <tr><th colspan="3">Zookeeper</th></tr>
-                  <tr><th>Server</th><th>Mode</th><th>Clients</th></tr>
-                  <tr><td class="center" colspan="3"><i>No Zookeepers</i></td></tr>
-                  </tbody>
-                </table>
-            </div>
-          </div>
+      <div class="row">
+        <div class="col-xs-12 center nowrap">
+          <h3>${title}</h3>
         </div>
       </div>
-      <div class="center-block">
-        <div class="container">
-          <div class="row">
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Ingest (Entries/s)</div>
-              <div id="ingest_entries" class="plot"></div>
-            </div>
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Scan (Entries/s)</div>
-              <div id="scan_entries" class="plot"></div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Ingest (MB/s)</div>
-              <div id="ingest_mb" class="plot"></div>
-            </div>
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Scan (MB/s)</div>
-              <div id="scan_mb" class="plot"></div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Load Average</div>
-              <div id="load_avg" class="plot"></div>
-            </div>
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Seeks</div>
-              <div id="seeks" class="plot"></div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Minor Compactions</div>
-              <div id="minor" class="plot"></div>
-            </div>
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Major Compactions</div>
-              <div id="major" class="plot"></div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Index Cache Hit Rate</div>
-              <div id="index_cache" class="plot"></div>
-            </div>
-            <div class="col-md-6">
-              <br>
-              <div class="plotHeading">Data Cache Hit Rate</div>
-              <div id="data_cache" class="plot"></div>
-            </div>
-          </div>
+      <div class="row">
+        <div class="col-sm-6" id="master">
+          <table class="table table-bordered table-striped table-condensed">
+            <tbody>
+              <tr><th colspan="2"><a href="/master">Accumulo Master</a></th></tr>
+              <tr><td colspan="2" class="center" ><span class="label label-danger nowrap">Master is Down</span></td></tr>
+              <tr><td class="left"><a href="/tables">Tables</a></td><td class="right"></td></tr>
+              <tr><td class="left"><a href="/tservers">Tablet&nbsp;Servers</a></td><td class="right"></td></tr>
+              <tr><td class="left"><a href="/tservers">Dead&nbsp;Tablet&nbsp;Servers</a></td><td class="right"></td></tr>
+              <tr><td class="left">Tablets</td><td class="right"></td></tr>
+              <tr><td class="left">Entries</td><td class="right"></td></tr>
+              <tr><td class="left">Lookups</td><td class="right"></td></tr>
+              <tr><td class="left">Uptime</td><td class="right"></td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="col-sm-6" id="zookeeper">
+          <table class="table table-bordered table-striped table-condensed">
+            <tbody>
+              <tr><th colspan="3">Zookeeper</th></tr>
+              <tr><th>Server</th><th>Mode</th><th>Clients</th></tr>
+              <tr><td class="center" colspan="3"><i>No Zookeepers</i></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <div class="plotHeading">Ingest (Entries/s)</div>
+          <div id="ingest_entries" class="plot"></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="plotHeading">Scan (Entries/s)</div>
+          <div id="scan_entries" class="plot"></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <div class="plotHeading">Ingest (MB/s)</div>
+          <div id="ingest_mb" class="plot"></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="plotHeading">Scan (MB/s)</div>
+          <div id="scan_mb" class="plot"></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <div class="plotHeading">Load Average</div>
+          <div id="load_avg" class="plot"></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="plotHeading">Seeks</div>
+          <div id="seeks" class="plot"></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <div class="plotHeading">Minor Compactions</div>
+          <div id="minor" class="plot"></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="plotHeading">Major Compactions</div>
+          <div id="major" class="plot"></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          <div class="plotHeading">Index Cache Hit Rate</div>
+          <div id="index_cache" class="plot"></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="plotHeading">Data Cache Hit Rate</div>
+          <div id="data_cache" class="plot"></div>
         </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/problems.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/problems.ftl
@@ -23,9 +23,14 @@
           refreshProblems();
         });
       </script>
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="problemSummary" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="problemSummary" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Summary</span></caption>
             <tbody><tr><th class="firstcell">Table&nbsp;</th>
                 <th>FILE_READ&nbsp;</th>
@@ -33,8 +38,8 @@
                 <th>TABLET_LOAD&nbsp;</th>
                 <th>Operations&nbsp;</th></tr>
             </tbody>
-        </table>
-        <table id="problemDetails" class="table table-bordered table-striped table-condensed">
+          </table>
+          <table id="problemDetails" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Details</span></caption>
             <tbody><tr><th class="firstcell" >Table&nbsp;</th>
                 <th>Problem&nbsp;Type&nbsp;</th>
@@ -44,5 +49,6 @@
                 <th>Exception&nbsp;</th>
                 <th>Operations&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/replication.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/replication.ftl
@@ -14,15 +14,21 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="replicationStats" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="replicationStats" class="table table-bordered table-striped table-condensed">
             <tbody>
-            <tr><th class="firstcell">Table&nbsp;</th>
+              <tr><th class="firstcell">Table&nbsp;</th>
                 <th>Peer&nbsp;</th>
                 <th>Remote&nbsp;Identifier&nbsp;</th>
                 <th>Replica&nbsp;System&nbsp;Type&nbsp;</th>
                 <th>Files&nbsp;needing&nbsp;replication&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
@@ -14,13 +14,20 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="scanStatus" class="table table-bordered table-striped table-condensed">
-            <tbody><tr><th class="firstcell">Server&nbsp;</th>
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="scanStatus" class="table table-bordered table-striped table-condensed">
+            <tbody>
+              <tr><th class="firstcell">Server&nbsp;</th>
                 <th title="Number of scans presently running">#&nbsp;</th>
                 <th title="The age of the oldest scan on this server.">Oldest&nbsp;Age&nbsp;</th>
-            </tr>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/server.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/server.ftl
@@ -72,24 +72,31 @@
         refreshServer();
       });
       </script>
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="tServerDetail" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="tServerDetail" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">${server}</span></caption>
             <tbody>
-            <tr><th class="firstcell">Hosted&nbsp;Tablets&nbsp;</th>
+              <tr><th class="firstcell">Hosted&nbsp;Tablets&nbsp;</th>
                 <th>Entries&nbsp;</th>
                 <th>Minor&nbsp;Compacting&nbsp;</th>
                 <th>Major&nbsp;Compacting&nbsp;</th>
                 <th>Splitting&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>
-      <div class="center-block">
-        <table id="opHistoryDetails" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="opHistoryDetails" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">All-Time&nbsp;Tablet&nbsp;Operation&nbsp;Results</span></caption>
             <tbody>
-            <tr><th class="firstcell">Operation&nbsp;</th>
+              <tr><th class="firstcell">Operation&nbsp;</th>
                 <th>Success&nbsp;</th>
                 <th>Failure&nbsp;</th>
                 <th>Average<br/>Queue&nbsp;Time&nbsp;</th>
@@ -98,24 +105,28 @@
                 <th>Std.&nbsp;Dev.<br/>Time&nbsp;</th>
                 <th>Percentage&nbsp;Time&nbsp;Spent&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>
-      <div class="center-block">
-        <table id="currentTabletOps" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="currentTabletOps" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Current&nbsp;Tablet&nbsp;Operation&nbsp;Results</span></caption>
             <tbody>
-            <tr><th class="firstcell">Minor&nbsp;Average&nbsp;</th>
+              <tr><th class="firstcell">Minor&nbsp;Average&nbsp;</th>
                 <th>Minor&nbsp;Std&nbsp;Dev&nbsp;</th>
                 <th>Major&nbsp;Avg&nbsp;</th>
                 <th>Major&nbsp;Std&nbsp;Dev&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>
-      <div class="center-block">
-        <table id="perTabletResults" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="perTabletResults" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Detailed Tablet Operations</span></caption>
             <thead>
-            <tr><th>Table&nbsp;</th>
+              <tr><th>Table&nbsp;</th>
                 <th>Tablet&nbsp;</th>
                 <th class="big-num">Entries&nbsp;</th>
                 <th class="big-num">Ingest&nbsp;</th>
@@ -128,5 +139,6 @@
                 <th class="big-num">Major&nbsp;Avg&nbsp;e/s&nbsp;</th></tr>
             </thead>
             <tbody></tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/show.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/show.ftl
@@ -57,12 +57,18 @@
           }
         }
       </script>
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="trace" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="trace" class="table table-bordered table-striped table-condensed">
             <caption><span id="caption" class="table-caption">Trace ${id} started at<br/></span></caption>
             <tbody>
             <tr><th>Time&nbsp;</th><th>Start&nbsp;</th><th>Service@Location&nbsp;</th><th>Name&nbsp;</th><th>Addl&nbsp;Data&nbsp;</th></tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/summary.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/summary.ftl
@@ -24,9 +24,14 @@
         });
       </script>
 
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="traceSummary" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="traceSummary" class="table table-bordered table-striped table-condensed">
             <tbody><tr><th class="firstcell" title="Trace Type">Type&nbsp;</th>
                 <th title="Number of spans of this type">Total&nbsp;</th>
                 <th title="Shortest span duration">min&nbsp;</th>
@@ -35,5 +40,6 @@
                 <th title="Counts of spans of different duration. Columns start at milliseconds, and each column is ten times longer: tens of milliseconds, seconds, tens of seconds, etc.">Histogram&nbsp;</th>
             </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -23,9 +23,14 @@
           refreshTable();
         });
       </script>
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-      <table id="participatingTServers" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="participatingTServers" class="table table-bordered table-striped table-condensed">
           <caption><span class="table-caption">${table}</span></caption>
           <tbody>
           <tr><th class="firstcell">Server&nbsp;</th>
@@ -42,5 +47,6 @@
           <th title="The recent data cache hit rate.">Data Cache<br/>Hit Rate&nbsp;</th>
           <th title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load&nbsp;</th></tr>
           </tbody>
-      </table>
+          </table>
+        </div>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tservers.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tservers.ftl
@@ -14,20 +14,25 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-      <div><h3>${title}</h3></div>
-      <div class="center-block">
-        <table id="badtservers" class="table table-bordered table-striped table-condensed">
+      <div class="row">
+        <div class="col-xs-12">
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <table id="badtservers" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Non-Functioning Tablet Servers</span><br/>
-                <span class="table-subcaption">The following tablet servers reported a status other than Online</span><br/></caption>
+              <span class="table-subcaption">The following tablet servers reported a status other than Online</span></caption>
             <thead><tr>
                 <th>Server</th>
                 <th>Status</th></tr>
             </thead>
             <tbody></tbody>
-        </table>
-        <table id="deadtservers" class="table table-bordered table-striped table-condensed">
+          </table>
+          <table id="deadtservers" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Dead Tablet Servers</span><br/>
-                <span class="table-subcaption">The following tablet servers are no longer reachable.</span><br/></caption>
+              <span class="table-subcaption">The following tablet servers are no longer reachable.</span><br/></caption>
             <thead><tr>
                 <th>Server</th>
                 <th class="duration">Last Updated</th>
@@ -35,8 +40,8 @@
                 <th>Clear</th></tr>
             </thead>
             <tbody></tbody>
-        </table>
-        <table id="tservers" class="table table-bordered table-striped table-condensed">
+          </table>
+          <table id="tservers" class="table table-bordered table-striped table-condensed">
             <thead><tr><th class="firstcell">Server&nbsp;</th>
                 <th class="big-num">Hosted&nbsp;Tablets&nbsp;</th>
                 <th class="duration">Last&nbsp;Contact&nbsp;</th>
@@ -51,8 +56,9 @@
                 <th title="The recent index cache hit rate." class="percent">Index Cache<br/>Hit Rate&nbsp;</th>
                 <th title="The recent data cache hit rate." class="percent">Data Cache<br/>Hit Rate&nbsp;</th>
                 <th title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval."  class="big-num">OS&nbsp;Load&nbsp;</th>
-            </tr>
+              </tr>
             </thead>
             <tbody></tbody>
-        </table>
+          </table>
+        </div>
       </div>


### PR DESCRIPTION
Fixed a .container div nested in a .container-fluid. Bootstrap [container classes are not nestable](https://getbootstrap.com/docs/3.3/css/#overview-container).

Changed main div from absolute positioning to relative.  This was causing plot tooltips to display offset from the actual location of the data point. (Tooltips to be added as a separate pull request)

Replaced divs using .center-block class with Bootstrap's .row and .col-* to improve layout responsiveness.
Also moved h3 titles inside .row and .col-* divs.

Cleaned up unused and redundant CSS rules.

Side-by-side plots on the overview page still look fine at the small layout. Changed .col-md-6 to .col-sm-6

Removed time zone from plots' X axis tick labels. Planning to add other means of displaying and selecting time zone.  Plot option objects can be reused so they were moved outside of makePlots().
