### PR TITLE
Made tablet assignment wait on upgrade.

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/UpgradeCoordinator.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/UpgradeCoordinator.java
@@ -22,45 +22,125 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.master.EventCoordinator;
 import org.apache.accumulo.server.ServerConstants;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class UpgradeCoordinator {
 
+  public enum UpgradeStatus {
+    /**
+     * This signifies the upgrade status is in the process of being determined. Its best to assume
+     * nothing is upgraded when seeing this.
+     */
+    INITIAL {
+      @Override
+      public boolean isParentLevelUpgraded(KeyExtent extent) {
+        return false;
+      }
+    },
+    /**
+     * This signifies that only zookeeper has been upgraded so far.
+     */
+    UPGRADED_ZOOKEEPER {
+      @Override
+      public boolean isParentLevelUpgraded(KeyExtent extent) {
+        return extent.isRootTablet();
+      }
+    },
+    /**
+     * This signifies that only zookeeper and the root table have been upgraded so far.
+     */
+    UPGRADED_ROOT {
+      @Override
+      public boolean isParentLevelUpgraded(KeyExtent extent) {
+        return extent.isMeta();
+      }
+    },
+    /**
+     * This signifies that everything (zookeeper, root table, metadata table) is upgraded.
+     */
+    COMPLETE {
+      @Override
+      public boolean isParentLevelUpgraded(KeyExtent extent) {
+        return true;
+      }
+    },
+    /**
+     * This signifies a failure occurred during upgrade.
+     */
+    FAILED {
+      @Override
+      public boolean isParentLevelUpgraded(KeyExtent extent) {
+        return false;
+      }
+    };
+
+    /**
+     * Determines if the place where this extent stores its metadata was upgraded for a given
+     * upgrade status.
+     */
+    public abstract boolean isParentLevelUpgraded(KeyExtent extent);
+  }
+
   private static Logger log = LoggerFactory.getLogger(UpgradeCoordinator.class);
 
   private ServerContext context;
-  private boolean haveUpgradedZooKeeper = false;
-  private boolean startedMetadataUpgrade = false;
   private int currentVersion;
   private Map<Integer,Upgrader> upgraders = Map.of(ServerConstants.SHORTEN_RFILE_KEYS,
       new Upgrader8to9(), ServerConstants.CRYPTO_CHANGES, new Upgrader9to10());
 
-  public UpgradeCoordinator(ServerContext ctx) {
+  private volatile UpgradeStatus status;
+
+  private EventCoordinator eventCoordinator;
+
+  public UpgradeCoordinator(ServerContext ctx, EventCoordinator eventCoordinator) {
     int currentVersion = ServerUtil.getAccumuloPersistentVersion(ctx.getVolumeManager());
 
     ServerUtil.ensureDataVersionCompatible(currentVersion);
 
     this.currentVersion = currentVersion;
     this.context = ctx;
+    this.eventCoordinator = eventCoordinator;
+
+    if (currentVersion < ServerConstants.DATA_VERSION) {
+      status = UpgradeStatus.INITIAL;
+    } else {
+      status = UpgradeStatus.COMPLETE;
+    }
+  }
+
+  private void setStatus(UpgradeStatus status) {
+    UpgradeStatus oldStatus = this.status;
+    this.status = status;
+    // calling this will wake up threads that may assign tablets. After the upgrade status changes
+    // those threads may make different assignment decisions.
+    eventCoordinator.event("Upgrade status changed from %s to %s", oldStatus, status);
   }
 
   @SuppressFBWarnings(value = "DM_EXIT",
       justification = "Want to immediately stop all master threads on upgrade error")
   private void handleFailure(Exception e) {
     log.error("FATAL: Error performing upgrade", e);
+    // do not want to call setStatus and signal an event in this case
+    status = UpgradeStatus.FAILED;
     System.exit(1);
   }
 
   public synchronized void upgradeZookeeper() {
-    if (haveUpgradedZooKeeper) {
-      throw new IllegalStateException("Only expect this method to be called once");
-    }
+    if (status == UpgradeStatus.COMPLETE)
+      return;
+
+    Preconditions.checkState(status == UpgradeStatus.INITIAL,
+        "Not currently in a suitable state to do zookeeper upgrade %s", status);
 
     try {
       if (currentVersion < ServerConstants.DATA_VERSION) {
@@ -72,28 +152,30 @@ public class UpgradeCoordinator {
         }
       }
 
-      haveUpgradedZooKeeper = true;
+      setStatus(UpgradeStatus.UPGRADED_ZOOKEEPER);
     } catch (Exception e) {
       handleFailure(e);
     }
+
   }
 
   public synchronized Future<Void> upgradeMetadata() {
-    if (startedMetadataUpgrade) {
-      throw new IllegalStateException("Only expect this method to be called once");
-    }
+    if (status == UpgradeStatus.COMPLETE)
+      return CompletableFuture.completedFuture(null);
 
-    if (!haveUpgradedZooKeeper) {
-      throw new IllegalStateException("We should only attempt to upgrade"
-          + " Accumulo's metadata table if we've already upgraded ZooKeeper."
-          + " Please save all logs and file a bug.");
-    }
-
-    startedMetadataUpgrade = true;
+    Preconditions.checkState(status == UpgradeStatus.UPGRADED_ZOOKEEPER,
+        "Not currently in a suitable state to do metadata upgrade %s", status);
 
     if (currentVersion < ServerConstants.DATA_VERSION) {
       return Executors.newCachedThreadPool().submit(() -> {
         try {
+          for (int v = currentVersion; v < ServerConstants.DATA_VERSION; v++) {
+            log.info("Upgrading Root from data version {}", v);
+            upgraders.get(v).upgradeRoot(context);
+          }
+
+          setStatus(UpgradeStatus.UPGRADED_ROOT);
+
           for (int v = currentVersion; v < ServerConstants.DATA_VERSION; v++) {
             log.info("Upgrading Metadata from data version {}", v);
             upgraders.get(v).upgradeMetadata(context);
@@ -102,6 +184,7 @@ public class UpgradeCoordinator {
           log.info("Updating persistent data version.");
           ServerUtil.updateAccumuloVersion(context.getVolumeManager(), currentVersion);
           log.info("Upgrade complete");
+          setStatus(UpgradeStatus.COMPLETE);
         } catch (Exception e) {
           handleFailure(e);
         }
@@ -110,5 +193,9 @@ public class UpgradeCoordinator {
     } else {
       return CompletableFuture.completedFuture(null);
     }
+  }
+
+  public UpgradeStatus getStatus() {
+    return status;
   }
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader.java
@@ -31,5 +31,7 @@ import org.apache.accumulo.server.ServerContext;
 public interface Upgrader {
   void upgradeZookeeper(ServerContext ctx);
 
+  void upgradeRoot(ServerContext ctx);
+
   void upgradeMetadata(ServerContext ctx);
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader8to9.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader8to9.java
@@ -31,7 +31,13 @@ public class Upgrader8to9 implements Upgrader {
   }
 
   @Override
+  public void upgradeRoot(ServerContext ctx) {
+    // There is no action that needs to be taken for metadata
+  }
+
+  @Override
   public void upgradeMetadata(ServerContext ctx) {
     // There is no action that needs to be taken for metadata
   }
+
 }

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -114,10 +114,13 @@ public class Upgrader9to10 implements Upgrader {
   }
 
   @Override
-  public void upgradeMetadata(ServerContext ctx) {
+  public void upgradeRoot(ServerContext ctx) {
     upgradeDirColumns(ctx, Ample.DataLevel.METADATA);
     upgradeFileDeletes(ctx, Ample.DataLevel.METADATA);
+  }
 
+  @Override
+  public void upgradeMetadata(ServerContext ctx) {
     upgradeDirColumns(ctx, Ample.DataLevel.USER);
     upgradeFileDeletes(ctx, Ample.DataLevel.USER);
   }


### PR DESCRIPTION
While working on #1389 I noticed that tablets were being assigned to tservers
before their metadata was upgraded.  This commit makes assignment wait until a
tablets metadata is upgraded.  For example, assignment of the root tablet should
wait for zookeeper to be upgraded,  assignment of metadata tablets should wait
for the root tablet to be upgraded, and assignment of user tablets should wait
for metadata tablets to be upgraded.

The way waiting is done is by considering the upgrade status when computing
a tablets goal state.  If a tablets metadata store is not upgraded, then its
goal state will be unassigned.