### PR TITLE
Include Guava's failureaccess in assembly

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -79,6 +79,11 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
+      <artifactId>failureaccess</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <optional>true</optional>
     </dependency>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -39,6 +39,7 @@
         <include>com.fasterxml:classmate</include>
         <include>com.github.ben-manes.caffeine:caffeine</include>
         <include>com.google.code.gson:gson</include>
+        <include>com.google.guava:failureaccess</include>
         <include>com.google.guava:guava</include>
         <include>com.google.protobuf:protobuf-java</include>
         <include>com.sun.xml.bind:jaxb-core</include>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,12 @@
         <version>2.8.5</version>
       </dependency>
       <dependency>
+        <!-- this is a runtime dependency of guava, no longer included with guava as of 27.1 -->
+        <groupId>com.google.guava</groupId>
+        <artifactId>failureaccess</artifactId>
+        <version>1.0.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>27.1-jre</version>


### PR DESCRIPTION
Include Guava's only runtime dependency in the binary tarball assembly.
failureaccess was separated from Guava's main jar and updated to include
OSGi stuffs for Android, and is no longer bundled with Guava in 27.1 and
later.