### PR TITLE
Update to libthrift 0.9.3-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <surefire.groups />
     <!-- Thrift version -->
-    <thrift.version>0.9.3</thrift.version>
+    <thrift.version>0.9.3-1</thrift.version>
     <!-- ZooKeeper version -->
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>


### PR DESCRIPTION
Apply update for THRIFT-4506 CVE-2018-1320
Generator does not change between 0.9.3 and 0.9.3-1, only libthrift jar