### PR TITLE
Fix bad unit tests found while building on Java 11

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -31,6 +31,8 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Tests the Table ID class, mainly the internal cache.
  */
@@ -98,6 +100,7 @@ public class TableIdTest {
     }
   }
 
+  @SuppressFBWarnings(value = "DM_GC", justification = "gc is okay for test")
   static void tryToGc() {
     System.gc();
     try {

--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -28,22 +28,18 @@ import org.apache.accumulo.core.replication.ReplicationTable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests the Table ID class, mainly the internal cache.
  */
 public class TableIdTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TableIdTest.class);
+
   @Rule
   public TestName name = new TestName();
-
-  @Test
-  public void testCacheIncreases() {
-    long initialSize = TableId.cache.asMap().entrySet().stream().count();
-    String tableString = "table-" + name.getMethodName();
-    TableId table1 = TableId.of(tableString);
-    assertEquals(initialSize + 1, TableId.cache.asMap().entrySet().stream().count());
-    assertEquals(tableString, table1.canonical());
-  }
 
   @Test
   public void testCacheNoDuplicates() {
@@ -74,28 +70,40 @@ public class TableIdTest {
     assertSame(table1, table2);
   }
 
-  @Test(timeout = 60_000)
-  public void testCacheDecreasesAfterGC() {
-    Long initialSize = TableId.cache.asMap().entrySet().stream().count();
-    generateJunkCacheEntries();
-    Long postGCSize;
-    do {
-      System.gc();
-      try {
-        Thread.sleep(500);
-      } catch (InterruptedException e) {
-        fail("Thread interrupted while waiting for GC");
-      }
-      postGCSize = TableId.cache.asMap().entrySet().stream().count();
-    } while (postGCSize > initialSize);
+  @Test(timeout = 30_000)
+  public void testCacheIncreasesAndDecreasesAfterGC() {
+    long initialSize = TableId.cache.asMap().entrySet().stream().count();
+    assertTrue(initialSize < 20); // verify initial amount is reasonably low
+    LOG.info("Initial cache size: {}", initialSize);
+    LOG.info(TableId.cache.asMap().toString());
 
-    assertTrue("Cache did not decrease with GC.",
-        TableId.cache.asMap().entrySet().stream().count() < initialSize);
-  }
+    // add one and check increase
+    String tableString = "table-" + name.getMethodName();
+    TableId table1 = TableId.of(tableString);
+    assertEquals(initialSize + 1, TableId.cache.asMap().entrySet().stream().count());
+    assertEquals(tableString, table1.canonical());
 
-  private void generateJunkCacheEntries() {
-    for (int i = 0; i < 1000; i++)
+    // create a bunch more and throw them away
+    for (int i = 0; i < 999; i++) {
       TableId.of(new String("table" + i));
+    }
+    long preGCSize = TableId.cache.asMap().entrySet().stream().count();
+    LOG.info("Entries before System.gc(): {}", preGCSize);
+    assertTrue(preGCSize > 500); // verify amount increased significantly
+    long postGCSize = preGCSize;
+    while (postGCSize >= preGCSize) {
+      tryToGc();
+      postGCSize = TableId.cache.asMap().entrySet().stream().count();
+      LOG.info("Entries after System.gc(): {}", postGCSize);
+    }
   }
 
+  static void tryToGc() {
+    System.gc();
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      fail("Thread interrupted while waiting for GC");
+    }
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <powermock.version>1.7.4</powermock.version>
+    <powermock.version>2.0.2</powermock.version>
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>
     <servlet.api.version>3.1.0</servlet.api.version>
@@ -545,7 +545,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.6</version>
+        <version>4.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -382,7 +382,12 @@ public class AccumuloVFSClassLoader {
         }
 
         boolean sawFirst = false;
-        if (classLoader instanceof URLClassLoader) {
+        if (classLoader.getClass().getName().startsWith("jdk.internal")) {
+          if (debug) {
+            out.print("Level " + classLoaderDescription + " " + classLoader.getClass().getName()
+                + " configuration not inspectable.\n");
+          }
+        } else if (classLoader instanceof URLClassLoader) {
           if (debug) {
             out.print("Level " + classLoaderDescription + " URL classpath items are:\n");
           }

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
@@ -46,7 +46,7 @@ import org.powermock.reflect.Whitebox;
     "org.apache.log4j.LogManager"})
 @PowerMockIgnore({"org.apache.log4j.*", "org.apache.hadoop.log.metrics",
     "org.apache.commons.logging.*", "org.xml.*", "javax.xml.*", "org.w3c.dom.*",
-    "org.apache.hadoop.*"})
+    "org.apache.hadoop.*", "com.sun.org.apache.xerces.*"})
 public class AccumuloVFSClassLoaderTest {
 
   private TemporaryFolder folder1 =


### PR DESCRIPTION
* Primarily fixes some bad unit tests
* But also helps build and run unit tests on Java 11

* Fixes #1195 Updates EasyMock and PowerMock
* Fixes #1194 Remove assumptions in AccumuloVFSClassLoader about the
  type of the system class loader and the system's app class loader
  (specifically, stop assuming they are a URLClassloader instance by
  accounting for some other instances they could also be)