### PR TITLE
correctly handle first and last tablets in LinkingIterator #1260

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
@@ -63,7 +63,6 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
   @Override
   public boolean hasNext() {
     boolean hasNext = source.hasNext();
-    // TODO open issue to make Ample handle case of not tablets seen
 
     // Always expect the default tablet to exist for a table. The following checks for the case when
     // the default tablet was not seen when it should have been seen.
@@ -153,8 +152,6 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
           if (prevRow != null) {
             prevMetaRow = TabletsSection.getRow(tmp.getExtent().getTableId(), prevRow);
           }
-
-          // TODO check table ID in range??
 
           // If the first tablet seen has a prev endrow within the range it means a preceding tablet
           // exists that we need to go back and read. This could be caused by the first tablet in

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/LinkingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/LinkingIteratorTest.java
@@ -153,4 +153,13 @@ public class LinkingIteratorTest {
       li.next();
     }
   }
+
+  @Test
+  public void testIncompleteTableWithRange() {
+    // because the scan range does not got to end of table, this should not care about missing
+    // tablets at end of table.
+    List<TabletMetadata> tablets1 = Arrays.asList(create("4", null, "f"), create("4", "f", "m"));
+    check(tablets1, new IterFactory(tablets1, tablets1),
+        new KeyExtent(TableId.of("4"), new Text("r"), new Text("e")).toMetadataRange());
+  }
 }


### PR DESCRIPTION
The LinkingIterator checks the structure of the AccumuloMetadata table
as it is scans.   It was not properly handling a split of the first
tablet.  It was also not ensuring the last tablet for a table was seen.
This patch fixes those two issues.  These issues were discovered while
researching #1260, however I am not sure if these issues could have
caused #1260.