### PR TITLE
Fix #952 - Support running Accumulo using Java 11

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -80,6 +80,14 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
@@ -109,6 +117,10 @@
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
@@ -128,6 +140,10 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jline</groupId>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -41,6 +41,8 @@
         <include>com.google.code.gson:gson</include>
         <include>com.google.guava:guava</include>
         <include>com.google.protobuf:protobuf-java</include>
+        <include>com.sun.xml.bind:jaxb-core</include>
+        <include>com.sun.xml.bind:jaxb-impl</include>
         <include>commons-cli:commons-cli</include>
         <include>commons-codec:commons-codec</include>
         <include>commons-collections:commons-collections</include>
@@ -48,11 +50,13 @@
         <include>commons-io:commons-io</include>
         <include>commons-lang:commons-lang</include>
         <include>commons-logging:commons-logging</include>
+        <include>javax.activation:activation</include>
         <include>javax.annotation:javax.annotation-api</include>
         <include>javax.el:javax.el-api</include>
         <include>javax.servlet:javax.servlet-api</include>
         <include>javax.validation:validation-api</include>
         <include>javax.ws.rs:javax.ws.rs-api</include>
+        <include>javax.xml.bind:jaxb-api</include>
         <include>jline:jline</include>
         <include>log4j:log4j</include>
         <include>org.apache.commons:commons-math3</include>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <jackson.version>2.9.8</jackson.version>
     <javax.el.version>2.2.4</javax.el.version>
+    <jaxb.version>2.3.0</jaxb.version>
     <jersey.version>2.27</jersey.version>
     <jetty.version>9.4.11.v20180605</jetty.version>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -225,6 +226,16 @@
         <version>2.5.0</version>
       </dependency>
       <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>${jaxb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>${jaxb.version}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.4</version>
@@ -260,6 +271,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.2</version>
@@ -292,7 +308,7 @@
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.2.12</version>
+        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>jline</groupId>


### PR DESCRIPTION
* Accumulo can be run with Java 11. More work needed
  to get Accumulo to build using Java 11.
* Added depedencies that are no longer included by JVM in Java 11