### PR TITLE
Upgrade process should not assume the administrative user is named 'root'.

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -466,7 +466,10 @@ public class Master extends AccumuloServerContext
               NamespacePermission.READ);
         }
         // because we need to refer to the root username, we can't use the
-        // ZKPermHandler directly. The security object should work since
+        // ZKPermHandler directly since that violates our earlier assumption that we don't
+        // care about contents of the username. PermissionHandlers that need to
+        // encode the username in some way, i.e. the KerberosPermissionHandler, things would
+        // fail. Instead we should be able to use the security object since
         // the loop above should have made the needed structure in ZK.
         security.grantNamespacePermission(rpcCreds(), security.getRootUsername(),
             Namespaces.ACCUMULO_NAMESPACE_ID, NamespacePermission.ALTER_TABLE);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -455,7 +455,7 @@ public class Master extends AccumuloServerContext
         // modify the structure so long as we pass back in whatever we read.
         // This is true for any permission handler, including KerberosPermissionHandler,
         // that uses the ZKPermHandler for permissions storage so long
-        // as we don't need to refer to a human readable username.
+        // as the PermHandler only overrides the user name, and we don't care what the user name is.
         ZKPermHandler perm = new ZKPermHandler();
         perm.initialize(getInstance().getInstanceID(), true);
         String users = ZooUtil.getRoot(getInstance()) + "/users";

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -467,7 +467,7 @@ public class Master extends AccumuloServerContext
         }
         // because we need to refer to the root username, we can't use the
         // ZKPermHandler directly since that violates our earlier assumption that we don't
-        // care about contents of the username. PermissionHandlers that need to
+        // care about contents of the username. When using a PermissionHandler that needs to
         // encode the username in some way, i.e. the KerberosPermissionHandler, things would
         // fail. Instead we should be able to use the security object since
         // the loop above should have made the needed structure in ZK.

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -453,7 +453,8 @@ public class Master extends AccumuloServerContext
         // N.B. this section is ignoring the configured PermissionHandler
         // under the assumption that these details are in zk and we can
         // modify the structure so long as we pass back in whatever we read.
-        // This is currently true for the KerberosPermissionHandler so long
+        // This is true for any permission handler, including KerberosPermissionHandler,
+        // that uses the ZKPermHandler for permissions storage so long
         // as we don't need to refer to a human readable username.
         ZKPermHandler perm = new ZKPermHandler();
         perm.initialize(getInstance().getInstanceID(), true);


### PR DESCRIPTION
When Accumulo is configured to use Kerberos for client authentication the
administrative user is configured at security initialization. Before this
change the upgrade process would attempt to grant access to the system
namespace to the 'root' user rather than to the configured administrative
user.