### PR TITLE
Update packaged class path for Java 11

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -93,16 +93,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <optional>true</optional>
@@ -134,7 +124,7 @@
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
+      <artifactId>javax.activation-api</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -356,6 +346,16 @@
     <dependency>
       <groupId>org.glassfish.hk2.external</groupId>
       <artifactId>jakarta.inject</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -42,15 +42,13 @@
         <include>com.google.guava:failureaccess</include>
         <include>com.google.guava:guava</include>
         <include>com.google.protobuf:protobuf-java</include>
-        <include>com.sun.xml.bind:jaxb-core</include>
-        <include>com.sun.xml.bind:jaxb-impl</include>
         <include>commons-beanutils:commons-beanutils</include>
         <include>commons-cli:commons-cli</include>
         <include>commons-codec:commons-codec</include>
         <include>commons-io:commons-io</include>
         <include>commons-lang:commons-lang</include>
         <include>commons-logging:commons-logging</include>
-        <include>javax.activation:activation</include>
+        <include>javax.activation:javax.activation-api</include>
         <include>javax.annotation:javax.annotation-api</include>
         <include>javax.el:javax.el-api</include>
         <include>javax.servlet:javax.servlet-api</include>
@@ -82,6 +80,8 @@
         <include>org.glassfish.hk2:hk2-locator</include>
         <include>org.glassfish.hk2:hk2-utils</include>
         <include>org.glassfish.hk2:osgi-resource-locator</include>
+        <include>org.glassfish.jaxb:jaxb-core</include>
+        <include>org.glassfish.jaxb:jaxb-runtime</include>
         <include>org.glassfish.jersey.containers:jersey-container-jetty-http</include>
         <include>org.glassfish.jersey.containers:jersey-container-servlet-core</include>
         <include>org.glassfish.jersey.containers:jersey-container-servlet</include>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
     <!-- bouncycastle version for test dependencies -->
-    <bouncycastle.version>1.60</bouncycastle.version>
+    <bouncycastle.version>1.62</bouncycastle.version>
     <!-- Curator version -->
     <curator.version>2.12.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
@@ -129,9 +129,9 @@
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <jackson.version>2.9.9</jackson.version>
     <javax.el.version>3.0.1-b06</javax.el.version>
-    <jaxb.version>2.3.0</jaxb.version>
-    <jersey.version>2.27</jersey.version>
-    <jetty.version>9.4.17.v20190418</jetty.version>
+    <jaxb.version>2.3.0.1</jaxb.version>
+    <jersey.version>2.28</jersey.version>
+    <jetty.version>9.4.19.v20190610</jetty.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- surefire/failsafe plugin option -->
@@ -139,7 +139,6 @@
     <powermock.version>2.0.2</powermock.version>
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>
-    <servlet.api.version>3.1.0</servlet.api.version>
     <slf4j.version>1.7.26</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <spotbugs.version>3.1.7</spotbugs.version>
