### PR TITLE
Lexicoder API improvements

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -205,8 +205,6 @@
                 <allow>javax[.]security[.]auth[.]DestroyFailedException</allow>
                 <!-- allow questionable Hadoop exceptions for mapreduce -->
                 <allow>org[.]apache[.]hadoop[.]mapred[.](FileAlreadyExistsException|InvalidJobConfException)</allow>
-                <!-- allow lexicoders to throw iterator exceptions -->
-                <allow>org[.]apache[.]accumulo[.]core[.]iterators[.]ValueFormatException</allow>
               </allows>
             </configuration>
           </execution>

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/AbstractEncoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/AbstractEncoder.java
@@ -19,12 +19,10 @@ package org.apache.accumulo.core.client.lexicoder;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import org.apache.accumulo.core.iterators.ValueFormatException;
-
 /**
- * AbstractEncoder is an {@link org.apache.accumulo.core.client.lexicoder.Encoder} that implements
- * all of Encoder's methods validating the input, but has those methods defer logic to to a new
- * method, {@link #decodeUnchecked(byte[], int, int)}.
+ * AbstractEncoder is an {@link Encoder} that implements all of Encoder's methods validating the
+ * input, but has those methods defer logic to to a new method,
+ * {@link #decodeUnchecked(byte[], int, int)}.
  *
  * @since 1.7.0
  */
