### PR TITLE
Fix #1181 Update MasterMetadataUtil to use new Ample api

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -138,6 +138,8 @@ public interface Ample {
 
     public TabletMutator putCompactionId(long compactionId);
 
+    public TabletMutator putFlushId(long flushId);
+
     public TabletMutator putLocation(TServer tserver, LocationType type);
 
     public TabletMutator deleteLocation(TServer tserver, LocationType type);
@@ -151,6 +153,12 @@ public interface Ample {
     public TabletMutator deleteWal(String wal);
 
     public TabletMutator deleteWal(LogEntry logEntry);
+
+    public TabletMutator putTime(String time);
+
+    public TabletMutator putBulkFile(Ample.FileMeta bulkref, long tid);
+
+    public TabletMutator deleteBulkFile(Ample.FileMeta bulkref);
 
     /**
      * This method persist (or queues for persisting) previous put and deletes against this object.

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -17,8 +17,6 @@
 
 package org.apache.accumulo.server.metadata;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -61,8 +59,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   @Override
   public Ample.TabletMutator putDir(String dir) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mutation,
-        new Value(dir.getBytes(UTF_8)));
+    TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mutation, new Value(dir));
     return this;
   }
 
@@ -91,7 +88,21 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   public Ample.TabletMutator putCompactionId(long compactionId) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     TabletsSection.ServerColumnFamily.COMPACT_COLUMN.put(mutation,
-        new Value(("" + compactionId).getBytes()));
+        new Value(Long.toString(compactionId)));
+    return this;
+  }
+
+  @Override
+  public Ample.TabletMutator putFlushId(long flushId) {
+    Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
+    TabletsSection.ServerColumnFamily.FLUSH_COLUMN.put(mutation, new Value(Long.toString(flushId)));
+    return this;
+  }
+
+  @Override
+  public Ample.TabletMutator putTime(String time) {
+    Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
+    TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mutation, new Value(time));
     return this;
   }
 
@@ -126,7 +137,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   public Ample.TabletMutator putZooLock(ZooLock zooLock) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     TabletsSection.ServerColumnFamily.LOCK_COLUMN.put(mutation,
-        new Value(zooLock.getLockID().serialize(context.getZooKeeperRoot() + "/").getBytes(UTF_8)));
+        new Value(zooLock.getLockID().serialize(context.getZooKeeperRoot() + "/")));
     return this;
   }
 
@@ -148,6 +159,21 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   public Ample.TabletMutator deleteWal(String wal) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.putDelete(MetadataSchema.TabletsSection.LogColumnFamily.STR_NAME, wal);
+    return this;
+  }
+
+  @Override
+  public Ample.TabletMutator putBulkFile(Ample.FileMeta bulkref, long tid) {
+    Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
+    mutation.put(TabletsSection.BulkFileColumnFamily.NAME, bulkref.meta(),
+        new Value(Long.toString(tid)));
+    return this;
+  }
+
+  @Override
+  public Ample.TabletMutator deleteBulkFile(Ample.FileMeta bulkref) {
+    Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
+    mutation.putDelete(TabletsSection.BulkFileColumnFamily.NAME, bulkref.meta());
     return this;
   }
 


### PR DESCRIPTION
@keith-turner , I pushed this for review.  It's pretty straightforward.  the sunny tests ran and I ran many of the Split IT tests that seemed to use it.  In process of testing against the standalone instance I ran into problems and need to recreate my whole setup and will provide a status on that when its working.

Note my comment on the collections assumed "not null".  Personally I dislike null checks and usually try to ensure objects floating around are not null  and have noticed they are not prevalent in the code base BUT, often the checks do serve a needed purpose.