### PR TITLE
Add exclusion to test for vuln in mini-kdc lib

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -152,6 +152,11 @@
           <groupId>bouncycastle</groupId>
           <artifactId>bcprov-jdk15</artifactId>
         </exclusion>
+        <!-- avoid vuln in JOSE library see https://nvd.nist.gov/vuln/detail/CVE-2017-12974 -->
+        <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>nimbus-jose-jwt</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hadoop mini-kdc brings in a vulnerable dependency we don't need so we can just exclude it.