### PR TITLE
Update Accumulo to build and run with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
     - $HOME/.m2
 install: echo NOOP Skipping pre-fetch of Maven dependencies
 jdk:
-  - openjdk8
+  - openjdk11
 before_script:
   - unset _JAVA_OPTIONS
 env:

--- a/core/src/main/spotbugs/exclude-filter.xml
+++ b/core/src/main/spotbugs/exclude-filter.xml
@@ -32,4 +32,9 @@
       <Package name="org.apache.accumulo.core.trace.thrift" />
     </Or>
   </Match>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
 </FindBugsFilter>

--- a/hadoop-mapreduce/src/main/spotbugs/exclude-filter.xml
+++ b/hadoop-mapreduce/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated files -->
-    <Package name="org.apache.accumulo.test.rpc.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/minicluster/src/main/spotbugs/exclude-filter.xml
+++ b/minicluster/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated files -->
-    <Package name="org.apache.accumulo.test.rpc.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/pom.xml
+++ b/pom.xml
@@ -132,17 +132,20 @@
     <jaxb.version>2.3.0</jaxb.version>
     <jersey.version>2.27</jersey.version>
     <jetty.version>9.4.17.v20190418</jetty.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
+    <!-- temporary until other Java 11 issues are resolved -->
+    <modernizer.skip>true</modernizer.skip>
     <powermock.version>1.7.4</powermock.version>
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>
     <servlet.api.version>3.1.0</servlet.api.version>
     <slf4j.version>1.7.26</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
-    <spotbugs.version>3.1.7</spotbugs.version>
+    <spotbugs.version>3.1.12</spotbugs.version>
     <surefire.excludedGroups />
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <surefire.groups />
@@ -778,7 +781,7 @@
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>1.8.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
@@ -880,7 +883,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
             <quiet>true</quiet>
-            <javadocVersion>1.8.0</javadocVersion>
+            <javadocVersion>11</javadocVersion>
             <additionalJOption>-J-Xmx512m</additionalJOption>
             <doclint>all,-missing</doclint>
           </configuration>
@@ -951,13 +954,6 @@
               </requireJavaVersion>
             </rules>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>animal-sniffer-enforcer-rule</artifactId>
-              <version>1.17</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <!-- Allows us to get the apache-ds bundle artifacts -->
@@ -1027,6 +1023,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <!-- needed for Java 11 until maven-dependency-plugin 3.1.2 is released -->
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-analyzer</artifactId>
+            <version>1.11.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>analyze</id>
@@ -1112,28 +1116,6 @@
               <goal>enforce</goal>
             </goals>
             <phase>validate</phase>
-          </execution>
-          <execution>
-            <id>enforce-java-signatures</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>process-test-classes</phase>
-            <configuration>
-              <rules>
-                <checkSignatureRule implementation="org.codehaus.mojo.animal_sniffer.enforcer.CheckSignatureRule">
-                  <signature>
-                    <groupId>org.codehaus.mojo.signature</groupId>
-                    <artifactId>java18</artifactId>
-                    <version>1.0</version>
-                  </signature>
-                  <ignores>
-                    <ignore>org.apache.hadoop.conf.Configuration</ignore>
-                    <ignore>org.apache.hadoop.fs.FileSystem</ignore>
-                  </ignores>
-                </checkSignatureRule>
-              </rules>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/server/base/src/main/spotbugs/exclude-filter.xml
+++ b/server/base/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated files -->
-    <Package name="org.apache.accumulo.test.rpc.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/server/master/src/main/spotbugs/exclude-filter.xml
+++ b/server/master/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated files -->
-    <Package name="org.apache.accumulo.test.rpc.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/server/tracer/src/main/spotbugs/exclude-filter.xml
+++ b/server/tracer/src/main/spotbugs/exclude-filter.xml
@@ -23,4 +23,9 @@
     <!-- ignore thrift-generated classes -->
     <Package name="org.apache.accumulo.tracer.thrift" />
   </Match>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
 </FindBugsFilter>

--- a/server/tserver/src/main/spotbugs/exclude-filter.xml
+++ b/server/tserver/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated files -->
-    <Package name="org.apache.accumulo.test.rpc.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />


### PR DESCRIPTION
* Configure Maven to build with Java 11
* Remove animal-sniffer (unnecessary with new javac release flag)
* Add exceptions to spotbugs to avoid false positive bug
  (https://github.com/spotbugs/spotbugs/issues/756)
* Update Travis to use OpenJDK11

This is a much more conservative change than my initial. The build is broken, but it's much easier to do this incrementally. Eventually, all the build tests will be fixed, but this is a necessary starting point.