### PR TITLE
fix #405 - Utilize newTableConfig in ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
@@ -88,7 +89,7 @@ public class DurabilityIT extends ConfigurableMacBase {
   }
 
   private void createTable(AccumuloClient c, String tableName) throws Exception {
-    c.tableOperations().create(tableName);
+    c.tableOperations().create(tableName, new NewTableConfiguration());
   }
 
   @Test(timeout = 2 * 60 * 1000)
@@ -199,7 +200,7 @@ public class DurabilityIT extends ConfigurableMacBase {
       c.instanceOperations().setProperty(Property.TABLE_DURABILITY.getKey(), "none");
       Map<String,String> props = map(c.tableOperations().getProperties(MetadataTable.NAME));
       assertEquals("sync", props.get(Property.TABLE_DURABILITY.getKey()));
-      c.tableOperations().create(tableName);
+      c.tableOperations().create(tableName, new NewTableConfiguration());
       props = map(c.tableOperations().getProperties(tableName));
       assertEquals("none", props.get(Property.TABLE_DURABILITY.getKey()));
       restartTServer();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
@@ -19,6 +19,8 @@ package org.apache.accumulo.test.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
+
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -27,6 +29,7 @@ import org.apache.accumulo.core.client.ConditionalWriter;
 import org.apache.accumulo.core.client.ConditionalWriter.Status;
 import org.apache.accumulo.core.client.ConditionalWriterConfig;
 import org.apache.accumulo.core.client.Durability;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Condition;
 import org.apache.accumulo.core.data.ConditionalMutation;
@@ -55,8 +58,8 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default has no durability
-      c.tableOperations().create(tableName);
-      c.tableOperations().setProperty(tableName, Property.TABLE_DURABILITY.getKey(), "none");
+      c.tableOperations().create(tableName, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_DURABILITY.getKey(), "none")));
       // send durable writes
       BatchWriterConfig cfg = new BatchWriterConfig();
       cfg.setDurability(Durability.SYNC);
@@ -73,8 +76,8 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default is durable writes
-      c.tableOperations().create(tableName);
-      c.tableOperations().setProperty(tableName, Property.TABLE_DURABILITY.getKey(), "sync");
+      c.tableOperations().create(tableName, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_DURABILITY.getKey(), "sync")));
       // write with no durability
       BatchWriterConfig cfg = new BatchWriterConfig();
       cfg.setDurability(Durability.NONE);
@@ -105,8 +108,8 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default is durable writes
-      c.tableOperations().create(tableName);
-      c.tableOperations().setProperty(tableName, Property.TABLE_DURABILITY.getKey(), "sync");
+      c.tableOperations().create(tableName, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_DURABILITY.getKey(), "sync")));
       // write without durability
       ConditionalWriterConfig cfg = new ConditionalWriterConfig();
       cfg.setDurability(Durability.NONE);
@@ -124,8 +127,8 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = getUniqueNames(1)[0];
       // table default is durable writes
-      c.tableOperations().create(tableName);
-      c.tableOperations().setProperty(tableName, Property.TABLE_DURABILITY.getKey(), "none");
+      c.tableOperations().create(tableName, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_DURABILITY.getKey(), "none")));
       // write with durability
       ConditionalWriterConfig cfg = new ConditionalWriterConfig();
       cfg.setDurability(Durability.SYNC);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.test.functional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeSet;
@@ -27,6 +28,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -76,10 +78,11 @@ public class TabletIT extends AccumuloClusterHarness {
       }
 
       // presplit
