### PR TITLE
Revert core/mapred* serialization

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
@@ -103,7 +103,7 @@ public class ClientOpts extends Help {
 
   @Parameter(names = {"-z", "--keepers"},
       description = "Comma separated list of zookeeper hosts (host:port,host:port)")
-  private String zookeepers = null;
+  protected String zookeepers = null;
 
   @Parameter(names = {"-i", "--instance"}, description = "The name of the accumulo instance")
   protected String instance = null;

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.client.rfile.RFile;
 import org.apache.accumulo.core.client.rfile.RFileWriter;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
+import org.apache.accumulo.core.clientImpl.mapreduce.lib.FileOutputConfigurator;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -54,10 +55,6 @@ import org.apache.log4j.Logger;
 @Deprecated
 public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
 
-  // static wrapper class to make references to deprecated configurator easier
-  private static class Configurator
-      extends org.apache.accumulo.core.clientImpl.mapreduce.lib.FileOutputConfigurator {}
-
   private static final Class<?> CLASS = AccumuloFileOutputFormat.class;
   protected static final Logger log = Logger.getLogger(CLASS);
 
@@ -72,7 +69,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setCompressionType(JobConf job, String compressionType) {
-    Configurator.setCompressionType(CLASS, job, compressionType);
+    FileOutputConfigurator.setCompressionType(CLASS, job, compressionType);
   }
 
   /**
@@ -91,7 +88,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setDataBlockSize(JobConf job, long dataBlockSize) {
-    Configurator.setDataBlockSize(CLASS, job, dataBlockSize);
+    FileOutputConfigurator.setDataBlockSize(CLASS, job, dataBlockSize);
   }
 
   /**
@@ -105,7 +102,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setFileBlockSize(JobConf job, long fileBlockSize) {
-    Configurator.setFileBlockSize(CLASS, job, fileBlockSize);
+    FileOutputConfigurator.setFileBlockSize(CLASS, job, fileBlockSize);
   }
 
   /**
@@ -120,7 +117,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setIndexBlockSize(JobConf job, long indexBlockSize) {
-    Configurator.setIndexBlockSize(CLASS, job, indexBlockSize);
+    FileOutputConfigurator.setIndexBlockSize(CLASS, job, indexBlockSize);
   }
 
   /**
@@ -134,7 +131,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setReplication(JobConf job, int replication) {
-    Configurator.setReplication(CLASS, job, replication);
+    FileOutputConfigurator.setReplication(CLASS, job, replication);
   }
 
   /**
@@ -149,7 +146,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    */
 
   public static void setSampler(JobConf job, SamplerConfiguration samplerConfig) {
-    Configurator.setSampler(CLASS, job, samplerConfig);
+    FileOutputConfigurator.setSampler(CLASS, job, samplerConfig);
   }
 
   @Override
@@ -157,12 +154,13 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
       Progressable progress) throws IOException {
     // get the path of the temporary output file
     final Configuration conf = job;
-    final AccumuloConfiguration acuConf = Configurator.getAccumuloConfiguration(CLASS, job);
+    final AccumuloConfiguration acuConf = FileOutputConfigurator.getAccumuloConfiguration(CLASS,
+        job);
 
     final String extension = acuConf.get(Property.TABLE_FILE_TYPE);
     final Path file = new Path(getWorkOutputPath(job),
         getUniqueName(job, "part") + "." + extension);
-    final int visCacheSize = Configurator.getVisibilityCacheSize(conf);
+    final int visCacheSize = FileOutputConfigurator.getVisibilityCacheSize(conf);
 
     return new RecordWriter<Key,Value>() {
       RFileWriter out = null;

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/InputFormatBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/InputFormatBase.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
+import org.apache.accumulo.core.clientImpl.mapreduce.lib.InputConfigurator;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -59,10 +60,6 @@ import org.apache.hadoop.mapred.Reporter;
 @Deprecated
 public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
 
-  // static wrapper class to make references to deprecated configurator easier
-  private static class Configurator
-      extends org.apache.accumulo.core.clientImpl.mapreduce.lib.InputConfigurator {}
-
   /**
    * Sets the name of the input table, over which this job will scan.
    *
@@ -73,7 +70,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setInputTableName(JobConf job, String tableName) {
-    Configurator.setInputTableName(CLASS, job, tableName);
+    InputConfigurator.setInputTableName(CLASS, job, tableName);
   }
 
   /**
@@ -86,7 +83,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setInputTableName(JobConf, String)
    */
   protected static String getInputTableName(JobConf job) {
-    return Configurator.getInputTableName(CLASS, job);
+    return InputConfigurator.getInputTableName(CLASS, job);
   }
 
   /**
@@ -100,7 +97,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setRanges(JobConf job, Collection<Range> ranges) {
-    Configurator.setRanges(CLASS, job, ranges);
+    InputConfigurator.setRanges(CLASS, job, ranges);
   }
 
   /**
@@ -115,7 +112,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setRanges(JobConf, Collection)
    */
   protected static List<Range> getRanges(JobConf job) throws IOException {
-    return Configurator.getRanges(CLASS, job);
+    return InputConfigurator.getRanges(CLASS, job);
   }
 
   /**
@@ -131,7 +128,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    */
   public static void fetchColumns(JobConf job,
       Collection<Pair<Text,Text>> columnFamilyColumnQualifierPairs) {
-    Configurator.fetchColumns(CLASS, job, columnFamilyColumnQualifierPairs);
+    InputConfigurator.fetchColumns(CLASS, job, columnFamilyColumnQualifierPairs);
   }
 
   /**
@@ -144,7 +141,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #fetchColumns(JobConf, Collection)
    */
   protected static Set<Pair<Text,Text>> getFetchedColumns(JobConf job) {
-    return Configurator.getFetchedColumns(CLASS, job);
+    return InputConfigurator.getFetchedColumns(CLASS, job);
   }
 
   /**
@@ -157,7 +154,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void addIterator(JobConf job, IteratorSetting cfg) {
-    Configurator.addIterator(CLASS, job, cfg);
+    InputConfigurator.addIterator(CLASS, job, cfg);
   }
 
   /**
@@ -171,7 +168,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #addIterator(JobConf, IteratorSetting)
    */
   protected static List<IteratorSetting> getIterators(JobConf job) {
-    return Configurator.getIterators(CLASS, job);
+    return InputConfigurator.getIterators(CLASS, job);
   }
 
   /**
@@ -190,7 +187,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setAutoAdjustRanges(JobConf job, boolean enableFeature) {
-    Configurator.setAutoAdjustRanges(CLASS, job, enableFeature);
+    InputConfigurator.setAutoAdjustRanges(CLASS, job, enableFeature);
   }
 
   /**
@@ -204,7 +201,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setAutoAdjustRanges(JobConf, boolean)
    */
   protected static boolean getAutoAdjustRanges(JobConf job) {
-    return Configurator.getAutoAdjustRanges(CLASS, job);
+    return InputConfigurator.getAutoAdjustRanges(CLASS, job);
   }
 
   /**
@@ -220,7 +217,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setScanIsolation(JobConf job, boolean enableFeature) {
-    Configurator.setScanIsolation(CLASS, job, enableFeature);
+    InputConfigurator.setScanIsolation(CLASS, job, enableFeature);
   }
 
   /**
@@ -233,7 +230,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setScanIsolation(JobConf, boolean)
    */
   protected static boolean isIsolated(JobConf job) {
-    return Configurator.isIsolated(CLASS, job);
+    return InputConfigurator.isIsolated(CLASS, job);
   }
 
   /**
@@ -252,7 +249,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setLocalIterators(JobConf job, boolean enableFeature) {
-    Configurator.setLocalIterators(CLASS, job, enableFeature);
+    InputConfigurator.setLocalIterators(CLASS, job, enableFeature);
   }
 
   /**
@@ -265,7 +262,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setLocalIterators(JobConf, boolean)
    */
   protected static boolean usesLocalIterators(JobConf job) {
-    return Configurator.usesLocalIterators(CLASS, job);
+    return InputConfigurator.usesLocalIterators(CLASS, job);
   }
 
   /**
@@ -304,7 +301,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setOfflineTableScan(JobConf job, boolean enableFeature) {
-    Configurator.setOfflineTableScan(CLASS, job, enableFeature);
+    InputConfigurator.setOfflineTableScan(CLASS, job, enableFeature);
   }
 
   /**
@@ -317,7 +314,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setOfflineTableScan(JobConf, boolean)
    */
   protected static boolean isOfflineScan(JobConf job) {
-    return Configurator.isOfflineScan(CLASS, job);
+    return InputConfigurator.isOfflineScan(CLASS, job);
   }
 
   /**
@@ -348,7 +345,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.7.0
    */
   public static void setBatchScan(JobConf job, boolean enableFeature) {
-    Configurator.setBatchScan(CLASS, job, enableFeature);
+    InputConfigurator.setBatchScan(CLASS, job, enableFeature);
   }
 
   /**
@@ -360,7 +357,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setBatchScan(JobConf, boolean)
    */
   public static boolean isBatchScan(JobConf job) {
-    return Configurator.isBatchScan(CLASS, job);
+    return InputConfigurator.isBatchScan(CLASS, job);
   }
 
   /**
@@ -379,7 +376,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see ScannerBase#setSamplerConfiguration(SamplerConfiguration)
    */
   public static void setSamplerConfiguration(JobConf job, SamplerConfiguration samplerConfig) {
-    Configurator.setSamplerConfiguration(CLASS, job, samplerConfig);
+    InputConfigurator.setSamplerConfiguration(CLASS, job, samplerConfig);
   }
 
   protected abstract static class RecordReaderBase<K,V> extends AbstractRecordReader<K,V> {

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.client.rfile.RFile;
 import org.apache.accumulo.core.client.rfile.RFileWriter;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
+import org.apache.accumulo.core.clientImpl.mapreduce.lib.FileOutputConfigurator;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -52,10 +53,6 @@ import org.apache.log4j.Logger;
 @Deprecated
 public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
 
-  // static wrapper class to make references to deprecated configurator easier
-  private static class Configurator
-      extends org.apache.accumulo.core.clientImpl.mapreduce.lib.FileOutputConfigurator {}
-
   private static final Class<?> CLASS = AccumuloFileOutputFormat.class;
   protected static final Logger log = Logger.getLogger(CLASS);
 
@@ -70,7 +67,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setCompressionType(Job job, String compressionType) {
-    Configurator.setCompressionType(CLASS, job.getConfiguration(), compressionType);
+    FileOutputConfigurator.setCompressionType(CLASS, job.getConfiguration(), compressionType);
   }
 
   /**
@@ -89,7 +86,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setDataBlockSize(Job job, long dataBlockSize) {
-    Configurator.setDataBlockSize(CLASS, job.getConfiguration(), dataBlockSize);
+    FileOutputConfigurator.setDataBlockSize(CLASS, job.getConfiguration(), dataBlockSize);
   }
 
   /**
@@ -103,7 +100,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setFileBlockSize(Job job, long fileBlockSize) {
-    Configurator.setFileBlockSize(CLASS, job.getConfiguration(), fileBlockSize);
+    FileOutputConfigurator.setFileBlockSize(CLASS, job.getConfiguration(), fileBlockSize);
   }
 
   /**
@@ -118,7 +115,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setIndexBlockSize(Job job, long indexBlockSize) {
-    Configurator.setIndexBlockSize(CLASS, job.getConfiguration(), indexBlockSize);
+    FileOutputConfigurator.setIndexBlockSize(CLASS, job.getConfiguration(), indexBlockSize);
   }
 
   /**
@@ -132,7 +129,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @since 1.5.0
    */
   public static void setReplication(Job job, int replication) {
-    Configurator.setReplication(CLASS, job.getConfiguration(), replication);
+    FileOutputConfigurator.setReplication(CLASS, job.getConfiguration(), replication);
   }
 
   /**
@@ -147,19 +144,19 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    */
 
   public static void setSampler(Job job, SamplerConfiguration samplerConfig) {
-    Configurator.setSampler(CLASS, job.getConfiguration(), samplerConfig);
+    FileOutputConfigurator.setSampler(CLASS, job.getConfiguration(), samplerConfig);
   }
 
   @Override
   public RecordWriter<Key,Value> getRecordWriter(TaskAttemptContext context) throws IOException {
     // get the path of the temporary output file
     final Configuration conf = context.getConfiguration();
-    final AccumuloConfiguration acuConf = Configurator.getAccumuloConfiguration(CLASS,
+    final AccumuloConfiguration acuConf = FileOutputConfigurator.getAccumuloConfiguration(CLASS,
         context.getConfiguration());
 
     final String extension = acuConf.get(Property.TABLE_FILE_TYPE);
     final Path file = this.getDefaultWorkFile(context, "." + extension);
-    final int visCacheSize = Configurator.getVisibilityCacheSize(conf);
+    final int visCacheSize = FileOutputConfigurator.getVisibilityCacheSize(conf);
 
     return new RecordWriter<Key,Value>() {
       RFileWriter out = null;

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputFormatBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputFormatBase.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
+import org.apache.accumulo.core.clientImpl.mapreduce.lib.InputConfigurator;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -60,10 +61,6 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 @Deprecated
 public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
 
-  // static wrapper class to make references to deprecated configurator easier
-  private static class Configurator
-      extends org.apache.accumulo.core.clientImpl.mapreduce.lib.InputConfigurator {}
-
   /**
    * Gets the table name from the configuration.
    *
@@ -74,7 +71,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setInputTableName(Job, String)
    */
   protected static String getInputTableName(JobContext context) {
-    return Configurator.getInputTableName(CLASS, context.getConfiguration());
+    return InputConfigurator.getInputTableName(CLASS, context.getConfiguration());
   }
 
   /**
@@ -87,7 +84,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setInputTableName(Job job, String tableName) {
-    Configurator.setInputTableName(CLASS, job.getConfiguration(), tableName);
+    InputConfigurator.setInputTableName(CLASS, job.getConfiguration(), tableName);
   }
 
   /**
@@ -101,7 +98,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setRanges(Job job, Collection<Range> ranges) {
-    Configurator.setRanges(CLASS, job.getConfiguration(), ranges);
+    InputConfigurator.setRanges(CLASS, job.getConfiguration(), ranges);
   }
 
   /**
@@ -114,7 +111,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setRanges(Job, Collection)
    */
   protected static List<Range> getRanges(JobContext context) throws IOException {
-    return Configurator.getRanges(CLASS, context.getConfiguration());
+    return InputConfigurator.getRanges(CLASS, context.getConfiguration());
   }
 
   /**
@@ -130,7 +127,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    */
   public static void fetchColumns(Job job,
       Collection<Pair<Text,Text>> columnFamilyColumnQualifierPairs) {
-    Configurator.fetchColumns(CLASS, job.getConfiguration(), columnFamilyColumnQualifierPairs);
+    InputConfigurator.fetchColumns(CLASS, job.getConfiguration(), columnFamilyColumnQualifierPairs);
   }
 
   /**
@@ -143,7 +140,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #fetchColumns(Job, Collection)
    */
   protected static Set<Pair<Text,Text>> getFetchedColumns(JobContext context) {
-    return Configurator.getFetchedColumns(CLASS, context.getConfiguration());
+    return InputConfigurator.getFetchedColumns(CLASS, context.getConfiguration());
   }
 
   /**
@@ -156,7 +153,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void addIterator(Job job, IteratorSetting cfg) {
-    Configurator.addIterator(CLASS, job.getConfiguration(), cfg);
+    InputConfigurator.addIterator(CLASS, job.getConfiguration(), cfg);
   }
 
   /**
@@ -170,7 +167,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #addIterator(Job, IteratorSetting)
    */
   protected static List<IteratorSetting> getIterators(JobContext context) {
-    return Configurator.getIterators(CLASS, context.getConfiguration());
+    return InputConfigurator.getIterators(CLASS, context.getConfiguration());
   }
 
   /**
@@ -189,7 +186,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setAutoAdjustRanges(Job job, boolean enableFeature) {
-    Configurator.setAutoAdjustRanges(CLASS, job.getConfiguration(), enableFeature);
+    InputConfigurator.setAutoAdjustRanges(CLASS, job.getConfiguration(), enableFeature);
   }
 
   /**
@@ -203,7 +200,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setAutoAdjustRanges(Job, boolean)
    */
   protected static boolean getAutoAdjustRanges(JobContext context) {
-    return Configurator.getAutoAdjustRanges(CLASS, context.getConfiguration());
+    return InputConfigurator.getAutoAdjustRanges(CLASS, context.getConfiguration());
   }
 
   /**
@@ -219,7 +216,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setScanIsolation(Job job, boolean enableFeature) {
-    Configurator.setScanIsolation(CLASS, job.getConfiguration(), enableFeature);
+    InputConfigurator.setScanIsolation(CLASS, job.getConfiguration(), enableFeature);
   }
 
   /**
@@ -232,7 +229,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setScanIsolation(Job, boolean)
    */
   protected static boolean isIsolated(JobContext context) {
-    return Configurator.isIsolated(CLASS, context.getConfiguration());
+    return InputConfigurator.isIsolated(CLASS, context.getConfiguration());
   }
 
   /**
@@ -251,7 +248,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setLocalIterators(Job job, boolean enableFeature) {
-    Configurator.setLocalIterators(CLASS, job.getConfiguration(), enableFeature);
+    InputConfigurator.setLocalIterators(CLASS, job.getConfiguration(), enableFeature);
   }
 
   /**
@@ -264,7 +261,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setLocalIterators(Job, boolean)
    */
   protected static boolean usesLocalIterators(JobContext context) {
-    return Configurator.usesLocalIterators(CLASS, context.getConfiguration());
+    return InputConfigurator.usesLocalIterators(CLASS, context.getConfiguration());
   }
 
   /**
@@ -303,7 +300,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.5.0
    */
   public static void setOfflineTableScan(Job job, boolean enableFeature) {
-    Configurator.setOfflineTableScan(CLASS, job.getConfiguration(), enableFeature);
+    InputConfigurator.setOfflineTableScan(CLASS, job.getConfiguration(), enableFeature);
   }
 
   /**
@@ -316,7 +313,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setOfflineTableScan(Job, boolean)
    */
   protected static boolean isOfflineScan(JobContext context) {
-    return Configurator.isOfflineScan(CLASS, context.getConfiguration());
+    return InputConfigurator.isOfflineScan(CLASS, context.getConfiguration());
   }
 
   /**
@@ -347,7 +344,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @since 1.7.0
    */
   public static void setBatchScan(Job job, boolean enableFeature) {
-    Configurator.setBatchScan(CLASS, job.getConfiguration(), enableFeature);
+    InputConfigurator.setBatchScan(CLASS, job.getConfiguration(), enableFeature);
   }
 
   /**
@@ -359,7 +356,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see #setBatchScan(Job, boolean)
    */
   public static boolean isBatchScan(JobContext context) {
-    return Configurator.isBatchScan(CLASS, context.getConfiguration());
+    return InputConfigurator.isBatchScan(CLASS, context.getConfiguration());
   }
 
   /**
@@ -378,7 +375,7 @@ public abstract class InputFormatBase<K,V> extends AbstractInputFormat<K,V> {
    * @see ScannerBase#setSamplerConfiguration(SamplerConfiguration)
    */
   public static void setSamplerConfiguration(Job job, SamplerConfiguration samplerConfig) {
-    Configurator.setSamplerConfiguration(CLASS, job.getConfiguration(), samplerConfig);
+    InputConfigurator.setSamplerConfiguration(CLASS, job.getConfiguration(), samplerConfig);
   }
 
   protected abstract static class RecordReaderBase<K,V> extends AbstractRecordReader<K,V> {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConnectorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConnectorImpl.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchDeleter;
@@ -72,7 +71,7 @@ public class ConnectorImpl extends org.apache.accumulo.core.client.Connector {
     }
   }
 
-  public AccumuloClient getAccumuloClient() {
+  public ClientContext getAccumuloClient() {
     return context;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -32,9 +32,7 @@ import org.apache.hadoop.conf.Configuration;
 
 /**
  * @since 1.6.0
- * @deprecated since 2.0.0
  */
-@Deprecated
 public class FileOutputConfigurator extends ConfiguratorBase {
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/OutputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/OutputConfigurator.java
@@ -28,11 +28,6 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.hadoop.conf.Configuration;
 
-/**
- * @since 1.6.0
- * @deprecated since 2.0.0
- */
-@Deprecated
 public class OutputConfigurator extends ConfiguratorBase {
 
   /**


### PR DESCRIPTION
* Fix broken core/mapred* ITs
* Revert serialization to previous (1.9) serialization in core
* Make use of stored fields in input splits before reading job
configuration for constructing client
* Use ConnectorImpl's ClientContext in core/mapred
* Revert unnecessary closing of ClientContext from ConnectorImpl
* Revert unnecessary "simplification" of Configurators to manage
deprecated types (remove unnecessary deprecation of internal
configurator classes)
* Slight simplifications to ITs to ease debugging
* Check failure state when core/mapred ITs fail