### PR TITLE
Use ConcurrentHashMap instead of synchronized blocks

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/RowLocks.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/RowLocks.java
@@ -17,10 +17,12 @@
 package org.apache.accumulo.tserver;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
@@ -29,18 +31,20 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.tserver.ConditionalMutationSet.DeferFilter;
 import org.apache.accumulo.tserver.data.ServerConditionalMutation;
 
+import com.google.common.base.Preconditions;
+
 class RowLocks {
 
-  private Map<ByteSequence,RowLock> rowLocks = new HashMap<>();
+  private final Map<ByteSequence,RowLock> rowLocks = new ConcurrentHashMap<>();
 
   static class RowLock {
     ReentrantLock rlock;
-    int count;
+    AtomicInteger count;
     ByteSequence rowSeq;
 
     RowLock(ReentrantLock rlock, ByteSequence rowSeq) {
       this.rlock = rlock;
-      this.count = 0;
+      this.count = new AtomicInteger(1);
       this.rowSeq = rowSeq;
     }
 
@@ -58,24 +62,22 @@ class RowLocks {
   }
 
   private RowLock getRowLock(ArrayByteSequence rowSeq) {
-    RowLock lock = rowLocks.get(rowSeq);
-    if (lock == null) {
-      lock = new RowLock(new ReentrantLock(), rowSeq);
-      rowLocks.put(rowSeq, lock);
-    }
-
-    lock.count++;
-    return lock;
+    return rowLocks.compute(rowSeq, (key, value) -> {
+      if (value == null) {
+        return new RowLock(new ReentrantLock(), rowSeq);
+      }
+      value.count.incrementAndGet();
+      return value;
+    });
   }
 
   private void returnRowLock(RowLock lock) {
-    if (lock.count == 0)
-      throw new IllegalStateException();
-    lock.count--;
-
-    if (lock.count == 0) {
-      rowLocks.remove(lock.rowSeq);
-    }
+    rowLocks.compute(lock.rowSeq, (key, value) -> {
+      Objects.requireNonNull(value);
+      Preconditions.checkState(value.count.intValue() > 0);
+      final int newCount = value.count.decrementAndGet();
+      return (newCount > 0) ? value : null;
+    });
   }
 
   List<RowLock> acquireRowlocks(Map<KeyExtent,List<ServerConditionalMutation>> updates,
@@ -83,11 +85,9 @@ class RowLocks {
     ArrayList<RowLock> locks = new ArrayList<>();
 
     // assume that mutations are in sorted order to avoid deadlock
-    synchronized (rowLocks) {
-      for (List<ServerConditionalMutation> scml : updates.values()) {
-        for (ServerConditionalMutation scm : scml) {
-          locks.add(getRowLock(new ArrayByteSequence(scm.getRow())));
-        }
+    for (List<ServerConditionalMutation> scml : updates.values()) {
+      for (ServerConditionalMutation scm : scml) {
+        locks.add(getRowLock(new ArrayByteSequence(scm.getRow())));
       }
     }
 
@@ -135,10 +135,8 @@ class RowLocks {
         }
       }
 
-      synchronized (rowLocks) {
-        for (RowLock rowLock : locksToReturn) {
-          returnRowLock(rowLock);
-        }
+      for (RowLock rowLock : locksToReturn) {
+        returnRowLock(rowLock);
       }
 
       locks = filteredLocks;
@@ -151,10 +149,8 @@ class RowLocks {
       rowLock.unlock();
     }
 
-    synchronized (rowLocks) {
-      for (RowLock rowLock : locks) {
-        returnRowLock(rowLock);
-      }
+    for (RowLock rowLock : locks) {
+      returnRowLock(rowLock);
     }
   }
 


### PR DESCRIPTION
May endure a bit more overhead since `ConcurrentHashMap` a lock is obtained for every insertion/deletion (v.s. one lock for the entire operation) but will allow for greater concurrency since two threads could lock just sub-sections of the Map at one time.