### PR TITLE
Fix GcMetricsIT test when multiple IT tests run

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/GcMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GcMetricsIT.java
@@ -74,7 +74,9 @@ public class GcMetricsIT extends AccumuloClusterHarness {
 
       long testStart = System.currentTimeMillis();
 
+      // ignore first line - if file exists it can be from another test / run
       LineUpdate firstUpdate = waitForUpdate(-1, gcTail);
+      firstUpdate = waitForUpdate(firstUpdate.getLastUpdate(), gcTail);
 
       Map<String,Long> firstSeenMap = parseLine(firstUpdate.getLine());
 


### PR DESCRIPTION
The test previously did not account for metrics that were published from previous runs or if multiple IT tests were run without cleaning the target directory.  The metrics are read from a file that is appended, so previous test values could cause test failures - with this change, the GcMetricsIT test ignores the first line and then processes the subsequent updates generated during the test.