### PR TITLE
Add gc metrics reporting

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -326,7 +326,7 @@ public enum Property {
   MASTER_WALOG_CLOSER_IMPLEMETATION("master.walog.closer.implementation",
       "org.apache.accumulo.server.master.recovery.HadoopLogCloser", PropertyType.CLASSNAME,
       "A class that implements a mechansim to steal write access to a file"),
-  MASTER_FATE_METRICS_ENABLED("master.fate.metrics.enabled", "false", PropertyType.BOOLEAN,
+  MASTER_FATE_METRICS_ENABLED("master.fate.metrics.enabled", "true", PropertyType.BOOLEAN,
       "Enable reporting of FATE metrics in JMX (and logging with Hadoop Metrics2"),
   MASTER_FATE_METRICS_MIN_UPDATE_INTERVAL("master.fate.metrics.min.update.interval", "60s",
       PropertyType.TIMEDURATION, "Limit calls from metric sinks to zookeeper to update interval"),
@@ -561,6 +561,8 @@ public enum Property {
           + " to force the changes to be written to disk, the metadata and root tables can be flushed"
           + " and possibly compacted. Legal values are: compact - which both flushes and compacts the"
           + " metadata; flush - which flushes only (compactions may be triggered if required); or none"),
+  GC_ENABLE_METRICS2("gc.enable.metrics2", "true", PropertyType.BOOLEAN,
+      "Enable detailed gc metrics reporting with hadoop metrics2.  Since 1.9.4"),
 
   // properties that are specific to the monitor server behavior
   MONITOR_PREFIX("monitor.", null, PropertyType.PREFIX,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -326,7 +326,7 @@ public enum Property {
   MASTER_WALOG_CLOSER_IMPLEMETATION("master.walog.closer.implementation",
       "org.apache.accumulo.server.master.recovery.HadoopLogCloser", PropertyType.CLASSNAME,
       "A class that implements a mechansim to steal write access to a file"),
-  MASTER_FATE_METRICS_ENABLED("master.fate.metrics.enabled", "true", PropertyType.BOOLEAN,
+  MASTER_FATE_METRICS_ENABLED("master.fate.metrics.enabled", "false", PropertyType.BOOLEAN,
       "Enable reporting of FATE metrics in JMX (and logging with Hadoop Metrics2"),
   MASTER_FATE_METRICS_MIN_UPDATE_INTERVAL("master.fate.metrics.min.update.interval", "60s",
       PropertyType.TIMEDURATION, "Limit calls from metric sinks to zookeeper to update interval"),
@@ -561,7 +561,7 @@ public enum Property {
           + " to force the changes to be written to disk, the metadata and root tables can be flushed"
           + " and possibly compacted. Legal values are: compact - which both flushes and compacts the"
           + " metadata; flush - which flushes only (compactions may be triggered if required); or none"),
-  GC_ENABLE_METRICS2("gc.enable.metrics2", "true", PropertyType.BOOLEAN,
+  GC_ENABLE_METRICS2("gc.enable.metrics2", "false", PropertyType.BOOLEAN,
       "Enable detailed gc metrics reporting with hadoop metrics2.  Since 1.9.4"),
 
   // properties that are specific to the monitor server behavior

--- a/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcHadoopMetrics2.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcHadoopMetrics2.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
-public class GcMetrics2 implements Metrics, MetricsSource {
+public class GcHadoopMetrics2 implements Metrics, MetricsSource {
 
   public static final String NAME = "AccGC" + ",sub=AccGcRunStats";
   public static final String DESCRIPTION = "Accumulo GC Metrics";
@@ -40,7 +40,7 @@ public class GcMetrics2 implements Metrics, MetricsSource {
   private final MetricsSystem metricsSystem;
   private final MetricsRegistry registry;
 
-  private static GcMetrics2 _instance;
+  private static GcHadoopMetrics2 _instance;
 
   private MutableGaugeLong gcStarted;
   private MutableGaugeLong gcFinished;
@@ -59,7 +59,7 @@ public class GcMetrics2 implements Metrics, MetricsSource {
   private MutableGaugeLong postOpDuration;
   private MutableGaugeLong runCycleCount;
 
-  private GcMetrics2(final SimpleGarbageCollector gc, final MetricsSystem metricsSystem) {
+  private GcHadoopMetrics2(final SimpleGarbageCollector gc, final MetricsSystem metricsSystem) {
     this.gc = gc;
     this.metricsSystem = metricsSystem;
 
@@ -89,10 +89,10 @@ public class GcMetrics2 implements Metrics, MetricsSource {
         registry.newGauge("AccGcRunCycleCount", "counter of completed gc collect cycles", 0L);
   }
 
-  public static synchronized GcMetrics2 init(SimpleGarbageCollector gc,
+  public static synchronized GcHadoopMetrics2 init(SimpleGarbageCollector gc,
       MetricsSystem metricsSystem) {
     if (_instance == null) {
-      _instance = new GcMetrics2(gc, metricsSystem);
+      _instance = new GcHadoopMetrics2(gc, metricsSystem);
     }
     return _instance;
   }
@@ -125,7 +125,7 @@ public class GcMetrics2 implements Metrics, MetricsSource {
     walDeleted.set(values.getLastWalCollect().deleted);
     walErrors.set(values.getLastWalCollect().errors);
 
-    postOpDuration.set(TimeUnit.NANOSECONDS.toMillis(values.getPostOpDuration()));
+    postOpDuration.set(TimeUnit.NANOSECONDS.toMillis(values.getPostOpDurationNanos()));
     runCycleCount.set(values.getRunCycleCount());
   }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcMetrics2.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcMetrics2.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.gc.metrics2;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.gc.SimpleGarbageCollector;
+import org.apache.accumulo.server.metrics.Metrics;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.impl.MsInfo;
+import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
+
+public class GcMetrics2 implements Metrics, MetricsSource {
+
+  public static final String NAME = "AccGC" + ",sub=AccGcRunStats";
+  public static final String DESCRIPTION = "Accumulo GC Metrics";
+  public static final String CONTEXT = "accumulo.gc";
+  public static final String RECORD = "AccGc";
+
+  private final SimpleGarbageCollector gc;
+  private final MetricsSystem metricsSystem;
+  private final MetricsRegistry registry;
+
+  private static GcMetrics2 _instance;
+
+  private MutableGaugeLong gcStarted;
+  private MutableGaugeLong gcFinished;
+  private MutableGaugeLong gcCandidates;
+  private MutableGaugeLong gcInUse;
+  private MutableGaugeLong gcDeleted;
+  private MutableGaugeLong gcErrors;
+
+  private MutableGaugeLong walStarted;
+  private MutableGaugeLong walFinished;
+  private MutableGaugeLong walCandidates;
+  private MutableGaugeLong walInUse;
+  private MutableGaugeLong walDeleted;
+  private MutableGaugeLong walErrors;
+
+  private MutableGaugeLong postOpDuration;
+  private MutableGaugeLong runCycleCount;
+
+  private GcMetrics2(final SimpleGarbageCollector gc, final MetricsSystem metricsSystem) {
+    this.gc = gc;
+    this.metricsSystem = metricsSystem;
+
+    this.registry = new MetricsRegistry(Interns.info(NAME, DESCRIPTION));
+    this.registry.tag(MsInfo.ProcessName, CONTEXT);
+
+    // create gauges
+
+    gcStarted = registry.newGauge("AccGcStarted", "gc collect start timestamp", 0L);
+    gcFinished = registry.newGauge("AccGcFinished", "gc collect finished timestamp", 0L);
+    gcCandidates = registry.newGauge("AccGcCandidates", "number of gc candidates", 0L);
+    gcInUse = registry.newGauge("AccGcInUse", "number of gc candidates still in use", 0L);
+    gcDeleted = registry.newGauge("AccGcDeleted", "number of gc candidates deleted", 0L);
+    gcErrors = registry.newGauge("AccGcDeleteErrors", "number of gc delete errors", 0L);
+
+    walStarted = registry.newGauge("AccGcWalStarted", "gc wal collect start timestamp", 0L);
+    walFinished = registry.newGauge("AccGcWalFinished", "gc wal collect finished timestamp", 0L);
+    walCandidates = registry.newGauge("AccGcWalCandidates", "number of gc wal candidates", 0L);
+    walInUse = registry.newGauge("AccGcWalInUse", "number of candidates still inuse", 0L);
+    walDeleted = registry.newGauge("AccGcWalDeleted", "number of wals deleted", 0L);
+    walErrors = registry.newGauge("AccGcWalErrors", "number of wal deletion errors", 0L);
+
+    postOpDuration = registry.newGauge("AccGcPostOpDurationMillis",
+        "duration of post gc op in milliseconds", 0L);
+
+    runCycleCount =
+        registry.newGauge("AccGcRunCycleCount", "counter of completed gc collect cycles", 0L);
+  }
+
+  public static synchronized GcMetrics2 init(SimpleGarbageCollector gc,
+      MetricsSystem metricsSystem) {
+    if (_instance == null) {
+      _instance = new GcMetrics2(gc, metricsSystem);
+    }
+    return _instance;
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+
+    fillValues();
+    // create the metrics record and publish to the registry.
+    MetricsRecordBuilder builder = collector.addRecord(RECORD).setContext(CONTEXT);
+    registry.snapshot(builder, all);
+
+  }
+
+  private void fillValues() {
+
+    GcRunMetrics values = gc.getGcRunMetrics();
+
+    gcStarted.set(values.getLastCollect().started);
+    gcFinished.set(values.getLastCollect().finished);
+    gcCandidates.set(values.getLastCollect().candidates);
+    gcInUse.set(values.getLastCollect().inUse);
+    gcDeleted.set(values.getLastCollect().deleted);
+    gcErrors.set(values.getLastCollect().errors);
+
+    walStarted.set(values.getLastWalCollect().started);
+    walFinished.set(values.getLastWalCollect().finished);
+    walCandidates.set(values.getLastWalCollect().candidates);
+    walInUse.set(values.getLastWalCollect().inUse);
+    walDeleted.set(values.getLastWalCollect().deleted);
+    walErrors.set(values.getLastWalCollect().errors);
+
+    postOpDuration.set(TimeUnit.NANOSECONDS.toMillis(values.getPostOpDuration()));
+    runCycleCount.set(values.getRunCycleCount());
+  }
+
+  @Override
+  public void register() {
+    metricsSystem.register(NAME, DESCRIPTION, this);
+  }
+
+  @Override
+  public void add(String name, long time) {
+    throw new UnsupportedOperationException("add() is not implemented");
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcRunMetrics.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcRunMetrics.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.gc.metrics2;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.accumulo.core.gc.thrift.GcCycleStats;
+
+/**
+ * Wrapper class for GcCycleStats so that underlying thrift code is not modified. Provides Thread
+ * safe access to gc metrics for reporting.
+ */
+public class GcRunMetrics {
+
+  private AtomicReference<GcCycleStats> lastCollect = new AtomicReference<>(new GcCycleStats());
+  private AtomicReference<GcCycleStats> lastWalCollect = new AtomicReference<>(new GcCycleStats());
+
+  private AtomicLong postOpDuration = new AtomicLong(0);
+  private AtomicLong runCycleCount = new AtomicLong(0);
+
+  public GcRunMetrics() {}
+
+  /**
+   * Get the last gc run statistics.
+   *
+   * @return the statistics for the last gc run.
+   */
+  public GcCycleStats getLastCollect() {
+    return lastCollect.get();
+  }
+
+  /**
+   * Set the last gc run statistics. Makes a defensive deep copy so that if the gc implementation
+   * modifies the values.
+   *
+   * @param lastCollect
+   *          the last gc run statistics.
+   */
+  public void setLastCollect(final GcCycleStats lastCollect) {
+    this.lastCollect.set(new GcCycleStats(lastCollect));
+  }
+
+  /**
+   * The statistics from the last wal collection.
+   *
+   * @return the last wal collection statistics.
+   */
+  public GcCycleStats getLastWalCollect() {
+    return lastWalCollect.get();
+  }
+
+  /**
+   * Set the lost wal collection statistics
+   *
+   * @param lastWalCollect
+   *          last wal statistics
+   */
+  public void setLastWalCollect(final GcCycleStats lastWalCollect) {
+    this.lastWalCollect.set(new GcCycleStats(lastWalCollect));
+  }
+
+  /**
+   * Duration of post operation (compact, flush, none) in nanoseconds.
+   *
+   * @return duration in nanoseconds.
+   */
+  public long getPostOpDuration() {
+    return postOpDuration.get();
+  }
+
+  /**
+   * Duration of post operation (compact, flush, none) in nanoseconds.
+   *
+   * @param postOpDuration
+   *          the duration, in nanoseconds.
+   */
+  public void setPostOpDuration(long postOpDuration) {
+    this.postOpDuration.set(postOpDuration);
+  }
+
+  /**
+   * Duration of post operation (compact, flush, none) in nanoseconds.
+   *
+   * @return duration in nanoseconds.
+   */
+  public long getRunCycleCount() {
+    return runCycleCount.get();
+  }
+
+  /**
+   * Duration of post operation (compact, flush, none) in nanoseconds.
+   *
+   * @param runCycleCount
+   *          the number of gc collect cycles completed.
+   */
+  public void setRunCycleCount(long runCycleCount) {
+    this.runCycleCount.set(runCycleCount);
+  }
+
+  public void incrementRunCycleCount() {
+    this.runCycleCount.incrementAndGet();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("GcMetricsValues{");
+    sb.append("lastCollect=").append(lastCollect.get());
+    sb.append(", lastWalCollect=").append(lastWalCollect.get());
+    sb.append(", postOpDuration=").append(postOpDuration.get());
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcRunMetrics.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/metrics2/GcRunMetrics.java
@@ -30,7 +30,7 @@ public class GcRunMetrics {
   private AtomicReference<GcCycleStats> lastCollect = new AtomicReference<>(new GcCycleStats());
   private AtomicReference<GcCycleStats> lastWalCollect = new AtomicReference<>(new GcCycleStats());
 
-  private AtomicLong postOpDuration = new AtomicLong(0);
+  private AtomicLong postOpDurationNanos = new AtomicLong(0);
   private AtomicLong runCycleCount = new AtomicLong(0);
 
   public GcRunMetrics() {}
@@ -79,18 +79,18 @@ public class GcRunMetrics {
    *
    * @return duration in nanoseconds.
    */
-  public long getPostOpDuration() {
-    return postOpDuration.get();
+  public long getPostOpDurationNanos() {
+    return postOpDurationNanos.get();
   }
 
   /**
    * Duration of post operation (compact, flush, none) in nanoseconds.
    *
-   * @param postOpDuration
+   * @param postOpDurationNanos
    *          the duration, in nanoseconds.
    */
-  public void setPostOpDuration(long postOpDuration) {
-    this.postOpDuration.set(postOpDuration);
+  public void setPostOpDurationNanos(long postOpDurationNanos) {
+    this.postOpDurationNanos.set(postOpDurationNanos);
   }
 
   /**
@@ -121,7 +121,7 @@ public class GcRunMetrics {
     final StringBuilder sb = new StringBuilder("GcMetricsValues{");
     sb.append("lastCollect=").append(lastCollect.get());
     sb.append(", lastWalCollect=").append(lastWalCollect.get());
-    sb.append(", postOpDuration=").append(postOpDuration.get());
+    sb.append(", postOpDuration=").append(postOpDurationNanos.get());
     sb.append('}');
     return sb.toString();
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/GcMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GcMetricsIT.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.test.metrics.HttpMetrics2Receiver;
+import org.apache.accumulo.test.metrics.HttpMetrics2SinkProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Functional test that uses a test hadoop metrics 2 sink to publish metrics for verification.
+ */
+public class GcMetricsIT extends AccumuloClusterHarness {
+
+  private static final Logger log = LoggerFactory.getLogger(GcMetricsIT.class);
+
+  private Connector connector;
+
+  private String tableName;
+
+  private String secret;
+
+  @Before
+  public void setup() {
+
+    connector = getConnector();
+
+    tableName = getUniqueNames(1)[0];
+
+    secret = cluster.getSiteConfiguration().get(Property.INSTANCE_SECRET);
+
+  }
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
+  @Test
+  public void gcMetricsPublished() throws IOException {
+
+    HttpMetrics2Receiver masterMetrics =
+        new HttpMetrics2Receiver(HttpMetrics2SinkProperties.ACC_MASTER_SINK_PREFIX);
+
+    HttpMetrics2Receiver gcMetrics =
+        new HttpMetrics2Receiver(HttpMetrics2SinkProperties.ACC_GC_SINK_PREFIX);
+
+    boolean haveMasterMetrics = false;
+    boolean haveGcMetrics = false;
+
+    boolean needMetricsReport = true;
+
+    try {
+
+      long testStart = System.currentTimeMillis();
+
+      int count = 20;
+
+      while ((count-- > 0) && needMetricsReport) {
+
+        if (!haveMasterMetrics && masterMetrics.getMetrics() != null) {
+          haveMasterMetrics = true;
+        }
+
+        if (!haveGcMetrics && gcMetrics.getMetrics() != null) {
+          haveGcMetrics = true;
+        }
+
+        if (haveMasterMetrics && haveGcMetrics) {
+          needMetricsReport = false;
+        }
+
+        log.info("waiting for metrics report. Have master: {}, Have GC: {}", haveMasterMetrics,
+            haveGcMetrics);
+
+        Thread.sleep(5_000);
+      }
+
+      assertFalse(needMetricsReport);
+
+      assertTrue(masterMetrics.getMetrics().getTimestamp() > testStart);
+      assertTrue(gcMetrics.getMetrics().getTimestamp() > testStart);
+
+      log.debug("Master metrics: {}", masterMetrics.getMetrics());
+      log.debug("GC metrics: {}", gcMetrics.getMetrics());
+
+    } catch (Exception ex) {
+      log.debug("reads", ex);
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/GcMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GcMetricsIT.java
@@ -63,6 +63,14 @@ public class GcMetricsIT extends AccumuloClusterHarness {
   @Test
   public void gcMetricsPublished() throws IOException {
 
+    boolean gcMetricsEnabled = cluster.getSiteConfiguration().getBoolean(Property.GC_ENABLE_METRICS2);
+    boolean fateMetricsEnabled = cluster.getSiteConfiguration().getBoolean(Property.MASTER_FATE_METRICS_ENABLED);
+
+    // test only valid when hadoop metrics 2 enabled for master and gc.
+    if(!gcMetricsEnabled && !fateMetricsEnabled){
+      return;
+    }
+
     HttpMetrics2Receiver masterMetrics =
         new HttpMetrics2Receiver(HttpMetrics2SinkProperties.ACC_MASTER_SINK_PREFIX);
 

--- a/test/src/main/java/org/apache/accumulo/test/metrics/HttpMetrics2Receiver.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/HttpMetrics2Receiver.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+public class HttpMetrics2Receiver {
+
+  private static final Logger log = LoggerFactory.getLogger(HttpMetrics2Receiver.class);
+
+  // set max content length for messages to 1M
+  private static final int MAX_MESSAGE_PAYLOAD = 1024 * 1024;
+
+  private final HttpServer server;
+  private final AtomicReference<JsonMetricsValues> metrics = new AtomicReference<>();
+
+  private final String metricsPrefix;
+
+  /**
+   * Looks on the classpath for hadoop-metrics2-accumulo.properties file and configures an http
+   * server that will listen for POST requests from the HttpMetrics sink. Multiple instances can be
+   * created if the use different prefixes which defines separate ports. This class is to help
+   * testing metrics and has not been developed or tested as a generic http metrics listener for
+   * production.
+   *
+   * @param metricsPrefix
+   *          defines the subset of properties that will be used for configuration.
+   * @throws IOException
+   *           if the http server cannot be created.
+   */
+  public HttpMetrics2Receiver(final String metricsPrefix) throws IOException {
+
+    this.metricsPrefix = metricsPrefix;
+
+    Configuration sub = loadMetricsConfig();
+
+    String host = sub.getString(HttpMetrics2SinkProperties.HTTP_HOST_PROP_NAME);
+    int port = sub.getInt(HttpMetrics2SinkProperties.HTTP_PORT_PROP_NAME);
+
+    // strip starting /'s if any.
+    String endpoint =
+        sub.getString(HttpMetrics2SinkProperties.HTTP_ENDPOINT_PROP_NAME).replaceAll("^/+", "");
+
+    log.info("Creating http server that will listen on {}:{}/{} for POST", host, port, endpoint);
+
+    server = HttpServer.create(new InetSocketAddress(host, port), 0);
+    server.createContext("/" + endpoint, new MyHandler(metrics));
+    server.setExecutor(null); // creates a default executor
+    server.start();
+
+  }
+
+  /**
+   * Look for the accumulo metrics configuration file on the classpath and return the subset for the
+   * http sink.
+   *
+   * @return a configuration with http sink properties.
+   */
+  private Configuration loadMetricsConfig() {
+    try {
+
+      final URL propUrl =
+          getClass().getClassLoader().getResource(HttpMetrics2SinkProperties.METRICS_PROP_FILENAME);
+
+      if (propUrl == null) {
+        throw new IllegalStateException(
+            "Could not find " + HttpMetrics2SinkProperties.METRICS_PROP_FILENAME + " on classpath");
+      }
+
+      String filename = propUrl.getFile();
+      Configuration config = new PropertiesConfiguration(filename);
+
+      final Configuration sub = config.subset(metricsPrefix);
+
+      if (log.isTraceEnabled()) {
+        log.trace("Config {}", config);
+        @SuppressWarnings("unchecked")
+        Iterator<String> iterator = sub.getKeys();
+        while (iterator.hasNext()) {
+          String key = iterator.next();
+          log.trace("'{}\'=\'{}\'", key, sub.getProperty(key));
+        }
+      }
+
+      return sub;
+
+    } catch (ConfigurationException ex) {
+      throw new IllegalStateException(
+          String.format("Could not find configuration file \'%s\' on classpath",
+              HttpMetrics2SinkProperties.METRICS_PROP_FILENAME));
+    }
+  }
+
+  public JsonMetricsValues getMetrics() {
+    return metrics.get();
+  }
+
+  static class MyHandler implements HttpHandler {
+
+    private final AtomicReference<JsonMetricsValues> update;
+
+    MyHandler(AtomicReference<JsonMetricsValues> update) {
+      this.update = update;
+    }
+
+    @Override
+    public void handle(HttpExchange t) {
+
+      if (log.isTraceEnabled()) {
+        // print received message header
+        log.trace("Received Request Header: {}", t.getRequestHeaders().entrySet());
+        log.trace("Request Method: {}", t.getRequestMethod());
+        log.trace("HTTP context: {}", t.getHttpContext().getAttributes());
+      }
+
+      // guard excessive length malformed messages
+
+      String headerValue = "";
+      try {
+        headerValue = t.getRequestHeaders().getFirst("Content-length");
+        int len = Integer.parseInt(headerValue);
+        if (len > MAX_MESSAGE_PAYLOAD) {
+          throw new IllegalStateException(
+              "Message content length " + len + " exceeded max allowed " + MAX_MESSAGE_PAYLOAD);
+        }
+
+      } catch (NumberFormatException nex) {
+        throw new IllegalArgumentException("Invalid request header length " + headerValue, nex);
+      }
+
+      if (t.getRequestMethod().equals("POST")) {
+        processPost(t);
+      }
+
+    }
+
+    private void processPost(final HttpExchange t) {
+
+      try (InputStream is = t.getRequestBody()) {
+
+        String msgContents = IOUtils.toString(is);
+        is.close();
+
+        update.set(JsonMetricsValues.fromJson(msgContents));
+
+        t.sendResponseHeaders(200, -1);
+
+      } catch (IOException ex) {
+        log.info("failed to process POST message");
+      }
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/metrics/HttpMetrics2Sink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/HttpMetrics2Sink.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.configuration.SubsetConfiguration;
+import org.apache.hadoop.metrics2.AbstractMetric;
+import org.apache.hadoop.metrics2.MetricsRecord;
+import org.apache.hadoop.metrics2.MetricsSink;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A hadoop metrics sink that pushes results via http using POST. The sink can also be configured to
+ * dump the same metrics to a file for debugging.
+ */
+public class HttpMetrics2Sink implements MetricsSink, Closeable {
+
+  private static final Logger log = LoggerFactory.getLogger(HttpMetrics2Sink.class);
+
+  private final AtomicBoolean initialized = new AtomicBoolean(Boolean.FALSE);
+
+  private PrintWriter writer = null;
+  private String postUrl = "";
+
+  @Override
+  public void putMetrics(MetricsRecord metricsRecord) {
+
+    JsonMetricsValues metrics = new JsonMetricsValues();
+    metrics.setTimestamp(System.currentTimeMillis());
+
+    for (AbstractMetric r : metricsRecord.metrics()) {
+      metrics.addMetric(r.name(), Long.toString(r.value().longValue()));
+    }
+
+    metrics.sign();
+
+    String json = metrics.toJson();
+
+    httpPost(json);
+
+    // stub.set(lastUpdate.get().toJson());
+
+    writer.println(String.format("%s", json));
+    writer.flush();
+  }
+
+  @Override
+  public void flush() {
+    if (writer != null) {
+      writer.flush();
+    }
+  }
+
+  public synchronized void close() {
+    if (writer != null) {
+      writer.flush();
+      PrintWriter tmp = writer;
+      writer = null;
+      tmp.close();
+    }
+  }
+
+  @Override
+  public synchronized void init(SubsetConfiguration config) {
+
+    if (initialized.get()) {
+      return;
+    }
+
+    try {
+
+      if (config.containsKey(HttpMetrics2SinkProperties.OUT_FILENAME_PROP_NAME)) {
+        createOutputFile(config);
+      }
+
+      if (config.containsKey(HttpMetrics2SinkProperties.HTTP_HOST_PROP_NAME)) {
+
+        String host = config.getString(HttpMetrics2SinkProperties.HTTP_HOST_PROP_NAME, "");
+        int port = config.getInt(HttpMetrics2SinkProperties.HTTP_PORT_PROP_NAME);
+        String endpoint = config.getString(HttpMetrics2SinkProperties.HTTP_ENDPOINT_PROP_NAME, "");
+
+        endpoint = endpoint.replaceAll("^/+", "");
+
+        postUrl = String.format("http://%s:%d/%s", host, port, endpoint);
+
+      }
+    } catch (Exception ex) {
+      log.error("Configuration error prevented initialization - sink may not be available", ex);
+      return;
+    }
+
+    initialized.set(Boolean.TRUE);
+
+  }
+
+  /**
+   * Sink output will be logged to a file if a file / pathname is provided in the sink
+   * configuration. The file can be optionally truncated.
+   *
+   * @param config
+   *          sink configuration.
+   */
+  private void createOutputFile(SubsetConfiguration config) {
+
+    // prevent multiple file initialization calls when init fails.
+    if (writer != null) {
+      return;
+    }
+
+    // use context to avoid file name collisions.
+    String context = "";
+    if (config.containsKey("context")) {
+      context = String.format("%s_", config.getProperty("context"));
+    }
+
+    String filename = config.getString(HttpMetrics2SinkProperties.OUT_FILENAME_PROP_NAME,
+        "/tmp/" + context + "metrics.txt");
+
+    try {
+
+      boolean truncate =
+          config.getBoolean(HttpMetrics2SinkProperties.TRUNCATE_FILE_PROP_NAME, Boolean.FALSE);
+
+      // this erases previous content
+      if (truncate) {
+        FileWriter dummy = new FileWriter(filename);
+        dummy.close();
+      }
+
+      // this reopens file for appending
+      writer = new PrintWriter(new BufferedWriter(new FileWriter(filename, true)));
+
+      if (config.getBoolean(HttpMetrics2SinkProperties.DUMP_CONFIG_PROP_NAME, Boolean.FALSE)) {
+        dumpConfig(config);
+      }
+
+    } catch (IOException ex) {
+      ex.printStackTrace();
+      if (writer != null) {
+        writer.close();
+        writer = null;
+      }
+    }
+  }
+
+  /**
+   * Write the received configuration to the output file if it is configured and dump requested.
+   *
+   * @param config
+   *          The subset configuration received from metrics system.
+   */
+  private void dumpConfig(SubsetConfiguration config) {
+
+    if (writer == null) {
+      return;
+    }
+
+    @SuppressWarnings("unchecked")
+    Iterator<String> keys = config.getKeys();
+    writer.println("::config start::");
+    while (keys.hasNext()) {
+      String key = keys.next();
+      writer.println(String.format("'%s\'=\'%s\'", key, config.getProperty(key)));
+    }
+    writer.println("::config end::");
+
+  }
+
+  /**
+   * POST the json metrics object.
+   *
+   * @param json
+   *          json formatted metrics values, as string.
+   */
+  private synchronized void httpPost(final String json) {
+
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+
+      final String postUri = postUrl;
+
+      log.debug("post destination uri: \'{}\'", postUri);
+
+      StringEntity entity = new StringEntity(json);
+      HttpPost httpPost = new HttpPost(postUri);
+
+      httpPost.setEntity(entity);
+      httpPost.setHeader("Accept", "application/json");
+      httpPost.setHeader("Content-type", "application/json");
+
+      CloseableHttpResponse response = httpclient.execute(httpPost);
+
+      int status = response.getStatusLine().getStatusCode();
+
+      if (status >= 200 && status < 300) {
+        log.debug("metrics post successful");
+      } else {
+        log.debug("metrics post failed with status {}", status);
+      }
+
+    } catch (Exception ex) {
+      log.debug("metrics POST failed, listener endpoint may not present", ex);
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/metrics/HttpMetrics2SinkProperties.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/HttpMetrics2SinkProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+public class HttpMetrics2SinkProperties {
+
+  public static final String METRICS_PROP_FILENAME = "hadoop-metrics2-accumulo.properties";
+  public static final String ACC_GC_SINK_PREFIX = "accumulo.sink.http-gc";
+  public static final String ACC_MASTER_SINK_PREFIX = "accumulo.sink.http-master";
+
+  public static final String OUT_FILENAME_PROP_NAME = "filename";
+  public static final String TRUNCATE_FILE_PROP_NAME = "truncate";
+  public static final String DUMP_CONFIG_PROP_NAME = "dumpConfig";
+  public static final String HTTP_HOST_PROP_NAME = "httpHostname";
+  public static final String HTTP_PORT_PROP_NAME = "httpPort";
+  public static final String HTTP_ENDPOINT_PROP_NAME = "httpPostEndpoint";
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/metrics/JsonMetricsValues.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/JsonMetricsValues.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class JsonMetricsValues {
+
+  private static final Logger log = LoggerFactory.getLogger(JsonMetricsValues.class);
+
+  private long timestamp;
+  private final Map<String,String> metrics;
+  private String signature;
+
+  public JsonMetricsValues() {
+    metrics = new TreeMap<>();
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public Map<String,String> getMetrics() {
+    return metrics;
+  }
+
+  public void addMetric(final String name, final String value) {
+    metrics.put(name, value);
+  }
+
+  public String getSignature() {
+    return signature;
+  }
+
+  /**
+   * Similar to git sha-1, use 8 bytes of a message digest to create a hex formatted string to
+   * create a signature for the contents.
+   */
+  public void sign() {
+    byte[] md = digest();
+    signature = Long.toHexString(mdformatter(md));
+  }
+
+  /**
+   * Verify that the candidate signatues matches the digest calculated from the current contents.
+   *
+   * @param candidate
+   *          a hex formatted, 8-byte signature
+   *
+   * @return true if content signature matches provided candidate.
+   */
+  public boolean verify(final String candidate) {
+    byte[] md = digest();
+    String calculated = Long.toHexString(mdformatter(md));
+    return calculated.equals(candidate);
+  }
+
+  private byte[] digest() {
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException ex) {
+      byte[] invalid = {-1};
+      return invalid;
+    }
+
+    digest.reset();
+    digest.update(Long.toString(timestamp).getBytes());
+    for (Map.Entry<String,String> e : metrics.entrySet()) {
+      digest.update(e.getKey().getBytes());
+      digest.update(e.getValue().getBytes());
+    }
+    return digest.digest();
+  }
+
+  /**
+   * Create a long from the first 8 bytes to create a signature.
+   *
+   * @param bytes
+   *          byte array
+   * @return hex-formatted string of first 8 bytes.
+   */
+  private Long mdformatter(final byte[] bytes) {
+
+    long x = 0;
+    for (int i = 0; i < 8 && i < bytes.length; i++) {
+      x |= (0xff & (long) bytes[i]) << i * 8;
+    }
+    return x;
+  }
+
+  public String toJson() {
+    Gson gson = new GsonBuilder().create();
+    return gson.toJson(this);
+  }
+
+  public static JsonMetricsValues fromJson(final String json) {
+    Gson gson = new GsonBuilder().create();
+    return gson.fromJson(json, JsonMetricsValues.class);
+  }
+
+  public static JsonMetricsValues fromJson(final InputStream in) {
+
+    try {
+      Gson gson = new GsonBuilder().create();
+      return gson.fromJson(IOUtils.toString(in), JsonMetricsValues.class);
+    } catch (IOException ex) {
+      log.info("Failed to process input stream");
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("JsonValues{");
+    sb.append("timestamp=").append(timestamp);
+    sb.append(", metrics=").append(metrics);
+    sb.append(", signature='").append(signature).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+}

--- a/test/src/test/java/org/apache/accumulo/test/metrics/JsonMetricsValuesTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/metrics/JsonMetricsValuesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JsonMetricsValuesTest {
+
+  JsonMetricsValues v1;
+
+  @Before
+  public void init() {
+    v1 = new JsonMetricsValues();
+    v1.setTimestamp(System.currentTimeMillis());
+    v1.addMetric("a", "1");
+    v1.addMetric("b", "2");
+    v1.sign();
+  }
+
+  @Test
+  public void roundTrip() {
+
+    String json = v1.toJson();
+
+    JsonMetricsValues result = JsonMetricsValues.fromJson(json);
+
+    assertEquals(v1.getTimestamp(), result.getTimestamp());
+    assertEquals(v1.getMetrics(), result.getMetrics());
+    assertEquals(v1.getSignature(), result.getSignature());
+  }
+
+  @Test
+  public void signing() {
+
+    String signature = v1.getSignature();
+
+    assertTrue(v1.verify(signature));
+
+    v1.setTimestamp(System.currentTimeMillis());
+    assertFalse(v1.verify(signature));
+
+  }
+}

--- a/test/src/test/java/org/apache/accumulo/test/metrics/MetricsClientTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/metrics/MetricsClientTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test.metrics;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * throw away test class for development.
+ */
+public class MetricsClientTest {
+
+  private static final Logger log = LoggerFactory.getLogger(MetricsClientTest.class);
+
+  AtomicReference<String> payload = new AtomicReference<>(null);
+
+  private HttpServer server;
+
+  @Before
+  public void init() throws Exception {
+
+    String context = "post";
+
+    server = HttpServer.create(new InetSocketAddress(InetAddress.getLocalHost(), 12332), 0);
+    server.createContext("/" + context, new MyHandler(payload));
+    server.setExecutor(null); // creates a default executor
+    server.start();
+
+  }
+
+  static class MyHandler implements HttpHandler {
+
+    private AtomicReference<String> update;
+
+    public MyHandler(AtomicReference<String> update) {
+      this.update = update;
+    }
+
+    @Override
+    public void handle(HttpExchange t) throws IOException {
+      log.info("Received H: {}", t.getRequestHeaders().entrySet());
+      log.info("Received M: {}", t.getRequestMethod());
+
+      log.info("C: {}", t.getHttpContext());
+
+      InputStream is = t.getRequestBody();
+      log.info("MB:{}", IOUtils.toString(is));
+
+      t.sendResponseHeaders(200, -1);
+      // OutputStream os = t.getResponseBody();
+      // os.write("200".getBytes(StandardCharsets.UTF_8));
+      // os.close();
+    }
+  }
+
+  @Test
+  public void post() throws Exception {
+
+    CloseableHttpClient httpclient = HttpClients.createDefault();
+
+    final String u =
+        String.format("http://%s:%d/post", InetAddress.getLocalHost().getHostAddress(), 12332);
+
+    log.info("Connect to: {}", u);
+
+    try {
+
+      JsonMetricsValues v = new JsonMetricsValues();
+      v.setTimestamp(System.currentTimeMillis());
+      v.addMetric("a", "1");
+      v.addMetric("b", "2");
+      v.sign();
+
+      StringEntity entity = new StringEntity(v.toJson());
+      HttpPost httpPost = new HttpPost(u);
+
+      httpPost.setEntity(entity);
+      httpPost.setHeader("Accept", "application/json");
+      httpPost.setHeader("Content-type", "application/json");
+
+      CloseableHttpResponse response = httpclient.execute(httpPost);
+
+      log.info("PR: {}", response.getStatusLine().getStatusCode());
+
+      httpclient.close();
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+  }
+}

--- a/test/src/test/resources/hadoop-metrics2-accumulo.properties
+++ b/test/src/test/resources/hadoop-metrics2-accumulo.properties
@@ -31,8 +31,7 @@
 accumulo.sink.file-all.class=org.apache.hadoop.metrics2.sink.FileSink
 accumulo.sink.file-all.filename=./target/it.all.metrics
 
-#accumulo.sink.http-sink
-# Test sink - will publish to http end-point and optional write to file
+# Test sink - will publish gc metrics to http end-point and optional write to file
 accumulo.sink.http-gc.class=org.apache.accumulo.test.metrics.HttpMetrics2Sink
 accumulo.sink.http-gc.context=accumulo.gc
 accumulo.sink.http-gc.filename=./target/acc_gc.metrics
@@ -43,7 +42,7 @@ accumulo.sink.http-gc.httpHostname=localhost
 accumulo.sink.http-gc.httpPort=12332
 accumulo.sink.http-gc.httpPostEndpoint=metrics/post
 
-
+# Test sink - will publish master metrics to http end-point and optional write to file
 accumulo.sink.http-master.class=org.apache.accumulo.test.metrics.HttpMetrics2Sink
 accumulo.sink.http-master.context=master
 accumulo.sink.http-master.filename=./target/acc_master.metrics
@@ -53,9 +52,6 @@ accumulo.sink.http-master.dumpConfig=true
 accumulo.sink.http-master.httpHostname=localhost
 accumulo.sink.http-master.httpPort=12333
 accumulo.sink.http-master.httpPostEndpoint=metrics/post
-
-# accumulo.sink.test-sink.context=*
-# accumulo.sink.test-sink.period=5
 
 # File sink for tserver metrics
 # accumulo.sink.file-tserver.class=org.apache.hadoop.metrics2.sink.FileSink

--- a/test/src/test/resources/hadoop-metrics2-accumulo.properties
+++ b/test/src/test/resources/hadoop-metrics2-accumulo.properties
@@ -31,10 +31,28 @@
 accumulo.sink.file-all.class=org.apache.hadoop.metrics2.sink.FileSink
 accumulo.sink.file-all.filename=./target/it.all.metrics
 
-accumulo.sink.test-sink.class=org.apache.accumulo.test.functional.util.Metrics2TestSink
-accumulo.sink.test-sink.context=master
-accumulo.sink.test-sink.filename=test.metrics
-accumulo.sink.test-sink.period=7
+#accumulo.sink.http-sink
+# Test sink - will publish to http end-point and optional write to file
+accumulo.sink.http-gc.class=org.apache.accumulo.test.metrics.HttpMetrics2Sink
+accumulo.sink.http-gc.context=accumulo.gc
+accumulo.sink.http-gc.filename=./target/acc_gc.metrics
+accumulo.sink.http-gc.period=7
+accumulo.sink.http-gc.truncate=true
+accumulo.sink.http-gc.dumpConfig=true
+accumulo.sink.http-gc.httpHostname=localhost
+accumulo.sink.http-gc.httpPort=12332
+accumulo.sink.http-gc.httpPostEndpoint=metrics/post
+
+
+accumulo.sink.http-master.class=org.apache.accumulo.test.metrics.HttpMetrics2Sink
+accumulo.sink.http-master.context=master
+accumulo.sink.http-master.filename=./target/acc_master.metrics
+accumulo.sink.http-master.period=7
+accumulo.sink.http-master.truncate=true
+accumulo.sink.http-master.dumpConfig=true
+accumulo.sink.http-master.httpHostname=localhost
+accumulo.sink.http-master.httpPort=12333
+accumulo.sink.http-master.httpPostEndpoint=metrics/post
 
 # accumulo.sink.test-sink.context=*
 # accumulo.sink.test-sink.period=5


### PR DESCRIPTION
Add gc metrics reporting using hadoop 2 metrics system
Adds metric sink and test end point that can receive / poll metrics from the metrics system via http

This pull request is to solicit comments on approach - there may a few adjustments:
 - metric naming.
 - the location of the test sink - not sure if under test or somewhere else would be preferred.

This supersedes pull request https://github.com/apache/accumulo/pull/1360 - and adopts an approach that does not modify the current implementation synchronization. 1360 will be closed.
