### PR TITLE
Fix latest round of warnings

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
@@ -30,7 +30,6 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.clientImpl.ClientConfConverter;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.ClientInfoImpl;
-import org.apache.accumulo.core.clientImpl.ConnectorImpl;
 import org.apache.accumulo.core.clientImpl.InstanceOperationsImpl;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
@@ -226,7 +225,8 @@ public class ZooKeeperInstance implements Instance {
     Properties properties = ClientConfConverter.toProperties(clientConf);
     properties.setProperty(ClientProperty.AUTH_PRINCIPAL.getKey(), principal);
     properties.setProperty(ClientProperty.INSTANCE_NAME.getKey(), getInstanceName());
-    return new ConnectorImpl(new ClientContext(new ClientInfoImpl(properties, token)));
+    return new org.apache.accumulo.core.clientImpl.ConnectorImpl(
+        new ClientContext(new ClientInfoImpl(properties, token)));
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
@@ -35,9 +35,10 @@ public class KeyShortenerTest {
     assertTrue(s.compareTo(c) < 0);
   }
 
-  private void testKeys(Key prev, Key current) {
+  private void testKeys(Key prev, Key current, Key expected) {
     Key sk = KeyShortener.shorten(prev, current);
     assertBetween(prev, sk, current);
+    assertEquals(expected, sk);
   }
 
   /**
@@ -72,30 +73,32 @@ public class KeyShortenerTest {
   public void testOneCharacterDifference() {
     // row has char that differs by one byte
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hbhahaha", "f89222", "q90232e"));
+        new Key("r321hbhahaha", "f89222", "q90232e"), newKey(apendFF("r321ha"), E, E, 0));
 
     // family has char that differs by one byte
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahaha", "f89322", "q90232e"));
+        new Key("r321hahahaha", "f89322", "q90232e"),
+        newKey("r321hahahaha", apendFF("f892"), E, 0));
 
     // qualifier has char that differs by one byte
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahaha", "f89222", "q91232e"));
+        new Key("r321hahahaha", "f89222", "q91232e"),
+        newKey("r321hahahaha", "f89222", apendFF("q90"), 0));
   }
 
   @Test
   public void testMultiCharacterDifference() {
     // row has char that differs by two bytes
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hchahaha", "f89222", "q90232e"));
+        new Key("r321hchahaha", "f89222", "q90232e"), newKey("r321hb", E, E, 0));
 
     // family has char that differs by two bytes
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahaha", "f89422", "q90232e"));
+        new Key("r321hahahaha", "f89422", "q90232e"), newKey("r321hahahaha", "f893", E, 0));
 
     // qualifier has char that differs by two bytes
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahaha", "f89222", "q92232e"));
+        new Key("r321hahahaha", "f89222", "q92232e"), newKey("r321hahahaha", "f89222", "q91", 0));
   }
 
   @Test
@@ -103,34 +106,44 @@ public class KeyShortenerTest {
     byte[] ff1 = Bytes.concat(apendFF("mop"), "b".getBytes());
     byte[] ff2 = Bytes.concat(apendFF("mop"), FF, "b".getBytes());
 
-    byte[] eff1 = Bytes.concat(apendFF("mop"), FF, FF);
-    byte[] eff2 = Bytes.concat(apendFF("mop"), FF, FF, FF);
+    String eff1 = "moq";
 
-    testKeys(newKey(ff1, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"));
-    testKeys(newKey("r1", ff1, "q90232e", 34), new Key("r1", "mor56", "q90232e"));
-    testKeys(newKey("r1", "f1", ff1, 34), new Key("r1", "f1", "mor56"));
+    testKeys(newKey(ff1, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"),
+        newKey(eff1, E, E, 0));
+    testKeys(newKey("r1", ff1, "q90232e", 34), new Key("r1", "mor56", "q90232e"),
+        newKey("r1", eff1, E, 0));
+    testKeys(newKey("r1", "f1", ff1, 34), new Key("r1", "f1", "mor56"),
+        newKey("r1", "f1", eff1, 0));
 
-    testKeys(newKey(ff2, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"));
-    testKeys(newKey("r1", ff2, "q90232e", 34), new Key("r1", "mor56", "q90232e"));
-    testKeys(newKey("r1", "f1", ff2, 34), new Key("r1", "f1", "mor56"));
+    testKeys(newKey(ff2, "f89222", "q90232e", 34), new Key("mor56", "f89222", "q90232e"),
+        newKey(eff1, E, E, 0));
+    testKeys(newKey("r1", ff2, "q90232e", 34), new Key("r1", "mor56", "q90232e"),
+        newKey("r1", eff1, E, 0));
+    testKeys(newKey("r1", "f1", ff2, 34), new Key("r1", "f1", "mor56"),
+        newKey("r1", "f1", eff1, 0));
 
   }
 
   @Test
   public void testOneCharacterDifferenceAtEnd() {
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahahb", "f89222", "q90232e"));
+        new Key("r321hahahahb", "f89222", "q90232e"), newKey(append00("r321hahahaha"), E, E, 0));
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahaha", "f89223", "q90232e"));
+        new Key("r321hahahaha", "f89223", "q90232e"),
+        newKey("r321hahahaha", append00("f89222"), E, 0));
     testKeys(new Key("r321hahahaha", "f89222", "q90232e"),
-        new Key("r321hahahaha", "f89222", "q90232f"));
+        new Key("r321hahahaha", "f89222", "q90232f"),
+        newKey("r321hahahaha", "f89222", append00("q90232e"), 0));
   }
 
   @Test
   public void testSamePrefix() {
-    testKeys(new Key("r3boot4", "f89222", "q90232e"), new Key("r3boot452", "f89222", "q90232e"));
-    testKeys(new Key("r3boot4", "f892", "q90232e"), new Key("r3boot4", "f89222", "q90232e"));
-    testKeys(new Key("r3boot4", "f89222", "q902"), new Key("r3boot4", "f89222", "q90232e"));
+    testKeys(new Key("r3boot4", "f89222", "q90232e"), new Key("r3boot452", "f89222", "q90232e"),
+        newKey(append00("r3boot4"), E, E, 0));
+    testKeys(new Key("r3boot4", "f892", "q90232e"), new Key("r3boot4", "f89222", "q90232e"),
+        newKey("r3boot4", append00("f892"), E, 0));
+    testKeys(new Key("r3boot4", "f89222", "q902"), new Key("r3boot4", "f89222", "q90232e"),
+        newKey("r3boot4", "f89222", append00("q902"), 0));
   }
 
   @Test

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -48,7 +48,6 @@ public class ServerInfo implements ClientInfo {
   private String instanceName;
   private String zooKeepers;
   private int zooKeepersSessionTimeOut;
-  private String zooKeeperRoot;
   private VolumeManager volumeManager;
   private ZooCache zooCache;
 
@@ -79,7 +78,6 @@ public class ServerInfo implements ClientInfo {
       throw new RuntimeException("Instance id " + instanceID + " pointed to by the name "
           + instanceName + " does not exist in zookeeper");
     }
-    zooKeeperRoot = ZooUtil.getRoot(instanceID);
   }
 
   ServerInfo(SiteConfiguration config) {
@@ -92,7 +90,6 @@ public class ServerInfo implements ClientInfo {
     }
     Path instanceIdPath = ServerUtil.getAccumuloInstanceIdPath(volumeManager);
     instanceID = ZooUtil.getInstanceIDFromHdfs(instanceIdPath, config);
-    zooKeeperRoot = ZooUtil.getRoot(instanceID);
     zooKeepers = config.get(Property.INSTANCE_ZK_HOST);
     zooKeepersSessionTimeOut = (int) config.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT);
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -125,16 +125,6 @@ public class MasterMetadataUtil {
           "Metadata entry does not have time (" + metadataEntry + ")");
     }
 
-    Value flushID = columns.get(TabletsSection.ServerColumnFamily.FLUSH_COLUMN);
-    long initFlushID = -1;
-    if (flushID != null)
-      initFlushID = Long.parseLong(flushID.toString());
-
-    Value compactID = columns.get(TabletsSection.ServerColumnFamily.COMPACT_COLUMN);
-    long initCompactID = -1;
-    if (compactID != null)
-      initCompactID = Long.parseLong(compactID.toString());
-
     Text metadataPrevEndRow = KeyExtent.decodePrevEndRow(prevEndRowIBW);
 
     Table.ID tableId = (new KeyExtent(metadataEntry, (Text) null)).getTableId();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -163,7 +163,6 @@ public class TabletServerResource {
       return null;
     }
 
-    double totalElapsedForAll = 0;
     double splitStdDev = 0;
     double minorStdDev = 0;
     double minorQueueStdDev = 0;
@@ -210,7 +209,6 @@ public class TabletServerResource {
 
     ActionStatsUpdator.update(total.minors, historical.minors);
     ActionStatsUpdator.update(total.majors, historical.majors);
-    totalElapsedForAll += total.majors.elapsed + historical.splits.elapsed + total.minors.elapsed;
 
     minorStdDev = stddev(total.minors.elapsed, total.minors.num, total.minors.sumDev);
     minorQueueStdDev = stddev(total.minors.queueTime, total.minors.num, total.minors.queueSumDev);


### PR DESCRIPTION
* Remove import statement for deprecated class
* Restore some deleted KeyShortenerTest code, and make use of the
expected parameter for verifying shortened keys
* Remove some unused variables