### PR TITLE
Revert thrift server to custom_hs_ha

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -607,17 +607,17 @@ public class TServerUtils {
             serverAddress = createBlockingServer(address, processor, protocolFactory,
                 maxMessageSize, serverName, numThreads, numSTThreads, timeBetweenThreadChecks);
             break;
-          case CUSTOM_HS_HA:
-            log.debug("Instantiating unsecure custom half-async Thrift server");
-            serverAddress = createNonBlockingServer(address, processor, protocolFactory, serverName,
-                numThreads, numSTThreads, timeBetweenThreadChecks, maxMessageSize);
-            break;
-          case THREADED_SELECTOR: // Intentional passthrough -- Our custom wrapper around threaded
-                                  // selector is the default
-          default:
+          case THREADED_SELECTOR:
             log.debug("Instantiating default, unsecure Threaded selector Thrift server");
             serverAddress = createThreadedSelectorServer(address, processor, protocolFactory,
                 serverName, numThreads, numSTThreads, timeBetweenThreadChecks, maxMessageSize);
+            break;
+          case CUSTOM_HS_HA: // Intentional passthrough -- Our custom wrapper around threaded
+                             // selector is the default
+          default:
+            log.debug("Instantiating unsecure custom half-async Thrift server");
+            serverAddress = createNonBlockingServer(address, processor, protocolFactory, serverName,
+                numThreads, numSTThreads, timeBetweenThreadChecks, maxMessageSize);
             break;
         }
         break;

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -612,13 +612,13 @@ public class TServerUtils {
             serverAddress = createThreadedSelectorServer(address, processor, protocolFactory,
                 serverName, numThreads, numSTThreads, timeBetweenThreadChecks, maxMessageSize);
             break;
-          case CUSTOM_HS_HA: // Intentional passthrough -- Our custom wrapper around threaded
-                             // selector is the default
-          default:
+          case CUSTOM_HS_HA:
             log.debug("Instantiating unsecure custom half-async Thrift server");
             serverAddress = createNonBlockingServer(address, processor, protocolFactory, serverName,
                 numThreads, numSTThreads, timeBetweenThreadChecks, maxMessageSize);
             break;
+          default:
+            throw new IllegalArgumentException("Unknown server type " + serverType);
         }
         break;
       } catch (TTransportException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
@@ -43,7 +43,7 @@ public enum ThriftServerType {
   public static ThriftServerType get(String name) {
     // Our custom HsHa server is the default (if none is provided)
     if (StringUtils.isBlank(name)) {
-      return THREADED_SELECTOR;
+      return CUSTOM_HS_HA;
     }
     return ThriftServerType.valueOf(name.trim().toUpperCase());
   }
@@ -54,6 +54,6 @@ public enum ThriftServerType {
   }
 
   public static ThriftServerType getDefault() {
-    return THREADED_SELECTOR;
+    return CUSTOM_HS_HA;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
@@ -41,9 +41,8 @@ public enum ThriftServerType {
   }
 
   public static ThriftServerType get(String name) {
-    // Our custom HsHa server is the default (if none is provided)
     if (StringUtils.isBlank(name)) {
-      return CUSTOM_HS_HA;
+      return getDefault();
     }
     return ThriftServerType.valueOf(name.trim().toUpperCase());
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/ThriftServerTypeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/ThriftServerTypeTest.java
@@ -25,7 +25,7 @@ public class ThriftServerTypeTest {
 
   @Test
   public void testDefaultServer() {
-    assertEquals(ThriftServerType.THREADED_SELECTOR,
+    assertEquals(ThriftServerType.CUSTOM_HS_HA,
         ThriftServerType.get(Property.GENERAL_RPC_SERVER_TYPE.getDefaultValue()));
   }
 


### PR DESCRIPTION
After the changes in #1059 some of the ITs were failing. The new thrift
server was failing.  This change reverts to the previous thrift server
type as the default while leaving the new type configurable.