### PR TITLE
fix #1247 store fate txid in ~blip marker value

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -95,7 +95,7 @@ public class AgeOffStore<T> implements TStore<T> {
             case FAILED:
             case SUCCESSFUL:
               store.delete(txid);
-              log.debug("Aged off FATE tx {}", String.format("%016x", txid));
+              log.debug("Aged off FATE tx {}", FateTxId.formatTid(txid));
               break;
             default:
               break;
@@ -105,7 +105,7 @@ public class AgeOffStore<T> implements TStore<T> {
           store.unreserve(txid, 0);
         }
       } catch (Exception e) {
-        log.warn("Failed to age off FATE tx " + String.format("%016x", txid), e);
+        log.warn("Failed to age off FATE tx " + FateTxId.formatTid(txid), e);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/fate/FateTxId.java
+++ b/core/src/main/java/org/apache/accumulo/fate/FateTxId.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.accumulo.fate;
+
+import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
+
+public class FateTxId {
+
+  private static final String PREFIX = "FTID[";
+  private static final String SUFFIX = "]";
+
+  private final static Pattern PATTERN =
+      Pattern.compile(Pattern.quote(PREFIX) + "[0-9a-fA-F]+" + Pattern.quote(SUFFIX));
+
+  private static String getHex(String fmtTid) {
+    return fmtTid.substring(PREFIX.length(), fmtTid.length() - SUFFIX.length());
+  }
+
+  /**
+   * @return true if string was created by {@link #formatTid(long)} and false otherwise.
+   */
+  public static boolean isFormatedTid(String fmtTid) {
+    return PATTERN.matcher(fmtTid).matches();
+  }
+
+  /**
+   * Reverses {@link #formatTid(long)}
+   */
+  public static long fromString(String fmtTid) {
+    Preconditions.checkArgument(fmtTid.startsWith(PREFIX) && fmtTid.endsWith(SUFFIX));
+    return Long.parseLong(getHex(fmtTid), 16);
+  }
+
+  /**
+   * Formats transaction ids in a consistent way that is useful for logging and persisting.
+   */
+  public static String formatTid(long tid) {
+    // do not change how this formats without considering implications for persistence
+    return String.format("%s%016x%s", PREFIX, tid, SUFFIX);
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -227,7 +227,7 @@ public class ZooStore<T> implements TStore<T> {
     synchronized (this) {
       if (!reserved.remove(tid))
         throw new IllegalStateException(
-            "Tried to unreserve id that was not reserved " + String.format("%016x", tid));
+            "Tried to unreserve id that was not reserved " + FateTxId.formatTid(tid));
 
       // do not want this unreserve to unesc wake up threads in reserve()... this leads to infinite
       // loop when tx is stuck in NEW...
@@ -246,7 +246,7 @@ public class ZooStore<T> implements TStore<T> {
     synchronized (this) {
       if (!reserved.remove(tid))
         throw new IllegalStateException(
-            "Tried to unreserve id that was not reserved " + String.format("%016x", tid));
+            "Tried to unreserve id that was not reserved " + FateTxId.formatTid(tid));
 
       if (deferTime > 0)
         defered.put(tid, System.currentTimeMillis() + deferTime);
@@ -260,7 +260,7 @@ public class ZooStore<T> implements TStore<T> {
     synchronized (this) {
       if (!reserved.contains(tid))
         throw new IllegalStateException(
-            "Tried to operate on unreserved transaction " + String.format("%016x", tid));
+            "Tried to operate on unreserved transaction " + FateTxId.formatTid(tid));
     }
   }
 
@@ -341,7 +341,7 @@ public class ZooStore<T> implements TStore<T> {
       String txpath = getTXPath(tid);
       String top = findTop(txpath);
       if (top == null)
-        throw new IllegalStateException("Tried to pop when empty " + tid);
+        throw new IllegalStateException("Tried to pop when empty " + FateTxId.formatTid(tid));
       zk.recursiveDelete(txpath + "/" + top, NodeMissingPolicy.SKIP);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 import org.apache.hadoop.io.Text;
@@ -229,7 +230,7 @@ public class MetadataConstraints implements Constraint {
           }
 
           if (!isSplitMutation && !isLocationMutation) {
-            long tid = Long.parseLong(tidString);
+            long tid = MetadataTableUtil.getBulkLoadTid(new Value(tidString));
 
             try {
               if (otherTidCount > 0 || !dataFiles.equals(loadedFiles) || !getArbitrator(context)

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilter.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class MetadataBulkLoadFilter extends Filter {
   @Override
   public boolean accept(Key k, Value v) {
     if (!k.isDeleted() && k.compareColumnFamily(TabletsSection.BulkFileColumnFamily.NAME) == 0) {
-      long txid = Long.parseLong(v.toString());
+      long txid = MetadataTableUtil.getBulkLoadTid(v);
 
       Status status = bulkTxStatusCache.get(txid);
       if (status == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -48,6 +48,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Lo
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -88,9 +89,9 @@ public class MasterMetadataUtil {
     }
 
     for (Entry<Long,? extends Collection<FileRef>> entry : bulkLoadedFiles.entrySet()) {
-      Value tidBytes = new Value(Long.toString(entry.getKey()).getBytes());
+      Value tidVal = new Value(FateTxId.formatTid(entry.getKey()));
       for (FileRef ref : entry.getValue()) {
-        m.put(TabletsSection.BulkFileColumnFamily.NAME, ref.meta(), new Value(tidBytes));
+        m.put(TabletsSection.BulkFileColumnFamily.NAME, ref.meta(), tidVal);
       }
     }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CleanUpBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CleanUpBulkImport.java
@@ -20,6 +20,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
@@ -63,7 +64,7 @@ public class CleanUpBulkImport extends MasterRepo {
     Utils.unreserveHdfsDirectory(master, source, tid);
     Utils.unreserveHdfsDirectory(master, error, tid);
     Utils.getReadLock(master, tableId, tid).unlock();
-    log.debug("completing bulkDir import transaction " + tid);
+    log.debug("completing bulkDir import transaction " + FateTxId.formatTid(tid));
     ZooArbitrator.cleanup(master.getContext(), Constants.BULK_ARBITRATOR_TYPE, tid);
     master.removeBulkImportStatus(source);
     return null;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
@@ -67,7 +68,7 @@ public class CleanUpBulkImport extends MasterRepo {
       log.debug("Failed to delete renames and/or loadmap", ioe);
     }
 
-    log.debug("completing bulkDir import transaction " + tid);
+    log.debug("completing bulkDir import transaction " + FateTxId.formatTid(tid));
     if (info.tableState == TableState.ONLINE) {
       ZooArbitrator.cleanup(master.getContext(), Constants.BULK_ARBITRATOR_TYPE, tid);
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -51,6 +51,7 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.PeekingIterator;
 import org.apache.accumulo.core.util.TextUtil;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
@@ -82,7 +83,8 @@ class LoadFiles extends MasterRepo {
   @Override
   public long isReady(long tid, Master master) throws Exception {
     if (master.onlineTabletServers().size() == 0) {
-      log.warn("There are no tablet server to process bulkDir import, waiting (tid = " + tid + ")");
+      log.warn("There are no tablet server to process bulkDir import, waiting (tid = "
+          + FateTxId.formatTid(tid) + ")");
       return 100;
     }
     VolumeManager fs = master.getFileSystem();
@@ -140,7 +142,7 @@ class LoadFiles extends MasterRepo {
       super.start(bulkDir, master, tid, setTime);
 
       timeInMillis = master.getConfiguration().getTimeInMillis(Property.MASTER_BULK_TIMEOUT);
-      fmtTid = String.format("%016x", tid);
+      fmtTid = FateTxId.formatTid(tid);
 
       loadMsgs = new MapCounter<>();
 
@@ -152,7 +154,7 @@ class LoadFiles extends MasterRepo {
         loadQueue.forEach((server, tabletFiles) -> {
 
           if (log.isTraceEnabled()) {
-            log.trace("tid {} asking {} to bulk import {} files for {} tablets", fmtTid, server,
+            log.trace("{} asking {} to bulk import {} files for {} tablets", fmtTid, server,
                 tabletFiles.values().stream().mapToInt(Map::size).sum(), tabletFiles.size());
           }
 
@@ -162,8 +164,7 @@ class LoadFiles extends MasterRepo {
             client.loadFiles(TraceUtil.traceInfo(), master.getContext().rpcCreds(), tid,
                 bulkDir.toString(), tabletFiles, setTime);
           } catch (TException ex) {
-            log.debug("rpc failed server: " + server + ", tid:" + fmtTid + " " + ex.getMessage(),
-                ex);
+            log.debug("rpc failed server: " + server + ", " + fmtTid + " " + ex.getMessage(), ex);
           } finally {
             ThriftUtil.returnClient(client);
           }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -112,12 +112,8 @@ public class TabletData {
       } else if (family.equals(LastLocationColumnFamily.NAME)) {
         lastLocation = new TServerInstance(value, key.getColumnQualifier());
       } else if (family.equals(BulkFileColumnFamily.NAME)) {
-        Long id = Long.decode(value.toString());
-        List<FileRef> lst = bulkImported.get(id);
-        if (lst == null) {
-          bulkImported.put(id, lst = new ArrayList<>());
-        }
-        lst.add(new FileRef(fs, key));
+        Long id = MetadataTableUtil.getBulkLoadTid(value);
+        bulkImported.computeIfAbsent(id, l -> new ArrayList<FileRef>()).add(new FileRef(fs, key));
       } else if (PREV_ROW_COLUMN.hasColumns(key)) {
         KeyExtent check = new KeyExtent(key.getRow(), value);
         if (!check.equals(extent)) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.AdminUtil;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.ReadOnlyRepo;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.Repo;
@@ -109,6 +110,14 @@ public class FateCommand extends Command {
   private Option statusOption;
   private Option disablePaginationOpt;
 
+  private long parseTxid(String s) {
+    if (FateTxId.isFormatedTid(s)) {
+      return FateTxId.fromString(s);
+    } else {
+      return Long.parseLong(s, 16);
+    }
+  }
+
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws ParseException, KeeperException, InterruptedException, IOException {
@@ -158,7 +167,7 @@ public class FateCommand extends Command {
         filterTxid = new HashSet<>(args.length);
         for (int i = 1; i < args.length; i++) {
           try {
-            Long val = Long.parseLong(args[i], 16);
+            Long val = parseTxid(args[i]);
             filterTxid.add(val);
           } catch (NumberFormatException nfe) {
             // Failed to parse, will exit instead of displaying everything since the intention was
@@ -198,7 +207,7 @@ public class FateCommand extends Command {
       } else {
         txids = new ArrayList<>();
         for (int i = 1; i < args.length; i++) {
-          txids.add(Long.parseLong(args[i], 16));
+          txids.add(parseTxid(args[i]));
         }
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
@@ -126,7 +126,8 @@ public class BulkFailureIT extends AccumuloClusterHarness {
       VolumeManager vm = asCtx.getVolumeManager();
 
       // move the file into a directory for the table and rename the file to something unique
-      String bulkDir = BulkImport.prepareBulkImport(asCtx, vm, testFile, TableId.of(tableId));
+      String bulkDir =
+          BulkImport.prepareBulkImport(asCtx, vm, testFile, TableId.of(tableId), fateTxid);
 
       // determine the files new name and path
       FileStatus status = fs.listStatus(new Path(bulkDir))[0];


### PR DESCRIPTION
Before this change the bulk import code was serializing and logging fate
transaction ids differently than other parts of the code.  When adding
FATE transaction ids to blip markers, I decided it would be best if they
were consistently persisted (in metadata table ) and logged. That
decision made this change much larger than simply adding something to
the blip value, but I feel its worth it.

The following are the main changes :

 * Introduce new class FateTxId with methods for consistenly formatting
   fate transaction ids.
 * Make bulk fate logging use FateTxId
 * Update ~blip and loaded family to use FateTxId.  Made loaded family
   backwards compat.
 * Update existing fate logging code to use FateTxId.  Instead of
   String.format

Follow on work to update all Repos to use FateTxId would be nice.  Chose
not do to that in the change because it would make it harder to review.