### PR TITLE
Remove extra loop in InMemoryMap

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -528,11 +528,7 @@ public class InMemoryMap {
    * Applies changes to a row in the InMemoryMap
    *
    */
-  public void mutate(List<Mutation> mutations) {
-    int numKVs = 0;
-    for (Mutation mutation : mutations)
-      numKVs += mutation.size();
-
+  public void mutate(List<Mutation> mutations, int numKVs) {
     // Can not update mutationCount while writes that started before
     // are in progress, this would cause partial mutations to be seen.
     // Also, can not continue until mutation count is updated, because

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CommitSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CommitSession.java
@@ -111,7 +111,7 @@ public class CommitSession {
     return maxCommittedTime;
   }
 
-  public void mutate(List<Mutation> mutations) {
-    memTable.mutate(mutations);
+  public void mutate(List<Mutation> mutations, int count) {
+    memTable.mutate(mutations, count);
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -445,7 +445,7 @@ public class Tablet implements TabletCommitter {
                     maxTime.set(Math.max(maxTime.get(), columnUpdate.getTimestamp()));
                   }
                 }
-                getTabletMemory().mutate(commitSession, Collections.singletonList(m));
+                getTabletMemory().mutate(commitSession, Collections.singletonList(m), 1);
                 entriesUsedOnTablet.incrementAndGet();
               }
             });
@@ -1284,7 +1284,7 @@ public class Tablet implements TabletCommitter {
       totalBytes += mutation.numBytes();
     }
 
-    getTabletMemory().mutate(commitSession, mutations);
+    getTabletMemory().mutate(commitSession, mutations, totalCount);
 
     synchronized (this) {
       if (writesInProgress < 1) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -147,8 +147,8 @@ class TabletMemory implements Closeable {
     }
   }
 
-  public void mutate(CommitSession cm, List<Mutation> mutations) {
-    cm.mutate(mutations);
+  public void mutate(CommitSession cm, List<Mutation> mutations, int count) {
+    cm.mutate(mutations, count);
   }
 
   public void updateMemoryUsageStats() {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -127,7 +127,7 @@ public class InMemoryMapTest {
     String[] sa = column.split(":");
     m.putDelete(new Text(sa[0]), new Text(sa[1]), ts);
 
-    imm.mutate(Collections.singletonList(m));
+    imm.mutate(Collections.singletonList(m), 1);
   }
 
   public void mutate(InMemoryMap imm, String row, String column, long ts, String value) {
@@ -135,7 +135,7 @@ public class InMemoryMapTest {
     String[] sa = column.split(":");
     m.put(new Text(sa[0]), new Text(sa[1]), ts, new Value(value.getBytes()));
 
-    imm.mutate(Collections.singletonList(m));
+    imm.mutate(Collections.singletonList(m), 1);
   }
 
   static Key newKey(String row, String column, long ts) {
@@ -492,7 +492,7 @@ public class InMemoryMapTest {
     Mutation m = new Mutation(new Text("r1"));
     m.put(new Text("foo"), new Text("cq"), 3, new Value("v1".getBytes()));
     m.put(new Text("foo"), new Text("cq"), 3, new Value("v2".getBytes()));
-    imm.mutate(Collections.singletonList(m));
+    imm.mutate(Collections.singletonList(m), 2);
 
     MemoryIterator skvi1 = imm.skvIterator(null);
     skvi1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
@@ -529,7 +529,7 @@ public class InMemoryMapTest {
                 Mutation m = new Mutation("row");
                 m.put("cf", "cq", new Value("v".getBytes()));
                 List<Mutation> mutations = Collections.singletonList(m);
-                imm.mutate(mutations);
+                imm.mutate(mutations, 1);
                 counts[threadId]++;
               }
             }
@@ -583,7 +583,7 @@ public class InMemoryMapTest {
     m5.put("cf3", "z", 6, "A");
     m5.put("cf4", "z", 6, "B");
 
-    imm.mutate(Arrays.asList(m1, m2, m3, m4, m5));
+    imm.mutate(Arrays.asList(m1, m2, m3, m4, m5), 10);
 
     MemoryIterator iter1 = imm.skvIterator(null);
 

--- a/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
@@ -267,10 +267,13 @@ public class InMemoryMapIT {
     assertEquals("Not a LocalityGroupMap with native", InMemoryMap.TYPE_LOCALITY_GROUP_MAP_NATIVE,
         localityGroupMapWithNative.getMapType());
 
-    defaultMap.mutate(mutations);
-    nativeMapWrapper.mutate(mutations);
-    localityGroupMap.mutate(mutations);
-    localityGroupMapWithNative.mutate(mutations);
+    int count = 0;
+    for (Mutation m : mutations)
+      count += m.size();
+    defaultMap.mutate(mutations, count);
+    nativeMapWrapper.mutate(mutations, count);
+    localityGroupMap.mutate(mutations, count);
+    localityGroupMapWithNative.mutate(mutations, count);
 
     // let's use the transitive property to assert all four are equivalent
     assertMutatesEquivalent(mutations, defaultMap, nativeMapWrapper);


### PR DESCRIPTION
* The number of total keys across mutations was counted twice so just
pass the count down to the InMemoryMap