### PR TITLE
Fixes #593 Hide Master is Down message on startup

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/overview.ftl
@@ -24,7 +24,7 @@
           <table class="table table-bordered table-striped table-condensed">
             <tbody>
               <tr><th colspan="2"><a href="/master">Accumulo Master</a></th></tr>
-              <tr><td colspan="2" class="center" ><span class="label label-danger nowrap">Master is Down</span></td></tr>
+              <tr><td colspan="2" class="center" style="display:none;"><span class="label label-danger nowrap">Master is Down</span></td></tr>
               <tr><td class="left"><a href="/tables">Tables</a></td><td class="right"></td></tr>
               <tr><td class="left"><a href="/tservers">Tablet&nbsp;Servers</a></td><td class="right"></td></tr>
               <tr><td class="left"><a href="/tservers">Dead&nbsp;Tablet&nbsp;Servers</a></td><td class="right"></td></tr>


### PR DESCRIPTION
Added "display:none" to table column - attempted to use bootstrap .hide but was attributed with !important so could not be overwritten.