### PR TITLE
Fix #886 Deprecate general.dynamic.classpaths

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -178,10 +178,6 @@ public enum Property {
   GENERAL_PREFIX("general.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of accumulo overall, but"
           + " do not have to be consistent throughout a cloud."),
-  GENERAL_DYNAMIC_CLASSPATHS(AccumuloVFSClassLoader.DYNAMIC_CLASSPATH_PROPERTY_NAME,
-      AccumuloVFSClassLoader.DEFAULT_DYNAMIC_CLASSPATH_VALUE, PropertyType.STRING,
-      "A list of all of the places where changes in jars or classes will force "
-          + "a reload of the classloader."),
   GENERAL_RPC_TIMEOUT("general.rpc.timeout", "120s", PropertyType.TIMEDURATION,
       "Time to wait on I/O for simple, short RPC calls"),
   @Experimental
@@ -903,6 +899,14 @@ public enum Property {
           + " of the places to look for a class. Order does matter, as it will look for"
           + " the jar starting in the first location to the last. Supports full regex"
           + " on filename alone."),
+  @Deprecated
+  GENERAL_DYNAMIC_CLASSPATHS(AccumuloVFSClassLoader.DYNAMIC_CLASSPATH_PROPERTY_NAME,
+      AccumuloVFSClassLoader.DEFAULT_DYNAMIC_CLASSPATH_VALUE, PropertyType.STRING,
+      "This property is deprecated since 2.0.0. A list of all of the places where changes "
+          + "in jars or classes will force a reload of the classloader. Built-in dynamic class "
+          + "loading will be removed in a future version. If this is needed, consider overriding "
+          + "the Java system class loader with one that has this feature "
+          + "(https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getSystemClassLoader--)."),
   @Deprecated
   @ReplacedBy(property = TABLE_DURABILITY)
   TSERV_WAL_SYNC_METHOD("tserver.wal.sync.method", "hsync", PropertyType.STRING,

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportVolumeIT.java
@@ -70,7 +70,8 @@ public class BulkImportVolumeIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.tableOperations().create(tableName);
       FileSystem fs = getFileSystem();
-      Path rootPath = new Path(fs.getUri().toString() + cluster.getTemporaryPath(), getClass().getName());
+      Path rootPath =
+          new Path(fs.getUri().toString() + cluster.getTemporaryPath(), getClass().getName());
       fs.deleteOnExit(rootPath);
 
       Path bulk = new Path(rootPath, "bulk");

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFileIT.java
@@ -74,7 +74,7 @@ public class BulkFileIT extends AccumuloClusterHarness {
       Configuration conf = new Configuration();
       AccumuloConfiguration aconf = getCluster().getServerContext().getConfiguration();
       FileSystem fs = getCluster().getFileSystem();
-      String rootPath = fs.getUri().toString()  + cluster.getTemporaryPath().toString();
+      String rootPath = fs.getUri().toString() + cluster.getTemporaryPath().toString();
 
       String dir = rootPath + "/bulk_test_diff_files_89723987592_" + getUniqueNames(1)[0];
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -115,7 +115,8 @@ public class CompactionIT extends AccumuloClusterHarness {
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");
       FileSystem fs = getFileSystem();
-      Path root = new Path(fs.getUri().toString() + cluster.getTemporaryPath(), getClass().getName());
+      Path root =
+          new Path(fs.getUri().toString() + cluster.getTemporaryPath(), getClass().getName());
       fs.deleteOnExit(root);
       Path testrf = new Path(root, "testrf");
       fs.deleteOnExit(testrf);


### PR DESCRIPTION
Logging of deprecated properties is already present therefore the only change required was to deprecate the general.dynamic.classpaths property.  

Note:  considered removing the default value but noticed that it is still used "as a default value" for additional classpaths ..lib/ext.   So maybe this is deprecated as a "configurable" property but clearly still being used.