### PR TITLE
Quick query

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -21,6 +21,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -29,6 +33,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
@@ -209,4 +214,8 @@ public class ServerContext extends ClientContext {
     return cryptoService;
   }
 
+  @Override
+  public Scanner createScanner(String tableName) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
+    return super.createScanner(tableName, Authorizations.EMPTY);
+  }
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -229,16 +229,14 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     }
   }
 
-  public Query fetchQuery(String tableName, Range range) {
-    if (tableName == null)
-      tableName = "test_ingest";
+  public Query fetchQuery(String tableId, Range range) {
     ServerContext context = getContext();
     Query result = new Query();
     long count = 0L;
     log.info("MIKE query value = " + range);
 
     try {
-      BatchScanner scanner = context.createBatchScanner(tableName, Authorizations.EMPTY);
+      BatchScanner scanner = context.createBatchScanner(tableId, Authorizations.EMPTY);
       ArrayList<Range> ranges = new ArrayList<>();
       ranges.add(range);
       scanner.setRanges(ranges);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -229,18 +229,18 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     }
   }
 
-  public Query fetchQuery(String tableName, String value) {
+  public Query fetchQuery(String tableName, Range range) {
     if (tableName == null)
       tableName = "test_ingest";
     ServerContext context = getContext();
     Query result = new Query();
     long count = 0L;
-    log.info("MIKE query value = " + value);
+    log.info("MIKE query value = " + range);
 
     try {
       BatchScanner scanner = context.createBatchScanner(tableName, Authorizations.EMPTY);
       ArrayList<Range> ranges = new ArrayList<>();
-      ranges.add(new Range(value));
+      ranges.add(range);
       scanner.setRanges(ranges);
       for (Entry<Key, Value> entry : scanner) {
         count++;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/Query.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/Query.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.monitor.rest.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Generates a new scan list as a JSON object
+ *
+ * @since 2.0.0
+ */
+public class Query {
+
+  // Variable names become JSON keys
+  public QueryInformation query = new QueryInformation();
+
+}

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryInformation.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryInformation.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.monitor.rest.query;
+
+/**
+ * Generates a scan JSON object
+ *
+ * @since 2.0.0
+ */
+public class QueryInformation {
+
+  // Variable names become JSON keys
+  public long count;
+
+  public QueryInformation() {}
+
+
+  public QueryInformation(long count) {
+   this.count = count;
+  }
+}

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryResource.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.monitor.Monitor.ScanStats;
  *
  * @since 2.0.0
  */
-@Path("/query/{tableName}/{value}")
+@Path("/query/{tableId}/{value}")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class QueryResource {
 
@@ -55,8 +55,8 @@ public class QueryResource {
    * @return Scan JSON object
    */
   @GET
-  public Query runQuery(@PathParam("tableName") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String tableName,
+  public Query runQuery(@PathParam("tableId") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String tableId,
                         @PathParam("value") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String row) {
-    return monitor.fetchQuery(tableName, new Range(row));
+    return monitor.fetchQuery(tableId, new Range(row));
   }
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryResource.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.monitor.rest.query;
+
+import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX;
+import static org.apache.accumulo.monitor.util.ParameterValidator.ALPHA_NUM_REGEX_TABLE_ID;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.master.thrift.TabletServerStatus;
+import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.monitor.Monitor;
+import org.apache.accumulo.monitor.Monitor.ScanStats;
+
+/**
+ * Generate a new Scan list JSON object
+ *
+ * @since 2.0.0
+ */
+@Path("/query/{tableName}/{value}")
+@Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+public class QueryResource {
+
+  @Inject
+  private Monitor monitor;
+
+  /**
+   * Generates a new JSON object with scan information
+   *
+   * @return Scan JSON object
+   */
+  @GET
+  public Query runQuery(@PathParam("tableName") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String tableName,
+                        @PathParam("value") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String value) {
+    return monitor.fetchQuery(tableName, value);
+  }
+}

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/query/QueryResource.java
@@ -31,6 +31,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.monitor.Monitor;
@@ -55,7 +56,7 @@ public class QueryResource {
    */
   @GET
   public Query runQuery(@PathParam("tableName") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String tableName,
-                        @PathParam("value") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String value) {
-    return monitor.fetchQuery(tableName, value);
+                        @PathParam("value") @NotNull @Pattern(regexp = ALPHA_NUM_REGEX) String row) {
+    return monitor.fetchQuery(tableName, new Range(row));
   }
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -194,12 +194,14 @@ function timeDuration(time) {
 }
 
 /**
- * Changes + to %2B in the URL
+ * Changes + to %2B
+ * and . to %2E
  *
  * @param {string} url URL to sanitize
  */
 function sanitize(url) {
-  return url.split('+').join('%2B');
+  var newUrl = url.split(".").join('%2E');
+  return newUrl.split('+').join('%2B');
 }
 
 /**
@@ -257,10 +259,19 @@ function createTableCell(index, sortValue, showValue) {
 /**
  * REST GET call for the query, stores it on a sessionStorage variable
  */
-function runQuery(tableName, value) {
-  return $.getJSON('/rest/query/' + tableName + "/" + value, function(data) {
-    QUERY = JSON.stringify(data);
+function runQuery(tableName, row) {
+  var url =  '/rest/query/' + tableName + "/" + row;
+  $.ajax({
+    type: "GET",
+    url: url,
+    contentType: "application/json; charset=utf-8",
+    dataType: "json",
+    success: function(json) { QUERY = JSON.stringify(json); },
+    error: function (xhr, textStatus, errorThrown) {
+      $("#error").html(xhr.responseText);
+    }
   });
+  //return $.getJSON(url, function(data) { QUERY = JSON.stringify(data); });
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -254,6 +254,14 @@ function createTableCell(index, sortValue, showValue) {
 }
 
 ///// REST Calls /////////////
+/**
+ * REST GET call for the query, stores it on a sessionStorage variable
+ */
+function runQuery(tableName, value) {
+  return $.getJSON('/rest/query/' + tableName + "/" + value, function(data) {
+    QUERY = JSON.stringify(data);
+  });
+}
 
 /**
  * REST GET call for the master information,

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/global.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/global.js
@@ -24,3 +24,5 @@ var NAMESPACES = '';
  * Timer object
  */
 var TIMER;
+
+var QUERY;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -22,6 +22,7 @@ $(document).ready(function() {
   refreshSidebar();
 });
 
+
 /**
  * Makes the REST calls, generates the sidebar with the new information
  */

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -35,15 +35,21 @@ $(document).ready(function() {
 
   $.each(JSON.parse(sessionStorage.tables).table,function(key, value)
   {
+    var id = value.tableId;
     console.log("key = " + key);
-    console.log("value.tablename = " + value.tablename);
+    console.log("value.tableId = " + id);
 
-    $('#query-select-tables').append('<option value=' + value.tablename + '>' + value.tablename + '</option>');
+    $('#query-select-tables').append('<option value=' + id + '>' + value.tablename + '(' + id + ')</option>');
   });
 });
 
 function getQueryResult(){
   $('#query-output').val(QUERY);
+}
+
+function activateQueryLink() {
+  var id = $('#query-select-tables').val();
+  $('#query-link').attr("href", "/scans/" + id);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -20,7 +20,41 @@
  */
 $(document).ready(function() {
   refreshScans();
+  getTables();
+
+  // bind enter key to query input box
+  $('#quick-query').bind("enterKey",function(e){
+    doQuery();
+  });
+  $('#quick-query').keyup(function(e){
+    if(e.keyCode == 13)
+    {
+      $(this).trigger("enterKey");
+    }
+  });
+
+  $.each(JSON.parse(sessionStorage.tables).table,function(key, value)
+  {
+    console.log("key = " + key);
+    console.log("value.tablename = " + value.tablename);
+
+    $('#query-select-tables').append('<option value=' + value.tablename + '>' + value.tablename + '</option>');
+  });
 });
+
+function getQueryResult(){
+  $('#query-output').val(QUERY);
+}
+
+/**
+ * Execute a the REST quick query: "/query/{tableName}/{value}"
+ */
+function doQuery() {
+  var value = $('#quick-query').val();
+  var tableName = $('#query-select-tables').val();
+  console.log("user entered: " + value);
+  runQuery(tableName, value);
+}
 
 /**
  * Makes the REST calls, generates the tables with the new information

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
@@ -36,8 +36,8 @@
         <span id="query">
           <h3>Quick Query</h3>
           Row:<input id="quick-query" type="text"/></br>
-          <select id="query-select-tables"></select>
-          <input type="button" value="GO!" onclick="doQuery()"></br>
+          <select id="query-select-tables" onclick="activateQueryLink()"></select>
+          <a id="query-link">Execute Query</a></br>
           <input type="button" value="Load Result" onclick="getQueryResult()"/>
         </span>
         <textarea id="query-output"></textarea>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
@@ -31,3 +31,11 @@
           </table>
         </div>
       </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <span id="query">Quick Query:</span><input id="quick-query"></input><select id="query-select-tables" ></select>
+      <input type="button" value="GO!" onclick="doQuery()"></input></br>
+      <input type="button" value="Load Result" onclick="getQueryResult()"/>
+        <textarea id="query-output"></textarea>
+      </div>
+    </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/scans.ftl
@@ -33,9 +33,13 @@
       </div>
     <div class="row">
       <div class="col-xs-12">
-        <span id="query">Quick Query:</span><input id="quick-query"></input><select id="query-select-tables" ></select>
-      <input type="button" value="GO!" onclick="doQuery()"></input></br>
-      <input type="button" value="Load Result" onclick="getQueryResult()"/>
+        <span id="query">
+          <h3>Quick Query</h3>
+          Row:<input id="quick-query" type="text"/></br>
+          <select id="query-select-tables"></select>
+          <input type="button" value="GO!" onclick="doQuery()"></br>
+          <input type="button" value="Load Result" onclick="getQueryResult()"/>
+        </span>
         <textarea id="query-output"></textarea>
       </div>
     </div>


### PR DESCRIPTION
Just an idea I had... useful debugging/learning tool added to the Active Scans page.  Easy way to run a quick query on any table in Accumulo.  It uses the Monitor's credentials with EMPTY auths to do a restful query on Accumulo.. anything with Auths won't be counted.  Passes whatever the user puts in the text box as the Range(row) for a batch scan.  The result will be stored in a JSON object in the DOM.