### PR TITLE
Exclude vuln thrift dep from build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,13 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>${thrift.version}</version>
+        <!-- exclude vulnerable lib see https://issues.apache.org/jira/browse/HTTPCLIENT-1803 -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
Snyk CLI tool was flagging this Thrift dependency.  Excluding it from our pom seems to have no effect. 