### PR TITLE
Fix #1281 Update TabletTime.maxMetatdataTime

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -23,7 +23,7 @@ import org.apache.accumulo.core.client.admin.TimeType;
 /**
  * Immutable metadata time object
  */
-public final class MetadataTime {
+public final class MetadataTime implements Comparable<MetadataTime> {
   private final long time;
   private final TimeType type;
 
@@ -43,7 +43,7 @@ public final class MetadataTime {
   public static MetadataTime parse(String timestr) throws IllegalArgumentException {
 
     if (timestr != null && timestr.length() > 1) {
-      return new MetadataTime(Long.parseLong(timestr.substring(1)), valueOf(timestr.charAt(0)));
+      return new MetadataTime(Long.parseLong(timestr.substring(1)), getType(timestr.charAt(0)));
     } else
       throw new IllegalArgumentException("Unknown metadata time value " + timestr);
   }
@@ -55,7 +55,7 @@ public final class MetadataTime {
    *          character M or L otherwise exception thrown
    * @return a TimeType {@link TimeType} represented by code.
    */
-  public static TimeType valueOf(char code) {
+  public static TimeType getType(char code) {
     switch (code) {
       case 'M':
         return TimeType.MILLIS;
@@ -108,6 +108,15 @@ public final class MetadataTime {
   @Override
   public int hashCode() {
     return Objects.hash(time, type);
+  }
+
+  @Override
+  public int compareTo(MetadataTime mtime) {
+    if (this.type.equals(mtime.getType()))
+      return Long.compare(this.time, mtime.getTime());
+    else
+      throw new IllegalArgumentException(
+          "Cannot compare different time types: " + this + " and " + mtime);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
@@ -25,6 +25,11 @@ import org.junit.Test;
 
 public class MetadataTimeTest {
 
+  private static final MetadataTime m1234 = new MetadataTime(1234, TimeType.MILLIS);
+  private static final MetadataTime m5678 = new MetadataTime(5678, TimeType.MILLIS);
+  private static final MetadataTime l1234 = new MetadataTime(1234, TimeType.LOGICAL);
+  private static final MetadataTime l5678 = new MetadataTime(5678, TimeType.LOGICAL);
+
   @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_InvalidType() {
     MetadataTime.parse("X1234");
@@ -42,24 +47,22 @@ public class MetadataTimeTest {
 
   @Test
   public void testGetInstance_Millis() {
-    MetadataTime mTime = new MetadataTime(1234, TimeType.MILLIS);
-    assertEquals(1234, mTime.getTime());
-    assertEquals(TimeType.MILLIS, mTime.getType());
+    assertEquals(1234, m1234.getTime());
+    assertEquals(TimeType.MILLIS, m1234.getType());
   }
 
   @Test
   public void testGetInstance_Logical() {
-    MetadataTime lTime = new MetadataTime(1234, TimeType.LOGICAL);
-    assertEquals(1234, lTime.getTime());
-    assertEquals(TimeType.LOGICAL, lTime.getType());
+    assertEquals(1234, l1234.getTime());
+    assertEquals(TimeType.LOGICAL, l1234.getType());
 
   }
 
   @Test
   public void testEquality() {
-    assertEquals(new MetadataTime(21, TimeType.MILLIS), MetadataTime.parse("M21"));
-    assertNotEquals(new MetadataTime(21, TimeType.MILLIS), MetadataTime.parse("L21"));
-    assertNotEquals(new MetadataTime(21, TimeType.LOGICAL), new MetadataTime(44, TimeType.LOGICAL));
+    assertEquals(m1234, new MetadataTime(1234, TimeType.MILLIS));
+    assertNotEquals(m1234, l1234);
+    assertNotEquals(l1234, l5678);
   }
 
   @Test
@@ -85,14 +88,12 @@ public class MetadataTimeTest {
 
   @Test
   public void testgetCodeforMillis() {
-    MetadataTime mTime = new MetadataTime(0, TimeType.MILLIS);
-    assertEquals('M', mTime.getCode());
+    assertEquals('M', m1234.getCode());
   }
 
   @Test
   public void testgetCodeforLogical() {
-    MetadataTime mTime = new MetadataTime(0, TimeType.LOGICAL);
-    assertEquals('L', mTime.getCode());
+    assertEquals('L', l1234.getCode());
   }
 
   @Test
@@ -103,48 +104,29 @@ public class MetadataTimeTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testCompareTypesDiffer1() {
-    MetadataTime mTime = new MetadataTime(1234, TimeType.MILLIS);
-    MetadataTime lTime = new MetadataTime(1234, TimeType.LOGICAL);
-    mTime.compareTo(lTime);
+    m1234.compareTo(l1234);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCompareTypesDiffer2() {
-    MetadataTime mTime = new MetadataTime(1234, TimeType.MILLIS);
-    MetadataTime lTime = new MetadataTime(1234, TimeType.LOGICAL);
-    lTime.compareTo(mTime);
+    l1234.compareTo(m1234);
   }
 
   @Test
   public void testCompareSame() {
-    MetadataTime mTime1 = new MetadataTime(1234, TimeType.MILLIS);
-    MetadataTime mTime2 = new MetadataTime(1234, TimeType.MILLIS);
-    assertTrue(mTime1.compareTo(mTime2) == 0);
-
-    MetadataTime lTime1 = new MetadataTime(1234, TimeType.LOGICAL);
-    MetadataTime lTime2 = new MetadataTime(1234, TimeType.LOGICAL);
-    assertTrue(lTime1.compareTo(lTime2) == 0);
+    assertTrue(m1234.compareTo(m1234) == 0);
+    assertTrue(l1234.compareTo(l1234) == 0);
   }
 
   @Test
   public void testCompare1() {
-    MetadataTime mTime1 = new MetadataTime(1234, TimeType.MILLIS);
-    MetadataTime mTime2 = new MetadataTime(5678, TimeType.MILLIS);
-    assertTrue(mTime1.compareTo(mTime2) < 0);
-
-    MetadataTime lTime1 = new MetadataTime(1234, TimeType.LOGICAL);
-    MetadataTime lTime2 = new MetadataTime(5678, TimeType.LOGICAL);
-    assertTrue(lTime1.compareTo(lTime2) < 0);
+    assertTrue(m1234.compareTo(m5678) < 0);
+    assertTrue(l1234.compareTo(l5678) < 0);
   }
 
   @Test
   public void testCompare2() {
-    MetadataTime mTime1 = new MetadataTime(1234, TimeType.MILLIS);
-    MetadataTime mTime2 = new MetadataTime(5678, TimeType.MILLIS);
-    assertTrue(mTime2.compareTo(mTime1) > 0);
-
-    MetadataTime lTime1 = new MetadataTime(1234, TimeType.LOGICAL);
-    MetadataTime lTime2 = new MetadataTime(5678, TimeType.LOGICAL);
-    assertTrue(lTime2.compareTo(lTime1) > 0);
+    assertTrue(m5678.compareTo(m1234) > 0);
+    assertTrue(l5678.compareTo(l1234) > 0);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
@@ -18,6 +18,7 @@ package org.apache.accumulo.core.metadata.schema;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.junit.Test;
@@ -26,17 +27,17 @@ public class MetadataTimeTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_InvalidType() {
-    MetadataTime mTime = MetadataTime.parse("X1234");
+    MetadataTime.parse("X1234");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_Logical_ParseFailure() {
-    MetadataTime mTime = MetadataTime.parse("LABCD");
+    MetadataTime.parse("LABCD");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetInstance_Millis_ParseFailure() {
-    MetadataTime mTime = MetadataTime.parse("MABCD");
+    MetadataTime.parse("MABCD");
   }
 
   @Test
@@ -48,9 +49,9 @@ public class MetadataTimeTest {
 
   @Test
   public void testGetInstance_Logical() {
-    MetadataTime mTime = new MetadataTime(1234, TimeType.LOGICAL);
-    assertEquals(1234, mTime.getTime());
-    assertEquals(TimeType.LOGICAL, mTime.getType());
+    MetadataTime lTime = new MetadataTime(1234, TimeType.LOGICAL);
+    assertEquals(1234, lTime.getTime());
+    assertEquals(TimeType.LOGICAL, lTime.getType());
 
   }
 
@@ -63,17 +64,17 @@ public class MetadataTimeTest {
 
   @Test
   public void testValueOfM() {
-    assertEquals(TimeType.MILLIS, MetadataTime.valueOf('M'));
+    assertEquals(TimeType.MILLIS, MetadataTime.getType('M'));
   }
 
   @Test
   public void testValueOfL() {
-    assertEquals(TimeType.LOGICAL, MetadataTime.valueOf('L'));
+    assertEquals(TimeType.LOGICAL, MetadataTime.getType('L'));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValueOfOtherChar() {
-    MetadataTime.valueOf('x');
+    MetadataTime.getType('x');
   }
 
   @Test
@@ -100,4 +101,50 @@ public class MetadataTimeTest {
     assertEquals("L45678", new MetadataTime(45678, TimeType.LOGICAL).encode());
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testCompareTypesDiffer1() {
+    MetadataTime mTime = new MetadataTime(1234, TimeType.MILLIS);
+    MetadataTime lTime = new MetadataTime(1234, TimeType.LOGICAL);
+    mTime.compareTo(lTime);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCompareTypesDiffer2() {
+    MetadataTime mTime = new MetadataTime(1234, TimeType.MILLIS);
+    MetadataTime lTime = new MetadataTime(1234, TimeType.LOGICAL);
+    lTime.compareTo(mTime);
+  }
+
+  @Test
+  public void testCompareSame() {
+    MetadataTime mTime1 = new MetadataTime(1234, TimeType.MILLIS);
+    MetadataTime mTime2 = new MetadataTime(1234, TimeType.MILLIS);
+    assertTrue(mTime1.compareTo(mTime2) == 0);
+
+    MetadataTime lTime1 = new MetadataTime(1234, TimeType.LOGICAL);
+    MetadataTime lTime2 = new MetadataTime(1234, TimeType.LOGICAL);
+    assertTrue(lTime1.compareTo(lTime2) == 0);
+  }
+
+  @Test
+  public void testCompare1() {
+    MetadataTime mTime1 = new MetadataTime(1234, TimeType.MILLIS);
+    MetadataTime mTime2 = new MetadataTime(5678, TimeType.MILLIS);
+    assertTrue(mTime1.compareTo(mTime2) < 0);
+
+    MetadataTime lTime1 = new MetadataTime(1234, TimeType.LOGICAL);
+    MetadataTime lTime2 = new MetadataTime(5678, TimeType.LOGICAL);
+    assertTrue(lTime1.compareTo(lTime2) < 0);
+  }
+
+  @Test
+  public void testCompare2() {
+    MetadataTime mTime1 = new MetadataTime(1234, TimeType.MILLIS);
+    MetadataTime mTime2 = new MetadataTime(5678, TimeType.MILLIS);
+    assertTrue(mTime2.compareTo(mTime1) > 0);
+
+    MetadataTime lTime1 = new MetadataTime(1234, TimeType.LOGICAL);
+    MetadataTime lTime2 = new MetadataTime(5678, TimeType.LOGICAL);
+    assertTrue(lTime2.compareTo(lTime1) > 0);
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
@@ -54,30 +54,12 @@ public abstract class TabletTime {
       throw new IllegalArgumentException("Time type unknown : " + metadataTime);
   }
 
-  public static String maxMetadataTime(String mv1, String mv2) {
-    if (mv1 == null && mv2 == null) {
-      return null;
-    }
-    // the parse is used to validate the string
-    if (mv1 == null) {
-      return MetadataTime.parse(mv2).encode();
-    }
+  public static MetadataTime maxMetadataTime(MetadataTime mv1, MetadataTime mv2) {
+    // null value will sort lower
+    if (mv1 == null || mv2 == null)
+      return mv1 == null ? (mv2 == null ? null : mv2) : mv1;
 
-    if (mv2 == null) {
-      return MetadataTime.parse(mv1).encode();
-    }
-
-    MetadataTime mv1Time = MetadataTime.parse(mv1);
-    MetadataTime mv2Time = MetadataTime.parse(mv2);
-
-    if (mv1Time.getType() != mv2Time.getType())
-      throw new IllegalArgumentException("Time types differ " + mv1 + " " + mv2);
-
-    if (mv1Time.getTime() < mv2Time.getTime())
-      return mv2;
-    else
-      return mv1;
-
+    return mv1.compareTo(mv2) < 0 ? mv2 : mv1;
   }
 
   static class MillisTime extends TabletTime {

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
@@ -33,6 +33,10 @@ import org.junit.Test;
 public class TabletTimeTest {
   private static final long TIME = 1234L;
   private MillisTime mtime;
+  private static final MetadataTime m1234 = new MetadataTime(1234, TimeType.MILLIS);
+  private static final MetadataTime m5678 = new MetadataTime(5678, TimeType.MILLIS);
+  private static final MetadataTime l1234 = new MetadataTime(1234, TimeType.LOGICAL);
+  private static final MetadataTime l5678 = new MetadataTime(5678, TimeType.LOGICAL);
 
   @Before
   public void setUp() {
@@ -65,72 +69,44 @@ public class TabletTimeTest {
 
   @Test
   public void testMaxMetadataTime_Logical() {
-    assertEquals("L5678", TabletTime.maxMetadataTime("L1234", "L5678"));
-    assertEquals("L5678", TabletTime.maxMetadataTime("L5678", "L1234"));
-    assertEquals("L5678", TabletTime.maxMetadataTime("L5678", "L5678"));
+    assertEquals(l5678, TabletTime.maxMetadataTime(l1234, l5678));
+    assertEquals(l5678, TabletTime.maxMetadataTime(l5678, l1234));
+    assertEquals(l5678, TabletTime.maxMetadataTime(l5678, l5678));
   }
 
   @Test
   public void testMaxMetadataTime_Millis() {
-    assertEquals("M5678", TabletTime.maxMetadataTime("M1234", "M5678"));
-    assertEquals("M5678", TabletTime.maxMetadataTime("M5678", "M1234"));
-    assertEquals("M5678", TabletTime.maxMetadataTime("M5678", "M5678"));
+    assertEquals(m5678, TabletTime.maxMetadataTime(m1234, m5678));
+    assertEquals(m5678, TabletTime.maxMetadataTime(m5678, m1234));
+    assertEquals(m5678, TabletTime.maxMetadataTime(m5678, m5678));
   }
 
   @Test
   public void testMaxMetadataTime_Null1() {
-    assertEquals("L5678", TabletTime.maxMetadataTime(null, "L5678"));
-    assertEquals("M5678", TabletTime.maxMetadataTime(null, "M5678"));
+    assertEquals(l5678, TabletTime.maxMetadataTime(null, l5678));
+    assertEquals(m5678, TabletTime.maxMetadataTime(null, m5678));
   }
 
   @Test
   public void testMaxMetadataTime_Null2() {
-    assertEquals("L5678", TabletTime.maxMetadataTime("L5678", null));
-    assertEquals("M5678", TabletTime.maxMetadataTime("M5678", null));
+    assertEquals(l5678, TabletTime.maxMetadataTime(l5678, null));
+    assertEquals(m5678, TabletTime.maxMetadataTime(m5678, null));
   }
 
   @Test
   public void testMaxMetadataTime_Null3() {
-    assertNull(TabletTime.maxMetadataTime(null, null));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testMaxMetadataTime_Null1_Invalid() {
-    TabletTime.maxMetadataTime(null, "X5678");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testMaxMetadataTime_Null2_Invalid() {
-    TabletTime.maxMetadataTime("X5678", null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testMaxMetadataTime_Invalid1() {
-    TabletTime.maxMetadataTime("X1234", "L5678");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testMaxMetadataTime_Invalid2() {
-    TabletTime.maxMetadataTime("L1234", "X5678");
+    MetadataTime nullTime = null;
+    assertNull(TabletTime.maxMetadataTime(nullTime, nullTime));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMaxMetadataTime_DifferentTypes1() {
-    TabletTime.maxMetadataTime("L1234", "M5678");
+    TabletTime.maxMetadataTime(l1234, m5678);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMaxMetadataTime_DifferentTypes2() {
-    TabletTime.maxMetadataTime("X1234", "Y5678");
+    TabletTime.maxMetadataTime(m1234, l5678);
   }
 
-  @Test(expected = NumberFormatException.class)
-  public void testMaxMetadataTime_ParseFailure1() {
-    TabletTime.maxMetadataTime("L1234", "LABCD");
-  }
-
-  @Test(expected = NumberFormatException.class)
-  public void testMaxMetadataTime_ParseFailure2() {
-    TabletTime.maxMetadataTime("LABCD", "L5678");
-  }
 }


### PR DESCRIPTION
Replaced string processing with MetadataTime objects. 

Renamed MetadataTime class method valueOf(char) to getType(char) .  The valueOf was confusing and didn't really make sense once it was pulled from the ENUM TimeType class.

