### PR TITLE
Fix race condition in Tables. Closes #768

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
@@ -51,8 +51,6 @@ public class Tables {
   // frequently
   private static Cache<String,TableMap> instanceToMapCache = CacheBuilder.newBuilder()
       .expireAfterAccess(10, TimeUnit.MINUTES).build();
-  private static Cache<String,ZooCache> instanceToZooCache = CacheBuilder.newBuilder()
-      .expireAfterAccess(10, TimeUnit.MINUTES).build();
 
   static {
     SingletonManager.register(new SingletonService() {
@@ -73,7 +71,6 @@ public class Tables {
       public synchronized void disable() {
         try {
           instanceToMapCache.invalidateAll();
-          instanceToZooCache.invalidateAll();
         } finally {
           enabled = false;
         }
@@ -95,28 +92,14 @@ public class Tables {
     }
   }
 
-  /**
-   * Return the cached ZooCache for provided context. ZooCache is initially created with a watcher
-   * that will clear the TableMap cache for that instance when WatchedEvent occurs.
-   */
   private static ZooCache getZooCache(final ClientContext context) {
     SecurityManager sm = System.getSecurityManager();
     if (sm != null) {
       sm.checkPermission(TABLES_PERMISSION);
     }
 
-    final String uuid = context.getInstanceID();
-
-    try {
-      return instanceToZooCache.get(uuid, () -> {
-        final String zks = context.getZooKeepers();
-        final int timeOut = context.getZooKeepersSessionTimeOut();
-        return new ZooCacheFactory().getZooCache(zks, timeOut,
-            watchedEvent -> instanceToMapCache.invalidate(uuid));
-      });
-    } catch (ExecutionException e) {
-      throw new RuntimeException(e);
-    }
+    return new ZooCacheFactory().getZooCache(context.getZooKeepers(),
+        context.getZooKeepersSessionTimeOut());
   }
 
   /**


### PR DESCRIPTION
This basically reverts the extra cacheing of the ZooCache that was added in 1.9.