### PR TITLE
Avoid multiple threads loading same cache block

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.client.rfile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
@@ -45,6 +47,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.blockfile.cache.BlockCache;
 import org.apache.accumulo.core.file.blockfile.cache.CacheEntry;
 import org.apache.accumulo.core.file.blockfile.cache.LruBlockCache;
+import org.apache.accumulo.core.file.blockfile.cache.LruBlockCache.Options;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.file.rfile.RFile.Reader;
@@ -75,6 +78,14 @@ class RFileScanner extends ScannerOptions implements Scanner {
 
   private static final long CACHE_BLOCK_SIZE = AccumuloConfiguration.getDefaultConfiguration()
       .getMemoryInBytes(Property.TSERV_DEFAULT_BLOCKSIZE);
+
+  private static final EnumSet<Options> CACHE_OPTS;
+
+  static {
+    EnumSet<Options> cacheOpts = EnumSet.allOf(Options.class);
+    cacheOpts.remove(Options.ENABLE_LOCKS);
+    CACHE_OPTS = cacheOpts;
+  }
 
   static class Opts {
     InputArgs in;
@@ -110,8 +121,18 @@ class RFileScanner extends ScannerOptions implements Scanner {
     }
 
     @Override
+    public CacheEntry getBlockNoStats(String blockName) {
+      return null;
+    }
+
+    @Override
     public long getMaxSize() {
       return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public Lock getLoadLock(String blockName) {
+      return null;
     }
   }
 
@@ -123,13 +144,13 @@ class RFileScanner extends ScannerOptions implements Scanner {
 
     this.opts = opts;
     if (opts.indexCacheSize > 0) {
-      this.indexCache = new LruBlockCache(opts.indexCacheSize, CACHE_BLOCK_SIZE);
+      this.indexCache = new LruBlockCache(opts.indexCacheSize, CACHE_BLOCK_SIZE, CACHE_OPTS);
     } else {
       this.indexCache = new NoopCache();
     }
 
     if (opts.dataCacheSize > 0) {
-      this.dataCache = new LruBlockCache(opts.dataCacheSize, CACHE_BLOCK_SIZE);
+      this.dataCache = new LruBlockCache(opts.dataCacheSize, CACHE_BLOCK_SIZE, CACHE_OPTS);
     } else {
       this.dataCache = new NoopCache();
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/BlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/BlockCache.java
@@ -17,6 +17,8 @@
  */
 package org.apache.accumulo.core.file.blockfile.cache;
 
+import java.util.concurrent.locks.Lock;
+
 /**
  * Block cache interface.
  */
@@ -52,10 +54,20 @@ public interface BlockCache {
    */
   CacheEntry getBlock(String blockName);
 
+  CacheEntry getBlockNoStats(String blockName);
+
   /**
    * Get the maximum size of this cache.
    *
    * @return max size in bytes
    */
   long getMaxSize();
+
+  /**
+   * Return a lock used for loading data not in the cache. Should always return the same lock for
+   * the same block name. Can return different locks for different block names. Its ok to return
+   * null if locking is not desired.
+   */
+  Lock getLoadLock(String blockName);
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Random;
 
+import org.apache.accumulo.core.file.blockfile.cache.LruBlockCache.Options;
 import org.junit.Test;
 
 /**
@@ -115,7 +117,7 @@ public class TestLruBlockCache {
     long maxSize = 100000;
     long blockSize = calculateBlockSizeDefault(maxSize, 10);
 
-    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, false);
+    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, EnumSet.noneOf(Options.class));
 
     Block[] blocks = generateFixedBlocks(10, blockSize, "block");
 
@@ -153,7 +155,7 @@ public class TestLruBlockCache {
     long maxSize = 100000;
     long blockSize = calculateBlockSizeDefault(maxSize, 10);
 
-    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, false,
+    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, EnumSet.noneOf(Options.class),
         (int) Math.ceil(1.2 * maxSize / blockSize), LruBlockCache.DEFAULT_LOAD_FACTOR,
         LruBlockCache.DEFAULT_CONCURRENCY_LEVEL, 0.98f, // min
         0.99f, // acceptable
@@ -216,7 +218,7 @@ public class TestLruBlockCache {
     long maxSize = 100000;
     long blockSize = calculateBlockSize(maxSize, 10);
 
-    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, false,
+    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, EnumSet.noneOf(Options.class),
         (int) Math.ceil(1.2 * maxSize / blockSize), LruBlockCache.DEFAULT_LOAD_FACTOR,
         LruBlockCache.DEFAULT_CONCURRENCY_LEVEL, 0.98f, // min
         0.99f, // acceptable
@@ -336,7 +338,7 @@ public class TestLruBlockCache {
     long maxSize = 100000;
     long blockSize = calculateBlockSize(maxSize, 10);
 
-    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, false,
+    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, EnumSet.noneOf(Options.class),
         (int) Math.ceil(1.2 * maxSize / blockSize), LruBlockCache.DEFAULT_LOAD_FACTOR,
         LruBlockCache.DEFAULT_CONCURRENCY_LEVEL, 0.66f, // min
         0.99f, // acceptable
@@ -397,7 +399,7 @@ public class TestLruBlockCache {
     long maxSize = 300000;
     long blockSize = calculateBlockSize(maxSize, 31);
 
-    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, false,
+    LruBlockCache cache = new LruBlockCache(maxSize, blockSize, EnumSet.noneOf(Options.class),
         (int) Math.ceil(1.2 * maxSize / blockSize), LruBlockCache.DEFAULT_LOAD_FACTOR,
         LruBlockCache.DEFAULT_CONCURRENCY_LEVEL, 0.98f, // min
         0.99f, // acceptable


### PR DESCRIPTION
These changes update 1.9 to have similar functionality to 2.0 for cache loading.  With this change when multiple threads attempt to load the same block into cache only one thread will do the work.  The other threads will wait for the load.

I ran some performance test with 32 threads trying to load the same bock at the same time for 1000 times.  With the changes the test took 16.4 seconds.  Without these changes it took 31.0 seconds.