### PR TITLE
ACCUMULO-1256: Add trash can for deleted tables

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -18,6 +18,8 @@ package org.apache.accumulo.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.util.regex.Pattern;
+
 public class Constants {
 
   public static final String VERSION = FilteredConstants.VERSION;
@@ -118,4 +120,8 @@ public class Constants {
   public static final String HDFS_TABLES_DIR = "/tables";
 
   public static final int DEFAULT_VISIBILITY_CACHE_SIZE = 1000;
+
+  public static final String TRASH_DATE_FORMAT = "yyyyMMddHHmmss";
+  public static final Pattern TRASH_TABLE_NAME_PATTERN =
+      Pattern.compile("^trash_(.*)_(\\d{14})_(\\d*)");
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1031,6 +1031,43 @@ public interface TableOperations {
       throws TableNotFoundException, AccumuloException, AccumuloSecurityException;
 
   /**
+   * @return tables currently in trash
+   */
+  SortedSet<String> listTrash();
+
+  /**
+   * Undelete a table to its former name.
+   *
+   * @param trashTableName
+   *          the name of a table currently in trash
+   *
+   * @throws TableNotFoundException
+   *           if trash table does not exists
+   * @throws TableExistsException
+   *           if former name is in use
+   */
+  default void undelete(String trashTableName) throws TableNotFoundException, TableExistsException,
+      AccumuloException, AccumuloSecurityException {
+    undelete(trashTableName, null);
+  }
+
+  /**
+   * Undelete a table to a new name.
+   *
+   * @param trashTableName
+   *          the name of a table currently in trash
+   * @param tableName
+   *          the name to use for this table after undeleting
+   *
+   * @throws TableNotFoundException
+   *           if trash table does not exists
+   * @throws TableExistsException
+   *           if new name is in use
+   */
+  void undelete(String trashTableName, String tableName) throws TableNotFoundException,
+      TableExistsException, AccumuloException, AccumuloSecurityException;
+
+  /**
    * Entry point for retrieving summaries with optional restrictions.
    *
    * <p>

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -423,8 +423,11 @@ public class ClientContext implements AccumuloClient {
 
   TableId getTableId(String tableName) throws TableNotFoundException {
     TableId tableId = Tables.getTableId(this, tableName);
-    if (Tables.getTableState(this, tableId) == TableState.OFFLINE)
+    TableState state = Tables.getTableState(this, tableId);
+    if (state == TableState.OFFLINE)
       throw new TableOfflineException(Tables.getTableOfflineMsg(this, tableId));
+    if (state == TableState.TRASH)
+      throw new TableNotFoundException(null, tableName, null);
     return tableId;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
@@ -104,6 +104,16 @@ public class Namespaces {
     return names;
   }
 
+  public static List<String> getTrashTableNames(ClientContext context, NamespaceId namespaceId)
+      throws NamespaceNotFoundException {
+    String namespace = getNamespaceName(context, namespaceId);
+    List<String> names = new LinkedList<>();
+    for (String name : Tables.getTrashNameToIdMap(context).keySet())
+      if (namespace.equals(Tables.qualify(name).getFirst()))
+        names.add(name);
+    return names;
+  }
+
   /**
    * Gets all the namespaces from ZK. The first arg (t) the BiConsumer accepts is the ID and the
    * second (u) is the namespaceName.

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
@@ -136,6 +136,33 @@ public class Tables {
     return tableName;
   }
 
+  public static TableId _getTrashTableId(ClientContext context, String tableName)
+      throws NamespaceNotFoundException, TableNotFoundException {
+    TableId tableId = getTrashNameToIdMap(context).get(tableName);
+    if (tableId == null) {
+      // maybe the table exist, but the cache was not updated yet... so try to clear the cache and
+      // check again
+      clearCache(context);
+      tableId = getTrashNameToIdMap(context).get(tableName);
+      if (tableId == null) {
+        String namespace = qualify(tableName).getFirst();
+        if (Namespaces.getNameToIdMap(context).containsKey(namespace))
+          throw new TableNotFoundException(null, tableName, null);
+        else
+          throw new NamespaceNotFoundException(null, namespace, null);
+      }
+    }
+    return tableId;
+  }
+
+  public static String getTrashTableName(ClientContext context, TableId tableId)
+      throws TableNotFoundException {
+    String tableName = getTrashIdToNameMap(context).get(tableId);
+    if (tableName == null)
+      throw new TableNotFoundException(tableId.canonical(), null, null);
+    return tableName;
+  }
+
   public static String getTableOfflineMsg(ClientContext context, TableId tableId) {
     if (tableId == null)
       return "Table <unknown table> is offline";
@@ -153,6 +180,14 @@ public class Tables {
 
   public static Map<TableId,String> getIdToNameMap(ClientContext context) {
     return getTableMap(context).getIdtoNameMap();
+  }
+
+  public static Map<String,TableId> getTrashNameToIdMap(ClientContext context) {
+    return getTableMap(context).getTrashNameToIdMap();
+  }
+
+  public static Map<TableId,String> getTrashIdToNameMap(ClientContext context) {
+    return getTableMap(context).getTrashIdToNameMap();
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/thrift/TableOperation.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/thrift/TableOperation.java
@@ -40,7 +40,9 @@ public enum TableOperation implements org.apache.thrift.TEnum {
   COMPACT(13),
   IMPORT(14),
   EXPORT(15),
-  COMPACT_CANCEL(16);
+  COMPACT_CANCEL(16),
+  TRASH(17),
+  UNDELETE(18);
 
   private final int value;
 
@@ -96,6 +98,10 @@ public enum TableOperation implements org.apache.thrift.TEnum {
         return EXPORT;
       case 16:
         return COMPACT_CANCEL;
+      case 17:
+        return TRASH;
+      case 18:
+        return UNDELETE;
       default:
         return null;
     }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -226,6 +226,13 @@ public enum Property {
   GENERAL_MAX_SCANNER_RETRY_PERIOD("general.max.scanner.retry.period", "5s",
       PropertyType.TIMEDURATION,
       "The maximum amount of time that a Scanner should wait before retrying a failed RPC"),
+  GENERAL_TRASH_ENABLED("general.trash.ebaled", "false", PropertyType.BOOLEAN,
+      "On delete move the table to Trash first, allowing it to be restored"
+          + " and only delete it after a given time period"),
+  GENERAL_TRASH_PERIOD("general.trash.period", "1d", PropertyType.TIMEDURATION,
+      "The maximum amount of time a table spends in Trash before deleted"),
+  GENERAL_TRASH_TIMER_PERIOD("general.trash.timer.period", "1h", PropertyType.TIMEDURATION,
+      "The time interval between checks for outdated trash tables."),
 
   // properties that are specific to master server behavior
   MASTER_PREFIX("master.", null, PropertyType.PREFIX,

--- a/core/src/main/java/org/apache/accumulo/core/master/state/tables/TableState.java
+++ b/core/src/main/java/org/apache/accumulo/core/master/state/tables/TableState.java
@@ -31,5 +31,9 @@ public enum TableState {
 
   // UNKNOWN is NOT a valid state; it is reserved for unrecognized serialized
   // representations of table state
-  UNKNOWN
+  UNKNOWN,
+
+  // TRASH optional temporary state before deletion, allows the table to be restored, but otherwise
+  // behaves as deleted
+  TRASH
 }

--- a/core/src/main/java/org/apache/accumulo/core/master/thrift/FateOperation.java
+++ b/core/src/main/java/org/apache/accumulo/core/master/thrift/FateOperation.java
@@ -40,7 +40,8 @@ public enum FateOperation implements org.apache.thrift.TEnum {
   NAMESPACE_CREATE(13),
   NAMESPACE_DELETE(14),
   NAMESPACE_RENAME(15),
-  TABLE_BULK_IMPORT2(16);
+  TABLE_BULK_IMPORT2(16),
+  TABLE_UNDELETE(17);
 
   private final int value;
 
@@ -96,6 +97,8 @@ public enum FateOperation implements org.apache.thrift.TEnum {
         return NAMESPACE_RENAME;
       case 16:
         return TABLE_BULK_IMPORT2;
+      case 17:
+        return TABLE_UNDELETE;
       default:
         return null;
     }

--- a/core/src/main/thrift/client.thrift
+++ b/core/src/main/thrift/client.thrift
@@ -38,6 +38,8 @@ enum TableOperation {
   IMPORT
   EXPORT
   COMPACT_CANCEL
+  TRASH
+  UNDELETE
 }
 
 enum TableOperationExceptionType {

--- a/core/src/main/thrift/master.thrift
+++ b/core/src/main/thrift/master.thrift
@@ -160,6 +160,7 @@ enum FateOperation {
   NAMESPACE_DELETE
   NAMESPACE_RENAME
   TABLE_BULK_IMPORT2
+  TABLE_UNDELETE
 }
 
 service FateService {

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
@@ -34,7 +34,10 @@ import java.util.TreeMap;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.DiskUsage;
 import org.apache.accumulo.core.client.admin.Locations;
@@ -219,6 +222,15 @@ public class TableOperationsHelperTest {
     public SamplerConfiguration getSamplerConfiguration(String tableName) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public SortedSet<String> listTrash() {
+      return null;
+    }
+
+    @Override
+    public void undelete(String trashTableName, String tableName) throws TableNotFoundException,
+        TableExistsException, AccumuloException, AccumuloSecurityException {}
 
     @Override
     public Locations locate(String tableName, Collection<Range> ranges) {

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -99,6 +99,20 @@ public class ClientServiceHandler implements ClientService.Iface {
     throw new ThriftTableOperationException(null, tableName, operation, reason, null);
   }
 
+  public static TableId checkTrashTableId(ClientContext context, String tableName,
+      TableOperation operation) throws ThriftTableOperationException {
+    TableOperationExceptionType reason = null;
+    try {
+      return Tables._getTrashTableId(context, tableName);
+    } catch (NamespaceNotFoundException e) {
+      reason = TableOperationExceptionType.NAMESPACE_NOTFOUND;
+    } catch (TableNotFoundException e) {
+      reason = TableOperationExceptionType.NOTFOUND;
+    }
+    throw new ThriftTableOperationException(null, tableName, operation, reason,
+        "Finding TableId for trash table failed");
+  }
+
   public static NamespaceId checkNamespaceId(ClientContext context, String namespaceName,
       TableOperation operation) throws ThriftTableOperationException {
     NamespaceId namespaceId = Namespaces.lookupNamespaceId(context, namespaceName);

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -520,6 +520,13 @@ public class SecurityOperation {
         || hasTablePermission(c, tableId, namespaceId, TablePermission.DROP_TABLE, false);
   }
 
+  public boolean canUndeleteTable(TCredentials c, TableId tableId, NamespaceId namespaceId)
+      throws ThriftSecurityException {
+    authenticate(c);
+    return hasSystemPermissionWithNamespaceId(c, SystemPermission.DROP_TABLE, namespaceId, false)
+        || hasTablePermission(c, tableId, namespaceId, TablePermission.DROP_TABLE, false);
+  }
+
   public boolean canOnlineOfflineTable(TCredentials c, TableId tableId, FateOperation op,
       NamespaceId namespaceId) throws ThriftSecurityException {
     authenticate(c);

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -167,6 +167,7 @@ public class TableManager {
               break;
             case ONLINE: // fall-through intended
             case UNKNOWN:// fall through intended
+            case TRASH: // fall through intended
             case OFFLINE:
               transition = (newState != TableState.NEW);
               break;

--- a/server/master/src/main/java/org/apache/accumulo/master/DeleteTrashTablesTask.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/DeleteTrashTablesTask.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.master;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.fate.Fate;
+import org.apache.accumulo.master.tableOps.TraceRepo;
+import org.apache.accumulo.master.tableOps.delete.DeleteTable;
+import org.apache.accumulo.server.ServerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DeleteTrashTablesTask implements Runnable {
+
+  private static final Logger log = LoggerFactory.getLogger(DeleteTrashTablesTask.class);
+
+  private final Fate<Master> fate;
+  private final ServerContext context;
+  private final long period;
+
+  DeleteTrashTablesTask(Fate<Master> fate, ServerContext context, long period) {
+    this.fate = fate;
+    this.context = context;
+    this.period = period;
+  }
+
+  @Override
+  public void run() {
+    Set<String> tables = Tables.getTrashNameToIdMap(context).keySet();
+    Set<String> outdatedTables = new HashSet<>();
+    Date now = new Date();
+
+    for (String table : tables) {
+      Matcher matcher = Constants.TRASH_TABLE_NAME_PATTERN.matcher(table);
+      if (matcher.find()) {
+        String timestamp = matcher.group(2);
+        try {
+          Date formatedDate = new SimpleDateFormat(Constants.TRASH_DATE_FORMAT).parse(timestamp);
+          Date eol = new Date(formatedDate.getTime() + period);
+          if (eol.before(now)) {
+            outdatedTables.add(table);
+          }
+        } catch (ParseException e) {
+          log.debug("Potentially ill-formatted trash table name: " + table);
+        }
+      }
+    }
+
+    for (String table : outdatedTables) {
+      long tid = fate.startTransaction();
+      log.debug("Seeding FATE op to delete trash table " + table + " with tid " + tid);
+      try {
+        TableId tableId = Tables.getTrashNameToIdMap(context).get(table);
+        NamespaceId namespaceId = Tables.getNamespaceId(context, tableId);
+
+        fate.seedTransaction(tid, new TraceRepo<>(new DeleteTable(namespaceId, tableId)), false);
+        fate.waitForCompletion(tid);
+      } catch (TableNotFoundException e) {
+        log.debug("FATE op deleting trash table " + table + " failed", e);
+      } finally {
+        fate.delete(tid);
+      }
+      log.debug("FATE op deleting trash table " + table + " finished");
+    }
+  }
+}

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -583,6 +583,7 @@ public class Master extends AbstractServer
         return TabletGoalState.DELETED;
       case OFFLINE:
       case NEW:
+      case TRASH:
         return TabletGoalState.UNASSIGNED;
       default:
         return TabletGoalState.HOSTED;
@@ -1163,6 +1164,15 @@ public class Master extends AbstractServer
       log.info("Failed to register {} metrics modules", failureCount);
     } else {
       log.info("All metrics modules registered");
+    }
+
+    if (getConfiguration().getBoolean(Property.GENERAL_TRASH_ENABLED)) {
+      long delayBetweenChecks =
+          getConfiguration().getTimeInMillis(Property.GENERAL_TRASH_TIMER_PERIOD);
+      long spendsInTrash = getConfiguration().getTimeInMillis(Property.GENERAL_TRASH_PERIOD);
+
+      DeleteTrashTablesTask task = new DeleteTrashTablesTask(fate, getContext(), spendsInTrash);
+      SimpleTimer.getInstance(getConfiguration()).schedule(task, 1000l, delayBetweenChecks);
     }
 
     // The master is fully initialized. Clients are allowed to connect now.

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/delete/TrashTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/delete/TrashTable.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.master.tableOps.delete;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.fate.Repo;
+import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
+import org.apache.accumulo.master.Master;
+import org.apache.accumulo.master.tableOps.MasterRepo;
+import org.apache.accumulo.master.tableOps.Utils;
+import org.slf4j.LoggerFactory;
+
+public class TrashTable extends MasterRepo {
+
+  private static final long serialVersionUID = 1L;
+  private static final int MAX_TABLES_WITH_MATCHING_NAMES = 100;
+
+  private TableId tableId;
+  private NamespaceId namespaceId;
+
+  @Override
+  public long isReady(long tid, Master env) throws Exception {
+    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.TRASH)
+        + Utils.reserveTable(env, tableId, tid, true, true, TableOperation.TRASH);
+  }
+
+  public TrashTable(NamespaceId namespaceId, TableId tableId) {
+    this.namespaceId = namespaceId;
+    this.tableId = tableId;
+  }
+
+  @Override
+  public Repo<Master> call(long tid, Master master) throws Exception {
+    final String tableOriginalName = Tables.getTableName(master.getContext(), tableId);
+    Pair<String,String> qualifiedName = Tables.qualify(tableOriginalName);
+    Date now = new Date();
+    String formatedDate = new SimpleDateFormat(Constants.TRASH_DATE_FORMAT).format(now);
+    String namespace = qualifiedName.getFirst() != null && qualifiedName.getFirst().length() > 0
+        ? qualifiedName.getFirst() + "." : "";
+    String trashTableBaseName =
+        namespace + "trash_" + qualifiedName.getSecond() + "_" + formatedDate + "_";
+
+    IZooReaderWriter zoo = master.getContext().getZooReaderWriter();
+
+    Utils.getTableNameLock().lock();
+    int counter = 1;
+    try {
+      boolean foundNotUsedCounter = false;
+      while (!foundNotUsedCounter) {
+        try {
+          Utils.checkTableDoesNotExist(master.getContext(), trashTableBaseName + counter, null,
+              TableOperation.TRASH);
+        } catch (Exception e) {
+          if (counter < MAX_TABLES_WITH_MATCHING_NAMES) {
+            continue;
+          }
+          throw e;
+        }
+        foundNotUsedCounter = true;
+      }
+
+      final String trashTableName = trashTableBaseName + counter;
+      final String tap =
+          master.getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_NAME;
+
+      zoo.mutate(tap, null, null, current -> {
+        final String currentName = new String(current, UTF_8);
+        if (currentName.equals(trashTableName))
+          return null; // assume in this case the operation is running again, so we are done
+        if (!currentName.equals(tableOriginalName)) {
+          throw new AcceptableThriftTableOperationException(null, tableOriginalName,
+              TableOperation.TRASH, TableOperationExceptionType.NOTFOUND,
+              "Name changed while processing");
+        }
+        return trashTableName.getBytes(UTF_8);
+      });
+      Tables.clearCache(master.getContext());
+    } finally {
+      Utils.getTableNameLock().unlock();
+      Utils.unreserveTable(master, tableId, tid, true);
+      Utils.unreserveNamespace(master, namespaceId, tid, false);
+    }
+
+    master.getTableManager().transitionTableState(tableId, TableState.TRASH);
+    master.getEventCoordinator().event("deleting table %s ", tableId);
+
+    LoggerFactory.getLogger(TrashTable.class).debug("Trash table {} {} {}", tableId,
+        trashTableBaseName + counter, tableOriginalName);
+
+    return null;
+  }
+
+  @Override
+  public void undo(long tid, Master env) {
+    Utils.unreserveTable(env, tableId, tid, true);
+    Utils.unreserveNamespace(env, namespaceId, tid, false);
+  }
+
+}

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/delete/UndeleteTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/delete/UndeleteTable.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.master.tableOps.delete;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.regex.Matcher;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.clientImpl.Namespaces;
+import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.fate.Repo;
+import org.apache.accumulo.fate.zookeeper.IZooReaderWriter;
+import org.apache.accumulo.master.Master;
+import org.apache.accumulo.master.tableOps.MasterRepo;
+import org.apache.accumulo.master.tableOps.Utils;
+import org.slf4j.LoggerFactory;
+
+public class UndeleteTable extends MasterRepo {
+
+  private static final long serialVersionUID = 1L;
+
+  private TableId tableId;
+  private NamespaceId namespaceId;
+  private String newTableName;
+
+  @Override
+  public long isReady(long tid, Master env) throws Exception {
+    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.UNDELETE)
+        + Utils.reserveTable(env, tableId, tid, true, true, TableOperation.UNDELETE);
+  }
+
+  public UndeleteTable(NamespaceId namespaceId, TableId tableId, String newTableName) {
+    this.namespaceId = namespaceId;
+    this.tableId = tableId;
+    this.newTableName = newTableName;
+  }
+
+  @Override
+  public Repo<Master> call(long tid, Master master) throws Exception {
+    final String trashTableFullName = Tables.getTrashTableName(master.getContext(), tableId);
+
+    if (Tables.getTableState(master.getContext(), tableId) != TableState.TRASH)
+      throw new AcceptableThriftTableOperationException(tableId.canonical(), trashTableFullName,
+          TableOperation.UNDELETE, TableOperationExceptionType.OTHER,
+          "Only tables from the Trash can be undeleted");
+
+    Pair<String,String> qualifiedName = Tables.qualify(trashTableFullName);
+    if (newTableName != null) {
+      Pair<String,String> qualifiedNewTableName = Tables.qualify(newTableName);
+
+      // ensure no attempt is made to rename across namespaces
+      if (newTableName.contains(".") && !namespaceId
+          .equals(Namespaces.getNamespaceId(master.getContext(), qualifiedNewTableName.getFirst())))
+        throw new AcceptableThriftTableOperationException(tableId.canonical(), trashTableFullName,
+            TableOperation.UNDELETE, TableOperationExceptionType.INVALID_NAME,
+            "Namespace in new table name does not match the old table name");
+    } else {
+      Matcher matcher = Constants.TRASH_TABLE_NAME_PATTERN.matcher(qualifiedName.getSecond());
+      matcher.find();
+      String originalName = matcher.group(1);
+      String namespace = qualifiedName.getFirst() != null && qualifiedName.getFirst().length() > 0
+          ? qualifiedName.getFirst() + "." : "";
+      newTableName = namespace + originalName;
+    }
+
+    final String finalName = newTableName;
+    IZooReaderWriter zoo = master.getContext().getZooReaderWriter();
+
+    Utils.getTableNameLock().lock();
+    try {
+      Utils.checkTableDoesNotExist(master.getContext(), newTableName, tableId,
+          TableOperation.UNDELETE);
+
+      final String tap =
+          master.getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_NAME;
+
+      zoo.mutate(tap, null, null, current -> {
+        final String currentName = new String(current, UTF_8);
+        if (currentName.equals(finalName))
+          return null; // assume in this case the operation is running again, so we are done
+        if (!currentName.equals(trashTableFullName)) {
+          throw new AcceptableThriftTableOperationException(null, trashTableFullName,
+              TableOperation.UNDELETE, TableOperationExceptionType.NOTFOUND,
+              "Name changed while processing");
+        }
+        return finalName.getBytes(UTF_8);
+      });
+      Tables.clearCache(master.getContext());
+    } finally {
+      Utils.getTableNameLock().unlock();
+      Utils.unreserveTable(master, tableId, tid, true);
+      Utils.unreserveNamespace(master, namespaceId, tid, false);
+    }
+
+    master.getTableManager().transitionTableState(tableId, TableState.ONLINE);
+    master.getEventCoordinator().event("undeleting table %s ", tableId);
+
+    LoggerFactory.getLogger(UndeleteTable.class).debug("Undelete table {} {} {}", tableId,
+        newTableName, trashTableFullName);
+
+    return null;
+  }
+
+  @Override
+  public void undo(long tid, Master env) {
+    Utils.unreserveTable(env, tableId, tid, true);
+    Utils.unreserveNamespace(env, namespaceId, tid, false);
+  }
+
+}

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/UndeleteTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/UndeleteTableCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.shell.commands;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.shell.Shell;
+import org.apache.accumulo.shell.Shell.Command;
+import org.apache.accumulo.shell.Token;
+import org.apache.commons.cli.CommandLine;
+
+public class UndeleteTableCommand extends Command {
+  @Override
+  public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
+      TableExistsException {
+
+    shellState.getAccumuloClient().tableOperations().undelete(cl.getArgs()[0],
+        cl.getArgs().length > 1 ? cl.getArgs()[1] : null);
+    if (shellState.getTableName().equals(Tables.qualified(cl.getArgs()[0]))) {
+      shellState.setTableName("");
+    }
+    return 0;
+  }
+
+  @Override
+  public String usage() {
+    return getName() + " <trash table name> (<restored table name>)";
+  }
+
+  @Override
+  public String description() {
+    return "restores a table from trash can";
+  }
+
+  @Override
+  public void registerCompletion(final Token root,
+      final Map<CompletionSet,Set<String>> completionSet) {
+    registerCompletionForTables(root, completionSet);
+  }
+
+  @Override
+  public int numArgs() {
+    // we have one required and one optional argument
+    return Shell.NO_FIXED_ARG_LENGTH_CHECK;
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/TrashCanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TrashCanIT.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.TestIngest;
+import org.apache.accumulo.test.VerifyIngest.VerifyParams;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+public class TrashCanIT extends AccumuloClusterHarness {
+
+  @Override
+  public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setProperty(Property.GENERAL_TRASH_ENABLED, "true");
+    cfg.setProperty(Property.GENERAL_TRASH_TIMER_PERIOD, "1s");
+    cfg.setProperty(Property.GENERAL_TRASH_PERIOD, "2s");
+  }
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 50 * 60;
+  }
+
+  @Test
+  public void deleteWithTrashTest() throws Exception {
+    String[] tableNames = getUniqueNames(1);
+    String name = tableNames[0];
+    VerifyParams params = new VerifyParams(cluster.getClientProperties(), name);
+    params.createTable = true;
+
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      TestIngest.ingest(c, params);
+      TableId tableId = Tables.getTableId((ClientContext) c, name);
+      TableState tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      String tableName = Tables.getTableName((ClientContext) c, tableId);
+
+      c.tableOperations().delete(name);
+
+      tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      assertTrue(TableState.TRASH.equals(tabeleState));
+
+      String trashName = Tables.getTrashTableName((ClientContext) c, tableId);
+      c.tableOperations().delete(trashName);
+
+      assertFalse(Tables.exists((ClientContext) c, tableId));
+      tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      assertTrue(TableState.UNKNOWN.equals(tabeleState));
+    }
+  }
+
+  @Test
+  public void undeleteFromTrashTest() throws Exception {
+    String[] tableNames = getUniqueNames(1);
+    String name = tableNames[0];
+    VerifyParams params = new VerifyParams(cluster.getClientProperties(), name);
+    params.createTable = true;
+
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      TestIngest.ingest(c, params);
+      TableId tableId = Tables.getTableId((ClientContext) c, name);
+      TableState tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      String tableName = Tables.getTableName((ClientContext) c, tableId);
+
+      c.tableOperations().delete(name);
+
+      tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      assertTrue(TableState.TRASH.equals(tabeleState));
+
+      String trashName = Tables.getTrashTableName((ClientContext) c, tableId);
+      c.tableOperations().undelete(trashName);
+
+      assertTrue(Tables.exists((ClientContext) c, tableId));
+      tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      assertTrue(TableState.ONLINE.equals(tabeleState));
+
+      String newTableName = Tables.getTableName((ClientContext) c, tableId);
+      assertTrue(tableName.equals(newTableName));
+    }
+  }
+
+  @Test
+  public void timerEmptyTrashTest() throws Exception {
+    String[] tableNames = getUniqueNames(1);
+    String name = tableNames[0];
+    VerifyParams params = new VerifyParams(cluster.getClientProperties(), name);
+    params.createTable = true;
+
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      TestIngest.ingest(c, params);
+      TableId tableId = Tables.getTableId((ClientContext) c, name);
+      TableState tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      String tableName = Tables.getTableName((ClientContext) c, tableId);
+
+      c.tableOperations().delete(name);
+
+      tabeleState = Tables.getTableState((ClientContext) c, tableId);
+      assertTrue(TableState.TRASH.equals(tabeleState));
+
+      // to make sure the task is triggered
+      Thread.sleep(3000l);
+
+      assertFalse(Tables.exists((ClientContext) c, tableId));
+    }
+  }
+
+}


### PR DESCRIPTION
This is more like a POC to get some feedback and start a discussion than a full implementation.

I tried to follow the original proposal attached to the ticket as closely as possible but it seems outdated and lacks some details. The main areas where I would appreciate feedback the most are the timer handling and the "separate tables in the trash from the rest" part.

- I use the SimpleTimer to run the task that deletes outdated tables from the Trash Can. It looks too fragile for something like this, but I couldn't find a better example in the code.

- My other concern is how to separate the tables in the trash from the rest of the application without breaking existing logic. I decided to store them separately in the cached TableMap and add dedicated Trash related getters for them where needed. As far as I can tell this solves the issue but I'm not familiar enough with the application to be sure I haven't moved them out of the reach of some crucial process.

- Also I found myself relying more and more on the trashed table's name pattern to recognize a trashed table instead of looking up the table state every time. This looked simpler and faster, but I'm not sure I like it. If this proves an acceptable approach the create and rename operations should be extended with a check to prevent users from using the same name format themselves.