### PR TITLE
Fix #1210 Create type for time in metadata

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -156,7 +156,7 @@ public interface Ample {
 
     public TabletMutator deleteWal(LogEntry logEntry);
 
-    public TabletMutator putTime(String time);
+    public TabletMutator putTime(MetadataTime time);
 
     public TabletMutator putBulkFile(Ample.FileMeta bulkref, long tid);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import java.util.Objects;
+
+import org.apache.accumulo.core.client.admin.TimeType;
+
+/**
+ * Immutable metadata time object
+ */
+public class MetadataTime {
+  private final long time;
+  private final TimeType type; // default type is M for milliseconds
+
+  public MetadataTime(long time, TimeType type) {
+    this.time = time;
+    this.type = type;
+  }
+
+  /**
+   * Creates a MetadataTime object from a string
+   *
+   * @param timestr
+   *          string representation of a metatdata time, ex. "M12345678"
+   * @return a MetadataTime object represented by string
+   */
+
+  public static MetadataTime parse(String timestr) throws IllegalArgumentException {
+
+    if (timestr != null && timestr.length() > 1) {
+      return new MetadataTime(Long.parseLong(timestr.substring(1)), valueOf(timestr.charAt(0)));
+    } else
+      throw new IllegalArgumentException("Unknown metadata time value " + timestr);
+  }
+
+  /**
+   * Converts timetypes to data codes used in the table data implementation
+   *
+   * @param code
+   *          character M or L otherwise exception thrown
+   * @return a TimeType {@link TimeType} represented by code.
+   */
+  public static TimeType valueOf(char code) {
+    switch (code) {
+      case 'M':
+        return TimeType.MILLIS;
+      case 'L':
+        return TimeType.LOGICAL;
+      default:
+        throw new IllegalArgumentException("Unknown time type code : " + code);
+    }
+  }
+
+  /**
+   * @return the single char code of this objects timeType
+   */
+  public static char getCode(TimeType type) {
+    switch (type) {
+      case MILLIS:
+        return 'M';
+      case LOGICAL:
+        return 'L';
+      default: // this should never happen
+        throw new IllegalArgumentException("Unknown time type: " + type);
+    }
+  }
+
+  public char getCode() {
+    return getCode(this.type);
+  }
+
+  public TimeType getType() {
+    return type;
+  }
+
+  public long getTime() {
+    return time;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof MetadataTime) {
+      MetadataTime t = (MetadataTime) o;
+      return time == t.getTime() && type == t.getType();
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(time, type);
+  }
+
+  @Override
+  public String toString() {
+    return "" + getCode() + time;
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.client.admin.TimeType;
  */
 public class MetadataTime {
   private final long time;
-  private final TimeType type; // default type is M for milliseconds
+  private final TimeType type;
 
   public MetadataTime(long time, TimeType type) {
     this.time = time;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -23,7 +23,7 @@ import org.apache.accumulo.core.client.admin.TimeType;
 /**
  * Immutable metadata time object
  */
-public class MetadataTime {
+public final class MetadataTime {
   private final long time;
   private final TimeType type;
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -84,6 +84,10 @@ public class MetadataTime {
     return getCode(this.type);
   }
 
+  public String encode() {
+    return "" + getCode() + time;
+  }
+
   public TimeType getType() {
     return type;
   }
@@ -104,11 +108,6 @@ public class MetadataTime {
   @Override
   public int hashCode() {
     return Objects.hash(time, type);
-  }
-
-  @Override
-  public String toString() {
-    return "" + getCode() + time;
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -79,7 +79,7 @@ public class TabletMetadata {
   private KeyExtent extent;
   private Location last;
   private String dir;
-  private String time;
+  private MetadataTime time;
   private String cloned;
   private SortedMap<Key,Value> keyValues;
   private OptionalLong flush = OptionalLong.empty();
@@ -208,7 +208,7 @@ public class TabletMetadata {
     return dir;
   }
 
-  public String getTime() {
+  public MetadataTime getTime() {
     ensureFetched(ColumnType.TIME);
     return time;
   }
@@ -283,7 +283,7 @@ public class TabletMetadata {
               te.dir = val;
               break;
             case TIME_QUAL:
-              te.time = val;
+              te.time = MetadataTime.parse(val);
               break;
             case FLUSH_QUAL:
               te.flush = OptionalLong.of(Long.parseLong(val));

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.apache.accumulo.core.client.admin.TimeType;
+import org.junit.Test;
+
+public class MetadataTimeTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetInstance_InvalidType() {
+    MetadataTime mTime = MetadataTime.parse("X1234");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetInstance_Logical_ParseFailure() {
+    MetadataTime mTime = MetadataTime.parse("LABCD");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetInstance_Millis_ParseFailure() {
+    MetadataTime mTime = MetadataTime.parse("MABCD");
+  }
+
+  @Test
+  public void testGetInstance_Millis() {
+    MetadataTime mTime = new MetadataTime(1234, TimeType.MILLIS);
+    assertEquals(1234, mTime.getTime());
+    assertEquals(TimeType.MILLIS, mTime.getType());
+  }
+
+  @Test
+  public void testGetInstance_Logical() {
+    MetadataTime mTime = new MetadataTime(1234, TimeType.LOGICAL);
+    assertEquals(1234, mTime.getTime());
+    assertEquals(TimeType.LOGICAL, mTime.getType());
+
+  }
+
+  @Test
+  public void testEquality() {
+    assertEquals(new MetadataTime(21, TimeType.MILLIS), MetadataTime.parse("M21"));
+    assertNotEquals(new MetadataTime(21, TimeType.MILLIS), MetadataTime.parse("L21"));
+    assertNotEquals(new MetadataTime(21, TimeType.LOGICAL), new MetadataTime(44, TimeType.LOGICAL));
+  }
+
+  @Test
+  public void testValueOfM() {
+    assertEquals(TimeType.MILLIS, MetadataTime.valueOf('M'));
+  }
+
+  @Test
+  public void testValueOfL() {
+    assertEquals(TimeType.LOGICAL, MetadataTime.valueOf('L'));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValueOfOtherChar() {
+    MetadataTime.valueOf('x');
+  }
+
+  @Test
+  public void testgetCodeforTimeType() {
+    assertEquals('M', MetadataTime.getCode(TimeType.MILLIS));
+    assertEquals('L', MetadataTime.getCode(TimeType.LOGICAL));
+  }
+
+  @Test
+  public void testgetCodeforMillis() {
+    MetadataTime mTime = new MetadataTime(0, TimeType.MILLIS);
+    assertEquals('M', mTime.getCode());
+  }
+
+  @Test
+  public void testgetCodeforLogical() {
+    MetadataTime mTime = new MetadataTime(0, TimeType.LOGICAL);
+    assertEquals('L', mTime.getCode());
+  }
+
+  @Test
+  public void testenCode() {
+    assertEquals("M21", new MetadataTime(21, TimeType.MILLIS).encode());
+    assertEquals("L45678", new MetadataTime(45678, TimeType.LOGICAL).encode());
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -115,7 +115,7 @@ public class TabletMetadataTest {
     assertEquals(extent.getPrevEndRow(), tm.getPrevEndRow());
     assertEquals(extent.getTableId(), tm.getTableId());
     assertTrue(tm.sawPrevEndRow());
-    assertEquals("M123456789", tm.getTime().toString());
+    assertEquals("M123456789", tm.getTime().encode());
     assertEquals(Set.of("sf1", "sf2"), Set.copyOf(tm.getScans()));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -115,7 +115,7 @@ public class TabletMetadataTest {
     assertEquals(extent.getPrevEndRow(), tm.getPrevEndRow());
     assertEquals(extent.getTableId(), tm.getTableId());
     assertTrue(tm.sawPrevEndRow());
-    assertEquals("M123456789", tm.getTime());
+    assertEquals("M123456789", tm.getTime().toString());
     assertEquals(Set.of("sf1", "sf2"), Set.copyOf(tm.getScans()));
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.IteratorSetting.Column;
+import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -69,6 +70,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Fu
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
@@ -99,7 +101,6 @@ import org.apache.accumulo.server.replication.StatusCombiner;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
 import org.apache.accumulo.server.security.SecurityUtil;
 import org.apache.accumulo.server.tables.TableManager;
-import org.apache.accumulo.server.tablets.TabletTime;
 import org.apache.accumulo.server.util.ReplicationTableUtil;
 import org.apache.accumulo.server.util.SystemPropUtil;
 import org.apache.accumulo.server.util.TablePropUtil;
@@ -571,8 +572,7 @@ public class Initialize implements KeywordExecutable {
     Value EMPTY_SIZE = new DataFileValue(0, 0).encodeAsValue();
     Text extent = new Text(TabletsSection.getRow(tablet.tableId, tablet.endRow));
     addEntry(map, extent, DIRECTORY_COLUMN, new Value(tablet.dir.getBytes(UTF_8)));
-    addEntry(map, extent, TIME_COLUMN,
-        new Value((TabletTime.LOGICAL_TIME_ID + "0").getBytes(UTF_8)));
+    addEntry(map, extent, TIME_COLUMN, new Value(new MetadataTime(0, TimeType.LOGICAL).toString()));
     addEntry(map, extent, PREV_ROW_COLUMN, KeyExtent.encodePrevEndRow(tablet.prevEndRow));
     for (String file : tablet.files) {
       addEntry(map, extent, new ColumnFQ(DataFileColumnFamily.NAME, new Text(file)), EMPTY_SIZE);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -572,7 +572,7 @@ public class Initialize implements KeywordExecutable {
     Value EMPTY_SIZE = new DataFileValue(0, 0).encodeAsValue();
     Text extent = new Text(TabletsSection.getRow(tablet.tableId, tablet.endRow));
     addEntry(map, extent, DIRECTORY_COLUMN, new Value(tablet.dir.getBytes(UTF_8)));
-    addEntry(map, extent, TIME_COLUMN, new Value(new MetadataTime(0, TimeType.LOGICAL).toString()));
+    addEntry(map, extent, TIME_COLUMN, new Value(new MetadataTime(0, TimeType.LOGICAL).encode()));
     addEntry(map, extent, PREV_ROW_COLUMN, KeyExtent.encodePrevEndRow(tablet.prevEndRow));
     for (String file : tablet.files) {
       addEntry(map, extent, new ColumnFQ(DataFileColumnFamily.NAME, new Text(file)), EMPTY_SIZE);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.fate.FateTxId;
@@ -108,9 +109,9 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putTime(String time) {
+  public Ample.TabletMutator putTime(MetadataTime time) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mutation, new Value(time));
+    TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mutation, new Value(time.toString()));
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -111,7 +111,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   @Override
   public Ample.TabletMutator putTime(MetadataTime time) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mutation, new Value(time.toString()));
+    TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mutation, new Value(time.encode()));
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
@@ -21,22 +21,20 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.server.util.time.RelativeTime;
 
 public abstract class TabletTime {
-  public static final char LOGICAL_TIME_ID = 'L';
-  public static final char MILLIS_TIME_ID = 'M';
+  public static final char LOGICAL_TIME_ID = MetadataTime.getCode(TimeType.LOGICAL);
+  public static final char MILLIS_TIME_ID = MetadataTime.getCode(TimeType.MILLIS);
 
   public static char getTimeID(TimeType timeType) {
-    switch (timeType) {
-      case LOGICAL:
-        return LOGICAL_TIME_ID;
-      case MILLIS:
-        return MILLIS_TIME_ID;
-    }
-
-    throw new IllegalArgumentException("Unknown time type " + timeType);
+    /*
+     * switch (timeType) { case LOGICAL: return LOGICAL_TIME_ID; case MILLIS: return MILLIS_TIME_ID;
+     * }
+     */ return MetadataTime.getCode(timeType);
+    // throw new IllegalArgumentException("Unknown time type " + timeType);
   }
 
   public abstract void useMaxTimeFromWALog(long time);
@@ -44,6 +42,10 @@ public abstract class TabletTime {
   public abstract String getMetadataValue(long time);
 
   public abstract String getMetadataValue();
+
+  public abstract MetadataTime getMetadataTime();
+
+  public abstract MetadataTime getMetadataTime(long time);
 
   public abstract long setUpdateTimes(List<Mutation> mutations);
 
@@ -56,15 +58,14 @@ public abstract class TabletTime {
     m.setSystemTimestamp(lastCommitTime);
   }
 
-  public static TabletTime getInstance(String metadataValue) {
-    if (metadataValue.charAt(0) == LOGICAL_TIME_ID) {
-      return new LogicalTime(Long.parseLong(metadataValue.substring(1)));
-    } else if (metadataValue.charAt(0) == MILLIS_TIME_ID) {
-      return new MillisTime(Long.parseLong(metadataValue.substring(1)));
-    }
+  public static TabletTime getInstance(MetadataTime metadataTime) throws IllegalArgumentException {
 
-    throw new IllegalArgumentException("Time type unknown : " + metadataValue);
-
+    if (metadataTime.getType().equals(TimeType.LOGICAL)) {
+      return new LogicalTime(metadataTime.getTime());
+    } else if (metadataTime.getType().equals(TimeType.MILLIS)) {
+      return new MillisTime(metadataTime.getTime());
+    } else // this should really never happen here
+      throw new IllegalArgumentException("Time type unknown : " + metadataTime);
   }
 
   public static String maxMetadataTime(String mv1, String mv2) {
@@ -118,6 +119,16 @@ public abstract class TabletTime {
     @Override
     public String getMetadataValue() {
       return getMetadataValue(lastTime);
+    }
+
+    @Override
+    public MetadataTime getMetadataTime() {
+      return getMetadataTime(lastTime);
+    }
+
+    @Override
+    public MetadataTime getMetadataTime(long time) {
+      return new MetadataTime(time, TimeType.MILLIS);
     }
 
     @Override
@@ -203,6 +214,16 @@ public abstract class TabletTime {
     @Override
     public String getMetadataValue(long time) {
       return LOGICAL_TIME_ID + "" + time;
+    }
+
+    @Override
+    public MetadataTime getMetadataTime() {
+      return getMetadataTime(getTime());
+    }
+
+    @Override
+    public MetadataTime getMetadataTime(long time) {
+      return new MetadataTime(time, TimeType.LOGICAL);
     }
 
     @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
@@ -63,7 +64,7 @@ public class MasterMetadataUtil {
 
   public static void addNewTablet(ServerContext context, KeyExtent extent, String path,
       TServerInstance location, Map<FileRef,DataFileValue> datafileSizes,
-      Map<Long,? extends Collection<FileRef>> bulkLoadedFiles, String time, long lastFlushID,
+      Map<Long,? extends Collection<FileRef>> bulkLoadedFiles, MetadataTime time, long lastFlushID,
       long lastCompactID, ZooLock zooLock) {
 
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
@@ -239,7 +240,7 @@ public class MasterMetadataUtil {
    *
    */
   public static void updateTabletDataFile(ServerContext context, KeyExtent extent, FileRef path,
-      FileRef mergeFile, DataFileValue dfv, String time, Set<FileRef> filesInUseByScans,
+      FileRef mergeFile, DataFileValue dfv, MetadataTime time, Set<FileRef> filesInUseByScans,
       String address, ZooLock zooLock, Set<String> unusedWalLogs, TServerInstance lastLocation,
       long flushId) {
     if (extent.isRootTablet()) {
@@ -267,7 +268,7 @@ public class MasterMetadataUtil {
    *
    */
   private static void updateForTabletDataFile(ServerContext context, KeyExtent extent, FileRef path,
-      FileRef mergeFile, DataFileValue dfv, String time, Set<FileRef> filesInUseByScans,
+      FileRef mergeFile, DataFileValue dfv, MetadataTime time, Set<FileRef> filesInUseByScans,
       String address, ZooLock zooLock, Set<String> unusedWalLogs, TServerInstance lastLocation,
       long flushId) {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/LogicalTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/LogicalTimeTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.List;
 
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.server.tablets.TabletTime.LogicalTime;
 import org.junit.Before;
@@ -35,7 +36,8 @@ public class LogicalTimeTest {
 
   @Before
   public void setUp() {
-    ltime = (LogicalTime) TabletTime.getInstance("L1234");
+    MetadataTime mTime = MetadataTime.parse("L1234");
+    ltime = (LogicalTime) TabletTime.getInstance(mTime);
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/LogicalTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/LogicalTimeTest.java
@@ -42,19 +42,19 @@ public class LogicalTimeTest {
 
   @Test
   public void testGetMetadataValue() {
-    assertEquals("L1234", ltime.getMetadataValue());
+    assertEquals("L1234", ltime.getMetadataTime().encode());
   }
 
   @Test
   public void testUseMaxTimeFromWALog_Update() {
     ltime.useMaxTimeFromWALog(5678L);
-    assertEquals("L5678", ltime.getMetadataValue());
+    assertEquals("L5678", ltime.getMetadataTime().encode());
   }
 
   @Test
   public void testUseMaxTimeFromWALog_NoUpdate() {
     ltime.useMaxTimeFromWALog(0L);
-    assertEquals("L1234", ltime.getMetadataValue());
+    assertEquals("L1234", ltime.getMetadataTime().encode());
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/MillisTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/MillisTimeTest.java
@@ -42,19 +42,19 @@ public class MillisTimeTest {
 
   @Test
   public void testGetMetadataValue() {
-    assertEquals("M1234", mtime.getMetadataValue());
+    assertEquals("M1234", mtime.getMetadataTime().encode());
   }
 
   @Test
   public void testUseMaxTimeFromWALog_Yes() {
     mtime.useMaxTimeFromWALog(5678L);
-    assertEquals("M5678", mtime.getMetadataValue());
+    assertEquals("M5678", mtime.getMetadataTime().encode());
   }
 
   @Test
   public void testUseMaxTimeFromWALog_No() {
     mtime.useMaxTimeFromWALog(0L);
-    assertEquals("M1234", mtime.getMetadataValue());
+    assertEquals("M1234", mtime.getMetadataTime().encode());
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.apache.accumulo.core.client.admin.TimeType;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.server.tablets.TabletTime.LogicalTime;
 import org.apache.accumulo.server.tablets.TabletTime.MillisTime;
@@ -56,31 +57,36 @@ public class TabletTimeTest {
 
   @Test
   public void testGetInstance_Logical() {
-    TabletTime t = TabletTime.getInstance("L1234");
+    MetadataTime mTime = MetadataTime.parse("L1234");
+    TabletTime t = TabletTime.getInstance(mTime);
     assertEquals(LogicalTime.class, t.getClass());
     assertEquals("L1234", t.getMetadataValue());
   }
 
   @Test
   public void testGetInstance_Millis() {
-    TabletTime t = TabletTime.getInstance("M1234");
+    MetadataTime mTime = MetadataTime.parse("M1234");
+    TabletTime t = TabletTime.getInstance(mTime);
     assertEquals(MillisTime.class, t.getClass());
     assertEquals("M1234", t.getMetadataValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_InvalidType() {
-    TabletTime.getInstance("X1234");
+    MetadataTime mTime = MetadataTime.parse("X1234");
+    TabletTime.getInstance(mTime);
   }
 
-  @Test(expected = NumberFormatException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_Logical_ParseFailure() {
-    TabletTime.getInstance("LABCD");
+    MetadataTime mTime = MetadataTime.parse("LABCD");
+    TabletTime.getInstance(mTime);
   }
 
-  @Test(expected = NumberFormatException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_Millis_ParseFailure() {
-    TabletTime.getInstance("MABCD");
+    MetadataTime mTime = MetadataTime.parse("MABCD");
+    TabletTime.getInstance(mTime);
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
@@ -40,12 +40,6 @@ public class TabletTimeTest {
   }
 
   @Test
-  public void testGetTimeID() {
-    assertEquals('L', TabletTime.getTimeID(TimeType.LOGICAL));
-    assertEquals('M', TabletTime.getTimeID(TimeType.MILLIS));
-  }
-
-  @Test
   public void testSetSystemTimes() {
     ServerMutation m = createMock(ServerMutation.class);
     long lastCommitTime = 1234L;
@@ -57,36 +51,16 @@ public class TabletTimeTest {
 
   @Test
   public void testGetInstance_Logical() {
-    MetadataTime mTime = MetadataTime.parse("L1234");
-    TabletTime t = TabletTime.getInstance(mTime);
+    TabletTime t = TabletTime.getInstance(new MetadataTime(1234, TimeType.LOGICAL));
     assertEquals(LogicalTime.class, t.getClass());
-    assertEquals("L1234", t.getMetadataValue());
+    assertEquals("L1234", t.getMetadataTime().encode());
   }
 
   @Test
   public void testGetInstance_Millis() {
-    MetadataTime mTime = MetadataTime.parse("M1234");
-    TabletTime t = TabletTime.getInstance(mTime);
+    TabletTime t = TabletTime.getInstance(new MetadataTime(1234, TimeType.MILLIS));
     assertEquals(MillisTime.class, t.getClass());
-    assertEquals("M1234", t.getMetadataValue());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetInstance_InvalidType() {
-    MetadataTime mTime = MetadataTime.parse("X1234");
-    TabletTime.getInstance(mTime);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetInstance_Logical_ParseFailure() {
-    MetadataTime mTime = MetadataTime.parse("LABCD");
-    TabletTime.getInstance(mTime);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetInstance_Millis_ParseFailure() {
-    MetadataTime mTime = MetadataTime.parse("MABCD");
-    TabletTime.getInstance(mTime);
+    assertEquals("M1234", t.getMetadataTime().encode());
   }
 
   @Test

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableInfo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TableInfo.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.admin.InitialTableState;
+import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 
@@ -31,7 +32,7 @@ public class TableInfo implements Serializable {
   private TableId tableId;
   private NamespaceId namespaceId;
 
-  private char timeType;
+  private TimeType timeType;
   private String user;
 
   // Record requested initial state at creation
@@ -69,11 +70,11 @@ public class TableInfo implements Serializable {
     this.namespaceId = namespaceId;
   }
 
-  public char getTimeType() {
+  public TimeType getTimeType() {
     return timeType;
   }
 
-  public void setTimeType(char timeType) {
+  public void setTimeType(TimeType timeType) {
     this.timeType = timeType;
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
 import org.apache.accumulo.master.tableOps.TableInfo;
 import org.apache.accumulo.master.tableOps.Utils;
-import org.apache.accumulo.server.tablets.TabletTime;
 
 public class CreateTable extends MasterRepo {
   private static final long serialVersionUID = 1L;
@@ -40,7 +39,7 @@ public class CreateTable extends MasterRepo {
       NamespaceId namespaceId) {
     tableInfo = new TableInfo();
     tableInfo.setTableName(tableName);
-    tableInfo.setTimeType(TabletTime.getTimeID(timeType));
+    tableInfo.setTimeType(timeType);
     tableInfo.setUser(user);
     tableInfo.props = props;
     tableInfo.setNamespaceId(namespaceId);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
@@ -90,7 +90,7 @@ class PopulateMetadata extends MasterRepo {
           (split == null) ? new Value(tableInfo.defaultTabletDir) : new Value(data.get(split));
       MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut, dirValue);
       MetadataSchema.TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut,
-          new Value(new MetadataTime(0, timeType).toString()));
+          new Value(new MetadataTime(0, timeType).encode()));
       MetadataTableUtil.putLockID(ctx, lock, mut);
       prevSplit = split;
       bw.addMutation(mut);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
@@ -24,11 +24,13 @@ import java.util.SortedSet;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.master.Master;
@@ -78,7 +80,7 @@ class PopulateMetadata extends MasterRepo {
   }
 
   private void writeSplitsToMetadataTable(ServerContext ctx, TableId tableId,
-      SortedSet<Text> splits, Map<Text,Text> data, char timeType, ZooLock lock, BatchWriter bw)
+      SortedSet<Text> splits, Map<Text,Text> data, TimeType timeType, ZooLock lock, BatchWriter bw)
       throws MutationsRejectedException {
     Text prevSplit = null;
     Value dirValue;
@@ -88,7 +90,7 @@ class PopulateMetadata extends MasterRepo {
           (split == null) ? new Value(tableInfo.defaultTabletDir) : new Value(data.get(split));
       MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut, dirValue);
       MetadataSchema.TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut,
-          new Value(timeType + "0"));
+          new Value(new MetadataTime(0, timeType).toString()));
       MetadataTableUtil.putLockID(ctx, lock, mut);
       prevSplit = split;
       bw.addMutation(mut);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -79,6 +79,7 @@ import org.apache.accumulo.core.master.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationConfigurationUtil;
 import org.apache.accumulo.core.security.Authorizations;
@@ -301,7 +302,8 @@ public class Tablet {
   }
 
   public Tablet(final TabletServer tabletServer, final KeyExtent extent,
-      final TabletResourceManager trm, TabletData data) throws IOException {
+      final TabletResourceManager trm, TabletData data)
+      throws IOException, IllegalArgumentException {
 
     this.tabletServer = tabletServer;
     this.context = tabletServer.getContext();
@@ -2255,7 +2257,7 @@ public class Tablet {
       log.debug("Files for low split {} {}", low, lowDatafileSizes.keySet());
       log.debug("Files for high split {} {}", high, highDatafileSizes.keySet());
 
-      String time = tabletTime.getMetadataValue();
+      MetadataTime time = tabletTime.getMetadataTime(); /** hik **/
 
       MetadataTableUtil.splitTablet(high, extent.getPrevEndRow(), splitRatio,
           getTabletServer().getContext(), getTabletServer().getLock());
@@ -2726,7 +2728,7 @@ public class Tablet {
       }
 
       MetadataTableUtil.updateTabletDataFile(tid, extent, paths,
-          tabletTime.getMetadataValue(persistedTime), getTabletServer().getContext(),
+          tabletTime.getMetadataTime(persistedTime), getTabletServer().getContext(),
           getTabletServer().getLock());
     }
 
@@ -2739,10 +2741,10 @@ public class Tablet {
         persistedTime = maxCommittedTime;
       }
 
-      String time = tabletTime.getMetadataValue(persistedTime);
       MasterMetadataUtil.updateTabletDataFile(getTabletServer().getContext(), extent, newDatafile,
-          absMergeFile, dfv, time, filesInUseByScans, tabletServer.getClientAddressString(),
-          tabletServer.getLock(), unusedWalLogs, lastLocation, flushId);
+          absMergeFile, dfv, tabletTime.getMetadataTime(persistedTime), filesInUseByScans,
+          tabletServer.getClientAddressString(), tabletServer.getLock(), unusedWalLogs,
+          lastLocation, flushId);
     }
 
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2257,7 +2257,7 @@ public class Tablet {
       log.debug("Files for low split {} {}", low, lowDatafileSizes.keySet());
       log.debug("Files for high split {} {}", high, highDatafileSizes.keySet());
 
-      MetadataTime time = tabletTime.getMetadataTime(); /** hik **/
+      MetadataTime time = tabletTime.getMetadataTime();
 
       MetadataTableUtil.splitTablet(high, extent.getPrevEndRow(), splitRatio,
           getTabletServer().getContext(), getTabletServer().getLock());

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -388,8 +388,10 @@ public class CollectTabletStats {
     return tabletsToTest;
   }
 
-  private static List<FileRef> getTabletFiles(ServerContext context, KeyExtent ke) {
-    return new ArrayList<>(MetadataTableUtil.getDataFileSizes(ke, context).keySet());
+  private static List<FileRef> getTabletFiles(ServerContext context, KeyExtent ke)
+      throws IOException {
+    return new ArrayList<>(
+        MetadataTableUtil.getFileAndLogEntries(context, ke).getSecond().keySet());
   }
 
   private static void reportHdfsBlockLocations(ServerContext context, List<FileRef> files)


### PR DESCRIPTION
Created a MetadataTime object  and utilized the TimeType instead of a single
char M and L; Also removed the MetadataTableUtil.getDataFileSizes which
was only used by tests.  It was replaced with using
getFileAndLogEntries(..).getSecond();

Quite a few files were effected by this change but most of them are small.  More work can be done to clean the time data passed around.  I would like to remove the getMetadataValue methods from the TabletTime  (replaced with the getMetadataTime methods) but that can be a second pass.  Additionally I will write a small unit test for the MetadataTime class.
