### PR TITLE
Make new Bulk Import tableTime take boolean

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -567,8 +567,11 @@ public interface TableOperations {
      * timestamp used depends on how the table was created.
      *
      * @see NewTableConfiguration#setTimeType(TimeType)
+     * @param value
+     *          override the time values in the input files, and use the current time for all
+     *          mutations
      */
-    ImportMappingOptions tableTime();
+    ImportMappingOptions tableTime(boolean value);
 
     /**
      * Loads the files into the table.

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/BulkImport.java
@@ -106,8 +106,8 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
   }
 
   @Override
-  public ImportMappingOptions tableTime() {
-    this.setTime = true;
+  public ImportMappingOptions tableTime(boolean value) {
+    this.setTime = value;
     return this;
   }
 

--- a/proxy/src/main/java/org/apache/accumulo/proxy/ProxyServer.java
+++ b/proxy/src/main/java/org/apache/accumulo/proxy/ProxyServer.java
@@ -59,7 +59,6 @@ import org.apache.accumulo.core.client.admin.ActiveCompaction;
 import org.apache.accumulo.core.client.admin.ActiveScan;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
-import org.apache.accumulo.core.client.admin.TableOperations.ImportMappingOptions;
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -1766,13 +1765,9 @@ public class ProxyServer implements AccumuloProxy.Iface {
       org.apache.accumulo.proxy.thrift.AccumuloException,
       org.apache.accumulo.proxy.thrift.AccumuloSecurityException, TException {
     try {
-      ImportMappingOptions loader = getConnector(login).tableOperations().importDirectory(importDir)
-          .to(tableName);
-      if (setTime) {
-        loader.tableTime().load();
-      } else {
-        loader.load();
-      }
+      getConnector(login).tableOperations().importDirectory(importDir).to(tableName)
+          .tableTime(setTime).load();
+
     } catch (Exception e) {
       handleExceptionTNF(e);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ImportDirectoryCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ImportDirectoryCommand.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.commons.cli.CommandLine;
@@ -49,12 +48,8 @@ public class ImportDirectoryCommand extends Command {
     // new bulk import only takes 2 args
     if (args.length == 2) {
       setTime = Boolean.parseBoolean(cl.getArgs()[1]);
-      TableOperations.ImportMappingOptions bulk = shellState.getAccumuloClient().tableOperations()
-          .importDirectory(dir).to(shellState.getTableName());
-      if (setTime)
-        bulk.tableTime().load();
-      else
-        bulk.load();
+      shellState.getAccumuloClient().tableOperations().importDirectory(dir)
+          .to(shellState.getTableName()).tableTime(setTime).load();
     } else if (args.length == 3) {
       // warn using deprecated bulk import
       Shell.log.warn(

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
@@ -155,9 +155,6 @@ public class BulkLoadIT extends AccumuloClusterHarness {
       // set logical time type so we can set time on bulk import
       newTableConf.setTimeType(TimeType.LOGICAL);
       client.tableOperations().create(tableName, newTableConf);
-      aconf = getCluster().getServerContext().getConfiguration();
-      fs = getCluster().getFileSystem();
-      rootPath = cluster.getTemporaryPath().toString();
       testSingleTabletSingleFile(client, false, true);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.clientImpl.Table;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
@@ -117,7 +119,8 @@ public class BulkLoadIT extends AccumuloClusterHarness {
     return dir;
   }
 
-  private void testSingleTabletSingleFile(AccumuloClient c, boolean offline) throws Exception {
+  private void testSingleTabletSingleFile(AccumuloClient c, boolean offline, boolean setTime)
+      throws Exception {
     addSplits(c, tableName, "0333");
 
     if (offline)
@@ -127,12 +130,12 @@ public class BulkLoadIT extends AccumuloClusterHarness {
 
     String h1 = writeData(dir + "/f1.", aconf, 0, 332);
 
-    c.tableOperations().importDirectory(dir).to(tableName).load();
+    c.tableOperations().importDirectory(dir).to(tableName).tableTime(setTime).load();
 
     if (offline)
       c.tableOperations().online(tableName);
 
-    verifyData(c, tableName, 0, 332);
+    verifyData(c, tableName, 0, 332, setTime);
     verifyMetadata(c, tableName,
         ImmutableMap.of("0333", ImmutableSet.of(h1), "null", ImmutableSet.of()));
   }
@@ -140,14 +143,29 @@ public class BulkLoadIT extends AccumuloClusterHarness {
   @Test
   public void testSingleTabletSingleFile() throws Exception {
     try (AccumuloClient client = createAccumuloClient()) {
-      testSingleTabletSingleFile(client, false);
+      testSingleTabletSingleFile(client, false, false);
+    }
+  }
+
+  @Test
+  public void testSetTime() throws Exception {
+    try (AccumuloClient client = createAccumuloClient()) {
+      tableName = "testSetTime_table1";
+      NewTableConfiguration newTableConf = new NewTableConfiguration();
+      // set logical time type so we can set time on bulk import
+      newTableConf.setTimeType(TimeType.LOGICAL);
+      client.tableOperations().create(tableName, newTableConf);
+      aconf = getCluster().getServerContext().getConfiguration();
+      fs = getCluster().getFileSystem();
+      rootPath = cluster.getTemporaryPath().toString();
+      testSingleTabletSingleFile(client, false, true);
     }
   }
 
   @Test
   public void testSingleTabletSingleFileOffline() throws Exception {
     try (AccumuloClient client = createAccumuloClient()) {
-      testSingleTabletSingleFile(client, true);
+      testSingleTabletSingleFile(client, true, false);
     }
   }
 
@@ -165,7 +183,7 @@ public class BulkLoadIT extends AccumuloClusterHarness {
     if (offline)
       c.tableOperations().online(tableName);
 
-    verifyData(c, tableName, 0, 333);
+    verifyData(c, tableName, 0, 333, false);
     verifyMetadata(c, tableName, ImmutableMap.of("null", ImmutableSet.of(h1)));
   }
 
@@ -270,7 +288,7 @@ public class BulkLoadIT extends AccumuloClusterHarness {
       if (offline)
         c.tableOperations().online(tableName);
 
-      verifyData(c, tableName, 0, 1999);
+      verifyData(c, tableName, 0, 1999, false);
       verifyMetadata(c, tableName, hashes);
     }
   }
@@ -345,12 +363,13 @@ public class BulkLoadIT extends AccumuloClusterHarness {
     client.tableOperations().addSplits(tableName, splits);
   }
 
-  private void verifyData(AccumuloClient client, String table, int s, int e) throws Exception {
+  private void verifyData(AccumuloClient client, String table, int start, int end, boolean setTime)
+      throws Exception {
     try (Scanner scanner = client.createScanner(table, Authorizations.EMPTY)) {
 
       Iterator<Entry<Key,Value>> iter = scanner.iterator();
 
-      for (int i = s; i <= e; i++) {
+      for (int i = start; i <= end; i++) {
         if (!iter.hasNext())
           throw new Exception("row " + i + " not found");
 
@@ -363,6 +382,9 @@ public class BulkLoadIT extends AccumuloClusterHarness {
 
         if (Integer.parseInt(entry.getValue().toString()) != i)
           throw new Exception("unexpected value " + entry + " " + i);
+
+        if (setTime)
+          assertEquals(1L, entry.getKey().getTimestamp());
       }
 
       if (iter.hasNext())


### PR DESCRIPTION
* Also add new test to BulkLoadIT for tableTime

The fluent API for the new Bulk Import has an option to set the time on bulk import:
   ` c.tableOperations().importDirectory(dir).to(tableName).tableTime().load();`

But this can be awkward if you have a boolean in your code to set the time so making it take a boolean seems less awkward:
`    c.tableOperations().importDirectory(dir).to(tableName).tableTime(setTime).load();
`