### PR TITLE
Fixes #888 - AccumuloInputFormat.fetchColumns should accept empty col…

### DIFF
--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -16,13 +16,7 @@
  */
 package org.apache.accumulo.hadoopImpl.mapreduce;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
+import java.util.*;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -105,11 +99,16 @@ public class InputFormatBuilderImpl<T>
   @Override
   public InputFormatBuilder.InputFormatOptions<T> fetchColumns(
       Collection<IteratorSetting.Column> fetchColumns) {
-    Collection<IteratorSetting.Column> newFetchColumns = ImmutableList
-        .copyOf(Objects.requireNonNull(fetchColumns, "Collection of fetch columns is null"));
-    if (newFetchColumns.size() == 0)
-      throw new IllegalArgumentException("Specified collection of fetch columns is empty.");
+
+    Collection<IteratorSetting.Column> newFetchColumns;
+    if (fetchColumns != null) {
+      newFetchColumns = ImmutableList.copyOf(fetchColumns);
+    } else {
+      throw new NullPointerException("Collection of fetch columns is null");
+    }
+
     tableConfigMap.get(currentTable).fetchColumns(newFetchColumns);
+
     return this;
   }
 

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
@@ -225,4 +225,13 @@ public class AccumuloInputFormatTest {
 
     assertEquals(cols, InputConfigurator.getFetchedColumns(AccumuloInputFormat.class, job));
   }
+
+  @Test
+  public void testEmptyFetchColumns() throws Exception {
+    Set<IteratorSetting.Column> cols = new HashSet<>();
+    AccumuloInputFormat.configure().clientProperties(clientProperties).table("test")
+        .auths(Authorizations.EMPTY).fetchColumns(cols).store(job);
+
+    assertEquals(cols, InputConfigurator.getFetchedColumns(AccumuloInputFormat.class, job));
+  }
 }


### PR DESCRIPTION
…lection.  Made the requested change allowing zero sized collections while at the same time throwing a NullPointerException for null collection objects. Added a test too.