### PR TITLE
Fixes #1052 - Review DistributedCache usage - Changed how token files and property files get cached

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/partition/RangePartitioner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/lib/partition/RangePartitioner.java
@@ -16,21 +16,22 @@
  */
 package org.apache.accumulo.core.client.mapreduce.lib.partition;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.BufferedReader;
-import java.io.FileInputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Scanner;
 import java.util.TreeSet;
 
+import javax.imageio.IIOException;
+
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
@@ -90,26 +91,31 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
       justification = "path provided by distributed cache framework, not user input")
   private synchronized Text[] getCutPoints() throws IOException {
     if (cutPointArray == null) {
+      Path path;
       String cutFileName = conf.get(CUTFILE_KEY);
-      Path[] cf = Job.getInstance().getLocalCacheFiles();
+      File tempFile = new File(CUTFILE_KEY);
+      if (tempFile.exists()) {
+        path = new Path(CUTFILE_KEY);
+      } else {
+        path = new Path(cutFileName);
+      }
 
-      if (cf != null) {
-        for (Path path : cf) {
-          if (path.toUri().getPath()
-              .endsWith(cutFileName.substring(cutFileName.lastIndexOf('/')))) {
-            TreeSet<Text> cutPoints = new TreeSet<>();
-            try (Scanner in = new Scanner(new BufferedReader(
-                new InputStreamReader(new FileInputStream(path.toString()), UTF_8)))) {
-              while (in.hasNextLine())
-                cutPoints.add(new Text(Base64.getDecoder().decode(in.nextLine())));
-            }
-            cutPointArray = cutPoints.toArray(new Text[cutPoints.size()]);
-            break;
-          }
+      if (path == null)
+        throw new FileNotFoundException("Cut point file not found in distributed cache");
+
+      TreeSet<Text> cutPoints = new TreeSet<>();
+      FileSystem fs = FileSystem.get(conf);
+      FSDataInputStream inputStream = fs.open(path);
+      try (Scanner in = new Scanner(inputStream)) {
+        while (in.hasNextLine()) {
+          cutPoints.add(new Text(Base64.getDecoder().decode(in.nextLine())));
         }
       }
+
+      cutPointArray = cutPoints.toArray(new Text[cutPoints.size()]);
+
       if (cutPointArray == null)
-        throw new FileNotFoundException(cutFileName + " not found in distributed cache");
+        throw new IIOException("Cutpoint array not properly created from file" + path.getName());
     }
     return cutPointArray;
   }
@@ -129,7 +135,14 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
    * points that represent ranges for partitioning
    */
   public static void setSplitFile(Job job, String file) {
-    URI uri = new Path(file).toUri();
+    URI uri;
+    try {
+      uri = new URI(file + "#" + CUTFILE_KEY);
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException(
+          "Unable to add split file \"" + CUTFILE_KEY + "\" to distributed cache.");
+    }
+
     job.addCacheFile(uri);
     job.getConfiguration().set(CUTFILE_KEY, uri.getPath());
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/DistributedCacheHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/DistributedCacheHelper.java
@@ -41,5 +41,4 @@ public class DistributedCacheHelper {
   public static URI[] getCacheFiles(Configuration conf) throws IOException {
     return org.apache.hadoop.filecache.DistributedCache.getCacheFiles(conf);
   }
-
 }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/RangePartitioner.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/RangePartitioner.java
@@ -94,7 +94,6 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
       File tempFile = new File(CUTFILE_KEY);
       if (tempFile.exists()) {
         path = new Path(CUTFILE_KEY);
-        // System.out.println("Cutpoint file hdfs fragement found " + CUTFILE_KEY);
       } else {
         path = new Path(cutFileName);
       }
@@ -108,7 +107,6 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
       try (Scanner in = new Scanner(inputStream)) {
         while (in.hasNextLine()) {
           cutPoints.add(new Text(Base64.getDecoder().decode(in.nextLine())));
-          System.out.println("Adding a cut point");
         }
       }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/RangePartitioner.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/RangePartitioner.java
@@ -16,21 +16,21 @@
  */
 package org.apache.accumulo.hadoop.mapreduce.partition;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.BufferedReader;
-import java.io.FileInputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Scanner;
 import java.util.TreeSet;
 
+import org.apache.accumulo.core.clientImpl.mapreduce.lib.DistributedCacheHelper;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
@@ -38,6 +38,8 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Partitioner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.imageio.IIOException;
 
 /**
  * Hadoop partitioner that uses ranges, and optionally sub-bins based on hashing.
@@ -88,26 +90,33 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
       justification = "path provided by distributed cache framework, not user input")
   private synchronized Text[] getCutPoints() throws IOException {
     if (cutPointArray == null) {
+      Path path;
       String cutFileName = conf.get(CUTFILE_KEY);
-      Path[] cf = Job.getInstance().getLocalCacheFiles();
+      File tempFile = new File(CUTFILE_KEY);
+      if (tempFile.exists()) {
+        path = new Path(CUTFILE_KEY);
+        //System.out.println("Cutpoint file hdfs fragement found " + CUTFILE_KEY);
+      } else {
+        path = new Path(cutFileName);
+      }
 
-      if (cf != null) {
-        for (Path path : cf) {
-          if (path.toUri().getPath()
-              .endsWith(cutFileName.substring(cutFileName.lastIndexOf('/')))) {
-            TreeSet<Text> cutPoints = new TreeSet<>();
-            try (Scanner in = new Scanner(new BufferedReader(
-                new InputStreamReader(new FileInputStream(path.toString()), UTF_8)))) {
-              while (in.hasNextLine())
-                cutPoints.add(new Text(Base64.getDecoder().decode(in.nextLine())));
-            }
-            cutPointArray = cutPoints.toArray(new Text[cutPoints.size()]);
-            break;
-          }
+      if (path == null)
+        throw new FileNotFoundException("Cut point file not found in distributed cache");
+
+      TreeSet<Text> cutPoints = new TreeSet<>();
+      FileSystem fs = FileSystem.get(conf);
+      FSDataInputStream inputStream = fs.open(path);
+      try (Scanner in = new Scanner(inputStream)) {
+        while (in.hasNextLine()) {
+          cutPoints.add(new Text(Base64.getDecoder().decode(in.nextLine())));
+          System.out.println("Adding a cut point");
         }
       }
+
+      cutPointArray = cutPoints.toArray(new Text[cutPoints.size()]);
+
       if (cutPointArray == null)
-        throw new FileNotFoundException(cutFileName + " not found in distributed cache");
+        throw new IIOException( "Cutpoint array not properly created from file" + path.getName());
     }
     return cutPointArray;
   }
@@ -127,7 +136,14 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
    * points that represent ranges for partitioning
    */
   public static void setSplitFile(Job job, String file) {
-    URI uri = new Path(file).toUri();
+    URI uri;
+    try {
+      uri = new URI(file + "#" + CUTFILE_KEY);
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException("Unable to add split file \"" + CUTFILE_KEY
+              + "\" to distributed cache.");
+    }
+
     job.addCacheFile(uri);
     job.getConfiguration().set(CUTFILE_KEY, uri.getPath());
   }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/RangePartitioner.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/partition/RangePartitioner.java
@@ -26,7 +26,8 @@ import java.util.Base64;
 import java.util.Scanner;
 import java.util.TreeSet;
 
-import org.apache.accumulo.core.clientImpl.mapreduce.lib.DistributedCacheHelper;
+import javax.imageio.IIOException;
+
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -38,8 +39,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Partitioner;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-import javax.imageio.IIOException;
 
 /**
  * Hadoop partitioner that uses ranges, and optionally sub-bins based on hashing.
@@ -95,7 +94,7 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
       File tempFile = new File(CUTFILE_KEY);
       if (tempFile.exists()) {
         path = new Path(CUTFILE_KEY);
-        //System.out.println("Cutpoint file hdfs fragement found " + CUTFILE_KEY);
+        // System.out.println("Cutpoint file hdfs fragement found " + CUTFILE_KEY);
       } else {
         path = new Path(cutFileName);
       }
@@ -116,7 +115,7 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
       cutPointArray = cutPoints.toArray(new Text[cutPoints.size()]);
 
       if (cutPointArray == null)
-        throw new IIOException( "Cutpoint array not properly created from file" + path.getName());
+        throw new IIOException("Cutpoint array not properly created from file" + path.getName());
     }
     return cutPointArray;
   }
@@ -140,8 +139,8 @@ public class RangePartitioner extends Partitioner<Text,Writable> implements Conf
     try {
       uri = new URI(file + "#" + CUTFILE_KEY);
     } catch (URISyntaxException e) {
-      throw new IllegalStateException("Unable to add split file \"" + CUTFILE_KEY
-              + "\" to distributed cache.");
+      throw new IllegalStateException(
+          "Unable to add split file \"" + CUTFILE_KEY + "\" to distributed cache.");
     }
 
     job.addCacheFile(uri);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/ConfiguratorBase.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/ConfiguratorBase.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.hadoopImpl.mapreduce.lib;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -43,6 +44,8 @@ public class ConfiguratorBase {
     CLIENT_PROPS, CLIENT_PROPS_FILE, IS_CONFIGURED, STORE_JOB_CALLED
   }
 
+  public static final String clientPropsFileName = "propsfile";
+
   /**
    * Configuration keys for general configuration options.
    *
@@ -62,6 +65,7 @@ public class ConfiguratorBase {
    * @return the configuration key
    * @since 1.6.0
    */
+
   protected static String enumToConfKey(Class<?> implementingClass, Enum<?> e) {
     return implementingClass.getSimpleName() + "." + e.getDeclaringClass().getSimpleName() + "."
         + StringUtils.camelize(e.name().toLowerCase());
@@ -83,7 +87,8 @@ public class ConfiguratorBase {
       Properties props, String clientPropsPath) {
     if (clientPropsPath != null) {
       try {
-        DistributedCacheHelper.addCacheFile(new URI(clientPropsPath), conf);
+        DistributedCacheHelper.addCacheFile(new URI(clientPropsPath + "#" + clientPropsFileName),
+            conf);
       } catch (URISyntaxException e) {
         throw new IllegalStateException("Unable to add client properties file \"" + clientPropsPath
             + "\" to distributed cache.");
@@ -107,13 +112,18 @@ public class ConfiguratorBase {
         .get(enumToConfKey(implementingClass, ClientOpts.CLIENT_PROPS_FILE), "");
     if (!clientPropsFile.isEmpty()) {
       try {
-        URI[] uris = DistributedCacheHelper.getCacheFiles(conf);
-        Path path = null;
-        for (URI u : uris) {
-          if (u.toString().equals(clientPropsFile)) {
-            path = new Path(u);
-          }
+        Path path;
+        // See if the "propsfile" symlink was created and try to open the file it points to by it.
+        File tempFile = new File(ConfiguratorBase.clientPropsFileName);
+        if (tempFile.exists()) {
+          path = new Path(ConfiguratorBase.clientPropsFileName);
+        } else {
+          path = new Path(clientPropsFile);
         }
+
+        if (path == null)
+          throw new IllegalStateException("Could not initialize properties file");
+
         FileSystem fs = FileSystem.get(conf);
         FSDataInputStream inputStream = fs.open(path);
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
I tried to demonstrate that DistributedCaching is working and demonstrated how we can create a pseudonym for a cached file by putting at the end of a URI the # symbol followed by a pseudonym like in this example: job.addCacheFile(new URI("hdfs://localhost:8020/tokenfile.json#tokenfile"));

I tested this new code with a running instance of Hadoop on port 8020 and it works.  I had to remove much of the code that relies on this so the TokenFileIT will run and clean up properly during the build process.   

The system call: 'hdfs dfs -put tokenfilepath /'  in the setTokenFileInHDFS function is vestigial now.  So is the 'hdfs -rm call' .  Since I had to test a real HDFS file system I have left this code in for further investigation in case someone wants to test it the way I did originally.  The system calls in the annotated After cleanUpHDFS function are vestigial too but left in to demonstrate the steps taken to evaluate this issue of concern that distributed caching was not working as expected. 