### PR TITLE
restore exception handling #949 #1005

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -302,6 +302,12 @@ public class TabletServerLogger {
               }
             }
 
+            try {
+              nextLog.offer(t, 12, TimeUnit.HOURS);
+            } catch (InterruptedException ex) {
+              // ignore
+            }
+
             continue;
           }
 
@@ -330,6 +336,12 @@ public class TabletServerLogger {
               tserver.walogClosed(alog);
             } catch (Exception e) {
               log.error("Failed to close WAL that failed to open: " + fileName, e);
+            }
+
+            try {
+              nextLog.offer(t, 12, TimeUnit.HOURS);
+            } catch (InterruptedException ex) {
+              // ignore
             }
 
             continue;


### PR DESCRIPTION
This change restores the exception handling in TabletServerLogger to the way it was before the changes in #1005.  This changes makes TabletServerGivesUpIT pass.