### PR TITLE
Fix #1084 partial - IT tests failing on Standalone

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -142,14 +142,19 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
         standaloneCluster.setAccumuloHome(conf.getAccumuloHome());
         standaloneCluster.setClientAccumuloConfDir(conf.getClientAccumuloConfDir());
         standaloneCluster.setHadoopConfDir(conf.getHadoopConfDir());
-        standaloneCluster.setServerCmdPrefix(conf.getServerCmdPrefix());
-        standaloneCluster.setClientCmdPrefix(conf.getClientCmdPrefix());
+        // If these were not provided then ensure they are not null
+        standaloneCluster
+            .setServerCmdPrefix(conf.getServerCmdPrefix() == null ? "" : conf.getServerCmdPrefix());
+        standaloneCluster
+            .setClientCmdPrefix(conf.getClientCmdPrefix() == null ? "" : conf.getClientCmdPrefix());
         cluster = standaloneCluster;
 
         // For SASL, we need to get the Hadoop configuration files as well otherwise UGI will log in
         // as SIMPLE instead of KERBEROS
-        Configuration hadoopConfiguration = standaloneCluster.getHadoopConfiguration();
         if (saslEnabled()) {
+          // Note that getting the Hadoop config creates a servercontext which wacks up the
+          // AccumuloClientIT test so if SASL is enabled then the testclose() will fail
+          Configuration hadoopConfiguration = standaloneCluster.getHadoopConfiguration();
           UserGroupInformation.setConfiguration(hadoopConfiguration);
           // Login as the admin user to start the tests
           UserGroupInformation.loginUserFromKeytab(conf.getAdminPrincipal(),

--- a/test/src/main/java/org/apache/accumulo/test/IteratorEnvIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/IteratorEnvIT.java
@@ -17,9 +17,6 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -80,12 +77,14 @@ public class IteratorEnvIT extends AccumuloClusterHarness {
 
       // Checking for compaction on a scan should throw an error.
       try {
-        assertFalse(env.isUserCompaction());
-        fail("Expected to throw IllegalStateException when checking compaction on a scan.");
+        env.isUserCompaction();
+        throw new RuntimeException(
+            "Test failed - Expected to throw IllegalStateException when checking compaction on a scan.");
       } catch (IllegalStateException e) {}
       try {
-        assertFalse(env.isFullMajorCompaction());
-        fail("Expected to throw IllegalStateException when checking compaction on a scan.");
+        env.isFullMajorCompaction();
+        throw new RuntimeException(
+            "Test failed - Expected to throw IllegalStateException when checking compaction on a scan.");
       } catch (IllegalStateException e) {}
     }
   }
@@ -101,8 +100,16 @@ public class IteratorEnvIT extends AccumuloClusterHarness {
         IteratorEnvironment env) throws IOException {
       super.init(source, options, env);
       testEnv(scope, options, env);
-      assertTrue(env.isUserCompaction());
-      assertTrue(env.isFullMajorCompaction());
+      try {
+        env.isUserCompaction();
+      } catch (IllegalStateException e) {
+        throw new RuntimeException("Test failed");
+      }
+      try {
+        env.isFullMajorCompaction();
+      } catch (IllegalStateException e) {
+        throw new RuntimeException("Test failed");
+      }
     }
   }
 
@@ -118,12 +125,14 @@ public class IteratorEnvIT extends AccumuloClusterHarness {
       super.init(source, options, env);
       testEnv(scope, options, env);
       try {
-        assertTrue(env.isUserCompaction());
-        fail("Expected to throw IllegalStateException when checking compaction on a scan.");
+        env.isUserCompaction();
+        throw new RuntimeException(
+            "Test failed - Expected to throw IllegalStateException when checking compaction on a scan.");
       } catch (IllegalStateException e) {}
       try {
-        assertFalse(env.isFullMajorCompaction());
-        fail("Expected to throw IllegalStateException when checking compaction on a scan.");
+        env.isFullMajorCompaction();
+        throw new RuntimeException(
+            "Test failed - Expected to throw IllegalStateException when checking compaction on a scan.");
       } catch (IllegalStateException e) {}
     }
   }
@@ -135,13 +144,16 @@ public class IteratorEnvIT extends AccumuloClusterHarness {
   private static void testEnv(IteratorScope scope, Map<String,String> opts,
       IteratorEnvironment env) {
     TableId expectedTableId = TableId.of(opts.get("expected.table.id"));
-    assertEquals("Expected table property not found", "value1",
-        env.getConfig().get("table.custom.iterator.env.test"));
-    assertEquals("Expected table property not found", "value1",
-        env.getServiceEnv().getConfiguration(env.getTableId()).getTableCustom("iterator.env.test"));
-    assertEquals("Error getting iterator scope", scope, env.getIteratorScope());
-    assertFalse("isSamplingEnabled returned true, expected false", env.isSamplingEnabled());
-    assertEquals("Error getting Table ID", expectedTableId, env.getTableId());
+    if (!"value1".equals(env.getConfig().get("table.custom.iterator.env.test")) && !"value1".equals(
+        env.getServiceEnv().getConfiguration(env.getTableId()).getTableCustom("iterator.env.test")))
+      throw new RuntimeException("Test failed - Expected table property not found.");
+    if (!scope.equals(env.getIteratorScope()))
+      throw new RuntimeException("Test failed - Error getting iterator scope");
+    if (env.isSamplingEnabled())
+      throw new RuntimeException("Test failed - isSamplingEnabled returned true, expected false");
+    if (!expectedTableId.equals(env.getTableId()))
+      throw new RuntimeException("Test failed - Error getting Table ID");
+
   }
 
   @Before

--- a/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
@@ -118,6 +118,10 @@ public class YieldingIterator extends WrappingIterator {
             .yield(range.getStartKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
         log.info("end YieldingIterator.next: yielded at " + range.getStartKey());
       }
+    } else {
+      // must be a new scan so re-initialize the counters
+      log.info("reseting counters");
+      resetCounters();
     }
 
     // if not yielding, then simply pass on the call to the source
@@ -131,5 +135,13 @@ public class YieldingIterator extends WrappingIterator {
   @Override
   public void enableYielding(YieldCallback<Key> yield) {
     this.yield = Optional.of(yield);
+  }
+
+  protected void resetCounters() {
+    yieldNexts.set(0);
+    yieldSeeks.set(0);
+    rebuilds.set(0);
+    yieldNextKey.set(false);
+    yieldSeekKey.set(false);
   }
 }


### PR DESCRIPTION
AccumuloClientIT, - fixed in AccumuloClusterHarness (avoid setting Servercontext)  Will likely still fail if running SASL.  The tests were not cleaning up the users so used more the scheme already in the harness but that could really be cleaned up even more for all tests and probably a separate ticket.
ManyWariteaheadLogsIT - Needed to alter standalone config.
ReadWriteIT, -  reduced what was necessary to identify an SSL monitor and removed dependency on reading the props file.
YieldScannersIT, - adding a cleanup to the YieldingIterator
 BadDeleteMarkers...IT and others that failed due to null in the command prefix - One solution is to always have an entry in the accumulo.it.properties file for server and client prefix but additionally added the cleanup in AccumuloClusterHarness to ensure a null is not passed.
For tests timing out I added a comment to the Testing.md to up the timeout.
