### PR TITLE
Use appropriate types to prevent casting

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -372,11 +372,8 @@ class ConditionalWriterImpl implements ConditionalWriter {
 
       for (int i = 1; i < mutations.size(); i++) {
         for (Entry<KeyExtent,List<QCMutation>> entry : mutations.get(i).getMutations().entrySet()) {
-          List<QCMutation> list = tsm.getMutations().get(entry.getKey());
-          if (list == null) {
-            list = new ArrayList<>();
-            tsm.getMutations().put(entry.getKey(), list);
-          }
+          List<QCMutation> list = tsm.getMutations().computeIfAbsent(entry.getKey(),
+              k -> new ArrayList<>());
 
           list.addAll(entry.getValue());
         }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -372,10 +372,8 @@ class ConditionalWriterImpl implements ConditionalWriter {
 
       for (int i = 1; i < mutations.size(); i++) {
         for (Entry<KeyExtent,List<QCMutation>> entry : mutations.get(i).getMutations().entrySet()) {
-          List<QCMutation> list = tsm.getMutations().computeIfAbsent(entry.getKey(),
-              k -> new ArrayList<>());
-
-          list.addAll(entry.getValue());
+          tsm.getMutations().computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
+              .addAll(entry.getValue());
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -639,7 +639,11 @@ public class TableOperationsImpl extends TableOperationsHelper {
   @Override
   public Collection<Text> listSplits(String tableName)
       throws TableNotFoundException, AccumuloSecurityException {
+    return _listSplits(tableName);
+  }
 
+  private List<Text> _listSplits(String tableName)
+      throws TableNotFoundException, AccumuloSecurityException {
     checkArgument(tableName != null, "tableName is null");
 
     TableId tableId = Tables.getTableId(context, tableName);
@@ -675,12 +679,13 @@ public class TableOperationsImpl extends TableOperationsHelper {
         endRows.add(ke.getEndRow());
 
     return endRows;
+
   }
 
   @Override
   public Collection<Text> listSplits(String tableName, int maxSplits)
       throws TableNotFoundException, AccumuloSecurityException {
-    Collection<Text> endRows = listSplits(tableName);
+    List<Text> endRows = _listSplits(tableName);
 
     if (endRows.size() <= maxSplits)
       return endRows;
@@ -694,7 +699,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     for (int i = 0; i < endRows.size() && j < maxSplits; i++) {
       pos += r;
       while (pos > 1) {
-        subset.add(((ArrayList<Text>) endRows).get(i));
+        subset.add(endRows.get(i));
         j++;
         pos -= 1;
       }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocator.java
@@ -267,12 +267,7 @@ public abstract class TabletLocator {
     }
 
     public void addMutation(KeyExtent ke, T m) {
-      List<T> mutList = mutations.get(ke);
-      if (mutList == null) {
-        mutList = new ArrayList<>();
-        mutations.put(ke, mutList);
-      }
-
+      List<T> mutList = mutations.computeIfAbsent(ke, k -> new ArrayList<>());
       mutList.add(m);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -603,10 +603,7 @@ public class TabletServerBatchWriter {
 
     synchronized void add(TabletServerMutations<Mutation> tsm) {
       init();
-      for (Entry<KeyExtent,List<Mutation>> entry : tsm.getMutations().entrySet()) {
-        recentFailures.addAll(entry.getKey().getTableId(), entry.getValue());
-      }
-
+      tsm.getMutations().forEach((ke, muts) -> recentFailures.addAll(ke.getTableId(), muts));
     }
 
     @Override
@@ -966,7 +963,7 @@ public class TabletServerBatchWriter {
 
               getLocator(tableId).invalidateCache(failedExtent);
 
-              ArrayList<Mutation> mutations = (ArrayList<Mutation>) tabMuts.get(failedExtent);
+              List<Mutation> mutations = tabMuts.get(failedExtent);
               allFailures.addAll(tableId, mutations.subList(numCommitted, mutations.size()));
             }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -400,7 +400,7 @@ public class MultiLevelIndex {
 
     }
 
-    List<IndexEntry> getIndex() {
+    SerializedIndex getIndex() {
       // create SerializedIndex on demand as each has an internal input stream over byte array...
       // keeping a SerializedIndex ref for the object could lead to
       // problems with deep copies.
@@ -848,8 +848,8 @@ public class MultiLevelIndex {
       if (count == null)
         count = 0L;
 
-      List<IndexEntry> index = ib.getIndex();
-      size += ((SerializedIndex) index).sizeInBytes();
+      SerializedIndex index = ib.getIndex();
+      size += index.sizeInBytes();
       count++;
 
       sizesByLevel.put(ib.getLevel(), size);


### PR DESCRIPTION
Also use lambdas and computeIfAbsent with these types while I was in the area.

These changes should fix 3 java/abstract-to-concrete-cast alerts from lgtm. 