### PR TITLE
Ensures correct use of ZooKeeper getAcl

### DIFF
--- a/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooReader.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooReader.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.accumulo.fate.util.Retry.RetryFactory;
-import org.apache.accumulo.fate.zookeeper.ZooUtil.ZooKeeperConnectionInfo;
 import org.apache.zookeeper.AsyncCallback.VoidCallback;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
@@ -39,7 +38,6 @@ public class ZooReader implements IZooReader {
   protected String keepers;
   protected int timeout;
   private final RetryFactory retryFactory;
-  private final ZooKeeperConnectionInfo info;
 
   protected ZooKeeper getSession(String keepers, int timeout, String scheme, byte[] auth) {
     return ZooSession.getSession(keepers, timeout, scheme, auth);
@@ -255,13 +253,12 @@ public class ZooReader implements IZooReader {
 
   @Override
   public List<ACL> getACL(String zPath, Stat stat) throws KeeperException, InterruptedException {
-    return ZooUtil.getACL(info, zPath, stat);
+    return ZooUtil.getACL(getZooKeeper(), zPath, stat);
   }
 
   public ZooReader(String keepers, int timeout) {
     this.keepers = keepers;
     this.timeout = timeout;
     this.retryFactory = ZooUtil.DEFAULT_RETRY;
-    this.info = new ZooKeeperConnectionInfo(keepers, timeout, null, null);
   }
 }

--- a/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooUtil.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooUtil.java
@@ -545,12 +545,12 @@ public class ZooUtil {
     }
   }
 
-  public static List<ACL> getACL(ZooKeeperConnectionInfo info, String zPath, Stat stat)
+  public static List<ACL> getACL(ZooKeeper zk, String zPath, Stat stat)
       throws KeeperException, InterruptedException {
     final Retry retry = RETRY_FACTORY.createRetry();
     while (true) {
       try {
-        return getZooKeeper(info).getACL(zPath, stat);
+        return zk.getACL(zPath, stat);
       } catch (KeeperException e) {
         final Code c = e.code();
         if (c == Code.CONNECTIONLOSS || c == Code.OPERATIONTIMEOUT || c == Code.SESSIONEXPIRED) {

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <!-- Thrift version -->
     <thrift.version>0.9.3-1</thrift.version>
     <!-- ZooKeeper version -->
-    <zookeeper.version>3.4.6</zookeeper.version>
+    <zookeeper.version>3.4.14</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This fixes a bug in Accumulo where we were using an unauthenticated
ZooKeeper session to read ACLs on a node that we had previously written.

ZooKeeper 3.4.14 fixed a bug in their code that allowed unauthenticated
connections to read ACLs on paths for which they did not have READ
permission.

Using Accumulo with that version of ZooKeeper exposed the bug in our
code that passed the incorrect ZooKeeper session when retrieving ACLs.