### PR TITLE
Update spotbugs filters to accomodate Java 11

### DIFF
--- a/core/src/main/spotbugs/exclude-filter.xml
+++ b/core/src/main/spotbugs/exclude-filter.xml
@@ -32,4 +32,9 @@
       <Package name="org.apache.accumulo.core.trace.thrift" />
     </Or>
   </Match>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
 </FindBugsFilter>

--- a/core/src/test/java/org/apache/accumulo/core/conf/CredentialProviderFactoryShimTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/CredentialProviderFactoryShimTest.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class CredentialProviderFactoryShimTest {
 
   private static final Configuration hadoopConf = new Configuration();
@@ -52,7 +53,6 @@ public class CredentialProviderFactoryShimTest {
       emptyKeyStoreName = "/empty.jceks";
   private static File emptyKeyStore, populatedKeyStore;
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
   @BeforeClass
   public static void checkCredentialProviderAvailable() {
     try {

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class BloomFilterLayerLookupTest {
 
   private static final Logger log = LoggerFactory.getLogger(BloomFilterLayerLookupTest.class);
@@ -60,8 +61,6 @@ public class BloomFilterLayerLookupTest {
   public TemporaryFolder tempDir =
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
-      justification = "tempDir is not provided by user")
   @Test
   public void test() throws IOException {
     HashSet<Integer> valsSet = new HashSet<>();

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MultiThreadedRFileTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(MultiThreadedRFileTest.class);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
@@ -40,6 +40,9 @@ import org.junit.rules.TemporaryFolder;
 
 import com.google.common.util.concurrent.AtomicLongMap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class RFileMetricsTest {
 
   @Rule

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -99,6 +99,9 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.Bytes;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class RFileTest {
 
   public static class SampleIE implements IteratorEnvironment {

--- a/hadoop-mapreduce/src/main/spotbugs/exclude-filter.xml
+++ b/hadoop-mapreduce/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated classes -->
-    <Package name="org.apache.accumulo.tracer.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
@@ -62,6 +62,9 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not from user input")
 public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
   private static final Logger log = LoggerFactory.getLogger(AccumuloFileOutputFormatIT.class);
   private static final int JOB_VISIBILITY_CACHE_SIZE = 3000;

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
@@ -57,6 +57,7 @@ import org.junit.rules.TemporaryFolder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not from user input")
 public class TokenFileIT extends AccumuloClusterHarness {
   private static AssertionError e1 = null;
 

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
@@ -57,6 +57,9 @@ import org.junit.rules.TemporaryFolder;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not from user input")
 public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
   private String PREFIX;

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
@@ -54,6 +54,7 @@ import org.junit.rules.TemporaryFolder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not from user input")
 public class TokenFileIT extends AccumuloClusterHarness {
   private static AssertionError e1 = null;
 

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -196,7 +196,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     }
   }
 
-  @SuppressFBWarnings(value = "COMMAND_INJECTION",
+  @SuppressFBWarnings(value = {"COMMAND_INJECTION", "PATH_TRAVERSAL_IN"},
       justification = "mini runs in the same security context as user providing the args")
   private ProcessInfo _exec(Class<?> clazz, List<String> extraJvmOpts, String... args)
       throws IOException {

--- a/minicluster/src/main/spotbugs/exclude-filter.xml
+++ b/minicluster/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated classes -->
-    <Package name="org.apache.accumulo.tracer.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloClusterExistingZooKeepersTest {
   private static final File BASE_DIR = new File(System.getProperty("user.dir")
       + "/target/mini-tests/" + MiniAccumuloClusterExistingZooKeepersTest.class.getName());
@@ -53,7 +54,6 @@ public class MiniAccumuloClusterExistingZooKeepersTest {
   @Rule
   public TestName testName = new TestName();
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "intput determined by test")
   @Before
   public void setupTestCluster() throws Exception {
     assertTrue(BASE_DIR.mkdirs() || BASE_DIR.isDirectory());

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloClusterStartStopTest {
 
   private static final Logger log = LoggerFactory.getLogger(MiniAccumuloClusterStartStopTest.class);
@@ -42,7 +43,6 @@ public class MiniAccumuloClusterStartStopTest {
   @Rule
   public TestName testName = new TestName();
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "input determined by test")
   @Before
   public void setupTestCluster() throws IOException {
     assertTrue(baseDir.mkdirs() || baseDir.isDirectory());

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -56,6 +56,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloClusterTest {
 
   public static File testDir;

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/CleanShutdownMacTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/CleanShutdownMacTest.java
@@ -27,6 +27,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class CleanShutdownMacTest {
 
   @Rule

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -44,6 +44,9 @@ import org.junit.Test;
 
 import com.google.common.collect.Iterators;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloClusterImplTest {
   public static File testDir;
 

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -32,6 +32,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloConfigImplTest {
 
   @SuppressWarnings("deprecation")

--- a/pom.xml
+++ b/pom.xml
@@ -1626,5 +1626,14 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>jdk-release-flag</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/server/base/src/main/spotbugs/exclude-filter.xml
+++ b/server/base/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated classes -->
-    <Package name="org.apache.accumulo.tracer.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerConstantsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerConstantsTest.java
@@ -36,6 +36,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class ServerConstantsTest {
 
   AccumuloConfiguration conf = DefaultConfiguration.getInstance();

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
@@ -37,6 +37,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class VolumeUtilTest {
 
   @Rule

--- a/server/base/src/test/java/org/apache/accumulo/server/util/FileUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/FileUtilTest.java
@@ -41,6 +41,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class FileUtilTest {
   @SuppressWarnings("deprecation")
   private static Property INSTANCE_DFS_DIR = Property.INSTANCE_DFS_DIR;

--- a/server/master/src/main/spotbugs/exclude-filter.xml
+++ b/server/master/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated classes -->
-    <Package name="org.apache.accumulo.tracer.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/server/tserver/src/main/spotbugs/exclude-filter.xml
+++ b/server/tserver/src/main/spotbugs/exclude-filter.xml
@@ -20,10 +20,6 @@
     can be excluded inline by adding the @SuppressFBWarnings annotation.
   -->
   <Match>
-    <!-- ignore thrift-generated classes -->
-    <Package name="org.apache.accumulo.tracer.thrift" />
-  </Match>
-  <Match>
     <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
     <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -67,6 +67,9 @@ import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableMap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class InMemoryMapTest {
 
   private static class SampleIE implements IteratorEnvironment {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsReaderTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsReaderTest.java
@@ -44,6 +44,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class RecoveryLogsReaderTest {
 
   VolumeManager fs;

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -59,6 +59,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class SortedLogRecoveryTest {
 
   static final KeyExtent extent = new KeyExtent(TableId.of("table"), null, null);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
@@ -41,6 +41,7 @@ import org.junit.rules.TemporaryFolder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class TestUpgradePathForWALogs {
 
   private static final String WALOG_FROM_15 = "/walog-from-15.walog";
@@ -72,7 +73,6 @@ public class TestUpgradePathForWALogs {
     fs.create(SortedLogState.getFinishedMarkerPath(manyMapsPath)).close();
   }
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test code")
   @Test
   public void testUpgradeOf15WALog() throws IOException {
     InputStream walogStream = null;
@@ -107,7 +107,6 @@ public class TestUpgradePathForWALogs {
     }
   }
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test code")
   @Test
   public void testBasic16WALogRead() throws IOException {
     String walogToTest = WALOG_FROM_16;

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/RootFilesTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/RootFilesTest.java
@@ -39,6 +39,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class RootFilesTest {
 
   @Rule

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -525,6 +525,8 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     new Shell(new ConsoleReader()).execute(args);
   }
 
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
+      justification = "user-provided paths intentional")
   public int start() throws IOException {
     String input;
     if (isVerbose()) {

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
@@ -259,6 +259,8 @@ public class ShellOptionsJC {
     return unrecognizedOptions;
   }
 
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
+      justification = "user-provided paths intentional")
   public String getClientPropertiesFile() {
     if (clientConfigFile == null) {
       List<String> searchPaths = new LinkedList<>();

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellUtilTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellUtilTest.java
@@ -33,6 +33,9 @@ import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableList;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class ShellUtilTest {
 
   @Rule

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
@@ -34,6 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class AccumuloReloadingVFSClassLoaderTest {
 
   private TemporaryFolder folder1 =

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
@@ -40,6 +40,9 @@ import org.powermock.core.classloader.annotations.SuppressStaticInitializationFo
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AccumuloVFSClassLoader.class)
 @SuppressStaticInitializationFor({"org.apache.accumulo.start.classloader.AccumuloVFSClassLoader",

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/ContextManagerTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/ContextManagerTest.java
@@ -36,6 +36,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class ContextManagerTest {
 
   private TemporaryFolder folder1 =

--- a/start/src/test/java/org/apache/accumulo/start/test/AccumuloDFSBase.java
+++ b/start/src/test/java/org/apache/accumulo/start/test/AccumuloDFSBase.java
@@ -35,6 +35,9 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class AccumuloDFSBase {
 
   protected static Configuration conf = null;

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -62,6 +62,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
     return type == ClusterType.MINI;
   }
 
+  @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "url is not from user")
   @Test
   public void testMonitorService() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfDeadTServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfDeadTServerIT.java
@@ -212,6 +212,8 @@ public class HalfDeadTServerIT extends ConfigurableMacBase {
     }
   }
 
+  @SuppressFBWarnings(value = "COMMAND_INJECTION",
+      justification = "command executed is not from user input")
   private boolean makeDiskFailureLibrary() throws Exception {
     String root = System.getProperty("user.dir");
     String source = root + "/src/test/c/fake_disk_failure.c";

--- a/test/src/main/spotbugs/exclude-filter.xml
+++ b/test/src/main/spotbugs/exclude-filter.xml
@@ -23,4 +23,13 @@
     <!-- ignore thrift-generated files -->
     <Package name="org.apache.accumulo.test.rpc.thrift" />
   </Match>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
+  <Match>
+    <!-- paths in test code are provided by user input -->
+    <Bug pattern="PATH_TRAVERSAL_IN" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Update filters to suppress triaged warnings from spotbugs findsecbugs
when building with Java 11