### PR TITLE
Created SequenceLexicoder to resolve #1252 (2.0)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -30,8 +30,8 @@ import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
  * A lexicoder to encode/decode a Java List to/from a byte array where the concatenation of each
  * encoded element sorts lexicographically.
  *
- * Note: Empty lists are not supported.
- * See {@link SequenceLexicoder} for an encoding that supports empty lists.
+ * Note: Empty lists are not supported. See {@link SequenceLexicoder} for an encoding that supports
+ * empty lists.
  *
  * @since 1.6.0
  */

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
  * encoded element sorts lexicographically.
  *
  * Note: Empty lists are not supported.
+ * @see SequenceLexicoder for an encoding that supports empty lists.
  *
  * @since 1.6.0
  */
@@ -49,6 +50,9 @@ public class ListLexicoder<LT> extends AbstractLexicoder<List<LT>> {
    */
   @Override
   public byte[] encode(List<LT> v) {
+    if (v.isEmpty()) {
+      throw new IllegalArgumentException("ListLexicoder does not support empty lists");
+    }
     byte[][] encElements = new byte[v.size()][];
 
     int index = 0;

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
  * encoded element sorts lexicographically.
  *
  * Note: Empty lists are not supported.
- * @see SequenceLexicoder for an encoding that supports empty lists.
+ * See {@link SequenceLexicoder} for an encoding that supports empty lists.
  *
  * @since 1.6.0
  */

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
  * Note: Unlike {@link ListLexicoder}, this implementation supports empty lists.
  *
  * The lists are encoded with the elements separated by null (0x0) bytes, which null bytes appearing in the
- * elements escaped as 0x1 bytes, and 0x1 bytes appearing in the elements escaped as two 0x1 bytes. The list
+ * elements escaped as two 0x1 bytes, and 0x1 bytes appearing in the elements escaped as 0x1 and 0x2 bytes. The list
  * is terminated with a final delimiter, with no bytes following it.
  *
  * @since 2.0.0

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -27,19 +27,19 @@ import java.util.List;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 
-
 /**
  * A Lexicoder to encode/decode a Java List to/from a byte array where the concatenation of each
  * encoded element sorts lexicographically.
  *
  * Note: Unlike {@link ListLexicoder}, this implementation supports empty lists.
  *
- * The lists are encoded with the elements separated by null (0x0) bytes, which null bytes appearing in the
- * elements escaped as two 0x1 bytes, and 0x1 bytes appearing in the elements escaped as 0x1 and 0x2 bytes. The list
- * is terminated with a final delimiter, with no bytes following it.
+ * The lists are encoded with the elements separated by null (0x0) bytes, which null bytes appearing
+ * in the elements escaped as two 0x1 bytes, and 0x1 bytes appearing in the elements escaped as 0x1
+ * and 0x2 bytes. The list is terminated with a final delimiter, with no bytes following it.
  *
  * @since 2.0.0
- * @param <E> list element type.
+ * @param <E>
+ *          list element type.
  */
 public class SequenceLexicoder<E> extends AbstractLexicoder<List<E>> {
 
@@ -49,12 +49,12 @@ public class SequenceLexicoder<E> extends AbstractLexicoder<List<E>> {
   /**
    * Primary constructor.
    *
-   * @param elementLexicoder Lexicoder to apply to elements.
+   * @param elementLexicoder
+   *          Lexicoder to apply to elements.
    */
   public SequenceLexicoder(final Lexicoder<E> elementLexicoder) {
     this.elementLexicoder = requireNonNull(elementLexicoder, "elementLexicoder");
   }
-
 
   /**
    * {@inheritDoc}
@@ -72,15 +72,16 @@ public class SequenceLexicoder<E> extends AbstractLexicoder<List<E>> {
     return concat(encElements);
   }
 
-
   @Override
   protected List<E> decodeUnchecked(final byte[] b, final int offset, final int len) {
     final byte[][] escapedElements = split(b, offset, len);
-    assert escapedElements.length > 0 : "ByteUtils.split always returns a minimum of 1 element, even for empty input";
+    assert escapedElements.length
+        > 0 : "ByteUtils.split always returns a minimum of 1 element, even for empty input";
     // There should be no bytes after the final delimiter. Lack of delimiter indicates empty list.
     final byte[] lastElement = escapedElements[escapedElements.length - 1];
     if (lastElement.length > 0) {
-      throw new IllegalArgumentException(lastElement.length + " trailing bytes found at end of list");
+      throw new IllegalArgumentException(
+          lastElement.length + " trailing bytes found at end of list");
     }
     final ArrayList<E> decodedElements = new ArrayList<>(escapedElements.length - 1);
     for (int i = 0; i < escapedElements.length - 1; i++) {

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -35,7 +35,9 @@ import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
  *
  * The lists are encoded with the elements separated by null (0x0) bytes, which null bytes appearing
  * in the elements escaped as two 0x1 bytes, and 0x1 bytes appearing in the elements escaped as 0x1
- * and 0x2 bytes. The list is terminated with a final delimiter, with no bytes following it.
+ * and 0x2 bytes. The list is terminated with a final delimiter after the last element, with no
+ * bytes following it. An empty list is represented as an empty byte array, with no delimiter,
+ * whereas a list with a single empty element is represented as a single terminating delimiter.
  *
  * @since 2.0.0
  * @param <E>

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -16,7 +16,10 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
-import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.*;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.concat;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.escape;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.split;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 
-import javax.annotation.Nonnull;
 
 /**
  * A lexicoder to encode/decode a Java List to/from a byte array where the concatenation of each
@@ -36,41 +35,41 @@ import javax.annotation.Nonnull;
  * Note: Unlike {@link ListLexicoder}, this implementation supports empty lists.
  *
  * @since 2.0.0
- * @param <LT> list element type.
+ * @param <E> list element type.
  */
-public class SequenceLexicoder<LT> extends AbstractLexicoder<List<LT>> {
+public class SequenceLexicoder<E> extends AbstractLexicoder<List<E>> {
 
-  private Lexicoder<LT> lexicoder;
+  private Lexicoder<E> lexicoder;
 
   /**
    * Primary constructor.
    *
    * @param lexicoder Lexicoder to apply to elements.
    */
-  public SequenceLexicoder(@Nonnull final Lexicoder<LT> lexicoder) {
+  public SequenceLexicoder(final Lexicoder<E> lexicoder) {
     this.lexicoder = requireNonNull(lexicoder, "lexicoder");
   }
+
 
   /**
    * {@inheritDoc}
    *
    * @return a byte array containing the concatenation of each element in the list encoded.
    */
-  @Nonnull
   @Override
-  public byte[] encode(@Nonnull final List<LT> v) {
+  public byte[] encode(final List<E> v) {
     final byte[][] encElements = new byte[v.size() + 1][];
     int index = 0;
-    for (final LT element : v) {
+    for (final E element : v) {
       encElements[index++] = escape(lexicoder.encode(element));
     }
     encElements[v.size()] = new byte[0];
     return concat(encElements);
   }
 
-  @Nonnull
+
   @Override
-  protected List<LT> decodeUnchecked(@Nonnull final byte[] b, final int offset, final int len) {
+  protected List<E> decodeUnchecked(final byte[] b, final int offset, final int len) {
     final byte[][] escapedElements = split(b, offset, len);
     assert escapedElements.length > 0 : "ByteUtils.split always returns a minimum of 1 element, even for empty input";
     // There should be no bytes after the final delimiter. Lack of delimiter indicates empty list.
@@ -78,7 +77,7 @@ public class SequenceLexicoder<LT> extends AbstractLexicoder<List<LT>> {
     if (lastElement.length > 0) {
       throw new IllegalArgumentException(lastElement.length + " trailing bytes found at end of list");
     }
-    final ArrayList<LT> ret = new ArrayList<>(escapedElements.length);
+    final ArrayList<E> ret = new ArrayList<>(escapedElements.length);
     for (int i = 0; i < escapedElements.length - 1; i++) {
       final byte[] escapedElement = escapedElements[i];
       ret.add(lexicoder.decode(unescape(escapedElement)));

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/ListLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/ListLexicoderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -91,5 +92,10 @@ public class ListLexicoderTest extends AbstractLexicoderTest {
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data3);
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data4);
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data5);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRejectsEmptyLists() {
+    new ListLexicoder<>(new LongLexicoder()).encode(emptyList());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -16,83 +16,61 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TreeSet;
-
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
 import org.junit.Test;
 
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link SequenceLexicoder}.
+ */
 public class SequenceLexicoderTest extends AbstractLexicoderTest {
 
-  private final List<Long> data0 = new ArrayList<>();
-  private final List<Long> data1 = new ArrayList<>();
-  private final List<Long> data2 = new ArrayList<>();
-  private final List<Long> data3 = new ArrayList<>();
-  private final List<Long> data4 = new ArrayList<>();
-  private final List<Long> data5 = new ArrayList<>();
+  private final List<String> nodata = emptyList();
+  private final List<String> data0 = singletonList("");
+  private final List<String> data1 = asList("a", "b");
+  private final List<String> data2 = asList("a");
+  private final List<String> data3 = asList("a", "c");
+  private final List<String> data4 = asList("a", "b", "c");
+  private final List<String> data5 = asList("b", "a");
 
-  @Before
-  public void setUp() {
-
-    data1.add(1L);
-    data1.add(2L);
-
-    data2.add(1L);
-
-    data3.add(1L);
-    data3.add(3L);
-
-    data4.add(1L);
-    data4.add(2L);
-    data4.add(3L);
-
-    data5.add(2L);
-    data5.add(1L);
-  }
 
   @Test
   public void testSortOrder() {
-    final List<List<Long>> data = new ArrayList<>();
-
-    // add list in expected sort order
-    data.add(data0);
-    data.add(data2);
-    data.add(data1);
-    data.add(data4);
-    data.add(data3);
-    data.add(data5);
-
+    // expected sort order
+    final List<List<String>> data = asList(nodata, data0, data2, data1, data4, data3, data5);
     final TreeSet<Text> sortedEnc = new TreeSet<>();
-
-    final SequenceLexicoder<Long> sequenceLexicoder = new SequenceLexicoder<>(new LongLexicoder());
-
-    for (final List<Long> list : data) {
+    final SequenceLexicoder<String> sequenceLexicoder = new SequenceLexicoder<>(new StringLexicoder());
+    for (final List<String> list : data) {
       sortedEnc.add(new Text(sequenceLexicoder.encode(list)));
     }
-
-    final List<List<Long>> unenc = new ArrayList<>();
-
+    final List<List<String>> unenc = new ArrayList<>();
     for (final Text enc : sortedEnc) {
       unenc.add(sequenceLexicoder.decode(TextUtil.getBytes(enc)));
     }
-
     assertEquals(data, unenc);
-
   }
 
   @Test
   public void testDecodes() {
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data0);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data1);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data2);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data3);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data4);
-    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data5);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), nodata);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data0);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data1);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data2);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data3);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data4);
+    assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data5);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void tesRejectsTrailingBytes() {
+    new SequenceLexicoder<>(new StringLexicoder()).decode(new byte[] {10});
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
-import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
-import org.apache.accumulo.core.util.TextUtil;
-import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
+import org.apache.accumulo.core.util.TextUtil;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link SequenceLexicoder}.
@@ -43,13 +43,13 @@ public class SequenceLexicoderTest extends AbstractLexicoderTest {
   private final List<String> data4 = asList("a", "b", "c");
   private final List<String> data5 = asList("b", "a");
 
-
   @Test
   public void testSortOrder() {
     // expected sort order
     final List<List<String>> data = asList(nodata, data0, data2, data1, data4, data3, data5);
     final TreeSet<Text> sortedEnc = new TreeSet<>();
-    final SequenceLexicoder<String> sequenceLexicoder = new SequenceLexicoder<>(new StringLexicoder());
+    final SequenceLexicoder<String> sequenceLexicoder =
+        new SequenceLexicoder<>(new StringLexicoder());
     for (final List<String> list : data) {
       sortedEnc.add(new Text(sequenceLexicoder.encode(list)));
     }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.client.lexicoder;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoderTest;
+import org.apache.accumulo.core.util.TextUtil;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SequenceLexicoderTest extends AbstractLexicoderTest {
+
+  private final List<Long> data0 = new ArrayList<>();
+  private final List<Long> data1 = new ArrayList<>();
+  private final List<Long> data2 = new ArrayList<>();
+  private final List<Long> data3 = new ArrayList<>();
+  private final List<Long> data4 = new ArrayList<>();
+  private final List<Long> data5 = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+
+    data1.add(1L);
+    data1.add(2L);
+
+    data2.add(1L);
+
+    data3.add(1L);
+    data3.add(3L);
+
+    data4.add(1L);
+    data4.add(2L);
+    data4.add(3L);
+
+    data5.add(2L);
+    data5.add(1L);
+  }
+
+  @Test
+  public void testSortOrder() {
+    final List<List<Long>> data = new ArrayList<>();
+
+    // add list in expected sort order
+    data.add(data0);
+    data.add(data2);
+    data.add(data1);
+    data.add(data4);
+    data.add(data3);
+    data.add(data5);
+
+    final TreeSet<Text> sortedEnc = new TreeSet<>();
+
+    final SequenceLexicoder<Long> sequenceLexicoder = new SequenceLexicoder<>(new LongLexicoder());
+
+    for (final List<Long> list : data) {
+      sortedEnc.add(new Text(sequenceLexicoder.encode(list)));
+    }
+
+    final List<List<Long>> unenc = new ArrayList<>();
+
+    for (final Text enc : sortedEnc) {
+      unenc.add(sequenceLexicoder.decode(TextUtil.getBytes(enc)));
+    }
+
+    assertEquals(data, unenc);
+
+  }
+
+  @Test
+  public void testDecodes() {
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data0);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data1);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data2);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data3);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data4);
+    assertDecodes(new SequenceLexicoder<>(new LongLexicoder()), data5);
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -21,7 +21,9 @@ import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -36,7 +36,7 @@ public class SequenceLexicoderTest extends AbstractLexicoderTest {
   private final List<String> nodata = emptyList();
   private final List<String> data0 = singletonList("");
   private final List<String> data1 = asList("a", "b");
-  private final List<String> data2 = asList("a");
+  private final List<String> data2 = singletonList("a");
   private final List<String> data3 = asList("a", "c");
   private final List<String> data4 = asList("a", "b", "c");
   private final List<String> data5 = asList("b", "a");


### PR DESCRIPTION
This provides a replacement for ListLexicoder that supports empty lists, resolving #1252 .

This PR replaces #1253 , which was originally targeted to `master` and Java 11. This one targets the `2.0` branch and Java 8.