### PR TITLE
Support isPropSet for table config

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
@@ -88,6 +88,18 @@ public class NamespaceConfiguration extends ObservableConfiguration {
   }
 
   @Override
+  public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
+    if (!cacheAndWatch)
+      throw new UnsupportedOperationException(
+          "Namespace configuration only supports checking if a property is set in cache.");
+
+    if (getPropCacheAccessor().isPropertySet(prop, getPath()))
+      return true;
+
+    return parent.isPropertySet(prop, cacheAndWatch);
+  }
+
+  @Override
   public String get(Property property) {
     String key = property.getKey();
     AccumuloConfiguration getParent;

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -120,6 +120,18 @@ public class TableConfiguration extends ObservableConfiguration {
   }
 
   @Override
+  public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
+    if (!cacheAndWatch)
+      throw new UnsupportedOperationException(
+          "Table configuration only supports checking if a property is set in cache.");
+
+    if (getPropCacheAccessor().isPropertySet(prop, getPath()))
+      return true;
+
+    return parent.isPropertySet(prop, cacheAndWatch);
+  }
+
+  @Override
   public String get(Property property) {
     return getPropCacheAccessor().get(property, getPath(), parent);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
@@ -85,6 +85,10 @@ public class ZooCachePropertyAccessor {
     return propCache;
   }
 
+  boolean isPropertySet(Property property, String path) {
+    return propCache.get(path + "/" + property.getKey()) != null;
+  }
+
   /**
    * Gets a property. If the property is not in ZooKeeper or is present but an invalid format for
    * the property type, the parent configuration is consulted (if provided).


### PR DESCRIPTION
This fixes a bug introduced by #1008 which attempted to call isPropSet
for a table config object.  Table config did not implement that method
before this change.