### PR TITLE
Fix #876 - Refactor WorkAssigner Tests to use AccumuloClient

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/replication/DistributedWorkQueueWorkAssigner.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/DistributedWorkQueueWorkAssigner.java
@@ -67,20 +67,12 @@ public abstract class DistributedWorkQueueWorkAssigner implements WorkAssigner {
   protected int maxQueueSize;
   protected ZooCache zooCache;
 
-  protected void setClient(AccumuloClient client) {
-    this.client = client;
-  }
-
   protected void setWorkQueue(DistributedWorkQueue workQueue) {
     this.workQueue = workQueue;
   }
 
   protected void setMaxQueueSize(int maxQueueSize) {
     this.maxQueueSize = maxQueueSize;
-  }
-
-  protected void setZooCache(ZooCache zooCache) {
-    this.zooCache = zooCache;
   }
 
   /**

--- a/server/master/src/test/java/org/apache/accumulo/master/replication/SequentialWorkAssignerTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/replication/SequentialWorkAssignerTest.java
@@ -66,30 +66,29 @@ public class SequentialWorkAssignerTest {
 
     queuedWork.put("cluster1", cluster1Work);
 
-    assigner.setClient(client);
-    assigner.setZooCache(zooCache);
-    assigner.setWorkQueue(workQueue);
+    assigner.zooCache = zooCache;
+    assigner.workQueue = workQueue;
     assigner.setQueuedWork(queuedWork);
 
     expect(client.getInstanceID()).andReturn("instance");
 
     // file1 replicated
-    expect(zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
-        + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1",
+    expect(assigner.zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE
+        + "/" + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1",
             new ReplicationTarget("cluster1", "1", Table.ID.of("1"))))).andReturn(null);
     // file2 still needs to replicate
     expect(
-        zooCache
+        assigner.zooCache
             .get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
                 + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2",
                     new ReplicationTarget("cluster1", "2", Table.ID.of("2")))))
                         .andReturn(new byte[0]);
 
-    replay(workQueue, zooCache, client);
+    replay(assigner.workQueue, assigner.zooCache, assigner.client);
 
     assigner.cleanupFinishedWork();
 
-    verify(workQueue, zooCache, client);
+    verify(assigner.workQueue, assigner.zooCache, assigner.client);
 
     assertEquals(1, cluster1Work.size());
     assertEquals(

--- a/test/src/main/java/org/apache/accumulo/test/replication/SequentialWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/SequentialWorkAssignerIT.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.replication.ReplicationSchema.WorkSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.master.replication.SequentialWorkAssigner;
 import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHelper;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
@@ -58,18 +57,13 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
     }
 
     @Override
-    public void setClient(AccumuloClient client) {
-      super.setClient(client);
-    }
-
-    @Override
     public void setQueuedWork(Map<String,Map<Table.ID,String>> queuedWork) {
       super.setQueuedWork(queuedWork);
     }
 
     @Override
     public void setWorkQueue(DistributedWorkQueue workQueue) {
-      super.setWorkQueue(workQueue);
+      super.workQueue = workQueue;
     }
 
     @Override
@@ -80,11 +74,6 @@ public class SequentialWorkAssignerIT extends ConfigurableMacBase {
     @Override
     public void createWork() {
       super.createWork();
-    }
-
-    @Override
-    public void setZooCache(ZooCache zooCache) {
-      super.setZooCache(zooCache);
     }
 
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.replication.ReplicationSchema.WorkSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.master.replication.UnorderedWorkAssigner;
 import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHelper;
 import org.apache.accumulo.server.replication.StatusUtil;
@@ -64,7 +63,7 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
 
     @Override
     protected void setWorkQueue(DistributedWorkQueue workQueue) {
-      super.setWorkQueue(workQueue);
+      super.workQueue = workQueue;
     }
 
     @Override
@@ -83,11 +82,6 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
     }
 
     @Override
-    protected void setClient(AccumuloClient client) {
-      super.setClient(client);
-    }
-
-    @Override
     protected void setMaxQueueSize(int maxQueueSize) {
       super.setMaxQueueSize(maxQueueSize);
     }
@@ -95,11 +89,6 @@ public class UnorderedWorkAssignerIT extends ConfigurableMacBase {
     @Override
     protected void createWork() {
       super.createWork();
-    }
-
-    @Override
-    protected void setZooCache(ZooCache zooCache) {
-      super.setZooCache(zooCache);
     }
 
     @Override


### PR DESCRIPTION
- Remove the use of setClient() and setZooCache()
- remove setClient() and setZooCache() from
DistributedWorkQueueWorkAssigner as they are no longer used
- refactor and remove setClient and setZooCache from IT's
- refactor workQueue