### PR TITLE
Add configSanityCheck to initialize. Fixes #834

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.client.IteratorSetting.Column;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.ConfigSanityCheck;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
@@ -929,6 +930,7 @@ public class Initialize implements KeywordExecutable {
     Opts opts = new Opts();
     opts.parseArgs("accumulo init", args);
     SiteConfiguration siteConfig = new SiteConfiguration();
+    ConfigSanityCheck.validate(siteConfig);
 
     try {
       setZooReaderWriter(new ZooReaderWriter(siteConfig));


### PR DESCRIPTION
This check will ensure if the crypto service is set that the class is valid.  Otherwise a fatal exception will be thrown.  This check appears to be called quite frequently any time we get configuration but for some reason it is not called during Initialize. 