### PR TITLE
Add missing LRUMap generic parameters

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriter.java
@@ -89,13 +89,13 @@ import com.google.common.base.Preconditions;
 public class RFileWriter implements AutoCloseable {
 
   private FileSKVWriter writer;
-  private final LRUMap validVisibilities;
+  private final LRUMap<ByteSequence,Boolean> validVisibilities;
   private boolean startedLG;
   private boolean startedDefaultLG;
 
   RFileWriter(FileSKVWriter fileSKVWriter, int visCacheSize) {
     this.writer = fileSKVWriter;
-    this.validVisibilities = new LRUMap(visCacheSize);
+    this.validVisibilities = new LRUMap<>(visCacheSize);
   }
 
   private void _startNewLocalityGroup(String name, Set<ByteSequence> columnFamilies)
@@ -206,7 +206,7 @@ public class RFileWriter implements AutoCloseable {
     if (!startedLG) {
       startDefaultLocalityGroup();
     }
-    Boolean wasChecked = (Boolean) validVisibilities.get(key.getColumnVisibilityData());
+    Boolean wasChecked = validVisibilities.get(key.getColumnVisibilityData());
     if (wasChecked == null) {
       byte[] cv = key.getColumnVisibilityData().toArray();
       new ColumnVisibility(cv);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -110,8 +110,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
 
   private Authorizations auths;
   private VisibilityEvaluator ve;
-  @SuppressWarnings("unchecked")
-  private Map<Text,Boolean> cache = Collections.synchronizedMap(new LRUMap(1000));
+  private Map<Text,Boolean> cache = Collections.synchronizedMap(new LRUMap<>(1000));
   private final ClientContext context;
   private TabletLocator locator;
   private final TableId tableId;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/VisibilityFilter.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class VisibilityFilter extends SynchronizedServerFilter {
   protected VisibilityEvaluator ve;
   protected ByteSequence defaultVisibility;
-  protected LRUMap cache;
+  protected LRUMap<ByteSequence,Boolean> cache;
   protected Authorizations authorizations;
 
   private static final Logger log = LoggerFactory.getLogger(VisibilityFilter.class);
@@ -54,7 +54,7 @@ public class VisibilityFilter extends SynchronizedServerFilter {
     this.ve = new VisibilityEvaluator(authorizations);
     this.authorizations = authorizations;
     this.defaultVisibility = new ArrayByteSequence(defaultVisibility);
-    this.cache = new LRUMap(1000);
+    this.cache = new LRUMap<>(1000);
   }
 
   @Override
@@ -71,7 +71,7 @@ public class VisibilityFilter extends SynchronizedServerFilter {
     else if (testVis.length() == 0)
       testVis = defaultVisibility;
 
-    Boolean b = (Boolean) cache.get(testVis);
+    Boolean b = cache.get(testVis);
     if (b != null)
       return b;
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class VisibilityFilter extends Filter implements OptionDescriber {
 
   protected VisibilityEvaluator ve;
-  protected LRUMap cache;
+  protected LRUMap<ByteSequence,Boolean> cache;
 
   private static final Logger log = LoggerFactory.getLogger(VisibilityFilter.class);
 
@@ -66,14 +66,14 @@ public class VisibilityFilter extends Filter implements OptionDescriber {
           : new Authorizations(auths.getBytes(UTF_8));
       this.ve = new VisibilityEvaluator(authObj);
     }
-    this.cache = new LRUMap(1000);
+    this.cache = new LRUMap<>(1000);
   }
 
   @Override
   public boolean accept(Key k, Value v) {
     ByteSequence testVis = k.getColumnVisibilityData();
     if (filterInvalid) {
-      Boolean b = (Boolean) cache.get(testVis);
+      Boolean b = cache.get(testVis);
       if (b != null)
         return b;
       try {
@@ -89,7 +89,7 @@ public class VisibilityFilter extends Filter implements OptionDescriber {
         return true;
       }
 
-      Boolean b = (Boolean) cache.get(testVis);
+      Boolean b = cache.get(testVis);
       if (b != null)
         return b;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -57,7 +57,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
 
   private static final Logger log = LoggerFactory.getLogger(ProblemReports.class);
 
-  private final LRUMap problemReports = new LRUMap(1000);
+  private final LRUMap<ProblemReport,Long> problemReports = new LRUMap<>(1000);
 
   /**
    * use a thread pool so that reporting a problem never blocks

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -316,9 +316,8 @@ public class TabletServer extends AbstractServer {
       Collections.synchronizedSortedSet(new TreeSet<KeyExtent>());
   private final SortedSet<KeyExtent> openingTablets =
       Collections.synchronizedSortedSet(new TreeSet<KeyExtent>());
-  @SuppressWarnings("unchecked")
   private final Map<KeyExtent,Long> recentlyUnloadedCache =
-      Collections.synchronizedMap(new LRUMap(1000));
+      Collections.synchronizedMap(new LRUMap<>(1000));
 
   private final TabletServerResourceManager resourceManager;
   private final SecurityOperation security;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogReader.java
@@ -111,7 +111,7 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
     }
   }
 
-  private PriorityQueue heap = new PriorityQueue<>();
+  private PriorityQueue<Index> heap = new PriorityQueue<>();
   private Iterator<Entry<LogFileKey,LogFileValue>> iter;
 
   public RecoveryLogReader(VolumeManager fs, Path directory) throws IOException {
@@ -152,7 +152,7 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
 
   @VisibleForTesting
   synchronized boolean next(WritableComparable<?> key, Writable val) throws IOException {
-    Index elt = (Index) heap.remove();
+    Index elt = heap.remove();
     try {
       elt.cache();
       if (elt.cached) {
@@ -170,10 +170,9 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
 
   @VisibleForTesting
   synchronized boolean seek(WritableComparable<?> key) throws IOException {
-    PriorityQueue reheap = new PriorityQueue(heap.size());
+    PriorityQueue<Index> reheap = new PriorityQueue<>(heap.size());
     boolean result = false;
-    for (Object obj : heap) {
-      Index index = (Index) obj;
+    for (Index index : heap) {
       try {
         WritableComparable<?> found = index.reader.getClosest(key, index.value, true);
         if (found != null && found.equals(key)) {
@@ -192,8 +191,7 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
   @Override
   public void close() throws IOException {
     IOException problem = null;
-    for (Object obj : heap) {
-      Index index = (Index) obj;
+    for (Index index : heap) {
       try {
         index.reader.close();
       } catch (IOException ex) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/TablesCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/TablesCommand.java
@@ -42,7 +42,6 @@ public class TablesCommand extends Command {
   private Option sortByTableIdOption;
   private Option disablePaginationOpt;
 
-  @SuppressWarnings("unchecked")
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws AccumuloException, AccumuloSecurityException, IOException, NamespaceNotFoundException {
@@ -56,7 +55,7 @@ public class TablesCommand extends Command {
         tableName -> namespace == null || Tables.qualify(tableName).getFirst().equals(namespace));
 
     final boolean sortByTableId = cl.hasOption(sortByTableIdOption.getOpt());
-    tables = new TreeMap<String,String>((sortByTableId ? MapUtils.invertMap(tables) : tables));
+    tables = new TreeMap<>((sortByTableId ? MapUtils.invertMap(tables) : tables));
 
     Iterator<String> it = Iterators.transform(tables.entrySet().iterator(), entry -> {
       String tableName = String.valueOf(sortByTableId ? entry.getValue() : entry.getKey());


### PR DESCRIPTION
Since the update to commons-collections 4.3 in #1110, the LRUMap now
accepts generic parameter types. This change adds those that were
missing, which gives us better type safety when using these maps.