### PR TITLE
Fix CLASSPATH bug causing current dir to be added

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -51,7 +51,12 @@ if [ ! -d "$HADOOP_HOME" ]; then
 fi
 
 ## Build using existing CLASSPATH, conf/ directory, dependencies in lib/, and external Hadoop & Zookeeper dependencies
-CLASSPATH="${CLASSPATH}:${conf}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${HADOOP_HOME}/share/hadoop/client/*"
+if [ -n "$CLASSPATH" ]; then
+  CLASSPATH="${CLASSPATH}:${conf}"
+else
+  CLASSPATH="${conf}"
+fi
+CLASSPATH="${CLASSPATH}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${HADOOP_HOME}/share/hadoop/client/*"
 export CLASSPATH
 
 ##################################################################


### PR DESCRIPTION
* If CLASSPATH variable was empty, a colon would be added
  to front of CLASSPATH causing user's current directory
  to be added to directory.
* This could unexpected files like accumulo.properties to be
  added to the classpath