### PR TITLE
fixes #819 Handle bad locality group config.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NewTableConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NewTableConfiguration.java
@@ -27,6 +27,9 @@ import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
+import org.apache.accumulo.core.util.LocalityGroupUtil;
+import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
+import org.slf4j.LoggerFactory;
 
 /**
  * This object stores table creation parameters. Currently includes: {@link TimeType}, whether to
@@ -90,6 +93,15 @@ public class NewTableConfiguration {
   public NewTableConfiguration setProperties(Map<String,String> prop) {
     checkArgument(prop != null, "properties is null");
     SamplerConfigurationImpl.checkDisjoint(prop, samplerConfiguration);
+
+    try {
+      LocalityGroupUtil.checkLocalityGroups(prop.entrySet());
+    } catch (LocalityGroupConfigurationError e) {
+      LoggerFactory.getLogger(NewTableConfiguration.class).warn(
+          "Setting new table properties with bad locality group config.   Even though this warning"
+              + " was displayed, the properties were set. props:" + prop,
+          e);
+    }
 
     this.properties = new HashMap<>(prop);
     return this;

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/InstanceOperationsImpl.java
@@ -43,12 +43,15 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Client;
 import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.core.util.LocalityGroupUtil;
+import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.core.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides a class for administering the accumulo instance
@@ -72,6 +75,8 @@ public class InstanceOperationsImpl implements InstanceOperations {
         client.setSystemProperty(Tracer.traceInfo(), context.rpcCreds(), property, value);
       }
     });
+
+    checkLocalityGroups(property);
   }
 
   @Override
@@ -84,6 +89,22 @@ public class InstanceOperationsImpl implements InstanceOperations {
         client.removeSystemProperty(Tracer.traceInfo(), context.rpcCreds(), property);
       }
     });
+
+    checkLocalityGroups(property);
+  }
+
+  void checkLocalityGroups(String propChanged) throws AccumuloSecurityException, AccumuloException {
+    if (LocalityGroupUtil.isLocalityGroupProperty(propChanged)) {
+      try {
+        LocalityGroupUtil.checkLocalityGroups(getSystemConfiguration().entrySet());
+      } catch (LocalityGroupConfigurationError | RuntimeException e) {
+        LoggerFactory.getLogger(this.getClass()).warn("Changing '" + propChanged
+            + "' resulted in bad locality group config. This may be a transient situation since "
+            + "the config spreads over multiple properties. Setting properties in a different "
+            + "order may help. Even though this warning was displayed, the property was updated. "
+            + "Please check your config to ensure consistency.", e);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
@@ -50,6 +50,8 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.master.thrift.FateOperation;
 import org.apache.accumulo.core.master.thrift.MasterClientService;
 import org.apache.accumulo.core.trace.Tracer;
+import org.apache.accumulo.core.util.LocalityGroupUtil;
+import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.core.util.OpTimer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -181,6 +183,8 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
             value);
       }
     });
+
+    checkLocalityGroups(namespace, property);
   }
 
   @Override
@@ -195,6 +199,8 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
         client.removeNamespaceProperty(Tracer.traceInfo(), context.rpcCreds(), namespace, property);
       }
     });
+
+    checkLocalityGroups(namespace, property);
   }
 
   @Override
@@ -289,6 +295,23 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
     } catch (TableNotFoundException e) {
       // should not happen
       throw new AssertionError(e);
+    }
+  }
+
+  private void checkLocalityGroups(String namespace, String propChanged)
+      throws AccumuloException, NamespaceNotFoundException {
+    if (LocalityGroupUtil.isLocalityGroupProperty(propChanged)) {
+      Iterable<Entry<String,String>> allProps = getProperties(namespace);
+      try {
+        LocalityGroupUtil.checkLocalityGroups(allProps);
+      } catch (LocalityGroupConfigurationError | RuntimeException e) {
+        LoggerFactory.getLogger(this.getClass()).warn("Changing '" + propChanged
+            + "' for namespace '" + namespace
+            + "'resulted in bad locality group config. This may be a transient situation since the"
+            + " config spreads over multiple properties. Setting properties in a different order "
+            + "may help. Even though this warning was displayed, the property was updated. Please check"
+            + " your config to ensure consistency.", e);
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/NamespaceOperationsImpl.java
@@ -309,8 +309,8 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
             + "' for namespace '" + namespace
             + "'resulted in bad locality group config. This may be a transient situation since the"
             + " config spreads over multiple properties. Setting properties in a different order "
-            + "may help. Even though this warning was displayed, the property was updated. Please check"
-            + " your config to ensure consistency.", e);
+            + "may help. Even though this warning was displayed, the property was updated. Please "
+            + "check your config to ensure consistency.", e);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -1032,6 +1032,10 @@ public class TableOperationsImpl extends TableOperationsHelper {
             "Group " + entry.getKey() + " overlaps with another group");
       }
 
+      if(entry.getValue().isEmpty()) {
+        throw new IllegalArgumentException("Group "+entry.getKey()+" is empty");
+      }
+
       all.addAll(entry.getValue());
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TableOperationsImpl.java
@@ -110,6 +110,7 @@ import org.apache.accumulo.core.trace.Tracer;
 import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
+import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.NamingThreadFactory;
 import org.apache.accumulo.core.util.OpTimer;
@@ -929,16 +930,23 @@ public class TableOperationsImpl extends TableOperationsHelper {
     checkArgument(property != null, "property is null");
     checkArgument(value != null, "value is null");
     try {
-      MasterClient.executeTable(context, new ClientExec<MasterClientService.Client>() {
-        @Override
-        public void execute(MasterClientService.Client client) throws Exception {
-          client.setTableProperty(Tracer.traceInfo(), context.rpcCreds(), tableName, property,
-              value);
-        }
-      });
+      setPropertyNoChecks(tableName, property, value);
+
+      checkLocalityGroups(tableName, property);
     } catch (TableNotFoundException e) {
       throw new AccumuloException(e);
     }
+  }
+
+  private void setPropertyNoChecks(final String tableName, final String property,
+      final String value)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+    MasterClient.executeTable(context, new ClientExec<MasterClientService.Client>() {
+      @Override
+      public void execute(MasterClientService.Client client) throws Exception {
+        client.setTableProperty(Tracer.traceInfo(), context.rpcCreds(), tableName, property, value);
+      }
+    });
   }
 
   @Override
@@ -947,14 +955,38 @@ public class TableOperationsImpl extends TableOperationsHelper {
     checkArgument(tableName != null, "tableName is null");
     checkArgument(property != null, "property is null");
     try {
-      MasterClient.executeTable(context, new ClientExec<MasterClientService.Client>() {
-        @Override
-        public void execute(MasterClientService.Client client) throws Exception {
-          client.removeTableProperty(Tracer.traceInfo(), context.rpcCreds(), tableName, property);
-        }
-      });
+      removePropertyNoChecks(tableName, property);
+
+      checkLocalityGroups(tableName, property);
     } catch (TableNotFoundException e) {
       throw new AccumuloException(e);
+    }
+  }
+
+  private void removePropertyNoChecks(final String tableName, final String property)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+    MasterClient.executeTable(context, new ClientExec<MasterClientService.Client>() {
+      @Override
+      public void execute(MasterClientService.Client client) throws Exception {
+        client.removeTableProperty(Tracer.traceInfo(), context.rpcCreds(), tableName, property);
+      }
+    });
+  }
+
+  void checkLocalityGroups(String tableName, String propChanged)
+      throws AccumuloException, TableNotFoundException {
+    if (LocalityGroupUtil.isLocalityGroupProperty(propChanged)) {
+      Iterable<Entry<String,String>> allProps = getProperties(tableName);
+      try {
+        LocalityGroupUtil.checkLocalityGroups(allProps);
+      } catch (LocalityGroupConfigurationError | RuntimeException e) {
+        LoggerFactory.getLogger(this.getClass()).warn("Changing '" + propChanged + "' for table '"
+            + tableName
+            + "' resulted in bad locality group config.  This may be a transient situation since "
+            + "the config spreads over multiple properties.  Setting properties in a different "
+            + "order may help.  Even though this warning was displayed, the property was updated. "
+            + "Please check your config to ensure consistency.", e);
+      }
     }
   }
 
@@ -1006,11 +1038,11 @@ public class TableOperationsImpl extends TableOperationsHelper {
     for (Entry<String,Set<Text>> entry : groups.entrySet()) {
       Set<Text> colFams = entry.getValue();
       String value = LocalityGroupUtil.encodeColumnFamilies(colFams);
-      setProperty(tableName, Property.TABLE_LOCALITY_GROUP_PREFIX + entry.getKey(), value);
+      setPropertyNoChecks(tableName, Property.TABLE_LOCALITY_GROUP_PREFIX + entry.getKey(), value);
     }
 
     try {
-      setProperty(tableName, Property.TABLE_LOCALITY_GROUPS.getKey(),
+      setPropertyNoChecks(tableName, Property.TABLE_LOCALITY_GROUPS.getKey(),
           Joiner.on(",").join(groups.keySet()));
     } catch (AccumuloException e) {
       if (e.getCause() instanceof TableNotFoundException)
@@ -1029,7 +1061,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         String group = parts[parts.length - 1];
 
         if (!groups.containsKey(group)) {
-          removeProperty(tableName, property);
+          removePropertyNoChecks(tableName, property);
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -31,6 +31,7 @@ import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -43,6 +44,8 @@ import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.rfile.RFile.Reader;
 import org.apache.commons.lang.mutable.MutableLong;
 import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
@@ -50,7 +53,7 @@ import com.google.common.collect.ImmutableSet.Builder;
 
 public class LocalityGroupUtil {
 
-  // private static final Logger log = Logger.getLogger(ColumnFamilySet.class);
+  private static final Logger log = LoggerFactory.getLogger(LocalityGroupUtil.class);
 
   // using an ImmutableSet here for more efficient comparisons in LocalityGroupIterator
   public static final ImmutableSet<ByteSequence> EMPTY_CF_SET = ImmutableSet.of();
@@ -79,6 +82,31 @@ public class LocalityGroupUtil {
     LocalityGroupConfigurationError(String why) {
       super(why);
     }
+  }
+
+  public static boolean isLocalityGroupProperty(String prop) {
+    return prop.startsWith(Property.TABLE_LOCALITY_GROUP_PREFIX.getKey())
+        || prop.equals(Property.TABLE_LOCALITY_GROUPS.getKey());
+  }
+
+  public static void checkLocalityGroups(Iterable<Entry<String,String>> config)
+      throws LocalityGroupConfigurationError {
+    ConfigurationCopy cc = new ConfigurationCopy(config);
+    if (cc.get(Property.TABLE_LOCALITY_GROUPS) != null) {
+      getLocalityGroups(cc);
+    }
+  }
+
+  public static Map<String,Set<ByteSequence>> getLocalityGroupsIgnoringErrors(
+      AccumuloConfiguration acuconf, String tableId) {
+    try {
+      return getLocalityGroups(acuconf);
+    } catch (LocalityGroupConfigurationError | RuntimeException e) {
+      log.warn("Failed to get locality group config for tableId:" + tableId
+          + ", proceeding without locality groups.", e);
+    }
+
+    return Collections.emptyMap();
   }
 
   public static Map<String,Set<ByteSequence>> getLocalityGroups(AccumuloConfiguration acuconf)
@@ -114,6 +142,15 @@ public class LocalityGroupUtil {
         }
       }
     }
+
+    Set<Entry<String,Set<ByteSequence>>> es = result.entrySet();
+    for (Entry<String,Set<ByteSequence>> entry : es) {
+      if (entry.getValue().isEmpty()) {
+        throw new LocalityGroupConfigurationError(
+            "Locality group " + entry.getKey() + " specified but not declared");
+      }
+    }
+
     // result.put("", all);
     return result;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -77,7 +77,6 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
@@ -130,11 +129,6 @@ public class InMemoryMap {
     }
 
     return pair.getSecond();
-  }
-
-  @VisibleForTesting
-  public InMemoryMap(AccumuloConfiguration config) {
-    this(config, "--TEST--");
   }
 
   public InMemoryMap(AccumuloConfiguration config, String tableId) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -67,7 +67,6 @@ import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
 import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
-import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.core.util.LocalityGroupUtil.Partitioner;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.PreAllocatedArray;
@@ -78,6 +77,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
@@ -132,12 +132,17 @@ public class InMemoryMap {
     return pair.getSecond();
   }
 
-  public InMemoryMap(AccumuloConfiguration config) throws LocalityGroupConfigurationError {
+  @VisibleForTesting
+  public InMemoryMap(AccumuloConfiguration config) {
+    this(config, "--TEST--");
+  }
+
+  public InMemoryMap(AccumuloConfiguration config, String tableId) {
 
     boolean useNativeMap = config.getBoolean(Property.TSERV_NATIVEMAP_ENABLED);
 
     this.memDumpDir = config.get(Property.TSERV_MEMDUMP_DIR);
-    this.lggroups = LocalityGroupUtil.getLocalityGroups(config);
+    this.lggroups = LocalityGroupUtil.getLocalityGroupsIgnoringErrors(config, tableId);
 
     this.config = config;
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -179,6 +179,15 @@ public class Compactor implements Callable<CompactionStats> {
     return MajorCompactionReason.values()[reason];
   }
 
+  protected Map<String,Set<ByteSequence>> getLocalityGroups(AccumuloConfiguration acuTableConf)
+      throws IOException {
+    try {
+      return LocalityGroupUtil.getLocalityGroups(acuTableConf);
+    } catch (LocalityGroupConfigurationError e) {
+      throw new IOException(e);
+    }
+  }
+
   @Override
   public CompactionStats call() throws IOException, CompactionCanceledException {
 
@@ -203,12 +212,7 @@ public class Compactor implements Callable<CompactionStats> {
       mfw = fileFactory.newWriterBuilder().forFile(outputFilePathName, ns, ns.getConf())
           .withTableConfiguration(acuTableConf).withRateLimiter(env.getWriteLimiter()).build();
 
-      Map<String,Set<ByteSequence>> lGroups;
-      try {
-        lGroups = LocalityGroupUtil.getLocalityGroups(acuTableConf);
-      } catch (LocalityGroupConfigurationError e) {
-        throw new IOException(e);
-      }
+      Map<String,Set<ByteSequence>> lGroups = getLocalityGroups(acuTableConf);
 
       long t1 = System.currentTimeMillis();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -22,13 +22,17 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.impl.Tables;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.FileRef;
@@ -94,6 +98,12 @@ public class MinorCompactor extends Compactor {
       log.warn("Failed to determine if table " + extent.getTableId() + " was deleting ", e);
       return false; // can not get positive confirmation that its deleting.
     }
+  }
+
+  @Override
+  protected Map<String,Set<ByteSequence>> getLocalityGroups(AccumuloConfiguration acuTableConf)
+      throws IOException {
+    return LocalityGroupUtil.getLocalityGroupsIgnoringErrors(acuTableConf, extent.getTableId());
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
-import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.tserver.InMemoryMap;
 import org.apache.accumulo.tserver.InMemoryMap.MemoryIterator;
 import org.slf4j.Logger;
@@ -41,11 +40,7 @@ class TabletMemory implements Closeable {
 
   TabletMemory(TabletCommitter tablet) {
     this.tablet = tablet;
-    try {
-      memTable = new InMemoryMap(tablet.getTableConfiguration());
-    } catch (LocalityGroupConfigurationError e) {
-      throw new RuntimeException(e);
-    }
+    memTable = new InMemoryMap(tablet.getTableConfiguration(), tablet.getExtent().getTableId());
     commitSession = new CommitSession(tablet, nextSeq, memTable);
     nextSeq += 2;
   }
@@ -71,11 +66,7 @@ class TabletMemory implements Closeable {
     }
 
     otherMemTable = memTable;
-    try {
-      memTable = new InMemoryMap(tablet.getTableConfiguration());
-    } catch (LocalityGroupConfigurationError e) {
-      throw new RuntimeException(e);
-    }
+    memTable = new InMemoryMap(tablet.getTableConfiguration(), tablet.getExtent().getTableId());
 
     CommitSession oldCommitSession = commitSession;
     commitSession = new CommitSession(tablet, nextSeq, memTable);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -178,7 +178,7 @@ public class InMemoryMapTest {
     ConfigurationCopy config = new ConfigurationCopy(DefaultConfiguration.getInstance());
     config.set(Property.TSERV_NATIVEMAP_ENABLED, "" + useNative);
     config.set(Property.TSERV_MEMDUMP_DIR, memDumpDir);
-    return new InMemoryMap(config);
+    return new InMemoryMap(config, "--TEST--");
   }
 
   @Test
@@ -551,7 +551,7 @@ public class InMemoryMapTest {
         LocalityGroupUtil.encodeColumnFamilies(toTextSet("cf3", "cf4")));
     config.set(Property.TABLE_LOCALITY_GROUPS.getKey(), "lg1,lg2");
 
-    InMemoryMap imm = new InMemoryMap(config);
+    InMemoryMap imm = new InMemoryMap(config, "--TEST--");
 
     Mutation m1 = new Mutation("r1");
     m1.put("cf1", "x", 2, "1");
@@ -614,7 +614,7 @@ public class InMemoryMapTest {
 
     for (ConfigurationCopy config : Arrays.asList(config1, config2)) {
 
-      InMemoryMap imm = new InMemoryMap(config);
+      InMemoryMap imm = new InMemoryMap(config, "--TEST--");
 
       TreeMap<Key,Value> expectedSample = new TreeMap<>();
       TreeMap<Key,Value> expectedAll = new TreeMap<>();
@@ -700,7 +700,7 @@ public class InMemoryMapTest {
       config1.set(entry.getKey(), entry.getValue());
     }
 
-    InMemoryMap imm = new InMemoryMap(config1);
+    InMemoryMap imm = new InMemoryMap(config1, "--TEST--");
 
     TreeMap<Key,Value> expectedSample = new TreeMap<>();
     TreeMap<Key,Value> expectedAll = new TreeMap<>();
@@ -760,7 +760,7 @@ public class InMemoryMapTest {
       config1.set(entry.getKey(), entry.getValue());
     }
 
-    InMemoryMap imm = new InMemoryMap(config1);
+    InMemoryMap imm = new InMemoryMap(config1, "--TEST--");
 
     mutate(imm, "r", "cf:cq", 5, "b");
 
@@ -805,7 +805,7 @@ public class InMemoryMapTest {
       config1.set(entry.getKey(), entry.getValue());
     }
 
-    InMemoryMap imm = new InMemoryMap(config1);
+    InMemoryMap imm = new InMemoryMap(config1, "--TEST--");
 
     // change sampler config after creating in mem map.
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(

--- a/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
@@ -236,12 +236,14 @@ public class InMemoryMapIT {
       localityGroupNativeConfig.put(Property.TSERV_MEMDUMP_DIR.getKey(),
           tempFolder.newFolder().getAbsolutePath());
 
-      defaultMap = new InMemoryMap(new ConfigurationCopy(defaultMapConfig));
-      nativeMapWrapper = new InMemoryMap(new ConfigurationCopy(nativeMapConfig));
+      defaultMap = new InMemoryMap(new ConfigurationCopy(defaultMapConfig), "--TEST--");
+      nativeMapWrapper = new InMemoryMap(new ConfigurationCopy(nativeMapConfig), "--TEST--");
       localityGroupMap = new InMemoryMap(
-          updateConfigurationForLocalityGroups(new ConfigurationCopy(localityGroupConfig)));
+          updateConfigurationForLocalityGroups(new ConfigurationCopy(localityGroupConfig)),
+          "--TEST--");
       localityGroupMapWithNative = new InMemoryMap(
-          updateConfigurationForLocalityGroups(new ConfigurationCopy(localityGroupNativeConfig)));
+          updateConfigurationForLocalityGroups(new ConfigurationCopy(localityGroupNativeConfig)),
+          "--TEST--");
     } catch (Exception e) {
       log.error("Error getting new InMemoryMap ", e);
       fail(e.getMessage());

--- a/test/src/main/java/org/apache/accumulo/test/InMemoryMapMemoryUsageTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/InMemoryMapMemoryUsageTest.java
@@ -53,7 +53,7 @@ class InMemoryMapMemoryUsageTest extends MemoryUsageTest {
 
   @Override
   void init() {
-    imm = new InMemoryMap(DefaultConfiguration.getInstance());
+    imm = new InMemoryMap(DefaultConfiguration.getInstance(), "--TEST--");
     key = new Text();
 
     colf = new Text(String.format("%0" + colFamLen + "d", 0));

--- a/test/src/main/java/org/apache/accumulo/test/InMemoryMapMemoryUsageTest.java
+++ b/test/src/main/java/org/apache/accumulo/test/InMemoryMapMemoryUsageTest.java
@@ -22,7 +22,6 @@ import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.tserver.InMemoryMap;
 import org.apache.hadoop.io.Text;
 
@@ -54,11 +53,7 @@ class InMemoryMapMemoryUsageTest extends MemoryUsageTest {
 
   @Override
   void init() {
-    try {
-      imm = new InMemoryMap(DefaultConfiguration.getInstance());
-    } catch (LocalityGroupConfigurationError e) {
-      throw new RuntimeException(e);
-    }
+    imm = new InMemoryMap(DefaultConfiguration.getInstance());
     key = new Text();
 
     colf = new Text(String.format("%0" + colFamLen + "d", 0));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BadLocalityGroupMincIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BadLocalityGroupMincIT.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.hadoop.io.Text;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+
+public class BadLocalityGroupMincIT extends AccumuloClusterHarness {
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 60;
+  }
+
+  @Test
+  public void test() throws Exception {
+    Connector c = getConnector();
+
+    String tableName = getUniqueNames(1)[0];
+    Map<String,String> props = new HashMap<>();
+
+    // intentionally bad locality group config where two groups share a family
+    props.put(Property.TABLE_LOCALITY_GROUP_PREFIX.getKey() + "g1", "fam1,fam2");
+    props.put(Property.TABLE_LOCALITY_GROUP_PREFIX.getKey() + "g2", "fam2,fam3");
+    props.put(Property.TABLE_LOCALITY_GROUPS.getKey(), "g1,g2");
+
+    c.tableOperations().create(tableName, new NewTableConfiguration().setProperties(props));
+
+    BatchWriter bw = c.createBatchWriter(tableName, new BatchWriterConfig());
+    Mutation m = new Mutation(new Text("r1"));
+    m.put(new Text("acf"), new Text(tableName), new Value("1".getBytes(UTF_8)));
+
+    bw.addMutation(m);
+    bw.close();
+
+    FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);
+
+    // even with bad locality group config, the minor compaction should still work
+    c.tableOperations().flush(tableName, null, null, true);
+
+    FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 1, 1);
+
+    Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY);
+    Entry<Key,Value> entry = Iterables.getOnlyElement(scanner);
+
+    Assert.assertEquals("r1", entry.getKey().getRowData().toString());
+    Assert.assertEquals("acf", entry.getKey().getColumnFamilyData().toString());
+    Assert.assertEquals(tableName, entry.getKey().getColumnQualifierData().toString());
+    Assert.assertEquals("1", entry.getValue().toString());
+
+    // this should not hang
+    c.tableOperations().delete(tableName);
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/BadLocalityGroupMincIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BadLocalityGroupMincIT.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +35,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Iterables;
@@ -77,10 +77,10 @@ public class BadLocalityGroupMincIT extends AccumuloClusterHarness {
     Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY);
     Entry<Key,Value> entry = Iterables.getOnlyElement(scanner);
 
-    Assert.assertEquals("r1", entry.getKey().getRowData().toString());
-    Assert.assertEquals("acf", entry.getKey().getColumnFamilyData().toString());
-    Assert.assertEquals(tableName, entry.getKey().getColumnQualifierData().toString());
-    Assert.assertEquals("1", entry.getValue().toString());
+    assertEquals("r1", entry.getKey().getRowData().toString());
+    assertEquals("acf", entry.getKey().getColumnFamilyData().toString());
+    assertEquals(tableName, entry.getKey().getColumnQualifierData().toString());
+    assertEquals("1", entry.getValue().toString());
 
     // this should not hang
     c.tableOperations().delete(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
@@ -64,7 +64,6 @@ public class RowDeleteIT extends AccumuloClusterHarness {
     c.tableOperations().create(tableName);
     Map<String,Set<Text>> groups = new HashMap<>();
     groups.put("lg1", Collections.singleton(new Text("foo")));
-    groups.put("dg", Collections.<Text> emptySet());
     c.tableOperations().setLocalityGroups(tableName, groups);
     IteratorSetting setting = new IteratorSetting(30, RowDeletingIterator.class);
     c.tableOperations().attachIterator(tableName, setting, EnumSet.of(IteratorScope.majc));


### PR DESCRIPTION
Two changes were made for bad locality group config.  First, when setting
properties a warning  is issued if the change results in bad LG config.
Second, minor compactions will log a warning and proceed with no LG config
if the config is bad.