### PR TITLE
Purge mortbay logger from example configs

### DIFF
--- a/assemble/conf/log4j-service.properties
+++ b/assemble/conf/log4j-service.properties
@@ -52,7 +52,6 @@ log4j.logger.org.apache.accumulo=INHERITED, monitor
 
 ## Constrain some particularly spammy loggers
 log4j.logger.org.apache.accumulo.core.file.rfile.bcfile=INFO
-log4j.logger.org.mortbay.log=WARN
 log4j.logger.org.apache.zookeeper=ERROR
 
 ## Append most logs to file

--- a/test/src/main/resources/log4j.properties
+++ b/test/src/main/resources/log4j.properties
@@ -36,7 +36,6 @@ log4j.logger.org.apache.accumulo.core.file.rfile.bcfile=INFO
 log4j.logger.org.apache.accumulo.server.util.ReplicationTableUtil=TRACE
 log4j.logger.org.apache.accumulo.core.clientImpl.ThriftScanner=INFO
 log4j.logger.org.apache.accumulo.fate.zookeeper.DistributedReadWriteLock=WARN
-log4j.logger.org.mortbay.log=WARN
 log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.apache.jasper=INFO
 log4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=WARN


### PR DESCRIPTION
We no longer have a dependency on mortbay versions of jetty, so there
should be no reason to regulate its spamminess in our config files.