### PR TITLE
Closes #1053 add multi-volume support to import table command.

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/FinishImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/FinishImportTable.java
@@ -44,14 +44,18 @@ class FinishImportTable extends MasterRepo {
   @Override
   public Repo<Master> call(long tid, Master env) throws Exception {
 
-    env.getVolumeManager().deleteRecursively(new Path(tableInfo.importDir, "mappings.txt"));
+    for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
+      env.getVolumeManager().deleteRecursively(new Path(dm.importDir, "mappings.txt"));
+    }
 
     env.getTableManager().transitionTableState(tableInfo.tableId, TableState.ONLINE);
 
     Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, false);
     Utils.unreserveTable(env, tableInfo.tableId, tid, true);
 
-    Utils.unreserveHdfsDirectory(env, new Path(tableInfo.exportDir).toString(), tid);
+    for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
+      Utils.unreserveHdfsDirectory(env, new Path(dm.exportDir).toString(), tid);
+    }
 
     env.getEventCoordinator().event("Imported table %s ", tableInfo.tableName);
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.Namespaces;
 import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
@@ -58,7 +57,7 @@ class ImportPopulateZookeeper extends MasterRepo {
 
   private Map<String,String> getExportedProps(VolumeManager fs) throws Exception {
 
-    Path path = new Path(tableInfo.exportDir, Constants.EXPORT_FILE);
+    Path path = new Path(tableInfo.exportFile);
 
     try {
       FileSystem ns = fs.getFileSystemByPath(path);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/ImportTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/ImportTable.java
@@ -23,11 +23,16 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
@@ -55,15 +60,19 @@ public class ImportTable extends MasterRepo {
     tableInfo = new ImportedTableInfo();
     tableInfo.tableName = tableName;
     tableInfo.user = user;
-    tableInfo.exportDir = exportDir;
     tableInfo.namespaceId = namespaceId;
+    tableInfo.directories = parseExportDir(exportDir);
   }
 
   @Override
   public long isReady(long tid, Master environment) throws Exception {
-    return Utils.reserveHdfsDirectory(environment, new Path(tableInfo.exportDir).toString(), tid)
-        + Utils.reserveNamespace(environment, tableInfo.namespaceId, tid, false, true,
-            TableOperation.IMPORT);
+    long result = 0;
+    for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
+      result += Utils.reserveHdfsDirectory(environment, new Path(dm.exportDir).toString(), tid);
+    }
+    result += Utils.reserveNamespace(environment, tableInfo.namespaceId, tid, false, true,
+        TableOperation.IMPORT);
+    return result;
   }
 
   @Override
@@ -88,11 +97,20 @@ public class ImportTable extends MasterRepo {
   @SuppressFBWarnings(value = "OS_OPEN_STREAM",
       justification = "closing intermediate readers would close the ZipInputStream")
   public void checkVersions(Master env) throws AcceptableThriftTableOperationException {
-    Path path = new Path(tableInfo.exportDir, Constants.EXPORT_FILE);
+    String[] exportDirs =
+        tableInfo.directories.stream().map(dm -> dm.exportDir).toArray(String[]::new);
+
+    log.debug("Searching for export file in {}", exportDirs);
+
     Integer exportVersion = null;
     Integer dataVersion = null;
 
-    try (ZipInputStream zis = new ZipInputStream(env.getVolumeManager().open(path))) {
+    try {
+      Path exportFilePath = TableOperationsImpl.findExportFile(env.getContext(), exportDirs);
+      tableInfo.exportFile = exportFilePath.toString();
+      log.info("Export file is {}", tableInfo.exportFile);
+
+      ZipInputStream zis = new ZipInputStream(env.getVolumeManager().open(exportFilePath));
       ZipEntry zipEntry;
       while ((zipEntry = zis.getNextEntry()) != null) {
         if (zipEntry.getName().equals(Constants.EXPORT_INFO_FILE)) {
@@ -109,11 +127,11 @@ public class ImportTable extends MasterRepo {
           break;
         }
       }
-    } catch (IOException ioe) {
-      log.warn("{}", ioe.getMessage(), ioe);
+    } catch (IOException | AccumuloException e) {
+      log.warn("{}", e.getMessage(), e);
       throw new AcceptableThriftTableOperationException(null, tableInfo.tableName,
           TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-          "Failed to read export metadata " + ioe.getMessage());
+          "Failed to read export metadata " + e.getMessage());
     }
 
     if (exportVersion == null || exportVersion > ExportTable.VERSION)
@@ -129,7 +147,26 @@ public class ImportTable extends MasterRepo {
 
   @Override
   public void undo(long tid, Master env) throws Exception {
-    Utils.unreserveHdfsDirectory(env, new Path(tableInfo.exportDir).toString(), tid);
+    for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
+      Utils.unreserveHdfsDirectory(env, new Path(dm.exportDir).toString(), tid);
+    }
+
     Utils.unreserveNamespace(env, tableInfo.namespaceId, tid, false);
+  }
+
+  static List<ImportedTableInfo.DirectoryMapping> parseExportDir(String exportDir) {
+    if (exportDir == null || exportDir.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    String[] exportDirs = exportDir.split(",");
+    List<ImportedTableInfo.DirectoryMapping> dirs = new ArrayList<>(exportDirs.length);
+    for (String ed : exportDirs) {
+      log.info("Extracted import directory: {}", ed);
+      ImportedTableInfo.DirectoryMapping dir = new ImportedTableInfo.DirectoryMapping();
+      dir.exportDir = ed;
+      dirs.add(dir);
+    }
+    return dirs;
   }
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/ImportedTableInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/ImportedTableInfo.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.master.tableOps.tableImport;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
@@ -27,10 +28,17 @@ class ImportedTableInfo implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  public String exportDir;
   public String user;
   public String tableName;
   public TableId tableId;
-  public String importDir;
   public NamespaceId namespaceId;
+  public List<DirectoryMapping> directories;
+  public String exportFile;
+
+  static class DirectoryMapping implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String exportDir;
+    public String importDir;
+  }
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/PopulateMetadataTable.java
@@ -65,28 +65,30 @@ class PopulateMetadataTable extends MasterRepo {
     this.tableInfo = ti;
   }
 
-  static Map<String,String> readMappingFile(VolumeManager fs, ImportedTableInfo tableInfo)
-      throws Exception {
-
+  static void readMappingFile(VolumeManager fs, ImportedTableInfo tableInfo, String importDir,
+      Map<String,String> fileNameMappings) throws Exception {
     try (BufferedReader in = new BufferedReader(
-        new InputStreamReader(fs.open(new Path(tableInfo.importDir, "mappings.txt")), UTF_8))) {
-      Map<String,String> map = new HashMap<>();
-
-      String line = null;
+        new InputStreamReader(fs.open(new Path(importDir, "mappings.txt")), UTF_8))) {
+      String line, prev;
       while ((line = in.readLine()) != null) {
         String[] sa = line.split(":", 2);
-        map.put(sa[0], sa[1]);
+        prev = fileNameMappings.put(sa[0], importDir + "/" + sa[1]);
+
+        if (prev != null) {
+          String msg = "File exists in multiple import directories: '"
+              + sa[0].replaceAll("[\r\n]", "") + "'";
+          log.warn(msg);
+          throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(),
+              tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER, msg);
+        }
       }
-
-      return map;
     }
-
   }
 
   @Override
   public Repo<Master> call(long tid, Master master) throws Exception {
 
-    Path path = new Path(tableInfo.exportDir, Constants.EXPORT_FILE);
+    Path path = new Path(tableInfo.exportFile);
 
     BatchWriter mbw = null;
     ZipInputStream zis = null;
@@ -98,13 +100,13 @@ class PopulateMetadataTable extends MasterRepo {
 
       zis = new ZipInputStream(fs.open(path));
 
-      Map<String,String> fileNameMappings = readMappingFile(fs, tableInfo);
-
-      log.info("importDir is " + tableInfo.importDir);
-
-      // This is a directory already prefixed with proper volume information e.g.
-      // hdfs://localhost:8020/path/to/accumulo/tables/...
-      final String bulkDir = tableInfo.importDir;
+      Map<String,String> fileNameMappings = new HashMap<>();
+      for (ImportedTableInfo.DirectoryMapping dm : tableInfo.directories) {
+        log.info("importDir is " + dm.importDir);
+        // mappings are prefixed with the proper volume information, e.g:
+        // hdfs://localhost:8020/path/to/accumulo/tables/...
+        readMappingFile(fs, tableInfo, dm.importDir, fileNameMappings);
+      }
 
       ZipEntry zipEntry;
       while ((zipEntry = zis.getNextEntry()) != null) {
@@ -137,7 +139,7 @@ class PopulateMetadataTable extends MasterRepo {
                     "File " + oldName + " does not exist in import dir");
               }
 
-              cq = new Text(bulkDir + "/" + newName);
+              cq = new Text(newName);
             } else {
               cq = key.getColumnQualifier();
             }

--- a/server/master/src/test/java/org/apache/accumulo/master/tableOps/tableImport/ImportTableTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/tableOps/tableImport/ImportTableTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.master.tableOps.tableImport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.master.Master;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.server.tablets.UniqueNameAllocator;
+import org.apache.hadoop.fs.Path;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class ImportTableTest {
+
+  @Test
+  public void testParseExportDir() {
+    List<ImportedTableInfo.DirectoryMapping> out;
+
+    // null
+    out = ImportTable.parseExportDir(null);
+    assertEquals(0, out.size());
+
+    // empty
+    out = ImportTable.parseExportDir("");
+    assertEquals(0, out.size());
+
+    // single
+    out = ImportTable.parseExportDir("hdfs://nn1:8020/apps/import");
+    assertEquals(1, out.size());
+    assertEquals("hdfs://nn1:8020/apps/import", out.get(0).exportDir);
+    assertNull(out.get(0).importDir);
+
+    // multiple
+    out = ImportTable.parseExportDir("hdfs://nn1:8020/apps/import,hdfs://nn2:8020/apps/import");
+    assertEquals(2, out.size());
+    assertEquals("hdfs://nn1:8020/apps/import", out.get(0).exportDir);
+    assertNull(out.get(0).importDir);
+    assertEquals("hdfs://nn2:8020/apps/import", out.get(1).exportDir);
+    assertNull(out.get(1).importDir);
+  }
+
+  @Test
+  public void testCreateImportDir() throws Exception {
+    Master master = EasyMock.createMock(Master.class);
+    ServerContext context = EasyMock.createMock(ServerContext.class);
+    VolumeManager volumeManager = EasyMock.createMock(VolumeManager.class);
+    UniqueNameAllocator uniqueNameAllocator = EasyMock.createMock(UniqueNameAllocator.class);
+
+    String[] expDirs = {"hdfs://nn1:8020/import-dir-nn1", "hdfs://nn2:8020/import-dir-nn2",
+        "hdfs://nn3:8020/import-dir-nn3"};
+    String joinedImpDirs = expDirs[0] + "," + expDirs[1] + "," + expDirs[2];
+    String[] tableDirs =
+        {"hdfs://nn1:8020/apps/accumulo1/tables", "hdfs://nn2:8020/applications/accumulo/tables",
+            "hdfs://nn3:8020/applications/accumulo/tables"};
+
+    Set<String> tableDirSet = Set.of(tableDirs);
+
+    String dirName = "abcd";
+
+    EasyMock.expect(master.getContext()).andReturn(context);
+    EasyMock.expect(master.getVolumeManager()).andReturn(volumeManager).times(3);
+    EasyMock.expect(context.getUniqueNameAllocator()).andReturn(uniqueNameAllocator);
+    EasyMock.expect(volumeManager.matchingFileSystem(EasyMock.eq(new Path(expDirs[0])),
+        EasyMock.eq(tableDirSet))).andReturn(new Path(tableDirs[0]));
+    EasyMock.expect(volumeManager.matchingFileSystem(EasyMock.eq(new Path(expDirs[1])),
+        EasyMock.eq(tableDirSet))).andReturn(new Path(tableDirs[1]));
+    EasyMock.expect(volumeManager.matchingFileSystem(EasyMock.eq(new Path(expDirs[2])),
+        EasyMock.eq(tableDirSet))).andReturn(new Path(tableDirs[2]));
+    EasyMock.expect(uniqueNameAllocator.getNextName()).andReturn(dirName).times(3);
+
+    ImportedTableInfo ti = new ImportedTableInfo();
+    ti.tableId = TableId.of("5b");
+    ti.directories = ImportTable.parseExportDir(joinedImpDirs);
+    assertEquals(3, ti.directories.size());
+
+    EasyMock.replay(master, context, volumeManager, uniqueNameAllocator);
+
+    CreateImportDir ci = new CreateImportDir(ti);
+    ci.create(tableDirSet, master);
+    assertEquals(3, ti.directories.size());
+    for (ImportedTableInfo.DirectoryMapping dm : ti.directories) {
+      assertNotNull(dm.exportDir);
+      assertNotNull(dm.importDir);
+      assertTrue(dm.importDir.contains(Constants.HDFS_TABLES_DIR));
+      assertMatchingFilesystem(dm.exportDir, dm.importDir);
+      assertTrue(
+          dm.importDir.contains(ti.tableId.canonical() + "/" + Constants.BULK_PREFIX + dirName));
+    }
+    EasyMock.verify(master, context, volumeManager, uniqueNameAllocator);
+  }
+
+  private static void assertMatchingFilesystem(String expected, String target) {
+    URI uri1 = URI.create(expected);
+    URI uri2 = URI.create(target);
+
+    if (uri1.getScheme().equals(uri2.getScheme())) {
+      String a1 = uri1.getAuthority();
+      String a2 = uri2.getAuthority();
+      if ((a1 == null && a2 == null) || (a1 != null && a1.equals(a2))) {
+        return;
+      }
+    }
+
+    fail("Filesystems do not match: " + expected + " vs. " + target);
+  }
+}


### PR DESCRIPTION
 - Import table now takes a comma-delimited set of directories
   to import from. A separate mapping file is generated for each
   and the rfiles are loaded into the volume corresponding to
   each directory.
 - It is expected that there will be a single export metadata zip file
   present in one of the import directories.
 - Currently a work in progress, needs unit/integration tests
   up for early review to validate the approach