### PR TITLE
Fix #1043 Support stable ~del split points

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.io.Text;
 public class MetadataSchema {
 
   public static final String RESERVED_PREFIX = "~";
+  public static final int ENCODED_PREFIX_LENGTH =
+      MetadataSchema.DeletesSection.getRowPrefix().length() + SortSkew.SORTSKEW_LENGTH;
 
   /**
    * Used for storing information about tablets
@@ -261,6 +263,14 @@ public class MetadataSchema {
 
     public static String getRowPrefix() {
       return section.getRowPrefix();
+    }
+
+    public static String encodeRow(String value) {
+      return getRowPrefix() + SortSkew.getCode(value) + value;
+    }
+
+    public static String decodeRow(String row) {
+      return row.substring(ENCODED_PREFIX_LENGTH);
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -37,8 +37,6 @@ import org.apache.hadoop.io.Text;
 public class MetadataSchema {
 
   public static final String RESERVED_PREFIX = "~";
-  public static final int ENCODED_PREFIX_LENGTH =
-      MetadataSchema.DeletesSection.getRowPrefix().length() + SortSkew.SORTSKEW_LENGTH;
 
   /**
    * Used for storing information about tablets
@@ -257,20 +255,19 @@ public class MetadataSchema {
     private static final Section section =
         new Section(RESERVED_PREFIX + "del", true, RESERVED_PREFIX + "dem", false);
 
+    private static final int encoded_prefix_length =
+        section.getRowPrefix().length() + SortSkew.SORTSKEW_LENGTH;
+
     public static Range getRange() {
       return section.getRange();
     }
 
-    public static String getRowPrefix() {
-      return section.getRowPrefix();
-    }
-
     public static String encodeRow(String value) {
-      return getRowPrefix() + SortSkew.getCode(value) + value;
+      return section.getRowPrefix() + SortSkew.getCode(value) + value;
     }
 
     public static String decodeRow(String row) {
-      return row.substring(ENCODED_PREFIX_LENGTH);
+      return row.substring(encoded_prefix_length);
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/SortSkew.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/SortSkew.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static com.google.common.hash.Hashing.murmur3_32;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Strings;
+
+/*
+ * A subprefix used to remove sort skew from some of the metadata generated entries, for example: file deletes
+ * prefixed with ~del.  NOTE:  This is persisted data so any change to this processing should
+ * consider any existing data.
+ */
+public class SortSkew {
+
+  // A specified length for the skew code used is necessary to parse the key correctly.
+  // The Hex code for an integer will always be <= 8
+  public static final int SORTSKEW_LENGTH = Integer.BYTES * 2;
+
+  /**
+   * Creates a left justified hex string for the path hashcode of a deterministic length, therefore
+   * if necessary it is right padded with zeros
+   *
+   * @param keypart
+   *          value to be coded
+   * @return coded value of keypart
+   */
+  public static String getCode(String keypart) {
+    int hashCode = murmur3_32().hashString(keypart, UTF_8).asInt();
+    return Strings.padStart(Integer.toHexString(hashCode), SORTSKEW_LENGTH, '0');
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/DeleteMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/DeleteMetadataTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class DeleteMetadataTest {
+
+  @Test
+  public void encodeRowTest() {
+    String path = "/dir/testpath";
+    assertEquals(path,
+        MetadataSchema.DeletesSection.decodeRow(MetadataSchema.DeletesSection.encodeRow(path)));
+    path = "hdfs://localhost:8020/dir/r+/1_table/f$%#";
+    assertEquals(path,
+        MetadataSchema.DeletesSection.decodeRow(MetadataSchema.DeletesSection.encodeRow(path)));
+
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/SortSkewTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/SortSkewTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+public class SortSkewTest {
+  private static final String shortpath = "1";
+  private static final String longpath =
+      "/verylongpath/12345679xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii/zzzzzzzzzzzzzzzzzzzzz"
+          + "aaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbccccccccccccccccccccccccccxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzz";;
+  // these are values previously generated from SortSkew.getCode() for the above
+  private static final String shortcode = "9416ac93";
+  private static final String longcode = "b9ddf266";
+
+  @Test
+  public void verifyCodeSize() {
+    int expectedLength = SortSkew.SORTSKEW_LENGTH;
+    assertEquals(expectedLength, SortSkew.getCode(shortpath).length());
+    assertEquals(expectedLength, SortSkew.getCode(longpath).length());
+  }
+
+  @Test
+  public void verifySame() {
+    assertEquals(SortSkew.getCode("123"), SortSkew.getCode("123"));
+    assertNotEquals(SortSkew.getCode("123"), SortSkew.getCode("321"));
+  }
+
+  @Test
+  public void verifyStable() {
+    assertEquals(shortcode, SortSkew.getCode(shortpath));
+    assertEquals(longcode, SortSkew.getCode(longpath));
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -79,11 +79,11 @@ public class ListVolumesUsed {
 
   }
 
-  private static void listTable(Ample.DataLevel name, ServerContext context) throws Exception {
+  private static void listTable(Ample.DataLevel level, ServerContext context) throws Exception {
 
-    System.out.println("Listing volumes referenced in " + name + " tablets section");
+    System.out.println("Listing volumes referenced in " + level + " tablets section");
 
-    Scanner scanner = context.createScanner(name.metaTable(), Authorizations.EMPTY);
+    Scanner scanner = context.createScanner(level.metaTable(), Authorizations.EMPTY);
 
     scanner.setRange(MetadataSchema.TabletsSection.getRange());
     scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
@@ -110,11 +110,11 @@ public class ListVolumesUsed {
       System.out.println("\tVolume : " + volume);
     }
 
-    System.out.println("Listing volumes referenced in " + name
+    System.out.println("Listing volumes referenced in " + level
         + " deletes section (volume replacement occurrs at deletion time)");
     volumes.clear();
 
-    Iterator<String> delPaths = context.getAmple().getGcCandidates(name, "");
+    Iterator<String> delPaths = context.getAmple().getGcCandidates(level, "");
     while (delPaths.hasNext()) {
       volumes.add(getTableURI(delPaths.next()));
     }
@@ -122,7 +122,7 @@ public class ListVolumesUsed {
       System.out.println("\tVolume : " + volume);
     }
 
-    System.out.println("Listing volumes referenced in " + name + " current logs");
+    System.out.println("Listing volumes referenced in " + level + " current logs");
     volumes.clear();
 
     WalStateManager wals = new WalStateManager(context);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.server.util;
 
+import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.TreeSet;
 
@@ -23,8 +24,8 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
@@ -78,11 +79,11 @@ public class ListVolumesUsed {
 
   }
 
-  private static void listTable(String name, ServerContext context) throws Exception {
+  private static void listTable(Ample.DataLevel name, ServerContext context) throws Exception {
 
     System.out.println("Listing volumes referenced in " + name + " tablets section");
 
-    Scanner scanner = context.createScanner(name, Authorizations.EMPTY);
+    Scanner scanner = context.createScanner(name.metaTable(), Authorizations.EMPTY);
 
     scanner.setRange(MetadataSchema.TabletsSection.getRange());
     scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
@@ -109,33 +110,25 @@ public class ListVolumesUsed {
       System.out.println("\tVolume : " + volume);
     }
 
-    volumes.clear();
-
-    scanner.clearColumns();
-    scanner.setRange(MetadataSchema.DeletesSection.getRange());
-
-    for (Entry<Key,Value> entry : scanner) {
-      String delPath = entry.getKey().getRow().toString()
-          .substring(MetadataSchema.DeletesSection.getRowPrefix().length());
-      volumes.add(getTableURI(delPath));
-    }
-
     System.out.println("Listing volumes referenced in " + name
         + " deletes section (volume replacement occurrs at deletion time)");
+    volumes.clear();
 
+    Iterator<String> delPaths = context.getAmple().getGcCandidates(name, "");
+    while (delPaths.hasNext()) {
+      volumes.add(getTableURI(delPaths.next()));
+    }
     for (String volume : volumes) {
       System.out.println("\tVolume : " + volume);
     }
 
+    System.out.println("Listing volumes referenced in " + name + " current logs");
     volumes.clear();
 
     WalStateManager wals = new WalStateManager(context);
     for (Path path : wals.getAllState().keySet()) {
       volumes.add(getLogURI(path.toString()));
     }
-
-    System.out.println("Listing volumes referenced in " + name + " current logs");
-
     for (String volume : volumes) {
       System.out.println("\tVolume : " + volume);
     }
@@ -144,9 +137,9 @@ public class ListVolumesUsed {
   public static void listVolumes(ServerContext context) throws Exception {
     listZookeeper(context);
     System.out.println();
-    listTable(RootTable.NAME, context);
+    listTable(Ample.DataLevel.METADATA, context);
     System.out.println();
-    listTable(MetadataTable.NAME, context);
+    listTable(Ample.DataLevel.USER, context);
   }
 
 }


### PR DESCRIPTION
This commit addresses the modification of metadata ~del mutations to reduce hotspots and stablize split points but does not yet address the migration update required.  

If this solution is accepted then the migration path would be to convert the existing ~del entries to the new ~del entries doing something like the following:
```
for each key with ~del prefix and value.isEmpty(){
  create new del key with value("Converted on initialization")
  delete old delete entry
}
```