@@ -34,7 +32,8 @@ public abstract class AbstractEncoder<T> implements Encoder<T> {
    * Decodes a byte array without checking if the offset and len exceed the bounds of the actual
    * array.
    */
-  protected abstract T decodeUnchecked(byte[] b, int offset, int len) throws ValueFormatException;
+  protected abstract T decodeUnchecked(byte[] b, int offset, int len)
+      throws IllegalArgumentException;
 
   @Override
   public T decode(byte[] b) {

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BigIntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BigIntegerLexicoder.java
@@ -24,7 +24,6 @@ import java.math.BigInteger;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.clientImpl.lexicoder.FixedByteArrayOutputStream;
-import org.apache.accumulo.core.iterators.ValueFormatException;
 
 /**
  * A lexicoder to encode/decode a BigInteger to/from bytes that maintain its native Java sort order.
@@ -65,14 +64,13 @@ public class BigIntegerLexicoder extends AbstractLexicoder<BigInteger> {
 
   @Override
   public BigInteger decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 
   @Override
-  protected BigInteger decodeUnchecked(byte[] b, int offset, int origLen)
-      throws ValueFormatException {
+  protected BigInteger decodeUnchecked(byte[] b, int offset, int origLen) {
 
     try {
       DataInputStream dis = new DataInputStream(new ByteArrayInputStream(b, offset, origLen));

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DateLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DateLexicoder.java
@@ -36,8 +36,8 @@ public class DateLexicoder extends AbstractLexicoder<Date> {
 
   @Override
   public Date decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DoubleLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DoubleLexicoder.java
@@ -40,8 +40,8 @@ public class DoubleLexicoder extends AbstractLexicoder<Double> {
 
   @Override
   public Double decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/Encoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/Encoder.java
@@ -21,7 +21,8 @@ package org.apache.accumulo.core.client.lexicoder;
  *
  * @since 1.6.0
  */
-public interface Encoder<T>
-    extends org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder<T> {
+public interface Encoder<T> {
+  byte[] encode(T object);
 
+  T decode(byte[] bytes) throws IllegalArgumentException;
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/FloatLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/FloatLexicoder.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.client.lexicoder;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
-import org.apache.accumulo.core.iterators.ValueFormatException;
 
 /**
  * A lexicoder for preserving the native Java sort order of Float values.
@@ -42,13 +41,13 @@ public class FloatLexicoder extends AbstractLexicoder<Float> {
 
   @Override
   public Float decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 
   @Override
-  protected Float decodeUnchecked(byte[] b, int offset, int len) throws ValueFormatException {
+  protected Float decodeUnchecked(byte[] b, int offset, int len) {
     int i = intEncoder.decodeUnchecked(b, offset, len);
     if (i < 0) {
       i = i ^ 0x80000000;

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/IntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/IntegerLexicoder.java
@@ -35,8 +35,8 @@ public class IntegerLexicoder extends AbstractLexicoder<Integer> {
 
   @Override
   public Integer decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -65,8 +65,8 @@ public class ListLexicoder<LT> extends AbstractLexicoder<List<LT>> {
 
   @Override
   public List<LT> decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
@@ -69,8 +69,8 @@ public class PairLexicoder<A extends Comparable<A>,B extends Comparable<B>>
 
   @Override
   public ComparablePair<A,B> decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/StringLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/StringLexicoder.java
@@ -35,8 +35,8 @@ public class StringLexicoder extends AbstractLexicoder<String> {
 
   @Override
   public String decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/TextLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/TextLexicoder.java
@@ -35,8 +35,8 @@ public class TextLexicoder extends AbstractLexicoder<Text> {
 
   @Override
   public Text decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UIntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UIntegerLexicoder.java
@@ -56,8 +56,8 @@ public class UIntegerLexicoder extends AbstractLexicoder<Integer> {
 
   @Override
   public Integer decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ULongLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ULongLexicoder.java
@@ -77,8 +77,8 @@ public class ULongLexicoder extends AbstractLexicoder<Long> {
 
   @Override
   public Long decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UUIDLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UUIDLexicoder.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.clientImpl.lexicoder.FixedByteArrayOutputStream;
-import org.apache.accumulo.core.iterators.ValueFormatException;
 
 /**
  * A lexicoder for a UUID that maintains its lexicographic sorting order.
@@ -58,13 +57,13 @@ public class UUIDLexicoder extends AbstractLexicoder<UUID> {
 
   @Override
   public UUID decode(byte[] b) {
-    // This concrete implementation is provided for binary compatibility with 1.6; it can be removed
-    // in 2.0. See ACCUMULO-3789.
+    // This concrete implementation is provided for binary compatibility, since the corresponding
+    // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
     return super.decode(b);
   }
 
   @Override
-  protected UUID decodeUnchecked(byte[] b, int offset, int len) throws ValueFormatException {
+  protected UUID decodeUnchecked(byte[] b, int offset, int len) {
     try {
       DataInputStream in = new DataInputStream(new ByteArrayInputStream(b, offset, len));
       return new UUID(in.readLong() ^ 0x8000000000000000L, in.readLong() ^ 0x8000000000000000L);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/LongCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/LongCombiner.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -53,7 +54,7 @@ public abstract class LongCombiner extends TypedValueCombiner<Long> {
   protected static final String TYPE = "type";
   protected static final String CLASS_PREFIX = "class:";
 
-  public static enum Type {
+  public enum Type {
     /**
      * indicates a variable-length encoding of a Long using {@link LongCombiner.VarLenEncoder}
      */
@@ -143,8 +144,8 @@ public abstract class LongCombiner extends TypedValueCombiner<Long> {
 
     @Override
     public Long decode(byte[] b) {
-      // This concrete implementation is provided for binary compatibility with 1.6; it can be
-      // removed in 2.0. See ACCUMULO-3789.
+      // This concrete implementation is provided for binary compatibility, since the corresponding
+      // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
       return super.decode(b);
     }
 
@@ -179,8 +180,8 @@ public abstract class LongCombiner extends TypedValueCombiner<Long> {
 
     @Override
     public Long decode(byte[] b) {
-      // This concrete implementation is provided for binary compatibility with 1.6; it can be
-      // removed in 2.0. See ACCUMULO-3789.
+      // This concrete implementation is provided for binary compatibility, since the corresponding
+      // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
       return super.decode(b);
     }
 
@@ -225,8 +226,8 @@ public abstract class LongCombiner extends TypedValueCombiner<Long> {
 
     @Override
     public Long decode(byte[] b) {
-      // This concrete implementation is provided for binary compatibility with 1.6; it can be
-      // removed in 2.0. See ACCUMULO-3789.
+      // This concrete implementation is provided for binary compatibility, since the corresponding
+      // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
       return super.decode(b);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/TypedValueCombiner.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
@@ -107,16 +108,6 @@ public abstract class TypedValueCombiner<V> extends Combiner {
     public void remove() {
       source.remove();
     }
-  }
-
-  /**
-   * An interface for translating from byte[] to V and back. Decodes the entire contents of the byte
-   * array.
-   */
-  public interface Encoder<V> {
-    byte[] encode(V v);
-
-    V decode(byte[] b) throws ValueFormatException;
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/BigDecimalCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/BigDecimalCombiner.java
@@ -109,8 +109,8 @@ public abstract class BigDecimalCombiner extends TypedValueCombiner<BigDecimal> 
 
     @Override
     public BigDecimal decode(byte[] b) {
-      // This concrete implementation is provided for binary compatibility with 1.6; it can be
-      // removed in 2.0. See ACCUMULO-3789.
+      // This concrete implementation is provided for binary compatibility, since the corresponding
+      // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
       return super.decode(b);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.lexicoder.AbstractEncoder;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -52,7 +53,7 @@ public class SummingArrayCombiner extends TypedValueCombiner<List<Long>> {
   private static final String TYPE = "type";
   private static final String CLASS_PREFIX = "class:";
 
-  public static enum Type {
+  public enum Type {
     /**
      * indicates a variable-length encoding of a list of Longs using
      * {@link SummingArrayCombiner.VarLongArrayEncoder}
@@ -169,8 +170,8 @@ public class SummingArrayCombiner extends TypedValueCombiner<List<Long>> {
 
     @Override
     public List<V> decode(byte[] b) {
-      // This concrete implementation is provided for binary compatibility with 1.6; it can be
-      // removed in 2.0. See ACCUMULO-3789.
+      // This concrete implementation is provided for binary compatibility, since the corresponding
+      // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
       return super.decode(b);
     }
 
@@ -229,8 +230,8 @@ public class SummingArrayCombiner extends TypedValueCombiner<List<Long>> {
 
     @Override
     public List<Long> decode(byte[] b) {
-      // This concrete implementation is provided for binary compatibility with 1.6; it can be
-      // removed in 2.0. See ACCUMULO-3789.
+      // This concrete implementation is provided for binary compatibility, since the corresponding
+      // superclass method has type-erased return type Object. See ACCUMULO-3789 and #1285.
       return super.decode(b);
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/BigDecimalCombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/BigDecimalCombinerTest.java
@@ -30,13 +30,13 @@ import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.IteratorSetting.Column;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
-import org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -48,7 +49,6 @@ import org.apache.accumulo.core.iterators.LongCombiner.VarLenEncoder;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.iterators.TypedValueCombiner;
-import org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder;
 import org.apache.accumulo.core.iterators.ValueFormatException;
 import org.apache.accumulo.core.iterators.system.MultiIterator;
 import org.apache.hadoop.io.Text;

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/VersioningIteratorTest.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -35,7 +36,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.LongCombiner;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
-import org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 import org.slf4j.Logger;


### PR DESCRIPTION
* Remove public API use of internal ValueFormatException and
TypedValueCombiner.Encoder interface
* Remove exception in Apilyzer configuration for ValueFormatException in
Lexicoder public APIs
* Remove redundant and no-longer needed TypedValueCombiner.Encoder
interface
* Remove unnecessarily overridden decode methods that merely call
super.decode; these were kept for binary compatibility, with very old
versions of Accumulo, but that can be dropped in a major version now,
since Accumulo code isn't compatible with those versions anyway.