### PR TITLE
Fixes #1123 - Monitor log recovery says invalid date - Temporary Fix

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/master.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/master.js
@@ -71,6 +71,9 @@ function recoveryList() {
       items.push(createFirstCell(val.server, val.server));
       items.push(createRightCell(val.log, val.log));
       var date = new Date(parseInt(val.runtime));
+      if (date.toString() === 'Invalid Date')  {
+         date = new Date();
+      }
       var dateStr = date.toLocaleString().split(' ').join('&nbsp;');
       items.push(createRightCell(val.runtime, dateStr));
       items.push(createRightCell(val.progress, val.progress));


### PR DESCRIPTION
I have looked around the code trying to see what is causing this in the REST service and the underlying solution of why a bad value is being passed into the RecoveryStatus.runtime value is not that apparent. I am putting out this option that for the present we can just set the date to "Date.now" which is what the Date constructor gives you (only when the date is 'Invalid Date') .   I will work on a better solution to this issue. 