### PR TITLE
Remove direct uses of log4j

### DIFF
--- a/assemble/conf/log4j.properties
+++ b/assemble/conf/log4j.properties
@@ -31,5 +31,8 @@ log4j.logger.org.apache.commons.vfs2.impl.DefaultFileSystemManager=WARN
 log4j.logger.org.apache.hadoop.io.compress=WARN
 log4j.logger.org.apache.zookeeper=ERROR
 
+## Uncomment the following for detailed logging (for example, in the Shell)
+#log4j.logger.org.apache.accumulo.core=TRACE
+
 ## Append most logs to console
 log4j.rootLogger=INFO, console

--- a/assemble/conf/log4j.properties
+++ b/assemble/conf/log4j.properties
@@ -17,7 +17,7 @@
 
 ## Define a console appender
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.Target=System.out
+log4j.appender.console.Target=System.err
 log4j.appender.console.Threshold=ALL
 log4j.appender.console.layout.ConversionPattern=%d{ISO8601} [%-8c{2}] %-5p: %m%n
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
@@ -30,7 +30,6 @@ log4j.logger.org.apache.accumulo.core.file.rfile.bcfile.Compression=WARN
 log4j.logger.org.apache.commons.vfs2.impl.DefaultFileSystemManager=WARN
 log4j.logger.org.apache.hadoop.io.compress=WARN
 log4j.logger.org.apache.zookeeper=ERROR
-log4j.logger.org.mortbay.log=WARN
 
 ## Append most logs to console
 log4j.rootLogger=INFO, console

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -201,8 +201,6 @@
                 <allow>org[.]apache[.]hadoop[.]mapred[.](JobConf|RecordReader|InputSplit|RecordWriter|Reporter)</allow>
                 <allow>org[.]apache[.]hadoop[.]mapreduce[.](Job|JobContext|RecordReader|InputSplit|TaskAttemptContext|RecordWriter|OutputCommitter|TaskInputOutputContext)</allow>
                 <allow>org[.]apache[.]hadoop[.]util[.]Progressable</allow>
-                <!--ugghhh-->
-                <allow>org[.]apache[.]log4j[.](Level|Logger)</allow>
                 <!-- allow javax security exceptions for Authentication tokens -->
                 <allow>javax[.]security[.]auth[.]DestroyFailedException</allow>
                 <!-- allow questionable Hadoop exceptions for mapreduce -->

--- a/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.clientImpl.ClientInfoImpl;
 import org.apache.accumulo.core.conf.ClientProperty;
@@ -35,8 +34,6 @@ import org.apache.htrace.NullScope;
 import org.apache.htrace.Sampler;
 import org.apache.htrace.Trace;
 import org.apache.htrace.TraceScope;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
@@ -100,9 +97,6 @@ public class ClientOpts extends Help {
       description = "the authorizations to use when reading or writing")
   public Authorizations auths = Authorizations.EMPTY;
 
-  @Parameter(names = "--debug", description = "turn on TRACE-level log messages")
-  public boolean debug = false;
-
   @Parameter(names = {"-c", "--config-file"}, description = "Read the given client config file. "
       + "If omitted, the classpath will be searched for file named accumulo-client.properties")
   private String clientConfigFile = null;
