### PR TITLE
Fix #1230 INVALID date for GC on master monitor page

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/master.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/master.js
@@ -108,10 +108,12 @@ function refreshMasterTable() {
 
     items.push(createRightCell(data.totalTabletServers,
         data.totalTabletServers));
+    var date = data.lastGC;
+    //this will be a finish time or a status of Running, Waiting, or down
+    if (!isNaN(date))
+        date = new Date(parseInt(data.lastGC)).toLocaleString().split(' ').join('&nbsp;');
 
-    var date = new Date(parseInt(data.lastGC));
-    date = date.toLocaleString().split(' ').join('&nbsp;');
-    items.push(createLeftCell(data.lasGC, '<a href="/gc">' + date + '</a>'));
+    items.push(createLeftCell(data.lastGC, '<a href="/gc">' + date + '</a>'));
 
     items.push(createRightCell(data.tablets,
         bigNumberForQuantity(data.tablets)));


### PR DESCRIPTION
Tested this by deploying to my uno instance.  I could see "waiting" when I first brought up the monitor after startup.  I will be out until July 1st. 