@@ -223,22 +222,12 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>27.1-jre</version>
+        <version>28.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>3.7.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-core</artifactId>
-        <version>${jaxb.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -272,8 +261,8 @@
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
+        <artifactId>javax.activation-api</artifactId>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>
@@ -288,7 +277,7 @@
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
-        <version>${servlet.api.version}</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -308,7 +297,7 @@
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>${jaxb.version}</version>
+        <version>2.3.1</version>
       </dependency>
       <dependency>
         <groupId>jline</groupId>
@@ -440,7 +429,6 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
-        <!-- commons-vfs2 version 2.2 has defects that impacts changing Accumulo classpath contexts. -->
         <version>2.3</version>
       </dependency>
       <dependency>
@@ -618,6 +606,16 @@
         <version>${hk2.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>${jaxb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>${jaxb.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-jetty-http</artifactId>
         <version>${jersey.version}</version>
@@ -705,7 +703,7 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
-        <version>1.3</version>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.validator</groupId>
@@ -715,7 +713,7 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.24.1-GA</version>
+        <version>3.25.0-GA</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
@@ -955,7 +953,7 @@
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>animal-sniffer-enforcer-rule</artifactId>
-              <version>1.17</version>
+              <version>1.18</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -1037,38 +1035,38 @@
               <failOnWarning>true</failOnWarning>
               <ignoredUsedUndeclaredDependencies>
                 <!-- used/undeclared child jars brought in by parents below -->
-                <usedUndeclaredDependency>org.apache.curator:curator-client:jar:${curator.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.apache.hadoop:hadoop-hdfs:*:${hadoop.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.apache.hadoop:hadoop-mapreduce-client-core:jar:${hadoop.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.apache.curator:curator-client:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.apache.hadoop:hadoop-common:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.apache.hadoop:hadoop-hdfs:*:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.apache.hadoop:hadoop-mapreduce-client-core:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.apache.hadoop:hadoop-auth:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.httpcomponents:httpcore:jar:*</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.glassfish.jersey.ext:jersey-mvc:jar:${jersey.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.glassfish.jersey.core:jersey-server:jar:${jersey.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.glassfish.jersey.core:jersey-common:jar:${jersey.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.powermock:powermock-core:jar:${powermock.version}</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.powermock:powermock-reflect:jar:${powermock.version}</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.glassfish.jersey.ext:jersey-mvc:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.glassfish.jersey.core:jersey-server:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.glassfish.jersey.core:jersey-common:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.powermock:powermock-core:jar:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.powermock:powermock-reflect:jar:*</usedUndeclaredDependency>
               </ignoredUsedUndeclaredDependencies>
               <ignoredUnusedDeclaredDependencies>
                 <!-- auto-service isn't detected as use since the annotation has retention of source -->
                 <unusedDeclaredDependency>com.google.auto.service:auto-service:jar:*</unusedDeclaredDependency>
                 <!-- unused/declared implementation jars or parent jars that bring in children -->
-                <unusedDeclaredDependency>org.apache.hadoop:hadoop-client:jar:${hadoop.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.apache.hadoop:hadoop-client-runtime:jar:${hadoop.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.apache.hadoop:hadoop-minicluster:jar:${hadoop.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.glassfish.jersey.containers:jersey-container-jetty-http:jar:${jersey.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.glassfish.jersey.ext:jersey-bean-validation:jar:${jersey.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2:jar:${jersey.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:jar:${jersey.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.powermock:powermock-api-easymock:jar:${powermock.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>org.slf4j:slf4j-log4j12:jar:${slf4j.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>junit:junit:jar:4.12</unusedDeclaredDependency>
-                <unusedDeclaredDependency>javax.servlet:javax.servlet-api:jar:${servlet.api.version}</unusedDeclaredDependency>
-                <unusedDeclaredDependency>javax.el:javax.el-api:jar:${javax.el.version}</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.apache.hadoop:hadoop-client:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.apache.hadoop:hadoop-client-runtime:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.apache.hadoop:hadoop-minicluster:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.glassfish.jersey.containers:jersey-container-jetty-http:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.glassfish.jersey.ext:jersey-bean-validation:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.powermock:powermock-api-easymock:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.slf4j:slf4j-log4j12:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>junit:junit:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>javax.servlet:javax.servlet-api:jar:*</unusedDeclaredDependency>
+                <unusedDeclaredDependency>javax.el:javax.el-api:jar:*</unusedDeclaredDependency>
                 <!-- spotbugs annotations may or may not be used in each module -->
-                <unusedDeclaredDependency>com.github.spotbugs:spotbugs-annotations:jar:${spotbugs.version}</unusedDeclaredDependency>
+                <unusedDeclaredDependency>com.github.spotbugs:spotbugs-annotations:jar:*</unusedDeclaredDependency>
                 <!-- ignore unused native; analysis isn't possible with tar.gz dependency -->
-                <unusedDeclaredDependency>org.apache.accumulo:accumulo-native:tar.gz:${project.version}</unusedDeclaredDependency>
+                <unusedDeclaredDependency>org.apache.accumulo:accumulo-native:tar.gz:*</unusedDeclaredDependency>
                 <!-- ignore runtime dependencies of commons-configuration2 -->
                 <unusedDeclaredDependency>commons-beanutils:commons-beanutils:jar:*</unusedDeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
@@ -1229,7 +1227,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
+            <version>8.21</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Update several dependencies, mostly pertaining to the monitor, which are
included in the build, so that the class path is sufficient for the
monitor to run on Java 8 or 11.