### PR TITLE
Reduce use of CachedConfiguration for #735

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -64,6 +64,7 @@ import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +90,7 @@ public class ClientContext implements AccumuloClient {
   private Credentials creds;
   private BatchWriterConfig batchWriterConfig;
   private AccumuloConfiguration serverConf;
+  private Configuration hadoopConf;
 
   // These fields are very frequently accessed (each time a connection is created) and expensive to
   // compute, so cache them.
@@ -136,6 +138,7 @@ public class ClientContext implements AccumuloClient {
   public ClientContext(SingletonReservation reservation, ClientInfo info,
       AccumuloConfiguration serverConf) {
     this.info = info;
+    this.hadoopConf = info.getHadoopConf();
     zooCache = new ZooCacheFactory().getZooCache(info.getZooKeepers(),
         info.getZooKeepersSessionTimeOut());
     this.serverConf = serverConf;
@@ -239,6 +242,14 @@ public class ClientContext implements AccumuloClient {
   public AccumuloConfiguration getConfiguration() {
     ensureOpen();
     return serverConf;
+  }
+
+  /**
+   * Retrieve the hadoop configuration
+   */
+  public Configuration getHadoopConf() {
+    ensureOpen();
+    return this.hadoopConf;
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfo.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * Accumulo client information. Can be built using {@link Accumulo#newClient()}
@@ -63,6 +64,11 @@ public interface ClientInfo {
    * @return All Accumulo client properties set for this connection
    */
   Properties getProperties();
+
+  /**
+   * @return hadoop Configuration
+   */
+  Configuration getHadoopConf();
 
   /**
    * @return ClientInfo given properties

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfoImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfoImpl.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
+import org.apache.hadoop.conf.Configuration;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -33,6 +34,7 @@ public class ClientInfoImpl implements ClientInfo {
 
   private Properties properties;
   private AuthenticationToken token;
+  private Configuration hadoopConf;
 
   public ClientInfoImpl(Path propertiesFile) {
     this(ClientInfoImpl.toProperties(propertiesFile));
@@ -45,6 +47,7 @@ public class ClientInfoImpl implements ClientInfo {
   public ClientInfoImpl(Properties properties, AuthenticationToken token) {
     this.properties = properties;
     this.token = token;
+    this.hadoopConf = new Configuration();
   }
 
   @Override
@@ -108,5 +111,10 @@ public class ClientInfoImpl implements ClientInfo {
       throw new IllegalArgumentException("Failed to load properties from " + propertiesFile, e);
     }
     return properties;
+  }
+
+  @Override
+  public Configuration getHadoopConf() {
+    return this.hadoopConf;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -120,7 +120,6 @@ import org.apache.accumulo.core.summary.SummaryCollection;
 import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.trace.Tracer;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
@@ -1151,7 +1150,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     Map<String,String> props = context.instanceOperations().getSystemConfiguration();
     AccumuloConfiguration conf = new ConfigurationCopy(props);
 
-    FileSystem fs = VolumeConfiguration.getVolume(dir, CachedConfiguration.getInstance(), conf)
+    FileSystem fs = VolumeConfiguration.getVolume(dir, context.getHadoopConf(), conf)
         .getFileSystem();
 
     if (dir.contains(":")) {
@@ -1481,7 +1480,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     }
 
     try {
-      FileSystem fs = new Path(importDir).getFileSystem(CachedConfiguration.getInstance());
+      FileSystem fs = new Path(importDir).getFileSystem(context.getHadoopConf());
       Map<String,String> props = getExportedProps(fs, new Path(importDir, Constants.EXPORT_FILE));
 
       for (Entry<String,String> entry : props.entrySet()) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -72,7 +72,6 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -120,7 +119,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
     Map<String,String> props = context.instanceOperations().getSystemConfiguration();
     AccumuloConfiguration conf = new ConfigurationCopy(props);
 
-    FileSystem fs = VolumeConfiguration.getVolume(dir, CachedConfiguration.getInstance(), conf)
+    FileSystem fs = VolumeConfiguration.getVolume(dir, context.getHadoopConf(), conf)
         .getFileSystem();
 
     Path srcPath = checkPath(fs, dir);

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.NamingThreadFactory;
 import org.apache.accumulo.fate.util.LoggingRunnable;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
@@ -473,7 +472,7 @@ public class BloomFilterLayer {
     acuconf.set(Property.TABLE_BLOOM_LOAD_THRESHOLD, "1");
     acuconf.set(Property.TSERV_BLOOM_LOAD_MAXCONCURRENT, "1");
 
-    Configuration conf = CachedConfiguration.getInstance();
+    Configuration conf = new Configuration();
     FileSystem fs = FileSystem.get(conf);
 
     String suffix = FileOperations.getNewFileExtension(acuconf);

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.bcfile.Compression;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -75,7 +74,7 @@ public class CreateEmpty {
   }
 
   public static void main(String[] args) throws Exception {
-    Configuration conf = CachedConfiguration.getInstance();
+    Configuration conf = new Configuration();
 
     Opts opts = new Opts();
     opts.parseArgs(CreateEmpty.class.getName(), args);

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/SplitLarge.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/SplitLarge.java
@@ -33,7 +33,6 @@ import org.apache.accumulo.core.file.rfile.RFile.Reader;
 import org.apache.accumulo.core.file.rfile.RFile.Writer;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -56,7 +55,7 @@ public class SplitLarge {
   }
 
   public static void main(String[] args) throws Exception {
-    Configuration conf = CachedConfiguration.getInstance();
+    Configuration conf = new Configuration();
     FileSystem fs = FileSystem.get(conf);
     Opts opts = new Opts();
     opts.parseArgs(SplitLarge.class.getName(), args);

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -66,7 +66,6 @@ import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.spi.crypto.CryptoService.CryptoException;
 import org.apache.accumulo.core.spi.crypto.FileDecrypter;
 import org.apache.accumulo.core.spi.crypto.FileEncrypter;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -91,13 +90,14 @@ public class CryptoTest {
       + "/target/CryptoTest-testkeyfile";
   public static final String emptyKeyPath = System.getProperty("user.dir")
       + "/target/CryptoTest-emptykeyfile";
+  private static Configuration hadoopConf = new Configuration();
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
   @BeforeClass
   public static void setupKeyFiles() throws Exception {
-    FileSystem fs = FileSystem.getLocal(CachedConfiguration.getInstance());
+    FileSystem fs = FileSystem.getLocal(hadoopConf);
     Path aesPath = new Path(keyPath);
     try (FSDataOutputStream out = fs.create(aesPath)) {
       out.writeUTF("sixteenbytekey"); // 14 + 2 from writeUTF
@@ -206,7 +206,7 @@ public class CryptoTest {
   @Test
   public void testRFileEncrypted() throws Exception {
     AccumuloConfiguration cryptoOnConf = getAccumuloConfig(CRYPTO_ON_CONF);
-    FileSystem fs = FileSystem.getLocal(CachedConfiguration.getInstance());
+    FileSystem fs = FileSystem.getLocal(hadoopConf);
     ArrayList<Key> keys = testData();
     SummarizerConfiguration sumConf = SummarizerConfiguration.builder(KeyCounter.class.getName())
         .build();
@@ -243,7 +243,7 @@ public class CryptoTest {
   public void testReadNoCryptoWithCryptoConfigured() throws Exception {
     AccumuloConfiguration cryptoOffConf = getAccumuloConfig(CRYPTO_OFF_CONF);
     AccumuloConfiguration cryptoOnConf = getAccumuloConfig(CRYPTO_ON_CONF);
-    FileSystem fs = FileSystem.getLocal(CachedConfiguration.getInstance());
+    FileSystem fs = FileSystem.getLocal(hadoopConf);
     ArrayList<Key> keys = testData();
 
     String file = "target/testFile2.rf";

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
@@ -80,7 +79,7 @@ public class BloomFilterLayerLookupTest {
     acuconf.set(Property.TABLE_BLOOM_LOAD_THRESHOLD, "1");
     acuconf.set(Property.TSERV_BLOOM_LOAD_MAXCONCURRENT, "1");
 
-    Configuration conf = CachedConfiguration.getInstance();
+    Configuration conf = new Configuration();
     FileSystem fs = FileSystem.get(conf);
 
     // get output file name

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -38,13 +38,14 @@ import org.apache.accumulo.core.file.rfile.MultiLevelIndex.Reader.IndexIterator;
 import org.apache.accumulo.core.file.rfile.MultiLevelIndex.Writer;
 import org.apache.accumulo.core.file.rfile.RFileTest.SeekableByteArrayInputStream;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile;
-import org.apache.accumulo.core.util.CachedConfiguration;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.Test;
 
 public class MultiLevelIndexTest {
+  private Configuration hadoopConf = new Configuration();
 
   @Test
   public void test1() throws Exception {
@@ -62,7 +63,7 @@ public class MultiLevelIndexTest {
     AccumuloConfiguration aconf = DefaultConfiguration.getInstance();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     FSDataOutputStream dos = new FSDataOutputStream(baos, new FileSystem.Statistics("a"));
-    BCFile.Writer _cbw = new BCFile.Writer(dos, null, "gz", CachedConfiguration.getInstance(),
+    BCFile.Writer _cbw = new BCFile.Writer(dos, null, "gz", hadoopConf,
         CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA));
 
     BufferedWriter mliw = new BufferedWriter(new Writer(_cbw, maxBlockSize));
@@ -83,8 +84,7 @@ public class MultiLevelIndexTest {
     byte[] data = baos.toByteArray();
     SeekableByteArrayInputStream bais = new SeekableByteArrayInputStream(data);
     FSDataInputStream in = new FSDataInputStream(bais);
-    CachableBuilder cb = new CachableBuilder().input(in).length(data.length)
-        .conf(CachedConfiguration.getInstance())
+    CachableBuilder cb = new CachableBuilder().input(in).length(data.length).conf(hadoopConf)
         .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA));
     CachableBlockFile.Reader _cbr = new CachableBlockFile.Reader(cb);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -55,7 +55,6 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.NamingThreadFactory;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.hadoop.conf.Configuration;
@@ -108,7 +107,7 @@ public class MultiThreadedRFileTest {
 
   public static class TestRFile {
 
-    private Configuration conf = CachedConfiguration.getInstance();
+    private Configuration conf = new Configuration();
     public RFile.Writer writer;
     private FSDataOutputStream dos;
     private AccumuloConfiguration accumuloConfiguration;

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -82,7 +82,6 @@ import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
 import org.apache.accumulo.core.spi.cache.BlockCacheManager;
 import org.apache.accumulo.core.spi.cache.CacheType;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -122,6 +121,7 @@ public class RFileTest {
   }
 
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
+  private static final Configuration hadoopConf = new Configuration();
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder(
@@ -218,7 +218,7 @@ public class RFileTest {
 
   public static class TestRFile {
 
-    protected Configuration conf = CachedConfiguration.getInstance();
+    protected Configuration conf = new Configuration();
     public RFile.Writer writer;
     protected ByteArrayOutputStream baos;
     protected FSDataOutputStream dos;
@@ -1735,8 +1735,7 @@ public class RFileTest {
     byte data[] = baos.toByteArray();
     SeekableByteArrayInputStream bais = new SeekableByteArrayInputStream(data);
     FSDataInputStream in2 = new FSDataInputStream(bais);
-    CachableBuilder cb = new CachableBuilder().input(in2).length(data.length)
-        .conf(CachedConfiguration.getInstance())
+    CachableBuilder cb = new CachableBuilder().input(in2).length(data.length).conf(hadoopConf)
         .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA));
     Reader reader = new RFile.Reader(cb);
     checkIndex(reader);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/DefaultIteratorEnvironment.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/DefaultIteratorEnvironment.java
@@ -24,13 +24,13 @@ import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.system.MapFileIterator;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
 public class DefaultIteratorEnvironment extends BaseIteratorEnvironment {
 
   AccumuloConfiguration conf;
+  Configuration hadoopConf = new Configuration();
 
   public DefaultIteratorEnvironment(AccumuloConfiguration conf) {
     this.conf = conf;
@@ -43,9 +43,8 @@ public class DefaultIteratorEnvironment extends BaseIteratorEnvironment {
   @Override
   public SortedKeyValueIterator<Key,Value> reserveMapFileReader(String mapFileName)
       throws IOException {
-    Configuration conf = CachedConfiguration.getInstance();
-    FileSystem fs = FileSystem.get(conf);
-    return new MapFileIterator(this.conf, fs, mapFileName, conf);
+    FileSystem fs = FileSystem.get(hadoopConf);
+    return new MapFileIterator(this.conf, fs, mapFileName, hadoopConf);
   }
 
   @Override

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloCluster.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.master.thrift.MasterGoalState;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.conf.Configuration;
@@ -189,7 +188,7 @@ public class StandaloneAccumuloCluster implements AccumuloCluster {
   public Configuration getHadoopConfiguration() {
     String confDir = getHadoopConfDir();
     // Using CachedConfiguration will make repeatedly calling this method much faster
-    final Configuration conf = CachedConfiguration.getInstance();
+    final Configuration conf = getServerContext().getHadoopConf();
     conf.addResource(new Path(confDir, "core-site.xml"));
     // Need hdfs-site.xml for NN HA
     conf.addResource(new Path(confDir, "hdfs-site.xml"));

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -62,7 +62,6 @@ import org.apache.accumulo.core.util.StopWatch;
 import org.apache.accumulo.fate.util.LoggingRunnable;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
-import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.accumulo.server.util.FileUtil;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -104,7 +103,7 @@ public class BulkImporter {
     this.setTime = setTime;
   }
 
-  public AssignmentStats importFiles(List<String> files) throws IOException {
+  public AssignmentStats importFiles(List<String> files) {
 
     int numThreads = context.getConfiguration().getCount(Property.TSERV_BULK_PROCESS_THREADS);
     int numAssignThreads = context.getConfiguration()
@@ -113,8 +112,7 @@ public class BulkImporter {
     timer = new StopWatch<>(Timers.class);
     timer.start(Timers.TOTAL);
 
-    VolumeManagerImpl.get(context.getConfiguration());
-    final VolumeManager fs = VolumeManagerImpl.get(context.getConfiguration());
+    final VolumeManager fs = context.getVolumeManager();
 
     Set<Path> paths = new HashSet<>();
     for (String file : files) {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -335,10 +335,6 @@ public class VolumeManagerImpl implements VolumeManager {
 
   private static final String DEFAULT = "";
 
-  public static VolumeManager get(AccumuloConfiguration conf) throws IOException {
-    return get(conf, CachedConfiguration.getInstance());
-  }
-
   public static VolumeManager get(AccumuloConfiguration conf, final Configuration hadoopConf)
       throws IOException {
     final Map<String,Volume> volumes = new HashMap<>();

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -843,14 +843,14 @@ public class Initialize implements KeywordExecutable {
     return false;
   }
 
-  private static void addVolumes(VolumeManager fs, SiteConfiguration siteConfig)
-      throws IOException {
+  private static void addVolumes(VolumeManager fs, SiteConfiguration siteConfig,
+      Configuration hadoopConf) throws IOException {
 
-    String[] volumeURIs = VolumeConfiguration.getVolumeUris(siteConfig);
+    String[] volumeURIs = VolumeConfiguration.getVolumeUris(siteConfig, hadoopConf);
 
     HashSet<String> initializedDirs = new HashSet<>();
-    initializedDirs
-        .addAll(Arrays.asList(ServerConstants.checkBaseUris(siteConfig, volumeURIs, true)));
+    initializedDirs.addAll(
+        Arrays.asList(ServerConstants.checkBaseUris(siteConfig, hadoopConf, volumeURIs, true)));
 
     HashSet<String> uinitializedDirs = new HashSet<>();
     uinitializedDirs.addAll(Arrays.asList(volumeURIs));
@@ -860,7 +860,7 @@ public class Initialize implements KeywordExecutable {
     Path iidPath = new Path(aBasePath, ServerConstants.INSTANCE_ID_DIR);
     Path versionPath = new Path(aBasePath, ServerConstants.VERSION_DIR);
 
-    UUID uuid = UUID.fromString(ZooUtil.getInstanceIDFromHdfs(iidPath, siteConfig));
+    UUID uuid = UUID.fromString(ZooUtil.getInstanceIDFromHdfs(iidPath, siteConfig, hadoopConf));
     for (Pair<Path,Path> replacementVolume : ServerConstants.getVolumeReplacements(siteConfig)) {
       if (aBasePath.equals(replacementVolume.getFirst()))
         log.error(
@@ -932,9 +932,9 @@ public class Initialize implements KeywordExecutable {
     try {
       setZooReaderWriter(new ZooReaderWriter(siteConfig));
       SecurityUtil.serverLogin(siteConfig);
-      Configuration hadoopConfig = CachedConfiguration.getInstance();
+      Configuration hadoopConfig = new Configuration();
 
-      VolumeManager fs = VolumeManagerImpl.get(siteConfig);
+      VolumeManager fs = VolumeManagerImpl.get(siteConfig, hadoopConfig);
 
       if (opts.resetSecurity) {
         log.info("Resetting security on accumulo.");
@@ -960,7 +960,7 @@ public class Initialize implements KeywordExecutable {
       }
 
       if (opts.addVolumes) {
-        addVolumes(fs, siteConfig);
+        addVolumes(fs, siteConfig, hadoopConfig);
       }
 
       if (!opts.resetSecurity && !opts.addVolumes)

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -60,7 +61,7 @@ public class ChangeSecret {
 
   public static void main(String[] args) throws Exception {
     SiteConfiguration siteConfig = new SiteConfiguration();
-    VolumeManager fs = VolumeManagerImpl.get(siteConfig);
+    VolumeManager fs = VolumeManagerImpl.get(siteConfig, new Configuration());
     verifyHdfsWritePermission(fs);
 
     Opts opts = new Opts();

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerConstantsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerConstantsTest.java
@@ -39,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 public class ServerConstantsTest {
 
   AccumuloConfiguration conf = DefaultConfiguration.getInstance();
+  Configuration hadoopConf = new Configuration();
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder(
@@ -70,17 +71,18 @@ public class ServerConstantsTest {
   }
 
   private void verifyAllPass(ArrayList<String> paths) {
-    assertEquals(paths, Arrays.asList(
-        ServerConstants.checkBaseUris(conf, paths.toArray(new String[paths.size()]), true)));
-    assertEquals(paths, Arrays.asList(
-        ServerConstants.checkBaseUris(conf, paths.toArray(new String[paths.size()]), false)));
+    assertEquals(paths, Arrays.asList(ServerConstants.checkBaseUris(conf, hadoopConf,
+        paths.toArray(new String[paths.size()]), true)));
+    assertEquals(paths, Arrays.asList(ServerConstants.checkBaseUris(conf, hadoopConf,
+        paths.toArray(new String[paths.size()]), false)));
   }
 
   private void verifySomePass(ArrayList<String> paths) {
-    assertEquals(paths.subList(0, 2), Arrays.asList(
-        ServerConstants.checkBaseUris(conf, paths.toArray(new String[paths.size()]), true)));
+    assertEquals(paths.subList(0, 2), Arrays.asList(ServerConstants.checkBaseUris(conf, hadoopConf,
+        paths.toArray(new String[paths.size()]), true)));
     try {
-      ServerConstants.checkBaseUris(conf, paths.toArray(new String[paths.size()]), false);
+      ServerConstants.checkBaseUris(conf, hadoopConf, paths.toArray(new String[paths.size()]),
+          false);
       fail();
     } catch (Exception e) {
       // ignored
@@ -89,14 +91,16 @@ public class ServerConstantsTest {
 
   private void verifyError(ArrayList<String> paths) {
     try {
-      ServerConstants.checkBaseUris(conf, paths.toArray(new String[paths.size()]), true);
+      ServerConstants.checkBaseUris(conf, hadoopConf, paths.toArray(new String[paths.size()]),
+          true);
       fail();
     } catch (Exception e) {
       // ignored
     }
 
     try {
-      ServerConstants.checkBaseUris(conf, paths.toArray(new String[paths.size()]), false);
+      ServerConstants.checkBaseUris(conf, hadoopConf, paths.toArray(new String[paths.size()]),
+          false);
       fail();
     } catch (Exception e) {
       // ignored

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -39,11 +39,11 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
@@ -110,7 +110,7 @@ public class BulkImporterTest {
   @Test
   public void testFindOverlappingTablets() throws Exception {
     MockTabletLocator locator = new MockTabletLocator();
-    FileSystem fs = FileSystem.getLocal(CachedConfiguration.getInstance());
+    FileSystem fs = FileSystem.getLocal(new Configuration());
     ServerContext context = EasyMock.createMock(ServerContext.class);
     EasyMock.expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance())
         .anyTimes();
@@ -145,7 +145,7 @@ public class BulkImporterTest {
     writer.append(new Key("iterator", "cf", "cq5"), empty);
     writer.append(new Key("xyzzy", "cf", "cq"), empty);
     writer.close();
-    VolumeManager vm = VolumeManagerImpl.get(context.getConfiguration());
+    VolumeManager vm = VolumeManagerImpl.get(context.getConfiguration(), new Configuration());
     List<TabletLocation> overlaps = BulkImporter.findOverlappingTablets(context, vm, locator,
         new Path(file));
     assertEquals(5, overlaps.size());

--- a/server/base/src/test/java/org/apache/accumulo/server/data/ServerMutationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/data/ServerMutationTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.CachedConfiguration;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class ServerMutationTest {
     assertEquals(42L, cu.getTimestamp());
 
     ServerMutation m2 = new ServerMutation();
-    ReflectionUtils.copy(CachedConfiguration.getInstance(), m, m2);
+    ReflectionUtils.copy(new Configuration(), m, m2);
 
     updates = m2.getUpdates();
 

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,6 +37,7 @@ import org.junit.rules.ExpectedException;
 public class VolumeManagerImplTest {
 
   protected VolumeManager fs;
+  private Configuration hadoopConf = new Configuration();
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -78,7 +80,7 @@ public class VolumeManagerImplTest {
     conf.set(Property.GENERAL_VOLUME_CHOOSER,
         "org.apache.accumulo.server.fs.ChooserThatDoesntExist");
     thrown.expect(RuntimeException.class);
-    VolumeManagerImpl.get(conf);
+    VolumeManagerImpl.get(conf, hadoopConf);
   }
 
   @Test
@@ -112,7 +114,7 @@ public class VolumeManagerImplTest {
     ConfigurationCopy conf = new ConfigurationCopy();
     conf.set(Property.INSTANCE_VOLUMES, "viewfs://dummy");
     thrown.expect(IllegalArgumentException.class);
-    VolumeManagerImpl.get(conf);
+    VolumeManagerImpl.get(conf, hadoopConf);
   }
 
   public static class WrongVolumeChooser implements VolumeChooser {
@@ -134,7 +136,7 @@ public class VolumeManagerImplTest {
     conf.set(Property.INSTANCE_VOLUMES, StringUtils.join(volumes, ","));
     conf.set(Property.GENERAL_VOLUME_CHOOSER, WrongVolumeChooser.class.getName());
     thrown.expect(RuntimeException.class);
-    VolumeManager vm = VolumeManagerImpl.get(conf);
+    VolumeManager vm = VolumeManagerImpl.get(conf, hadoopConf);
     VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(Table.ID.of("sometable"),
         null);
     String choice = vm.choose(chooserEnv, volumes.toArray(new String[0]));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -742,7 +742,7 @@ public class InMemoryMap {
     if (activeIters.size() > 0) {
       // dump memmap exactly as is to a tmp file on disk, and switch scans to that temp file
       try {
-        Configuration conf = this.context.getHadoopConf();
+        Configuration conf = context.getHadoopConf();
         FileSystem fs = FileSystem.getLocal(conf);
 
         String tmpFile = memDumpDir + "/memDump" + UUID.randomUUID() + "." + RFile.EXTENSION;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -63,7 +63,6 @@ import org.apache.accumulo.core.iterators.system.SourceSwitchingIterator;
 import org.apache.accumulo.core.iterators.system.SourceSwitchingIterator.DataSource;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.core.util.LocalityGroupUtil.Partitioner;
 import org.apache.accumulo.core.util.Pair;
@@ -582,7 +581,7 @@ public class InMemoryMap {
 
     private synchronized FileSKVIterator getReader() throws IOException {
       if (reader == null) {
-        Configuration conf = CachedConfiguration.getInstance();
+        Configuration conf = context.getHadoopConf();
         FileSystem fs = FileSystem.getLocal(conf);
 
         reader = new RFileOperations().newReaderBuilder()
@@ -743,7 +742,7 @@ public class InMemoryMap {
     if (activeIters.size() > 0) {
       // dump memmap exactly as is to a tmp file on disk, and switch scans to that temp file
       try {
-        Configuration conf = CachedConfiguration.getInstance();
+        Configuration conf = this.context.getHadoopConf();
         FileSystem fs = FileSystem.getLocal(conf);
 
         String tmpFile = memDumpDir + "/memDump" + UUID.randomUUID() + "." + RFile.EXTENSION;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -152,7 +152,6 @@ import org.apache.accumulo.core.trace.Trace;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.trace.wrappers.TraceWrap;
 import org.apache.accumulo.core.util.ByteBufferUtil;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.core.util.Daemon;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -384,7 +383,7 @@ public class TabletServer implements Runnable {
 
     final long walogMaxSize = aconf.getAsBytes(Property.TSERV_WALOG_MAX_SIZE);
     final long walogMaxAge = aconf.getTimeInMillis(Property.TSERV_WALOG_MAX_AGE);
-    final long minBlockSize = CachedConfiguration.getInstance()
+    final long minBlockSize = context.getHadoopConf()
         .getLong("dfs.namenode.fs-limits.min-block-size", 0);
     if (minBlockSize != 0 && minBlockSize > walogMaxSize)
       throw new RuntimeException("Unable to start TabletServer. Logger is set to use blocksize "

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.tserver.log.DfsLogger;
 import org.apache.accumulo.tserver.log.DfsLogger.DFSLoggerInputStreams;
 import org.apache.accumulo.tserver.log.DfsLogger.LogHeaderIncompleteException;
 import org.apache.accumulo.tserver.log.RecoveryLogReader;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
@@ -76,7 +77,7 @@ public class LogReader {
     Opts opts = new Opts();
     opts.parseArgs(LogReader.class.getName(), args);
     SiteConfiguration siteConfig = new SiteConfiguration();
-    VolumeManager fs = VolumeManagerImpl.get(siteConfig);
+    VolumeManager fs = VolumeManagerImpl.get(siteConfig, new Configuration());
 
     Matcher rowMatcher = null;
     KeyExtent ke = null;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -123,7 +123,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
     conf = context.getConfiguration();
 
     try {
-      fs = VolumeManagerImpl.get(conf);
+      fs = VolumeManagerImpl.get(conf, context.getHadoopConf());
     } catch (IOException e) {
       log.error("Could not connect to filesystem", e);
       throw new RuntimeException(e);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -62,6 +62,7 @@ import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfiguratio
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.ZooConfiguration;
 import org.apache.accumulo.tserver.InMemoryMap.MemoryIterator;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -110,11 +111,13 @@ public class InMemoryMapTest {
   }
 
   public static ServerContext getServerContext() {
+    Configuration hadoopConf = new Configuration();
     ServerContext context = EasyMock.createMock(ServerContext.class);
     EasyMock.expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())
         .anyTimes();
     EasyMock.expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance())
         .anyTimes();
+    EasyMock.expect(context.getHadoopConf()).andReturn(hadoopConf).anyTimes();
     EasyMock.replay(context);
     return context;
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/RootFilesTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/RootFilesTest.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.server.fs.FileRef;
 import org.apache.accumulo.server.fs.RandomVolumeChooser;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.Rule;
 import org.junit.Test;
@@ -127,7 +128,7 @@ public class RootFilesTest {
     conf.set(Property.INSTANCE_DFS_DIR, "/");
     conf.set(Property.GENERAL_VOLUME_CHOOSER, RandomVolumeChooser.class.getName());
 
-    VolumeManager vm = VolumeManagerImpl.get(conf);
+    VolumeManager vm = VolumeManagerImpl.get(conf, new Configuration());
 
     TestWrapper wrapper = new TestWrapper(vm, conf, "A00004.rf", "A00002.rf", "F00003.rf");
     wrapper.prepareReplacement();

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
@@ -38,7 +38,6 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.master.thrift.MasterMonitorInfo;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -81,7 +80,6 @@ public class BulkImportMonitoringIT extends ConfigurableMacBase {
       log.info("Creating lots of bulk import files");
       final FileSystem fs = getCluster().getFileSystem();
       final Path basePath = getCluster().getTemporaryPath();
-      CachedConfiguration.setInstance(fs.getConf());
 
       final Path base = new Path(basePath, "testBulkLoad" + tableName);
       fs.delete(base, true);

--- a/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
@@ -41,7 +41,6 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.master.thrift.MasterMonitorInfo;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -113,7 +112,6 @@ public class CountNameNodeOpsBulkIT extends ConfigurableMacBase {
       log.info("Creating lots of bulk import files");
       final FileSystem fs = getCluster().getFileSystem();
       final Path basePath = getCluster().getTemporaryPath();
-      CachedConfiguration.setInstance(fs.getConf());
 
       final Path base = new Path(basePath, "testBulkLoad" + tableName);
       fs.delete(base, true);

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
+import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.TabletServerBatchWriter;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
@@ -226,8 +227,9 @@ public class TestIngest {
     FileSKVWriter writer = null;
 
     if (opts.outputFile != null) {
+      ClientContext cc = (ClientContext) accumuloClient;
       writer = FileOperations.getInstance().newWriterBuilder()
-          .forFile(opts.outputFile + "." + RFile.EXTENSION, fs, new Configuration(),
+          .forFile(opts.outputFile + "." + RFile.EXTENSION, fs, cc.getHadoopConf(),
               CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(DefaultConfiguration.getInstance()).build();
       writer.startDefaultLocalityGroup();
@@ -355,6 +357,7 @@ public class TestIngest {
   public static void ingest(AccumuloClient c, Opts opts, BatchWriterOpts batchWriterOpts)
       throws MutationsRejectedException, IOException, AccumuloException, AccumuloSecurityException,
       TableNotFoundException, TableExistsException {
-    ingest(c, FileSystem.get(new Configuration()), opts, batchWriterOpts);
+    ClientContext cc = (ClientContext) c;
+    ingest(c, FileSystem.get(cc.getHadoopConf()), opts, batchWriterOpts);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.trace.DistributedTrace;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -227,9 +226,8 @@ public class TestIngest {
     FileSKVWriter writer = null;
 
     if (opts.outputFile != null) {
-      Configuration conf = CachedConfiguration.getInstance();
       writer = FileOperations.getInstance().newWriterBuilder()
-          .forFile(opts.outputFile + "." + RFile.EXTENSION, fs, conf,
+          .forFile(opts.outputFile + "." + RFile.EXTENSION, fs, new Configuration(),
               CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(DefaultConfiguration.getInstance()).build();
       writer.startDefaultLocalityGroup();
@@ -357,6 +355,6 @@ public class TestIngest {
   public static void ingest(AccumuloClient c, Opts opts, BatchWriterOpts batchWriterOpts)
       throws MutationsRejectedException, IOException, AccumuloException, AccumuloSecurityException,
       TableNotFoundException, TableExistsException {
-    ingest(c, FileSystem.get(CachedConfiguration.getInstance()), opts, batchWriterOpts);
+    ingest(c, FileSystem.get(new Configuration()), opts, batchWriterOpts);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientInfo;
-import org.apache.accumulo.core.util.CachedConfiguration;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.TestIngest;
 import org.apache.accumulo.test.TestIngest.Opts;
@@ -33,8 +32,6 @@ import org.apache.accumulo.test.VerifyIngest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class BulkIT extends AccumuloClusterHarness {
@@ -47,20 +44,6 @@ public class BulkIT extends AccumuloClusterHarness {
   @Override
   protected int defaultTimeoutSeconds() {
     return 4 * 60;
-  }
-
-  private Configuration origConf;
-
-  @Before
-  public void saveConf() {
-    origConf = CachedConfiguration.getInstance();
-  }
-
-  @After
-  public void restoreConf() {
-    if (origConf != null) {
-      CachedConfiguration.setInstance(origConf);
-    }
   }
 
   @Test


### PR DESCRIPTION
* Add hadoop conf to ClientContext and utilize where available
* Drop use of CachedConfiguration in Volume Manager
* Remove unused instances of CachedConfiguration from Tests
* Replace with new object in unit tests where reuse doesn't matter