### PR TITLE
Refactor FATE AdminUtil spliting getStatus method.

### DIFF
--- a/fate/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class AdminUtil<T> {
   private static final Logger log = LoggerFactory.getLogger(AdminUtil.class);
 
-  private boolean exitOnError = false;
+  private final boolean exitOnError;
 
   /**
    * Default constructor
@@ -172,7 +172,7 @@ public class AdminUtil<T> {
     }
 
     /**
-     * Get locks that are waiting to be aquired by non existent FATE transactions. These are table
+     * Get locks that are waiting to be acquired by non existent FATE transactions. These are table
      * or namespace locks.
      *
      * @return map where keys are transaction ids and values are a list of table IDs and/or
@@ -187,13 +187,44 @@ public class AdminUtil<T> {
   public FateStatus getStatus(ReadOnlyTStore<T> zs, IZooReader zk, String lockPath,
       Set<Long> filterTxid, EnumSet<TStatus> filterStatus)
       throws KeeperException, InterruptedException {
+
     Map<Long,List<String>> heldLocks = new HashMap<>();
     Map<Long,List<String>> waitingLocks = new HashMap<>();
 
+    findLocks(zk, lockPath, heldLocks, waitingLocks);
+
+    FateStatus status = getTransactionStatus(zs, filterTxid, filterStatus, heldLocks, waitingLocks);
+
+    return status;
+  }
+
+  /**
+   * Walk through the lock nodes in zookeeper to find and populate held locks and waiting locks.
+   *
+   * @param zk
+   *          zookeeper reader
+   * @param lockPath
+   *          the zookeeper path for locks
+   * @param heldLocks
+   *          map for returning transactions with held locks
+   * @param waitingLocks
+   *          map for returning transactions with waiting locks
+   * @throws KeeperException
+   *           if initial lock list cannot be read.
+   * @throws InterruptedException
+   *           if thread interrupt detected while processing.
+   */
+  private void findLocks(IZooReader zk, final String lockPath,
+      final Map<Long,List<String>> heldLocks, final Map<Long,List<String>> waitingLocks)
+      throws KeeperException, InterruptedException {
+
+    // stop with exception if lock ids cannot be retrieved from zookeeper
     List<String> lockedIds = zk.getChildren(lockPath);
 
     for (String id : lockedIds) {
+
       try {
+
         List<String> lockNodes = zk.getChildren(lockPath + "/" + id);
         lockNodes = new ArrayList<>(lockNodes);
         Collections.sort(lockNodes);
@@ -235,10 +266,40 @@ public class AdminUtil<T> {
           pos++;
         }
 
-      } catch (Exception e) {
-        log.error("Failed to read locks for " + id + " continuing.", e);
+      } catch (KeeperException ex) {
+        /*
+         * could be transient zk error. Log, but try to process rest of list rather than throwing
+         * exception here
+         */
+        log.error("Failed to read locks for " + id + " continuing.", ex);
+
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw ex;
       }
     }
+  }
+
+  /**
+   * Returns fate status, possibly filtered
+   *
+   * @param zs
+   *          read-only access to a populated transaction store.
+   * @param filterTxid
+   *          Optional. List of transactions to filter results - if null, all transactions are
+   *          returned
+   * @param filterStatus
+   *          Optional. List of status types to filter results - if null, all transactions are
+   *          returned.
+   * @param heldLocks
+   *          populated list of locks held by transaction - or an empty map if none.
+   * @param waitingLocks
+   *          populated list of locks held by transaction - or an empty map if none.
+   * @return current fate and lock status
+   */
+  public FateStatus getTransactionStatus(ReadOnlyTStore<T> zs, Set<Long> filterTxid,
+      EnumSet<TStatus> filterStatus, Map<Long,List<String>> heldLocks,
+      Map<Long,List<String>> waitingLocks) {
 
     List<Long> transactions = zs.list();
     List<TransactionStatus> statuses = new ArrayList<>(transactions.size());
@@ -249,21 +310,36 @@ public class AdminUtil<T> {
 
       String debug = (String) zs.getProperty(tid, "debug");
 
-      List<String> hlocks = heldLocks.remove(tid);
-      if (hlocks == null)
-        hlocks = Collections.emptyList();
+      List<String> hlocks = null;
 
-      List<String> wlocks = waitingLocks.remove(tid);
-      if (wlocks == null)
+      if (heldLocks == null) {
+        heldLocks = Collections.emptyMap();
+      } else {
+        hlocks = heldLocks.remove(tid);
+      }
+
+      if (hlocks == null) {
+        hlocks = Collections.emptyList();
+      }
+
+      List<String> wlocks = null;
+
+      if (waitingLocks == null) {
+        waitingLocks = Collections.emptyMap();
+      } else {
+        wlocks = waitingLocks.remove(tid);
+      }
+
+      if (wlocks == null) {
         wlocks = Collections.emptyList();
+      }
 
       String top = null;
       ReadOnlyRepo<T> repo = zs.top(tid);
       if (repo != null)
         top = repo.getDescription();
 
-      TStatus status = null;
-      status = zs.getStatus(tid);
+      TStatus status = zs.getStatus(tid);
 
       zs.unreserve(tid, 0);
 
@@ -275,6 +351,7 @@ public class AdminUtil<T> {
     }
 
     return new FateStatus(statuses, heldLocks, waitingLocks);
+
   }
 
   public void print(ReadOnlyTStore<T> zs, IZooReader zk, String lockPath)

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -64,14 +64,13 @@ import org.slf4j.LoggerFactory;
 /**
  * IT Tests that create / run a "slow" FATE transaction so that other operations can be checked.
  * Included tests for:
- * <p/>
- * ACCUMULO-4574. Test to verify that changing table state to online / offline
+ * <ul>
+ * <li>ACCUMULO-4574. Test to verify that changing table state to online / offline
  * {@link org.apache.accumulo.core.client.admin.TableOperations#online(String)} when the table is
- * already in that state returns without blocking.
- * </p>
- * AdminUtil refactor to provide methods that provide FATE status, one with table lock info
- * (original) and additional method without.
- *
+ * already in that state returns without blocking.</li>
+ * <li>AdminUtil refactor to provide methods that provide FATE status, one with table lock info
+ * (original) and additional method without.</li>
+ *</ul>
  */
 public class FateConcurrencyIT extends AccumuloClusterHarness {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -62,13 +62,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * IT Tests that create / run a "slow" FATE transaction so that other operations can be checked.
+ * Included tests for:
+ * <p/>
  * ACCUMULO-4574. Test to verify that changing table state to online / offline
  * {@link org.apache.accumulo.core.client.admin.TableOperations#online(String)} when the table is
  * already in that state returns without blocking.
+ * </p>
+ * AdminUtil refactor to provide methods that provide FATE status, one with table lock info
+ * (original) and additional method without.
+ *
  */
-public class TableChangeStateIT extends AccumuloClusterHarness {
+public class FateConcurrencyIT extends AccumuloClusterHarness {
 
-  private static final Logger log = LoggerFactory.getLogger(TableChangeStateIT.class);
+  private static final Logger log = LoggerFactory.getLogger(FateConcurrencyIT.class);
 
   private static final int NUM_ROWS = 1000;
   private static final long SLOW_SCAN_SLEEP_MS = 250L;

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -232,9 +231,7 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
 
         if (tx.getTop().contains("CompactionDriver") && tx.getDebug().contains("CompactRange")) {
 
-          Iterator<AdminUtil.TransactionStatus> itor = noLocks.listIterator();
-          while (itor.hasNext()) {
-            AdminUtil.TransactionStatus tx2 = itor.next();
+          for (AdminUtil.TransactionStatus tx2 : noLocks) {
             if (tx2.getTxid().equals(tx.getTxid())) {
               matchCount++;
             }
@@ -469,13 +466,14 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
 
       OnlineOpTiming status = new OnlineOpTiming();
 
-      log.trace("Online completed in {} ms",
-          TimeUnit.MILLISECONDS.convert(status.runningTime(), TimeUnit.NANOSECONDS));
       log.trace("Setting {} online", tableName);
 
       connector.tableOperations().online(tableName, true);
       // stop timing
       status.setComplete();
+
+      log.trace("Online completed in {} ms",
+          TimeUnit.MILLISECONDS.convert(status.runningTime(), TimeUnit.NANOSECONDS));
 
       return status;
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -288,14 +287,14 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
           ZooUtil.getRoot(instance) + Constants.ZTABLE_LOCKS + "/" + tableId, null, null);
 
       // call with no locks - passed as null.
-      AdminUtil.FateStatus noLocks = admin.getTransactionStatus(zs, null, null, null, null);
+      List<AdminUtil.TransactionStatus> noLocks = admin.getTransactionStatus(zs, zk, null, null);
 
-      assertEquals(withLocks.getTransactions().size(), noLocks.getTransactions().size());
+      assertEquals(withLocks.getTransactions().size(), noLocks.size());
 
       // exercise methods on returned status.
-      assertNotNull(noLocks.getDanglingHeldLocks());
-      assertNotNull(noLocks.getDanglingWaitingLocks());
-      assertNotNull(noLocks.getTransactions());
+      // assertNotNull(noLocks.getDanglingHeldLocks());
+      // assertNotNull(noLocks.getDanglingWaitingLocks());
+      // assertNotNull(noLocks.getTransactions());
 
     } catch (KeeperException | TableNotFoundException | InterruptedException ex) {
       throw new IllegalStateException(ex);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableChangeStateIT.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -55,6 +56,7 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriterFactory;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -70,13 +72,27 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
   private static final Logger log = LoggerFactory.getLogger(TableChangeStateIT.class);
 
   private static final int NUM_ROWS = 1000;
-  private static final long SLOW_SCAN_SLEEP_MS = 100L;
+  private static final long SLOW_SCAN_SLEEP_MS = 250L;
 
   private Connector connector;
 
+  private static final ExecutorService pool = Executors.newCachedThreadPool();
+
+  private String tableName;
+
   @Before
   public void setup() {
+
     connector = getConnector();
+
+    tableName = getUniqueNames(1)[0];
+
+    createData(tableName);
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    pool.shutdownNow();
   }
 
   @Override
@@ -96,12 +112,6 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
    */
   @Test
   public void changeTableStateTest() throws Exception {
-
-    ExecutorService pool = Executors.newCachedThreadPool();
-
-    String tableName = getUniqueNames(1)[0];
-
-    createData(tableName);
 
     assertEquals("verify table online after created", TableState.ONLINE, getTableState(tableName));
 
@@ -135,9 +145,7 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
     // launch a full table compaction with the slow iterator to ensure table lock is acquired and
     // held by the compaction
 
-    Future<?> compactTask = pool.submit(new SlowCompactionRunner(tableName));
-    assertTrue("verify that compaction running and fate transaction exists",
-        blockUntilCompactionRunning(tableName));
+    Future<?> compactTask = startCompactTask();
 
     // try to set online while fate transaction is in progress - before ACCUMULO-4574 this would
     // block
@@ -171,6 +179,47 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
     // block if compaction still running
     compactTask.get();
 
+  }
+
+  /**
+   * Validate the the AdminUtil.getStatus works correctly after refactor and validate that
+   * getTransactionStatus can be called without lock map(s). The test starts a long running fate
+   * transaction (slow compaction) and the calls AdminUtil functions to get the FATE.
+   *
+   * @throws Exception
+   *           any exception is a test failure
+   */
+  @Test
+  public void getFateStatus() throws Exception {
+
+    assertEquals("verify table online after created", TableState.ONLINE, getTableState(tableName));
+
+    Future<?> compactTask = startCompactTask();
+
+    assertTrue("compaction fate transaction exits", findFate(tableName));
+
+    // exercise refactored method, with null for lock maps.
+    useGetTransactionStatus(tableName);
+
+    // test complete, cancel compaction and move on.
+    connector.tableOperations().cancelCompaction(tableName);
+
+    // block if compaction still running
+    compactTask.get();
+
+  }
+
+  /**
+   * Create and run a slow running compaction task. The method will block until the compaction has
+   * been started.
+   *
+   * @return a reference to the running compaction task.
+   */
+  private Future<?> startCompactTask() {
+    Future<?> compactTask = pool.submit(new SlowCompactionRunner(tableName));
+    assertTrue("verify that compaction running and fate transaction exists",
+        blockUntilCompactionRunning(tableName));
+    return compactTask;
   }
 
   /**
@@ -214,6 +263,47 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
   }
 
   /**
+   * Exercise the AdminUtil.getTransactionStatus() method, passing nulls for lock maps.
+   *
+   * @param tableName
+   *          the test table name
+   */
+  private void useGetTransactionStatus(final String tableName) {
+
+    Instance instance = connector.getInstance();
+    AdminUtil<String> admin = new AdminUtil<>(false);
+
+    try {
+
+      String tableId = Tables.getTableId(instance, tableName);
+
+      log.trace("tid: {}", tableId);
+
+      String secret = cluster.getSiteConfiguration().get(Property.INSTANCE_SECRET);
+      IZooReaderWriter zk = new ZooReaderWriterFactory().getZooReaderWriter(
+          instance.getZooKeepers(), instance.getZooKeepersSessionTimeOut(), secret);
+      ZooStore<String> zs = new ZooStore<>(ZooUtil.getRoot(instance) + Constants.ZFATE, zk);
+
+      AdminUtil.FateStatus withLocks = admin.getStatus(zs, zk,
+          ZooUtil.getRoot(instance) + Constants.ZTABLE_LOCKS + "/" + tableId, null, null);
+
+      // call with no locks - passed as null.
+      AdminUtil.FateStatus noLocks = admin.getTransactionStatus(zs, null, null, null, null);
+
+      assertEquals(withLocks.getTransactions().size(), noLocks.getTransactions().size());
+
+      // exercise methods on returned status.
+      assertNotNull(noLocks.getDanglingHeldLocks());
+      assertNotNull(noLocks.getDanglingWaitingLocks());
+      assertNotNull(noLocks.getTransactions());
+
+    } catch (KeeperException | TableNotFoundException | InterruptedException ex) {
+      throw new IllegalStateException(ex);
+    }
+
+  }
+
+  /**
    * Checks fates in zookeeper looking for transaction associated with a compaction as a double
    * check that the test will be valid because the running compaction does have a fate transaction
    * lock.
@@ -238,7 +328,11 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
       AdminUtil.FateStatus fateStatus = admin.getStatus(zs, zk,
           ZooUtil.getRoot(instance) + Constants.ZTABLE_LOCKS + "/" + tableId, null, null);
 
+      log.trace("current fates: {}", fateStatus.getTransactions().size());
+
       for (AdminUtil.TransactionStatus tx : fateStatus.getTransactions()) {
+
+        log.trace("Fate id: {}, status: {}", tx.getTxid(), tx.getStatus());
 
         if (tx.getTop().contains("CompactionDriver") && tx.getDebug().contains("CompactRange")) {
           return true;
@@ -291,8 +385,7 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
       // populate
       for (int i = 0; i < NUM_ROWS; i++) {
         Mutation m = new Mutation(new Text(String.format("%05d", i)));
-        m.put(new Text("col" + Integer.toString((i % 3) + 1)), new Text("qual"),
-            new Value("junk".getBytes(UTF_8)));
+        m.put(new Text("col" + ((i % 3) + 1)), new Text("qual"), new Value("junk".getBytes(UTF_8)));
         bw.addMutation(m);
       }
       bw.close();
@@ -323,11 +416,11 @@ public class TableChangeStateIT extends AccumuloClusterHarness {
   }
 
   /**
-   * Provides timing information for oline operation.
+   * Provides timing information for online operation.
    */
   private static class OnlineOpTiming {
 
-    private long started = 0L;
+    private final long started;
     private long completed = 0L;
 
     OnlineOpTiming() {


### PR DESCRIPTION
Refactor AdminUtil to provide refactor the existing fate status methods into two - one that provides the existing behaviour and a second
that does not need to process lock information when that information is not required. This refactoring is a step to providing FATE metrics
where a count of existing FATES does not need the lock information.
* Adds unit test
* Includes code analysis clean-up.