### PR TITLE
Speed up some longer running ITs 

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.security.TablePermission;
@@ -213,5 +214,17 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
     } else {
       return krb.getClientPrincipal(offset);
     }
+  }
+
+  public static ClientInfo getClientInfo() {
+    return ClientInfo.from(cluster.getClientProperties());
+  }
+
+  public static boolean saslEnabled() {
+    return getClientInfo().saslEnabled();
+  }
+
+  public static String getAdminPrincipal() {
+    return cluster.getConfig().getRootUserName();
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -75,25 +75,35 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.accumulo.test.constraints.NumericValueConstraint;
 import org.apache.hadoop.io.Text;
 import org.junit.After;
-import org.junit.Assume;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
- * Testing default namespace configuration with inheritance requires altering the system state and
- * restoring it back to normal. Punt on this for now and just let it use a minicluster.
+ * Test different namespace permissions
  */
 @Category(MiniClusterOnlyTests.class)
-public class NamespacesIT extends AccumuloClusterHarness {
+public class NamespacesIT extends SharedMiniClusterBase {
 
   private AccumuloClient c;
   private String namespace;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
 
   @Override
   public int defaultTimeoutSeconds() {
@@ -102,8 +112,6 @@ public class NamespacesIT extends AccumuloClusterHarness {
 
   @Before
   public void setupConnectorAndNamespace() {
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
-
     // prepare a unique namespace and get a new root client for each test
     c = Accumulo.newClient().from(getClientProps()).build();
     namespace = "ns_" + getUniqueNames(1)[0];


### PR DESCRIPTION
Change NamespacesIT, ConditionalWriterIT and BulkLoadIT to be a single cluster IT base class (SharedMinClusterBase).  These were the 3 ITs with the most tests.
Running times greatly improved:
NamespacesIT ~5 mins -> 1 min
ConditionalWriterIT ~4 mins -> 1 min
BulkLoadIT ~2 mins -> 20s