### PR TITLE
Replace use of deprecated newInstance calls.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
@@ -63,7 +63,7 @@ public interface AuthenticationToken extends Writable, Destroyable, Cloneable {
         byte[] tokenBytes) {
       T type = null;
       try {
-        type = tokenType.newInstance();
+        type = tokenType.getDeclaredConstructor().newInstance();
       } catch (Exception e) {
         throw new IllegalArgumentException("Cannot instantiate " + tokenType.getName(), e);
       }

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.conf;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -158,8 +159,8 @@ public class ConfigSanityCheck {
       Class<?> requiredBaseClass) {
     try {
       ConfigurationTypeHelper.getClassInstance(null, className, requiredBaseClass);
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-        | IOException e) {
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IOException
+        | NoSuchMethodException | InvocationTargetException e) {
       fatal(confOption + " has an invalid class name: " + className);
     } catch (ClassCastException e) {
       fatal(confOption + " must implement " + requiredBaseClass

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.conf;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -159,8 +158,7 @@ public class ConfigSanityCheck {
       Class<?> requiredBaseClass) {
     try {
       ConfigurationTypeHelper.getClassInstance(null, className, requiredBaseClass);
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IOException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (IOException | ReflectiveOperationException e) {
       fatal(confOption + " has an invalid class name: " + className);
     } catch (ClassCastException e) {
       fatal(confOption + " must implement " + requiredBaseClass

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.conf;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -173,7 +174,7 @@ public class ConfigurationTypeHelper {
     try {
       instance = getClassInstance(context, clazzName, base);
     } catch (RuntimeException | ClassNotFoundException | IOException | InstantiationException
-        | IllegalAccessException e) {
+        | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
       log.warn("Failed to load class {}", clazzName, e);
     }
 
@@ -196,7 +197,8 @@ public class ConfigurationTypeHelper {
    * @return a new instance of the class
    */
   public static <T> T getClassInstance(String context, String clazzName, Class<T> base)
-      throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException {
+      throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException,
+      NoSuchMethodException, InvocationTargetException {
     T instance;
 
     Class<? extends T> clazz;
@@ -206,7 +208,7 @@ public class ConfigurationTypeHelper {
       clazz = AccumuloVFSClassLoader.loadClass(clazzName, base);
     }
 
-    instance = clazz.newInstance();
+    instance = clazz.getDeclaredConstructor().newInstance();
     if (loaded.put(clazzName, clazz) != clazz)
       log.debug("Loaded class : {}", clazzName);
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.conf;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -173,8 +172,7 @@ public class ConfigurationTypeHelper {
 
     try {
       instance = getClassInstance(context, clazzName, base);
-    } catch (RuntimeException | ClassNotFoundException | IOException | InstantiationException
-        | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+    } catch (RuntimeException | IOException | ReflectiveOperationException e) {
       log.warn("Failed to load class {}", clazzName, e);
     }
 
@@ -197,8 +195,7 @@ public class ConfigurationTypeHelper {
    * @return a new instance of the class
    */
   public static <T> T getClassInstance(String context, String clazzName, Class<T> base)
-      throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException,
-      NoSuchMethodException, InvocationTargetException {
+      throws IOException, ReflectiveOperationException {
     T instance;
 
     Class<? extends T> clazz;

--- a/core/src/main/java/org/apache/accumulo/core/conf/CredentialProviderFactoryShim.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/CredentialProviderFactoryShim.java
@@ -115,8 +115,10 @@ public class CredentialProviderFactoryShim {
 
     // Instantiate Hadoop CredentialProviderFactory
     try {
-      hadoopCredProviderFactory = hadoopCredProviderFactoryClz.newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      hadoopCredProviderFactory =
+          hadoopCredProviderFactoryClz.getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+        | InvocationTargetException e) {
       log.trace("Could not instantiate class {}", HADOOP_CRED_PROVIDER_FACTORY_CLASS_NAME, e);
       return false;
     }

--- a/core/src/main/java/org/apache/accumulo/core/conf/CredentialProviderFactoryShim.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/CredentialProviderFactoryShim.java
@@ -117,8 +117,7 @@ public class CredentialProviderFactoryShim {
     try {
       hadoopCredProviderFactory =
           hadoopCredProviderFactoryClz.getDeclaredConstructor().newInstance();
-    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
-        | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       log.trace("Could not instantiate class {}", HADOOP_CRED_PROVIDER_FACTORY_CLASS_NAME, e);
       return false;
     }

--- a/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.core.conf;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -228,8 +227,7 @@ public class IterConfigUtil {
         skvi.init(prev, options, iterLoad.iteratorEnvironment);
         prev = skvi;
       }
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       log.error(e.toString());
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
@@ -19,6 +19,7 @@ package org.apache.accumulo.core.conf;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -217,7 +218,7 @@ public class IterConfigUtil {
           clazz = loadClass(iterLoad.useAccumuloClassLoader, iterLoad.context, iterInfo);
         }
 
-        SortedKeyValueIterator<Key,Value> skvi = clazz.newInstance();
+        SortedKeyValueIterator<Key,Value> skvi = clazz.getDeclaredConstructor().newInstance();
 
         Map<String,String> options = iterLoad.iterOpts.get(iterInfo.iterName);
 
@@ -227,7 +228,8 @@ public class IterConfigUtil {
         skvi.init(prev, options, iterLoad.iteratorEnvironment);
         prev = skvi;
       }
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException
+        | NoSuchMethodException | InvocationTargetException e) {
       log.error(e.toString());
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/crypto/CryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/CryptoServiceFactory.java
@@ -16,6 +16,8 @@
  */
 package org.apache.accumulo.core.crypto;
 
+import java.lang.reflect.InvocationTargetException;
+
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -45,8 +47,9 @@ public class CryptoServiceFactory {
       } else {
         try {
           newCryptoService = CryptoServiceFactory.class.getClassLoader().loadClass(clazzName)
-              .asSubclass(CryptoService.class).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+              .asSubclass(CryptoService.class).getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException
+            | NoSuchMethodException | InvocationTargetException e) {
           throw new RuntimeException(e);
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/crypto/CryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/CryptoServiceFactory.java
@@ -16,8 +16,6 @@
  */
 package org.apache.accumulo.core.crypto;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -48,8 +46,7 @@ public class CryptoServiceFactory {
         try {
           newCryptoService = CryptoServiceFactory.class.getClassLoader().loadClass(clazzName)
               .asSubclass(CryptoService.class).getDeclaredConstructor().newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException
-            | NoSuchMethodException | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
           throw new RuntimeException(e);
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -24,6 +24,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -134,7 +135,7 @@ public class BloomFilterLayer {
         else
           clazz = AccumuloVFSClassLoader.loadClass(classname, KeyFunctor.class);
 
-        transformer = clazz.newInstance();
+        transformer = clazz.getDeclaredConstructor().newInstance();
 
       } catch (Exception e) {
         LOG.error("Failed to find KeyFunctor: " + acuconf.get(Property.TABLE_BLOOM_KEY_FUNCTOR), e);
@@ -245,7 +246,7 @@ public class BloomFilterLayer {
                 KeyFunctor.class);
           else
             clazz = AccumuloVFSClassLoader.loadClass(ClassName, KeyFunctor.class);
-          transformer = clazz.newInstance();
+          transformer = clazz.getDeclaredConstructor().newInstance();
 
           /**
            * read in bloom filter
@@ -266,7 +267,7 @@ public class BloomFilterLayer {
         } catch (ClassNotFoundException e) {
           LOG.error("Failed to find KeyFunctor in config: " + sanitize(ClassName), e);
           bloomFilter = null;
-        } catch (InstantiationException e) {
+        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
           LOG.error("Could not instantiate KeyFunctor: " + sanitize(ClassName), e);
           bloomFilter = null;
         } catch (IllegalAccessException e) {

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -24,7 +24,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -267,11 +266,8 @@ public class BloomFilterLayer {
         } catch (ClassNotFoundException e) {
           LOG.error("Failed to find KeyFunctor in config: " + sanitize(ClassName), e);
           bloomFilter = null;
-        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
           LOG.error("Could not instantiate KeyFunctor: " + sanitize(ClassName), e);
-          bloomFilter = null;
-        } catch (IllegalAccessException e) {
-          LOG.error("Illegal acess exception", e);
           bloomFilter = null;
         } catch (RuntimeException rte) {
           if (!closed)

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheManagerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheManagerFactory.java
@@ -44,7 +44,7 @@ public class BlockCacheManagerFactory {
     Class<? extends BlockCacheManager> clazz =
         AccumuloVFSClassLoader.loadClass(impl, BlockCacheManager.class);
     LOG.info("Created new block cache manager of type: {}", clazz.getSimpleName());
-    return clazz.newInstance();
+    return clazz.getDeclaredConstructor().newInstance();
   }
 
   /**
@@ -62,6 +62,6 @@ public class BlockCacheManagerFactory {
     Class<? extends BlockCacheManager> clazz =
         Class.forName(impl).asSubclass(BlockCacheManager.class);
     LOG.info("Created new block cache factory of type: {}", clazz.getSimpleName());
-    return clazz.newInstance();
+    return clazz.getDeclaredConstructor().newInstance();
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -310,7 +310,7 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
     // TODO test
     Combiner newInstance;
     try {
-      newInstance = this.getClass().newInstance();
+      newInstance = this.getClass().getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
@@ -42,7 +42,7 @@ public abstract class Filter extends WrappingIterator implements OptionDescriber
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     Filter newInstance;
     try {
-      newInstance = this.getClass().newInstance();
+      newInstance = this.getClass().getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.iterators;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -139,8 +138,7 @@ public abstract class TypedValueCombiner<V> extends Combiner {
       Class<? extends Encoder<V>> clazz = (Class<? extends Encoder<V>>) AccumuloVFSClassLoader
           .loadClass(encoderClass, Encoder.class);
       encoder = clazz.getDeclaredConstructor().newInstance();
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       throw new IllegalArgumentException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.iterators;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -137,8 +138,9 @@ public abstract class TypedValueCombiner<V> extends Combiner {
       @SuppressWarnings("unchecked")
       Class<? extends Encoder<V>> clazz = (Class<? extends Encoder<V>>) AccumuloVFSClassLoader
           .loadClass(encoderClass, Encoder.class);
-      encoder = clazz.newInstance();
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+      encoder = clazz.getDeclaredConstructor().newInstance();
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException
+        | NoSuchMethodException | InvocationTargetException e) {
       throw new IllegalArgumentException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/conf/ColumnToClassMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/conf/ColumnToClassMapping.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.iterators.conf;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -43,14 +42,12 @@ public class ColumnToClassMapping<K> {
   }
 
   public ColumnToClassMapping(Map<String,String> objectStrings, Class<? extends K> c)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException, IOException,
-      NoSuchMethodException, InvocationTargetException {
+      throws ReflectiveOperationException, IOException {
     this(objectStrings, c, null);
   }
 
   public ColumnToClassMapping(Map<String,String> objectStrings, Class<? extends K> c,
-      String context) throws InstantiationException, IllegalAccessException, ClassNotFoundException,
-      IOException, NoSuchMethodException, InvocationTargetException {
+      String context) throws ReflectiveOperationException, IOException {
     this();
 
     for (Entry<String,String> entry : objectStrings.entrySet()) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/conf/ColumnToClassMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/conf/ColumnToClassMapping.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.iterators.conf;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -42,13 +43,14 @@ public class ColumnToClassMapping<K> {
   }
 
   public ColumnToClassMapping(Map<String,String> objectStrings, Class<? extends K> c)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException, IOException {
+      throws InstantiationException, IllegalAccessException, ClassNotFoundException, IOException,
+      NoSuchMethodException, InvocationTargetException {
     this(objectStrings, c, null);
   }
 
   public ColumnToClassMapping(Map<String,String> objectStrings, Class<? extends K> c,
-      String context)
-      throws InstantiationException, IllegalAccessException, ClassNotFoundException, IOException {
+      String context) throws InstantiationException, IllegalAccessException, ClassNotFoundException,
+      IOException, NoSuchMethodException, InvocationTargetException {
     this();
 
     for (Entry<String,String> entry : objectStrings.entrySet()) {
@@ -65,7 +67,7 @@ public class ColumnToClassMapping<K> {
         clazz = AccumuloVFSClassLoader.loadClass(className, c);
 
       @SuppressWarnings("unchecked")
-      K inst = (K) clazz.newInstance();
+      K inst = (K) clazz.getDeclaredConstructor().newInstance();
       if (pcic.getSecond() == null) {
         addObject(pcic.getFirst(), inst);
       } else {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowEncodingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowEncodingIterator.java
@@ -87,7 +87,7 @@ public abstract class RowEncodingIterator
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     RowEncodingIterator newInstance;
     try {
-      newInstance = this.getClass().newInstance();
+      newInstance = this.getClass().getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowFilter.java
@@ -151,7 +151,7 @@ public abstract class RowFilter extends WrappingIterator {
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     RowFilter newInstance;
     try {
-      newInstance = getClass().newInstance();
+      newInstance = getClass().getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
@@ -153,7 +153,7 @@ public abstract class SeekingFilter extends WrappingIterator {
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     SeekingFilter newInstance;
     try {
-      newInstance = this.getClass().newInstance();
+      newInstance = this.getClass().getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -175,7 +175,7 @@ public abstract class TransformingIterator extends WrappingIterator implements O
     TransformingIterator copy;
 
     try {
-      copy = getClass().newInstance();
+      copy = getClass().getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/sample/impl/SamplerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/sample/impl/SamplerFactory.java
@@ -18,6 +18,7 @@
 package org.apache.accumulo.core.sample.impl;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import org.apache.accumulo.core.client.sample.Sampler;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -40,13 +41,14 @@ public class SamplerFactory {
       else
         clazz = AccumuloVFSClassLoader.loadClass(config.getClassName(), Sampler.class);
 
-      Sampler sampler = clazz.newInstance();
+      Sampler sampler = clazz.getDeclaredConstructor().newInstance();
 
       sampler.init(config.toSamplerConfiguration());
 
       return sampler;
 
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+        | NoSuchMethodException | InvocationTargetException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/sample/impl/SamplerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/sample/impl/SamplerFactory.java
@@ -18,7 +18,6 @@
 package org.apache.accumulo.core.sample.impl;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 
 import org.apache.accumulo.core.client.sample.Sampler;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -47,8 +46,7 @@ public class SamplerFactory {
 
       return sampler;
 
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
@@ -18,6 +18,7 @@
 package org.apache.accumulo.core.summary;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
@@ -42,23 +43,26 @@ public class SummarizerFactory {
   }
 
   private Summarizer newSummarizer(String classname)
-      throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException {
+      throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException,
+      NoSuchMethodException, InvocationTargetException {
     if (classloader != null) {
-      return classloader.loadClass(classname).asSubclass(Summarizer.class).newInstance();
+      return classloader.loadClass(classname).asSubclass(Summarizer.class).getDeclaredConstructor()
+          .newInstance();
     } else {
       if (context != null && !context.equals(""))
         return AccumuloVFSClassLoader.getContextManager()
-            .loadClass(context, classname, Summarizer.class).newInstance();
+            .loadClass(context, classname, Summarizer.class).getDeclaredConstructor().newInstance();
       else
-        return AccumuloVFSClassLoader.loadClass(classname, Summarizer.class).newInstance();
+        return AccumuloVFSClassLoader.loadClass(classname, Summarizer.class)
+            .getDeclaredConstructor().newInstance();
     }
   }
 
   public Summarizer getSummarizer(SummarizerConfiguration conf) {
     try {
       return newSummarizer(conf.getClassName());
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-        | IOException e) {
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IOException
+        | NoSuchMethodException | InvocationTargetException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
@@ -18,7 +18,6 @@
 package org.apache.accumulo.core.summary;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
@@ -43,8 +42,7 @@ public class SummarizerFactory {
   }
 
   private Summarizer newSummarizer(String classname)
-      throws ClassNotFoundException, IOException, InstantiationException, IllegalAccessException,
-      NoSuchMethodException, InvocationTargetException {
+      throws IOException, ReflectiveOperationException {
     if (classloader != null) {
       return classloader.loadClass(classname).asSubclass(Summarizer.class).getDeclaredConstructor()
           .newInstance();
@@ -61,8 +59,7 @@ public class SummarizerFactory {
   public Summarizer getSummarizer(SummarizerConfiguration conf) {
     try {
       return newSummarizer(conf.getClassName());
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IOException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException | IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.util;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 
 import org.apache.accumulo.core.cli.ClientOpts.Password;
 import org.apache.accumulo.core.cli.ClientOpts.PasswordConverter;
@@ -112,8 +111,7 @@ public class CreateToken implements KeywordExecutable {
       System.out.println("auth.type = " + opts.tokenClassName);
       System.out.println("auth.principal = " + principal);
       System.out.println("auth.token = " + ClientProperty.encodeToken(token));
-    } catch (IOException | InstantiationException | IllegalAccessException | ClassNotFoundException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (IOException | ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.core.util;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 import org.apache.accumulo.core.cli.ClientOpts.Password;
 import org.apache.accumulo.core.cli.ClientOpts.PasswordConverter;
@@ -91,8 +92,8 @@ public class CreateToken implements KeywordExecutable {
         principal = getConsoleReader().readLine("Username (aka principal): ");
       }
 
-      AuthenticationToken token =
-          Class.forName(opts.tokenClassName).asSubclass(AuthenticationToken.class).newInstance();
+      AuthenticationToken token = Class.forName(opts.tokenClassName)
+          .asSubclass(AuthenticationToken.class).getDeclaredConstructor().newInstance();
       Properties props = new Properties();
       for (TokenProperty tp : token.getProperties()) {
         String input;
@@ -111,8 +112,8 @@ public class CreateToken implements KeywordExecutable {
       System.out.println("auth.type = " + opts.tokenClassName);
       System.out.println("auth.principal = " + principal);
       System.out.println("auth.token = " + ClientProperty.encodeToken(token));
-    } catch (IOException | InstantiationException | IllegalAccessException
-        | ClassNotFoundException e) {
+    } catch (IOException | InstantiationException | IllegalAccessException | ClassNotFoundException
+        | NoSuchMethodException | InvocationTargetException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/format/FormatterFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/FormatterFactory.java
@@ -30,7 +30,7 @@ public class FormatterFactory {
       Iterable<Entry<Key,Value>> scanner, FormatterConfig config) {
     Formatter formatter = null;
     try {
-      formatter = formatterClass.newInstance();
+      formatter = formatterClass.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       log.warn("Unable to instantiate formatter. Using default formatter.", e);
       formatter = new DefaultFormatter();

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -30,6 +30,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -265,8 +266,8 @@ public class CryptoTest {
   }
 
   @Test
-  public void testMissingConfigProperties()
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+  public void testMissingConfigProperties() throws ClassNotFoundException, InstantiationException,
+      IllegalAccessException, NoSuchMethodException, InvocationTargetException {
     ConfigurationCopy aconf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     Configuration conf = new Configuration(false);
     for (Map.Entry<String,String> e : conf) {
@@ -277,7 +278,7 @@ public class CryptoTest {
     String configuredClass = aconf.get(Property.INSTANCE_CRYPTO_SERVICE.getKey());
     Class<? extends CryptoService> clazz =
         AccumuloVFSClassLoader.loadClass(configuredClass, CryptoService.class);
-    CryptoService cs = clazz.newInstance();
+    CryptoService cs = clazz.getDeclaredConstructor().newInstance();
 
     exception.expect(NullPointerException.class);
     cs.init(aconf.getAllPropertiesWithPrefix(Property.TABLE_PREFIX));

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -30,7 +30,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -266,8 +265,7 @@ public class CryptoTest {
   }
 
   @Test
-  public void testMissingConfigProperties() throws ClassNotFoundException, InstantiationException,
-      IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+  public void testMissingConfigProperties() throws ReflectiveOperationException {
     ConfigurationCopy aconf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     Configuration conf = new Configuration(false);
     for (Map.Entry<String,String> e : conf) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -695,8 +694,7 @@ public class CombinerTest {
   }
 
   public static void sumArray(Class<? extends Encoder<List<Long>>> encoderClass,
-      SummingArrayCombiner.Type type) throws IOException, InstantiationException,
-      IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+      SummingArrayCombiner.Type type) throws IOException, ReflectiveOperationException {
     Encoder<List<Long>> encoder = encoderClass.getDeclaredConstructor().newInstance();
 
     TreeMap<Key,Value> tm1 = new TreeMap<>();
@@ -790,8 +788,7 @@ public class CombinerTest {
   }
 
   @Test
-  public void sumArrayTest() throws IOException, InstantiationException, IllegalAccessException,
-      NoSuchMethodException, InvocationTargetException {
+  public void sumArrayTest() throws IOException, ReflectiveOperationException {
     sumArray(SummingArrayCombiner.VarLongArrayEncoder.class, SummingArrayCombiner.Type.VARLEN);
     sumArray(SummingArrayCombiner.FixedLongArrayEncoder.class, SummingArrayCombiner.Type.FIXEDLEN);
     sumArray(SummingArrayCombiner.StringArrayEncoder.class, SummingArrayCombiner.Type.STRING);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -694,9 +695,9 @@ public class CombinerTest {
   }
 
   public static void sumArray(Class<? extends Encoder<List<Long>>> encoderClass,
-      SummingArrayCombiner.Type type)
-      throws IOException, InstantiationException, IllegalAccessException {
-    Encoder<List<Long>> encoder = encoderClass.newInstance();
+      SummingArrayCombiner.Type type) throws IOException, InstantiationException,
+      IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    Encoder<List<Long>> encoder = encoderClass.getDeclaredConstructor().newInstance();
 
     TreeMap<Key,Value> tm1 = new TreeMap<>();
 
@@ -789,7 +790,8 @@ public class CombinerTest {
   }
 
   @Test
-  public void sumArrayTest() throws IOException, InstantiationException, IllegalAccessException {
+  public void sumArrayTest() throws IOException, InstantiationException, IllegalAccessException,
+      NoSuchMethodException, InvocationTargetException {
     sumArray(SummingArrayCombiner.VarLongArrayEncoder.class, SummingArrayCombiner.Type.VARLEN);
     sumArray(SummingArrayCombiner.FixedLongArrayEncoder.class, SummingArrayCombiner.Type.FIXEDLEN);
     sumArray(SummingArrayCombiner.StringArrayEncoder.class, SummingArrayCombiner.Type.STRING);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
@@ -288,7 +288,8 @@ public abstract class TestCfCqSlice {
     firstOpts.put(CfCqSliceOpts.OPT_MAX_CF, new String(LONG_LEX.encode(sliceMaxCf), UTF_8));
     secondOpts.put(CfCqSliceOpts.OPT_MIN_CQ, new String(LONG_LEX.encode(sliceMinCq), UTF_8));
     secondOpts.put(CfCqSliceOpts.OPT_MAX_CQ, new String(LONG_LEX.encode(sliceMaxCq), UTF_8));
-    SortedKeyValueIterator<Key,Value> skvi = getFilterClass().newInstance();
+    SortedKeyValueIterator<Key,Value> skvi =
+        getFilterClass().getDeclaredConstructor().newInstance();
     skvi.init(new SortedMapIterator(data), firstOpts, null);
     loadKvs(skvi.deepCopy(null), foundKvs, secondOpts, INFINITY);
     for (int i = 0; i < LR_DIM; i++) {
@@ -373,7 +374,8 @@ public abstract class TestCfCqSlice {
   private void loadKvs(SortedKeyValueIterator<Key,Value> parent, boolean[][][] foundKvs,
       Map<String,String> options, Range range) {
     try {
-      SortedKeyValueIterator<Key,Value> skvi = getFilterClass().newInstance();
+      SortedKeyValueIterator<Key,Value> skvi =
+          getFilterClass().getDeclaredConstructor().newInstance();
       skvi.init(parent, options, null);
       skvi.seek(range, EMPTY_CF_SET, false);
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -90,8 +89,7 @@ public class TransformingIteratorTest {
     reuserIter.init(visFilter, EMPTY_OPTS, null);
     try {
       titer = clazz.getDeclaredConstructor().newInstance();
-    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
-        | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -88,8 +89,9 @@ public class TransformingIteratorTest {
     ReuseIterator reuserIter = new ReuseIterator();
     reuserIter.init(visFilter, EMPTY_OPTS, null);
     try {
-      titer = clazz.newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      titer = clazz.getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+        | InvocationTargetException e) {
       throw new RuntimeException(e);
     }
 
@@ -143,7 +145,7 @@ public class TransformingIteratorTest {
       setUpTransformIterator(clazz);
 
       // All rows with visibilities reversed
-      TransformingIterator iter = clazz.newInstance();
+      TransformingIterator iter = clazz.getDeclaredConstructor().newInstance();
       TreeMap<Key,Value> expected = new TreeMap<>();
       for (int row = 1; row <= 3; ++row) {
         for (int cf = 1; cf <= 3; ++cf) {

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestCaseFinder.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestCaseFinder.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.iteratortest;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,8 +71,9 @@ public class IteratorTestCaseFinder {
       }
 
       try {
-        testCases.add((IteratorTestCase) clz.newInstance());
-      } catch (IllegalAccessException | InstantiationException e) {
+        testCases.add((IteratorTestCase) clz.getDeclaredConstructor().newInstance());
+      } catch (IllegalAccessException | InstantiationException | NoSuchMethodException
+          | InvocationTargetException e) {
         log.warn("Could not instantiate {}", clz, e);
       }
     }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestCaseFinder.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestCaseFinder.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.iteratortest;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,8 +71,7 @@ public class IteratorTestCaseFinder {
 
       try {
         testCases.add((IteratorTestCase) clz.getDeclaredConstructor().newInstance());
-      } catch (IllegalAccessException | InstantiationException | NoSuchMethodException
-          | InvocationTargetException e) {
+      } catch (ReflectiveOperationException e) {
         log.warn("Could not instantiate {}", clz, e);
       }
     }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestUtil.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestUtil.java
@@ -18,8 +18,6 @@ package org.apache.accumulo.iteratortest;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
@@ -35,8 +33,7 @@ public class IteratorTestUtil {
   public static SortedKeyValueIterator<Key,Value> instantiateIterator(IteratorTestInput input) {
     try {
       return requireNonNull(input.getIteratorClass()).getDeclaredConstructor().newInstance();
-    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
-        | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
   }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestUtil.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestUtil.java
@@ -18,6 +18,8 @@ package org.apache.accumulo.iteratortest;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.reflect.InvocationTargetException;
+
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
@@ -32,8 +34,9 @@ public class IteratorTestUtil {
 
   public static SortedKeyValueIterator<Key,Value> instantiateIterator(IteratorTestInput input) {
     try {
-      return requireNonNull(input.getIteratorClass()).newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      return requireNonNull(input.getIteratorClass()).getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+        | InvocationTargetException e) {
       throw new RuntimeException(e);
     }
   }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/InstantiationTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/InstantiationTestCase.java
@@ -35,7 +35,7 @@ public class InstantiationTestCase implements IteratorTestCase {
     try {
       // We should be able to instantiate the Iterator given the Class
       @SuppressWarnings("unused")
-      SortedKeyValueIterator<Key,Value> iter = clz.newInstance();
+      SortedKeyValueIterator<Key,Value> iter = clz.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       return new IteratorTestOutput(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.server;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -128,15 +127,13 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   @Override
   public <T> T instantiate(String className, Class<T> base)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException,
-      NoSuchMethodException, InvocationTargetException {
+      throws ReflectiveOperationException, IOException {
     return ConfigurationTypeHelper.getClassInstance(null, className, base);
   }
 
   @Override
   public <T> T instantiate(TableId tableId, String className, Class<T> base)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException,
-      NoSuchMethodException, InvocationTargetException {
+      throws ReflectiveOperationException, IOException {
     String ctx =
         srvCtx.getServerConfFactory().getTableConfiguration(tableId).get(Property.TABLE_CLASSPATH);
     return ConfigurationTypeHelper.getClassInstance(ctx, className, base);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.server;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -127,13 +128,15 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   @Override
   public <T> T instantiate(String className, Class<T> base)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
+      throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException,
+      NoSuchMethodException, InvocationTargetException {
     return ConfigurationTypeHelper.getClassInstance(null, className, base);
   }
 
   @Override
   public <T> T instantiate(TableId tableId, String className, Class<T> base)
-      throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
+      throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException,
+      NoSuchMethodException, InvocationTargetException {
     String ctx =
         srvCtx.getServerConfFactory().getTableConfiguration(tableId).get(Property.TABLE_CLASSPATH);
     return ConfigurationTypeHelper.getClassInstance(ctx, className, base);

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.server.client;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -371,8 +370,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       Class test = AccumuloVFSClassLoader.loadClass(className, shouldMatch);
       test.getDeclaredConstructor().newInstance();
       return true;
-    } catch (ClassCastException | IllegalAccessException | InstantiationException
-        | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ClassCastException | ReflectiveOperationException e) {
       log.warn("Error checking object types", e);
       return false;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.server.client;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -368,10 +369,10 @@ public class ClientServiceHandler implements ClientService.Iface {
     try {
       shouldMatch = loader.loadClass(interfaceMatch);
       Class test = AccumuloVFSClassLoader.loadClass(className, shouldMatch);
-      test.newInstance();
+      test.getDeclaredConstructor().newInstance();
       return true;
     } catch (ClassCastException | IllegalAccessException | InstantiationException
-        | ClassNotFoundException e) {
+        | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
       log.warn("Error checking object types", e);
       return false;
     }
@@ -404,7 +405,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       }
 
       Class<?> test = currentLoader.loadClass(className).asSubclass(shouldMatch);
-      test.newInstance();
+      test.getDeclaredConstructor().newInstance();
       return true;
     } catch (Exception e) {
       log.warn("Error checking object types", e);
@@ -440,7 +441,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       }
 
       Class<?> test = currentLoader.loadClass(className).asSubclass(shouldMatch);
-      test.newInstance();
+      test.getDeclaredConstructor().newInstance();
       return true;
     } catch (Exception e) {
       log.warn("Error checking object types", e);

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicaSystemFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicaSystemFactory.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.server.replication;
 
 import static java.util.Objects.requireNonNull;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.server.ServerContext;
@@ -50,8 +49,7 @@ public class ReplicaSystemFactory {
 
       throw new IllegalArgumentException(
           "Class is not assignable to ReplicaSystem: " + entry.getKey());
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-        | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       log.error("Error creating ReplicaSystem object", e);
       throw new IllegalArgumentException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicaSystemFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicaSystemFactory.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.server.replication;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.server.ServerContext;
@@ -41,7 +42,7 @@ public class ReplicaSystemFactory {
       Class<?> clz = Class.forName(entry.getKey());
 
       if (ReplicaSystem.class.isAssignableFrom(clz)) {
-        Object o = clz.newInstance();
+        Object o = clz.getDeclaredConstructor().newInstance();
         ReplicaSystem rs = (ReplicaSystem) o;
         rs.configure(context, entry.getValue());
         return rs;
@@ -49,7 +50,8 @@ public class ReplicaSystemFactory {
 
       throw new IllegalArgumentException(
           "Class is not assignable to ReplicaSystem: " + entry.getKey());
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+        | NoSuchMethodException | InvocationTargetException e) {
       log.error("Error creating ReplicaSystem object", e);
       throw new IllegalArgumentException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/DefaultMap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/DefaultMap.java
@@ -50,7 +50,7 @@ public class DefaultMap<K,V> extends HashMap<K,V> {
   @SuppressWarnings("unchecked")
   private V construct() {
     try {
-      return (V) dfault.getClass().newInstance();
+      return (V) dfault.getClass().getDeclaredConstructor().newInstance();
     } catch (Exception ex) {
       return dfault;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/LoginProperties.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/LoginProperties.java
@@ -47,7 +47,7 @@ public class LoginProperties implements KeywordExecutable {
       AccumuloConfiguration config = context.getServerConfFactory().getSystemConfiguration();
       Authenticator authenticator = AccumuloVFSClassLoader.getClassLoader()
           .loadClass(config.get(Property.INSTANCE_SECURITY_AUTHENTICATOR))
-          .asSubclass(Authenticator.class).newInstance();
+          .asSubclass(Authenticator.class).getDeclaredConstructor().newInstance();
 
       System.out
           .println("Supported token types for " + authenticator.getClass().getName() + " are : ");
@@ -56,7 +56,8 @@ public class LoginProperties implements KeywordExecutable {
         System.out
             .println("\t" + tokenType.getName() + ", which accepts the following properties : ");
 
-        for (TokenProperty tokenProperty : tokenType.newInstance().getProperties()) {
+        for (TokenProperty tokenProperty : tokenType.getDeclaredConstructor().newInstance()
+            .getProperties()) {
           System.out.println("\t\t" + tokenProperty);
         }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkDriver.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkDriver.java
@@ -18,7 +18,6 @@ package org.apache.accumulo.master.replication;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -61,8 +60,7 @@ public class WorkDriver extends Daemon {
         Class<?> clz = Class.forName(workAssignerClass);
         Class<? extends WorkAssigner> workAssignerClz = clz.asSubclass(WorkAssigner.class);
         this.assigner = workAssignerClz.getDeclaredConstructor().newInstance();
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-          | NoSuchMethodException | InvocationTargetException e) {
+      } catch (ReflectiveOperationException e) {
         log.error("Could not instantiate configured work assigner {}", workAssignerClass, e);
         throw new RuntimeException(e);
       }

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkDriver.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkDriver.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.master.replication;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -59,8 +60,9 @@ public class WorkDriver extends Daemon {
       try {
         Class<?> clz = Class.forName(workAssignerClass);
         Class<? extends WorkAssigner> workAssignerClz = clz.asSubclass(WorkAssigner.class);
-        this.assigner = workAssignerClz.newInstance();
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        this.assigner = workAssignerClz.getDeclaredConstructor().newInstance();
+      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+          | NoSuchMethodException | InvocationTargetException e) {
         log.error("Could not instantiate configured work assigner {}", workAssignerClass, e);
         throw new RuntimeException(e);
       }

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -20,7 +20,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.channels.ServerSocketChannel;
@@ -244,8 +243,7 @@ public class TraceServer implements Watcher, AutoCloseable {
    *           if the trace user has the wrong permissions
    */
   private AccumuloClient ensureTraceTableExists(final AccumuloConfiguration conf)
-      throws AccumuloSecurityException, ClassNotFoundException, InstantiationException,
-      IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+      throws AccumuloSecurityException, ReflectiveOperationException {
     AccumuloClient accumuloClient = null;
     while (true) {
       try {

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.channels.ServerSocketChannel;
@@ -244,7 +245,7 @@ public class TraceServer implements Watcher, AutoCloseable {
    */
   private AccumuloClient ensureTraceTableExists(final AccumuloConfiguration conf)
       throws AccumuloSecurityException, ClassNotFoundException, InstantiationException,
-      IllegalAccessException {
+      IllegalAccessException, NoSuchMethodException, InvocationTargetException {
     AccumuloClient accumuloClient = null;
     while (true) {
       try {
@@ -266,7 +267,7 @@ public class TraceServer implements Watcher, AutoCloseable {
           Properties props = new Properties();
           AuthenticationToken token =
               AccumuloVFSClassLoader.getClassLoader().loadClass(conf.get(Property.TRACE_TOKEN_TYPE))
-                  .asSubclass(AuthenticationToken.class).newInstance();
+                  .asSubclass(AuthenticationToken.class).getDeclaredConstructor().newInstance();
 
           int prefixLength = Property.TRACE_TOKEN_PROPERTY_PREFIX.getKey().length();
           for (Entry<String,String> entry : loginMap.entrySet()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
@@ -66,7 +66,7 @@ public class ConstraintChecker {
           Class<? extends Constraint> clazz =
               loader.loadClass(className).asSubclass(Constraint.class);
           log.debug("Loaded constraint {} for {}", clazz.getName(), conf.getTableId());
-          constrains.add(clazz.newInstance());
+          constrains.add(clazz.getDeclaredConstructor().newInstance());
         }
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.accumulo.tserver.replication;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -96,8 +95,7 @@ public class ReplicationServicerHandler implements Iface {
     AccumuloReplicationReplayer replayer;
     try {
       replayer = clz.getDeclaredConstructor().newInstance();
-    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
-        | InvocationTargetException e1) {
+    } catch (ReflectiveOperationException e1) {
       log.error("Could not instantiate replayer class {}", clz.getName());
       throw new RemoteReplicationException(RemoteReplicationErrorCode.CANNOT_INSTANTIATE_REPLAYER,
           "Could not instantiate replayer class" + clz.getName());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationServicerHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.tserver.replication;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -94,8 +95,9 @@ public class ReplicationServicerHandler implements Iface {
     // Create an instance
     AccumuloReplicationReplayer replayer;
     try {
-      replayer = clz.newInstance();
-    } catch (InstantiationException | IllegalAccessException e1) {
+      replayer = clz.getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+        | InvocationTargetException e1) {
       log.error("Could not instantiate replayer class {}", clz.getName());
       throw new RemoteReplicationException(RemoteReplicationErrorCode.CANNOT_INSTANTIATE_REPLAYER,
           "Could not instantiate replayer class" + clz.getName());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2719,7 +2719,7 @@ public class Tablet {
       } else {
         clazz = AccumuloVFSClassLoader.loadClass(clazzName, CompactionStrategy.class);
       }
-      CompactionStrategy strategy = clazz.newInstance();
+      CompactionStrategy strategy = clazz.getDeclaredConstructor().newInstance();
       strategy.init(strategyConfig.getOptions());
       return strategy;
     } catch (Exception e) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -240,7 +240,7 @@ public class ScanCommand extends Command {
     if (clazz == null)
       clazz = DefaultScanInterpreter.class;
 
-    return clazz.newInstance();
+    return clazz.getDeclaredConstructor().newInstance();
   }
 
   protected Class<? extends Formatter> getFormatter(final CommandLine cl, final String tableName,

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.shell.commands;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -207,7 +206,7 @@ public class SetIterCommand extends Command {
     try {
       clazz = classloader.loadClass(className).asSubclass(SortedKeyValueIterator.class);
       untypedInstance = clazz.getDeclaredConstructor().newInstance();
-    } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       StringBuilder msg = new StringBuilder("Unable to load ").append(className);
       if (className.indexOf('.') < 0) {
         msg.append("; did you use a fully qualified package name?");
@@ -215,8 +214,6 @@ public class SetIterCommand extends Command {
         msg.append("; class not found.");
       }
       throw new ShellCommandException(ErrorCode.INITIALIZATION_FAILURE, msg.toString());
-    } catch (InstantiationException | IllegalAccessException e) {
-      throw new IllegalArgumentException(e.getMessage());
     } catch (ClassCastException e) {
       String msg = className + " loaded successfully but does not implement SortedKeyValueIterator."
           + " This class cannot be used with this command.";

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.shell.commands;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -205,8 +206,8 @@ public class SetIterCommand extends Command {
     Class<? extends SortedKeyValueIterator> clazz;
     try {
       clazz = classloader.loadClass(className).asSubclass(SortedKeyValueIterator.class);
-      untypedInstance = clazz.newInstance();
-    } catch (ClassNotFoundException e) {
+      untypedInstance = clazz.getDeclaredConstructor().newInstance();
+    } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
       StringBuilder msg = new StringBuilder("Unable to load ").append(className);
       if (className.indexOf('.') < 0) {
         msg.append("; did you use a fully qualified package name?");

--- a/start/src/main/java/org/apache/accumulo/start/Main.java
+++ b/start/src/main/java/org/apache/accumulo/start/Main.java
@@ -103,8 +103,7 @@ public class Main {
       try {
         classLoader = (ClassLoader) getVFSClassLoader().getMethod("getClassLoader").invoke(null);
         Thread.currentThread().setContextClassLoader(classLoader);
-      } catch (ClassNotFoundException | IOException | IllegalAccessException
-          | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+      } catch (IOException | IllegalArgumentException | ReflectiveOperationException
           | SecurityException e) {
         log.error("Problem initializing the class loader", e);
         System.exit(1);

--- a/start/src/main/java/org/apache/accumulo/start/Main.java
+++ b/start/src/main/java/org/apache/accumulo/start/Main.java
@@ -57,7 +57,7 @@ public class Main {
       }
       Object conf = null;
       try {
-        conf = confClass.newInstance();
+        conf = confClass.getDeclaredConstructor().newInstance();
       } catch (Exception e) {
         log.error("Error creating new instance of Hadoop Configuration", e);
         System.exit(1);

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
@@ -96,7 +96,7 @@ public class AccumuloReloadingVFSClassLoaderTest {
     arvcl.setMaxRetries(1);
 
     Class<?> clazz1 = arvcl.getClassLoader().loadClass("test.HelloWorld");
-    Object o1 = clazz1.newInstance();
+    Object o1 = clazz1.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o1.toString());
 
     // Check that the class is the same before the update
@@ -117,7 +117,7 @@ public class AccumuloReloadingVFSClassLoaderTest {
     Thread.sleep(7000);
 
     Class<?> clazz2 = arvcl.getClassLoader().loadClass("test.HelloWorld");
-    Object o2 = clazz2.newInstance();
+    Object o2 = clazz2.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o2.toString());
 
     // This is false because they are loaded by a different classloader
@@ -142,7 +142,7 @@ public class AccumuloReloadingVFSClassLoaderTest {
     arvcl.setMaxRetries(3);
 
     Class<?> clazz1 = arvcl.getClassLoader().loadClass("test.HelloWorld");
-    Object o1 = clazz1.newInstance();
+    Object o1 = clazz1.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o1.toString());
 
     // Check that the class is the same before the update
@@ -163,7 +163,7 @@ public class AccumuloReloadingVFSClassLoaderTest {
     Thread.sleep(7000);
 
     Class<?> clazz2 = arvcl.getClassLoader().loadClass("test.HelloWorld");
-    Object o2 = clazz2.newInstance();
+    Object o2 = clazz2.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o2.toString());
 
     // This is true because they are loaded by the same classloader due to the new retry

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
@@ -139,7 +139,7 @@ public class AccumuloVFSClassLoaderTest {
     // We can't be sure what the authority/host will be due to FQDN mappings, so just check the path
     assertTrue(arvcl.getFileObjects()[0].getURL().toString().contains("HelloWorld.jar"));
     Class<?> clazz1 = arvcl.loadClass("test.HelloWorld");
-    Object o1 = clazz1.newInstance();
+    Object o1 = clazz1.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o1.toString());
     Whitebox.setInternalState(AccumuloVFSClassLoader.class, "loader",
         (AccumuloReloadingVFSClassLoader) null);

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/ContextManagerTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/ContextManagerTest.java
@@ -111,11 +111,11 @@ public class ContextManagerTest {
     assertArrayEquals(createFileSystems(dirContents2), files2);
 
     Class<?> defaultContextClass = cl1.loadClass("test.HelloWorld");
-    Object o1 = defaultContextClass.newInstance();
+    Object o1 = defaultContextClass.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o1.toString());
 
     Class<?> myContextClass = cl2.loadClass("test.HelloWorld");
-    Object o2 = myContextClass.newInstance();
+    Object o2 = myContextClass.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o2.toString());
 
     assertNotEquals(defaultContextClass, myContextClass);

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/providers/VfsClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/providers/VfsClassLoaderTest.java
@@ -62,7 +62,7 @@ public class VfsClassLoaderTest extends AccumuloDFSBase {
   @Test
   public void testGetClass() throws Exception {
     Class<?> helloWorldClass = this.cl.loadClass("test.HelloWorld");
-    Object o = helloWorldClass.newInstance();
+    Object o = helloWorldClass.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o.toString());
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/BatchWriterIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/BatchWriterIterator.java
@@ -264,7 +264,7 @@ public class BatchWriterIterator extends WrappingIterator {
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     BatchWriterIterator newInstance;
     try {
-      newInstance = this.getClass().newInstance();
+      newInstance = this.getClass().getDeclaredConstructor().newInstance();
       newInstance.init(getSource().deepCopy(env), originalOptions, env);
       return newInstance;
     } catch (Exception e) {

--- a/test/src/main/java/org/apache/accumulo/test/HardListIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/HardListIterator.java
@@ -74,7 +74,7 @@ public class HardListIterator implements SortedKeyValueIterator<Key,Value> {
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
     HardListIterator newInstance;
     try {
-      newInstance = HardListIterator.class.newInstance();
+      newInstance = HardListIterator.class.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java
@@ -27,6 +27,7 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Base64;
 import java.util.Objects;
 
@@ -65,8 +66,9 @@ public class SerializationUtil {
           classname + " is not a subclass of " + parentClass.getName(), e);
     }
     try {
-      return cm.newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      return cm.getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+        | InvocationTargetException e) {
       throw new IllegalArgumentException("can't instantiate new instance of " + cm.getName(), e);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java
@@ -27,7 +27,6 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Base64;
 import java.util.Objects;
 
@@ -67,8 +66,7 @@ public class SerializationUtil {
     }
     try {
       return cm.getDeclaredConstructor().newInstance();
-    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
-        | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       throw new IllegalArgumentException("can't instantiate new instance of " + cm.getName(), e);
     }
   }


### PR DESCRIPTION
Calls to newInstance() are deprecated in JDK 9+. Replace with calls to
getDeclaredConstructor().newInstance()