### PR TITLE
Avoid locking in tserver when reading online tablets

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/OnlineTablets.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/OnlineTablets.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.accumulo.tserver;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.tserver.tablet.Tablet;
+
+import com.google.common.collect.ImmutableSortedMap;
+
+/*
+ * The set of online tablets is frequently read by many threads and infrequently updated.  This
+ * class exists to create a simple wrapper that keeps an immutable snapshot up to date.  Many
+ * threads can access the snapshot without interfering with each other.
+ */
+public class OnlineTablets {
+  private volatile ImmutableSortedMap<KeyExtent,Tablet> snapshot = ImmutableSortedMap.of();
+  private final SortedMap<KeyExtent,Tablet> onlineTablets = new TreeMap<KeyExtent,Tablet>();
+
+  public synchronized void put(KeyExtent ke, Tablet t) {
+    onlineTablets.put(ke, t);
+    snapshot = ImmutableSortedMap.copyOf(onlineTablets);
+  }
+
+  public synchronized void remove(KeyExtent ke) {
+    onlineTablets.remove(ke);
+    snapshot = ImmutableSortedMap.copyOf(onlineTablets);
+  }
+
+  public synchronized void split(KeyExtent oldTablet, Tablet newTablet1, Tablet newTablet2) {
+    onlineTablets.remove(oldTablet);
+    onlineTablets.put(newTablet1.getExtent(), newTablet1);
+    onlineTablets.put(newTablet2.getExtent(), newTablet2);
+    snapshot = ImmutableSortedMap.copyOf(onlineTablets);
+  }
+
+  ImmutableSortedMap<KeyExtent,Tablet> snapshot() {
+    return snapshot;
+  }
+}

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetricsUtil.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetricsUtil.java
@@ -34,7 +34,7 @@ public class TabletServerMetricsUtil {
 
   public long getEntries() {
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.getNumEntries();
     }
     return result;
@@ -42,7 +42,7 @@ public class TabletServerMetricsUtil {
 
   public long getEntriesInMemory() {
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.getNumEntriesInMemory();
     }
     return result;
@@ -50,7 +50,7 @@ public class TabletServerMetricsUtil {
 
   public double getIngest() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.ingestRate();
     }
     return result;
@@ -58,7 +58,7 @@ public class TabletServerMetricsUtil {
 
   public double getIngestByteRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.ingestByteRate();
     }
     return result;
@@ -66,7 +66,7 @@ public class TabletServerMetricsUtil {
 
   public double getQueryRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.queryRate();
     }
     return result;
@@ -74,7 +74,7 @@ public class TabletServerMetricsUtil {
 
   public double getQueryByteRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.queryByteRate();
     }
     return result;
@@ -82,7 +82,7 @@ public class TabletServerMetricsUtil {
 
   public double getScannedRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.scanRate();
     }
     return result;
@@ -90,7 +90,7 @@ public class TabletServerMetricsUtil {
 
   public int getMajorCompactions() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       if (tablet.isMajorCompactionRunning())
         result++;
     }
@@ -99,7 +99,7 @@ public class TabletServerMetricsUtil {
 
   public int getMajorCompactionsQueued() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       if (tablet.isMajorCompactionQueued())
         result++;
     }
@@ -108,7 +108,7 @@ public class TabletServerMetricsUtil {
 
   public int getMinorCompactions() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       if (tablet.isMinorCompactionRunning())
         result++;
     }
@@ -117,7 +117,7 @@ public class TabletServerMetricsUtil {
 
   public int getMinorCompactionsQueued() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       if (tablet.isMinorCompactionQueued())
         result++;
     }
@@ -125,7 +125,7 @@ public class TabletServerMetricsUtil {
   }
 
   public int getOnlineCount() {
-    return tserver.getOnlineSnapshot().values().size();
+    return tserver.getOnlineTablets().values().size();
   }
 
   public int getOpeningCount() {
@@ -134,7 +134,7 @@ public class TabletServerMetricsUtil {
 
   public long getQueries() {
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.totalQueries();
     }
     return result;
@@ -159,7 +159,7 @@ public class TabletServerMetricsUtil {
   public double getAverageFilesPerTablet() {
     int count = 0;
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
+    for (Tablet tablet : tserver.getOnlineTablets().values()) {
       result += tablet.getDatafiles().size();
       count++;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetricsUtil.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/TabletServerMetricsUtil.java
@@ -34,7 +34,7 @@ public class TabletServerMetricsUtil {
 
   public long getEntries() {
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.getNumEntries();
     }
     return result;
@@ -42,7 +42,7 @@ public class TabletServerMetricsUtil {
 
   public long getEntriesInMemory() {
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.getNumEntriesInMemory();
     }
     return result;
@@ -50,7 +50,7 @@ public class TabletServerMetricsUtil {
 
   public double getIngest() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.ingestRate();
     }
     return result;
@@ -58,7 +58,7 @@ public class TabletServerMetricsUtil {
 
   public double getIngestByteRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.ingestByteRate();
     }
     return result;
@@ -66,7 +66,7 @@ public class TabletServerMetricsUtil {
 
   public double getQueryRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.queryRate();
     }
     return result;
@@ -74,7 +74,7 @@ public class TabletServerMetricsUtil {
 
   public double getQueryByteRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.queryByteRate();
     }
     return result;
@@ -82,7 +82,7 @@ public class TabletServerMetricsUtil {
 
   public double getScannedRate() {
     double result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.scanRate();
     }
     return result;
@@ -90,7 +90,7 @@ public class TabletServerMetricsUtil {
 
   public int getMajorCompactions() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       if (tablet.isMajorCompactionRunning())
         result++;
     }
@@ -99,7 +99,7 @@ public class TabletServerMetricsUtil {
 
   public int getMajorCompactionsQueued() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       if (tablet.isMajorCompactionQueued())
         result++;
     }
@@ -108,7 +108,7 @@ public class TabletServerMetricsUtil {
 
   public int getMinorCompactions() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       if (tablet.isMinorCompactionRunning())
         result++;
     }
@@ -117,7 +117,7 @@ public class TabletServerMetricsUtil {
 
   public int getMinorCompactionsQueued() {
     int result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       if (tablet.isMinorCompactionQueued())
         result++;
     }
@@ -125,7 +125,7 @@ public class TabletServerMetricsUtil {
   }
 
   public int getOnlineCount() {
-    return tserver.getOnlineTablets().size();
+    return tserver.getOnlineSnapshot().values().size();
   }
 
   public int getOpeningCount() {
@@ -134,7 +134,7 @@ public class TabletServerMetricsUtil {
 
   public long getQueries() {
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.totalQueries();
     }
     return result;
@@ -159,7 +159,7 @@ public class TabletServerMetricsUtil {
   public double getAverageFilesPerTablet() {
     int count = 0;
     long result = 0;
-    for (Tablet tablet : tserver.getOnlineTablets()) {
+    for (Tablet tablet : tserver.getOnlineSnapshot().values()) {
       result += tablet.getDatafiles().size();
       count++;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
@@ -39,7 +39,7 @@ public class BulkImportCacheCleaner implements Runnable {
   public void run() {
     // gather the list of transactions the tablets have cached
     final Set<Long> tids = new HashSet<>();
-    for (Tablet tablet : server.getOnlineTablets()) {
+    for (Tablet tablet : server.getOnlineSnapshot().values()) {
       tids.addAll(tablet.getBulkIngestedFiles().keySet());
     }
     try {
@@ -49,7 +49,7 @@ public class BulkImportCacheCleaner implements Runnable {
       // remove any that are still alive
       tids.removeAll(allTransactionsAlive);
       // cleanup any memory of these transactions
-      for (Tablet tablet : server.getOnlineTablets()) {
+      for (Tablet tablet : server.getOnlineSnapshot().values()) {
         tablet.cleanupBulkLoadedFiles(tids);
       }
     } catch (KeeperException | InterruptedException e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
@@ -39,7 +39,7 @@ public class BulkImportCacheCleaner implements Runnable {
   public void run() {
     // gather the list of transactions the tablets have cached
     final Set<Long> tids = new HashSet<>();
-    for (Tablet tablet : server.getOnlineSnapshot().values()) {
+    for (Tablet tablet : server.getOnlineTablets().values()) {
       tids.addAll(tablet.getBulkIngestedFiles().keySet());
     }
     try {
@@ -49,7 +49,7 @@ public class BulkImportCacheCleaner implements Runnable {
       // remove any that are still alive
       tids.removeAll(allTransactionsAlive);
       // cleanup any memory of these transactions
-      for (Tablet tablet : server.getOnlineSnapshot().values()) {
+      for (Tablet tablet : server.getOnlineTablets().values()) {
         tablet.cleanupBulkLoadedFiles(tids);
       }
     } catch (KeeperException | InterruptedException e) {


### PR DESCRIPTION
Profiling Accumulo during running a performance test showed lots of lock
contention for the map of online tablets.  Most operations need to read
this map.  This change creates a read only snapshot of the online
tablets that is used to avoid lock contention.