### PR TITLE
Fixes #1225 - Place all table configurations under single Zookeeper path.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -25,11 +25,9 @@ public class Constants {
   // Zookeeper locations
   public static final String ZROOT = "/accumulo";
   public static final String ZINSTANCES = "/instances";
-
   public static final String ZTABLES = "/tables";
   public static final byte[] ZTABLES_INITIAL_ID = {'0'};
   public static final String ZTABLE_NAME = "/name";
-  public static final String ZTABLE_CONF = "/conf";
   public static final String ZTABLE_STATE = "/state";
   public static final String ZTABLE_FLUSH_ID = "/flush-id";
   public static final String ZTABLE_COMPACT_ID = "/compact-id";
@@ -87,6 +85,8 @@ public class Constants {
   public static final String DEFAULT_TABLET_LOCATION = "/default_tablet";
 
   public static final String ZTABLE_LOCKS = "/table_locks";
+
+  public static final String TABLE_CONFIGS = "/table_configs";
 
   public static final String BULK_PREFIX = "b-";
   public static final String BULK_RENAME_FILE = "renames.json";

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -107,7 +107,7 @@ public class TableConfiguration extends AccumuloConfiguration {
   }
 
   private String getPath() {
-    return context.getZooKeeperRoot() + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_CONF;
+    return context.getZooKeeperRoot() + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + tableId;
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -663,6 +663,11 @@ public class Initialize implements KeywordExecutable {
         NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLE_LOCKS, EMPTY_BYTE_ARRAY,
         NodeExistsPolicy.FAIL);
+    zoo.putPersistentData(zkInstanceRoot + Constants.TABLE_CONFIGS, EMPTY_BYTE_ARRAY,
+        NodeExistsPolicy.FAIL);
+    zoo.putPersistentData(zkInstanceRoot + Constants.TABLE_CONFIGS + Constants.ZTABLES,
+        EMPTY_BYTE_ARRAY, NodeExistsPolicy.FAIL);
+    log.info("Execution Sequence - Initializing the zookeeper");
     zoo.putPersistentData(zkInstanceRoot + Constants.ZHDFS_RESERVATIONS, EMPTY_BYTE_ARRAY,
         NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZNEXT_FILE, ZERO_CHAR_ARRAY,

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -86,7 +86,6 @@ public class TableManager {
     tableName = qualifiedTableName.getSecond();
     String zTablePath = Constants.ZROOT + "/" + instanceId + Constants.ZTABLES + "/" + tableId;
     zoo.putPersistentData(zTablePath, new byte[0], existsPolicy);
-    zoo.putPersistentData(zTablePath + Constants.ZTABLE_CONF, new byte[0], existsPolicy);
     zoo.putPersistentData(zTablePath + Constants.ZTABLE_NAMESPACE,
         namespaceId.canonical().getBytes(UTF_8), existsPolicy);
     zoo.putPersistentData(zTablePath + Constants.ZTABLE_NAME, tableName.getBytes(UTF_8),
@@ -229,18 +228,18 @@ public class TableManager {
     prepareNewTableState(zoo, instanceID, tableId, namespaceId, tableName, TableState.NEW,
         existsPolicy);
 
-    String srcTablePath = Constants.ZROOT + "/" + instanceID + Constants.ZTABLES + "/" + srcTableId
-        + Constants.ZTABLE_CONF;
-    String newTablePath = Constants.ZROOT + "/" + instanceID + Constants.ZTABLES + "/" + tableId
-        + Constants.ZTABLE_CONF;
+    String srcTablePath = Constants.ZROOT + "/" + instanceID + Constants.TABLE_CONFIGS
+        + Constants.ZTABLES + "/" + srcTableId;
+    String newTablePath = Constants.ZROOT + "/" + instanceID + Constants.TABLE_CONFIGS
+        + Constants.ZTABLES + "/" + tableId;
     zoo.recursiveCopyPersistent(srcTablePath, newTablePath, NodeExistsPolicy.OVERWRITE);
 
     for (Entry<String,String> entry : propertiesToSet.entrySet())
       TablePropUtil.setTableProperty(context, tableId, entry.getKey(), entry.getValue());
 
     for (String prop : propertiesToExclude)
-      zoo.recursiveDelete(Constants.ZROOT + "/" + instanceID + Constants.ZTABLES + "/" + tableId
-          + Constants.ZTABLE_CONF + "/" + prop, NodeMissingPolicy.SKIP);
+      zoo.recursiveDelete(Constants.ZROOT + "/" + instanceID + Constants.TABLE_CONFIGS
+          + Constants.ZTABLES + "/" + tableId + "/" + prop, NodeMissingPolicy.SKIP);
 
     updateTableStateCache(tableId);
   }
@@ -251,6 +250,8 @@ public class TableManager {
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_STATE,
           NodeMissingPolicy.SKIP);
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId, NodeMissingPolicy.SKIP);
+      zoo.recursiveDelete(zkRoot + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + tableId,
+          NodeMissingPolicy.SKIP);
     }
   }
 
@@ -309,7 +310,6 @@ public class TableManager {
         case NodeDeleted:
           if (zPath != null && tableId != null
               && (zPath.equals(tablesPrefix + "/" + tableId + Constants.ZTABLE_STATE)
-                  || zPath.equals(tablesPrefix + "/" + tableId + Constants.ZTABLE_CONF)
                   || zPath.equals(tablesPrefix + "/" + tableId + Constants.ZTABLE_NAME)))
             tableStateCache.remove(tableId);
           break;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TablePropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TablePropUtil.java
@@ -64,6 +64,6 @@ public class TablePropUtil {
   }
 
   private static String getTablePath(String zkRoot, TableId tableId) {
-    return zkRoot + Constants.ZTABLES + "/" + tableId.canonical() + Constants.ZTABLE_CONF;
+    return zkRoot + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + tableId.canonical();
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
@@ -84,8 +84,8 @@ public class TableConfigurationTest {
   @Test
   public void testGet_InZK() {
     Property p = Property.INSTANCE_SECRET;
-    expect(zc.get(ZooUtil.getRoot(iid) + Constants.ZTABLES + "/" + TID + Constants.ZTABLE_CONF + "/"
-        + p.getKey())).andReturn("sekrit".getBytes(UTF_8));
+    expect(zc.get(ZooUtil.getRoot(iid) + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + TID
+        + "/" + p.getKey())).andReturn("sekrit".getBytes(UTF_8));
     replay(zc);
     assertEquals("sekrit", c.get(Property.INSTANCE_SECRET));
   }
@@ -93,8 +93,8 @@ public class TableConfigurationTest {
   @Test
   public void testGet_InParent() {
     Property p = Property.INSTANCE_SECRET;
-    expect(zc.get(ZooUtil.getRoot(iid) + Constants.ZTABLES + "/" + TID + Constants.ZTABLE_CONF + "/"
-        + p.getKey())).andReturn(null);
+    expect(zc.get(ZooUtil.getRoot(iid) + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + TID
+        + "/" + p.getKey())).andReturn(null);
     replay(zc);
     expect(parent.get(p)).andReturn("sekrit");
     replay(parent);
@@ -110,14 +110,13 @@ public class TableConfigurationTest {
     List<String> children = new java.util.ArrayList<>();
     children.add("foo");
     children.add("ding");
-    expect(zc
-        .getChildren(ZooUtil.getRoot(iid) + Constants.ZTABLES + "/" + TID + Constants.ZTABLE_CONF))
+    expect(zc.getChildren(
+        ZooUtil.getRoot(iid) + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + TID))
             .andReturn(children);
-    expect(zc.get(
-        ZooUtil.getRoot(iid) + Constants.ZTABLES + "/" + TID + Constants.ZTABLE_CONF + "/" + "foo"))
-            .andReturn("bar".getBytes(UTF_8));
-    expect(zc.get(ZooUtil.getRoot(iid) + Constants.ZTABLES + "/" + TID + Constants.ZTABLE_CONF + "/"
-        + "ding")).andReturn("dong".getBytes(UTF_8));
+    expect(zc.get(ZooUtil.getRoot(iid) + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + TID
+        + "/" + "foo")).andReturn("bar".getBytes(UTF_8));
+    expect(zc.get(ZooUtil.getRoot(iid) + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + TID
+        + "/" + "ding")).andReturn("dong".getBytes(UTF_8));
     replay(zc);
     c.getProperties(props, all);
     assertEquals(2, props.size());
@@ -129,8 +128,8 @@ public class TableConfigurationTest {
   public void testInvalidateCache() {
     // need to do a get so the accessor is created
     Property p = Property.INSTANCE_SECRET;
-    expect(zc.get(ZooUtil.getRoot(iid) + Constants.ZTABLES + "/" + TID + Constants.ZTABLE_CONF + "/"
-        + p.getKey())).andReturn("sekrit".getBytes(UTF_8));
+    expect(zc.get(ZooUtil.getRoot(iid) + Constants.TABLE_CONFIGS + Constants.ZTABLES + "/" + TID
+        + "/" + p.getKey())).andReturn("sekrit".getBytes(UTF_8));
     zc.clear();
     replay(zc);
     c.get(Property.INSTANCE_SECRET);


### PR DESCRIPTION
This pull request adds a new Zookeeper path to put the table configurations for all tables under a single Znode.  This path is located at  /accumulo/{instance-id}/table_configs  in Zookeeper.  Many of the other table configurations will be still located under  /accumulo/{instance-id}/tables to maintain the current functional operation of the code with the present ZooCache class which has not been modified at all.  The relocated configurations are ones like these:  table.iterator.majc.vers, table.constraint.1, table.iterator.scan.vers.opt.maxVersions, table.iterator.minc.vers, table.iterator.majc.vers.opt.maxVersions, table.iterator.minc.vers.opt.maxVersions, table.iterator.scan.vers.  

Those configuration values were being cleared from the ZooCache during  add/remove/clone table operations. This necessitated calling Zookeeper again for all the configurations of all the tables.  For large systems that constantly added and removed tables this caused ZooCache.get to created new Watchers on configurations that ZooKeeper already had a watch on.  On systems with many TServers with many tables this must have put a larger burden on Zookeeper than we would see in smaller systems.
I think that this pull request reduces the number of Zookeeper Watchers that get created in the ZooCache.get function.  I have observed this in trace debugging.  

I have run the ingest testing in the Accumulo-Testing project on this code.  Also I have verified table creation, deletion and cloning in the accumulo command line interface.  I verified the creation of the table configurations at their new locations inside of the ZooKeeper command line interface. 