### PR TITLE
Use concurrent map instead of cache for bulkImported map

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
@@ -40,7 +40,7 @@ public class BulkImportCacheCleaner implements Runnable {
     // gather the list of transactions the tablets have cached
     final Set<Long> tids = new HashSet<>();
     for (Tablet tablet : server.getOnlineTablets().values()) {
-      tids.addAll(tablet.getBulkIngestedFiles().keySet());
+      tids.addAll(tablet.getBulkIngestedTxIds());
     }
     try {
       // get the current transactions from ZooKeeper


### PR DESCRIPTION
While analyzing some tablet code I noticed a Guava cahce was being used
like a map.  When I first saw the code I was concerned the cache may
evict entries (which would be a bug).  However the cache was created
with default settings, which according to the javadoc does not
automatically evict.  This commit replaces the cache with a concurrent
map so no one has to do this analysis again.