### PR TITLE
Make Monitor service non-static

### DIFF
--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -101,6 +101,20 @@
       <artifactId>jetty-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2.external</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
     </dependency>

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -39,11 +39,11 @@ public class EmbeddedWebServer {
   private final ServerConnector connector;
   private final ServletContextHandler handler;
 
-  public EmbeddedWebServer(String host, int port) {
+  public EmbeddedWebServer(Monitor monitor, int port) {
     server = new Server();
-    final AccumuloConfiguration conf = Monitor.getContext().getConfiguration();
+    final AccumuloConfiguration conf = monitor.getContext().getConfiguration();
     connector = new ServerConnector(server, getConnectionFactories(conf));
-    connector.setHost(host);
+    connector.setHost(monitor.getContext().getHostname());
     connector.setPort(port);
 
     handler = new ServletContextHandler(

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -237,7 +237,8 @@ public class Monitor implements Runnable, HighlyAvailableService {
     if (!fetching.compareAndSet(false, true)) {
       return;
     }
-
+    // DO NOT ADD CODE HERE that could throw an exception before we enter the try block
+    // Otherwise, we'll never release the lock by unsetting 'fetching' in the the finally block
     try {
       while (retry) {
         MasterClientService.Iface client = null;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -233,8 +233,8 @@ public class Monitor implements Runnable, HighlyAvailableService {
       return;
     }
 
-    // begin fetch or return if another thread was already fetching
-    if (fetching.getAndSet(true)) {
+    // try to begin fetching; return if unsuccessful (because another thread is already fetching)
+    if (!fetching.compareAndSet(false, true)) {
       return;
     }
 
@@ -354,7 +354,10 @@ public class Monitor implements Runnable, HighlyAvailableService {
 
     } finally {
       lastRecalc.set(currentTime);
-      fetching.set(false);
+      // stop fetching; log an error if this thread wasn't already fetching
+      if (!fetching.compareAndSet(true, false)) {
+        throw new AssertionError("Not supposed to happen; somebody broke this code");
+      }
     }
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/XMLResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/XMLResource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.monitor.rest;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -39,6 +40,9 @@ import org.apache.accumulo.monitor.rest.tservers.TabletServer;
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class XMLResource {
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Generates summary of the Monitor
    *
@@ -46,18 +50,18 @@ public class XMLResource {
    */
   public SummaryInformation getInformation() {
 
-    MasterMonitorInfo mmi = Monitor.getMmi();
+    MasterMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
 
     // Add Monitor information
     SummaryInformation xml = new SummaryInformation(mmi.tServerInfo.size(),
-        MasterResource.getTables(), TablesResource.getTables());
+        MasterResource.getTables(monitor), TablesResource.getTables(monitor));
 
     // Add tserver information
     for (TabletServerStatus status : mmi.tServerInfo) {
-      xml.addTabletServer(new TabletServer(status));
+      xml.addTabletServer(new TabletServer(monitor, status));
     }
 
     return xml;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/bulkImports/BulkImportResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/bulkImports/BulkImportResource.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.monitor.rest.bulkImports;
 
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -37,6 +38,9 @@ import org.apache.accumulo.monitor.Monitor;
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class BulkImportResource {
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Generates bulk import and tserver bulk imports with the information from the Monitor
    *
@@ -48,13 +52,13 @@ public class BulkImportResource {
     BulkImport bulkImport = new BulkImport();
 
     // Generating Bulk Import and adding it to the return object
-    for (BulkImportStatus bulk : Monitor.getMmi().bulkImports) {
+    for (BulkImportStatus bulk : monitor.getMmi().bulkImports) {
       bulkImport
           .addBulkImport(new BulkImportInformation(bulk.filename, bulk.startTime, bulk.state));
     }
 
     // Generating TServer Bulk Import and adding it to the return object
-    for (TabletServerStatus tserverInfo : Monitor.getMmi().getTServerInfo()) {
+    for (TabletServerStatus tserverInfo : monitor.getMmi().getTServerInfo()) {
       int size = 0;
       long oldest = 0L;
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/gc/GarbageCollectorResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/gc/GarbageCollectorResource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.monitor.rest.gc;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -33,6 +34,9 @@ import org.apache.accumulo.monitor.Monitor;
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class GarbageCollectorResource {
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Returns the garbage collector status
    *
@@ -40,7 +44,7 @@ public class GarbageCollectorResource {
    */
   @GET
   public GarbageCollectorStatus getStatus() {
-    return new GarbageCollectorStatus(Monitor.getGcStatus());
+    return new GarbageCollectorStatus(monitor.getGcStatus());
   }
 
   /**
@@ -51,7 +55,7 @@ public class GarbageCollectorResource {
   @Path("files")
   @GET
   public GarbageCollection getFileStatus() {
-    GCStatus gcStatus = Monitor.getGcStatus();
+    GCStatus gcStatus = monitor.getGcStatus();
     if (gcStatus == null) {
       return GarbageCollection.getEmpty();
     }
@@ -66,7 +70,7 @@ public class GarbageCollectorResource {
   @Path("files/last")
   @GET
   public GarbageCollectorCycle getLastCycle() {
-    GCStatus status = Monitor.getGcStatus();
+    GCStatus status = monitor.getGcStatus();
     if (status == null) {
       return GarbageCollectorCycle.getEmpty();
     }
@@ -81,7 +85,7 @@ public class GarbageCollectorResource {
   @Path("files/current")
   @GET
   public GarbageCollectorCycle getCurrentCycle() {
-    GCStatus status = Monitor.getGcStatus();
+    GCStatus status = monitor.getGcStatus();
     if (status == null) {
       return GarbageCollectorCycle.getEmpty();
     }
@@ -96,7 +100,7 @@ public class GarbageCollectorResource {
   @Path("wals")
   @GET
   public GarbageCollection getWalStatus() {
-    GCStatus gcStatus = Monitor.getGcStatus();
+    GCStatus gcStatus = monitor.getGcStatus();
     if (gcStatus == null) {
       return GarbageCollection.getEmpty();
     }
@@ -111,7 +115,7 @@ public class GarbageCollectorResource {
   @Path("wals/last")
   @GET
   public GarbageCollectorCycle getLastWalCycle() {
-    GCStatus status = Monitor.getGcStatus();
+    GCStatus status = monitor.getGcStatus();
     if (status == null) {
       return GarbageCollectorCycle.getEmpty();
     }
@@ -126,7 +130,7 @@ public class GarbageCollectorResource {
   @Path("wals/current")
   @GET
   public GarbageCollectorCycle getCurrentWalCycle() {
-    GCStatus status = Monitor.getGcStatus();
+    GCStatus status = monitor.getGcStatus();
     if (status == null) {
       return GarbageCollectorCycle.getEmpty();
     }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/master/MasterResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/master/MasterResource.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -53,12 +54,8 @@ import org.apache.accumulo.server.master.state.TabletServerState;
 public class MasterResource {
   public static final String NO_MASTERS = "No Masters running";
 
-  /**
-   * Gets the MasterMonitorInfo, allowing for mocking frameworks for testability
-   */
-  protected static MasterMonitorInfo getMmi() {
-    return Monitor.getMmi();
-  }
+  @Inject
+  private Monitor monitor;
 
   /**
    * Generates a master information JSON object
@@ -66,13 +63,16 @@ public class MasterResource {
    * @return master JSON object
    */
   @GET
-  public static MasterInformation getTables() {
+  public MasterInformation getTables() {
+    return getTables(monitor);
+  }
 
+  public static MasterInformation getTables(Monitor monitor) {
     MasterInformation masterInformation;
-    MasterMonitorInfo mmi = Monitor.getMmi();
+    MasterMonitorInfo mmi = monitor.getMmi();
 
     if (mmi != null) {
-      GCStatus gcStatusObj = Monitor.getGcStatus();
+      GCStatus gcStatusObj = monitor.getGcStatus();
       String gcStatus = "Waiting";
       String label = "";
       if (gcStatusObj != null) {
@@ -97,31 +97,31 @@ public class MasterResource {
       for (DeadServer down : mmi.deadTabletServers) {
         tservers.add(down.server);
       }
-      List<String> masters = Monitor.getContext().getMasterLocations();
+      List<String> masters = monitor.getContext().getMasterLocations();
 
       String master = masters.size() == 0 ? "Down"
           : AddressUtil.parseAddress(masters.get(0), false).getHost();
       int onlineTabletServers = mmi.tServerInfo.size();
       int totalTabletServers = tservers.size();
-      int tablets = Monitor.getTotalTabletCount();
+      int tablets = monitor.getTotalTabletCount();
       int unassignedTablets = mmi.unassignedTablets;
-      long entries = Monitor.getTotalEntries();
-      double ingest = Monitor.getTotalIngestRate();
-      double entriesRead = Monitor.getTotalScanRate();
-      double entriesReturned = Monitor.getTotalQueryRate();
-      long holdTime = Monitor.getTotalHoldTime();
+      long entries = monitor.getTotalEntries();
+      double ingest = monitor.getTotalIngestRate();
+      double entriesRead = monitor.getTotalScanRate();
+      double entriesReturned = monitor.getTotalQueryRate();
+      long holdTime = monitor.getTotalHoldTime();
       double osLoad = ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage();
 
-      int tables = Monitor.getTotalTables();
+      int tables = monitor.getTotalTables();
       int deadTabletServers = mmi.deadTabletServers.size();
-      long lookups = Monitor.getTotalLookups();
-      long uptime = System.currentTimeMillis() - Monitor.getStartTime();
+      long lookups = monitor.getTotalLookups();
+      long uptime = System.currentTimeMillis() - monitor.getStartTime();
 
       masterInformation = new MasterInformation(master, onlineTabletServers, totalTabletServers,
           gcStatus, tablets, unassignedTablets, entries, ingest, entriesRead, entriesReturned,
-          holdTime, osLoad, tables, deadTabletServers, lookups, uptime, label, getGoalState(),
-          getState(), getNumBadTservers(), getServersShuttingDown(), getDeadTservers(),
-          getDeadLoggers());
+          holdTime, osLoad, tables, deadTabletServers, lookups, uptime, label,
+          getGoalState(monitor), getState(monitor), getNumBadTservers(monitor),
+          getServersShuttingDown(monitor), getDeadTservers(monitor), getDeadLoggers(monitor));
     } else {
       masterInformation = new MasterInformation();
     }
@@ -133,8 +133,8 @@ public class MasterResource {
    *
    * @return master state
    */
-  public static String getState() {
-    MasterMonitorInfo mmi = getMmi();
+  public static String getState(Monitor monitor) {
+    MasterMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return NO_MASTERS;
     }
@@ -146,8 +146,8 @@ public class MasterResource {
    *
    * @return master goal state
    */
-  public static String getGoalState() {
-    MasterMonitorInfo mmi = getMmi();
+  public static String getGoalState(Monitor monitor) {
+    MasterMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return NO_MASTERS;
     }
@@ -159,8 +159,8 @@ public class MasterResource {
    *
    * @return dead server list
    */
-  public static DeadServerList getDeadTservers() {
-    MasterMonitorInfo mmi = getMmi();
+  public static DeadServerList getDeadTservers(Monitor monitor) {
+    MasterMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return new DeadServerList();
     }
@@ -179,8 +179,8 @@ public class MasterResource {
    *
    * @return dead logger list
    */
-  public static DeadLoggerList getDeadLoggers() {
-    MasterMonitorInfo mmi = getMmi();
+  public static DeadLoggerList getDeadLoggers(Monitor monitor) {
+    MasterMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return new DeadLoggerList();
     }
@@ -199,8 +199,8 @@ public class MasterResource {
    *
    * @return bad tserver list
    */
-  public static BadTabletServers getNumBadTservers() {
-    MasterMonitorInfo mmi = getMmi();
+  public static BadTabletServers getNumBadTservers(Monitor monitor) {
+    MasterMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return new BadTabletServers();
     }
@@ -231,10 +231,10 @@ public class MasterResource {
    *
    * @return servers shutting down list
    */
-  public static ServersShuttingDown getServersShuttingDown() {
+  public static ServersShuttingDown getServersShuttingDown(Monitor monitor) {
     ServersShuttingDown servers = new ServersShuttingDown();
     // Add new servers to the list
-    for (String server : Monitor.getMmi().serversShuttingDown) {
+    for (String server : monitor.getMmi().serversShuttingDown) {
       servers.addServerShuttingDown(new ServerShuttingDownInformation(server));
     }
     return servers;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/replication/ReplicationResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/replication/ReplicationResource.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -66,6 +67,9 @@ import org.slf4j.LoggerFactory;
 public class ReplicationResource {
   private static final Logger log = LoggerFactory.getLogger(ReplicationResource.class);
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Generates the replication table as a JSON object
    *
@@ -74,7 +78,7 @@ public class ReplicationResource {
   @GET
   public List<ReplicationInformation> getReplicationInformation()
       throws AccumuloException, AccumuloSecurityException {
-    final AccumuloClient client = Monitor.getContext();
+    final AccumuloClient client = monitor.getContext();
 
     final TableOperations tops = client.tableOperations();
 
@@ -93,7 +97,7 @@ public class ReplicationResource {
         String peerName = property.getKey().substring(definedPeersPrefix.length());
         ReplicaSystem replica;
         try {
-          replica = replicaSystemFactory.get(Monitor.getContext(), property.getValue());
+          replica = replicaSystemFactory.get(monitor.getContext(), property.getValue());
         } catch (Exception e) {
           log.warn("Could not instantiate ReplicaSystem for {} with configuration {}",
               property.getKey(), property.getValue(), e);
@@ -112,7 +116,7 @@ public class ReplicationResource {
     // Number of files per target we have to replicate
     Map<ReplicationTarget,Long> targetCounts = new HashMap<>();
 
-    Map<String,TableId> tableNameToId = Tables.getNameToIdMap(Monitor.getContext());
+    Map<String,TableId> tableNameToId = Tables.getNameToIdMap(monitor.getContext());
     Map<TableId,String> tableIdToName = invert(tableNameToId);
 
     for (String table : tops.list()) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/scans/ScansResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/scans/ScansResource.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.monitor.rest.scans;
 
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -37,6 +38,9 @@ import org.apache.accumulo.monitor.Monitor.ScanStats;
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class ScansResource {
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Generates a new JSON object with scan information
    *
@@ -47,10 +51,10 @@ public class ScansResource {
 
     Scans scans = new Scans();
 
-    Map<HostAndPort,ScanStats> entry = Monitor.getScans();
+    Map<HostAndPort,ScanStats> entry = monitor.getScans();
 
     // Adds new scans to the array
-    for (TabletServerStatus tserverInfo : Monitor.getMmi().getTServerInfo()) {
+    for (TabletServerStatus tserverInfo : monitor.getMmi().getTServerInfo()) {
       ScanStats stats = entry.get(HostAndPort.fromString(tserverInfo.name));
       if (stats != null) {
         scans.addScan(new ScanInformation(tserverInfo, stats.scanCount, stats.oldestScan));

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/statistics/StatisticsResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/statistics/StatisticsResource.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.monitor.rest.statistics;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -37,6 +38,9 @@ import org.apache.accumulo.monitor.Monitor;
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class StatisticsResource {
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Generates the total lookup rate
    *
@@ -45,7 +49,7 @@ public class StatisticsResource {
   @GET
   @Path("lookupRate")
   public double getLookupRate() {
-    return Monitor.getLookupRate();
+    return monitor.getLookupRate();
   }
 
   /**
@@ -56,7 +60,7 @@ public class StatisticsResource {
   @GET
   @Path("totalTables")
   public int getTotalTables() {
-    return Monitor.getTotalTables();
+    return monitor.getTotalTables();
   }
 
   /**
@@ -67,7 +71,7 @@ public class StatisticsResource {
   @GET
   @Path("totalTabletCount")
   public int getTotalTabletCount() {
-    return Monitor.getTotalTabletCount();
+    return monitor.getTotalTabletCount();
   }
 
   /**
@@ -78,7 +82,7 @@ public class StatisticsResource {
   @GET
   @Path("totalEntries")
   public long getTotalEntries() {
-    return Monitor.getTotalEntries();
+    return monitor.getTotalEntries();
   }
 
   /**
@@ -89,7 +93,7 @@ public class StatisticsResource {
   @GET
   @Path("totalIngestRate")
   public double getTotalIngestRate() {
-    return Monitor.getTotalIngestRate();
+    return monitor.getTotalIngestRate();
   }
 
   /**
@@ -100,7 +104,7 @@ public class StatisticsResource {
   @GET
   @Path("totalQueryRate")
   public double getTotalQueryRate() {
-    return Monitor.getTotalQueryRate();
+    return monitor.getTotalQueryRate();
   }
 
   /**
@@ -111,7 +115,7 @@ public class StatisticsResource {
   @GET
   @Path("totalScanRate")
   public double getTotalScanRate() {
-    return Monitor.getTotalScanRate();
+    return monitor.getTotalScanRate();
   }
 
   /**
@@ -122,7 +126,7 @@ public class StatisticsResource {
   @GET
   @Path("totalHoldTime")
   public long getTotalHoldTime() {
-    return Monitor.getTotalHoldTime();
+    return monitor.getTotalHoldTime();
   }
 
   /**
@@ -133,7 +137,7 @@ public class StatisticsResource {
   @GET
   @Path("gcStatus")
   public GCStatus getGcStatus() {
-    return Monitor.getGcStatus();
+    return monitor.getGcStatus();
   }
 
   /**
@@ -144,7 +148,7 @@ public class StatisticsResource {
   @GET
   @Path("totalLookups")
   public long getTotalLookups() {
-    return Monitor.getTotalLookups();
+    return monitor.getTotalLookups();
   }
 
   /**
@@ -155,7 +159,7 @@ public class StatisticsResource {
   @GET
   @Path("time/scanRate")
   public List<Pair<Long,Integer>> getScanRate() {
-    return Monitor.getScanRateOverTime();
+    return monitor.getScanRateOverTime();
   }
 
   /**
@@ -166,7 +170,7 @@ public class StatisticsResource {
   @GET
   @Path("time/queryRate")
   public List<Pair<Long,Integer>> getQueryRate() {
-    return Monitor.getQueryRateOverTime();
+    return monitor.getQueryRateOverTime();
   }
 
   /**
@@ -180,9 +184,9 @@ public class StatisticsResource {
 
     List<Pair<String,List<Pair<Long,Integer>>>> scanEntries = new ArrayList<>();
 
-    Pair<String,List<Pair<Long,Integer>>> read = new Pair<>("Read", Monitor.getScanRateOverTime());
+    Pair<String,List<Pair<Long,Integer>>> read = new Pair<>("Read", monitor.getScanRateOverTime());
     Pair<String,List<Pair<Long,Integer>>> returned = new Pair<>("Returned",
-        Monitor.getQueryRateOverTime());
+        monitor.getQueryRateOverTime());
 
     scanEntries.add(read);
     scanEntries.add(returned);
@@ -198,7 +202,7 @@ public class StatisticsResource {
   @GET
   @Path("time/queryByteRate")
   public List<Pair<Long,Double>> getQueryByteRate() {
-    return Monitor.getQueryByteRateOverTime();
+    return monitor.getQueryByteRateOverTime();
   }
 
   /**
@@ -209,7 +213,7 @@ public class StatisticsResource {
   @GET
   @Path("time/load")
   public List<Pair<Long,Double>> getLoad() {
-    return Monitor.getLoadOverTime();
+    return monitor.getLoadOverTime();
   }
 
   /**
@@ -220,7 +224,7 @@ public class StatisticsResource {
   @GET
   @Path("time/ingestRate")
   public List<Pair<Long,Double>> getIngestRate() {
-    return Monitor.getIngestRateOverTime();
+    return monitor.getIngestRateOverTime();
   }
 
   /**
@@ -231,7 +235,7 @@ public class StatisticsResource {
   @GET
   @Path("time/ingestByteRate")
   public List<Pair<Long,Double>> getIngestByteRate() {
-    return Monitor.getIngestByteRateOverTime();
+    return monitor.getIngestByteRateOverTime();
   }
 
   /**
@@ -242,7 +246,7 @@ public class StatisticsResource {
   @GET
   @Path("time/minorCompactions")
   public List<Pair<Long,Integer>> getMinorCompactions() {
-    return Monitor.getMinorCompactionsOverTime();
+    return monitor.getMinorCompactionsOverTime();
   }
 
   /**
@@ -253,7 +257,7 @@ public class StatisticsResource {
   @GET
   @Path("time/majorCompactions")
   public List<Pair<Long,Integer>> getMajorCompactions() {
-    return Monitor.getMajorCompactionsOverTime();
+    return monitor.getMajorCompactionsOverTime();
   }
 
   /**
@@ -264,7 +268,7 @@ public class StatisticsResource {
   @GET
   @Path("time/lookups")
   public List<Pair<Long,Double>> getLookups() {
-    return Monitor.getLookupsOverTime();
+    return monitor.getLookupsOverTime();
   }
 
   /**
@@ -275,7 +279,7 @@ public class StatisticsResource {
   @GET
   @Path("time/indexCacheHitRate")
   public List<Pair<Long,Double>> getIndexCacheHitRate() {
-    return Monitor.getIndexCacheHitRateOverTime();
+    return monitor.getIndexCacheHitRateOverTime();
   }
 
   /**
@@ -286,6 +290,6 @@ public class StatisticsResource {
   @GET
   @Path("time/dataCacheHitRate")
   public List<Pair<Long,Double>> getDataCacheHitRate() {
-    return Monitor.getDataCacheHitRateOverTime();
+    return monitor.getDataCacheHitRateOverTime();
   }
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/status/StatusResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/status/StatusResource.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.monitor.rest.status;
 
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -37,6 +38,9 @@ import org.apache.log4j.Level;
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class StatusResource {
 
+  @Inject
+  private Monitor monitor;
+
   public enum Status {
     OK, ERROR, WARN
   }
@@ -54,19 +58,19 @@ public class StatusResource {
     Status gcStatus;
     Status tServerStatus = Status.ERROR;
 
-    if (Monitor.getMmi() != null) {
-      if (Monitor.getGcStatus() != null) {
+    if (monitor.getMmi() != null) {
+      if (monitor.getGcStatus() != null) {
         gcStatus = Status.OK;
       } else {
         gcStatus = Status.ERROR;
       }
 
-      List<String> masters = Monitor.getContext().getMasterLocations();
+      List<String> masters = monitor.getContext().getMasterLocations();
       masterStatus = masters.size() == 0 ? Status.ERROR : Status.OK;
 
-      int tServerUp = Monitor.getMmi().getTServerInfoSize();
-      int tServerDown = Monitor.getMmi().getDeadTabletServersSize();
-      int tServerBad = Monitor.getMmi().getBadTServersSize();
+      int tServerUp = monitor.getMmi().getTServerInfoSize();
+      int tServerDown = monitor.getMmi().getDeadTabletServersSize();
+      int tServerBad = monitor.getMmi().getBadTServersSize();
 
       /*
        * If there are no dead or bad servers and there are tservers up, status is OK, if there are
@@ -82,7 +86,7 @@ public class StatusResource {
       }
     } else {
       masterStatus = Status.ERROR;
-      if (Monitor.getGcStatus() == null) {
+      if (monitor.getGcStatus() == null) {
         gcStatus = Status.ERROR;
       } else {
         gcStatus = Status.OK;
@@ -99,7 +103,7 @@ public class StatusResource {
       }
     }
 
-    int numProblems = Monitor.getProblemSummary().entrySet().size();
+    int numProblems = monitor.getProblemSummary().entrySet().size();
 
     status = new StatusInformation(masterStatus.toString(), gcStatus.toString(),
         tServerStatus.toString(), logs.size(), logsHaveError, numProblems);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
+import javax.inject.Inject;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -75,6 +76,9 @@ import org.apache.hadoop.security.UserGroupInformation;
 @Path("/trace")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class TracesResource {
+
+  @Inject
+  private Monitor monitor;
 
   /**
    * Generates a trace summary
@@ -295,7 +299,7 @@ public class TracesResource {
   }
 
   protected Pair<AccumuloClient,UserGroupInformation> getClient() {
-    AccumuloConfiguration conf = Monitor.getContext().getConfiguration();
+    AccumuloConfiguration conf = monitor.getContext().getConfiguration();
     final boolean saslEnabled = conf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED);
     UserGroupInformation traceUgi = null;
     final String principal;
@@ -339,7 +343,7 @@ public class TracesResource {
       at = null;
     }
 
-    java.util.Properties props = Monitor.getContext().getProperties();
+    java.util.Properties props = monitor.getContext().getProperties();
     AccumuloClient client;
     if (traceUgi != null) {
       try {
@@ -362,7 +366,7 @@ public class TracesResource {
 
   private Scanner getScanner(AccumuloClient client) throws AccumuloException {
     try {
-      AccumuloConfiguration conf = Monitor.getContext().getConfiguration();
+      AccumuloConfiguration conf = monitor.getContext().getConfiguration();
       final String table = conf.get(Property.TRACE_TABLE);
       if (!client.tableOperations().exists(table)) {
         return null;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServer.java
@@ -16,8 +16,8 @@
  */
 package org.apache.accumulo.monitor.rest.tservers;
 
-import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
+import org.apache.accumulo.monitor.Monitor;
 
 /**
  * To use for XML Resource
@@ -27,19 +27,18 @@ import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 public class TabletServer {
 
   // Variable names become JSON keys
-  public TabletServerInformation server = new TabletServerInformation();
+  public final TabletServerInformation server;
 
-  public TabletServer() {}
+  public TabletServer() {
+    server = new TabletServerInformation();
+  }
 
   public TabletServer(TabletServerInformation server) {
     this.server = server;
   }
 
-  public TabletServer(TabletServerStatus status) {
-    server = new TabletServerInformation(status);
+  public TabletServer(Monitor monitor, TabletServerStatus status) {
+    server = new TabletServerInformation(monitor, status);
   }
 
-  public void updateTabletServerInfo(TabletServerStatus status, TableInfo summary) {
-    server.updateTabletServerInfo(status, summary);
-  }
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformation.java
@@ -95,9 +95,9 @@ public class TabletServerInformation {
    * @param thriftStatus
    *          Thrift status to obtain information
    */
-  public TabletServerInformation(TabletServerStatus thriftStatus) {
+  public TabletServerInformation(Monitor monitor, TabletServerStatus thriftStatus) {
     TableInfo summary = TableInfoUtil.summarizeTableStats(thriftStatus);
-    updateTabletServerInfo(thriftStatus, summary);
+    updateTabletServerInfo(monitor, thriftStatus, summary);
   }
 
   /**
@@ -108,7 +108,8 @@ public class TabletServerInformation {
    * @param summary
    *          Table info summary
    */
-  public void updateTabletServerInfo(TabletServerStatus thriftStatus, TableInfo summary) {
+  public void updateTabletServerInfo(Monitor monitor, TabletServerStatus thriftStatus,
+      TableInfo summary) {
 
     long now = System.currentTimeMillis();
 
@@ -159,7 +160,7 @@ public class TabletServerInformation {
     this.ingestMB = cleanNumber(summary.ingestByteRate);
     this.queryMB = cleanNumber(summary.queryByteRate);
 
-    this.scansessions = Monitor.getLookupRate();
+    this.scansessions = monitor.getLookupRate();
     this.scanssessions = this.scansessions; // For backwards compatibility
 
     this.logRecoveries = new ArrayList<>(thriftStatus.logSorts.size());

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/view/WebViews.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -67,6 +68,9 @@ public class WebViews {
 
   private static final Logger log = LoggerFactory.getLogger(WebViews.class);
 
+  @Inject
+  private Monitor monitor;
+
   /**
    * Get HTML for external CSS and JS resources from configuration. See ACCUMULO-4739
    *
@@ -74,10 +78,11 @@ public class WebViews {
    *          map of the MVC model
    */
   private void addExternalResources(Map<String,Object> model) {
-    AccumuloConfiguration conf = Monitor.getContext().getConfiguration();
+    AccumuloConfiguration conf = monitor.getContext().getConfiguration();
     String resourcesProperty = conf.get(Property.MONITOR_RESOURCES_EXTERNAL);
-    if (isEmpty(resourcesProperty))
+    if (isEmpty(resourcesProperty)) {
       return;
+    }
     List<String> monitorResources = new ArrayList<>();
     ObjectMapper objectMapper = new ObjectMapper();
     try {
@@ -98,8 +103,8 @@ public class WebViews {
 
     Map<String,Object> model = new HashMap<>();
     model.put("version", Constants.VERSION);
-    model.put("instance_name", Monitor.cachedInstanceName.get());
-    model.put("instance_id", Monitor.getContext().getInstanceID());
+    model.put("instance_name", monitor.getContext().getInstanceName());
+    model.put("instance_id", monitor.getContext().getInstanceID());
     addExternalResources(model);
     return model;
   }
@@ -293,7 +298,7 @@ public class WebViews {
       @PathParam("tableID") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX_TABLE_ID) String tableID)
       throws TableNotFoundException {
 
-    String tableName = Tables.getTableName(Monitor.getContext(), TableId.of(tableID));
+    String tableName = Tables.getTableName(monitor.getContext(), TableId.of(tableID));
 
     Map<String,Object> model = getModel();
     model.put("title", "Table Status");

--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
@@ -38,6 +39,7 @@ import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.monitor.Monitor;
+import org.apache.accumulo.monitor.Monitor.MonitorFactory;
 import org.apache.accumulo.monitor.view.WebViews;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.categories.MonitorTests;
@@ -46,6 +48,8 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -66,6 +70,7 @@ public class WebViewsIT extends JerseyTest {
     enable(TestProperties.LOG_TRAFFIC);
     enable(TestProperties.DUMP_ENTITY);
     ResourceConfig config = new ResourceConfig(WebViews.class);
+    config.register(new MonitorFactory(monitor.get()));
     config.register(WebViewsIT.HashMapWriter.class);
     return config;
   }
@@ -74,6 +79,28 @@ public class WebViewsIT extends JerseyTest {
   protected void configureClient(ClientConfig config) {
     super.configureClient(config);
     config.register(WebViewsIT.HashMapWriter.class);
+  }
+
+  private static AtomicReference<Monitor> monitor = new AtomicReference<>(null);
+
+  @BeforeClass
+  public static void createMocks() {
+    ServerContext contextMock = EasyMock.createMock(ServerContext.class);
+    expect(contextMock.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+    expect(contextMock.getInstanceID()).andReturn("foo").atLeastOnce();
+    expect(contextMock.getInstanceName()).andReturn("foo").anyTimes();
+
+    Monitor monitorMock = EasyMock.createMock(Monitor.class);
+    expect(monitorMock.getContext()).andReturn(contextMock).anyTimes();
+
+    EasyMock.replay(contextMock, monitorMock);
+    monitor.set(monitorMock);
+  }
+
+  @AfterClass
+  public static void finishMocks() {
+    Monitor m = monitor.get();
+    verify(m.getContext(), m);
   }
 
   /**
@@ -100,17 +127,9 @@ public class WebViewsIT extends JerseyTest {
    */
   @Test
   public void testGetTablesConstraintPassing() throws Exception {
-    ServerContext contextMock = EasyMock.createMock(ServerContext.class);
-    expect(contextMock.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
-    expect(contextMock.getInstanceID()).andReturn("foo").atLeastOnce();
-
-    PowerMock.mockStatic(Monitor.class);
-    expect(Monitor.getContext()).andReturn(contextMock).anyTimes();
-
     PowerMock.mockStatic(Tables.class);
-    expect(Tables.getTableName(contextMock, TableId.of("foo"))).andReturn("bar");
+    expect(Tables.getTableName(monitor.get().getContext(), TableId.of("foo"))).andReturn("bar");
     PowerMock.replayAll();
-    org.easymock.EasyMock.replay(contextMock);
 
     // Using the mocks we can verify that the getModel method gets called via debugger
     // however it's difficult to continue to mock through the jersey MVC code for the properly built
@@ -120,7 +139,6 @@ public class WebViewsIT extends JerseyTest {
     assertEquals("should return status 200", 200, output.getStatus());
     String responseBody = output.readEntity(String.class);
     assertTrue(responseBody.contains("tableID=foo") && responseBody.contains("table=bar"));
-    verify(contextMock);
   }
 
   /**

--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformationTest.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/rest/tservers/TabletServerInformationTest.java
@@ -26,8 +26,10 @@ import org.apache.accumulo.core.master.thrift.Compacting;
 import org.apache.accumulo.core.master.thrift.RecoveryStatus;
 import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
+import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.monitor.rest.tables.CompactionsTypes;
 import org.apache.accumulo.monitor.rest.trace.RecoveryStatusInformation;
+import org.easymock.EasyMock;
 import org.junit.Test;
 
 public class TabletServerInformationTest {
@@ -66,7 +68,9 @@ public class TabletServerInformationTest {
     ts.setTableMap(Collections.singletonMap("tableId0", tableInfo));
     ts.setVersion("testVersion");
 
-    TabletServerInformation tsi = new TabletServerInformation(ts);
+    Monitor monitor = EasyMock.createMock(Monitor.class);
+
+    TabletServerInformation tsi = new TabletServerInformation(monitor, ts);
 
     assertEquals("tServerTestName:1234", tsi.server);
     assertEquals("tServerTestName:1234", tsi.hostname);


### PR DESCRIPTION
* Convert all static fields/methods in Monitor to instance members
(except for constants)
* Use dependency injection to wire the Monitor through Jetty and into
the Jersey application resources
* Remove unnecessary code to asynchronously get the instanceName (it's
available on server startup, and can be obtained from the ServerContext)
* Ensure the Monitor is properly instantiated with the ServerContext
* Simplify fetching lock mechanism (using a simple AtomicBoolean instead
of synchronization)
* Simplify some Monitor internals, especially those pertaining to
initializing container resources by inlining MaxList into an anonymous
subclass of LinkedList that is constructed by a convenience method; this
makes some of the many Monitor members more readable by reducing the
number of lines which are wrapped to construct these lists
* Remove unnecessary members and group static constants together at the
top of the class