### PR TITLE
Ref #1084 Fixes File not Found Error

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
@@ -70,9 +70,7 @@ public class BulkImportVolumeIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.tableOperations().create(tableName);
       FileSystem fs = getFileSystem();
-      // Add Fs.defaultFS to rootPath so importDirectory has the full path for Standalone Instance
-      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
-      Path rootPath = new Path(defaultFS + cluster.getTemporaryPath(), getClass().getName());
+      Path rootPath = new Path(fs.getUri().toString() + cluster.getTemporaryPath(), getClass().getName());
       fs.deleteOnExit(rootPath);
 
       Path bulk = new Path(rootPath, "bulk");

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
@@ -70,20 +70,27 @@ public class BulkImportVolumeIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.tableOperations().create(tableName);
       FileSystem fs = getFileSystem();
-      Path rootPath = new Path(cluster.getTemporaryPath(), getClass().getName());
+      // Add Fs.defaultFS to rootPath so importDirectory has the full path for Standalone Instance
+      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
+      Path rootPath = new Path(defaultFS + cluster.getTemporaryPath(), getClass().getName());
+      fs.deleteOnExit(rootPath);
+
       Path bulk = new Path(rootPath, "bulk");
+      fs.deleteOnExit(bulk);
       log.info("bulk: {}", bulk);
       if (fs.exists(bulk)) {
         fs.delete(bulk, true);
       }
       assertTrue(fs.mkdirs(bulk));
       Path err = new Path(rootPath, "err");
+      fs.deleteOnExit(err);
       log.info("err: {}", err);
       if (fs.exists(err)) {
         fs.delete(err, true);
       }
       assertTrue(fs.mkdirs(err));
       Path bogus = new Path(bulk, "bogus.rf");
+      fs.deleteOnExit(bogus);
       fs.create(bogus).close();
       log.info("bogus: {}", bogus);
       assertTrue(fs.exists(bogus));

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -92,9 +92,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       FileSystem fs = cluster.getFileSystem();
       Path tmp = cluster.getTemporaryPath();
       log.info("Using FileSystem: " + fs);
