### PR TITLE
Log busy tablets by ingest and query at a configurable time duration

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -485,6 +485,9 @@ public enum Property {
       "The time between adjustments of the server thread pool."),
   TSERV_MAX_MESSAGE_SIZE("tserver.server.message.size.max", "1G", PropertyType.MEMORY,
       "The maximum size of a message that can be sent to a tablet server."),
+  TSERV_LOG_TOP_TABLETS_COUNT("tserver.log.top.tablets.count", "0", PropertyType.COUNT,
+      "Number of top tablets to log when saving tablet stats. If <= 0, logging "
+          + "of top tablets is disabled"),
   TSERV_HOLD_TIME_SUICIDE("tserver.hold.time.max", "5m", PropertyType.TIMEDURATION,
       "The maximum time for a tablet server to be in the \"memory full\" state."
           + " If the tablet server cannot write out memory in this much time, it will"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -485,11 +485,11 @@ public enum Property {
       "The time between adjustments of the server thread pool."),
   TSERV_MAX_MESSAGE_SIZE("tserver.server.message.size.max", "1G", PropertyType.MEMORY,
       "The maximum size of a message that can be sent to a tablet server."),
-  TSERV_LOG_TOP_TABLETS_COUNT("tserver.log.top.tablets.count", "0", PropertyType.COUNT,
-      "Number of top tablets to log when saving tablet stats. If <= 0, logging "
-          + "of top tablets is disabled"),
-  TSERV_LOG_TOP_TABLETS_INTERVAL("tserver.log.top.tablets.interval", "1h",
-      PropertyType.TIMEDURATION, "Time interval between logging out top tablets information."),
+  TSERV_LOG_BUSIEST_TABLETS_COUNT("tserver.log.busiest.tablets.count", "0", PropertyType.COUNT,
+      "Number of busiest tablets to log. Logged at interval controlled by "
+          + "tserver.log.busiest.tablets.interval. If <= 0, logging of top tablets is disabled"),
+  TSERV_LOG_BUSIEST_TABLETS_INTERVAL("tserver.log.busiest.tablets.interval", "1h",
+      PropertyType.TIMEDURATION, "Time interval between logging out busiest tablets information."),
   TSERV_HOLD_TIME_SUICIDE("tserver.hold.time.max", "5m", PropertyType.TIMEDURATION,
       "The maximum time for a tablet server to be in the \"memory full\" state."
           + " If the tablet server cannot write out memory in this much time, it will"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -485,11 +485,11 @@ public enum Property {
       "The time between adjustments of the server thread pool."),
   TSERV_MAX_MESSAGE_SIZE("tserver.server.message.size.max", "1G", PropertyType.MEMORY,
       "The maximum size of a message that can be sent to a tablet server."),
-  TSERV_LOG_BUSIEST_TABLETS_COUNT("tserver.log.busiest.tablets.count", "0", PropertyType.COUNT,
+  TSERV_LOG_BUSY_TABLETS_COUNT("tserver.log.busy.tablets.count", "0", PropertyType.COUNT,
       "Number of busiest tablets to log. Logged at interval controlled by "
-          + "tserver.log.busiest.tablets.interval. If <= 0, logging of top tablets is disabled"),
-  TSERV_LOG_BUSIEST_TABLETS_INTERVAL("tserver.log.busiest.tablets.interval", "1h",
-      PropertyType.TIMEDURATION, "Time interval between logging out busiest tablets information."),
+          + "tserver.log.busy.tablets.interval. If <= 0, logging of busy tablets is disabled"),
+  TSERV_LOG_BUSY_TABLETS_INTERVAL("tserver.log.busy.tablets.interval", "1h",
+      PropertyType.TIMEDURATION, "Time interval between logging out busy tablets information."),
   TSERV_HOLD_TIME_SUICIDE("tserver.hold.time.max", "5m", PropertyType.TIMEDURATION,
       "The maximum time for a tablet server to be in the \"memory full\" state."
           + " If the tablet server cannot write out memory in this much time, it will"

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -488,6 +488,8 @@ public enum Property {
   TSERV_LOG_TOP_TABLETS_COUNT("tserver.log.top.tablets.count", "0", PropertyType.COUNT,
       "Number of top tablets to log when saving tablet stats. If <= 0, logging "
           + "of top tablets is disabled"),
+  TSERV_LOG_TOP_TABLETS_INTERVAL("tserver.log.top.tablets.interval", "1h",
+      PropertyType.TIMEDURATION, "Time interval between logging out top tablets information."),
   TSERV_HOLD_TIME_SUICIDE("tserver.hold.time.max", "5m", PropertyType.TIMEDURATION,
       "The maximum time for a tablet server to be in the \"memory full\" state."
           + " If the tablet server cannot write out memory in this much time, it will"

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -426,10 +426,11 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         private void logBusyTablets(Map<String,PriorityQueue<Pair<String,Double>>> busyTabletsMap,
             String label, int numBusiestTabletsToLog) {
           PriorityQueue<Pair<String,Double>> busyTabletsQueue = busyTabletsMap.get(label);
-          for (int i = 0; i < numBusiestTabletsToLog; i++) {
+          int i = 0;
+          while(!busyTabletsQueue.isEmpty()) {
             Pair<String,Double> pair = busyTabletsQueue.poll();
-            log.debug("{} busiest tablet by {} -- extent: {} count: {}", i, label, pair.getFirst(),
-                pair.getSecond());
+            log.debug("{} busiest tablet by {}: {} -- extent: {} ", i, label.toLowerCase(), pair.getSecond(),
+                    pair.getFirst());
           }
         }
       }, logBusyTabletsDelay, logBusyTabletsDelay);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -386,19 +386,19 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         }
 
         private void addToTopTablets(long count,
-            PriorityQueue<Pair<String,Long>> topTabletsByIngestCount, int numTopTabletsToLog) {
-          if (topTabletsByIngestCount.size() < numTopTabletsToLog
-              || topTabletsByIngestCount.peek().getSecond() < count) {
-            if (topTabletsByIngestCount.size() == numTopTabletsToLog) {
-              topTabletsByIngestCount.remove();
+            PriorityQueue<Pair<String,Long>> topTabletsQueue, int numTopTabletsToLog) {
+          if (topTabletsQueue.size() < numTopTabletsToLog
+              || topTabletsQueue.peek().getSecond() < count) {
+            if (topTabletsQueue.size() == numTopTabletsToLog) {
+              topTabletsQueue.remove();
             }
           }
         }
 
-        private void logTopTablets(PriorityQueue<Pair<String,Long>> topTabletsByIngestCount,
+        private void logTopTablets(PriorityQueue<Pair<String,Long>> topTabletsQueue,
             String label, int numTopTabletsToLog) {
           for (int i = 0; i < numTopTabletsToLog; i++) {
-            Pair<String,Long> pair = topTabletsByIngestCount.poll();
+            Pair<String,Long> pair = topTabletsQueue.poll();
             log.debug("Top {} tablet by {} count -- extent: {} count: {}", i, label,
                 pair.getFirst(), pair.getSecond());
           }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
@@ -358,17 +359,60 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
     this.logSorter = new LogSorter(instance, fs, aconf);
     this.replWorker = new ReplicationWorker(this, fs);
     this.statsKeeper = new TabletStatsKeeper();
+    final int numTopTabletsToLog = aconf.getCount(Property.TSERV_LOG_TOP_TABLETS_COUNT);
+    final boolean logTopTablets = numTopTabletsToLog > 0;
     SimpleTimer.getInstance(aconf).schedule(new Runnable() {
       @Override
       public void run() {
+
+        Comparator<Pair<String,Long>> topTabletComparator = new Comparator<Pair<String,Long>>() {
+          @Override
+          public int compare(Pair<String,Long> first, Pair<String,Long> second) {
+            return second.getSecond().compareTo(first.getSecond());
+          }
+        };
+        PriorityQueue<Pair<String,Long>> topTabletsByIngestCount =
+            new PriorityQueue<>(numTopTabletsToLog, topTabletComparator);
+        PriorityQueue<Pair<String,Long>> topTabletsByQueryCount =
+            new PriorityQueue<>(topTabletsByIngestCount);
         synchronized (onlineTablets) {
           long now = System.currentTimeMillis();
+          topTabletsByIngestCount.clear();
+          topTabletsByQueryCount.clear();
           for (Tablet tablet : onlineTablets.values())
             try {
               tablet.updateRates(now);
+              if (logTopTablets) {
+                addToTopTablets(tablet.totalIngest(), topTabletsByIngestCount, numTopTabletsToLog);
+                addToTopTablets(tablet.totalQueries(), topTabletsByQueryCount, numTopTabletsToLog);
+              }
             } catch (Exception ex) {
               log.error("Error updating rates for {}", tablet.getExtent(), ex);
             }
+
+          if (logTopTablets) {
+            logTopTablets(topTabletsByIngestCount, "QUERY", numTopTabletsToLog);
+            logTopTablets(topTabletsByQueryCount, "INGEST", numTopTabletsToLog);
+          }
+        }
+      }
+
+      private void addToTopTablets(long count,
+          PriorityQueue<Pair<String,Long>> topTabletsByIngestCount, int numTopTabletsToLog) {
+        if (topTabletsByIngestCount.size() < numTopTabletsToLog
+            || topTabletsByIngestCount.peek().getSecond() < count) {
+          if (topTabletsByIngestCount.size() == numTopTabletsToLog) {
+            topTabletsByIngestCount.remove();
+          }
+        }
+      }
+
+      private void logTopTablets(PriorityQueue<Pair<String,Long>> topTabletsByIngestCount,
+          String label, int numTopTabletsToLog) {
+        for (int i = 0; i < numTopTabletsToLog; i++) {
+          Pair<String,Long> pair = topTabletsByIngestCount.poll();
+          log.debug("Top {} tablet by {} count -- extent: {} count: {}", i, label, pair.getFirst(),
+              pair.getSecond());
         }
       }
     }, 5000, 5000);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -406,10 +406,10 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
                 numBusyTabletsToLog);
           }
 
-          logBusyTablets(busyTabletMap, QUERY_COUNT, numBusyTabletsToLog);
-          logBusyTablets(busyTabletMap, QUERY_RATE, numBusyTabletsToLog);
-          logBusyTablets(busyTabletMap, INGEST_COUNT, numBusyTabletsToLog);
-          logBusyTablets(busyTabletMap, INGEST_RATE, numBusyTabletsToLog);
+          logBusyTablets(busyTabletMap, QUERY_COUNT);
+          logBusyTablets(busyTabletMap, QUERY_RATE);
+          logBusyTablets(busyTabletMap, INGEST_COUNT);
+          logBusyTablets(busyTabletMap, INGEST_RATE);
         }
 
         private void addToBusiestTablets(String extent, double count,
@@ -424,13 +424,14 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
         }
 
         private void logBusyTablets(Map<String,PriorityQueue<Pair<String,Double>>> busyTabletsMap,
-            String label, int numBusiestTabletsToLog) {
+            String label) {
           PriorityQueue<Pair<String,Double>> busyTabletsQueue = busyTabletsMap.get(label);
-          int i = 0;
+          int i = 1;
           while(!busyTabletsQueue.isEmpty()) {
             Pair<String,Double> pair = busyTabletsQueue.poll();
             log.debug("{} busiest tablet by {}: {} -- extent: {} ", i, label.toLowerCase(), pair.getSecond(),
                     pair.getFirst());
+            i++;
           }
         }
       }, logBusyTabletsDelay, logBusyTabletsDelay);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2395,6 +2395,10 @@ public class Tablet implements TabletCommitter {
     return this.queryCount;
   }
 
+  public long totalIngest() {
+    return this.ingestCount;
+  }
+
   // synchronized?
   public void updateRates(long now) {
     queryRate.update(now, queryCount);


### PR DESCRIPTION
In order to aid in detection of read and write hot spots, the goal of this PR is to log the already calculated stats, only when a config property is set.

As our production systems are on the 1.9 line, and this PR will not have any effect unless the user explicitly updates the property, I would like to see this get into the 1.9 baseline.