### PR TITLE
Avoid calling auto-close on Accumulo client

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -698,8 +698,9 @@ abstract class TabletGroupWatcher extends Daemon {
       targetSystemTable = RootTable.NAME;
     }
 
-    try (AccumuloClient client = this.master.getContext();
-        BatchWriter bw = client.createBatchWriter(targetSystemTable, new BatchWriterConfig())) {
+    AccumuloClient client = this.master.getContext();
+
+    try (BatchWriter bw = client.createBatchWriter(targetSystemTable, new BatchWriterConfig())) {
       long fileCount = 0;
       // Make file entries in highest tablet
       Scanner scanner = client.createScanner(targetSystemTable, Authorizations.EMPTY);


### PR DESCRIPTION
After merge of pull request #1348 - Shell It tests failed - this change moves the Accumulo client out of the try-with-resources and restores previous behavior.  