### PR TITLE
Update to commons-configuration2.5

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -103,6 +103,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <optional>true</optional>
@@ -110,11 +115,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -255,7 +255,22 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -44,9 +44,9 @@
         <include>com.google.protobuf:protobuf-java</include>
         <include>com.sun.xml.bind:jaxb-core</include>
         <include>com.sun.xml.bind:jaxb-impl</include>
+        <include>commons-beanutils:commons-beanutils</include>
         <include>commons-cli:commons-cli</include>
         <include>commons-codec:commons-codec</include>
-        <include>commons-configuration:commons-configuration</include>
         <include>commons-io:commons-io</include>
         <include>commons-lang:commons-lang</include>
         <include>commons-logging:commons-logging</include>
@@ -60,7 +60,10 @@
         <include>jline:jline</include>
         <include>log4j:log4j</include>
         <include>org.apache.commons:commons-collections4</include>
+        <include>org.apache.commons:commons-configuration2</include>
+        <include>org.apache.commons:commons-lang3</include>
         <include>org.apache.commons:commons-math3</include>
+        <include>org.apache.commons:commons-text</include>
         <include>org.apache.commons:commons-vfs2</include>
         <include>org.apache.htrace:htrace-core4</include>
         <include>org.apache.htrace:htrace-core</include>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -82,6 +78,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -39,8 +39,8 @@ import org.apache.accumulo.core.util.format.DefaultFormatter;
 import org.apache.accumulo.core.util.interpret.DefaultScanInterpreter;
 import org.apache.accumulo.start.classloader.AccumuloClassLoader;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
