### PR TITLE
Fixes #1398 trace server advertising default bind address (0.0.0.0) in zookeeper

### DIFF
--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/AsyncSpanReceiver.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/AsyncSpanReceiver.java
@@ -94,13 +94,15 @@ public abstract class AsyncSpanReceiver<SpanKey,Destination> implements SpanRece
     }
 
     host = conf.get(TraceUtil.TRACE_HOST_PROPERTY, host);
-    if (host == null) {
+    log.info("host from config: {}", host);
+    if (host == null || "0.0.0.0".equals(host)) {
       try {
         host = InetAddress.getLocalHost().getCanonicalHostName().toString();
       } catch (UnknownHostException e) {
         host = "unknown";
       }
     }
+    log.info("starting span receiver with hostname {}", host);
     service = conf.get(TraceUtil.TRACE_SERVICE_PROPERTY, service);
     maxQueueSize = conf.getInt(QUEUE_SIZE, maxQueueSize);
     minSpanSize = conf.getInt(SPAN_MIN_MS, minSpanSize);

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.channels.ServerSocketChannel;
@@ -222,8 +223,14 @@ public class TraceServer implements Watcher, AutoCloseable {
     TThreadPoolServer.Args options = new TThreadPoolServer.Args(transport);
     options.processor(new Processor<Iface>(new Receiver()));
     server = new TThreadPoolServer(options);
-    registerInZooKeeper(sock.getInetAddress().getHostAddress() + ":" + sock.getLocalPort(),
-        conf.get(Property.TRACE_ZK_PATH));
+    // if sock is bound to the wildcard address, the local address will be 0.0.0.0.
+    // check for this, and try using InetAddress.getLocalHost instead.
+    // the problem is registering 0.0.0.0 in zookeeper doesn't work for non-local
+    // services (like remote tablet servers)
+    String hostAddr = sock.getInetAddress().getHostAddress();
+    if ("0.0.0.0".equals(hostAddr))
+      hostAddr = InetAddress.getLocalHost().getHostAddress();
+    registerInZooKeeper(hostAddr + ":" + sock.getLocalPort(), conf.get(Property.TRACE_ZK_PATH));
     writer = new AtomicReference<>(this.accumuloClient.createBatchWriter(tableName,
         new BatchWriterConfig().setMaxLatency(BATCH_WRITER_MAX_LATENCY, TimeUnit.SECONDS)));
   }


### PR DESCRIPTION
Fix for #1398 