### PR TITLE
More cleanup for WAL

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
@@ -27,7 +27,8 @@ public class TabletMutations {
   private final List<Mutation> mutations;
   private final Durability durability;
 
-  public TabletMutations(CommitSession commitSession, List<Mutation> mutations, Durability durability) {
+  public TabletMutations(CommitSession commitSession, List<Mutation> mutations,
+      Durability durability) {
     this.commitSession = commitSession;
     this.mutations = mutations;
     this.durability = durability;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletMutations.java
@@ -20,16 +20,15 @@ import java.util.List;
 
 import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.tserver.tablet.CommitSession;
 
 public class TabletMutations {
-  private final int tid;
-  private final long seq;
+  private CommitSession commitSession;
   private final List<Mutation> mutations;
   private final Durability durability;
 
-  public TabletMutations(int tid, long seq, List<Mutation> mutations, Durability durability) {
-    this.tid = tid;
-    this.seq = seq;
+  public TabletMutations(CommitSession commitSession, List<Mutation> mutations, Durability durability) {
+    this.commitSession = commitSession;
     this.mutations = mutations;
     this.durability = durability;
   }
@@ -39,11 +38,11 @@ public class TabletMutations {
   }
 
   public int getTid() {
-    return tid;
+    return commitSession.getLogId();
   }
 
   public long getSeq() {
-    return seq;
+    return commitSession.getWALogSeq();
   }
 
   public Durability getDurability() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1045,8 +1045,7 @@ public class TabletServer implements Runnable {
                 us.failures.put(tablet.getExtent(), us.successfulCommits.get(tablet));
               } else {
                 if (durability != Durability.NONE) {
-                  loggables.put(commitSession, new TabletMutations(commitSession.getLogId(),
-                      commitSession.getWALogSeq(), mutations, durability));
+                  loggables.put(commitSession, new TabletMutations(commitSession, mutations, durability));
                 }
                 sendables.put(commitSession, mutations);
                 mutationCount += mutations.size();
@@ -1063,8 +1062,7 @@ public class TabletServer implements Runnable {
                 // prepareMutationsForCommit() expects
                 CommitSession cs = e.getCommitSession();
                 if (durability != Durability.NONE) {
-                  loggables.put(cs, new TabletMutations(cs.getLogId(), cs.getWALogSeq(),
-                      e.getNonViolators(), durability));
+                  loggables.put(cs, new TabletMutations(cs, e.getNonViolators(), durability));
                 }
                 sendables.put(cs, e.getNonViolators());
               }
@@ -1272,7 +1270,7 @@ public class TabletServer implements Runnable {
           try {
             final Span wal = Trace.start("wal");
             try {
-              logger.log(cs, cs.getWALogSeq(), mutation, durability);
+              logger.log(cs, mutation, durability);
             } finally {
               wal.stop();
             }
@@ -1390,8 +1388,7 @@ public class TabletServer implements Runnable {
                   for (ServerConditionalMutation scm : entry.getValue())
                     results.add(new TCMResult(scm.getID(), TCMStatus.ACCEPTED));
                   if (durability != Durability.NONE) {
-                    loggables.put(cs, new TabletMutations(cs.getLogId(), cs.getWALogSeq(),
-                        mutations, durability));
+                    loggables.put(cs, new TabletMutations(cs, mutations, durability));
                   }
                   sendables.put(cs, mutations);
                 }
@@ -1400,8 +1397,7 @@ public class TabletServer implements Runnable {
               CommitSession cs = e.getCommitSession();
               if (e.getNonViolators().size() > 0) {
                 if (durability != Durability.NONE) {
-                  loggables.put(cs, new TabletMutations(cs.getLogId(), cs.getWALogSeq(),
-                      e.getNonViolators(), durability));
+                  loggables.put(cs, new TabletMutations(cs, e.getNonViolators(), durability));
                 }
                 sendables.put(cs, e.getNonViolators());
                 for (Mutation m : e.getNonViolators())

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1045,7 +1045,8 @@ public class TabletServer implements Runnable {
                 us.failures.put(tablet.getExtent(), us.successfulCommits.get(tablet));
               } else {
                 if (durability != Durability.NONE) {
-                  loggables.put(commitSession, new TabletMutations(commitSession, mutations, durability));
+                  loggables.put(commitSession,
+                      new TabletMutations(commitSession, mutations, durability));
                 }
                 sendables.put(commitSession, mutations);
                 mutationCount += mutations.size();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -544,7 +544,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
       }
   }
 
-  public synchronized LoggerOperation defineTablet(CommitSession cs) throws IOException {
+  public LoggerOperation defineTablet(CommitSession cs) throws IOException {
     // write this log to the METADATA table
     final LogFileKey key = new LogFileKey();
     key.event = DEFINE_TABLET;
@@ -572,17 +572,15 @@ public class DfsLogger implements Comparable<DfsLogger> {
   private LoggerOperation logFileData(List<Pair<LogFileKey,LogFileValue>> keys,
       Durability durability) throws IOException {
     DfsLogger.LogWork work = new DfsLogger.LogWork(new CountDownLatch(1), durability);
-    synchronized (DfsLogger.this) {
-      try {
-        for (Pair<LogFileKey,LogFileValue> pair : keys) {
-          write(pair.getFirst(), pair.getSecond());
-        }
-      } catch (ClosedChannelException ex) {
-        throw new LogClosedException();
-      } catch (Exception e) {
-        log.error("Failed to write log entries", e);
-        work.exception = e;
+    try {
+      for (Pair<LogFileKey,LogFileValue> pair : keys) {
+        write(pair.getFirst(), pair.getSecond());
       }
+    } catch (ClosedChannelException ex) {
+      throw new LogClosedException();
+    } catch (Exception e) {
+      log.error("Failed to write log entries", e);
+      work.exception = e;
     }
 
     if (durability == Durability.LOG)

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -451,8 +451,8 @@ public class TabletServerLogger {
     if (durability == Durability.DEFAULT || durability == Durability.NONE) {
       throw new IllegalArgumentException("Unexpected durability " + durability);
     }
-    write(singletonList(commitSession), false,
-        logger -> logger.log(commitSession, m, durability), writeRetryFactory.createRetry());
+    write(singletonList(commitSession), false, logger -> logger.log(commitSession, m, durability),
+        writeRetryFactory.createRetry());
     logSizeEstimate.addAndGet(m.numBytes());
   }
 
@@ -476,10 +476,9 @@ public class TabletServerLogger {
   }
 
   public void minorCompactionFinished(final CommitSession commitSession, final long walogSeq,
-                                      final Durability durability) throws IOException {
-    write(
-        singletonList(commitSession), true, logger -> logger.minorCompactionFinished(walogSeq,
-            commitSession.getLogId(), durability),
+      final Durability durability) throws IOException {
+    write(singletonList(commitSession), true,
+        logger -> logger.minorCompactionFinished(walogSeq, commitSession.getLogId(), durability),
         writeRetryFactory.createRetry());
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -271,11 +271,13 @@ public class TabletServerLogger {
         while (!nextLogMaker.isShutdown()) {
           DfsLogger alog = null;
           try {
-            log.debug("Creating next WAL");
+            if (log.isDebugEnabled())
+              log.debug("Creating next WAL");
             alog = new DfsLogger(tserver.getContext(), conf, syncCounter, flushCounter);
             alog.open(tserver.getClientAddressString());
             String fileName = alog.getFileName();
-            log.debug("Created next WAL " + fileName);
+            if (log.isDebugEnabled())
+              log.debug("Created next WAL " + fileName);
             tserver.addNewLogMarker(alog);
             while (!nextLog.offer(alog, 12, TimeUnit.HOURS)) {
               log.info("Our WAL was not used for 12 hours: {}", fileName);
@@ -348,9 +350,8 @@ public class TabletServerLogger {
     while (!success) {
       try {
         // get a reference to the loggers that no other thread can touch
-        DfsLogger copy = null;
         AtomicInteger currentId = new AtomicInteger(-1);
-        copy = initializeLoggers(currentId);
+        DfsLogger copy = initializeLoggers(currentId);
         currentLogId = currentId.get();
 
         // add the logger to the log set for the memory in the tablet,
@@ -361,7 +362,8 @@ public class TabletServerLogger {
             if (commitSession.beginUpdatingLogsUsed(copy, mincFinish)) {
               try {
                 // Scribble out a tablet definition and then write to the metadata table
-                defineTablet(commitSession, writeRetry);
+                write(singletonList(commitSession), false,
+                    logger -> logger.defineTablet(commitSession), writeRetry);
               } finally {
                 commitSession.finishUpdatingLogsUsed();
               }
@@ -441,27 +443,16 @@ public class TabletServerLogger {
     });
   }
 
-  public void defineTablet(final CommitSession commitSession, final Retry writeRetry)
-      throws IOException {
-    // scribble this into the metadata tablet, too.
-    write(singletonList(commitSession), false, logger -> {
-      logger.defineTablet(commitSession.getWALogSeq(), commitSession.getLogId(),
-          commitSession.getExtent());
-      return DfsLogger.NO_WAIT_LOGGER_OP;
-    }, writeRetry);
-  }
-
   /**
    * Log a single mutation. This method expects mutations that have a durability other than NONE.
    */
-  public void log(final CommitSession commitSession, final long tabletSeq, final Mutation m,
-      final Durability durability) throws IOException {
+  public void log(final CommitSession commitSession, final Mutation m, final Durability durability)
+      throws IOException {
     if (durability == Durability.DEFAULT || durability == Durability.NONE) {
       throw new IllegalArgumentException("Unexpected durability " + durability);
     }
     write(singletonList(commitSession), false,
-        logger -> logger.log(tabletSeq, commitSession.getLogId(), m, durability),
-        writeRetryFactory.createRetry());
+        logger -> logger.log(commitSession, m, durability), writeRetryFactory.createRetry());
     logSizeEstimate.addAndGet(m.numBytes());
   }
 
@@ -485,17 +476,11 @@ public class TabletServerLogger {
   }
 
   public void minorCompactionFinished(final CommitSession commitSession, final long walogSeq,
-      final Durability durability) throws IOException {
-
-    long t1 = System.currentTimeMillis();
-
-    write(singletonList(commitSession), true,
-        logger -> logger.minorCompactionFinished(walogSeq, commitSession.getLogId(), durability),
+                                      final Durability durability) throws IOException {
+    write(
+        singletonList(commitSession), true, logger -> logger.minorCompactionFinished(walogSeq,
+            commitSession.getLogId(), durability),
         writeRetryFactory.createRetry());
-
-    long t2 = System.currentTimeMillis();
-
-    log.debug(" wrote MinC finish: writeTime:{}ms  durability:{}", (t2 - t1), durability);
   }
 
   public long minorCompactionStarted(final CommitSession commitSession, final long seq,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -271,13 +271,11 @@ public class TabletServerLogger {
         while (!nextLogMaker.isShutdown()) {
           DfsLogger alog = null;
           try {
-            if (log.isDebugEnabled())
-              log.debug("Creating next WAL");
+            log.debug("Creating next WAL");
             alog = new DfsLogger(tserver.getContext(), conf, syncCounter, flushCounter);
             alog.open(tserver.getClientAddressString());
             String fileName = alog.getFileName();
-            if (log.isDebugEnabled())
-              log.debug("Created next WAL " + fileName);
+            log.debug("Created next WAL {}", fileName);
             tserver.addNewLogMarker(alog);
             while (!nextLog.offer(alog, 12, TimeUnit.HOURS)) {
               log.info("Our WAL was not used for 12 hours: {}", fileName);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -456,8 +456,8 @@ class DatafileManager {
         // passed in,
         // is because the new one will reference the logs used by current memory...
 
-        tablet.getTabletServer().minorCompactionFinished(tablet.getTabletMemory().getCommitSession(),
-            commitSession.getWALogSeq() + 2);
+        tablet.getTabletServer().minorCompactionFinished(
+            tablet.getTabletMemory().getCommitSession(), commitSession.getWALogSeq() + 2);
         break;
       } catch (IOException e) {
         log.error("Failed to write to write-ahead log " + e.getMessage() + " will retry", e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -456,8 +456,8 @@ class DatafileManager {
         // passed in,
         // is because the new one will reference the logs used by current memory...
 
-        tablet.getTabletServer().minorCompactionFinished(
-            tablet.getTabletMemory().getCommitSession(), commitSession.getWALogSeq() + 2);
+        tablet.getTabletServer().minorCompactionFinished(tablet.getTabletMemory().getCommitSession(),
+            commitSession.getWALogSeq() + 2);
         break;
       } catch (IOException e) {
         log.error("Failed to write to write-ahead log " + e.getMessage() + " will retry", e);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.tserver.TabletMutations;
+import org.apache.accumulo.tserver.tablet.CommitSession;
+import org.easymock.EasyMock;
 import org.junit.Test;
 
 public class DfsLoggerTest {
@@ -32,26 +34,27 @@ public class DfsLoggerTest {
   @Test
   public void testDurabilityForGroupCommit() {
     List<TabletMutations> lst = new ArrayList<>();
+    CommitSession commitSession = EasyMock.createMock(CommitSession.class);
     assertEquals(Durability.NONE, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m1 = new TabletMutations(0, 1, Collections.emptyList(), Durability.NONE);
+    TabletMutations m1 = new TabletMutations(commitSession, Collections.emptyList(), Durability.NONE);
     lst.add(m1);
     assertEquals(Durability.NONE, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m2 = new TabletMutations(0, 1, Collections.emptyList(), Durability.LOG);
+    TabletMutations m2 = new TabletMutations(commitSession, Collections.emptyList(), Durability.LOG);
     lst.add(m2);
     assertEquals(Durability.LOG, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m3 = new TabletMutations(0, 1, Collections.emptyList(), Durability.NONE);
+    TabletMutations m3 = new TabletMutations(commitSession, Collections.emptyList(), Durability.NONE);
     lst.add(m3);
     assertEquals(Durability.LOG, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m4 = new TabletMutations(0, 1, Collections.emptyList(), Durability.FLUSH);
+    TabletMutations m4 = new TabletMutations(commitSession, Collections.emptyList(), Durability.FLUSH);
     lst.add(m4);
     assertEquals(Durability.FLUSH, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m5 = new TabletMutations(0, 1, Collections.emptyList(), Durability.LOG);
+    TabletMutations m5 = new TabletMutations(commitSession, Collections.emptyList(), Durability.LOG);
     lst.add(m5);
     assertEquals(Durability.FLUSH, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m6 = new TabletMutations(0, 1, Collections.emptyList(), Durability.SYNC);
+    TabletMutations m6 = new TabletMutations(commitSession, Collections.emptyList(), Durability.SYNC);
     lst.add(m6);
     assertEquals(Durability.SYNC, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m7 = new TabletMutations(0, 1, Collections.emptyList(), Durability.FLUSH);
+    TabletMutations m7 = new TabletMutations(commitSession, Collections.emptyList(), Durability.FLUSH);
     lst.add(m7);
     assertEquals(Durability.SYNC, chooseDurabilityForGroupCommit(lst));
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
@@ -36,25 +36,32 @@ public class DfsLoggerTest {
     List<TabletMutations> lst = new ArrayList<>();
     CommitSession commitSession = EasyMock.createMock(CommitSession.class);
     assertEquals(Durability.NONE, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m1 = new TabletMutations(commitSession, Collections.emptyList(), Durability.NONE);
+    TabletMutations m1 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.NONE);
     lst.add(m1);
     assertEquals(Durability.NONE, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m2 = new TabletMutations(commitSession, Collections.emptyList(), Durability.LOG);
+    TabletMutations m2 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.LOG);
     lst.add(m2);
     assertEquals(Durability.LOG, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m3 = new TabletMutations(commitSession, Collections.emptyList(), Durability.NONE);
+    TabletMutations m3 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.NONE);
     lst.add(m3);
     assertEquals(Durability.LOG, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m4 = new TabletMutations(commitSession, Collections.emptyList(), Durability.FLUSH);
+    TabletMutations m4 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.FLUSH);
     lst.add(m4);
     assertEquals(Durability.FLUSH, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m5 = new TabletMutations(commitSession, Collections.emptyList(), Durability.LOG);
+    TabletMutations m5 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.LOG);
     lst.add(m5);
     assertEquals(Durability.FLUSH, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m6 = new TabletMutations(commitSession, Collections.emptyList(), Durability.SYNC);
+    TabletMutations m6 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.SYNC);
     lst.add(m6);
     assertEquals(Durability.SYNC, chooseDurabilityForGroupCommit(lst));
-    TabletMutations m7 = new TabletMutations(commitSession, Collections.emptyList(), Durability.FLUSH);
+    TabletMutations m7 = new TabletMutations(commitSession, Collections.emptyList(),
+        Durability.FLUSH);
     lst.add(m7);
     assertEquals(Durability.SYNC, chooseDurabilityForGroupCommit(lst));
   }


### PR DESCRIPTION
* Actually log MUTATION for single mutation
* Make TabletMutations constructor take CommitSession
* Simplify calls to defineTablet
* Remove unused datafile path param
* Add checks for debug

Only synchronize on write method