### PR TITLE
Update native map makefile to work with Java 11.

### DIFF
--- a/server/native/src/main/resources/Makefile
+++ b/server/native/src/main/resources/Makefile
@@ -27,7 +27,7 @@ endif
 ifeq ($(shell uname),Linux)
 	JAVA_HOME=$(shell env | grep "^JAVA_HOME=" | cut -d= -f2)
 	ifeq ($(strip $(JAVA_HOME)),)
-		JAVA_HOME=$(shell dirname "$$(dirname "$$(readlink -e "$$(which javah)")")")
+		JAVA_HOME=$(shell dirname "$$(dirname "$$(readlink -e "$$(which javac)")")")
 	endif
 	NATIVE_LIB := libaccumulo.so
 	CXXFLAGS=-g -fPIC -shared -O3 -Wall -I'$(JAVA_HOME)'/include -I'$(JAVA_HOME)'/include/linux -Ijavah $(USERFLAGS)
@@ -47,7 +47,7 @@ endif
 
 # escape space and parens in path for wildcard
 JAVA_HOME_ESCAPED=$(shell echo '$(JAVA_HOME)' | sed 's/ /\\ /g' | sed 's/\([()]\)/\\\1/g')
-ifeq (,$(wildcard $(JAVA_HOME_ESCAPED)/bin/javah))
+ifeq (,$(wildcard $(JAVA_HOME_ESCAPED)/bin/javac))
 $(error "JAVA_HOME does not point to a JDK. Exiting...")
 endif
 


### PR DESCRIPTION
The native map makefile checks to see if javah exists inorder to
determine if java is a JDK or JRE.  In Java 11, javah no longer exists.
The makefile was modfied to check if javac exists, which is a JDK
command that exists in Java 8 and 11.