### PR TITLE
Fix #1365 2.1 Upgrade processing for #1043 ~del

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -65,12 +65,16 @@ public interface Ample {
    * derived from the table id.
    */
   public enum DataLevel {
-    ROOT(null), METADATA(RootTable.NAME), USER(MetadataTable.NAME);
+    ROOT(null, null),
+    METADATA(RootTable.NAME, RootTable.ID),
+    USER(MetadataTable.NAME, MetadataTable.ID);
 
     private final String table;
+    private final TableId id;
 
-    private DataLevel(String table) {
+    private DataLevel(String table, TableId id) {
       this.table = table;
+      this.id = id;
     }
 
     /**
@@ -80,6 +84,15 @@ public interface Ample {
       if (table == null)
         throw new UnsupportedOperationException();
       return table;
+    }
+
+    /**
+     * @return The Id of the Accumulo table in which this data level stores its metadata.
+     */
+    public TableId tableId() {
+      if (id == null)
+        throw new UnsupportedOperationException();
+      return id;
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -270,6 +270,14 @@ public class MetadataSchema {
       return row.substring(encoded_prefix_length);
     }
 
+    /**
+     * Value to indicate that the row has been skewed/encoded.
+     */
+    public static class SkewedKeyValue {
+      public static final String STR_NAME = "skewed";
+      public static final Value NAME = new Value(STR_NAME);
+    }
+
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -171,11 +171,6 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       return StreamSupport.stream(scanner.spliterator(), false)
           .filter(entry -> entry.getValue().equals(DeletesSection.SkewedKeyValue.NAME))
           .map(entry -> DeletesSection.decodeRow(entry.getKey().getRow().toString())).iterator();
-      /*
-       * return Iterators.transform( Iterators.filter(scanner.iterator(), entry ->
-       * entry.getValue().equals(DeletesSection.SkewedKeyValue.NAME)), entry ->
-       * DeletesSection.decodeRow(entry.getKey().getRow().toString()));
-       */
     } else {
       throw new IllegalArgumentException();
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
@@ -50,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterators;
 
 public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
@@ -168,12 +168,14 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         throw new RuntimeException(e);
       }
       scanner.setRange(range);
-
-      return Iterators.transform(
-          Iterators.filter(scanner.iterator(),
-              entry -> entry.getValue().equals(DeletesSection.SkewedKeyValue.NAME)),
-          entry -> DeletesSection.decodeRow(entry.getKey().getRow().toString()));
-
+      return StreamSupport.stream(scanner.spliterator(), false)
+          .filter(entry -> entry.getValue().equals(DeletesSection.SkewedKeyValue.NAME))
+          .map(entry -> DeletesSection.decodeRow(entry.getKey().getRow().toString())).iterator();
+      /*
+       * return Iterators.transform( Iterators.filter(scanner.iterator(), entry ->
+       * entry.getValue().equals(DeletesSection.SkewedKeyValue.NAME)), entry ->
+       * DeletesSection.decodeRow(entry.getKey().getRow().toString()));
+       */
     } else {
       throw new IllegalArgumentException();
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/UpgradeCoordinator.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/UpgradeCoordinator.java
@@ -38,8 +38,8 @@ public class UpgradeCoordinator {
   private boolean haveUpgradedZooKeeper = false;
   private boolean startedMetadataUpgrade = false;
   private int currentVersion;
-  private Map<Integer,Upgrader> upgraders =
-      Map.of(ServerConstants.SHORTEN_RFILE_KEYS, new Upgrader8to9());
+  private Map<Integer,Upgrader> upgraders = Map.of(ServerConstants.SHORTEN_RFILE_KEYS,
+      new Upgrader8to9(), ServerConstants.CRYPTO_CHANGES, new Upgrader9to10());
 
   public UpgradeCoordinator(ServerContext ctx) {
     int currentVersion = ServerUtil.getAccumuloPersistentVersion(ctx.getVolumeManager());

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -89,7 +89,7 @@ public class Upgrader9to10 implements Upgrader {
   public static final String ZROOT_TABLET_WALOGS = ZROOT_TABLET + "/walogs";
   public static final String ZROOT_TABLET_CURRENT_LOGS = ZROOT_TABLET + "/current_logs";
   public static final String ZROOT_TABLET_PATH = ZROOT_TABLET + "/dir";
-  public static final String UPGRADED = "upgrade9to10";
+  public static final String UPGRADED = MetadataSchema.DeletesSection.SkewedKeyValue.STR_NAME;
   public static final String OLD_DELETE_PREFIX = "~del";
   static final float CANDIDATE_MEMORY_PERCENTAGE = 0.50f;
 

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgradeTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgradeTestIT.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.upgrade;
+
+import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.TablePermission;
+import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.master.upgrade.Upgrader9to10;
+import org.apache.accumulo.minicluster.MemoryUnit;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.miniclusterImpl.ProcessNotFoundException;
+import org.apache.accumulo.test.functional.ConfigurableMacBase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.io.Text;
+import org.apache.zookeeper.KeeperException;
+import org.junit.Test;
+
+import com.google.common.collect.Iterators;
+
+public class GCUpgradeTestIT extends ConfigurableMacBase {
+  private static final String OUR_SECRET = "itsreallysecret";
+
+  private static final String OLDDELPREFIX = "~del";
+
+  @Override
+  public int defaultTimeoutSeconds() {
+    return 5 * 60;
+  }
+
+  @Override
+  public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
+    cfg.setProperty(Property.INSTANCE_SECRET, OUR_SECRET);
+    cfg.setDefaultMemory(64, MemoryUnit.MEGABYTE);
+    cfg.setMemory(ServerType.MASTER, 16, MemoryUnit.MEGABYTE);
+    cfg.setMemory(ServerType.ZOOKEEPER, 32, MemoryUnit.MEGABYTE);
+    cfg.setProperty(Property.GC_CYCLE_START, "1");
+    cfg.setProperty(Property.GC_CYCLE_DELAY, "1");
+    cfg.setProperty(Property.GC_PORT, "0");
+    cfg.setProperty(Property.TSERV_MAXMEM, "5K");
+    cfg.setProperty(Property.TSERV_MAJC_DELAY, "1");
+
+    // use raw local file system so walogs sync and flush will work
+    hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
+  }
+
+  private void killMacGc() throws ProcessNotFoundException, InterruptedException, KeeperException {
+    // kill gc started by MAC
+    getCluster().killProcess(ServerType.GARBAGE_COLLECTOR,
+        getCluster().getProcesses().get(ServerType.GARBAGE_COLLECTOR).iterator().next());
+    // delete lock in zookeeper if there, this will allow next GC to start quickly
+    String path = getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK;
+    ZooReaderWriter zk = new ZooReaderWriter(cluster.getZooKeepers(), 30000, OUR_SECRET);
+    try {
+      ZooLock.deleteLock(zk, path);
+    } catch (IllegalStateException e) {
+      log.error("Unable to delete ZooLock for mini accumulo-gc", e);
+    }
+
+    assertNull(getCluster().getProcesses().get(ServerType.GARBAGE_COLLECTOR));
+  }
+
+  @Test
+  public void gcUpgradeRootTableDeletesIT() throws Exception {
+    gcUpgradeDeletesTest(Ample.DataLevel.METADATA);
+  }
+
+  @Test
+  public void gcUpgradeMetadataTableDeletesIT() throws Exception {
+    gcUpgradeDeletesTest(Ample.DataLevel.USER);
+  }
+
+  /**
+   * This is really hard to make happen - the minicluster can only use so little memory to start up.
+   * The {@link org.apache.accumulo.master.upgrade.Upgrader9to10} CANDIDATE_MEMORY_PERCENTAGE can be
+   * adjusted.
+   */
+  @Test
+  public void gcUpgradeOutofMemoryTest() throws Exception {
+    killMacGc(); // we do not want anything deleted
+    String longpathname = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee"
+        + "ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjjj"
+        + "kkkkkkkkkkkkkkkkkklllllllllllllllllllllmmmmmmmmmmmmmmmmmnnnnnnnnnnnnnnnn";
+    Ample.DataLevel level = Ample.DataLevel.USER;
+    log.info("Filling metadata table with lots of bogus delete flags");
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+      addEntries(c, level.metaTable(), 150000, longpathname);
+      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Upgrader9to10.upgradeFileDeletes(getServerContext(), level);
+      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Range range = MetadataSchema.DeletesSection.getRange();
+
+      Scanner scanner;
+      try {
+        scanner = c.createScanner(level.metaTable(), Authorizations.EMPTY);
+      } catch (TableNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+      scanner.setRange(range);
+      assertEquals(150000, Iterators.size(scanner.iterator()));
+    }
+  }
+
+  private void gcUpgradeDeletesTest(Ample.DataLevel level) throws Exception {
+    killMacGc();// we do not want anything deleted
+
+    log.info("Testing delete upgrades for {}", level.metaTable());
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+
+      Map<String,String> expected = addEntries(c, level.metaTable(), 3, "somefile");
+      Map<String,String> actual = new HashMap<>();
+
+      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Upgrader9to10.upgradeFileDeletes(getServerContext(), level);
+      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Range range = MetadataSchema.DeletesSection.getRange();
+
+      Scanner scanner;
+      try {
+        scanner = c.createScanner(level.metaTable(), Authorizations.EMPTY);
+      } catch (TableNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+      scanner.setRange(range);
+      scanner.iterator().forEachRemaining(entry -> {
+        actual.put(entry.getKey().getRow().toString(), entry.getValue().toString());
+      });
+
+      assertEquals(expected, actual);
+
+      // ENSURE IDEMPOTENCE - run upgrade again to ensure nothing is changed because there is
+      // nothing to change
+      Upgrader9to10.upgradeFileDeletes(getServerContext(), level);
+      try {
+        scanner = c.createScanner(level.metaTable(), Authorizations.EMPTY);
+      } catch (TableNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+      scanner.setRange(range);
+      actual.clear();
+      scanner.iterator().forEachRemaining(entry -> {
+        actual.put(entry.getKey().getRow().toString(), entry.getValue().toString());
+      });
+      assertEquals(expected, actual);
+    }
+  }
+
+  private Mutation createOldDelMutation(String path, String cf, String cq, String val) {
+    Text row = new Text(OLDDELPREFIX + path);
+    Mutation delFlag = new Mutation(row);
+    delFlag.put(cf, cq, val);
+    return delFlag;
+  }
+
+  private Map<String,String> addEntries(AccumuloClient client, String table, int count,
+      String filename) throws Exception {
+    client.securityOperations().grantTablePermission(client.whoami(), table, TablePermission.WRITE);
+    Map<String,String> expected = new TreeMap<>();
+    try (BatchWriter bw = client.createBatchWriter(table)) {
+      for (int i = 0; i < count; ++i) {
+        String longpath = String.format("hdfs://localhost:8020/%020d/%s", i, filename);
+        Mutation delFlag = createOldDelMutation(longpath, "", "", "");
+        bw.addMutation(delFlag);
+        expected.put(MetadataSchema.DeletesSection.encodeRow(longpath), Upgrader9to10.UPGRADED);
+      }
+      return expected;
+    }
+  }
+
+}


### PR DESCRIPTION
This is fairly simple code to modify the ~del entries on the master upgrade startup.  The IT test is just for verification of the upgrade processsing and should probably not be included if this is actually merged.  Attempts to test this in a "real time" upgrade process were not successful due to errors unrelated to this code. (so she says ;))