### PR TITLE
Fix #910 - Add setClasspathItems() to MiniAccumuloConfig

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
@@ -264,7 +264,7 @@ public class MiniAccumuloConfig {
    * @return the current instance
    * @since 2.0.0
    */
-  public MiniAccumuloConfig setClasspathItems(String... classpathItems) {
+  public MiniAccumuloConfig setClasspath(String... classpathItems) {
     impl.setClasspathItems(classpathItems);
     return this;
   }

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloConfig.java
@@ -255,4 +255,17 @@ public class MiniAccumuloConfig {
     impl.setNativeLibPaths(nativePathItems);
     return this;
   }
+
+  /**
+   * Sets the classpath elements to use when spawning processes.
+   *
+   * @param classpathItems
+   *          the classpathItems to set
+   * @return the current instance
+   * @since 2.0.0
+   */
+  public MiniAccumuloConfig setClasspathItems(String... classpathItems) {
+    impl.setClasspathItems(classpathItems);
+    return this;
+  }
 }


### PR DESCRIPTION
* This allows accumulo-maven-plugin to only use public API

See related PR: apache/accumulo-maven-plugin#3