@@ -110,11 +104,6 @@ public class ClientOpts extends Help {
   @Parameter(names = "-o", splitter = NullSplitter.class, description = "Overrides property in "
       + "accumulo-client.properties. Expected format: -o <key>=<value>")
   private List<String> overrides = new ArrayList<>();
-
-  public void startDebugLogging() {
-    if (debug)
-      Logger.getLogger(Constants.CORE_PACKAGE_NAME).setLevel(Level.TRACE);
-  }
 
   @Parameter(names = "--trace", description = "turn on distributed tracing")
   public boolean trace = false;
@@ -131,7 +120,6 @@ public class ClientOpts extends Help {
   @Override
   public void parseArgs(String programName, String[] args, Object... others) {
     super.parseArgs(programName, args, others);
-    startDebugLogging();
   }
 
   private Properties cachedProps = null;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/SyncingTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/SyncingTabletLocator.java
@@ -29,7 +29,8 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Syncs itself with the static collection of TabletLocators, so that when the server clears it, it
@@ -37,7 +38,7 @@ import org.apache.log4j.Logger;
  * using SyncingTabletLocator.
  */
 public class SyncingTabletLocator extends TabletLocator {
-  private static final Logger log = Logger.getLogger(SyncingTabletLocator.class);
+  private static final Logger log = LoggerFactory.getLogger(SyncingTabletLocator.class);
 
   private volatile TabletLocator locator;
   private final Callable<TabletLocator> getLocatorFunction;
@@ -58,16 +59,18 @@ public class SyncingTabletLocator extends TabletLocator {
 
   private TabletLocator syncLocator() {
     TabletLocator loc = this.locator;
-    if (!loc.isValid())
+    if (!loc.isValid()) {
       synchronized (this) {
-        if (locator == loc)
+        if (locator == loc) {
           try {
             loc = locator = getLocatorFunction.call();
           } catch (Exception e) {
             log.error("Problem obtaining TabletLocator", e);
             throw new RuntimeException(e);
           }
+        }
       }
+    }
     return loc;
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -61,16 +61,17 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Logger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class MultiThreadedRFileTest {
 
-  private static final Logger LOG = Logger.getLogger(MultiThreadedRFileTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MultiThreadedRFileTest.class);
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
   @Rule
@@ -83,16 +84,18 @@ public class MultiThreadedRFileTest {
     if (indexIter.hasTop()) {
       Key lastKey = new Key(indexIter.getTopKey());
 
-      if (reader.getFirstKey().compareTo(lastKey) > 0)
+      if (reader.getFirstKey().compareTo(lastKey) > 0) {
         throw new RuntimeException(
             "First key out of order " + reader.getFirstKey() + " " + lastKey);
+      }
 
       indexIter.next();
 
       while (indexIter.hasTop()) {
-        if (lastKey.compareTo(indexIter.getTopKey()) > 0)
+        if (lastKey.compareTo(indexIter.getTopKey()) > 0) {
           throw new RuntimeException(
               "Indext out of order " + lastKey + " " + indexIter.getTopKey());
+        }
 
         lastKey = new Key(indexIter.getTopKey());
         indexIter.next();
@@ -118,8 +121,9 @@ public class MultiThreadedRFileTest {
 
     public TestRFile(AccumuloConfiguration accumuloConfiguration) {
       this.accumuloConfiguration = accumuloConfiguration;
-      if (this.accumuloConfiguration == null)
+      if (this.accumuloConfiguration == null) {
         this.accumuloConfiguration = DefaultConfiguration.getInstance();
+      }
     }
 
     public void close() throws IOException {
@@ -162,8 +166,9 @@ public class MultiThreadedRFileTest {
       }
       writer = new RFile.Writer(_cbw, 1000, 1000, samplerConfig, sampler);
 
-      if (startDLG)
+      if (startDLG) {
         writer.startDefaultLocalityGroup();
+      }
     }
 
     public void openWriter() throws IOException {
@@ -285,8 +290,8 @@ public class MultiThreadedRFileTest {
     }
 
     for (String message : messages.keySet()) {
-      LOG.error(messages.get(message) + ": " + message);
-      LOG.error(stackTrace.get(message));
+      LOG.error("{}: {}", messages.get(message), message);
+      LOG.error("{}", stackTrace.get(message));
     }
 
     assertTrue(threadExceptions.isEmpty());

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
@@ -32,8 +32,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,11 +45,6 @@ public class RFileMetricsTest {
   @Rule
   public TemporaryFolder tempFolder =
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
-
-  static {
-    Logger.getLogger(org.apache.hadoop.io.compress.CodecPool.class).setLevel(Level.OFF);
-    Logger.getLogger(org.apache.hadoop.util.NativeCodeLoader.class).setLevel(Level.OFF);
-  }
 
   private TestRFile trf = null;
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/VisibilityFilterTest.java
@@ -30,8 +30,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
 public class VisibilityFilterTest {
@@ -44,14 +42,9 @@ public class VisibilityFilterTest {
     SortedKeyValueIterator<Key,Value> filter =
         VisibilityFilter.wrap(new SortedMapIterator(tm), new Authorizations("A"), "".getBytes());
 
-    // suppress logging
-    Level prevLevel = Logger.getLogger(VisibilityFilter.class).getLevel();
-    Logger.getLogger(VisibilityFilter.class).setLevel(Level.FATAL);
-
     filter.seek(new Range(), new HashSet<>(), false);
     assertFalse(filter.hasTop());
 
-    Logger.getLogger(VisibilityFilter.class).setLevel(prevLevel);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -41,14 +41,9 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.system.MultiIterator;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.junit.Before;
 import org.junit.Test;
 
 public class IndexedDocIteratorTest {
-
-  private static final Logger log = Logger.getLogger(IndexedDocIteratorTest.class);
 
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
   private static final byte[] nullByte = {0};
@@ -65,7 +60,6 @@ public class IndexedDocIteratorTest {
   static Text docColf = new Text(docColfPrefix);
 
   static {
-    log.setLevel(Level.OFF);
     docColf.append(nullByte, 0, 1);
     docColf.append("type".getBytes(), 0, "type".getBytes().length);
   }
@@ -81,10 +75,13 @@ public class IndexedDocIteratorTest {
 
     for (int i = 0; i < columnFamilies.length; i++) {
       negateMask[i] = false;
-      if (negatedColumns.length > 0)
-        for (Text ng : negatedColumns)
-          if (columnFamilies[i].equals(ng))
+      if (negatedColumns.length > 0) {
+        for (Text ng : negatedColumns) {
+          if (columnFamilies[i].equals(ng)) {
             negateMask[i] = true;
+          }
+        }
+      }
     }
     for (int i = 0; i < numRows; i++) {
       Text row = new Text(String.format("%06d", i));
@@ -106,11 +103,13 @@ public class IndexedDocIteratorTest {
             map.put(k, v);
             sb.append(" ");
             sb.append(columnFamilies[j]);
-            if (negateMask[j])
+            if (negateMask[j]) {
               docHits = false;
+            }
           } else {
-            if (!negateMask[j])
+            if (!negateMask[j]) {
               docHits = false;
+            }
           }
         }
         if (docHits) {
@@ -157,14 +156,16 @@ public class IndexedDocIteratorTest {
         columnFamilies, otherColumnFamilies, docs, negatedColumns);
     trf.writer.startNewLocalityGroup("docs", RFileTest.newColFamByteSequence(docColf.toString()));
     for (Entry<Key,Value> entry : inMemoryMap.entrySet()) {
-      if (entry.getKey().getColumnFamily().equals(docColf))
+      if (entry.getKey().getColumnFamily().equals(docColf)) {
         trf.writer.append(entry.getKey(), entry.getValue());
+      }
     }
     trf.writer.startNewLocalityGroup("terms",
         RFileTest.newColFamByteSequence(indexColf.toString()));
     for (Entry<Key,Value> entry : inMemoryMap.entrySet()) {
-      if (entry.getKey().getColumnFamily().equals(indexColf))
+      if (entry.getKey().getColumnFamily().equals(indexColf)) {
         trf.writer.append(entry.getKey(), entry.getValue());
+      }
     }
 
     trf.closeWriter();
@@ -176,11 +177,6 @@ public class IndexedDocIteratorTest {
   private static synchronized void cleanup() throws IOException {
     trf.closeReader();
     docid = 0;
-  }
-
-  @Before
-  public void setUp() {
-    Logger.getRootLogger().setLevel(Level.ERROR);
   }
 
   private static final int NUM_ROWS = 5;

--- a/hadoop-mapreduce/pom.xml
+++ b/hadoop-mapreduce/pom.xml
@@ -110,8 +110,6 @@
                 <allow>org[.]apache[.]hadoop[.]mapreduce[.]lib[.]output[.]FileOutputFormat[$]Counter</allow>
                 <allow>org[.]apache[.]hadoop[.]util[.]Progressable</allow>
                 <allow>org[.]apache[.]hadoop[.]mapred[.](FileAlreadyExistsException|InvalidJobConfException)</allow>
-                <!--ugghhh-->
-                <allow>org[.]apache[.]log4j[.](Level|Logger)</allow>
               </allows>
             </configuration>
           </execution>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -38,8 +38,6 @@ import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -58,8 +56,6 @@ public class MiniAccumuloClusterImplTest {
 
   @BeforeClass
   public static void setupMiniCluster() throws Exception {
-    Logger.getLogger("org.apache.zookeeper").setLevel(Level.ERROR);
-
     File baseDir = new File(System.getProperty("user.dir") + "/target/mini-tests");
     assertTrue(baseDir.mkdirs() || baseDir.isDirectory());
     testDir = new File(baseDir, MiniAccumuloClusterImplTest.class.getName());

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>
     <servlet.api.version>3.1.0</servlet.api.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.26</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <spotbugs.version>3.1.7</spotbugs.version>
     <surefire.excludedGroups />

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfWatcher.java
@@ -19,18 +19,14 @@ package org.apache.accumulo.server.conf;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class TableConfWatcher implements Watcher {
-  static {
-    Logger.getLogger("org.apache.zookeeper").setLevel(Level.WARN);
-    Logger.getLogger("org.apache.hadoop.io.compress").setLevel(Level.WARN);
-  }
 
-  private static final Logger log = Logger.getLogger(TableConfWatcher.class);
+  private static final Logger log = LoggerFactory.getLogger(TableConfWatcher.class);
   private final ServerContext context;
   private final String tablesPrefix;
   private ServerConfigurationFactory scf;
@@ -49,8 +45,9 @@ class TableConfWatcher implements Watcher {
   @Override
   public void process(WatchedEvent event) {
     String path = event.getPath();
-    if (log.isTraceEnabled())
-      log.trace("WatchedEvent : " + toString(event));
+    if (log.isTraceEnabled()) {
+      log.trace("WatchedEvent : {}", toString(event));
+    }
 
     String tableIdString = null;
     String key = null;
@@ -60,15 +57,16 @@ class TableConfWatcher implements Watcher {
         tableIdString = path.substring(tablesPrefix.length());
         if (tableIdString.contains("/")) {
           tableIdString = tableIdString.substring(0, tableIdString.indexOf('/'));
-          if (path.startsWith(tablesPrefix + tableIdString + Constants.ZTABLE_CONF + "/"))
+          if (path.startsWith(tablesPrefix + tableIdString + Constants.ZTABLE_CONF + "/")) {
             key = path
                 .substring((tablesPrefix + tableIdString + Constants.ZTABLE_CONF + "/").length());
+          }
         }
       }
 
       if (tableIdString == null) {
-        log.warn("Zookeeper told me about a path I was not watching: " + path + ", event "
-            + toString(event));
+        log.warn("Zookeeper told me about a path I was not watching: {}, event {}", path,
+            toString(event));
         return;
       }
     }
@@ -76,10 +74,12 @@ class TableConfWatcher implements Watcher {
 
     switch (event.getType()) {
       case NodeDataChanged:
-        if (log.isTraceEnabled())
-          log.trace("EventNodeDataChanged " + event.getPath());
-        if (key != null)
+        if (log.isTraceEnabled()) {
+          log.trace("EventNodeDataChanged {}", event.getPath());
+        }
+        if (key != null) {
           scf.getTableConfiguration(tableId).propertyChanged(key);
+        }
         break;
       case NodeChildrenChanged:
         scf.getTableConfiguration(tableId).propertiesChanged();
@@ -104,7 +104,7 @@ class TableConfWatcher implements Watcher {
           case Disconnected:
             break;
           default:
-            log.warn("EventNone event not handled " + toString(event));
+            log.warn("EventNone event not handled {}", toString(event));
         }
         break;
       case NodeCreated:
@@ -112,11 +112,11 @@ class TableConfWatcher implements Watcher {
           case SyncConnected:
             break;
           default:
-            log.warn("Event NodeCreated event not handled " + toString(event));
+            log.warn("Event NodeCreated event not handled {}", toString(event));
         }
         break;
       default:
-        log.warn("Event not handled " + toString(event));
+        log.warn("Event not handled {}", toString(event));
     }
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/DumpZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/DumpZookeeper.java
@@ -24,8 +24,6 @@ import java.util.Base64;
 import org.apache.accumulo.core.cli.ConfigOpts;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 
@@ -34,8 +32,6 @@ import com.beust.jcommander.Parameter;
 public class DumpZookeeper {
 
   private static IZooReaderWriter zk = null;
-
-  private static final Logger log = Logger.getLogger(DumpZookeeper.class);
 
   private static class Encoded {
     public String encoding;
@@ -56,41 +52,40 @@ public class DumpZookeeper {
     boolean xml = false;
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws KeeperException, InterruptedException {
     Opts opts = new Opts();
     opts.parseArgs(DumpZookeeper.class.getName(), args);
 
-    Logger.getRootLogger().setLevel(Level.WARN);
     PrintStream out = System.out;
-    try {
-      zk = new ZooReaderWriter(opts.getSiteConfiguration());
-      if (opts.xml) {
-        writeXml(out, opts.root);
-      } else {
-        writeHumanReadable(out, opts.root);
-      }
-    } catch (Exception ex) {
-      log.error(ex, ex);
+    zk = new ZooReaderWriter(opts.getSiteConfiguration());
+    if (opts.xml) {
+      writeXml(out, opts.root);
+    } else {
+      writeHumanReadable(out, opts.root);
     }
   }
 
   private static void writeXml(PrintStream out, String root)
       throws KeeperException, InterruptedException {
     write(out, 0, "<dump root='%s'>", root);
-    for (String child : zk.getChildren(root, null))
-      if (!child.equals("zookeeper"))
+    for (String child : zk.getChildren(root, null)) {
+      if (!child.equals("zookeeper")) {
         childXml(out, root, child, 1);
+      }
+    }
     write(out, 0, "</dump>");
   }
 
   private static void childXml(PrintStream out, String root, String child, int indent)
       throws KeeperException, InterruptedException {
     String path = root + "/" + child;
-    if (root.endsWith("/"))
+    if (root.endsWith("/")) {
       path = root + child;
+    }
     Stat stat = zk.getStatus(path);
-    if (stat == null)
+    if (stat == null) {
       return;
+    }
     String type = "node";
     if (stat.getEphemeralOwner() != 0) {
       type = "ephemeral";
@@ -120,36 +115,42 @@ public class DumpZookeeper {
 
   private static Encoded value(String path) throws KeeperException, InterruptedException {
     byte[] data = zk.getData(path, null);
-    for (int i = 0; i < data.length; i++) {
+    for (byte element : data) {
       // does this look like simple ascii?
-      if (data[i] < ' ' || data[i] > '~')
+      if (element < ' ' || element > '~') {
         return new Encoded("base64", Base64.getEncoder().encodeToString(data));
+      }
     }
     return new Encoded(UTF_8.name(), new String(data, UTF_8));
   }
 
   private static void write(PrintStream out, int indent, String fmt, Object... args) {
-    for (int i = 0; i < indent; i++)
+    for (int i = 0; i < indent; i++) {
       out.print("  ");
+    }
     out.println(String.format(fmt, args));
   }
 
   private static void writeHumanReadable(PrintStream out, String root)
       throws KeeperException, InterruptedException {
     write(out, 0, "%s:", root);
-    for (String child : zk.getChildren(root, null))
-      if (!child.equals("zookeeper"))
+    for (String child : zk.getChildren(root, null)) {
+      if (!child.equals("zookeeper")) {
         childHumanReadable(out, root, child, 1);
+      }
+    }
   }
 
   private static void childHumanReadable(PrintStream out, String root, String child, int indent)
       throws KeeperException, InterruptedException {
     String path = root + "/" + child;
-    if (root.endsWith("/"))
+    if (root.endsWith("/")) {
       path = root + child;
+    }
     Stat stat = zk.getStatus(path);
-    if (stat == null)
+    if (stat == null) {
       return;
+    }
     String node = child;
     if (stat.getEphemeralOwner() != 0) {
       node = "*" + child + "*";

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
@@ -31,8 +31,6 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.zookeeper.KeeperException;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
@@ -57,21 +55,24 @@ public class RestoreZookeeper {
     public void startElement(String uri, String localName, String name, Attributes attributes) {
       if ("node".equals(name)) {
         String child = attributes.getValue("name");
-        if (child == null)
+        if (child == null) {
           throw new RuntimeException("name attribute not set");
+        }
         String encoding = attributes.getValue("encoding");
         String value = attributes.getValue("value");
-        if (value == null)
+        if (value == null) {
           value = "";
+        }
         String path = cwd.lastElement() + "/" + child;
         create(path, value, encoding);
         cwd.push(path);
       } else if ("dump".equals(name)) {
         String root = attributes.getValue("root");
-        if (root.equals("/"))
+        if (root.equals("/")) {
           cwd.push("");
-        else
+        } else {
           cwd.push(root);
+        }
         create(root, "", UTF_8.name());
       } else if ("ephemeral".equals(name)) {
         cwd.push("");
@@ -86,15 +87,17 @@ public class RestoreZookeeper {
     // assume UTF-8 if not "base64"
     private void create(String path, String value, String encoding) {
       byte[] data = value.getBytes(UTF_8);
-      if ("base64".equals(encoding))
+      if ("base64".equals(encoding)) {
         data = Base64.getDecoder().decode(data);
+      }
       try {
         try {
           zk.putPersistentData(path, data,
               overwrite ? NodeExistsPolicy.OVERWRITE : NodeExistsPolicy.FAIL);
         } catch (KeeperException e) {
-          if (e.code().equals(KeeperException.Code.NODEEXISTS))
+          if (e.code().equals(KeeperException.Code.NODEEXISTS)) {
             throw new RuntimeException(path + " exists.  Remove it first.");
+          }
           throw e;
         }
       } catch (Exception e) {
@@ -113,7 +116,6 @@ public class RestoreZookeeper {
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
       justification = "code runs in same security context as user who provided input")
   public static void main(String[] args) throws Exception {
-    Logger.getRootLogger().setLevel(Level.WARN);
     Opts opts = new Opts();
     opts.parseArgs(RestoreZookeeper.class.getName(), args);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -31,8 +30,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Da
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
@@ -45,8 +42,9 @@ public class MetadataConstraintsTest {
 
         @Override
         public boolean transactionAlive(String type, long tid) {
-          if (tid == 9)
+          if (tid == 9) {
             throw new RuntimeException("txid 9 reserved for future use");
+          }
           return tid == 5 || tid == 7;
         }
 
@@ -68,7 +66,6 @@ public class MetadataConstraintsTest {
 
   @Test
   public void testCheck() {
-    Logger.getLogger(AccumuloConfiguration.class).setLevel(Level.ERROR);
     Mutation m = new Mutation(new Text("0;foo"));
     TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.put(m, new Value("1foo".getBytes()));
 

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -57,10 +57,6 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategy.java
@@ -28,7 +28,8 @@ import org.apache.accumulo.tserver.compaction.CompactionPlan;
 import org.apache.accumulo.tserver.compaction.DefaultCompactionStrategy;
 import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
 import org.apache.accumulo.tserver.compaction.WriteParameters;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A compaction strategy that covers the following uses cases.
@@ -61,7 +62,7 @@ import org.apache.log4j.Logger;
  */
 public class BasicCompactionStrategy extends DefaultCompactionStrategy {
 
-  private static final Logger log = Logger.getLogger(BasicCompactionStrategy.class);
+  private static final Logger log = LoggerFactory.getLogger(BasicCompactionStrategy.class);
 
   public static final String SIZE_LIMIT_OPT = "filter.size";
 
@@ -125,8 +126,8 @@ public class BasicCompactionStrategy extends DefaultCompactionStrategy {
       if (totalSize > largeThresh) {
         plan.writeParameters = new WriteParameters();
         if (log.isDebugEnabled()) {
-          log.debug("Changed compressType to " + largeCompress + ": totalSize(" + totalSize
-              + ") was greater than threshold " + largeThresh);
+          log.debug("Changed compressType to {}: totalSize({}) was greater than threshold {}",
+              largeCompress, totalSize, largeThresh);
         }
         plan.writeParameters.setCompressType(largeCompress);
       }
@@ -140,8 +141,9 @@ public class BasicCompactionStrategy extends DefaultCompactionStrategy {
     if (filterSize != null) {
       Map<FileRef,DataFileValue> filteredFiles = new HashMap<>();
       mcr.getFiles().forEach((fr, dfv) -> {
-        if (dfv.getSize() <= filterSize)
+        if (dfv.getSize() <= filterSize) {
           filteredFiles.put(fr, dfv);
+        }
       });
 
       mcr = new MajorCompactionRequest(mcr);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
@@ -33,8 +33,6 @@ import org.apache.accumulo.server.log.SortedLogState;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -66,8 +64,6 @@ public class TestUpgradePathForWALogs {
 
   @Before
   public void setUp() throws Exception {
-    // quiet log messages about compress.CodecPool
-    Logger.getRootLogger().setLevel(Level.ERROR);
     root.create();
     String path = root.getRoot().getAbsolutePath() + "/manyMaps";
     fs = VolumeManagerImpl.getLocal(path);

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -60,10 +60,6 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -84,7 +84,6 @@ import org.apache.accumulo.shell.commands.CreateNamespaceCommand;
 import org.apache.accumulo.shell.commands.CreateTableCommand;
 import org.apache.accumulo.shell.commands.CreateUserCommand;
 import org.apache.accumulo.shell.commands.DUCommand;
-import org.apache.accumulo.shell.commands.DebugCommand;
 import org.apache.accumulo.shell.commands.DeleteAuthsCommand;
 import org.apache.accumulo.shell.commands.DeleteCommand;
 import org.apache.accumulo.shell.commands.DeleteIterCommand;
@@ -168,8 +167,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
@@ -186,8 +185,8 @@ import jline.console.history.FileHistory;
  */
 @AutoService(KeywordExecutable.class)
 public class Shell extends ShellOptions implements KeywordExecutable {
-  public static final Logger log = Logger.getLogger(Shell.class);
-  private static final Logger audit = Logger.getLogger(Shell.class.getName() + ".audit");
+  public static final Logger log = LoggerFactory.getLogger(Shell.class);
+  private static final Logger audit = LoggerFactory.getLogger(Shell.class.getName() + ".audit");
 
   public static final Charset CHARSET = ISO_8859_1;
   public static final int NO_FIXED_ARG_LENGTH_CHECK = -1;
@@ -258,8 +257,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
    *           if problems occur creating the ConsoleReader
    */
   public boolean config(String... args) throws IOException {
-    if (this.reader == null)
+    if (this.reader == null) {
       this.reader = new ConsoleReader();
+    }
     ShellOptionsJC options = new ShellOptionsJC();
     JCommander jc = new JCommander();
 
@@ -287,7 +287,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
       return false;
     }
 
-    setDebugging(options.isDebugEnabled());
+    if (options.isDebugEnabled()) {
+      log.warn("Configure debugging through your logging configuration file");
+    }
     authTimeout = TimeUnit.MINUTES.toNanos(options.getAuthTimeout());
     disableAuthTimeout = options.isAuthTimeoutDisabled();
 
@@ -368,9 +370,10 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     Command[] dataCommands = {new DeleteCommand(), new DeleteManyCommand(), new DeleteRowsCommand(),
         new EGrepCommand(), new FormatterCommand(), new InterpreterCommand(), new GrepCommand(),
         new ImportDirectoryCommand(), new InsertCommand(), new MaxRowCommand(), new ScanCommand()};
-    Command[] debuggingCommands = {new ClasspathCommand(), new DebugCommand(),
-        new ListScansCommand(), new ListCompactionsCommand(), new TraceCommand(), new PingCommand(),
-        new ListBulkCommand()};
+    @SuppressWarnings("deprecation")
+    Command[] debuggingCommands = {new ClasspathCommand(),
+        new org.apache.accumulo.shell.commands.DebugCommand(), new ListScansCommand(),
+        new ListCompactionsCommand(), new TraceCommand(), new PingCommand(), new ListBulkCommand()};
     Command[] execCommands =
         {new ExecfileCommand(), new HistoryCommand(), new ExtensionCommand(), new ScriptCommand()};
     Command[] exitCommands = {new ByeCommand(), new ExitCommand(), new QuitCommand()};
@@ -411,8 +414,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     commandGrouping.put("-- User Administration Commands ---------", userCommands);
 
     for (Command[] cmds : commandGrouping.values()) {
-      for (Command cmd : cmds)
+      for (Command cmd : cmds) {
         commandFactory.put(cmd.getName(), cmd);
+      }
     }
     for (Command cmd : otherCommands) {
       commandFactory.put(cmd.getName(), cmd);
@@ -523,17 +527,20 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
   public int start() throws IOException {
     String input;
-    if (isVerbose())
+    if (isVerbose()) {
       printInfo();
+    }
 
     String home = System.getProperty("HOME");
-    if (home == null)
+    if (home == null) {
       home = System.getenv("HOME");
+    }
     String configDir = home + "/" + HISTORY_DIR_NAME;
     String historyPath = configDir + "/" + HISTORY_FILE_NAME;
     File accumuloDir = new File(configDir);
-    if (!accumuloDir.exists() && !accumuloDir.mkdirs())
-      log.warn("Unable to make directory for history at " + accumuloDir);
+    if (!accumuloDir.exists() && !accumuloDir.mkdirs()) {
+      log.warn("Unable to make directory for history at {}", accumuloDir);
+    }
     try {
       final FileHistory history = new FileHistory(new File(historyPath));
       reader.setHistory(history);
@@ -546,7 +553,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         }
       }));
     } catch (IOException e) {
-      log.warn("Unable to load history file at " + historyPath);
+      log.warn("Unable to load history file at {}", historyPath);
     }
 
     // Turn Ctrl+C into Exception instead of JVM exit
@@ -569,13 +576,15 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
     while (true) {
       try {
-        if (hasExited())
+        if (hasExited()) {
           return exitCode;
+        }
 
         // If tab completion is true we need to reset
         if (tabCompletion) {
-          if (userCompletor != null)
+          if (userCompletor != null) {
             reader.removeCompleter(userCompletor);
+          }
 
           userCompletor = setupCompletion();
           reader.addCompleter(userCompletor);
@@ -625,14 +634,15 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   public void printVerboseInfo() throws IOException {
     StringBuilder sb = new StringBuilder("-\n");
     sb.append("- Current user: ").append(accumuloClient.whoami()).append("\n");
-    if (execFile != null)
+    if (execFile != null) {
       sb.append("- Executing commands from: ").append(execFile).append("\n");
-    if (disableAuthTimeout)
+    }
+    if (disableAuthTimeout) {
       sb.append("- Authorization timeout: disabled\n");
-    else
+    } else {
       sb.append("- Authorization timeout: ")
           .append(String.format("%ds%n", TimeUnit.NANOSECONDS.toSeconds(authTimeout)));
-    sb.append("- Debug: ").append(isDebuggingEnabled() ? "on" : "off").append("\n");
+    }
     if (!scanIteratorOptions.isEmpty()) {
       for (Entry<String,List<IteratorSetting>> entry : scanIteratorOptions.entrySet()) {
         sb.append("- Session scan iterators for table ").append(entry.getKey()).append(":\n");
@@ -670,7 +680,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
   public void execCommand(String input, boolean ignoreAuthTimeout, boolean echoPrompt)
       throws IOException {
-    audit.log(Level.INFO, sanitize(getDefaultPrompt() + input));
+    audit.info("{}", sanitize(getDefaultPrompt() + input));
     if (echoPrompt) {
       reader.print(getDefaultPrompt());
       reader.println(input);
@@ -688,8 +698,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
       ++exitCode;
       return;
     }
-    if (fields.length == 0)
+    if (fields.length == 0) {
       return;
+    }
 
     String command = fields[0];
     fields = fields.length > 1 ? Arrays.copyOfRange(fields, 1, fields.length) : new String[] {};
@@ -727,8 +738,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
               printException(e);
             }
 
-            if (authFailed)
+            if (authFailed) {
               reader.print("Invalid password. ");
+            }
           } while (authFailed);
           lastUserActivity = System.nanoTime();
         }
@@ -764,8 +776,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         printConstraintViolationException(e);
       } catch (TableNotFoundException e) {
         ++exitCode;
-        if (getTableName().equals(e.getTableName()))
+        if (getTableName().equals(e.getTableName())) {
           setTableName("");
+        }
         printException(e);
       } catch (ParseException e) {
         // not really an error if the exception is a missing required
@@ -824,17 +837,20 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     Map<Command.CompletionSet,Set<String>> options = new HashMap<>();
 
     Set<String> commands = new HashSet<>();
-    for (String a : commandFactory.keySet())
+    for (String a : commandFactory.keySet()) {
       commands.add(a);
+    }
 
     Set<String> modifiedUserlist = new HashSet<>();
     Set<String> modifiedTablenames = new HashSet<>();
     Set<String> modifiedNamespaces = new HashSet<>();
 
-    for (String a : tableNames)
+    for (String a : tableNames) {
       modifiedTablenames.add(a.replaceAll("([\\s'\"])", "\\\\$1"));
-    for (String a : userlist)
+    }
+    for (String a : userlist) {
       modifiedUserlist.add(a.replaceAll("([\\s'\"])", "\\\\$1"));
+    }
     for (String a : namespaces) {
       String b = a.replaceAll("([\\s'\"])", "\\\\$1");
       modifiedNamespaces.add(b.isEmpty() ? "\"\"" : b);
@@ -1019,8 +1035,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     String peek = null;
     while (lines.hasNext()) {
       String nextLine = lines.next();
-      if (nextLine == null)
+      if (nextLine == null) {
         continue;
+      }
       for (String line : nextLine.split("\\n")) {
         if (out == null) {
           if (peek != null) {
@@ -1074,16 +1091,18 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
   public static String repeat(String s, int c) {
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < c; i++)
+    for (int i = 0; i < c; i++) {
       sb.append(s);
+    }
     return sb.toString();
   }
 
   public void checkTableState() {
-    if (getTableName().isEmpty())
+    if (getTableName().isEmpty()) {
       throw new IllegalStateException("Not in a table context. Please use"
           + " 'table <tableName>' to switch to a table, or use '-t' to specify a"
           + " table if option is available.");
+    }
   }
 
   private final void printConstraintViolationException(ConstraintViolationException cve) {
@@ -1097,9 +1116,10 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         "Constraint class", "Violation code", "Violation Description"));
     logError(String.format("%" + COL1 + "s-+-%" + COL2 + "s-+-%" + col3 + "s%n", repeat("-", COL1),
         repeat("-", COL2), repeat("-", col3)));
-    for (TConstraintViolationSummary cvs : cve.violationSummaries)
+    for (TConstraintViolationSummary cvs : cve.violationSummaries) {
       logError(String.format("%-" + COL1 + "s | %" + COL2 + "d | %-" + col3 + "s%n",
           cvs.constrainClass, cvs.violationCode, cvs.violationDescription));
+    }
     logError(String.format("%" + COL1 + "s-+-%" + COL2 + "s-+-%" + col3 + "s%n", repeat("-", COL1),
         repeat("-", COL2), repeat("-", col3)));
   }
@@ -1110,18 +1130,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
   private final void printException(Exception e, String msg) {
     logError(e.getClass().getName() + (msg != null ? ": " + msg : ""));
-    log.debug(e.getClass().getName() + (msg != null ? ": " + msg : ""), e);
-  }
-
-  public static final void setDebugging(boolean debuggingEnabled) {
-    Logger.getLogger(Constants.CORE_PACKAGE_NAME)
-        .setLevel(debuggingEnabled ? Level.TRACE : Level.INFO);
-    Logger.getLogger(Shell.class.getPackage().getName())
-        .setLevel(debuggingEnabled ? Level.TRACE : Level.INFO);
-  }
-
-  public static final boolean isDebuggingEnabled() {
-    return Logger.getLogger(Constants.CORE_PACKAGE_NAME).isTraceEnabled();
+    log.debug("{}{}", e.getClass().getName(), msg != null ? ": " + msg : "", e);
   }
 
   private final void printHelp(String usage, String description, Options opts) throws IOException {
@@ -1213,7 +1222,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   }
 
   private void logError(String s) {
-    log.error(s);
+    log.error("{}", s);
     if (logErrorsToConsole) {
       try {
         reader.println("ERROR: " + s);

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
@@ -131,7 +131,8 @@ public class ShellOptionsJC {
       description = "disables tab completion (for less overhead when scripting)")
   private boolean tabCompletionDisabled;
 
-  @Parameter(names = "--debug", description = "enables client debugging")
+  @Parameter(names = "--debug", description = "enables client debugging"
+      + "; deprecated, configure debugging through your logging configuration file")
   private boolean debugEnabled;
 
   @Parameter(names = {"-?", "--help"}, help = true, description = "display this help")

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/AddAuthsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/AddAuthsCommand.java
@@ -51,7 +51,7 @@ public class AddAuthsCommand extends Command {
     userAuths.append(scanOpts);
     shellState.getAccumuloClient().securityOperations().changeUserAuthorizations(user,
         ScanCommand.parseAuthorizations(userAuths.toString()));
-    Shell.log.debug("Changed record-level authorizations for user " + user);
+    Shell.log.debug("Changed record-level authorizations for user {}", user);
     return 0;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CompactCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CompactCommand.java
@@ -64,7 +64,7 @@ public class CompactCommand extends TableOperation {
     if (cancel) {
       try {
         shellState.getAccumuloClient().tableOperations().cancelCompaction(tableName);
-        Shell.log.info("Compaction canceled for table " + tableName);
+        Shell.log.info("Compaction canceled for table {}", tableName);
       } catch (TableNotFoundException e) {
         throw new AccumuloException(e);
       }
@@ -81,8 +81,8 @@ public class CompactCommand extends TableOperation {
 
         shellState.getAccumuloClient().tableOperations().compact(tableName, compactionConfig);
 
-        Shell.log.info("Compaction of table " + tableName + " "
-            + (compactionConfig.getWait() ? "completed" : "started") + " for given range");
+        Shell.log.info("Compaction of table {} {} for given range", tableName,
+            compactionConfig.getWait() ? "completed" : "started");
       } catch (Exception ex) {
         throw new AccumuloException(ex);
       }
@@ -140,7 +140,7 @@ public class CompactCommand extends TableOperation {
       List<IteratorSetting> iterators =
           shellState.iteratorProfiles.get(cl.getOptionValue(profileOpt.getOpt()));
       if (iterators == null) {
-        Shell.log.error("Profile " + cl.getOptionValue(profileOpt.getOpt()) + " does not exist");
+        Shell.log.error("Profile {} does not exist", cl.getOptionValue(profileOpt.getOpt()));
         return -1;
       }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -89,27 +89,26 @@ public class ConfigCommand extends Command {
         throw new BadArgumentException("Invalid '=' operator in delete operation.", fullCommand,
             fullCommand.indexOf('='));
       }
+      String invalidTablePropFormatString =
+          "Invalid per-table property : {}, still removing from zookeeper if it's there.";
       if (tableName != null) {
         if (!Property.isValidTablePropertyKey(property)) {
-          Shell.log.warn("Invalid per-table property : " + property
-              + ", still removing from zookeeper if it's there.");
+          Shell.log.warn(invalidTablePropFormatString, property);
         }
         shellState.getAccumuloClient().tableOperations().removeProperty(tableName, property);
         Shell.log.debug("Successfully deleted table configuration option.");
       } else if (namespace != null) {
         if (!Property.isValidTablePropertyKey(property)) {
-          Shell.log.warn("Invalid per-table property : " + property
-              + ", still removing from zookeeper if it's there.");
+          Shell.log.warn(invalidTablePropFormatString, property);
         }
         shellState.getAccumuloClient().namespaceOperations().removeProperty(namespace, property);
         Shell.log.debug("Successfully deleted namespace configuration option.");
       } else {
         if (!Property.isValidZooPropertyKey(property)) {
-          Shell.log.warn("Invalid per-table property : " + property
-              + ", still removing from zookeeper if it's there.");
+          Shell.log.warn(invalidTablePropFormatString, property);
         }
         shellState.getAccumuloClient().instanceOperations().removeProperty(property);
-        Shell.log.debug("Successfully deleted system configuration option");
+        Shell.log.debug("Successfully deleted system configuration option.");
       }
     } else if (cl.hasOption(setOpt.getOpt())) {
       // set property on table
@@ -149,7 +148,7 @@ public class ConfigCommand extends Command {
               fullCommand.indexOf(property));
         }
         shellState.getAccumuloClient().instanceOperations().setProperty(property, value);
-        Shell.log.debug("Successfully set system configuration option");
+        Shell.log.debug("Successfully set system configuration option.");
       }
     } else {
       // display properties

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -160,8 +160,8 @@ public class CreateTableCommand extends Command {
         shellState.getAccumuloClient().tableOperations().addConstraint(tableName,
             VisibilityConstraint.class.getName());
       } catch (AccumuloException e) {
-        Shell.log
-            .warn(e.getMessage() + " while setting visibility constraint, but table was created");
+        Shell.log.warn("{} while setting visibility constraint, but table was created",
+            e.getMessage(), e);
       }
     }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateUserCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateUserCommand.java
@@ -63,7 +63,7 @@ public class CreateUserCommand extends Command {
     }
 
     shellState.getAccumuloClient().securityOperations().createLocalUser(user, passwordToken);
-    Shell.log.debug("Created user " + user);
+    Shell.log.debug("Created user {}", user);
     return 0;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DebugCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DebugCommand.java
@@ -16,57 +16,31 @@
  */
 package org.apache.accumulo.shell.commands;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
-import org.apache.accumulo.shell.Token;
 import org.apache.commons.cli.CommandLine;
 
+/**
+ * @deprecated since 2.0; this command shouldn't be used; users should configure debug logging with
+ *             their log configuration file instead
+ */
+@Deprecated
 public class DebugCommand extends Command {
   @Override
-  public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
-      throws IOException {
-    if (cl.getArgs().length == 1) {
-      if (cl.getArgs()[0].equalsIgnoreCase("on")) {
-        Shell.setDebugging(true);
-      } else if (cl.getArgs()[0].equalsIgnoreCase("off")) {
-        Shell.setDebugging(false);
-      } else {
-        throw new BadArgumentException("Argument must be 'on' or 'off'", fullCommand,
-            fullCommand.indexOf(cl.getArgs()[0]));
-      }
-    } else if (cl.getArgs().length == 0) {
-      shellState.getReader().println(Shell.isDebuggingEnabled() ? "on" : "off");
-    } else {
-      shellState.printException(new IllegalArgumentException(
-          "Expected 0 or 1 argument. There were " + cl.getArgs().length + "."));
-      printHelp(shellState);
-      return 1;
-    }
-    return 0;
+  public int execute(final String fullCommand, final CommandLine cl, final Shell shellState) {
+    shellState.printException(new IllegalArgumentException("The debug command is deprecated; "
+        + "configure debug logging through your log configuration file instead."));
+    return 1;
   }
 
   @Override
   public String description() {
-    return "turns debug logging on or off";
-  }
-
-  @Override
-  public void registerCompletion(final Token root,
-      final Map<Command.CompletionSet,Set<String>> special) {
-    final Token debug_command = new Token(getName());
-    debug_command.addSubcommand(Arrays.asList("on", "off"));
-    root.addSubcommand(debug_command);
+    return "Deprecated since 2.0";
   }
 
   @Override
   public String usage() {
-    return getName() + " [ on | off ]";
+    return getName() + " [ on | off ] # this is now deprecated and does nothing";
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteAuthsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteAuthsCommand.java
@@ -65,7 +65,7 @@ public class DeleteAuthsCommand extends Command {
       accumuloClient.securityOperations().changeUserAuthorizations(user, new Authorizations());
     }
 
-    Shell.log.debug("Changed record-level authorizations for user " + user);
+    Shell.log.debug("Changed record-level authorizations for user {}", user);
     return 0;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteScanIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteScanIterCommand.java
@@ -33,17 +33,17 @@ public class DeleteScanIterCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws Exception {
-    Shell.log.warn("Deprecated, use " + new DeleteShellIterCommand().getName());
+    Shell.log.warn("Deprecated, use {}", new DeleteShellIterCommand().getName());
     final String tableName = OptUtil.getTableOpt(cl, shellState);
 
     if (cl.hasOption(allOpt.getOpt())) {
       final List<IteratorSetting> tableScanIterators =
           shellState.scanIteratorOptions.remove(tableName);
       if (tableScanIterators == null) {
-        Shell.log.info("No scan iterators set on table " + tableName);
+        Shell.log.info("No scan iterators set on table {}", tableName);
       } else {
-        Shell.log.info("Removed the following scan iterators from table " + tableName + ":"
-            + tableScanIterators);
+        Shell.log.info("Removed the following scan iterators from table {}:{}", tableName,
+            tableScanIterators);
       }
     } else if (cl.hasOption(nameOpt.getOpt())) {
       final String name = cl.getOptionValue(nameOpt.getOpt());
@@ -59,16 +59,16 @@ public class DeleteScanIterCommand extends Command {
           }
         }
         if (!found) {
-          Shell.log.info("No iterator named " + name + " found for table " + tableName);
+          Shell.log.info("No iterator named {} found for table {}", name, tableName);
         } else {
-          Shell.log.info("Removed scan iterator " + name + " from table " + tableName + " ("
-              + shellState.scanIteratorOptions.get(tableName).size() + " left)");
+          Shell.log.info("Removed scan iterator {} from table {} ({} left)", name, tableName,
+              shellState.scanIteratorOptions.get(tableName).size());
           if (shellState.scanIteratorOptions.get(tableName).size() == 0) {
             shellState.scanIteratorOptions.remove(tableName);
           }
         }
       } else {
-        Shell.log.info("No iterator named " + name + " found for table " + tableName);
+        Shell.log.info("No iterator named {} found for table {}", name, tableName);
       }
     }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteShellIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteShellIterCommand.java
@@ -38,7 +38,7 @@ public class DeleteShellIterCommand extends Command {
     if (shellState.iteratorProfiles.containsKey(profile)) {
       if (cl.hasOption(allOpt.getOpt())) {
         shellState.iteratorProfiles.remove(profile);
-        Shell.log.info("Removed profile " + profile);
+        Shell.log.info("Removed profile {}", profile);
       } else {
         List<IteratorSetting> iterSettings = shellState.iteratorProfiles.get(profile);
         String name = cl.getOptionValue(nameOpt.getOpt());
@@ -51,15 +51,15 @@ public class DeleteShellIterCommand extends Command {
           }
         }
         if (!found) {
-          Shell.log.info("No iterator named " + name + " found");
+          Shell.log.info("No iterator named {} found", name);
         } else {
-          Shell.log.info("Removed iterator " + name + " from profile " + profile + " ("
-              + iterSettings.size() + " left)");
+          Shell.log.info("Removed iterator {} from profile {} ( left)", name, profile,
+              iterSettings.size());
         }
       }
 
     } else {
-      Shell.log.info("No profile named " + profile);
+      Shell.log.info("No profile named {}", profile);
     }
 
     return 0;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DropUserCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DropUserCommand.java
@@ -57,7 +57,7 @@ public class DropUserCommand extends Command {
       }
       if (operate) {
         shellState.getAccumuloClient().securityOperations().dropLocalUser(user);
-        Shell.log.debug("Deleted user " + user);
+        Shell.log.debug("Deleted user {}", user);
       }
     } catch (IOException e) {
       throw new AccumuloException(e);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FlushCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FlushCommand.java
@@ -41,7 +41,7 @@ public class FlushCommand extends TableOperation {
   protected void doTableOp(final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     shellState.getAccumuloClient().tableOperations().flush(tableName, startRow, endRow, wait);
-    Shell.log.info("Flush of table " + tableName + (wait ? " completed." : " initiated..."));
+    Shell.log.info("Flush of table {} {}", tableName, wait ? " completed." : " initiated...");
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrantCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrantCommand.java
@@ -52,7 +52,7 @@ public class GrantCommand extends TableOperation {
       try {
         shellState.getAccumuloClient().securityOperations().grantSystemPermission(user,
             SystemPermission.valueOf(permission[1]));
-        Shell.log.debug("Granted " + user + " the " + permission[1] + " permission");
+        Shell.log.debug("Granted {} the {} permission", user, permission[1]);
       } catch (IllegalArgumentException e) {
         throw new BadArgumentException("No such system permission", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
@@ -84,8 +84,7 @@ public class GrantCommand extends TableOperation {
     try {
       shellState.getAccumuloClient().securityOperations().grantTablePermission(user, tableName,
           TablePermission.valueOf(permission[1]));
-      Shell.log
-          .debug("Granted " + user + " the " + permission[1] + " permission on table " + tableName);
+      Shell.log.debug("Granted {} the {} permission on table {}", user, permission[1], tableName);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("No such table permission", e);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
@@ -70,7 +70,7 @@ public class InsertCommand extends Command {
 
     if (cl.hasOption(insertOptAuths.getOpt())) {
       final ColumnVisibility le = new ColumnVisibility(cl.getOptionValue(insertOptAuths.getOpt()));
-      Shell.log.debug("Authorization label will be set to: " + le);
+      Shell.log.debug("Authorization label will be set to: {}", le);
 
       if (cl.hasOption(timestampOpt.getOpt()))
         m.put(colf, colq, le, Long.parseLong(cl.getOptionValue(timestampOpt.getOpt())), val);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OfflineCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OfflineCommand.java
@@ -39,10 +39,10 @@ public class OfflineCommand extends TableOperation {
   protected void doTableOp(final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     if (tableName.equals(MetadataTable.NAME)) {
-      Shell.log.info("  You cannot take the " + MetadataTable.NAME + " offline.");
+      Shell.log.info("  You cannot take the {} offline.", MetadataTable.NAME);
     } else {
       shellState.getAccumuloClient().tableOperations().offline(tableName, wait);
-      Shell.log.info("Offline of table " + tableName + (wait ? " completed." : " initiated..."));
+      Shell.log.info("Offline of table {} {}", tableName, wait ? " completed." : " initiated...");
     }
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OnlineCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OnlineCommand.java
@@ -39,10 +39,10 @@ public class OnlineCommand extends TableOperation {
   protected void doTableOp(final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     if (tableName.equals(RootTable.NAME)) {
-      Shell.log.info("  The " + RootTable.NAME + " is always online.");
+      Shell.log.info("  The {} is always online.", RootTable.NAME);
     } else {
       shellState.getAccumuloClient().tableOperations().online(tableName, wait);
-      Shell.log.info("Online of table " + tableName + (wait ? " completed." : " initiated..."));
+      Shell.log.info("Online of table {} {}", tableName, wait ? " completed." : " initiated...");
     }
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/PasswdCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/PasswdCommand.java
@@ -78,7 +78,7 @@ public class PasswdCommand extends Command {
     if (shellState.getAccumuloClient().whoami().equals(user)) {
       shellState.updateUser(user, new PasswordToken(pass));
     }
-    Shell.log.debug("Changed password for user " + user);
+    Shell.log.debug("Changed password for user {}", user);
     return 0;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/RevokeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/RevokeCommand.java
@@ -52,7 +52,7 @@ public class RevokeCommand extends TableOperation {
       try {
         shellState.getAccumuloClient().securityOperations().revokeSystemPermission(user,
             SystemPermission.valueOf(permission[1]));
-        Shell.log.debug("Revoked from " + user + " the " + permission[1] + " permission");
+        Shell.log.debug("Revoked from {} the {} permission", user, permission[1]);
       } catch (IllegalArgumentException e) {
         throw new BadArgumentException("No such system permission", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
@@ -84,8 +84,8 @@ public class RevokeCommand extends TableOperation {
     try {
       shellState.getAccumuloClient().securityOperations().revokeTablePermission(user, tableName,
           TablePermission.valueOf(permission[1]));
-      Shell.log.debug(
-          "Revoked from " + user + " the " + permission[1] + " permission on table " + tableName);
+      Shell.log.debug("Revoked from {} the {} permission on table {}", user, permission[1],
+          tableName);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("No such table permission", e);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -79,7 +79,7 @@ public class ScanCommand extends Command {
         throw new SampleNotPresentException(
             "Table " + tableName + " does not have sampling configured");
       }
-      Shell.log.debug("Using sampling configuration : " + samplerConfig);
+      Shell.log.debug("Using sampling configuration : {}", samplerConfig);
       scanner.setSamplerConfiguration(samplerConfig);
     }
   }
@@ -187,14 +187,14 @@ public class ScanCommand extends Command {
       }
     }
 
-    Shell.log.debug("Found " + tableScanIterators.size() + " scan iterators to set");
+    Shell.log.debug("Found {} scan iterators to set", tableScanIterators.size());
 
     for (IteratorSetting setting : tableScanIterators) {
-      Shell.log.debug("Setting scan iterator " + setting.getName() + " at priority "
-          + setting.getPriority() + " using class name " + setting.getIteratorClass());
+      Shell.log.debug("Setting scan iterator {} at priority {} using class name {}",
+          setting.getName(), setting.getPriority(), setting.getIteratorClass());
       for (Entry<String,String> option : setting.getOptions().entrySet()) {
-        Shell.log.debug("Setting option for " + setting.getName() + ": " + option.getKey() + "="
-            + option.getValue());
+        Shell.log.debug("Setting option for {}: {}={}", setting.getName(), option.getKey(),
+            option.getValue());
       }
       scanner.addScanIterator(setting);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetAuthsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetAuthsCommand.java
@@ -44,7 +44,7 @@ public class SetAuthsCommand extends Command {
         cl.hasOption(clearOptAuths.getOpt()) ? null : cl.getOptionValue(scanOptAuths.getOpt());
     shellState.getAccumuloClient().securityOperations().changeUserAuthorizations(user,
         ScanCommand.parseAuthorizations(scanOpts));
-    Shell.log.debug("Changed record-level authorizations for user " + user);
+    Shell.log.debug("Changed record-level authorizations for user {}", user);
     return 0;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetScanIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetScanIterCommand.java
@@ -42,7 +42,7 @@ public class SetScanIterCommand extends SetIterCommand {
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException,
       ShellCommandException {
-    Shell.log.warn("Deprecated, use " + new SetShellIterCommand().getName());
+    Shell.log.warn("Deprecated, use {}", new SetShellIterCommand().getName());
     return super.execute(fullCommand, cl, shellState);
   }
 
@@ -78,7 +78,7 @@ public class SetScanIterCommand extends SetIterCommand {
 
     // if no exception has been thrown, it's safe to add it to the list
     tableScanIterators.add(setting);
-    Shell.log.debug("Scan iterators :" + shellState.scanIteratorOptions.get(tableName));
+    Shell.log.debug("Scan iterators :{}", shellState.scanIteratorOptions.get(tableName));
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/TraceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/TraceCommand.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.accumulo.shell.Shell;
+import org.apache.accumulo.shell.Shell.Command;
 import org.apache.accumulo.tracer.TraceDump;
 import org.apache.commons.cli.CommandLine;
 import org.apache.hadoop.io.Text;
@@ -35,7 +36,7 @@ import org.apache.htrace.Sampler;
 import org.apache.htrace.Trace;
 import org.apache.htrace.TraceScope;
 
-public class TraceCommand extends DebugCommand {
+public class TraceCommand extends Command {
 
   private TraceScope traceScope = null;
 
@@ -92,9 +93,10 @@ public class TraceCommand extends DebugCommand {
         } else {
           shellState.getReader().println("Not tracing");
         }
-      } else
+      } else {
         throw new BadArgumentException("Argument must be 'on' or 'off'", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
+      }
     } else if (cl.getArgs().length == 0) {
       shellState.getReader().println(Trace.isTracing() ? "on" : "off");
     } else {
@@ -108,6 +110,17 @@ public class TraceCommand extends DebugCommand {
 
   @Override
   public String description() {
-    return "turns trace logging on or off";
+    return "turns tracing on or off";
   }
+
+  @Override
+  public String usage() {
+    return getName() + " [ on | off ]";
+  }
+
+  @Override
+  public int numArgs() {
+    return Shell.NO_FIXED_ARG_LENGTH_CHECK;
+  }
+
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/format/DeleterFormatter.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/format/DeleterFormatter.java
@@ -56,8 +56,10 @@ public class DeleterFormatter extends DefaultFormatter {
         writer.close();
       } catch (MutationsRejectedException e) {
         log.error(e.toString());
-        for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
-          log.trace(cvs.toString());
+        if (Shell.log.isTraceEnabled()) {
+          for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
+            log.trace(cvs.toString());
+          }
         }
       }
       return false;
@@ -89,8 +91,10 @@ public class DeleterFormatter extends DefaultFormatter {
           writer.addMutation(m);
         } catch (MutationsRejectedException e) {
           log.error(e.toString());
-          for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
-            log.trace(cvs.toString());
+          if (Shell.log.isTraceEnabled()) {
+            for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
+              log.trace(cvs.toString());
+            }
           }
         }
       }

--- a/shell/src/main/java/org/apache/accumulo/shell/format/DeleterFormatter.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/format/DeleterFormatter.java
@@ -56,9 +56,9 @@ public class DeleterFormatter extends DefaultFormatter {
         writer.close();
       } catch (MutationsRejectedException e) {
         log.error(e.toString());
-        if (Shell.isDebuggingEnabled())
-          for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries())
-            log.trace(cvs.toString());
+        for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
+          log.trace(cvs.toString());
+        }
       }
       return false;
     }
@@ -89,9 +89,9 @@ public class DeleterFormatter extends DefaultFormatter {
           writer.addMutation(m);
         } catch (MutationsRejectedException e) {
           log.error(e.toString());
-          if (Shell.isDebuggingEnabled())
-            for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries())
-              log.trace(cvs.toString());
+          for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
+            log.trace(cvs.toString());
+          }
         }
       }
       shellState.getReader()

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellConfigTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellConfigTest.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,8 +62,6 @@ public class ShellConfigTest {
 
   @Before
   public void setUp() throws Exception {
-    Shell.log.setLevel(Level.ERROR);
-
     out = System.out;
     output = new TestOutputStream();
     System.setOut(new PrintStream(output));

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
     </dependency>

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
@@ -29,8 +29,6 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.impl.VFSClassLoader;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -46,8 +44,6 @@ public class AccumuloReloadingVFSClassLoaderTest {
 
   @Before
   public void setup() throws Exception {
-    Logger.getRootLogger().setLevel(Level.ERROR);
-
     vfs = ContextManagerTest.getVFS();
 
     folder1.create();
@@ -60,10 +56,11 @@ public class AccumuloReloadingVFSClassLoaderTest {
   FileObject[] createFileSystems(FileObject[] fos) throws FileSystemException {
     FileObject[] rfos = new FileObject[fos.length];
     for (int i = 0; i < fos.length; i++) {
-      if (vfs.canCreateFileSystem(fos[i]))
+      if (vfs.canCreateFileSystem(fos[i])) {
         rfos[i] = vfs.createFileSystem(fos[i]);
-      else
+      } else {
         rfos[i] = fos[i];
+      }
     }
 
     return rfos;

--- a/test/src/main/java/org/apache/accumulo/test/BatchWriterInTabletServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BatchWriterInTabletServerIT.java
@@ -36,8 +36,9 @@ import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterators;
 
@@ -47,7 +48,7 @@ import com.google.common.collect.Iterators;
  * @see BatchWriterIterator
  */
 public class BatchWriterInTabletServerIT extends AccumuloClusterHarness {
-  private static final Logger log = Logger.getLogger(BatchWriterInTabletServerIT.class);
+  private static final Logger log = LoggerFactory.getLogger(BatchWriterInTabletServerIT.class);
 
   @Override
   public boolean canRunTest(ClusterType type) {
@@ -122,7 +123,7 @@ public class BatchWriterInTabletServerIT extends AccumuloClusterHarness {
     try (Scanner scanner = c.createScanner(t2, Authorizations.EMPTY)) {
       // ensure entries correctly wrote to table t2
       actual = Iterators.getOnlyElement(scanner.iterator());
-      log.debug("t2 entry is " + actual.getKey().toStringNoTime() + " -> " + actual.getValue());
+      log.debug("t2 entry is {} -> {}", actual.getKey().toStringNoTime(), actual.getValue());
       assertTrue(actual.getKey().equals(k, PartialKey.ROW_COLFAM_COLQUAL));
       assertEquals(numEntriesToWritePerEntry, Integer.parseInt(actual.getValue().toString()));
     }

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.accumulo.test.categories.SunnyDayTests;
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -90,10 +89,11 @@ public class ShellIT extends SharedMiniClusterBase {
 
     @Override
     public int read() {
-      if (offset == source.length())
+      if (offset == source.length()) {
         return '\n';
-      else
+      } else {
         return source.charAt(offset++);
+      }
     }
 
     public void set(String other) {
@@ -129,10 +129,11 @@ public class ShellIT extends SharedMiniClusterBase {
 
   void exec(String cmd, boolean expectGoodExit) throws IOException {
     exec(cmd);
-    if (expectGoodExit)
+    if (expectGoodExit) {
       assertGoodExit("", true);
-    else
+    } else {
       assertBadExit("", true);
+    }
   }
 
   void exec(String cmd, boolean expectGoodExit, String expectString) throws IOException {
@@ -142,16 +143,16 @@ public class ShellIT extends SharedMiniClusterBase {
   void exec(String cmd, boolean expectGoodExit, String expectString, boolean stringPresent)
       throws IOException {
     exec(cmd);
-    if (expectGoodExit)
+    if (expectGoodExit) {
       assertGoodExit(expectString, stringPresent);
-    else
+    } else {
       assertBadExit(expectString, stringPresent);
+    }
   }
 
   @Before
   public void setupShell() throws IOException {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    Shell.log.setLevel(Level.OFF);
     output = new TestOutputStream();
     input = new StringInputStream();
     config = Files.createTempFile(null, null).toFile();
@@ -172,19 +173,21 @@ public class ShellIT extends SharedMiniClusterBase {
   }
 
   void assertGoodExit(String s, boolean stringPresent) {
-    Shell.log.debug(output.get());
+    Shell.log.debug("{}", output.get());
     assertEquals(shell.getExitCode(), 0);
-    if (s.length() > 0)
+    if (s.length() > 0) {
       assertEquals(s + " present in " + output.get() + " was not " + stringPresent, stringPresent,
           output.get().contains(s));
+    }
   }
 
   void assertBadExit(String s, boolean stringPresent) {
-    Shell.log.debug(output.get());
+    Shell.log.debug("{}", output.get());
     assertTrue(shell.getExitCode() > 0);
-    if (s.length() > 0)
+    if (s.length() > 0) {
       assertEquals(s + " present in " + output.get() + " was not " + stringPresent, stringPresent,
           output.get().contains(s));
+    }
     shell.resetExitCode();
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -501,15 +501,20 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("deletetable -f " + table);
   }
 
+  /*
+   * This test should be deleted when the debug command is removed
+   */
+  @Deprecated
   @Test
   public void debug() throws Exception {
-    ts.exec("debug", true, "off", true);
-    ts.exec("debug on", true);
-    ts.exec("debug", true, "on", true);
-    ts.exec("debug off", true);
-    ts.exec("debug", true, "off", true);
-    ts.exec("debug debug", false);
-    ts.exec("debug debug debug", false);
+    String expectMsg = "The debug command is deprecated";
+    ts.exec("debug", false, expectMsg);
+    ts.exec("debug on", false, expectMsg);
+    ts.exec("debug", false, expectMsg);
+    ts.exec("debug off", false, expectMsg);
+    ts.exec("debug", false, expectMsg);
+    ts.exec("debug debug", false, expectMsg);
+    ts.exec("debug debug debug", false, expectMsg);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.clientImpl.TabletServerBatchWriter;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
@@ -53,8 +52,6 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 
 import com.beust.jcommander.Parameter;
 
@@ -171,8 +168,9 @@ public class TestIngest {
       TreeSet<Text> splits =
           getSplitPoints(params.startRow, params.startRow + params.rows, params.numsplits);
 
-      if (!client.tableOperations().exists(params.tableName))
+      if (!client.tableOperations().exists(params.tableName)) {
         client.tableOperations().create(params.tableName);
+      }
       try {
         client.tableOperations().addSplits(params.tableName, splits);
       } catch (TableNotFoundException ex) {
@@ -204,8 +202,9 @@ public class TestIngest {
 
     for (int i = 0; i < 10; i++) {
       bytevals[i] = new byte[dataSize];
-      for (int j = 0; j < dataSize; j++)
+      for (int j = 0; j < dataSize; j++) {
         bytevals[i][j] = letters[i];
+      }
     }
     return bytevals;
   }
@@ -235,9 +234,6 @@ public class TestIngest {
 
     Opts opts = new Opts();
     opts.parseArgs(TestIngest.class.getSimpleName(), args);
-
-    if (opts.debug)
-      Logger.getLogger(TabletServerBatchWriter.class.getName()).setLevel(Level.TRACE);
 
     try (AccumuloClient client = Accumulo.newClient().from(opts.getClientProps()).build()) {
       ingest(client, opts.getIngestPrams());
@@ -329,10 +325,11 @@ public class TestIngest {
           bytesWritten += key.getSize();
 
           if (params.delete) {
-            if (params.timestamp >= 0)
+            if (params.timestamp >= 0) {
               m.putDelete(colf, colq, params.columnVisibility, params.timestamp);
-            else
+            } else {
               m.putDelete(colf, colq, params.columnVisibility);
+            }
           } else {
             byte[] value;
             if (params.random != null) {
@@ -353,8 +350,9 @@ public class TestIngest {
         }
 
       }
-      if (bw != null)
+      if (bw != null) {
         bw.addMutation(m);
+      }
     }
 
     if (writer != null) {

--- a/test/src/main/java/org/apache/accumulo/test/performance/ContinuousOpts.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/ContinuousOpts.java
@@ -16,15 +16,6 @@
  */
 package org.apache.accumulo.test.performance;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-
-import org.apache.accumulo.core.Constants;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 
@@ -32,22 +23,6 @@ import com.beust.jcommander.Parameter;
  * Common CLI arguments for the Continuous Ingest suite.
  */
 public class ContinuousOpts {
-
-  public static class DebugConverter implements IStringConverter<String> {
-    @Override
-    public String convert(String debugLog) {
-      Logger logger = Logger.getLogger(Constants.CORE_PACKAGE_NAME);
-      logger.setLevel(Level.TRACE);
-      logger.setAdditivity(false);
-      try {
-        logger.addAppender(new FileAppender(
-            new PatternLayout("%d{dd HH:mm:ss,SSS} [%-8c{2}] %-5p: %m%n"), debugLog, true));
-      } catch (IOException ex) {
-        throw new UncheckedIOException(ex);
-      }
-      return debugLog;
-    }
-  }
 
   public static class ShortConverter implements IStringConverter<Short> {
     @Override
@@ -61,10 +36,6 @@ public class ContinuousOpts {
 
   @Parameter(names = "--max", description = "maximum random row number to use")
   long max = Long.MAX_VALUE;
-
-  @Parameter(names = "--debugLog", description = "file to write debugging output",
-      converter = DebugConverter.class)
-  String debugLog = null;
 
   @Parameter(names = "--num", description = "the number of entries to ingest")
   long num = Long.MAX_VALUE;

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
@@ -19,19 +19,12 @@ package org.apache.accumulo.test.rpc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.test.categories.SunnyDayTests;
 import org.apache.accumulo.test.rpc.thrift.SimpleThriftService;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.thrift.ProcessFunction;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-import org.apache.thrift.server.TSimpleServer;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
 import org.junit.Before;
@@ -58,23 +51,11 @@ public class ThriftBehaviorIT {
   private SimpleThriftServiceHandler handler;
   private SimpleThriftServiceRunner serviceRunner;
   private String propName;
-  private Map<Logger,Level> oldLogLevels = new HashMap<>();
 
   private static final String KITTY_MSG = "🐈 Kitty! 🐈";
 
-  private static final boolean SUPPRESS_SPAMMY_LOGGERS = true;
-
   @Before
   public void createClientAndServer() {
-    Arrays.stream(new Class<?>[] {TSimpleServer.class, ProcessFunction.class})
-        .forEach(spammyClass -> {
-          Logger spammyLogger = Logger.getLogger(spammyClass);
-          oldLogLevels.put(spammyLogger, spammyLogger.getLevel());
-          if (SUPPRESS_SPAMMY_LOGGERS) {
-            spammyLogger.setLevel(Level.OFF);
-          }
-        });
-
     String threadName = ThriftBehaviorIT.class.getSimpleName() + "." + testName.getMethodName();
     serviceRunner = new SimpleThriftServiceRunner(threadName);
     serviceRunner.startService();
@@ -95,10 +76,6 @@ public class ThriftBehaviorIT {
   @After
   public void shutdownServer() {
     serviceRunner.stopService();
-
-    oldLogLevels.forEach((spammyLogger, oldLevel) -> {
-      spammyLogger.setLevel(oldLevel);
-    });
 
     // make sure the method was actually executed by the service handler
     assertEquals(KITTY_MSG, System.getProperty(propName));


### PR DESCRIPTION
* Use more slf4j when possible
* Update default console logger in log4j.properties to use STDERR
* Eliminate custom log level manipulation in code (Fixes #1109)
* Remove/deprecate dynamic logging manipulation in the shell

NOTE: some uses could not be removed:

* We provide a Log4J appender in server/base for sending logs to the monitor
* The monitor REST service displays logs, and must filter by log Level
* A test captures log output to a String with a custom appender for evaluation
* Log Level manipulation is exposed in the public API for the old MapReduce code in core (which is all deprecated)

These uses can be upgraded to Log4J2 later, without impacting users (or dropped, in the case of the deprecated MapReduce code).