-      // Add Fs.defaultFS to baseDir so importDirectory has the full path for Standalone Instance
-      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
-      Path baseDir = new Path(defaultFS + tmp, getClass().getName());
+      Path baseDir = new Path(fs.getUri().toString() + tmp, getClass().getName());
       fs.deleteOnExit(baseDir);
       if (fs.exists(baseDir)) {
         log.info("{} exists on filesystem, deleting", baseDir);

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -92,7 +92,10 @@ public class ImportExportIT extends AccumuloClusterHarness {
       FileSystem fs = cluster.getFileSystem();
       Path tmp = cluster.getTemporaryPath();
       log.info("Using FileSystem: " + fs);
-      Path baseDir = new Path(tmp, getClass().getName());
+      // Add Fs.defaultFS to baseDir so importDirectory has the full path for Standalone Instance
+      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
+      Path baseDir = new Path(defaultFS + tmp, getClass().getName());
+      fs.deleteOnExit(baseDir);
       if (fs.exists(baseDir)) {
         log.info("{} exists on filesystem, deleting", baseDir);
         assertTrue("Failed to deleted " + baseDir, fs.delete(baseDir, true));
@@ -100,7 +103,9 @@ public class ImportExportIT extends AccumuloClusterHarness {
       log.info("Creating {}", baseDir);
       assertTrue("Failed to create " + baseDir, fs.mkdirs(baseDir));
       Path exportDir = new Path(baseDir, "export");
+      fs.deleteOnExit(exportDir);
       Path importDir = new Path(baseDir, "import");
+      fs.deleteOnExit(importDir);
       for (Path p : new Path[] {exportDir, importDir}) {
         assertTrue("Failed to create " + baseDir, fs.mkdirs(p));
       }
@@ -115,6 +120,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
 
       // Make sure the distcp.txt file that exporttable creates is available
       Path distcp = new Path(exportDir, "distcp.txt");
+      fs.deleteOnExit(distcp);
       assertTrue("Distcp file doesn't exist", fs.exists(distcp));
       FSDataInputStream is = fs.open(distcp);
       BufferedReader reader = new BufferedReader(new InputStreamReader(is));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
@@ -74,9 +74,7 @@ public class BulkFileIT extends AccumuloClusterHarness {
       Configuration conf = new Configuration();
       AccumuloConfiguration aconf = getCluster().getServerContext().getConfiguration();
       FileSystem fs = getCluster().getFileSystem();
-      // Add Fs.defaultFS to rootPath so importDirectory has the full path for Standalone Instance
-      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
-      String rootPath = defaultFS + cluster.getTemporaryPath().toString();
+      String rootPath = fs.getUri().toString()  + cluster.getTemporaryPath().toString();
 
       String dir = rootPath + "/bulk_test_diff_files_89723987592_" + getUniqueNames(1)[0];
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
@@ -74,8 +74,9 @@ public class BulkFileIT extends AccumuloClusterHarness {
       Configuration conf = new Configuration();
       AccumuloConfiguration aconf = getCluster().getServerContext().getConfiguration();
       FileSystem fs = getCluster().getFileSystem();
-
-      String rootPath = cluster.getTemporaryPath().toString();
+      // Add Fs.defaultFS to rootPath so importDirectory has the full path for Standalone Instance
+      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
+      String rootPath = defaultFS + cluster.getTemporaryPath().toString();
 
       String dir = rootPath + "/bulk_test_diff_files_89723987592_" + getUniqueNames(1)[0];
 
@@ -89,6 +90,7 @@ public class BulkFileIT extends AccumuloClusterHarness {
       Path failPath = new Path(failDir);
       fs.delete(failPath, true);
       fs.mkdirs(failPath);
+      fs.deleteOnExit(failPath);
 
       // Ensure server can read/modify files
       c.tableOperations().importDirectory(tableName, dir, failDir, false);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
@@ -64,9 +64,7 @@ public class BulkIT extends AccumuloClusterHarness {
   static void runTest(AccumuloClient c, ClientInfo info, FileSystem fs, Path basePath,
       String tableName, String filePrefix, String dirSuffix, boolean useOld) throws Exception {
     c.tableOperations().create(tableName);
-    // Add Fs.defaultFS to base so importDirectory has the full path for Standalone Instance
-    String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
-    Path base = new Path(defaultFS + basePath, "testBulkFail_" + dirSuffix);
+    Path base = new Path(fs.getUri().toString() + basePath, "testBulkFail_" + dirSuffix);
     fs.delete(base, true);
     fs.mkdirs(base);
     fs.deleteOnExit(base);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
@@ -64,12 +64,16 @@ public class BulkIT extends AccumuloClusterHarness {
   static void runTest(AccumuloClient c, ClientInfo info, FileSystem fs, Path basePath,
       String tableName, String filePrefix, String dirSuffix, boolean useOld) throws Exception {
     c.tableOperations().create(tableName);
-
-    Path base = new Path(basePath, "testBulkFail_" + dirSuffix);
+    // Add Fs.defaultFS to base so importDirectory has the full path for Standalone Instance
+    String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
+    Path base = new Path(defaultFS + basePath, "testBulkFail_" + dirSuffix);
     fs.delete(base, true);
     fs.mkdirs(base);
+    fs.deleteOnExit(base);
     Path bulkFailures = new Path(base, "failures");
+    fs.deleteOnExit(bulkFailures);
     Path files = new Path(base, "files");
+    fs.deleteOnExit(files);
     fs.mkdirs(bulkFailures);
     fs.mkdirs(files);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
@@ -90,7 +90,10 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
       c.tableOperations().setProperty(tableName, Property.TABLE_FILE_MAX.getKey(), "1000");
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "1G");
       FileSystem fs = cluster.getFileSystem();
-      Path testDir = new Path(getUsableDir(), "testmf");
+      // Add Fs.defaultFS to testDir so importDirectory has the full path for Standalone Instance
+      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
+      Path testDir = new Path(defaultFS + getUsableDir(), "testmf");
+      fs.deleteOnExit(testDir);
       FunctionalTestUtils.createRFiles(c, fs, testDir.toString(), ROWS, SPLITS, 8);
       FileStatus[] stats = fs.listStatus(testDir);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
@@ -90,9 +90,7 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
       c.tableOperations().setProperty(tableName, Property.TABLE_FILE_MAX.getKey(), "1000");
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "1G");
       FileSystem fs = cluster.getFileSystem();
-      // Add Fs.defaultFS to testDir so importDirectory has the full path for Standalone Instance
-      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
-      Path testDir = new Path(defaultFS + getUsableDir(), "testmf");
+      Path testDir = new Path(fs.getUri().toString() + getUsableDir(), "testmf");
       fs.deleteOnExit(testDir);
       FunctionalTestUtils.createRFiles(c, fs, testDir.toString(), ROWS, SPLITS, 8);
       FileStatus[] stats = fs.listStatus(testDir);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -115,9 +115,7 @@ public class CompactionIT extends AccumuloClusterHarness {
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");
       FileSystem fs = getFileSystem();
-      // Add Fs.defaultFS to rootPath so importDirectory has the full path for Standalone Instance
-      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
-      Path root = new Path(defaultFS + cluster.getTemporaryPath(), getClass().getName());
+      Path root = new Path(fs.getUri().toString() + cluster.getTemporaryPath(), getClass().getName());
       fs.deleteOnExit(root);
       Path testrf = new Path(root, "testrf");
       fs.deleteOnExit(testrf);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -115,8 +115,12 @@ public class CompactionIT extends AccumuloClusterHarness {
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");
       FileSystem fs = getFileSystem();
-      Path root = new Path(cluster.getTemporaryPath(), getClass().getName());
+      // Add Fs.defaultFS to rootPath so importDirectory has the full path for Standalone Instance
+      String defaultFS = fs.getConf().get(FileSystem.FS_DEFAULT_NAME_KEY);
+      Path root = new Path(defaultFS + cluster.getTemporaryPath(), getClass().getName());
+      fs.deleteOnExit(root);
       Path testrf = new Path(root, "testrf");
+      fs.deleteOnExit(testrf);
       FunctionalTestUtils.createRFiles(c, fs, testrf.toString(), 500000, 59, 4);
 
       c.tableOperations().importDirectory(testrf.toString()).to(tableName).load();


### PR DESCRIPTION
The main issue was importDirectory, when running a standalone instance, looked inside the users local filesystem instead of in hdfs which is what was causing this error. My fix for it was using the filesystem's default name key (mine being hdfs://localhost:8020 for example) and adding that to the front of the base path the test was using. This allowed the importDirectory function to have access to the full path so it would look inside hdfs instead of the users local filesystem. 

I added the delete on exit command since this change altered the test when run with MiniAccumuloCluster. The path wouldn't be just the tmp directory like it was previously so it wouldn't properly be deleted. This caused license issues when building. 

In reference to issue #1084 

 