### PR TITLE
Fix #1193 Replace Immutable* with Java built-ins

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/sample/AbstractHashSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/AbstractHashSampler.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.sample.impl.DataoutputHasher;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
@@ -56,7 +55,7 @@ public abstract class AbstractHashSampler implements Sampler {
   private HashFunction hashFunction;
   private int modulus;
 
-  private static final Set<String> VALID_OPTIONS = ImmutableSet.of("hasher", "modulus");
+  private static final Set<String> VALID_OPTIONS = Set.of("hasher", "modulus");
 
   /**
    * Subclasses with options should override this method and return true if the option is valid for

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * This sampler can hash any subset of a Key's fields. The fields that hashed for the sample are
  * determined by the configuration options passed in {@link #init(SamplerConfiguration)}. The
@@ -69,7 +67,7 @@ public class RowColumnSampler extends AbstractHashSampler {
   private boolean visibility = true;
 
   private static final Set<String> VALID_OPTIONS =
-      ImmutableSet.of("row", "family", "qualifier", "visibility");
+      Set.of("row", "family", "qualifier", "visibility");
 
   private boolean hashField(SamplerConfiguration config, String field) {
     String optValue = config.getOptions().get(field);

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -47,7 +47,7 @@ public class SummarizerConfiguration {
 
   private SummarizerConfiguration(String className, String configId, Map<String,String> options) {
     this.className = className;
-    this.options = ImmutableMap.copyOf(options);
+    this.options = Map.copyOf(options);
 
     if (configId == null) {
       ArrayList<String> keys = new ArrayList<>(this.options.keySet());

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/Summary.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/Summary.java
@@ -19,8 +19,6 @@ package org.apache.accumulo.core.client.summary;
 
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-
 /**
  * This class encapsulates summary statistics, information about how those statistics were
  * generated, and information about files the statistics were obtained from.
@@ -117,13 +115,13 @@ public class Summary {
     }
   }
 
-  private final ImmutableMap<String,Long> statistics;
+  private final Map<String,Long> statistics;
   private final SummarizerConfiguration config;
   private final FileStatistics fileStats;
 
   public Summary(Map<String,Long> summary, SummarizerConfiguration config, long totalFiles,
       long filesMissingSummary, long filesWithExtra, long filesWithLarge, long deletedFiles) {
-    this.statistics = ImmutableMap.copyOf(summary);
+    this.statistics = Map.copyOf(summary);
     this.config = config;
     this.fileStats = new FileStatistics(totalFiles, filesMissingSummary, filesWithExtra,
         filesWithLarge, deletedFiles);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -43,8 +43,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
 
-import com.google.common.collect.ImmutableMap;
-
 public class ScannerOptions implements ScannerBase {
 
   protected List<IterInfo> serverSideIteratorList = Collections.emptyList();
@@ -73,21 +71,25 @@ public class ScannerOptions implements ScannerBase {
   @Override
   public synchronized void addScanIterator(IteratorSetting si) {
     checkArgument(si != null, "si is null");
-    if (serverSideIteratorList.size() == 0)
+    if (serverSideIteratorList.size() == 0) {
       serverSideIteratorList = new ArrayList<>();
+    }
 
     for (IterInfo ii : serverSideIteratorList) {
-      if (ii.iterName.equals(si.getName()))
+      if (ii.iterName.equals(si.getName())) {
         throw new IllegalArgumentException("Iterator name is already in use " + si.getName());
-      if (ii.getPriority() == si.getPriority())
+      }
+      if (ii.getPriority() == si.getPriority()) {
         throw new IllegalArgumentException(
             "Iterator priority is already in use " + si.getPriority());
+      }
     }
 
     serverSideIteratorList.add(new IterInfo(si.getPriority(), si.getIteratorClass(), si.getName()));
 
-    if (serverSideIteratorOptions.size() == 0)
+    if (serverSideIteratorOptions.size() == 0) {
       serverSideIteratorOptions = new HashMap<>();
+    }
 
     Map<String,String> opts = serverSideIteratorOptions.get(si.getName());
 
@@ -102,8 +104,9 @@ public class ScannerOptions implements ScannerBase {
   public synchronized void removeScanIterator(String iteratorName) {
     checkArgument(iteratorName != null, "iteratorName is null");
     // if no iterators are set, we don't have it, so it is already removed
-    if (serverSideIteratorList.size() == 0)
+    if (serverSideIteratorList.size() == 0) {
       return;
+    }
 
     for (IterInfo ii : serverSideIteratorList) {
       if (ii.iterName.equals(iteratorName)) {
@@ -120,8 +123,9 @@ public class ScannerOptions implements ScannerBase {
     checkArgument(iteratorName != null, "iteratorName is null");
     checkArgument(key != null, "key is null");
     checkArgument(value != null, "value is null");
-    if (serverSideIteratorOptions.size() == 0)
+    if (serverSideIteratorOptions.size() == 0) {
       serverSideIteratorOptions = new HashMap<>();
+    }
 
     Map<String,String> opts = serverSideIteratorOptions.get(iteratorName);
 
@@ -179,8 +183,9 @@ public class ScannerOptions implements ScannerBase {
 
         dst.serverSideIteratorOptions = new HashMap<>();
         Set<Entry<String,Map<String,String>>> es = src.serverSideIteratorOptions.entrySet();
-        for (Entry<String,Map<String,String>> entry : es)
+        for (Entry<String,Map<String,String>> entry : es) {
           dst.serverSideIteratorOptions.put(entry.getKey(), new HashMap<>(entry.getValue()));
+        }
 
         dst.samplerConfig = src.samplerConfig;
         dst.batchTimeOut = src.batchTimeOut;
@@ -202,10 +207,11 @@ public class ScannerOptions implements ScannerBase {
       throw new IllegalArgumentException("TimeOut must be positive : " + timeOut);
     }
 
-    if (timeout == 0)
+    if (timeout == 0) {
       this.timeOut = Long.MAX_VALUE;
-    else
+    } else {
       this.timeOut = timeUnit.toMillis(timeout);
+    }
   }
 
   @Override
@@ -274,7 +280,7 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public synchronized void setExecutionHints(Map<String,String> hints) {
-    this.executionHints = ImmutableMap.copyOf(Objects.requireNonNull(hints));
+    this.executionHints = Map.copyOf(Objects.requireNonNull(hints));
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableMap.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableMap.java
@@ -53,8 +53,8 @@ public class TableMap {
 
     List<String> tableIds = zooCache.getChildren(context.getZooKeeperRoot() + Constants.ZTABLES);
     Map<NamespaceId,String> namespaceIdToNameMap = new HashMap<>();
-    ImmutableMap.Builder<String,TableId> tableNameToIdBuilder = new ImmutableMap.Builder<>();
-    ImmutableMap.Builder<TableId,String> tableIdToNameBuilder = new ImmutableMap.Builder<>();
+    var tableNameToIdBuilder = ImmutableMap.<String,TableId>builder();
+    var tableIdToNameBuilder = ImmutableMap.<TableId,String>builder();
 
     // use StringBuilder to construct zPath string efficiently across many tables
     StringBuilder zPathBuilder = new StringBuilder();

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * A configuration object.
@@ -172,7 +171,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
           Map<String,String> propMap = new HashMap<>();
           // The reason this caching exists is to avoid repeatedly making this expensive call.
           getProperties(propMap, key -> key.startsWith(property.getKey()));
-          propMap = ImmutableMap.copyOf(propMap);
+          propMap = Map.copyOf(propMap);
 
           // So that locking is not needed when reading from enum map, always create a new one.
           // Construct and populate map using a local var so its not visible
@@ -502,8 +501,8 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
    * changing, keeps returning the same object. Implementations should be thread safe and eventually
    * consistent. See {@link AccumuloConfiguration#newDeriver(Function)}
    */
-  public static interface Deriver<T> {
-    public T derive();
+  public interface Deriver<T> {
+    T derive();
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -34,8 +34,6 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -56,7 +54,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
 
   private static final AccumuloConfiguration parent = DefaultConfiguration.getInstance();
 
-  private final ImmutableMap<String,String> config;
+  private final Map<String,String> config;
 
   public SiteConfiguration() {
     this(getAccumuloPropsLocation());
@@ -85,7 +83,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
 
   @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD",
       justification = "location of props is specified by an admin")
-  private static ImmutableMap<String,String> createMap(URL accumuloPropsLocation,
+  private static Map<String,String> createMap(URL accumuloPropsLocation,
       Map<String,String> overrides) {
     CompositeConfiguration config = new CompositeConfiguration();
     if (accumuloPropsLocation != null) {
@@ -121,7 +119,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
         }
       }
     }
-    return ImmutableMap.copyOf(result);
+    return Map.copyOf(result);
   }
 
   private static URL toURL(File f) {
@@ -198,8 +196,9 @@ public class SiteConfiguration extends AccumuloConfiguration {
       parent.getProperties(props, filter);
     }
     config.keySet().forEach(k -> {
-      if (filter.test(k))
+      if (filter.test(k)) {
         props.put(k, config.get(k));
+      }
     });
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.accumulo.core.client.admin.TableOperations.ImportMappingOptions;
 import org.apache.hadoop.io.Text;
@@ -37,7 +38,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @since 2.0.0
  */
 public class LoadPlan {
-  private final ImmutableList<Destination> destinations;
+  private final List<Destination> destinations;
 
   private static byte[] copy(byte[] data) {
     return data == null ? null : Arrays.copyOf(data, data.length);
@@ -143,7 +144,7 @@ public class LoadPlan {
     }
   }
 
-  private LoadPlan(ImmutableList<Destination> destinations) {
+  private LoadPlan(List<Destination> destinations) {
     this.destinations = destinations;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCacheConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCacheConfiguration.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.spi.cache.BlockCacheManager.Configuration;
 import org.apache.accumulo.core.spi.cache.CacheType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 
 public final class LruBlockCacheConfiguration {
 
@@ -216,7 +215,7 @@ public final class LruBlockCacheConfiguration {
     }
 
     public Map<String,String> buildMap() {
-      return ImmutableMap.copyOf(props);
+      return Map.copyOf(props);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/LocalityGroupIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/LocalityGroupIterator.java
@@ -36,8 +36,6 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.commons.lang.mutable.MutableLong;
 
-import com.google.common.collect.ImmutableSet;
-
 public class LocalityGroupIterator extends HeapIterator implements InterruptibleIterator {
 
   private static final Collection<ByteSequence> EMPTY_CF_SET = Collections.emptySet();
@@ -104,11 +102,11 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
    * This will cache the arguments used in the seek call along with the locality groups seeked.
    */
   public static class LocalityGroupSeekCache {
-    private ImmutableSet<ByteSequence> lastColumnFamilies;
+    private Set<ByteSequence> lastColumnFamilies;
     private volatile boolean lastInclusive;
     private Collection<LocalityGroup> lastUsed;
 
-    public ImmutableSet<ByteSequence> getLastColumnFamilies() {
+    public Set<ByteSequence> getLastColumnFamilies() {
       return lastColumnFamilies;
     }
 
@@ -164,15 +162,16 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
     hiter.clear();
 
     Set<ByteSequence> cfSet;
-    if (columnFamilies.size() > 0)
+    if (columnFamilies.size() > 0) {
       if (columnFamilies instanceof Set<?>) {
         cfSet = (Set<ByteSequence>) columnFamilies;
       } else {
         cfSet = new HashSet<>();
         cfSet.addAll(columnFamilies);
       }
-    else
+    } else {
       cfSet = Collections.emptySet();
+    }
 
     // determine the set of groups to use
     Collection<LocalityGroup> groups = Collections.emptyList();
@@ -258,17 +257,18 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
   public static LocalityGroupSeekCache seek(HeapIterator hiter, LocalityGroupContext lgContext,
       Range range, Collection<ByteSequence> columnFamilies, boolean inclusive,
       LocalityGroupSeekCache lgSeekCache) throws IOException {
-    if (lgSeekCache == null)
+    if (lgSeekCache == null) {
       lgSeekCache = new LocalityGroupSeekCache();
+    }
 
     // determine if the arguments have changed since the last time
     boolean sameArgs = false;
-    ImmutableSet<ByteSequence> cfSet = null;
+    Set<ByteSequence> cfSet = null;
     if (lgSeekCache.lastUsed != null && inclusive == lgSeekCache.lastInclusive) {
       if (columnFamilies instanceof Set) {
         sameArgs = lgSeekCache.lastColumnFamilies.equals(columnFamilies);
       } else {
-        cfSet = ImmutableSet.copyOf(columnFamilies);
+        cfSet = Set.copyOf(columnFamilies);
         sameArgs = lgSeekCache.lastColumnFamilies.equals(cfSet);
       }
     }
@@ -283,8 +283,7 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
       }
     } else { // otherwise capture the parameters, and use the static seek method to locate the
              // locality groups to use.
-      lgSeekCache.lastColumnFamilies =
-          (cfSet == null ? ImmutableSet.copyOf(columnFamilies) : cfSet);
+      lgSeekCache.lastColumnFamilies = (cfSet == null ? Set.copyOf(columnFamilies) : cfSet);
       lgSeekCache.lastInclusive = inclusive;
       lgSeekCache.lastUsed = _seek(hiter, lgContext, range, columnFamilies, inclusive);
     }
@@ -304,8 +303,9 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
 
     for (int i = 0; i < lgContext.groups.size(); i++) {
       groupsCopy[i] = new LocalityGroup(lgContext.groups.get(i), env);
-      if (interruptFlag != null)
+      if (interruptFlag != null) {
         groupsCopy[i].getIterator().setInterruptFlag(interruptFlag);
+      }
     }
 
     return new LocalityGroupIterator(groupsCopy);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -60,7 +60,6 @@ import org.apache.hadoop.io.Text;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -87,11 +86,11 @@ public class TabletMetadata {
   private List<LogEntry> logs;
   private OptionalLong compact = OptionalLong.empty();
 
-  public static enum LocationType {
+  public enum LocationType {
     CURRENT, FUTURE, LAST
   }
 
-  public static enum ColumnType {
+  public enum ColumnType {
     LOCATION, PREV_ROW, FILES, LAST, LOADED, SCANS, DIR, TIME, CLONED, FLUSH_ID, LOGS, COMPACT_ID
   }
 
@@ -148,9 +147,10 @@ public class TabletMetadata {
 
   public Text getPrevEndRow() {
     ensureFetched(ColumnType.PREV_ROW);
-    if (!sawPrevEndRow)
+    if (!sawPrevEndRow) {
       throw new IllegalStateException(
           "No prev endrow seen.  tableId: " + tableId + " endrow: " + endRow);
+    }
     return prevEndRow;
   }
 
@@ -243,10 +243,10 @@ public class TabletMetadata {
       kvBuilder = ImmutableSortedMap.naturalOrder();
     }
 
-    ImmutableMap.Builder<String,DataFileValue> filesBuilder = ImmutableMap.builder();
-    Builder<String> scansBuilder = ImmutableList.builder();
-    Builder<LogEntry> logsBuilder = ImmutableList.builder();
-    final ImmutableSet.Builder<String> loadedFilesBuilder = ImmutableSet.builder();
+    var filesBuilder = ImmutableMap.<String,DataFileValue>builder();
+    var scansBuilder = ImmutableList.<String>builder();
+    var logsBuilder = ImmutableList.<LogEntry>builder();
+    final var loadedFilesBuilder = ImmutableSet.<String>builder();
     ByteSequence row = null;
 
     while (rowIter.hasNext()) {
@@ -334,9 +334,10 @@ public class TabletMetadata {
   }
 
   private void setLocationOnce(String val, String qual, LocationType lt) {
-    if (location != null)
+    if (location != null) {
       throw new IllegalStateException("Attempted to set second location for tableId: " + tableId
           + " endrow: " + endRow + " -- " + location + " " + qual + " " + val);
+    }
     location = new Location(val, qual, lt);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationTable.java
@@ -41,8 +41,6 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
-
 public class ReplicationTable {
   private static final Logger log = LoggerFactory.getLogger(ReplicationTable.class);
 
@@ -56,7 +54,7 @@ public class ReplicationTable {
   public static final String WORK_LG_NAME = WorkSection.NAME.toString();
   public static final Set<Text> WORK_LG_COLFAMS = Collections.singleton(WorkSection.NAME);
   public static final Map<String,Set<Text>> LOCALITY_GROUPS =
-      ImmutableMap.of(STATUS_LG_NAME, STATUS_LG_COLFAMS, WORK_LG_NAME, WORK_LG_COLFAMS);
+      Map.of(STATUS_LG_NAME, STATUS_LG_COLFAMS, WORK_LG_NAME, WORK_LG_COLFAMS);
 
   public static Scanner getScanner(AccumuloClient client) throws ReplicationTableOfflineException {
     try {

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizer.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 /**
  * When configured for a scan executor, this prioritizer allows scanners to set priorities as
@@ -115,7 +114,7 @@ public class HintScanPrioritizer implements ScanPrioritizer {
     int defaultPriority = Integer
         .parseInt(params.getOptions().getOrDefault("default_priority", Integer.MAX_VALUE + ""));
 
-    Builder<String,Integer> tpb = ImmutableMap.builder();
+    var tpb = ImmutableMap.<String,Integer>builder();
 
     params.getOptions().forEach((k, v) -> {
       if (k.startsWith(PRIO_PREFIX)) {
@@ -124,7 +123,7 @@ public class HintScanPrioritizer implements ScanPrioritizer {
       }
     });
 
-    ImmutableMap<String,Integer> typePriorities = tpb.build();
+    Map<String,Integer> typePriorities = tpb.build();
 
     HintProblemAction hpa = HintProblemAction.valueOf(params.getOptions()
         .getOrDefault("bad_hint_action", HintProblemAction.LOG.name()).toUpperCase());

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import org.apache.accumulo.core.client.ScannerBase;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * If no options are given, then this will dispatch to an executor named {@code default}. This
@@ -50,8 +48,7 @@ public class SimpleScanDispatcher implements ScanDispatcher {
 
   private final String EXECUTOR_PREFIX = "executor.";
 
-  private final Set<String> VALID_OPTS =
-      ImmutableSet.of("executor", "multi_executor", "single_executor");
+  private final Set<String> VALID_OPTS = Set.of("executor", "multi_executor", "single_executor");
   private String multiExecutor;
   private String singleExecutor;
 
@@ -63,7 +60,7 @@ public class SimpleScanDispatcher implements ScanDispatcher {
   public void init(InitParameters params) {
     Map<String,String> options = params.getOptions();
 
-    Builder<String,String> teb = ImmutableMap.builder();
+    var teb = ImmutableMap.<String,String>builder();
 
     options.forEach((k, v) -> {
       if (k.startsWith(EXECUTOR_PREFIX)) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -536,7 +536,7 @@ class SummarySerializer {
 
   private static Map<String,Long> readSummary(DataInputStream in, String[] symbols)
       throws IOException {
-    com.google.common.collect.ImmutableMap.Builder<String,Long> imb = ImmutableMap.builder();
+    var imb = ImmutableMap.<String,Long>builder();
     int numEntries = WritableUtils.readVInt(in);
 
     for (int i = 0; i < numEntries; i++) {

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -50,14 +50,13 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 
 public class LocalityGroupUtil {
 
   private static final Logger log = LoggerFactory.getLogger(LocalityGroupUtil.class);
 
   // using an ImmutableSet here for more efficient comparisons in LocalityGroupIterator
-  public static final ImmutableSet<ByteSequence> EMPTY_CF_SET = ImmutableSet.of();
+  public static final Set<ByteSequence> EMPTY_CF_SET = Set.of();
 
   /**
    * Create a set of families to be passed into the SortedKeyValueIterator seek call from a supplied
@@ -68,10 +67,11 @@ public class LocalityGroupUtil {
    *          The set of columns
    * @return An immutable set of columns
    */
-  public static ImmutableSet<ByteSequence> families(Collection<Column> columns) {
-    if (columns.size() == 0)
+  public static Set<ByteSequence> families(Collection<Column> columns) {
+    if (columns.size() == 0) {
       return EMPTY_CF_SET;
-    Builder<ByteSequence> builder = ImmutableSet.builder();
+    }
+    var builder = ImmutableSet.<ByteSequence>builder();
     columns.forEach(c -> builder.add(new ArrayByteSequence(c.getColumnFamily())));
     return builder.build();
   }
@@ -113,8 +113,9 @@ public class LocalityGroupUtil {
     Map<String,Set<ByteSequence>> result = new HashMap<>();
     String[] groups = acuconf.get(Property.TABLE_LOCALITY_GROUPS).split(",");
     for (String group : groups) {
-      if (group.length() > 0)
+      if (group.length() > 0) {
         result.put(group, new HashSet<>());
+      }
     }
     HashSet<ByteSequence> all = new HashSet<>();
     for (Entry<String,String> entry : acuconf) {
@@ -233,12 +234,13 @@ public class LocalityGroupUtil {
 
     for (int i = 0; i < len; i++) {
       int c = 0xff & ba[i];
-      if (c == '\\')
+      if (c == '\\') {
         sb.append("\\\\");
-      else if (c >= 32 && c <= 126 && c != ',')
+      } else if (c >= 32 && c <= 126 && c != ',') {
         sb.append((char) c);
-      else
+      } else {
         sb.append("\\x").append(String.format("%02X", c));
+      }
     }
 
     return sb.toString();
@@ -330,16 +332,19 @@ public class LocalityGroupUtil {
           }
 
           if (lgcount == 1) {
-            for (int i = 0; i < parts.length; i++)
+            for (int i = 0; i < parts.length; i++) {
               if (parts.get(i) != null) {
                 partitionedMutations.get(i).add(mutation);
                 break;
               }
+            }
           } else {
-            for (int i = 0; i < parts.length; i++)
-              if (parts.get(i) != null)
+            for (int i = 0; i < parts.length; i++) {
+              if (parts.get(i) != null) {
                 partitionedMutations.get(i)
                     .add(new PartitionedMutation(mutation.getRow(), parts.get(i)));
+              }
+            }
           }
         }
       }
@@ -348,8 +353,9 @@ public class LocalityGroupUtil {
     private Integer getLgid(MutableByteSequence mbs, ColumnUpdate cu) {
       mbs.setArray(cu.getColumnFamily(), 0, cu.getColumnFamily().length);
       Integer lgid = colfamToLgidMap.get(mbs);
-      if (lgid == null)
+      if (lgid == null) {
         lgid = groups.length;
+      }
       return lgid;
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
@@ -24,8 +24,6 @@ import java.util.WeakHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
-
 /**
  * Provides the ability to retrieve a {@link RateLimiter} keyed to a specific string, which will
  * dynamically update its rate according to a specified callback function.
@@ -108,7 +106,7 @@ public class SharedRateLimiterFactory {
   protected void update() {
     Map<String,SharedRateLimiter> limitersCopy;
     synchronized (activeLimiters) {
-      limitersCopy = ImmutableMap.copyOf(activeLimiters);
+      limitersCopy = Map.copyOf(activeLimiters);
     }
     for (Map.Entry<String,SharedRateLimiter> entry : limitersCopy.entrySet()) {
       try {
@@ -126,7 +124,7 @@ public class SharedRateLimiterFactory {
   protected void report() {
     Map<String,SharedRateLimiter> limitersCopy;
     synchronized (activeLimiters) {
-      limitersCopy = ImmutableMap.copyOf(activeLimiters);
+      limitersCopy = Map.copyOf(activeLimiters);
     }
     for (Map.Entry<String,SharedRateLimiter> entry : limitersCopy.entrySet()) {
       try {
@@ -170,8 +168,9 @@ public class SharedRateLimiterFactory {
     public void report() {
       if (log.isDebugEnabled()) {
         long duration = System.currentTimeMillis() - lastUpdate;
-        if (duration == 0)
+        if (duration == 0) {
           return;
+        }
         lastUpdate = System.currentTimeMillis();
 
         long sum = permitsAcquired;

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 /**
  * A cache for values stored in ZooKeeper. Values are kept up to date as they change.
@@ -165,15 +164,17 @@ public class ZooCache {
         case None:
           switch (event.getState()) {
             case Disconnected:
-              if (log.isTraceEnabled())
+              if (log.isTraceEnabled()) {
                 log.trace("Zoo keeper connection disconnected, clearing cache");
+              }
               clear();
               break;
             case SyncConnected:
               break;
             case Expired:
-              if (log.isTraceEnabled())
+              if (log.isTraceEnabled()) {
                 log.trace("Zoo keeper connection expired, clearing cache");
+              }
               clear();
               break;
             default:
@@ -311,7 +312,7 @@ public class ZooCache {
   public List<String> getChildren(final String zPath) {
     Preconditions.checkState(!closed);
 
-    ZooRunnable<List<String>> zr = new ZooRunnable<List<String>>() {
+    ZooRunnable<List<String>> zr = new ZooRunnable<>() {
 
       @Override
       public List<String> run() throws KeeperException, InterruptedException {
@@ -332,7 +333,7 @@ public class ZooCache {
 
           List<String> children = zooKeeper.getChildren(zPath, watcher);
           if (children != null) {
-            children = ImmutableList.copyOf(children);
+            children = List.copyOf(children);
           }
           childrenCache.put(zPath, children);
           immutableCache = new ImmutableCacheCopies(++updateCount, immutableCache, childrenCache);
@@ -376,7 +377,7 @@ public class ZooCache {
    */
   public byte[] get(final String zPath, final ZcStat status) {
     Preconditions.checkState(!closed);
-    ZooRunnable<byte[]> zr = new ZooRunnable<byte[]>() {
+    ZooRunnable<byte[]> zr = new ZooRunnable<>() {
 
       @Override
       public byte[] run() throws KeeperException, InterruptedException {

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -68,8 +68,6 @@ import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RFileClientTest {
@@ -337,19 +335,19 @@ public class RFileClientTest {
 
     Scanner scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withAuthorizations(new Authorizations("A")).build();
-    assertEquals(ImmutableMap.of(k2, v2, k3, v3), toMap(scanner));
+    assertEquals(Map.of(k2, v2, k3, v3), toMap(scanner));
     assertEquals(new Authorizations("A"), scanner.getAuthorizations());
     scanner.close();
 
     scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withAuthorizations(new Authorizations("A", "B")).build();
-    assertEquals(ImmutableMap.of(k1, v1, k2, v2, k3, v3), toMap(scanner));
+    assertEquals(Map.of(k1, v1, k2, v2, k3, v3), toMap(scanner));
     assertEquals(new Authorizations("A", "B"), scanner.getAuthorizations());
     scanner.close();
 
     scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withAuthorizations(new Authorizations("B")).build();
-    assertEquals(ImmutableMap.of(k3, v3), toMap(scanner));
+    assertEquals(Map.of(k3, v3), toMap(scanner));
     assertEquals(new Authorizations("B"), scanner.getAuthorizations());
     scanner.close();
   }
@@ -380,7 +378,7 @@ public class RFileClientTest {
 
     scanner =
         RFile.newScanner().from(testFile).withFileSystem(localFs).withoutSystemIterators().build();
-    assertEquals(ImmutableMap.of(k2, v2, k1, v1), toMap(scanner));
+    assertEquals(Map.of(k2, v2, k1, v1), toMap(scanner));
     scanner.setRange(new Range("r2"));
     assertFalse(scanner.iterator().hasNext());
     scanner.close();
@@ -442,11 +440,11 @@ public class RFileClientTest {
     // pass in table config that has versioning iterator configured
     Scanner scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withTableProperties(ntc.getProperties()).build();
-    assertEquals(ImmutableMap.of(k2, v2), toMap(scanner));
+    assertEquals(Map.of(k2, v2), toMap(scanner));
     scanner.close();
 
     scanner = RFile.newScanner().from(testFile).withFileSystem(localFs).build();
-    assertEquals(ImmutableMap.of(k2, v2, k1, v1), toMap(scanner));
+    assertEquals(Map.of(k2, v2, k1, v1), toMap(scanner));
     scanner.close();
   }
 
@@ -459,7 +457,7 @@ public class RFileClientTest {
     String testFile = createTmpTestFile();
 
     SamplerConfiguration sc = new SamplerConfiguration(RowSampler.class)
-        .setOptions(ImmutableMap.of("hasher", "murmur3_32", "modulus", "19"));
+        .setOptions(Map.of("hasher", "murmur3_32", "modulus", "19"));
 
     RFileWriter writer =
         RFile.newWriter().to(testFile).withFileSystem(localFs).withSampler(sc).build();
@@ -558,12 +556,11 @@ public class RFileClientTest {
       CounterSummary counterSummary = new CounterSummary(summary);
       if (className.equals(FamilySummarizer.class.getName())) {
         Map<String,Long> counters = counterSummary.getCounters();
-        Map<String,Long> expected =
-            ImmutableMap.of("0000", 200L, "0001", 200L, "0002", 200L, "0003", 200L);
+        Map<String,Long> expected = Map.of("0000", 200L, "0001", 200L, "0002", 200L, "0003", 200L);
         assertEquals(expected, counters);
       } else if (className.equals(VisibilitySummarizer.class.getName())) {
         Map<String,Long> counters = counterSummary.getCounters();
-        Map<String,Long> expected = ImmutableMap.of("A&B", 400L, "A&B&C", 400L);
+        Map<String,Long> expected = Map.of("A&B", 400L, "A&B&C", 400L);
         assertEquals(expected, counters);
       } else {
         fail("Unexpected classname " + className);
@@ -593,12 +590,11 @@ public class RFileClientTest {
       CounterSummary counterSummary = new CounterSummary(summary);
       if (className.equals(FamilySummarizer.class.getName())) {
         Map<String,Long> counters = counterSummary.getCounters();
-        Map<String,Long> expected =
-            ImmutableMap.of("0000", 400L, "0001", 400L, "0002", 400L, "0003", 400L);
+        Map<String,Long> expected = Map.of("0000", 400L, "0001", 400L, "0002", 400L, "0003", 400L);
         assertEquals(expected, counters);
       } else if (className.equals(VisibilitySummarizer.class.getName())) {
         Map<String,Long> counters = counterSummary.getCounters();
-        Map<String,Long> expected = ImmutableMap.of("A&B", 800L, "A&B&C", 800L);
+        Map<String,Long> expected = Map.of("A&B", 800L, "A&B&C", 800L);
         assertEquals(expected, counters);
       } else {
         fail("Unexpected classname " + className);
@@ -608,71 +604,71 @@ public class RFileClientTest {
     // verify reading a subset of summaries works
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 0);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 0);
 
     // the following test check boundary conditions for start row and end row
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(99)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 400L, "A&B&C", 400L), 0);
+    checkSummaries(summaries, Map.of("A&B", 400L, "A&B&C", 400L), 0);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(98)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 1);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(0)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 1);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow("#").read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 0);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 0);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(100)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 400L, "A&B&C", 400L), 1);
+    checkSummaries(summaries, Map.of("A&B", 400L, "A&B&C", 400L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).endRow(rowStr(99)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 400L, "A&B&C", 400L), 0);
+    checkSummaries(summaries, Map.of("A&B", 400L, "A&B&C", 400L), 0);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).endRow(rowStr(100)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 1);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).endRow(rowStr(199)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 0);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 0);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(50)).endRow(rowStr(150)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 2);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 2);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(120)).endRow(rowStr(150)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 400L, "A&B&C", 400L), 1);
+    checkSummaries(summaries, Map.of("A&B", 400L, "A&B&C", 400L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(50)).endRow(rowStr(199)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 1);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow("#").endRow(rowStr(150)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 800L, "A&B&C", 800L), 1);
+    checkSummaries(summaries, Map.of("A&B", 800L, "A&B&C", 800L), 1);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(199)).read();
-    checkSummaries(summaries, ImmutableMap.of(), 0);
+    checkSummaries(summaries, Map.of(), 0);
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).startRow(rowStr(200)).read();
-    checkSummaries(summaries, ImmutableMap.of(), 0);
+    checkSummaries(summaries, Map.of(), 0);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).endRow("#").read();
-    checkSummaries(summaries, ImmutableMap.of(), 0);
+    checkSummaries(summaries, Map.of(), 0);
 
     summaries = RFile.summaries().from(testFile, testFile2).withFileSystem(localFs)
         .selectSummaries(sc -> sc.equals(sc1)).endRow(rowStr(0)).read();
-    checkSummaries(summaries, ImmutableMap.of("A&B", 400L, "A&B&C", 400L), 1);
+    checkSummaries(summaries, Map.of("A&B", 400L, "A&B&C", 400L), 1);
   }
 
   private void checkSummaries(Collection<Summary> summaries, Map<String,Long> expected, int extra) {

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -34,8 +34,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.common.collect.ImmutableMap;
-
 public class AccumuloConfigurationTest {
 
   @Rule
@@ -271,8 +269,8 @@ public class AccumuloConfigurationTest {
     Map<String,String> pmF = tc.getAllPropertiesWithPrefix(Property.VFS_CONTEXT_CLASSPATH_PROPERTY);
     assertSame(pmE, pmF);
     assertNotSame(pm5, pmE);
-    assertEquals(ImmutableMap.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123",
-        "hdfs://ib/p1"), pmE);
+    assertEquals(
+        Map.of(Property.VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "ctx123", "hdfs://ib/p1"), pmE);
 
     Map<String,String> pmG = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
     Map<String,String> pmH = tc.getAllPropertiesWithPrefix(Property.TABLE_ITERATOR_SCAN_PREFIX);
@@ -363,7 +361,7 @@ public class AccumuloConfigurationTest {
     assertEquals(66, sec7.maxThreads);
     assertEquals(3, sec7.priority.getAsInt());
     assertEquals("com.foo.ScanPrioritizer", sec7.prioritizerClass.get());
-    assertEquals(ImmutableMap.of("k1", "v1", "k2", "v3"), sec7.prioritizerOpts);
+    assertEquals(Map.of("k1", "v1", "k2", "v3"), sec7.prioritizerOpts);
 
     tc.set(prefix + "hulksmash.threads", "44");
     assertEquals(66, sec7.maxThreads);

--- a/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class SiteConfigurationTest {
@@ -60,8 +58,8 @@ public class SiteConfigurationTest {
     assertNotNull(keystore);
     String credProvPath = "jceks://file" + new File(keystore.getFile()).getAbsolutePath();
 
-    SiteConfiguration config = new SiteConfiguration(ImmutableMap
-        .of(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), credProvPath));
+    SiteConfiguration config = new SiteConfiguration(
+        Map.of(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), credProvPath));
 
     assertEquals("mysecret", config.get(Property.INSTANCE_SECRET));
     assertNull(config.get("ignored.property"));
@@ -100,7 +98,7 @@ public class SiteConfigurationTest {
     assertEquals("localhost:2181", conf.get(Property.INSTANCE_ZK_HOST));
 
     conf = new SiteConfiguration((URL) null,
-        ImmutableMap.of(Property.INSTANCE_ZK_HOST.getKey(), "myhost:2181"));
+        Map.of(Property.INSTANCE_ZK_HOST.getKey(), "myhost:2181"));
     assertEquals("myhost:2181", conf.get(Property.INSTANCE_ZK_HOST));
 
     Map<String,String> results = new HashMap<>();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RowFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RowFilterTest.java
@@ -42,8 +42,6 @@ import org.apache.accumulo.core.iterators.system.ColumnFamilySkippingIterator;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 public class RowFilterTest {
 
   public static class SummingRowFilter extends RowFilter {
@@ -192,7 +190,7 @@ public class RowFilterTest {
 
     ByteSequence cf = new ArrayByteSequence("cf2");
 
-    filter.seek(new Range(), ImmutableSet.of(cf), true);
+    filter.seek(new Range(), Set.of(cf), true);
     assertEquals(new HashSet<>(Arrays.asList("1", "3", "0", "4")), getRows(filter));
 
     filter.seek(new Range("0", "4"), Collections.emptySet(), false);
@@ -204,7 +202,7 @@ public class RowFilterTest {
     filter.seek(new Range("4"), Collections.emptySet(), false);
     assertEquals(new HashSet<String>(), getRows(filter));
 
-    filter.seek(new Range("4"), ImmutableSet.of(cf), true);
+    filter.seek(new Range("4"), Set.of(cf), true);
     assertEquals(new HashSet<>(Arrays.asList("4")), getRows(filter));
 
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -55,13 +55,11 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class TransformingIteratorTest {
 
   private static Authorizations authorizations =
       new Authorizations("vis0", "vis1", "vis2", "vis3", "vis4");
-  private static final Map<String,String> EMPTY_OPTS = ImmutableMap.of();
+  private static final Map<String,String> EMPTY_OPTS = Map.of();
   private TransformingIterator titer;
 
   private TreeMap<Key,Value> data = new TreeMap<>();
@@ -104,7 +102,7 @@ public class TransformingIteratorTest {
           new Authorizations("vis0", "vis1", "vis2", "vis3"));
       opts = cfg.getOptions();
     } else {
-      opts = ImmutableMap.of();
+      opts = Map.of();
     }
     titer.init(reuserIter, opts, iterEnv);
   }
@@ -229,9 +227,11 @@ public class TransformingIteratorTest {
     // be inside the range.
 
     TreeMap<Key,Value> expected = new TreeMap<>();
-    for (int cq = 1; cq <= 3; ++cq)
-      for (int cv = 1; cv <= 3; ++cv)
+    for (int cq = 1; cq <= 3; ++cq) {
+      for (int cv = 1; cv <= 3; ++cv) {
         putExpected(expected, 1, 3, cq, cv, PartialKey.ROW);
+      }
+    }
     checkExpected(new Range(new Key("row1", "cf0"), true, new Key("row1", "cf1"), false), expected);
   }
 
@@ -276,10 +276,13 @@ public class TransformingIteratorTest {
     setUpTransformIterator(ColFamReversingKeyTransformingIterator.class);
 
     TreeMap<Key,Value> expected = new TreeMap<>();
-    for (int row = 1; row <= 3; ++row)
-      for (int cq = 1; cq <= 3; ++cq)
-        for (int cv = 1; cv <= 3; ++cv)
+    for (int row = 1; row <= 3; ++row) {
+      for (int cq = 1; cq <= 3; ++cq) {
+        for (int cv = 1; cv <= 3; ++cv) {
           putExpected(expected, row, expectedCF, cq, cv, PartialKey.ROW);
+        }
+      }
+    }
     checkExpected(expected, "cf2");
   }
 
@@ -328,10 +331,13 @@ public class TransformingIteratorTest {
     setUpTransformIterator(ColFamReversingCompactionKeyTransformingIterator.class);
 
     TreeMap<Key,Value> expected = new TreeMap<>();
-    for (int row = 1; row <= 3; ++row)
-      for (int cq = 1; cq <= 3; ++cq)
-        for (int cv = 1; cv <= 3; ++cv)
+    for (int row = 1; row <= 3; ++row) {
+      for (int cq = 1; cq <= 3; ++cq) {
+        for (int cv = 1; cv <= 3; ++cv) {
           putExpected(expected, row, expectedCF, cq, cv, PartialKey.ROW);
+        }
+      }
+    }
     checkExpected(expected, "cf2");
   }
 
@@ -604,8 +610,9 @@ public class TransformingIteratorTest {
     protected Collection<ByteSequence>
         untransformColumnFamilies(Collection<ByteSequence> columnFamilies) {
       HashSet<ByteSequence> untransformed = new HashSet<>();
-      for (ByteSequence cf : columnFamilies)
+      for (ByteSequence cf : columnFamilies) {
         untransformed.add(untransformColumnFamily(cf));
+      }
       return untransformed;
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeRowIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeRowIteratorTest.java
@@ -38,15 +38,13 @@ import org.apache.accumulo.core.iterators.system.MultiIterator;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class WholeRowIteratorTest {
 
   @Test(expected = IOException.class)
   public void testBadDecodeRow() throws IOException {
     Key k = new Key(new Text("r1"), new Text("cf1234567890"));
     Value v = new Value("v1".getBytes());
-    Value encoded = WholeRowIterator.encodeRow(ImmutableList.of(k), ImmutableList.of(v));
+    Value encoded = WholeRowIterator.encodeRow(List.of(k), List.of(v));
     encoded.set(Arrays.copyOfRange(encoded.get(), 0, 10)); // truncate to 10 bytes only
     WholeRowIterator.decodeRow(k, encoded);
   }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -48,9 +50,6 @@ import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 public class TabletMetadataTest {
 
@@ -99,11 +98,11 @@ public class TabletMetadataTest {
     assertEquals("/a/t/6/a/", tm.getDir());
     assertEquals(extent.getEndRow(), tm.getEndRow());
     assertEquals(extent, tm.getExtent());
-    assertEquals(ImmutableSet.of("df1", "df2"), ImmutableSet.copyOf(tm.getFiles()));
-    assertEquals(ImmutableMap.of("df1", dfv1, "df2", dfv2), tm.getFilesMap());
+    assertEquals(Set.of("df1", "df2"), Set.copyOf(tm.getFiles()));
+    assertEquals(Map.of("df1", dfv1, "df2", dfv2), tm.getFilesMap());
     assertEquals(6L, tm.getFlushId().getAsLong());
     assertEquals(rowMap, tm.getKeyValues());
-    assertEquals(ImmutableSet.of("bf1", "bf2"), ImmutableSet.copyOf(tm.getLoaded()));
+    assertEquals(Set.of("bf1", "bf2"), Set.copyOf(tm.getLoaded()));
     assertEquals(HostAndPort.fromParts("server1", 8555), tm.getLocation().getHostAndPort());
     assertEquals("s001", tm.getLocation().getSession());
     assertEquals(LocationType.CURRENT, tm.getLocation().getType());
@@ -111,14 +110,13 @@ public class TabletMetadataTest {
     assertEquals(HostAndPort.fromParts("server2", 8555), tm.getLast().getHostAndPort());
     assertEquals("s000", tm.getLast().getSession());
     assertEquals(LocationType.LAST, tm.getLast().getType());
-    assertEquals(
-        ImmutableSet.of(le1.getName() + " " + le1.timestamp, le2.getName() + " " + le2.timestamp),
+    assertEquals(Set.of(le1.getName() + " " + le1.timestamp, le2.getName() + " " + le2.timestamp),
         tm.getLogs().stream().map(le -> le.getName() + " " + le.timestamp).collect(toSet()));
     assertEquals(extent.getPrevEndRow(), tm.getPrevEndRow());
     assertEquals(extent.getTableId(), tm.getTableId());
     assertTrue(tm.sawPrevEndRow());
     assertEquals("M123456789", tm.getTime());
-    assertEquals(ImmutableSet.of("sf1", "sf2"), ImmutableSet.copyOf(tm.getScans()));
+    assertEquals(Set.of("sf1", "sf2"), Set.copyOf(tm.getScans()));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizerTest.java
@@ -28,8 +28,6 @@ import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.scan.ScanInfo.Type;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class HintScanPrioritizerTest {
   @Test
   public void testSort() {
@@ -57,8 +55,8 @@ public class HintScanPrioritizerTest {
 
           @Override
           public Map<String,String> getOptions() {
-            return ImmutableMap.of("priority.isbn", "10", "priority.background", "30",
-                "default_priority", "20");
+            return Map.of("priority.isbn", "10", "priority.background", "30", "default_priority",
+                "20");
           }
 
           @Override

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcherTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcherTest.java
@@ -30,8 +30,6 @@ import org.apache.accumulo.core.spi.scan.ScanDispatcher.DispatchParmaters;
 import org.apache.accumulo.core.spi.scan.ScanInfo.Type;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class SimpleScanDispatcherTest {
   @Test
   public void testProps() {
@@ -113,22 +111,21 @@ public class SimpleScanDispatcherTest {
     String dname = SimpleScanDispatcher.DEFAULT_SCAN_EXECUTOR_NAME;
 
     runTest(Collections.emptyMap(), dname, dname);
-    runTest(ImmutableMap.of("executor", "E1"), "E1", "E1");
-    runTest(ImmutableMap.of("single_executor", "E2"), "E2", dname);
-    runTest(ImmutableMap.of("multi_executor", "E3"), dname, "E3");
-    runTest(ImmutableMap.of("executor", "E1", "single_executor", "E2"), "E2", "E1");
-    runTest(ImmutableMap.of("executor", "E1", "multi_executor", "E3"), "E1", "E3");
-    runTest(ImmutableMap.of("single_executor", "E2", "multi_executor", "E3"), "E2", "E3");
-    runTest(ImmutableMap.of("executor", "E1", "single_executor", "E2", "multi_executor", "E3"),
-        "E2", "E3");
+    runTest(Map.of("executor", "E1"), "E1", "E1");
+    runTest(Map.of("single_executor", "E2"), "E2", dname);
+    runTest(Map.of("multi_executor", "E3"), dname, "E3");
+    runTest(Map.of("executor", "E1", "single_executor", "E2"), "E2", "E1");
+    runTest(Map.of("executor", "E1", "multi_executor", "E3"), "E1", "E3");
+    runTest(Map.of("single_executor", "E2", "multi_executor", "E3"), "E2", "E3");
+    runTest(Map.of("executor", "E1", "single_executor", "E2", "multi_executor", "E3"), "E2", "E3");
   }
 
   @Test
   public void testHints() {
-    runTest(ImmutableMap.of("executor", "E1"), ImmutableMap.of("scan_type", "quick"), "E1", "E1");
-    runTest(ImmutableMap.of("executor", "E1", "executor.quick", "E2"),
-        ImmutableMap.of("scan_type", "quick"), "E2", "E2");
-    runTest(ImmutableMap.of("executor", "E1", "executor.quick", "E2", "executor.slow", "E3"),
-        ImmutableMap.of("scan_type", "slow"), "E3", "E3");
+    runTest(Map.of("executor", "E1"), Map.of("scan_type", "quick"), "E1", "E1");
+    runTest(Map.of("executor", "E1", "executor.quick", "E2"), Map.of("scan_type", "quick"), "E2",
+        "E2");
+    runTest(Map.of("executor", "E1", "executor.quick", "E2", "executor.slow", "E3"),
+        Map.of("scan_type", "slow"), "E3", "E3");
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/TestScanInfo.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/TestScanInfo.java
@@ -29,8 +29,6 @@ import org.apache.accumulo.core.spi.common.IteratorConfiguration;
 import org.apache.accumulo.core.spi.common.Stats;
 import org.apache.accumulo.core.util.Stat;
 
-import com.google.common.collect.ImmutableMap;
-
 public class TestScanInfo implements ScanInfo {
 
   String testId;
@@ -59,7 +57,7 @@ public class TestScanInfo implements ScanInfo {
   }
 
   TestScanInfo setExecutionHints(String k, String v) {
-    this.executionHints = ImmutableMap.of(k, v);
+    this.executionHints = Map.of(k, v);
     return this;
   }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -39,9 +39,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 public class InputFormatBuilderImpl<T>
     implements InputFormatBuilder, InputFormatBuilder.ClientParams<T>,
     InputFormatBuilder.TableParams<T>, InputFormatBuilder.InputFormatOptions<T> {
@@ -73,8 +70,9 @@ public class InputFormatBuilderImpl<T>
   @Override
   public InputFormatBuilder.InputFormatOptions<T> table(String tableName) {
     this.currentTable = Objects.requireNonNull(tableName, "Table name must not be null");
-    if (tableConfigMap.isEmpty())
+    if (tableConfigMap.isEmpty()) {
       tableConfigMap = new LinkedHashMap<>();
+    }
     tableConfigMap.put(currentTable, new InputTableConfig());
     return this;
   }
@@ -95,9 +93,10 @@ public class InputFormatBuilderImpl<T>
   @Override
   public InputFormatBuilder.InputFormatOptions<T> ranges(Collection<Range> ranges) {
     List<Range> newRanges =
-        ImmutableList.copyOf(Objects.requireNonNull(ranges, "Collection of ranges is null"));
-    if (newRanges.size() == 0)
+        List.copyOf(Objects.requireNonNull(ranges, "Collection of ranges is null"));
+    if (newRanges.size() == 0) {
       throw new IllegalArgumentException("Specified collection of ranges is empty.");
+    }
     tableConfigMap.get(currentTable).setRanges(newRanges);
     return this;
   }
@@ -105,10 +104,11 @@ public class InputFormatBuilderImpl<T>
   @Override
   public InputFormatBuilder.InputFormatOptions<T>
       fetchColumns(Collection<IteratorSetting.Column> fetchColumns) {
-    Collection<IteratorSetting.Column> newFetchColumns = ImmutableList
-        .copyOf(Objects.requireNonNull(fetchColumns, "Collection of fetch columns is null"));
-    if (newFetchColumns.size() == 0)
+    Collection<IteratorSetting.Column> newFetchColumns =
+        List.copyOf(Objects.requireNonNull(fetchColumns, "Collection of fetch columns is null"));
+    if (newFetchColumns.size() == 0) {
       throw new IllegalArgumentException("Specified collection of fetch columns is empty.");
+    }
     tableConfigMap.get(currentTable).fetchColumns(newFetchColumns);
     return this;
   }
@@ -123,10 +123,11 @@ public class InputFormatBuilderImpl<T>
 
   @Override
   public InputFormatBuilder.InputFormatOptions<T> executionHints(Map<String,String> hints) {
-    Map<String,String> newHints = ImmutableMap
-        .copyOf(Objects.requireNonNull(hints, "Map of execution hints must not be null."));
-    if (newHints.size() == 0)
+    Map<String,String> newHints =
+        Map.copyOf(Objects.requireNonNull(hints, "Map of execution hints must not be null."));
+    if (newHints.size() == 0) {
       throw new IllegalArgumentException("Specified map of execution hints is empty.");
+    }
     tableConfigMap.get(currentTable).setExecutionHints(newHints);
     return this;
   }
@@ -165,8 +166,9 @@ public class InputFormatBuilderImpl<T>
   @Override
   public InputFormatOptions<T> batchScan(boolean value) {
     tableConfigMap.get(currentTable).setUseBatchScan(value);
-    if (value)
+    if (value) {
       tableConfigMap.get(currentTable).setAutoAdjustRanges(true);
+    }
     return this;
   }
 
@@ -207,19 +209,25 @@ public class InputFormatBuilderImpl<T>
       }
       InputConfigurator.setScanAuthorizations(callingClass, conf, config.getScanAuths().get());
       // all optional values
-      if (config.getContext().isPresent())
+      if (config.getContext().isPresent()) {
         InputConfigurator.setClassLoaderContext(callingClass, conf, config.getContext().get());
-      if (config.getRanges().size() > 0)
+      }
+      if (config.getRanges().size() > 0) {
         InputConfigurator.setRanges(callingClass, conf, config.getRanges());
-      if (config.getIterators().size() > 0)
+      }
+      if (config.getIterators().size() > 0) {
         InputConfigurator.writeIteratorsToConf(callingClass, conf, config.getIterators());
-      if (config.getFetchedColumns().size() > 0)
+      }
+      if (config.getFetchedColumns().size() > 0) {
         InputConfigurator.fetchColumns(callingClass, conf, config.getFetchedColumns());
-      if (config.getSamplerConfiguration() != null)
+      }
+      if (config.getSamplerConfiguration() != null) {
         InputConfigurator.setSamplerConfiguration(callingClass, conf,
             config.getSamplerConfiguration());
-      if (config.getExecutionHints().size() > 0)
+      }
+      if (config.getExecutionHints().size() > 0) {
         InputConfigurator.setExecutionHints(callingClass, conf, config.getExecutionHints());
+      }
       InputConfigurator.setAutoAdjustRanges(callingClass, conf, config.shouldAutoAdjustRanges());
       InputConfigurator.setScanIsolation(callingClass, conf, config.shouldUseIsolatedScanners());
       InputConfigurator.setLocalIterators(callingClass, conf, config.shouldUseLocalIterators());

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapred/RangeInputSplitTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapred/RangeInputSplitTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -37,8 +38,6 @@ import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 public class RangeInputSplitTest {
 
@@ -86,7 +85,7 @@ public class RangeInputSplitTest {
     split.setUsesLocalIterators(true);
     split.setFetchedColumns(fetchedColumns);
     split.setIterators(iterators);
-    split.setExecutionHints(ImmutableMap.of("priority", "9"));
+    split.setExecutionHints(Map.of("priority", "9"));
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/InputTableConfigTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/InputTableConfigTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -34,8 +35,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 public class InputTableConfigTest {
 
@@ -114,9 +113,9 @@ public class InputTableConfigTest {
 
   @Test
   public void testExecutionHints() throws IOException {
-    tableQueryConfig.setExecutionHints(ImmutableMap.of("priority", "9"));
+    tableQueryConfig.setExecutionHints(Map.of("priority", "9"));
     InputTableConfig actualConfig = deserialize(serialize(tableQueryConfig));
-    assertEquals(ImmutableMap.of("priority", "9"), actualConfig.getExecutionHints());
+    assertEquals(Map.of("priority", "9"), actualConfig.getExecutionHints());
   }
 
   private byte[] serialize(InputTableConfig tableQueryConfig) throws IOException {

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/RangeInputSplitTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/RangeInputSplitTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -37,8 +38,6 @@ import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 public class RangeInputSplitTest {
 
@@ -89,7 +88,7 @@ public class RangeInputSplitTest {
     split.setUsesLocalIterators(true);
     split.setFetchedColumns(fetchedColumns);
     split.setIterators(iterators);
-    split.setExecutionHints(ImmutableMap.of("priority", "9"));
+    split.setExecutionHints(Map.of("priority", "9"));
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestCaseFinder.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestCaseFinder.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.accumulo.iteratortest.testcases.IteratorTestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
 
@@ -48,8 +48,7 @@ public class IteratorTestCaseFinder {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    ImmutableSet<ClassInfo> classes =
-        cp.getTopLevelClasses(IteratorTestCase.class.getPackage().getName());
+    Set<ClassInfo> classes = cp.getTopLevelClasses(IteratorTestCase.class.getPackage().getName());
 
     final List<IteratorTestCase> testCases = new ArrayList<>();
     // final Set<Class<? extends IteratorTestCase>> classes =

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,6 @@
     <maven.compiler.target>11</maven.compiler.target>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <!-- temporary until other Java 11 issues are resolved -->
-    <modernizer.skip>true</modernizer.skip>
     <powermock.version>2.0.2</powermock.version>
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerConstants.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerConstants.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.server.fs.VolumeUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 public class ServerConstants {
@@ -76,9 +75,8 @@ public class ServerConstants {
   public static final int DATA_VERSION = ROOT_TABLET_META_CHANGES;
 
   public static final Set<Integer> CAN_RUN =
-      ImmutableSet.of(SHORTEN_RFILE_KEYS, CRYPTO_CHANGES, DATA_VERSION);
-  public static final Set<Integer> NEEDS_UPGRADE =
-      Sets.difference(CAN_RUN, ImmutableSet.of(DATA_VERSION));
+      Set.of(SHORTEN_RFILE_KEYS, CRYPTO_CHANGES, DATA_VERSION);
+  public static final Set<Integer> NEEDS_UPGRADE = Sets.difference(CAN_RUN, Set.of(DATA_VERSION));
 
   private static String[] baseUris = null;
 
@@ -117,10 +115,11 @@ public class ServerConstants {
         currentVersion =
             ServerUtil.getAccumuloPersistentVersion(vpath.getFileSystem(hadoopConf), vpath);
       } catch (Exception e) {
-        if (ignore)
+        if (ignore) {
           continue;
-        else
+        } else {
           throw new IllegalArgumentException("Accumulo volume " + path + " not initialized", e);
+        }
       }
 
       if (firstIid == null) {
@@ -177,8 +176,9 @@ public class ServerConstants {
 
       replacements = replacements.trim();
 
-      if (replacements.isEmpty())
+      if (replacements.isEmpty()) {
         return Collections.emptyList();
+      }
 
       String[] pairs = replacements.split(",");
       List<Pair<Path,Path>> ret = new ArrayList<>();
@@ -186,17 +186,19 @@ public class ServerConstants {
       for (String pair : pairs) {
 
         String[] uris = pair.split("\\s+");
-        if (uris.length != 2)
+        if (uris.length != 2) {
           throw new IllegalArgumentException(
               Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey() + " contains malformed pair " + pair);
+        }
 
         Path p1, p2;
         try {
           // URI constructor handles hex escaping
           p1 = new Path(new URI(VolumeUtil.removeTrailingSlash(uris[0].trim())));
-          if (p1.toUri().getScheme() == null)
+          if (p1.toUri().getScheme() == null) {
             throw new IllegalArgumentException(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey()
                 + " contains " + uris[0] + " which is not fully qualified");
+          }
         } catch (URISyntaxException e) {
           throw new IllegalArgumentException(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey()
               + " contains " + uris[0] + " which has a syntax error", e);
@@ -204,9 +206,10 @@ public class ServerConstants {
 
         try {
           p2 = new Path(new URI(VolumeUtil.removeTrailingSlash(uris[1].trim())));
-          if (p2.toUri().getScheme() == null)
+          if (p2.toUri().getScheme() == null) {
             throw new IllegalArgumentException(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey()
                 + " contains " + uris[1] + " which is not fully qualified");
+          }
         } catch (URISyntaxException e) {
           throw new IllegalArgumentException(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey()
               + " contains " + uris[1] + " which has a syntax error", e);
@@ -221,10 +224,12 @@ public class ServerConstants {
         baseDirs.add(new Path(baseDir));
       }
 
-      for (Pair<Path,Path> pair : ret)
-        if (!baseDirs.contains(pair.getSecond()))
+      for (Pair<Path,Path> pair : ret) {
+        if (!baseDirs.contains(pair.getSecond())) {
           throw new IllegalArgumentException(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey()
               + " contains " + pair.getSecond() + " which is not a configured volume");
+        }
+      }
 
       // only set if get here w/o exception
       replacementsList = ret;

--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
@@ -58,8 +57,9 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
       // Get prop to check if sensitive, also looking up by prop may be more efficient.
       Property prop = Property.getPropertyByKey(key);
       if (prop != null) {
-        if (prop.isSensitive())
+        if (prop.isSensitive()) {
           return null;
+        }
         return acfg.get(prop);
       } else {
         return acfg.get(key);
@@ -68,8 +68,9 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
     @Override
     public Map<String,String> getCustom() {
-      if (customProps == null)
+      if (customProps == null) {
         customProps = buildCustom(Property.GENERAL_ARBITRARY_PROP_PREFIX);
+      }
 
       return customProps;
     }
@@ -81,8 +82,9 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
     @Override
     public Map<String,String> getTableCustom() {
-      if (tableCustomProps == null)
+      if (tableCustomProps == null) {
         tableCustomProps = buildCustom(Property.TABLE_ARBITRARY_PROP_PREFIX);
+      }
 
       return tableCustomProps;
     }
@@ -95,7 +97,7 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
     private Map<String,String> buildCustom(Property customPrefix) {
       // This could be optimized as described in #947
       Map<String,String> props = acfg.getAllPropertiesWithPrefix(customPrefix);
-      Builder<String,String> builder = ImmutableMap.builder();
+      var builder = ImmutableMap.<String,String>builder();
       props.forEach((k, v) -> {
         builder.put(k.substring(customPrefix.getKey().length()), v);
       });

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -42,9 +42,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.conf.ZooCachePropertyAccessor.PropCacheKey;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 public class TableConfiguration extends AccumuloConfiguration {
 
@@ -100,8 +98,9 @@ public class TableConfiguration extends AccumuloConfiguration {
   private ZooCachePropertyAccessor getPropCacheAccessor() {
     // updateAndGet below always calls compare and set, so avoid if not null
     ZooCachePropertyAccessor zcpa = propCacheAccessor.get();
-    if (zcpa != null)
+    if (zcpa != null) {
       return zcpa;
+    }
 
     return propCacheAccessor
         .updateAndGet(pca -> pca == null ? new ZooCachePropertyAccessor(getZooCache()) : pca);
@@ -113,12 +112,14 @@ public class TableConfiguration extends AccumuloConfiguration {
 
   @Override
   public boolean isPropertySet(Property prop, boolean cacheAndWatch) {
-    if (!cacheAndWatch)
+    if (!cacheAndWatch) {
       throw new UnsupportedOperationException(
           "Table configuration only supports checking if a property is set in cache.");
+    }
 
-    if (getPropCacheAccessor().isPropertySet(prop, getPath()))
+    if (getPropCacheAccessor().isPropertySet(prop, getPath())) {
       return true;
+    }
 
     return parent.isPropertySet(prop, cacheAndWatch);
   }
@@ -182,10 +183,10 @@ public class TableConfiguration extends AccumuloConfiguration {
 
     private ParsedIteratorConfig(List<IterInfo> ii, Map<String,Map<String,String>> opts,
         String context) {
-      this.tableIters = ImmutableList.copyOf(ii);
-      Builder<String,Map<String,String>> imb = ImmutableMap.builder();
+      this.tableIters = List.copyOf(ii);
+      var imb = ImmutableMap.<String,Map<String,String>>builder();
       for (Entry<String,Map<String,String>> entry : opts.entrySet()) {
-        imb.put(entry.getKey(), ImmutableMap.copyOf(entry.getValue()));
+        imb.put(entry.getKey(), Map.copyOf(entry.getValue()));
       }
       tableOpts = imb.build();
       this.context = context;
@@ -213,7 +214,7 @@ public class TableConfiguration extends AccumuloConfiguration {
     ScanDispatcher newDispatcher = Property.createTableInstanceFromPropertyName(conf,
         Property.TABLE_SCAN_DISPATCHER, ScanDispatcher.class, null);
 
-    Builder<String,String> builder = ImmutableMap.builder();
+    var builder = ImmutableMap.<String,String>builder();
     conf.getAllPropertiesWithPrefix(Property.TABLE_SCAN_DISPATCHER_OPTS).forEach((k, v) -> {
       String optKey = k.substring(Property.TABLE_SCAN_DISPATCHER_OPTS.getKey().length());
       builder.put(optKey, v);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -57,7 +57,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 
@@ -126,7 +125,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
       }
     }
 
-    return ImmutableMap.copyOf(regexes);
+    return Map.copyOf(regexes);
   }
 
   /**
@@ -168,7 +167,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
         poolNameToRegexPatternBuilder.put(k, Pattern.compile(v));
       });
 
-      poolNameToRegexPattern = ImmutableMap.copyOf(poolNameToRegexPatternBuilder);
+      poolNameToRegexPattern = Map.copyOf(poolNameToRegexPatternBuilder);
     }
   }
 
@@ -391,8 +390,9 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     long minBalanceTime = 20 * 1000;
     // Iterate over the tables and balance each of them
     TableOperations t = getTableOperations();
-    if (t == null)
+    if (t == null) {
       return minBalanceTime;
+    }
 
     Map<String,String> tableIdMap = t.tableIdMap();
     Map<TableId,String> tableIdToTableName = createdTableNameMap(tableIdMap);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -50,12 +50,9 @@ import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class TableLoadBalancerTest {
 
-  private static Map<String,String> TABLE_ID_MAP =
-      ImmutableMap.of("t1", "a1", "t2", "b12", "t3", "c4");
+  private static Map<String,String> TABLE_ID_MAP = Map.of("t1", "a1", "t2", "b12", "t3", "c4");
 
   private static TServerInstance mkts(String address, String session) {
     return new TServerInstance(HostAndPort.fromParts(address, 1234), session);
@@ -194,8 +191,9 @@ public class TableLoadBalancerTest {
     movedByTable.put(TableId.of(t2Id), 0);
     movedByTable.put(TableId.of(t3Id), 0);
     for (TabletMigration migration : migrationsOut) {
-      if (migration.oldServer.equals(svr))
+      if (migration.oldServer.equals(svr)) {
         count++;
+      }
       TableId key = migration.tablet.getTableId();
       movedByTable.put(key, movedByTable.get(key) + 1);
     }

--- a/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
@@ -38,7 +38,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 
 public class UserImpersonationTest {
 
@@ -87,7 +86,7 @@ public class UserImpersonationTest {
   public void testAnyUserAndHosts() {
     String server = "server";
     setValidHosts("*");
-    setValidUsers(ImmutableMap.of(server, "*"));
+    setValidUsers(Map.of(server, "*"));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
@@ -103,7 +102,7 @@ public class UserImpersonationTest {
   @Test
   public void testNoHostByDefault() {
     String server = "server";
-    setValidUsers(ImmutableMap.of(server, "*"));
+    setValidUsers(Map.of(server, "*"));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
@@ -130,7 +129,7 @@ public class UserImpersonationTest {
   public void testSingleUserAndHost() {
     String server = "server", host = "single_host.domain.com", client = "single_client";
     setValidHosts(host);
-    setValidUsers(ImmutableMap.of(server, client));
+    setValidUsers(Map.of(server, client));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
@@ -153,7 +152,7 @@ public class UserImpersonationTest {
   public void testMultipleExplicitUsers() {
     String server = "server", client1 = "client1", client2 = "client2", client3 = "client3";
     setValidHosts("*");
-    setValidUsers(ImmutableMap.of(server, Joiner.on(',').join(client1, client2, client3)));
+    setValidUsers(Map.of(server, Joiner.on(',').join(client1, client2, client3)));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
@@ -175,7 +174,7 @@ public class UserImpersonationTest {
   public void testMultipleExplicitHosts() {
     String server = "server", host1 = "host1", host2 = "host2", host3 = "host3";
     setValidHosts(Joiner.on(',').join(host1, host2, host3));
-    setValidUsers(ImmutableMap.of(server, "*"));
+    setValidUsers(Map.of(server, "*"));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
@@ -198,7 +197,7 @@ public class UserImpersonationTest {
     String server = "server", host1 = "host1", host2 = "host2", host3 = "host3",
         client1 = "client1", client2 = "client2", client3 = "client3";
     setValidHosts(Joiner.on(',').join(host1, host2, host3));
-    setValidUsers(ImmutableMap.of(server, Joiner.on(',').join(client1, client2, client3)));
+    setValidUsers(Map.of(server, Joiner.on(',').join(client1, client2, client3)));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
@@ -228,8 +227,7 @@ public class UserImpersonationTest {
     // server1 can impersonate client1 and client2 from host1 or host2
     // server2 can impersonate only client3 from host3
     setValidHosts(Joiner.on(',').join(host1, host2), host3);
-    setValidUsers(
-        ImmutableMap.of(server1, Joiner.on(',').join(client1, client2), server2, client3));
+    setValidUsers(Map.of(server1, Joiner.on(',').join(client1, client2), server2, client3));
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server1);

--- a/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
@@ -72,7 +72,8 @@ public class UserImpersonationTest {
 
   // preserve order
   private void setValidUsers(String... remoteToAllowedUsers) {
-    assertEquals(0, remoteToAllowedUsers.length % 2); // make sure pairs are odd
+    // make sure args come in pairs (even), mapping remote servers to corresponding users
+    assertEquals(0, remoteToAllowedUsers.length % 2);
     StringBuilder sb = new StringBuilder();
     for (int v = 1; v < remoteToAllowedUsers.length; v += 2) {
       if (sb.length() > 0) {

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/UpgradeCoordinator.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/UpgradeCoordinator.java
@@ -28,8 +28,6 @@ import org.apache.accumulo.server.ServerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class UpgradeCoordinator {
@@ -41,7 +39,7 @@ public class UpgradeCoordinator {
   private boolean startedMetadataUpgrade = false;
   private int currentVersion;
   private Map<Integer,Upgrader> upgraders =
-      ImmutableMap.of(ServerConstants.SHORTEN_RFILE_KEYS, new Upgrader8to9());
+      Map.of(ServerConstants.SHORTEN_RFILE_KEYS, new Upgrader8to9());
 
   public UpgradeCoordinator(ServerContext ctx) {
     int currentVersion = ServerUtil.getAccumuloPersistentVersion(ctx.getVolumeManager());
@@ -60,8 +58,9 @@ public class UpgradeCoordinator {
   }
 
   public synchronized void upgradeZookeeper() {
-    if (haveUpgradedZooKeeper)
+    if (haveUpgradedZooKeeper) {
       throw new IllegalStateException("Only expect this method to be called once");
+    }
 
     try {
       if (currentVersion < ServerConstants.DATA_VERSION) {
@@ -80,8 +79,9 @@ public class UpgradeCoordinator {
   }
 
   public synchronized Future<Void> upgradeMetadata() {
-    if (startedMetadataUpgrade)
+    if (startedMetadataUpgrade) {
       throw new IllegalStateException("Only expect this method to be called once");
+    }
 
     if (!haveUpgradedZooKeeper) {
       throw new IllegalStateException("We should only attempt to upgrade"

--- a/server/master/src/test/java/org/apache/accumulo/master/metrics/ReplicationMetricsTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/metrics/ReplicationMetricsTest.java
@@ -17,6 +17,7 @@
 package org.apache.accumulo.master.metrics;
 
 import java.lang.reflect.Field;
+import java.util.Set;
 
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.ServerContext;
@@ -28,8 +29,6 @@ import org.apache.hadoop.metrics2.lib.MutableQuantiles;
 import org.apache.hadoop.metrics2.lib.MutableStat;
 import org.easymock.EasyMock;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableSet;
 
 public class ReplicationMetricsTest {
   private long currentTime = 1000L;
@@ -62,14 +61,14 @@ public class ReplicationMetricsTest {
 
     // First call will initialize the map of paths to modification time
     EasyMock.expect(master.getContext()).andReturn(context).anyTimes();
-    EasyMock.expect(util.getPendingReplicationPaths()).andReturn(ImmutableSet.of(path1, path2));
+    EasyMock.expect(util.getPendingReplicationPaths()).andReturn(Set.of(path1, path2));
     EasyMock.expect(master.getFileSystem()).andReturn(fileSystem);
     EasyMock.expect(fileSystem.getFileStatus(path1)).andReturn(createStatus(100));
     EasyMock.expect(master.getFileSystem()).andReturn(fileSystem);
     EasyMock.expect(fileSystem.getFileStatus(path2)).andReturn(createStatus(200));
 
     // Second call will recognize the missing path1 and add the latency stat
-    EasyMock.expect(util.getPendingReplicationPaths()).andReturn(ImmutableSet.of(path2));
+    EasyMock.expect(util.getPendingReplicationPaths()).andReturn(Set.of(path2));
 
     // Expect a call to reset the min/max
     stat.resetMinMax();

--- a/server/master/src/test/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.master.tableOps.bulkVer2.PrepBulkImport.TabletIterFac
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
@@ -66,7 +65,7 @@ public class PrepBulkImportTest {
   }
 
   Iterable<List<KeyExtent>> powerSet(KeyExtent... extents) {
-    Set<Set<KeyExtent>> powerSet = Sets.powerSet(ImmutableSet.copyOf(extents));
+    Set<Set<KeyExtent>> powerSet = Sets.powerSet(Set.copyOf(Arrays.asList(extents)));
 
     return Iterables.transform(powerSet, set -> {
       List<KeyExtent> list = new ArrayList<>(set);
@@ -137,7 +136,7 @@ public class PrepBulkImportTest {
       }
 
       List<String> requiredRows = Arrays.asList("b", "m", "r", "v");
-      for (Set<String> otherRows : Sets.powerSet(ImmutableSet.of("a", "c", "q", "t", "x"))) {
+      for (Set<String> otherRows : Sets.powerSet(Set.of("a", "c", "q", "t", "x"))) {
         runTest(loadRanges, createExtents(Iterables.concat(requiredRows, otherRows)));
       }
     }
@@ -166,14 +165,14 @@ public class PrepBulkImportTest {
         Set<String> rows2 = new HashSet<>(rows);
         rows2.remove(row);
         // test will all but one of the rows in the load mapping
-        for (Set<String> otherRows : Sets.powerSet(ImmutableSet.of("a", "c", "q", "t", "x"))) {
+        for (Set<String> otherRows : Sets.powerSet(Set.of("a", "c", "q", "t", "x"))) {
           runExceptionTest(loadRanges, createExtents(Iterables.concat(rows2, otherRows)));
         }
       }
 
       if (rows.size() > 1) {
         // test with none of the rows in the load mapping
-        for (Set<String> otherRows : Sets.powerSet(ImmutableSet.of("a", "c", "q", "t", "x"))) {
+        for (Set<String> otherRows : Sets.powerSet(Set.of("a", "c", "q", "t", "x"))) {
           runExceptionTest(loadRanges, createExtents(otherRows));
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -154,7 +154,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -2442,7 +2441,7 @@ public class Tablet {
      * Ensuring referencedLogs accurately tracks these sets ensures in use walogs are not GCed.
      */
 
-    Builder<DfsLogger> builder = ImmutableSet.builder();
+    var builder = ImmutableSet.<DfsLogger>builder();
     builder.addAll(currentLogs);
     builder.addAll(otherLogs);
     referencedLogs = builder.build();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
@@ -64,8 +65,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-
-import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -561,7 +560,7 @@ public class InMemoryMapTest {
   public void testSample() throws Exception {
 
     SamplerConfigurationImpl sampleConfig = new SamplerConfigurationImpl(RowSampler.class.getName(),
-        ImmutableMap.of("hasher", "murmur3_32", "modulus", "7"));
+        Map.of("hasher", "murmur3_32", "modulus", "7"));
     Sampler sampler = SamplerFactory.newSampler(sampleConfig, DefaultConfiguration.getInstance());
 
     ConfigurationCopy config1 = newConfig(tempFolder.newFolder().getAbsolutePath());
@@ -656,7 +655,7 @@ public class InMemoryMapTest {
   private void runInterruptSampleTest(boolean deepCopy, boolean delete, boolean dcAfterDelete)
       throws Exception {
     SamplerConfigurationImpl sampleConfig1 = new SamplerConfigurationImpl(
-        RowSampler.class.getName(), ImmutableMap.of("hasher", "murmur3_32", "modulus", "2"));
+        RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "2"));
     Sampler sampler = SamplerFactory.newSampler(sampleConfig1, DefaultConfiguration.getInstance());
 
     ConfigurationCopy config1 = newConfig(tempFolder.newFolder().getAbsolutePath());
@@ -717,7 +716,7 @@ public class InMemoryMapTest {
   @Test(expected = SampleNotPresentException.class)
   public void testDifferentSampleConfig() throws Exception {
     SamplerConfigurationImpl sampleConfig = new SamplerConfigurationImpl(RowSampler.class.getName(),
-        ImmutableMap.of("hasher", "murmur3_32", "modulus", "7"));
+        Map.of("hasher", "murmur3_32", "modulus", "7"));
 
     ConfigurationCopy config1 = newConfig(tempFolder.newFolder().getAbsolutePath());
     for (Entry<String,String> entry : sampleConfig.toTablePropertiesMap().entrySet()) {
@@ -729,7 +728,7 @@ public class InMemoryMapTest {
     mutate(imm, "r", "cf:cq", 5, "b");
 
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
-        RowSampler.class.getName(), ImmutableMap.of("hasher", "murmur3_32", "modulus", "9"));
+        RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
     iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
   }
@@ -741,7 +740,7 @@ public class InMemoryMapTest {
     mutate(imm, "r", "cf:cq", 5, "b");
 
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
-        RowSampler.class.getName(), ImmutableMap.of("hasher", "murmur3_32", "modulus", "9"));
+        RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
     iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
   }
@@ -751,7 +750,7 @@ public class InMemoryMapTest {
     InMemoryMap imm = newInMemoryMap(false, tempFolder.newFolder().getAbsolutePath());
 
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
-        RowSampler.class.getName(), ImmutableMap.of("hasher", "murmur3_32", "modulus", "9"));
+        RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
 
     // when in mem map is empty should be able to get sample iterator with any sample config
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
@@ -762,7 +761,7 @@ public class InMemoryMapTest {
   @Test
   public void testDeferredSamplerCreation() throws Exception {
     SamplerConfigurationImpl sampleConfig1 = new SamplerConfigurationImpl(
-        RowSampler.class.getName(), ImmutableMap.of("hasher", "murmur3_32", "modulus", "9"));
+        RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
 
     ConfigurationCopy config1 = newConfig(tempFolder.newFolder().getAbsolutePath());
     for (Entry<String,String> entry : sampleConfig1.toTablePropertiesMap().entrySet()) {
@@ -773,7 +772,7 @@ public class InMemoryMapTest {
 
     // change sampler config after creating in mem map.
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
-        RowSampler.class.getName(), ImmutableMap.of("hasher", "murmur3_32", "modulus", "7"));
+        RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "7"));
     for (Entry<String,String> entry : sampleConfig2.toTablePropertiesMap().entrySet()) {
       config1.set(entry.getKey(), entry.getValue());
     }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -36,8 +36,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class TabletServerSyncCheckTest {
   private static final String DFS_SUPPORT_APPEND = "dfs.support.append";
 
@@ -47,8 +45,7 @@ public class TabletServerSyncCheckTest {
     conf.set(DFS_SUPPORT_APPEND, "false");
 
     FileSystem fs = new TestFileSystem(conf);
-    TestVolumeManagerImpl vm =
-        new TestVolumeManagerImpl(ImmutableMap.of("foo", new VolumeImpl(fs, "/")));
+    TestVolumeManagerImpl vm = new TestVolumeManagerImpl(Map.of("foo", new VolumeImpl(fs, "/")));
 
     vm.ensureSyncIsEnabled();
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactionPlanTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactionPlanTest.java
@@ -24,8 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.common.collect.ImmutableSet;
-
 public class CompactionPlanTest {
 
   @Rule
@@ -43,7 +41,7 @@ public class CompactionPlanTest {
     cp1.deleteFiles.add(fr1);
     cp1.deleteFiles.add(fr2);
 
-    Set<FileRef> allFiles = ImmutableSet.of(fr1, fr2);
+    Set<FileRef> allFiles = Set.of(fr1, fr2);
 
     exception.expect(IllegalStateException.class);
     cp1.validate(allFiles);
@@ -61,7 +59,7 @@ public class CompactionPlanTest {
     cp1.inputFiles.add(fr2);
     cp1.inputFiles.add(fr3);
 
-    Set<FileRef> allFiles = ImmutableSet.of(fr1, fr2);
+    Set<FileRef> allFiles = Set.of(fr1, fr2);
 
     exception.expect(IllegalStateException.class);
     cp1.validate(allFiles);
@@ -79,7 +77,7 @@ public class CompactionPlanTest {
     cp1.deleteFiles.add(fr2);
     cp1.deleteFiles.add(fr3);
 
-    Set<FileRef> allFiles = ImmutableSet.of(fr1, fr2);
+    Set<FileRef> allFiles = Set.of(fr1, fr2);
 
     exception.expect(IllegalStateException.class);
     cp1.validate(allFiles);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/constraints/ConstraintCheckerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/constraints/ConstraintCheckerTest.java
@@ -38,8 +38,6 @@ import org.apache.hadoop.io.BinaryComparable;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 public class ConstraintCheckerTest {
@@ -74,7 +72,7 @@ public class ConstraintCheckerTest {
     Constraint c = createMock(Constraint.class);
     short code1 = 2;
     short code2 = 4;
-    List<Short> vCodes = ImmutableList.of(code1, code2);
+    List<Short> vCodes = List.of(code1, code2);
     expect(c.getViolationDescription(code1)).andReturn("ViolationCode1");
     expect(c.getViolationDescription(code2)).andReturn("ViolationCode2");
     expect(c.check(env, m)).andReturn(vCodes);
@@ -122,7 +120,7 @@ public class ConstraintCheckerTest {
     for (ConstraintViolationSummary cvs : cvsList) {
       violationDescs.add(cvs.getViolationDescription());
     }
-    assertEquals(ImmutableSet.of("ViolationCode1", "ViolationCode2"), violationDescs);
+    assertEquals(Set.of("ViolationCode1", "ViolationCode2"), violationDescs);
   }
 
   @Test

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
@@ -32,7 +32,6 @@ import org.apache.commons.cli.Option;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -67,7 +66,7 @@ public class ShellUtil {
 
   public static Map<String,String> parseMapOpt(CommandLine cl, Option opt) {
     if (cl.hasOption(opt.getLongOpt())) {
-      Builder<String,String> builder = ImmutableMap.builder();
+      var builder = ImmutableMap.<String,String>builder();
       String[] keyVals = cl.getOptionValue(opt.getLongOpt()).split(",");
       for (String keyVal : keyVals) {
         String[] sa = keyVal.split("=");

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellUtilTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellUtilTest.java
@@ -31,8 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.collect.ImmutableList;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
@@ -53,7 +51,7 @@ public class ShellUtilTest {
     File testFile = new File(folder.getRoot(), "testFileNoDecode.txt");
     FileUtils.writeStringToFile(testFile, FILEDATA, UTF_8);
     List<Text> output = ShellUtil.scanFile(testFile.getAbsolutePath(), false);
-    assertEquals(ImmutableList.of(new Text("line1"), new Text("line2")), output);
+    assertEquals(List.of(new Text("line1"), new Text("line2")), output);
   }
 
   @Test
@@ -61,7 +59,7 @@ public class ShellUtilTest {
     File testFile = new File(folder.getRoot(), "testFileWithDecode.txt");
     FileUtils.writeStringToFile(testFile, B64_FILEDATA, UTF_8);
     List<Text> output = ShellUtil.scanFile(testFile.getAbsolutePath(), true);
-    assertEquals(ImmutableList.of(new Text("line1"), new Text("line2")), output);
+    assertEquals(List.of(new Text("line1"), new Text("line2")), output);
   }
 
   @Test(expected = FileNotFoundException.class)

--- a/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InMemoryMapIT.java
@@ -59,8 +59,6 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * Integration Test for https://issues.apache.org/jira/browse/ACCUMULO-4148
  * <p>
@@ -272,8 +270,9 @@ public class InMemoryMapIT {
         localityGroupMapWithNative.getMapType());
 
     int count = 0;
-    for (Mutation m : mutations)
+    for (Mutation m : mutations) {
       count += m.size();
+    }
     defaultMap.mutate(mutations, count);
     nativeMapWrapper.mutate(mutations, count);
     localityGroupMap.mutate(mutations, count);
@@ -368,7 +367,7 @@ public class InMemoryMapIT {
     for (MemKey m : memKeys) {
       kvCounts.add(m.getKVCount());
     }
-    return ImmutableSet.copyOf(kvCounts).size();
+    return Set.copyOf(kvCounts).size();
   }
 
   private ConfigurationCopy updateConfigurationForLocalityGroups(ConfigurationCopy configuration) {

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -45,9 +45,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
 public class LocatorIT extends AccumuloClusterHarness {
 
   @Override
@@ -56,7 +53,7 @@ public class LocatorIT extends AccumuloClusterHarness {
   }
 
   private void assertContains(Locations locations, HashSet<String> tservers,
-      Map<Range,ImmutableSet<TabletId>> expected1, Map<TabletId,ImmutableSet<Range>> expected2) {
+      Map<Range,Set<TabletId>> expected1, Map<TabletId,Set<Range>> expected2) {
 
     Map<Range,Set<TabletId>> gbr = new HashMap<>();
     for (Entry<Range,List<TabletId>> entry : locations.groupByRange().entrySet()) {
@@ -107,23 +104,20 @@ public class LocatorIT extends AccumuloClusterHarness {
 
       ranges.add(r1);
       Locations ret = client.tableOperations().locate(tableName, ranges);
-      assertContains(ret, tservers, ImmutableMap.of(r1, ImmutableSet.of(t1)),
-          ImmutableMap.of(t1, ImmutableSet.of(r1)));
+      assertContains(ret, tservers, Map.of(r1, Set.of(t1)), Map.of(t1, Set.of(r1)));
 
       ranges.add(r2);
       ret = client.tableOperations().locate(tableName, ranges);
-      assertContains(ret, tservers,
-          ImmutableMap.of(r1, ImmutableSet.of(t1), r2, ImmutableSet.of(t1)),
-          ImmutableMap.of(t1, ImmutableSet.of(r1, r2)));
+      assertContains(ret, tservers, Map.of(r1, Set.of(t1), r2, Set.of(t1)),
+          Map.of(t1, Set.of(r1, r2)));
 
       TreeSet<Text> splits = new TreeSet<>();
       splits.add(new Text("r"));
       client.tableOperations().addSplits(tableName, splits);
 
       ret = client.tableOperations().locate(tableName, ranges);
-      assertContains(ret, tservers,
-          ImmutableMap.of(r1, ImmutableSet.of(t2), r2, ImmutableSet.of(t2, t3)),
-          ImmutableMap.of(t2, ImmutableSet.of(r1, r2), t3, ImmutableSet.of(r2)));
+      assertContains(ret, tservers, Map.of(r1, Set.of(t2), r2, Set.of(t2, t3)),
+          Map.of(t2, Set.of(r1, r2), t3, Set.of(r2)));
 
       client.tableOperations().offline(tableName, true);
 

--- a/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
@@ -43,8 +43,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 public class NewTableConfigurationIT extends SharedMiniClusterBase {
 
   @Override
@@ -102,8 +100,8 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
   public void testOverlappingGroupsFail() {
     NewTableConfiguration ntc = new NewTableConfiguration();
     Map<String,Set<Text>> lgroups = new HashMap<>();
-    lgroups.put("lg1", ImmutableSet.of(new Text("colFamA"), new Text("colFamB")));
-    lgroups.put("lg2", ImmutableSet.of(new Text("colFamC"), new Text("colFamB")));
+    lgroups.put("lg1", Set.of(new Text("colFamA"), new Text("colFamB")));
+    lgroups.put("lg2", Set.of(new Text("colFamC"), new Text("colFamB")));
     ntc.setLocalityGroups(lgroups);
   }
 
@@ -118,8 +116,8 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       NewTableConfiguration ntc = new NewTableConfiguration();
       // set locality groups map
       Map<String,Set<Text>> lgroups = new HashMap<>();
-      lgroups.put("lg1", ImmutableSet.of(new Text("dog"), new Text("cat")));
-      lgroups.put("lg2", ImmutableSet.of(new Text("lion"), new Text("tiger")));
+      lgroups.put("lg1", Set.of(new Text("dog"), new Text("cat")));
+      lgroups.put("lg2", Set.of(new Text("lion"), new Text("tiger")));
       // set groups via NewTableConfiguration
       ntc.setLocalityGroups(lgroups);
       client.tableOperations().create(tableName, ntc);
@@ -127,10 +125,8 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       Map<String,Set<Text>> createdLocalityGroups =
           client.tableOperations().getLocalityGroups(tableName);
       assertEquals(2, createdLocalityGroups.size());
-      assertEquals(createdLocalityGroups.get("lg1"),
-          ImmutableSet.of(new Text("dog"), new Text("cat")));
-      assertEquals(createdLocalityGroups.get("lg2"),
-          ImmutableSet.of(new Text("lion"), new Text("tiger")));
+      assertEquals(createdLocalityGroups.get("lg1"), Set.of(new Text("dog"), new Text("cat")));
+      assertEquals(createdLocalityGroups.get("lg2"), Set.of(new Text("lion"), new Text("tiger")));
     }
   }
 
@@ -145,19 +141,18 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       NewTableConfiguration ntc = new NewTableConfiguration();
       // set first locality groups map
       Map<String,Set<Text>> initalGroup = new HashMap<>();
-      initalGroup.put("lg1", ImmutableSet.of(new Text("dog"), new Text("cat")));
+      initalGroup.put("lg1", Set.of(new Text("dog"), new Text("cat")));
       ntc.setLocalityGroups(initalGroup);
       // set a second locality groups map and set in method call
       Map<String,Set<Text>> secondGroup = new HashMap<>();
-      secondGroup.put("lg1", ImmutableSet.of(new Text("blue"), new Text("red")));
+      secondGroup.put("lg1", Set.of(new Text("blue"), new Text("red")));
       ntc.setLocalityGroups(secondGroup);
       client.tableOperations().create(tableName, ntc);
       // verify
       Map<String,Set<Text>> createdLocalityGroups =
           client.tableOperations().getLocalityGroups(tableName);
       assertEquals(1, createdLocalityGroups.size());
-      assertEquals(createdLocalityGroups.get("lg1"),
-          ImmutableSet.of(new Text("red"), new Text("blue")));
+      assertEquals(createdLocalityGroups.get("lg1"), Set.of(new Text("red"), new Text("blue")));
     }
   }
 
@@ -177,7 +172,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       ntc.setProperties(props);
 
       Map<String,Set<Text>> lgroups = new HashMap<>();
-      lgroups.put("lg1", ImmutableSet.of(new Text("dog")));
+      lgroups.put("lg1", Set.of(new Text("dog")));
       ntc.setLocalityGroups(lgroups);
       client.tableOperations().create(tableName, ntc);
       // verify
@@ -204,7 +199,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       Map<String,Set<Text>> createdLocalityGroups =
           client.tableOperations().getLocalityGroups(tableName);
       assertEquals(1, createdLocalityGroups.size());
-      assertEquals(createdLocalityGroups.get("lg1"), ImmutableSet.of(new Text("dog")));
+      assertEquals(createdLocalityGroups.get("lg1"), Set.of(new Text("dog")));
     }
   }
 
@@ -238,14 +233,14 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       NewTableConfiguration ntc = new NewTableConfiguration().withoutDefaultIterators();
 
       Map<String,Set<Text>> lgroups = new HashMap<>();
-      lgroups.put("lg1", ImmutableSet.of(new Text("colF")));
+      lgroups.put("lg1", Set.of(new Text("colF")));
       ntc.setLocalityGroups(lgroups);
       client.tableOperations().create(tableName, ntc);
       // verify groups and verify no iterators
       Map<String,Set<Text>> createdLocalityGroups =
           client.tableOperations().getLocalityGroups(tableName);
       assertEquals(1, createdLocalityGroups.size());
-      assertEquals(createdLocalityGroups.get("lg1"), ImmutableSet.of(new Text("colF")));
+      assertEquals(createdLocalityGroups.get("lg1"), Set.of(new Text("colF")));
       Map<String,EnumSet<IteratorScope>> iterators =
           client.tableOperations().listIterators(tableName);
       assertEquals(0, iterators.size());
@@ -526,7 +521,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       props.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "prop1", "val1");
       ntc.setProperties(props);
       Map<String,Set<Text>> lgroups = new HashMap<>();
-      lgroups.put("lg1", ImmutableSet.of(new Text("colF")));
+      lgroups.put("lg1", Set.of(new Text("colF")));
       ntc.setLocalityGroups(lgroups);
       client.tableOperations().create(tableName, ntc);
       // verify user table properties
@@ -542,7 +537,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       Map<String,Set<Text>> createdLocalityGroups =
           client.tableOperations().getLocalityGroups(tableName);
       assertEquals(1, createdLocalityGroups.size());
-      assertEquals(createdLocalityGroups.get("lg1"), ImmutableSet.of(new Text("colF")));
+      assertEquals(createdLocalityGroups.get("lg1"), Set.of(new Text("colF")));
       // verify iterators
       verifyIterators(client, tableName, new String[] {"table.iterator.scan.someName=10,foo.bar"},
           true);
@@ -564,7 +559,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       IteratorSetting setting =
           new IteratorSetting(10, "anIterator", "it.class", Collections.emptyMap());
       Map<String,Set<Text>> lgroups = new HashMap<>();
-      lgroups.put("lgp", ImmutableSet.of(new Text("col")));
+      lgroups.put("lgp", Set.of(new Text("col")));
 
       NewTableConfiguration ntc = new NewTableConfiguration().withoutDefaultIterators()
           .attachIterator(setting, EnumSet.of(IteratorScope.scan)).setLocalityGroups(lgroups);
@@ -597,7 +592,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       Map<String,Set<Text>> createdLocalityGroups =
           client.tableOperations().getLocalityGroups(tableName);
       assertEquals(1, createdLocalityGroups.size());
-      assertEquals(createdLocalityGroups.get("lgp"), ImmutableSet.of(new Text("col")));
+      assertEquals(createdLocalityGroups.get("lgp"), Set.of(new Text("col")));
     }
   }
 
@@ -609,7 +604,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
     NewTableConfiguration ntc = new NewTableConfiguration();
 
     Map<String,Set<Text>> lgroups = new HashMap<>();
-    lgroups.put("lg1", ImmutableSet.of(new Text("dog")));
+    lgroups.put("lg1", Set.of(new Text("dog")));
     ntc.setLocalityGroups(lgroups);
 
     Map<String,String> props = new HashMap<>();
@@ -630,7 +625,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
     ntc.setProperties(props);
 
     Map<String,Set<Text>> lgroups = new HashMap<>();
-    lgroups.put("lg1", ImmutableSet.of(new Text("dog")));
+    lgroups.put("lg1", Set.of(new Text("dog")));
     ntc.setLocalityGroups(lgroups);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -66,15 +66,14 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 public class SampleIT extends AccumuloClusterHarness {
 
   private static final Map<String,String> OPTIONS_1 =
-      ImmutableMap.of("hasher", "murmur3_32", "modulus", "1009");
+      Map.of("hasher", "murmur3_32", "modulus", "1009");
   private static final Map<String,String> OPTIONS_2 =
-      ImmutableMap.of("hasher", "murmur3_32", "modulus", "997");
+      Map.of("hasher", "murmur3_32", "modulus", "997");
 
   private static final SamplerConfiguration SC1 =
       new SamplerConfiguration(RowSampler.class.getName()).setOptions(OPTIONS_1);

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -22,6 +22,7 @@ import java.net.Socket;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
@@ -43,8 +44,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -286,8 +285,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
         throw new IllegalArgumentException("Irrelevant server type for test");
     }
 
-    return cluster
-        ._exec(service, serverType, ImmutableMap.of(property.getKey(), Integer.toString(port)))
+    return cluster._exec(service, serverType, Map.of(property.getKey(), Integer.toString(port)))
         .getProcess();
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
@@ -59,9 +59,6 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class UserCompactionStrategyIT extends AccumuloClusterHarness {
@@ -97,17 +94,17 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
       // drop files that start with A
       CompactionStrategyConfig csConfig =
           new CompactionStrategyConfig(TestCompactionStrategy.class.getName());
-      csConfig.setOptions(ImmutableMap.of("dropPrefix", "A", "inputPrefix", "F"));
+      csConfig.setOptions(Map.of("dropPrefix", "A", "inputPrefix", "F"));
       c.tableOperations().compact(tableName,
           new CompactionConfig().setWait(true).setCompactionStrategy(csConfig));
 
-      assertEquals(ImmutableSet.of("c", "d"), getRows(c, tableName));
+      assertEquals(Set.of("c", "d"), getRows(c, tableName));
 
       // this compaction should not drop files starting with A
       c.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
       c.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
 
-      assertEquals(ImmutableSet.of("c", "d"), getRows(c, tableName));
+      assertEquals(Set.of("c", "d"), getRows(c, tableName));
     }
   }
 
@@ -127,7 +124,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
       c.tableOperations().compact(tableName,
           new CompactionConfig().setWait(true).setCompactionStrategy(csConfig));
 
-      assertEquals(ImmutableSet.of("a", "b"), getRows(c, tableName));
+      assertEquals(Set.of("a", "b"), getRows(c, tableName));
     }
   }
 
@@ -136,7 +133,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
     // test a compaction strategy that selects no files. In this case there is no work to do, want
     // to ensure it does not hang.
 
-    testDropNone(ImmutableMap.of("inputPrefix", "Z"));
+    testDropNone(Map.of("inputPrefix", "Z"));
   }
 
   @Test
@@ -145,7 +142,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
     // shouldCompact() will return true and getCompactionPlan() will
     // return no work to do.
 
-    testDropNone(ImmutableMap.of("inputPrefix", "Z", "shouldCompact", "true"));
+    testDropNone(Map.of("inputPrefix", "Z", "shouldCompact", "true"));
   }
 
   @Test
@@ -220,7 +217,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
       // drop files that start with A
       CompactionStrategyConfig csConfig =
           new CompactionStrategyConfig(TestCompactionStrategy.class.getName());
-      csConfig.setOptions(ImmutableMap.of("inputPrefix", "F"));
+      csConfig.setOptions(Map.of("inputPrefix", "F"));
 
       IteratorSetting iterConf = new IteratorSetting(21, "myregex", RegExFilter.class);
       RegExFilter.setRegexs(iterConf, "a|c", null, null, null, false);
@@ -231,14 +228,14 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
       // compaction strategy should only be applied to one file. If its applied to both, then row
       // 'b'
       // would be dropped by filter.
-      assertEquals(ImmutableSet.of("a", "b", "c"), getRows(c, tableName));
+      assertEquals(Set.of("a", "b", "c"), getRows(c, tableName));
 
       assertEquals(2, FunctionalTestUtils.countRFiles(c, tableName));
 
       c.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
 
       // ensure that iterator is not applied
-      assertEquals(ImmutableSet.of("a", "b", "c"), getRows(c, tableName));
+      assertEquals(Set.of("a", "b", "c"), getRows(c, tableName));
 
       assertEquals(1, FunctionalTestUtils.countRFiles(c, tableName));
     }
@@ -263,14 +260,14 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
       CompactionStrategyConfig csConfig =
           new CompactionStrategyConfig(SizeCompactionStrategy.class.getName());
-      csConfig.setOptions(ImmutableMap.of("size", "" + (1 << 15)));
+      csConfig.setOptions(Map.of("size", "" + (1 << 15)));
       c.tableOperations().compact(tableName,
           new CompactionConfig().setWait(true).setCompactionStrategy(csConfig));
 
       assertEquals(3, FunctionalTestUtils.countRFiles(c, tableName));
 
       csConfig = new CompactionStrategyConfig(SizeCompactionStrategy.class.getName());
-      csConfig.setOptions(ImmutableMap.of("size", "" + (1 << 17)));
+      csConfig.setOptions(Map.of("size", "" + (1 << 17)));
       c.tableOperations().compact(tableName,
           new CompactionConfig().setWait(true).setCompactionStrategy(csConfig));
 
@@ -308,8 +305,9 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
       try {
         // this compaction should fail because previous one set iterators
         c.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
-        if (System.currentTimeMillis() - t1 < 2000)
+        if (System.currentTimeMillis() - t1 < 2000) {
           fail("Expected compaction to fail because another concurrent compaction set iterators");
+        }
       } catch (AccumuloException e) {}
     }
   }
@@ -331,8 +329,9 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   private Set<String> getRows(AccumuloClient c, String tableName) throws TableNotFoundException {
     Set<String> rows = new HashSet<>();
     try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
-      for (Entry<Key,Value> entry : scanner)
+      for (Entry<Key,Value> entry : scanner) {
         rows.add(entry.getKey().getRowData().toString());
+      }
     }
     return rows;
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
@@ -76,12 +76,9 @@ import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
 public class BulkFailureIT extends AccumuloClusterHarness {
 
-  static interface Loader {
+  interface Loader {
     void load(long txid, ClientContext context, KeyExtent extent, Path path, long size,
         boolean expectFailure) throws Exception;
   }
@@ -135,8 +132,8 @@ public class BulkFailureIT extends AccumuloClusterHarness {
       // Directly ask the tablet to load the file.
       loader.load(fateTxid, asCtx, extent, bulkLoadPath, status.getLen(), false);
 
-      assertEquals(ImmutableSet.of(bulkLoadPath), getFiles(c, extent));
-      assertEquals(ImmutableSet.of(bulkLoadPath), getLoaded(c, extent));
+      assertEquals(Set.of(bulkLoadPath), getFiles(c, extent));
+      assertEquals(Set.of(bulkLoadPath), getLoaded(c, extent));
       assertEquals(testData, readTable(table, c));
 
       // Compact the bulk imported file. Subsequent request to load the file should be ignored.
@@ -145,14 +142,14 @@ public class BulkFailureIT extends AccumuloClusterHarness {
       Set<Path> tabletFiles = getFiles(c, extent);
       assertFalse(tabletFiles.contains(bulkLoadPath));
       assertEquals(1, tabletFiles.size());
-      assertEquals(ImmutableSet.of(bulkLoadPath), getLoaded(c, extent));
+      assertEquals(Set.of(bulkLoadPath), getLoaded(c, extent));
       assertEquals(testData, readTable(table, c));
 
       // this request should be ignored by the tablet
       loader.load(fateTxid, asCtx, extent, bulkLoadPath, status.getLen(), false);
 
       assertEquals(tabletFiles, getFiles(c, extent));
-      assertEquals(ImmutableSet.of(bulkLoadPath), getLoaded(c, extent));
+      assertEquals(Set.of(bulkLoadPath), getLoaded(c, extent));
       assertEquals(testData, readTable(table, c));
 
       // this is done to ensure the tablet reads the load flags from the metadata table when it
@@ -164,7 +161,7 @@ public class BulkFailureIT extends AccumuloClusterHarness {
       loader.load(fateTxid, asCtx, extent, bulkLoadPath, status.getLen(), false);
 
       assertEquals(tabletFiles, getFiles(c, extent));
-      assertEquals(ImmutableSet.of(bulkLoadPath), getLoaded(c, extent));
+      assertEquals(Set.of(bulkLoadPath), getLoaded(c, extent));
       assertEquals(testData, readTable(table, c));
 
       // After this, all load request should fail.
@@ -181,7 +178,7 @@ public class BulkFailureIT extends AccumuloClusterHarness {
       loader.load(fateTxid, asCtx, extent, bulkLoadPath, status.getLen(), true);
 
       assertEquals(tabletFiles, getFiles(c, extent));
-      assertEquals(ImmutableSet.of(), getLoaded(c, extent));
+      assertEquals(Set.of(), getLoaded(c, extent));
       assertEquals(testData, readTable(table, c));
     }
   }
@@ -256,8 +253,8 @@ public class BulkFailureIT extends AccumuloClusterHarness {
     TabletClientService.Iface client = getClient(context, extent);
     try {
 
-      Map<String,MapFileInfo> val = ImmutableMap.of(path.toString(), new MapFileInfo(size));
-      Map<KeyExtent,Map<String,MapFileInfo>> files = ImmutableMap.of(extent, val);
+      Map<String,MapFileInfo> val = Map.of(path.toString(), new MapFileInfo(size));
+      Map<KeyExtent,Map<String,MapFileInfo>> files = Map.of(extent, val);
 
       client.bulkImport(TraceUtil.traceInfo(), context.rpcCreds(), txid,
           Translator.translate(files, Translators.KET), false);
@@ -265,8 +262,9 @@ public class BulkFailureIT extends AccumuloClusterHarness {
         fail("Expected RPC to fail");
       }
     } catch (TApplicationException tae) {
-      if (!expectFailure)
+      if (!expectFailure) {
         throw tae;
+      }
     } finally {
       ThriftUtil.returnClient((TServiceClient) client);
     }
@@ -278,8 +276,8 @@ public class BulkFailureIT extends AccumuloClusterHarness {
     TabletClientService.Iface client = getClient(context, extent);
     try {
 
-      Map<String,MapFileInfo> val = ImmutableMap.of(path.getName(), new MapFileInfo(size));
-      Map<KeyExtent,Map<String,MapFileInfo>> files = ImmutableMap.of(extent, val);
+      Map<String,MapFileInfo> val = Map.of(path.getName(), new MapFileInfo(size));
+      Map<KeyExtent,Map<String,MapFileInfo>> files = Map.of(extent, val);
 
       client.loadFiles(TraceUtil.traceInfo(), context.rpcCreds(), txid, path.getParent().toString(),
           Translator.translate(files, Translators.KET), false);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkLoadIT.java
@@ -78,9 +78,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -142,8 +139,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
       throws Exception {
     addSplits(c, tableName, "0333");
 
-    if (offline)
+    if (offline) {
       c.tableOperations().offline(tableName);
+    }
 
     String dir = getDir("/testSingleTabletSingleFileNoSplits-");
 
@@ -151,12 +149,12 @@ public class BulkLoadIT extends SharedMiniClusterBase {
 
     c.tableOperations().importDirectory(dir).to(tableName).tableTime(setTime).load();
 
-    if (offline)
+    if (offline) {
       c.tableOperations().online(tableName);
+    }
 
     verifyData(c, tableName, 0, 332, setTime);
-    verifyMetadata(c, tableName,
-        ImmutableMap.of("0333", ImmutableSet.of(h1), "null", ImmutableSet.of()));
+    verifyMetadata(c, tableName, Map.of("0333", Set.of(h1), "null", Set.of()));
   }
 
   @Test
@@ -187,8 +185,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
 
   private void testSingleTabletSingleFileNoSplits(AccumuloClient c, boolean offline)
       throws Exception {
-    if (offline)
+    if (offline) {
       c.tableOperations().offline(tableName);
+    }
 
     String dir = getDir("/testSingleTabletSingleFileNoSplits-");
 
@@ -196,11 +195,12 @@ public class BulkLoadIT extends SharedMiniClusterBase {
 
     c.tableOperations().importDirectory(dir).to(tableName).load();
 
-    if (offline)
+    if (offline) {
       c.tableOperations().online(tableName);
+    }
 
     verifyData(c, tableName, 0, 333, false);
-    verifyMetadata(c, tableName, ImmutableMap.of("null", ImmutableSet.of(h1)));
+    verifyMetadata(c, tableName, Map.of("null", Set.of(h1)));
   }
 
   @Test
@@ -234,8 +234,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
       } catch (Exception e) {
         Throwable cause = e.getCause();
         if (!(cause instanceof FileNotFoundException)
-            && !(cause.getCause() instanceof FileNotFoundException))
+            && !(cause.getCause() instanceof FileNotFoundException)) {
           fail("Expected FileNotFoundException but threw " + e.getCause());
+        }
       } finally {
         fs.setPermission(rFilePath, originalPerms);
       }
@@ -245,8 +246,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
       try {
         c.tableOperations().importDirectory(dir).to(tableName).load();
       } catch (AccumuloException ae) {
-        if (!(ae.getCause() instanceof FileNotFoundException))
+        if (!(ae.getCause() instanceof FileNotFoundException)) {
           fail("Expected FileNotFoundException but threw " + ae.getCause());
+        }
       } finally {
         fs.setPermission(new Path(dir), originalPerms);
       }
@@ -257,8 +259,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       addSplits(c, tableName, "0333 0666 0999 1333 1666");
 
-      if (offline)
+      if (offline) {
         c.tableOperations().offline(tableName);
+      }
 
       String dir = getDir("/testBulkFile-");
 
@@ -301,8 +304,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
         c.tableOperations().importDirectory(dir).to(tableName).load();
       }
 
-      if (offline)
+      if (offline) {
         c.tableOperations().online(tableName);
+      }
 
       verifyData(c, tableName, 0, 1999, false);
       verifyMetadata(c, tableName, hashes);
@@ -374,8 +378,9 @@ public class BulkLoadIT extends SharedMiniClusterBase {
   private void addSplits(AccumuloClient client, String tableName, String splitString)
       throws Exception {
     SortedSet<Text> splits = new TreeSet<>();
-    for (String split : splitString.split(" "))
+    for (String split : splitString.split(" ")) {
       splits.add(new Text(split));
+    }
     client.tableOperations().addSplits(tableName, splits);
   }
 
@@ -386,25 +391,30 @@ public class BulkLoadIT extends SharedMiniClusterBase {
       Iterator<Entry<Key,Value>> iter = scanner.iterator();
 
       for (int i = start; i <= end; i++) {
-        if (!iter.hasNext())
+        if (!iter.hasNext()) {
           throw new Exception("row " + i + " not found");
+        }
 
         Entry<Key,Value> entry = iter.next();
 
         String row = String.format("%04d", i);
 
-        if (!entry.getKey().getRow().equals(new Text(row)))
+        if (!entry.getKey().getRow().equals(new Text(row))) {
           throw new Exception("unexpected row " + entry.getKey() + " " + i);
+        }
 
-        if (Integer.parseInt(entry.getValue().toString()) != i)
+        if (Integer.parseInt(entry.getValue().toString()) != i) {
           throw new Exception("unexpected value " + entry + " " + i);
+        }
 
-        if (setTime)
+        if (setTime) {
           assertEquals(1L, entry.getKey().getTimestamp());
+        }
       }
 
-      if (iter.hasNext())
+      if (iter.hasNext()) {
         throw new Exception("found more than expected " + iter.next());
+      }
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -89,8 +89,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -712,7 +710,7 @@ public class SummaryIT extends AccumuloClusterHarness {
   }
 
   private Map<String,Long> nm(Object... entries) {
-    Builder<String,Long> imb = ImmutableMap.builder();
+    var imb = ImmutableMap.<String,Long>builder();
     for (int i = 0; i < entries.length; i += 2) {
       imb.put((String) entries[i], (Long) entries[i + 1]);
     }
@@ -729,10 +727,10 @@ public class SummaryIT extends AccumuloClusterHarness {
       ntc.enableSummarization(sc1, sc2);
 
       Map<String,Set<Text>> lgroups = new HashMap<>();
-      lgroups.put("lg1", ImmutableSet.of(new Text("chocolate"), new Text("coffee")));
-      lgroups.put("lg2", ImmutableSet.of(new Text(" broccoli "), new Text("cabbage")));
+      lgroups.put("lg1", Set.of(new Text("chocolate"), new Text("coffee")));
+      lgroups.put("lg2", Set.of(new Text(" broccoli "), new Text("cabbage")));
       // create a locality group that will not have data in it
-      lgroups.put("lg3", ImmutableSet.of(new Text(" apple "), new Text("orange")));
+      lgroups.put("lg3", Set.of(new Text(" apple "), new Text("orange")));
 
       ntc.setLocalityGroups(lgroups);
       c.tableOperations().create(table, ntc);

--- a/test/src/main/java/org/apache/accumulo/test/replication/WorkMakerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/WorkMakerIT.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 public class WorkMakerIT extends ConfigurableMacBase {
@@ -116,7 +115,7 @@ public class WorkMakerIT extends ConfigurableMacBase {
       expected = new ReplicationTarget("remote_cluster_1", "4", tableId);
       workMaker.setBatchWriter(bw);
       workMaker.addWorkRecord(new Text(file), StatusUtil.fileCreatedValue(timeCreated),
-          ImmutableMap.of("remote_cluster_1", "4"), tableId);
+          Map.of("remote_cluster_1", "4"), tableId);
     }
 
     // Scan over just the WorkSection
@@ -158,8 +157,8 @@ public class WorkMakerIT extends ConfigurableMacBase {
 
       MockWorkMaker workMaker = new MockWorkMaker(client);
 
-      Map<String,String> targetClusters = ImmutableMap.of("remote_cluster_1", "4",
-          "remote_cluster_2", "6", "remote_cluster_3", "8");
+      Map<String,String> targetClusters =
+          Map.of("remote_cluster_1", "4", "remote_cluster_2", "6", "remote_cluster_3", "8");
 
       for (Entry<String,String> cluster : targetClusters.entrySet()) {
         expectedTargets.add(new ReplicationTarget(cluster.getKey(), cluster.getValue(), tableId));

--- a/test/src/test/java/org/apache/accumulo/test/constraints/AlphaNumKeyConstraintTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/constraints/AlphaNumKeyConstraintTest.java
@@ -19,12 +19,12 @@ package org.apache.accumulo.test.constraints;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.List;
+
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class AlphaNumKeyConstraintTest {
 
@@ -39,9 +39,8 @@ public class AlphaNumKeyConstraintTest {
     // Check that violations are in row, cf, cq order
     Mutation badMutation = new Mutation(new Text("Row#1"));
     badMutation.put(new Text("Colf$2"), new Text("Colq%3"), new Value("value".getBytes()));
-    assertEquals(
-        ImmutableList.of(AlphaNumKeyConstraint.NON_ALPHA_NUM_ROW,
-            AlphaNumKeyConstraint.NON_ALPHA_NUM_COLF, AlphaNumKeyConstraint.NON_ALPHA_NUM_COLQ),
+    assertEquals(List.of(AlphaNumKeyConstraint.NON_ALPHA_NUM_ROW,
+        AlphaNumKeyConstraint.NON_ALPHA_NUM_COLF, AlphaNumKeyConstraint.NON_ALPHA_NUM_COLQ),
         ankc.check(null, badMutation));
   }
 

--- a/test/src/test/java/org/apache/accumulo/test/iterator/RegExTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/iterator/RegExTest.java
@@ -32,8 +32,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
-
 public class RegExTest {
 
   private static TreeMap<Key,Value> data = new TreeMap<>();
@@ -42,11 +40,13 @@ public class RegExTest {
   public static void setupTests() {
 
     ArrayList<Character> chars = new ArrayList<>();
-    for (char c = 'a'; c <= 'z'; c++)
+    for (char c = 'a'; c <= 'z'; c++) {
       chars.add(c);
+    }
 
-    for (char c = '0'; c <= '9'; c++)
+    for (char c = '0'; c <= '9'; c++) {
       chars.add(c);
+    }
 
     // insert some data into accumulo
     for (Character rc : chars) {
@@ -61,8 +61,9 @@ public class RegExTest {
   }
 
   private void check(String regex, String val) throws Exception {
-    if (regex != null && !val.matches(regex))
+    if (regex != null && !val.matches(regex)) {
       throw new Exception(" " + val + " does not match " + regex);
+    }
   }
 
   private void check(String regex, Text val) throws Exception {
@@ -112,7 +113,7 @@ public class RegExTest {
       String valRegEx, int expected) throws Exception {
 
     SortedKeyValueIterator<Key,Value> source = new SortedMapIterator(data);
-    Set<ByteSequence> es = ImmutableSet.of();
+    Set<ByteSequence> es = Set.of();
     IteratorSetting is = new IteratorSetting(50, "regex", RegExFilter.class);
     RegExFilter.setRegexs(is, rowRegEx, cfRegEx, cqRegEx, valRegEx, false);
     RegExFilter iter = new RegExFilter();


### PR DESCRIPTION
* Re-enable the modernizer-maven-plugin
* Update use of all Guava Immutable{List,Set,Map} types with Java 11
  built-ins where possible (does not replace Immutable*.Builders)
* Use var to simplify Immutable*.Builder declarations

Replacing Immutable*.Builder objects can be done in a future commit.
This change is sufficient to satisfy modernizer checks for Java 11.