### PR TITLE
Exclude unused transitive dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,6 +46,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>listenablefuture</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -98,10 +104,22 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Hello, I noticed that dependencies `com.google.guava:listenablefuture`, `org.apache.httpcomponents:httpcore`, and `io.netty:netty` are not used. Hence, these transitive dependencies with compile scope can be safely excluded in the `pom`. This makes the core of accumulo slimmer in size and its dependency tree becomes less complex and easier to maintain.