-      accumuloClient.tableOperations().create(tableName);
-      accumuloClient.tableOperations().setProperty(tableName,
-          Property.TABLE_SPLIT_THRESHOLD.getKey(), "200");
-      accumuloClient.tableOperations().addSplits(tableName, keys);
+      accumuloClient.tableOperations().create(tableName,
+          new NewTableConfiguration()
+              .setProperties(
+                  Collections.singletonMap(Property.TABLE_SPLIT_THRESHOLD.getKey(), "200"))
+              .withSplits(keys));
       try (BatchWriter b = accumuloClient.createBatchWriter(tableName)) {
         // populate
         for (int i = 0; i < N; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -28,7 +28,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -51,6 +53,7 @@ import org.apache.accumulo.core.client.IteratorSetting.Column;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.conf.ClientProperty;
@@ -296,9 +299,9 @@ public class ReplicationIT extends ConfigurableMacBase {
   public void correctRecordsCompleteFile() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       String table = "table1";
-      client.tableOperations().create(table);
-      // If we have more than one tserver, this is subject to a race condition.
-      client.tableOperations().setProperty(table, Property.TABLE_REPLICATION.getKey(), "true");
+      client.tableOperations().create(table, new NewTableConfiguration()
+          // If we have more than one tserver, this is subject to a race condition.
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
 
       try (BatchWriter bw = client.createBatchWriter(table)) {
         for (int i = 0; i < 10; i++) {
@@ -378,7 +381,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       for (int i = 0; i < 5; i++) {
         String name = "table" + i;
         tables.add(name);
-        client.tableOperations().create(name);
+        client.tableOperations().create(name, new NewTableConfiguration());
       }
 
       // nor after we create some tables (that aren't being replicated)
@@ -417,8 +420,8 @@ public class ReplicationIT extends ConfigurableMacBase {
           ReplicationTable.isOnline(client));
 
       // Create two tables
-      client.tableOperations().create(table1);
-      client.tableOperations().create(table2);
+      client.tableOperations().create(table1, new NewTableConfiguration());
+      client.tableOperations().create(table2, new NewTableConfiguration());
       client.securityOperations().grantTablePermission("root", ReplicationTable.NAME,
           TablePermission.READ);
       // wait for permission to propagate
@@ -563,28 +566,25 @@ public class ReplicationIT extends ConfigurableMacBase {
       });
 
       t.start();
+      HashMap<String,String> replicate_props = new HashMap<>();
+      replicate_props.put(Property.TABLE_REPLICATION.getKey(), "true");
+      replicate_props.put(Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
 
-      client.tableOperations().create(table1);
-      client.tableOperations().setProperty(table1, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table1,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+      client.tableOperations().create(table1,
+          new NewTableConfiguration().setProperties(replicate_props));
       Thread.sleep(2000);
 
       // Write some data to table1
       writeSomeData(client, table1, 200, 500);
 
-      client.tableOperations().create(table2);
-      client.tableOperations().setProperty(table2, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table2,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+      client.tableOperations().create(table2,
+          new NewTableConfiguration().setProperties(replicate_props));
       Thread.sleep(2000);
 
       writeSomeData(client, table2, 200, 500);
 
-      client.tableOperations().create(table3);
-      client.tableOperations().setProperty(table3, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table3,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+      client.tableOperations().create(table3,
+          new NewTableConfiguration().setProperties(replicate_props));
       Thread.sleep(2000);
 
       writeSomeData(client, table3, 200, 500);
@@ -709,19 +709,19 @@ public class ReplicationIT extends ConfigurableMacBase {
           TablePermission.WRITE);
       client.tableOperations().deleteRows(ReplicationTable.NAME, null, null);
 
+      Map<String,String> replicate_props = new HashMap<>();
+      replicate_props.put(Property.TABLE_REPLICATION.getKey(), "true");
+      replicate_props.put(Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+
       String table1 = "table1", table2 = "table2", table3 = "table3";
-      client.tableOperations().create(table1);
-      client.tableOperations().setProperty(table1, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table1,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
-      client.tableOperations().create(table2);
-      client.tableOperations().setProperty(table2, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table2,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
-      client.tableOperations().create(table3);
-      client.tableOperations().setProperty(table3, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table3,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+      client.tableOperations().create(table1,
+          new NewTableConfiguration().setProperties(replicate_props));
+
+      client.tableOperations().create(table2,
+          new NewTableConfiguration().setProperties(replicate_props));
+
+      client.tableOperations().create(table3,
+          new NewTableConfiguration().setProperties(replicate_props));
 
       writeSomeData(client, table1, 200, 500);
 
@@ -750,14 +750,16 @@ public class ReplicationIT extends ConfigurableMacBase {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
 
       String table = "table";
-      client.tableOperations().create(table);
+      Map<String,String> replicate_props = new HashMap<>();
+      replicate_props.put(Property.TABLE_REPLICATION.getKey(), "true");
+      replicate_props.put(Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+
+      client.tableOperations().create(table,
+          new NewTableConfiguration().setProperties(replicate_props));
       TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(table));
 
       assertNotNull(tableId);
 
-      client.tableOperations().setProperty(table, Property.TABLE_REPLICATION.getKey(), "true");
-      client.tableOperations().setProperty(table,
-          Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
       // just sleep
       client.instanceOperations().setProperty(Property.REPLICATION_PEERS.getKey() + "cluster1",
           ReplicaSystemFactory.getPeerConfigurationValue(MockReplicaSystem.class, "50000"));
@@ -871,7 +873,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       assertFalse(ReplicationTable.isOnline(client));
 
       // Create a table
-      client.tableOperations().create(table1);
+      client.tableOperations().create(table1, new NewTableConfiguration());
 
       int attempts = 10;
 
@@ -1043,7 +1045,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       assertFalse(ReplicationTable.isOnline(client));
 
       // Create two tables
-      client.tableOperations().create(table1);
+      client.tableOperations().create(table1, new NewTableConfiguration());
 
       int attempts = 5;
       while (attempts > 0) {
@@ -1150,29 +1152,27 @@ public class ReplicationIT extends ConfigurableMacBase {
       t.start();
 
       String table1 = "table1", table2 = "table2", table3 = "table3";
+      Map<String,String> replicate_props = new HashMap<>();
+      replicate_props.put(Property.TABLE_REPLICATION.getKey(), "true");
+      replicate_props.put(Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
 
       try {
-        client.tableOperations().create(table1);
-        client.tableOperations().setProperty(table1, Property.TABLE_REPLICATION.getKey(), "true");
-        client.tableOperations().setProperty(table1,
-            Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+        client.tableOperations().create(table1,
+            new NewTableConfiguration().setProperties(replicate_props));
+
         client.instanceOperations().setProperty(Property.REPLICATION_PEERS.getKey() + "cluster1",
             ReplicaSystemFactory.getPeerConfigurationValue(MockReplicaSystem.class, null));
 
         // Write some data to table1
         writeSomeData(client, table1, 200, 500);
 
-        client.tableOperations().create(table2);
-        client.tableOperations().setProperty(table2, Property.TABLE_REPLICATION.getKey(), "true");
-        client.tableOperations().setProperty(table2,
-            Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+        client.tableOperations().create(table2,
+            new NewTableConfiguration().setProperties(replicate_props));
 
         writeSomeData(client, table2, 200, 500);
 
-        client.tableOperations().create(table3);
-        client.tableOperations().setProperty(table3, Property.TABLE_REPLICATION.getKey(), "true");
-        client.tableOperations().setProperty(table3,
-            Property.TABLE_REPLICATION_TARGET.getKey() + "cluster1", "1");
+        client.tableOperations().create(table3,
+            new NewTableConfiguration().setProperties(replicate_props));
 
         writeSomeData(client, table3, 200, 500);
 
@@ -1307,7 +1307,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       assertFalse(ReplicationTable.isOnline(client));
 
       // Create two tables
-      client.tableOperations().create(table1);
+      client.tableOperations().create(table1, new NewTableConfiguration());
 
       int attempts = 5;
       while (attempts > 0) {

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerReplicationIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -39,6 +40,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
@@ -207,20 +209,19 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
 
       final String masterTable = "master", peerTable = "peer";
 
-      clientMaster.tableOperations().create(masterTable);
-      String masterTableId = clientMaster.tableOperations().tableIdMap().get(masterTable);
-      assertNotNull(masterTableId);
-
-      clientPeer.tableOperations().create(peerTable);
+      clientPeer.tableOperations().create(peerTable, new NewTableConfiguration());
       String peerTableId = clientPeer.tableOperations().tableIdMap().get(peerTable);
       assertNotNull(peerTableId);
+
+      clientMaster.tableOperations().create(masterTable, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
+      String masterTableId = clientMaster.tableOperations().tableIdMap().get(masterTable);
+      assertNotNull(masterTableId);
 
       clientPeer.securityOperations().grantTablePermission(peerUserName, peerTable,
           TablePermission.WRITE);
 
       // Replicate this table to the peerClusterName in a table with the peerTableId table id
-      clientMaster.tableOperations().setProperty(masterTable, Property.TABLE_REPLICATION.getKey(),
-          "true");
       clientMaster.tableOperations().setProperty(masterTable,
           Property.TABLE_REPLICATION_TARGET.getKey() + peerClusterName, peerTableId);
 
@@ -371,19 +372,12 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
           peerTable2 = "peer2";
 
       // Create tables
-      clientMaster.tableOperations().create(masterTable1);
-      String masterTableId1 = clientMaster.tableOperations().tableIdMap().get(masterTable1);
-      assertNotNull(masterTableId1);
 
-      clientMaster.tableOperations().create(masterTable2);
-      String masterTableId2 = clientMaster.tableOperations().tableIdMap().get(masterTable2);
-      assertNotNull(masterTableId2);
-
-      clientPeer.tableOperations().create(peerTable1);
+      clientPeer.tableOperations().create(peerTable1, new NewTableConfiguration());
       String peerTableId1 = clientPeer.tableOperations().tableIdMap().get(peerTable1);
       assertNotNull(peerTableId1);
 
-      clientPeer.tableOperations().create(peerTable2);
+      clientPeer.tableOperations().create(peerTable2, new NewTableConfiguration());
       String peerTableId2 = clientPeer.tableOperations().tableIdMap().get(peerTable2);
       assertNotNull(peerTableId2);
 
@@ -393,14 +387,19 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
       clientPeer.securityOperations().grantTablePermission(peerUserName, peerTable2,
           TablePermission.WRITE);
 
-      // Replicate this table to the peerClusterName in a table with the peerTableId table id
-      clientMaster.tableOperations().setProperty(masterTable1, Property.TABLE_REPLICATION.getKey(),
-          "true");
+      clientMaster.tableOperations().create(masterTable1, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
+      String masterTableId1 = clientMaster.tableOperations().tableIdMap().get(masterTable1);
+      assertNotNull(masterTableId1);
+
+      clientMaster.tableOperations().create(masterTable2, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
+      String masterTableId2 = clientMaster.tableOperations().tableIdMap().get(masterTable2);
+      assertNotNull(masterTableId2);
+
+      // Replicate these tables to the peerClusterName in a table with the peerTableId table id
       clientMaster.tableOperations().setProperty(masterTable1,
           Property.TABLE_REPLICATION_TARGET.getKey() + peerClusterName, peerTableId1);
-
-      clientMaster.tableOperations().setProperty(masterTable2, Property.TABLE_REPLICATION.getKey(),
-          "true");
       clientMaster.tableOperations().setProperty(masterTable2,
           Property.TABLE_REPLICATION_TARGET.getKey() + peerClusterName, peerTableId2);
 
@@ -546,21 +545,20 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
 
       String masterTable = "master", peerTable = "peer";
 
-      clientMaster.tableOperations().create(masterTable);
-      String masterTableId = clientMaster.tableOperations().tableIdMap().get(masterTable);
-      assertNotNull(masterTableId);
-
-      clientPeer.tableOperations().create(peerTable);
+      clientPeer.tableOperations().create(peerTable, new NewTableConfiguration());
       String peerTableId = clientPeer.tableOperations().tableIdMap().get(peerTable);
       assertNotNull(peerTableId);
+
+      clientMaster.tableOperations().create(masterTable, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
+      String masterTableId = clientMaster.tableOperations().tableIdMap().get(masterTable);
+      assertNotNull(masterTableId);
 
       // Give our replication user the ability to write to the table
       clientPeer.securityOperations().grantTablePermission(peerUserName, peerTable,
           TablePermission.WRITE);
 
       // Replicate this table to the peerClusterName in a table with the peerTableId table id
-      clientMaster.tableOperations().setProperty(masterTable, Property.TABLE_REPLICATION.getKey(),
-          "true");
       clientMaster.tableOperations().setProperty(masterTable,
           Property.TABLE_REPLICATION_TARGET.getKey() + peerClusterName, peerTableId);
 
@@ -661,22 +659,23 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
 
       String masterTable1 = "master1", peerTable1 = "peer1", masterTable2 = "master2",
           peerTable2 = "peer2";
-
-      clientMaster.tableOperations().create(masterTable1);
-      String masterTableId1 = clientMaster.tableOperations().tableIdMap().get(masterTable1);
-      assertNotNull(masterTableId1);
-
-      clientMaster.tableOperations().create(masterTable2);
-      String masterTableId2 = clientMaster.tableOperations().tableIdMap().get(masterTable2);
-      assertNotNull(masterTableId2);
-
-      clientPeer.tableOperations().create(peerTable1);
+      clientPeer.tableOperations().create(peerTable1, new NewTableConfiguration());
       String peerTableId1 = clientPeer.tableOperations().tableIdMap().get(peerTable1);
       assertNotNull(peerTableId1);
 
-      clientPeer.tableOperations().create(peerTable2);
+      clientPeer.tableOperations().create(peerTable2, new NewTableConfiguration());
       String peerTableId2 = clientPeer.tableOperations().tableIdMap().get(peerTable2);
       assertNotNull(peerTableId2);
+
+      clientMaster.tableOperations().create(masterTable1, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
+      String masterTableId1 = clientMaster.tableOperations().tableIdMap().get(masterTable1);
+      assertNotNull(masterTableId1);
+
+      clientMaster.tableOperations().create(masterTable2, new NewTableConfiguration()
+          .setProperties(Collections.singletonMap(Property.TABLE_REPLICATION.getKey(), "true")));
+      String masterTableId2 = clientMaster.tableOperations().tableIdMap().get(masterTable2);
+      assertNotNull(masterTableId2);
 
       // Give our replication user the ability to write to the tables
       clientPeer.securityOperations().grantTablePermission(peerUserName, peerTable1,
@@ -685,13 +684,8 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
           TablePermission.WRITE);
 
       // Replicate this table to the peerClusterName in a table with the peerTableId table id
-      clientMaster.tableOperations().setProperty(masterTable1, Property.TABLE_REPLICATION.getKey(),
-          "true");
       clientMaster.tableOperations().setProperty(masterTable1,
           Property.TABLE_REPLICATION_TARGET.getKey() + peerClusterName, peerTableId1);
-
-      clientMaster.tableOperations().setProperty(masterTable2, Property.TABLE_REPLICATION.getKey(),
-          "true");
       clientMaster.tableOperations().setProperty(masterTable2,
           Property.TABLE_REPLICATION_TARGET.getKey() + peerClusterName, peerTableId2);
 


### PR DESCRIPTION
Updated suggested IT tests with NewTableConfiguration and consolidated most table property setting on the table initialization where applicable.  Verified all tests except for the KerberosReplicationIT.  MiniAccumuloClusterTest and CyclicReplicationIT were already utilizing the NewTableConfiguration so changes there.