### PR TITLE
Created SequenceLexicoder to resolve #1252

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
  * encoded element sorts lexicographically.
  *
  * Note: Empty lists are not supported.
+ * @see SequenceLexicoder for an encoding that supports empty lists.
  *
  * @since 1.6.0
  */
@@ -49,6 +50,9 @@ public class ListLexicoder<LT> extends AbstractLexicoder<List<LT>> {
    */
   @Override
   public byte[] encode(List<LT> v) {
+    if (v.isEmpty()) {
+      throw new IllegalArgumentException("ListLexicoder does not support empty lists");
+    }
     byte[][] encElements = new byte[v.size()][];
 
     int index = 0;

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -16,7 +16,10 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
-import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.*;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.concat;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.escape;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.split;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/ListLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/ListLexicoderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -91,5 +92,10 @@ public class ListLexicoderTest extends AbstractLexicoderTest {
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data3);
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data4);
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data5);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRejectsEmptyLists() {
+    new ListLexicoder<>(new LongLexicoder()).encode(emptyList());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -16,83 +16,61 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TreeSet;
-
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
 import org.junit.Test;
 
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link SequenceLexicoder}.
+ */
 public class SequenceLexicoderTest extends AbstractLexicoderTest {
 
-  private final List<Long> data0 = new ArrayList<>();
-  private final List<Long> data1 = new ArrayList<>();
-  private final List<Long> data2 = new ArrayList<>();
-  private final List<Long> data3 = new ArrayList<>();
-  private final List<Long> data4 = new ArrayList<>();
-  private final List<Long> data5 = new ArrayList<>();
+  private final List<String> nodata = emptyList();
+  private final List<String> data0 = singletonList("");
+  private final List<String> data1 = asList("a", "b");
+  private final List<String> data2 = asList("a");
+  private final List<String> data3 = asList("a", "c");
+  private final List<String> data4 = asList("a", "b", "c");
+  private final List<String> data5 = asList("b", "a");
 
-  @Before
-  public void setUp() {
-
-    data1.add(1L);
-    data1.add(2L);
-
-    data2.add(1L);
-
-    data3.add(1L);
-    data3.add(3L);
-
-    data4.add(1L);
-    data4.add(2L);
-    data4.add(3L);
-
-    data5.add(2L);
-    data5.add(1L);
-  }
 
   @Test
   public void testSortOrder() {
-    final List<List<Long>> data = new ArrayList<>();
-
-    // add list in expected sort order
-    data.add(data0);
-    data.add(data2);
-    data.add(data1);
-    data.add(data4);
-    data.add(data3);
-    data.add(data5);
-
+    // expected sort order
+    final List<List<String>> data = asList(nodata, data0, data2, data1, data4, data3, data5);
     final TreeSet<Text> sortedEnc = new TreeSet<>();
-
-    final SequenceLexicoder<Long> sequenceLexicoder = new SequenceLexicoder<>(new LongLexicoder());
-
-    for (final List<Long> list : data) {
+    final SequenceLexicoder<String> sequenceLexicoder = new SequenceLexicoder<>(new StringLexicoder());
+    for (final List<String> list : data) {
       sortedEnc.add(new Text(sequenceLexicoder.encode(list)));
     }
-
-    final List<List<Long>> unenc = new ArrayList<>();
-
+    final List<List<String>> unenc = new ArrayList<>();
     for (final Text enc : sortedEnc) {
       unenc.add(sequenceLexicoder.decode(TextUtil.getBytes(enc)));
     }
-
     assertEquals(data, unenc);
-
   }
 
   @Test
   public void testDecodes() {
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data0);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data1);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data2);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data3);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data4);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data5);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), nodata);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data0);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data1);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data2);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data3);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data4);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data5);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void tesRejectsTrailingBytes() {
+    new SequenceLexicoder<>(new StringLexicoder()).decode(new byte[] {10});
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.lexicoder;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
+import org.apache.accumulo.core.util.TextUtil;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SequenceLexicoderTest extends AbstractLexicoderTest {
+
+  private final List<Long> data0 = new ArrayList<>();
+  private final List<Long> data1 = new ArrayList<>();
+  private final List<Long> data2 = new ArrayList<>();
+  private final List<Long> data3 = new ArrayList<>();
+  private final List<Long> data4 = new ArrayList<>();
+  private final List<Long> data5 = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+
+    data1.add(1L);
+    data1.add(2L);
+
+    data2.add(1L);
+
+    data3.add(1L);
+    data3.add(3L);
+
+    data4.add(1L);
+    data4.add(2L);
+    data4.add(3L);
+
+    data5.add(2L);
+    data5.add(1L);
+  }
+
+  @Test
+  public void testSortOrder() {
+    final List<List<Long>> data = new ArrayList<>();
+
+    // add list in expected sort order
+    data.add(data0);
+    data.add(data2);
+    data.add(data1);
+    data.add(data4);
+    data.add(data3);
+    data.add(data5);
+
+    final TreeSet<Text> sortedEnc = new TreeSet<>();
+
+    final SequenceLexicoder<Long> sequenceLexicoder = new SequenceLexicoder<>(new LongLexicoder());
+
+    for (final List<Long> list : data) {
+      sortedEnc.add(new Text(sequenceLexicoder.encode(list)));
+    }
+
+    final List<List<Long>> unenc = new ArrayList<>();
+
+    for (final Text enc : sortedEnc) {
+      unenc.add(sequenceLexicoder.decode(TextUtil.getBytes(enc)));
+    }
+
+    assertEquals(data, unenc);
+
+  }
+
+  @Test
+  public void testDecodes() {
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data0);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data1);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data2);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data3);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data4);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data5);
+  }
+}


### PR DESCRIPTION
This provides a replacement for `ListLexicoder` that supports empty lists, resolving #1252 .

The branch is based on the `master` branch, but I can rebase it to a different branch if necessary to include it in the 2.0 release.

I'm also open to suggestions for a different name for the class if anyone can think of a better one.