### PR TITLE
Make replication services start when configured

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -456,8 +456,6 @@ public enum Property {
       "The amount of time an assignment can run before the server will print a"
           + " warning along with the current stack trace. Meant to help debug stuck"
           + " assignments"),
-  TSERV_REPLICATION_ENABLED("tserver.replication.services.enabled", "false", PropertyType.BOOLEAN,
-      "Start the replication services when tserver starts up."),
   TSERV_REPLICATION_REPLAYERS("tserver.replication.replayer.", null, PropertyType.PREFIX,
       "Allows configuration of implementation used to apply replicated data"),
   TSERV_REPLICATION_DEFAULT_HANDLER("tserver.replication.default.replayer",
@@ -1190,7 +1188,7 @@ public enum Property {
 
   private static final EnumSet<Property> fixedProperties = EnumSet.of(Property.TSERV_CLIENTPORT,
       Property.TSERV_NATIVEMAP_ENABLED, Property.TSERV_SCAN_MAX_OPENFILES,
-      Property.TSERV_REPLICATION_ENABLED, Property.MASTER_CLIENTPORT, Property.GC_PORT);
+      Property.MASTER_CLIENTPORT, Property.GC_PORT);
 
   /**
    * Checks if the given property may be changed via Zookeeper, but not recognized until the restart

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -456,6 +456,8 @@ public enum Property {
       "The amount of time an assignment can run before the server will print a"
           + " warning along with the current stack trace. Meant to help debug stuck"
           + " assignments"),
+  TSERV_REPLICATION_ENABLED("tserver.replication.services.enabled", "false", PropertyType.BOOLEAN,
+      "Start the replication services when tserver starts up."),
   TSERV_REPLICATION_REPLAYERS("tserver.replication.replayer.", null, PropertyType.PREFIX,
       "Allows configuration of implementation used to apply replicated data"),
   TSERV_REPLICATION_DEFAULT_HANDLER("tserver.replication.default.replayer",
@@ -1188,7 +1190,7 @@ public enum Property {
 
   private static final EnumSet<Property> fixedProperties = EnumSet.of(Property.TSERV_CLIENTPORT,
       Property.TSERV_NATIVEMAP_ENABLED, Property.TSERV_SCAN_MAX_OPENFILES,
-      Property.MASTER_CLIENTPORT, Property.GC_PORT);
+      Property.TSERV_REPLICATION_ENABLED, Property.MASTER_CLIENTPORT, Property.GC_PORT);
 
   /**
    * Checks if the given property may be changed via Zookeeper, but not recognized until the restart

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1381,8 +1381,8 @@ public class Master
     final AtomicReference<TServer> replServer = new AtomicReference<>();
     SimpleTimer.getInstance(getConfiguration()).schedule(() -> {
       try {
-        if (!getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
-          if (replServer.get() == null) {
+        if (replServer.get() == null) {
+          if (!getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
             log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
             replServer.set(setupReplication());
           }

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -1386,8 +1386,8 @@ public class Master
             replServer.setServer(setupReplication());
           }
         }
-      } catch (Exception e) {
-        log.error("Replication name was set but error occurred starting services. ", e);
+      } catch (UnknownHostException | KeeperException | InterruptedException e) {
+        log.error("Error occurred starting replication services. ", e);
       }
     }, 1000, 5000);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2846,7 +2846,7 @@ public class TabletServer implements Runnable {
         log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
         setupReplication(aconf);
       }
-    }, 1000, 5000);
+    }, 0, 5000);
 
     final long CLEANUP_BULK_LOADED_CACHE_MILLIS = 15 * 60 * 1000;
     SimpleTimer.getInstance(aconf).schedule(new BulkImportCacheCleaner(this),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2664,7 +2664,7 @@ public class TabletServer implements Runnable {
     return address;
   }
 
-  private HostAndPort startReplicationService() throws UnknownHostException {
+  private void startReplicationService() throws UnknownHostException {
     final ReplicationServicerHandler handler = new ReplicationServicerHandler(this);
     ReplicationServicer.Iface rpcProxy = TraceWrap.service(handler);
     ReplicationServicer.Iface repl = TCredentialsUpdatingWrapper.service(rpcProxy,
@@ -2695,8 +2695,6 @@ public class TabletServer implements Runnable {
       log.error("Could not advertise replication service port", e);
       throw new RuntimeException(e);
     }
-
-    return sp.address;
   }
 
   public ZooLock getLock() {
@@ -2841,35 +2839,11 @@ public class TabletServer implements Runnable {
       log.error("Error setting watches for recoveries");
       throw new RuntimeException(ex);
     }
-
-    // Start the thrift service listening for incoming replication requests
-    try {
-      startReplicationService();
-    } catch (UnknownHostException e) {
-      throw new RuntimeException("Failed to start replication service", e);
-    }
-
-    // Start the pool to handle outgoing replications
-    final ThreadPoolExecutor replicationThreadPool = new SimpleThreadPool(
-        getConfiguration().getCount(Property.REPLICATION_WORKER_THREADS), "replication task");
-    replWorker.setExecutor(replicationThreadPool);
-    replWorker.run();
-
-    // Check the configuration value for the size of the pool and, if changed, resize the pool,
-    // every 5 seconds);
     final AccumuloConfiguration aconf = getConfiguration();
-    Runnable replicationWorkThreadPoolResizer = new Runnable() {
-      @Override
-      public void run() {
-        int maxPoolSize = aconf.getCount(Property.REPLICATION_WORKER_THREADS);
-        if (replicationThreadPool.getMaximumPoolSize() != maxPoolSize) {
-          log.info("Resizing thread pool for sending replication work from {} to {}",
-              replicationThreadPool.getMaximumPoolSize(), maxPoolSize);
-          replicationThreadPool.setMaximumPoolSize(maxPoolSize);
-        }
-      }
-    };
-    SimpleTimer.getInstance(aconf).schedule(replicationWorkThreadPoolResizer, 10000, 30000);
+    final boolean replicating = !aconf.get(Property.REPLICATION_NAME).isEmpty();
+
+    if (replicating)
+      setupReplication(aconf);
 
     final long CLEANUP_BULK_LOADED_CACHE_MILLIS = 15 * 60 * 1000;
     SimpleTimer.getInstance(aconf).schedule(new BulkImportCacheCleaner(this),
@@ -2952,8 +2926,10 @@ public class TabletServer implements Runnable {
         }
       }
     }
-    log.debug("Stopping Replication Server");
-    TServerUtils.stopTServer(this.replServer);
+    if (replicating) {
+      log.debug("Stopping Replication Server");
+      TServerUtils.stopTServer(this.replServer);
+    }
     log.debug("Stopping Thrift Servers");
     TServerUtils.stopTServer(server);
 
@@ -2973,6 +2949,36 @@ public class TabletServer implements Runnable {
     } catch (Exception e) {
       log.warn("Failed to release tablet server lock", e);
     }
+  }
+
+  private void setupReplication(AccumuloConfiguration aconf) {
+    // Start the thrift service listening for incoming replication requests
+    try {
+      startReplicationService();
+    } catch (UnknownHostException e) {
+      throw new RuntimeException("Failed to start replication service", e);
+    }
+
+    // Start the pool to handle outgoing replications
+    final ThreadPoolExecutor replicationThreadPool = new SimpleThreadPool(
+        getConfiguration().getCount(Property.REPLICATION_WORKER_THREADS), "replication task");
+    replWorker.setExecutor(replicationThreadPool);
+    replWorker.run();
+
+    // Check the configuration value for the size of the pool and, if changed, resize the pool,
+    // every 5 seconds);
+    Runnable replicationWorkThreadPoolResizer = new Runnable() {
+      @Override
+      public void run() {
+        int maxPoolSize = aconf.getCount(Property.REPLICATION_WORKER_THREADS);
+        if (replicationThreadPool.getMaximumPoolSize() != maxPoolSize) {
+          log.info("Resizing thread pool for sending replication work from {} to {}",
+              replicationThreadPool.getMaximumPoolSize(), maxPoolSize);
+          replicationThreadPool.setMaximumPoolSize(maxPoolSize);
+        }
+      }
+    };
+    SimpleTimer.getInstance(aconf).schedule(replicationWorkThreadPoolResizer, 10000, 30000);
   }
 
   private static Pair<Text,KeyExtent> verifyRootTablet(ServerContext context,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2840,7 +2840,7 @@ public class TabletServer implements Runnable {
       throw new RuntimeException(ex);
     }
     final AccumuloConfiguration aconf = getConfiguration();
-    final boolean replicating = !aconf.get(Property.REPLICATION_NAME).isEmpty();
+    final boolean replicating = aconf.getBoolean(Property.TSERV_REPLICATION_ENABLED);
 
     if (replicating)
       setupReplication(aconf);

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -47,6 +48,7 @@ public class MultiTserverReplicationIT extends ConfigurableMacBase {
 
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setProperty(Property.REPLICATION_NAME.getKey(), "test");
     cfg.setNumTservers(2);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
@@ -48,6 +48,7 @@ public class MultiTserverReplicationIT extends ConfigurableMacBase {
 
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    // set the name to kick off the replication services
     cfg.setProperty(Property.REPLICATION_NAME.getKey(), "test");
     cfg.setNumTservers(2);
   }


### PR DESCRIPTION
* Only start the replication services in TabletServer if the required
properties are set at startup

I noticed tserver will always start multiple threads for replication, even if replication name is not configured.  As far as I can tell, this is the only required property for replication and if it is not set at startup anyway, there is a good chance not all data will be replicated. 