### PR TITLE
Fix #1345 - Allow gc initiated compaction as option.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -556,6 +556,9 @@ public enum Property {
       "Archive any files/directories instead of moving to the HDFS trash or deleting."),
   GC_TRACE_PERCENT("gc.trace.percent", "0.01", PropertyType.FRACTION,
       "Percent of gc cycles to trace"),
+  GC_USE_FULL_COMPACTION("gc.use.full.compaction", "true", PropertyType.BOOLEAN,
+      "When gc completes, initiate afull compaction of the metadata table if set,"
+          + " otherwise flush"),
 
   // properties that are specific to the monitor server behavior
   MONITOR_PREFIX("monitor.", null, PropertyType.PREFIX,


### PR DESCRIPTION
Added a property - gc.use.full.compaction that defaults to current behavior. When false,
performs a blocking flush instead.

This is for initial discussion - it may not be an optimal long term solution, but it would allow for some flexibility with current versions while other options are explored.