### PR TITLE
Add exceptions to standalone IT property file loading (#1168)

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -64,19 +64,19 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
         try {
           reader = new FileReader(f);
         } catch (FileNotFoundException e) {
-          log.warn("Could not read properties from specified file: {}", propertyFile, e);
+          throw new RuntimeException("Could not read properties from specified file: " + propertyFile, e);
         }
 
         if (reader != null) {
           try {
             fileProperties.load(reader);
           } catch (IOException e) {
-            log.warn("Could not load properties from specified file: {}", propertyFile, e);
+            throw new RuntimeException("Could not load properties from specified file: " + propertyFile, e);
           } finally {
             try {
               reader.close();
             } catch (IOException e) {
-              log.warn("Could not close reader", e);
+              throw new RuntimeException("Could not close reader", e);
             }
           }
 
@@ -84,10 +84,10 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
           clientConf = fileProperties.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
         }
       } else {
-        log.debug("Property file ({}) is not a readable file", propertyFile);
+        throw new RuntimeException("Property file (" + propertyFile + ") is not a readable file");
       }
     } else {
-      log.debug("No properties file found in {}", ACCUMULO_IT_PROPERTIES_FILE);
+      throw new RuntimeException("No properties file found in " + ACCUMULO_IT_PROPERTIES_FILE);
     }
 
     if (clusterTypeValue == null) {


### PR DESCRIPTION
This update changes logs to RuntimeExceptions so that bad standalone IT properties do not automatically convert to a mini cluster.