### PR TITLE
Fix #1122 Added concurrent structures to ThriftTransportPool

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
@@ -135,12 +135,35 @@ public class TransportCachingIT extends AccumuloClusterHarness {
           // Get a non-cached transport
           third = pool.getAnyTransport(servers, false).getSecond();
         } catch (TTransportException e) {
-          log.warn("Failed obtain 2nd transport to {}", servers);
+          log.warn("Failed obtain 3rd transport to {}", servers);
         }
       }
 
       assertNotSame("Expected second and third transport to be different instances", second, third);
       pool.returnTransport(third);
+
+      // ensure the LIFO scheme with a fourth and fifth entry
+      TTransport fourth = null;
+      while (fourth == null) {
+        try {
+          // Get a non-cached transport
+          fourth = pool.getAnyTransport(servers, false).getSecond();
+        } catch (TTransportException e) {
+          log.warn("Failed obtain 4th transport to {}", servers);
+        }
+      }
+      pool.returnTransport(fourth);
+      TTransport fifth = null;
+      while (fifth == null) {
+        try {
+          // Get a cached transport
+          fifth = pool.getAnyTransport(servers, true).getSecond();
+        } catch (TTransportException e) {
+          log.warn("Failed obtain 5th transport to {}", servers);
+        }
+      }
+      assertSame("Expected fourth and fifth transport to be the same instance", fourth, fifth);
+      pool.returnTransport(fifth);
     }
   }
 }


### PR DESCRIPTION
Also contains suggestions for removing syncrhonized blocks.
(previous pull request was closed because wron branch was pushed)

Syncrhronized blocks of text are commented out with "NOT NEEDED?"  in the diffs below. These may not be necessary if the object constructs handle write/delete concurrency. But maybe they are not that costly.
Additionally - I have a question on the section of code below. The connections are closed specifically after the sync block. It seems that since the "unreserved" is read and not deleted from then someone could use one that is designated to close by the sync blck.

```java
    synchronized (pool) {
         for (CachedConnections cachedConns : pool.getCache().values()) {
           Iterator<CachedConnection> iter = cachedConns.unreserved.iterator();
           while (iter.hasNext()) {
             CachedConnection cachedConnection = iter.next();

             if (System.currentTimeMillis() - cachedConnection.lastReturnTime > pool.killTime) {
               connectionsToClose.add(cachedConnection);
               iter.remove();
             }
           }

           for (CachedConnection cachedConnection : cachedConns.reserved.values()) {
             cachedConnection.transport.checkForStuckIO(STUCK_THRESHOLD);
           }
         }

         Iterator<Entry<ThriftTransportKey,Long>> iter = pool.errorTime.entrySet().iterator();
         while (iter.hasNext()) {
           Entry<ThriftTransportKey,Long> entry = iter.next();
           long delta = System.currentTimeMillis() - entry.getValue();
           if (delta >= STUCK_THRESHOLD) {
             pool.errorCount.remove(entry.getKey());
             iter.remove();
           }
         }
       }

       // close connections outside of sync block
       for (CachedConnection cachedConnection : connectionsToClose) {
         cachedConnection.transport.close();
       }
```