### PR TITLE
Improve logging for session expired events.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/ObservableConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ObservableConfiguration.java
@@ -22,10 +22,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A configuration that can be observed. Handling of observers is thread-safe.
  */
 public abstract class ObservableConfiguration extends AccumuloConfiguration {
+
+  private static final Logger log = LoggerFactory.getLogger(ObservableConfiguration.class);
 
   private Set<ConfigurationObserver> observers;
 
@@ -83,6 +88,7 @@ public abstract class ObservableConfiguration extends AccumuloConfiguration {
    */
   public void expireAllObservers() {
     Collection<ConfigurationObserver> copy = snapshot(observers);
+    log.info("Expiring {} observers", copy.size());
     for (ConfigurationObserver co : copy)
       co.sessionExpired();
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfWatcher.java
@@ -94,6 +94,7 @@ class NamespaceConfWatcher implements Watcher {
       case None:
         switch (event.getState()) {
           case Expired:
+            log.info("Zookeeper node event type None, state=expired. Expire all table observers");
             ServerConfigurationFactory.expireAllTableObservers();
             break;
           case SyncConnected:

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
@@ -94,6 +94,7 @@ class TableConfWatcher implements Watcher {
       case None:
         switch (event.getState()) {
           case Expired:
+            log.info("Zookeeper node event type None, state=expired. Expire all table observers");
             ServerConfigurationFactory.expireAllTableObservers();
             break;
           case SyncConnected:

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -166,6 +166,7 @@ import com.google.common.collect.ImmutableSet.Builder;
  *
  */
 public class Tablet implements TabletCommitter {
+
   static private final Logger log = Logger.getLogger(Tablet.class);
 
   private final TabletServer tabletServer;
@@ -406,7 +407,7 @@ public class Tablet implements TabletCommitter {
 
       @Override
       public void sessionExpired() {
-        log.debug("Session expired, no longer updating per table props...");
+        log.trace("Session expired, no longer updating per table props...");
       }
 
     });

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -314,8 +314,8 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
   /**
    * This method was helpful for debugging a condition that was causing transient test failures.
    * This forces a condition that the test should be able to handle. This method is not needed
-   * during normal testing, it was kept to aid future test development / troubleshooting if
-   * other transient failures occur.
+   * during normal testing, it was kept to aid future test development / troubleshooting if other
+   * transient failures occur.
    */
   private void runMultipleCompactions() {
 


### PR DESCRIPTION
When a tserver looses lock, the Session expired message is log for every watcher.
  - reduce current message to trace.
  - add summary logging messages that give number of sessions expired