### PR TITLE
Organize new Bulk Import code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -80,6 +80,7 @@ import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.client.summary.Summary;
 import org.apache.accumulo.core.clientImpl.TabletLocator.TabletLocation;
+import org.apache.accumulo.core.clientImpl.bulk.BulkImport;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService.Client;
 import org.apache.accumulo.core.clientImpl.thrift.TDiskUsage;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException;
@@ -319,6 +320,18 @@ public class TableOperationsImpl extends TableOperationsHelper {
       } finally {
         MasterClient.close(client);
       }
+    }
+  }
+
+  public String doBulkFateOperation(List<ByteBuffer> args, String tableName)
+      throws AccumuloSecurityException, AccumuloException {
+    try {
+      return doFateOperation(FateOperation.TABLE_BULK_IMPORT2, args, Collections.emptyMap(),
+          tableName);
+    } catch (TableExistsException | TableNotFoundException | NamespaceNotFoundException
+        | NamespaceExistsException e) {
+      // should not happen
+      throw new AssertionError(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.core.clientImpl;
+package org.apache.accumulo.core.clientImpl.bulk;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.accumulo.core.clientImpl.Table;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.fs.Path;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.core.clientImpl;
+package org.apache.accumulo.core.clientImpl.bulk;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,8 +30,9 @@ import java.util.stream.Stream;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.clientImpl.BulkImport.KeyExtentCache;
+import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.Table.ID;
+import org.apache.accumulo.core.clientImpl.bulk.BulkImport.KeyExtentCache;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -39,7 +40,6 @@ import org.apache.hadoop.io.Text;
 
 import com.google.common.annotations.VisibleForTesting;
 
-@VisibleForTesting
 class ConcurrentKeyExtentCache implements KeyExtentCache {
 
   private static final Text MAX = new Text();
@@ -54,8 +54,7 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
   private ID tableId;
   private ClientContext ctx;
 
-  @VisibleForTesting
-  ConcurrentKeyExtentCache(Table.ID tableId, ClientContext ctx) {
+  ConcurrentKeyExtentCache(ID tableId, ClientContext ctx) {
     this.tableId = tableId;
     this.ctx = ctx;
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -70,8 +70,6 @@ public class LoadMappingIterator
 
   @Override
   public Map.Entry<KeyExtent,Bulk.Files> next() {
-    if (!hasNext())
-      return null;
     Bulk.Mapping bm = gson.fromJson(reader, Bulk.Mapping.class);
     if (renameMap != null) {
       return new AbstractMap.SimpleEntry<>(bm.getKeyExtent(tableId),

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.clientImpl.bulk;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.clientImpl.bulk.BulkSerialize.createGson;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.accumulo.core.clientImpl.Table;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+
+/**
+ * Iterator for reading the Bulk Load Mapping JSON.
+ */
+public class LoadMappingIterator
+    implements Iterator<Map.Entry<KeyExtent,Bulk.Files>>, AutoCloseable {
+  private Table.ID tableId;
+  private JsonReader reader;
+  private Gson gson = createGson();
+  private Map<String,String> renameMap;
+
+  LoadMappingIterator(Table.ID tableId, InputStream loadMapFile) throws IOException {
+    this.tableId = tableId;
+    this.reader = new JsonReader(new BufferedReader(new InputStreamReader(loadMapFile, UTF_8)));
+    this.reader.beginArray();
+  }
+
+  public void setRenameMap(Map<String,String> renameMap) {
+    this.renameMap = renameMap;
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+
+  @Override
+  public boolean hasNext() {
+    try {
+      return reader.hasNext();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public Map.Entry<KeyExtent,Bulk.Files> next() {
+    if (!hasNext())
+      return null;
+    Bulk.Mapping bm = gson.fromJson(reader, Bulk.Mapping.class);
+    if (renameMap != null) {
+      return new AbstractMap.SimpleEntry<>(bm.getKeyExtent(tableId),
+          bm.getFiles().mapNames(renameMap));
+    } else {
+      return new AbstractMap.SimpleEntry<>(bm.getKeyExtent(tableId), bm.getFiles());
+    }
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/BulkSerializeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/BulkSerializeTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.core.clientImpl;
+package org.apache.accumulo.core.clientImpl.bulk;
 
 import static org.junit.Assert.assertEquals;
 
@@ -26,11 +26,10 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.clientImpl.Bulk.FileInfo;
-import org.apache.accumulo.core.clientImpl.Bulk.Files;
-import org.apache.accumulo.core.clientImpl.BulkSerialize.Input;
-import org.apache.accumulo.core.clientImpl.BulkSerialize.LoadMappingIterator;
-import org.apache.accumulo.core.clientImpl.Table.ID;
+import org.apache.accumulo.core.clientImpl.Table;
+import org.apache.accumulo.core.clientImpl.bulk.Bulk.FileInfo;
+import org.apache.accumulo.core.clientImpl.bulk.Bulk.Files;
+import org.apache.accumulo.core.clientImpl.bulk.BulkSerialize.Input;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
@@ -118,7 +117,7 @@ public class BulkSerializeTest {
 
   }
 
-  public SortedMap<KeyExtent,Bulk.Files> generateMapping(ID tableId) {
+  public SortedMap<KeyExtent,Bulk.Files> generateMapping(Table.ID tableId) {
     SortedMap<KeyExtent,Bulk.Files> mapping = new TreeMap<>();
     Bulk.Files testFiles = new Bulk.Files();
     Bulk.Files testFiles2 = new Bulk.Files();

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.accumulo.core.clientImpl;
+package org.apache.accumulo.core.clientImpl.bulk;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.Table;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.Text;
 import org.junit.BeforeClass;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.apache.accumulo.core.clientImpl.BulkImport;
+import org.apache.accumulo.core.clientImpl.bulk.BulkImport;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/BulkImportMove.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/BulkImportMove.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
-import org.apache.accumulo.core.clientImpl.BulkSerialize;
+import org.apache.accumulo.core.clientImpl.bulk.BulkSerialize;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.conf.Property;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -312,7 +312,7 @@ class LoadFiles extends MasterRepo {
    */
   private long loadFiles(Table.ID tableId, Path bulkDir, LoadMappingIterator loadMapIter,
       Master master, long tid) throws Exception {
-    PeekingIterator<Map.Entry<KeyExtent,Bulk.Files>> lmi = new PeekingIterator(loadMapIter);
+    PeekingIterator<Map.Entry<KeyExtent,Bulk.Files>> lmi = new PeekingIterator<>(loadMapIter);
     Map.Entry<KeyExtent,Bulk.Files> loadMapEntry = lmi.peek();
 
     Text startRow = loadMapEntry.getKey().getPrevEndRow();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -331,11 +331,10 @@ class LoadFiles extends MasterRepo {
       List<TabletMetadata> tablets = findOverlappingTablets(loadMapEntry.getKey(), tabletIter);
       loader.load(tablets, loadMapEntry.getValue());
     }
-    long t2 = System.currentTimeMillis();
 
     long sleepTime = loader.finish();
     if (sleepTime > 0) {
-      long scanTime = Math.min(t2 - t1, 30000);
+      long scanTime = Math.min(System.currentTimeMillis() - t1, 30000);
       sleepTime = Math.max(sleepTime, scanTime * 2);
     }
     return sleepTime;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -118,7 +118,7 @@ class LoadFiles extends MasterRepo {
 
     abstract void load(List<TabletMetadata> tablets, Files files) throws Exception;
 
-    abstract long finish(long startScanTime) throws Exception;
+    abstract long finish() throws Exception;
   }
 
   private static class OnlineLoader extends Loader {
@@ -226,10 +226,10 @@ class LoadFiles extends MasterRepo {
     }
 
     @Override
-    long finish(long startScanTime) {
-      long scanTime = Math.min(System.currentTimeMillis() - startScanTime, 30000);
+    long finish() {
 
       sendQueued(0);
+
       long sleepTime = 0;
       if (loadMsgs.size() > 0) {
         // find which tablet server had the most load messages sent to it and sleep 13ms for each
@@ -241,9 +241,6 @@ class LoadFiles extends MasterRepo {
         sleepTime = Math.max(Math.max(100L, locationLess), sleepTime);
       }
 
-      if (sleepTime > 0) {
-        sleepTime = Math.max(sleepTime, scanTime * 2);
-      }
       return sleepTime;
     }
 
@@ -288,8 +285,7 @@ class LoadFiles extends MasterRepo {
     }
 
     @Override
-    long finish(long startScanTime) throws Exception {
-      long scanTime = Math.min(System.currentTimeMillis() - startScanTime, 30000);
+    long finish() throws Exception {
 
       bw.close();
 
@@ -299,9 +295,6 @@ class LoadFiles extends MasterRepo {
         sleepTime = Collections.max(unloadingTablets.values()) * 13;
       }
 
-      if (sleepTime > 0) {
-        sleepTime = Math.max(sleepTime, scanTime * 2);
-      }
       return sleepTime;
     }
   }
@@ -338,7 +331,14 @@ class LoadFiles extends MasterRepo {
       List<TabletMetadata> tablets = findOverlappingTablets(loadMapEntry.getKey(), tabletIter);
       loader.load(tablets, loadMapEntry.getValue());
     }
-    return loader.finish(t1);
+    long t2 = System.currentTimeMillis();
+
+    long sleepTime = loader.finish();
+    if (sleepTime > 0) {
+      long scanTime = Math.min(t2 - t1, 30000);
+      sleepTime = Math.max(sleepTime, scanTime * 2);
+    }
+    return sleepTime;
   }
 
   /**

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
@@ -160,7 +160,6 @@ public class PrepBulkImport extends MasterRepo {
     try (LoadMappingIterator lmi = BulkSerialize.readLoadMapping(bulkDir.toString(),
         bulkInfo.tableId, p -> fs.open(p))) {
 
-
       TabletIterFactory tabletIterFactory = startRow -> TabletsMetadata.builder()
           .forTable(bulkInfo.tableId).overlapping(startRow, null).checkConsistency().fetchPrev()
           .build(master.getContext()).stream().map(TabletMetadata::getExtent).iterator();

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
@@ -160,7 +160,6 @@ public class PrepBulkImport extends MasterRepo {
     try (LoadMappingIterator lmi = BulkSerialize.readLoadMapping(bulkDir.toString(),
         bulkInfo.tableId, p -> fs.open(p))) {
 
-      Iterators.transform(lmi, entry -> entry.getKey());
 
       TabletIterFactory tabletIterFactory = startRow -> TabletsMetadata.builder()
           .forTable(bulkInfo.tableId).overlapping(startRow, null).checkConsistency().fetchPrev()

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
@@ -28,10 +28,10 @@ import java.util.function.Function;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
-import org.apache.accumulo.core.clientImpl.BulkSerialize;
-import org.apache.accumulo.core.clientImpl.BulkSerialize.LoadMappingIterator;
 import org.apache.accumulo.core.clientImpl.Table;
 import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.clientImpl.bulk.BulkSerialize;
+import org.apache.accumulo.core.clientImpl.bulk.LoadMappingIterator;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -162,11 +162,9 @@ public class PrepBulkImport extends MasterRepo {
 
       Iterators.transform(lmi, entry -> entry.getKey());
 
-      TabletIterFactory tabletIterFactory = startRow -> {
-        return TabletsMetadata.builder().forTable(bulkInfo.tableId).overlapping(startRow, null)
-            .checkConsistency().fetchPrev().build(master.getContext()).stream()
-            .map(TabletMetadata::getExtent).iterator();
-      };
+      TabletIterFactory tabletIterFactory = startRow -> TabletsMetadata.builder()
+          .forTable(bulkInfo.tableId).overlapping(startRow, null).checkConsistency().fetchPrev()
+          .build(master.getContext()).stream().map(TabletMetadata::getExtent).iterator();
 
       checkForMerge(bulkInfo.tableId.canonicalID(),
           Iterators.transform(lmi, entry -> entry.getKey()), tabletIterFactory);


### PR DESCRIPTION
My attempt to make the new code easier to follow and maintain. 

* Move bulk import clientImpl code to its own bulk package
* Pull some FaTE logic out of BulkImport
* Made the LoadMappingIterator its own class and push some of the reader logic into it
* Added comments to BulkSerialize
* Removed some VisibileForTesting annotations from ConcurrentKeyExtentCache where its used in BulkImport
* Pulled some logic out of LoadFiles.loadFiles and created some new methods for readability