### PR TITLE
Fixes #810 - Replace MiniAccumulo LogWriter's with ProcessBuilder.red…

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.cluster.ClusterControl;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.minicluster.ServerType;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.LogWriter;
 import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.server.util.Admin;
 import org.apache.accumulo.tracer.TraceServer;
@@ -95,9 +94,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
       Thread.currentThread().interrupt();
       throw new IOException(e);
     }
-    for (LogWriter writer : cluster.getLogWriters()) {
-      writer.flush();
-    }
+
     return Maps.immutableEntry(exitCode, readAll(new FileInputStream(cluster.getConfig().getLogDir()
         + "/" + clz.getSimpleName() + "_" + p.hashCode() + ".out")));
   }

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -47,7 +47,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -110,10 +109,6 @@ public class AuditMessageIT extends ConfigurableMacBase {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted waiting for data to be flushed to output streams");
-    }
-
-    for (MiniAccumuloClusterImpl.LogWriter lw : getCluster().getLogWriters()) {
-      lw.flush();
     }
 
     // Grab the audit messages

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.fate.AdminUtil.FateStatus;
 import org.apache.accumulo.fate.ZooStore;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.LogWriter;
 import org.apache.accumulo.server.zookeeper.ZooReaderWriterFactory;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.hadoop.fs.FileSystem;
@@ -169,8 +168,6 @@ public class FunctionalTestUtils {
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")
   public static String readAll(MiniAccumuloClusterImpl c, Class<?> klass, Process p)
       throws Exception {
-    for (LogWriter writer : c.getLogWriters())
-      writer.flush();
     return readAll(new FileInputStream(
         c.getConfig().getLogDir() + "/" + klass.getSimpleName() + "_" + p.hashCode() + ".out"));
   }


### PR DESCRIPTION
…irectOutput().    I fixed my master branch,  re-branched to accumulo-810_ and made my changes from a few weeks over again but also ran 'mvn test' this time to see which other classes used LogWriter.  I mistakenly thought the compiler would tell me which test classes used it so I broke the build last time.  I apologize.