### PR TITLE
check that the WAL directory and log files can sync

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -166,6 +166,9 @@ public interface VolumeManager {
   // decide on which of the given locations to create a new file
   String choose(VolumeChooserEnvironment env, String[] options);
 
+  // are sync and flush supported for the given path
+  boolean canSyncAndFlush(Path path);
+
   /**
    * Fetch the default Volume
    */

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -162,6 +162,7 @@ import org.apache.accumulo.core.util.ratelimit.SharedRateLimiterFactory.RateProv
 import org.apache.accumulo.fate.util.LoggingRunnable;
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.accumulo.fate.util.Retry.RetryFactory;
+import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
@@ -3017,11 +3018,7 @@ public class TabletServer extends AbstractServer {
     if (!fs.canSyncAndFlush(new Path(logPath))) {
       // sleep a few seconds in case this is at cluster start...give monitor
       // time to start so the warning will be more visible
-      try {
-        Thread.sleep(5000);
-      } catch (Exception ignored) {
-        // yes, really ignored
-      }
+      UtilWaitThread.sleep(5000);
       log.warn("WAL directory ({}) implementation does not support sync or flush."
           + " Data loss may occur.", logPath);
     }


### PR DESCRIPTION
hsync() and hflush() are silent no-ops when using HDFS erasure coding.  this change will check the base WAL directory at tserver startup, and also check log files when they are created, to make sure they are not using EC.  right now this just generates a warning.  