### PR TITLE
Fixes #1023 - Replace loops that iterate over collections with forEach

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/CompressedIterators.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/CompressedIterators.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
@@ -70,10 +69,10 @@ public class CompressedIterators {
       Map<String,String> opts = is.getOptions();
       out.writeVInt(opts.size());
 
-      for (Entry<String,String> entry : opts.entrySet()) {
-        out.writeVInt(getSymbolID(entry.getKey()));
-        out.writeVInt(getSymbolID(entry.getValue()));
-      }
+      opts.forEach((key, value) -> {
+        out.writeVInt(getSymbolID(key));
+        out.writeVInt(getSymbolID(value));
+      });
     }
 
     return out.toByteBuffer();


### PR DESCRIPTION
Since the removeIf change was well liked I thought I would find other places where some built in lambda functions over collectioms would work.   The collection API is supposed to improve parallel performance so maybe some of these changes will make the code faster.  I will keep working on this unless someone says it is unneeded. 