-import org.apache.commons.configuration.MapConfiguration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.conf;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,9 +26,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.CompositeConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,18 +88,16 @@ public class SiteConfiguration extends AccumuloConfiguration {
   private static ImmutableMap<String,String> createMap(URL accumuloPropsLocation,
       Map<String,String> overrides) {
     CompositeConfiguration config = new CompositeConfiguration();
-    config.setThrowExceptionOnMissing(false);
-    config.setDelimiterParsingDisabled(true);
-    PropertiesConfiguration propsConfig = new PropertiesConfiguration();
-    propsConfig.setDelimiterParsingDisabled(true);
     if (accumuloPropsLocation != null) {
+      FileBasedConfigurationBuilder<PropertiesConfiguration> propsBuilder =
+          new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+              .configure(new Parameters().properties().setURL(accumuloPropsLocation));
       try {
-        propsConfig.load(accumuloPropsLocation.openStream());
-      } catch (IOException | ConfigurationException e) {
+        config.addConfiguration(propsBuilder.getConfiguration());
+      } catch (ConfigurationException e) {
         throw new IllegalArgumentException(e);
       }
     }
-    config.addConfiguration(propsConfig);
 
     // Add all properties in config file
     Map<String,String> result = new HashMap<>();

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/ClassSize.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/ClassSize.java
@@ -18,8 +18,6 @@
 
 package org.apache.accumulo.core.file.blockfile.cache.impl;
 
-import java.util.Properties;
-
 /**
  * Class for determining the "size" of a class, an attempt to calculate the actual bytes that an
  * object of this class will occupy in memory
@@ -63,8 +61,7 @@ public class ClassSize {
    */
   static {
     // Figure out whether this is a 32 or 64 bit machine.
-    Properties sysProps = System.getProperties();
-    String arcModel = sysProps.getProperty("sun.arch.data.model");
+    String arcModel = System.getProperty("sun.arch.data.model");
 
     // Default value is set to 8, covering the case when arcModel is unknown
     REFERENCE = arcModel.equals(THIRTY_TWO) ? 4 : 8;

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -40,10 +40,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -82,6 +78,10 @@
     <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-tserver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
@@ -57,9 +57,8 @@ public class RemoteShellOptions {
       justification = "code runs in same security context as user who provided input file name")
   public RemoteShellOptions() {
     properties = new Properties();
-    Properties systemProperties = System.getProperties();
 
-    String propertyFile = systemProperties.getProperty(SSH_PROPERTIES_FILE);
+    String propertyFile = System.getProperty(SSH_PROPERTIES_FILE);
 
     // Load properties from the specified file
     if (propertyFile != null) {
@@ -90,7 +89,7 @@ public class RemoteShellOptions {
     }
 
     // Let other system properties override those in the file
-    for (Entry<Object,Object> entry : systemProperties.entrySet()) {
+    for (Entry<Object,Object> entry : System.getProperties().entrySet()) {
       if (!(entry.getKey() instanceof String)) {
         continue;
       }

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -45,7 +45,9 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.util.Pair;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.junit.AfterClass;
@@ -233,8 +235,10 @@ public class MiniAccumuloClusterTest {
   public void testRandomPorts() throws Exception {
     File confDir = new File(testDir, "conf");
     File accumuloProps = new File(confDir, "accumulo.properties");
-    PropertiesConfiguration conf = new PropertiesConfiguration();
-    conf.load(accumuloProps);
+    FileBasedConfigurationBuilder<PropertiesConfiguration> propsBuilder =
+        new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+            .configure(new Parameters().properties().setFile(accumuloProps));
+    PropertiesConfiguration conf = propsBuilder.getConfiguration();
     for (Property randomPortProp : new Property[] {Property.TSERV_CLIENTPORT, Property.MONITOR_PORT,
         Property.MONITOR_LOG4J_PORT, Property.MASTER_CLIENTPORT, Property.TRACE_PORT,
         Property.GC_PORT}) {

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,11 @@
         <version>${jaxb.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.3</version>
+      </dependency>
+      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.4</version>
@@ -250,11 +255,6 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.12</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-configuration</groupId>
-        <artifactId>commons-configuration</artifactId>
-        <version>1.10</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -415,6 +415,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>2.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
         <artifactId>commons-jci-core</artifactId>
         <version>1.1</version>
       </dependency>
@@ -432,6 +437,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-math3</artifactId>
         <version>3.6.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1065,6 +1075,8 @@
                 <unusedDeclaredDependency>com.github.spotbugs:spotbugs-annotations:jar:${spotbugs.version}</unusedDeclaredDependency>
                 <!-- ignore unused native; analysis isn't possible with tar.gz dependency -->
                 <unusedDeclaredDependency>org.apache.accumulo:accumulo-native:tar.gz:${project.version}</unusedDeclaredDependency>
+                <!-- ignore runtime dependencies of commons-configuration2 -->
+                <unusedDeclaredDependency>commons-beanutils:commons-beanutils:jar:*</unusedDeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -27,16 +27,16 @@
   <description>A library for launching Apache Accumulo services.</description>
   <dependencies>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -49,6 +49,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <!-- runtime for commons-configuration2 -->
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -28,7 +28,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,10 +83,10 @@ public class AccumuloClassLoader {
       return defaultValue;
     }
     try {
-      PropertiesConfiguration config = new PropertiesConfiguration();
-      config.setDelimiterParsingDisabled(true);
-      config.setThrowExceptionOnMissing(false);
-      config.load(accumuloConfigUrl);
+      FileBasedConfigurationBuilder<PropertiesConfiguration> propsBuilder =
+          new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+              .configure(new Parameters().properties().setURL(accumuloConfigUrl));
+      PropertiesConfiguration config = propsBuilder.getConfiguration();
       String value = config.getString(propertyName);
       if (value != null)
         return value;

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -126,6 +122,10 @@
     <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-tserver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -50,10 +50,9 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")
   public static AccumuloClusterPropertyConfiguration get() {
-    Properties systemProperties = System.getProperties();
 
     String clusterTypeValue = null, clientConf = null;
-    String propertyFile = systemProperties.getProperty(ACCUMULO_IT_PROPERTIES_FILE);
+    String propertyFile = System.getProperty(ACCUMULO_IT_PROPERTIES_FILE);
 
     if (propertyFile != null) {
       // Check for properties provided in a file
@@ -91,11 +90,11 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
     }
 
     if (clusterTypeValue == null) {
-      clusterTypeValue = systemProperties.getProperty(ACCUMULO_CLUSTER_TYPE_KEY);
+      clusterTypeValue = System.getProperty(ACCUMULO_CLUSTER_TYPE_KEY);
     }
 
     if (clientConf == null) {
-      clientConf = systemProperties.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
+      clientConf = System.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
     }
 
     ClusterType type;
@@ -147,9 +146,7 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
 
     Map<String,String> configuration = new HashMap<>();
 
-    Properties systemProperties = System.getProperties();
-
-    String propertyFile = systemProperties.getProperty(ACCUMULO_IT_PROPERTIES_FILE);
+    String propertyFile = System.getProperty(ACCUMULO_IT_PROPERTIES_FILE);
 
     // Check for properties provided in a file
     if (propertyFile != null) {
@@ -181,7 +178,7 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
     }
 
     // Load any properties specified directly in the system properties
-    loadFromProperties(prefix, systemProperties, configuration);
+    loadFromProperties(prefix, System.getProperties(), configuration);
 
     return configuration;
   }

--- a/test/src/main/java/org/apache/accumulo/test/RewriteTabletDirectoriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RewriteTabletDirectoriesIT.java
@@ -45,7 +45,9 @@ import org.apache.accumulo.server.init.Initialize;
 import org.apache.accumulo.server.util.Admin;
 import org.apache.accumulo.server.util.RandomizeVolumes;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
@@ -132,10 +134,12 @@ public class RewriteTabletDirectoriesIT extends ConfigurableMacBase {
         cluster.stop();
 
         // add the 2nd volume
-        PropertiesConfiguration conf = new PropertiesConfiguration();
-        conf.load(cluster.getAccumuloPropertiesPath());
-        conf.setProperty(Property.INSTANCE_VOLUMES.getKey(), v1 + "," + v2);
-        conf.save(cluster.getAccumuloPropertiesPath());
+        FileBasedConfigurationBuilder<PropertiesConfiguration> propsBuilder =
+            new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class).configure(
+                new Parameters().properties().setFileName(cluster.getAccumuloPropertiesPath()));
+        propsBuilder.getConfiguration().setProperty(Property.INSTANCE_VOLUMES.getKey(),
+            v1 + "," + v2);
+        propsBuilder.save();
 
         // initialize volume
         assertEquals(0, cluster.exec(Initialize.class, "--add-volumes").getProcess().waitFor());


### PR DESCRIPTION
* Update dependencies
* Use FileBasedConfigurationBuilder to load configuration files
* Use PropertiesConfigurationLayout to serialize/deserialize when needed
* Simplified some calls to get system properties en route to updating
the PropertiesConfiguration usages.

Note: list delimiter is disabled by default now, so those API calls
aren't needed and were removed; also removed setThrowsOnMissing(false)
calls becuase that was also the default behavior