### PR TITLE
Update Bulk import monitor page. Closes #475

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/bulkImport.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/bulkImport.ftl
@@ -22,7 +22,7 @@
       <div class="row">
         <div class="col-xs-12">
           <table id="masterBulkImportStatus" class="table table-bordered table-striped table-condensed">
-            <caption><span class="table-caption">All Bulk Imports</span><br/></caption>
+            <caption><span class="table-caption">Legacy Bulk Imports</span><br/></caption>
             <tbody>
               <tr><th class="firstcell">Directory&nbsp;</th>
                 <th title="The age of the import.">Age&nbsp;</th>


### PR DESCRIPTION
Tested old bulk import works on New Monitor page so just change the label.  If we have long running new Bulk Imports in the future, we can add something to handle them.