### PR TITLE
Fixes #1225 - Created a single ZooNode that tracks changes for all table configs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
   public static final String ZTABLE_COMPACT_ID = "/compact-id";
   public static final String ZTABLE_COMPACT_CANCEL_ID = "/compact-cancel-id";
   public static final String ZTABLE_NAMESPACE = "/namespace";
+  public static final String ZTABLE_CONFIG_VERSION = "/table-config-version";
 
   public static final String ZNAMESPACES = "/namespaces";
   public static final String ZNAMESPACE_NAME = "/name";

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -629,6 +629,8 @@ public class Initialize implements KeywordExecutable {
     zoo.putPersistentData(zkInstanceRoot, EMPTY_BYTE_ARRAY, NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLES, Constants.ZTABLES_INITIAL_ID,
         NodeExistsPolicy.FAIL);
+    zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLE_CONFIG_VERSION, new byte[0],
+        NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZNAMESPACES, new byte[0],
         NodeExistsPolicy.FAIL);
     TableManager.prepareNewNamespaceState(zoo, uuid, Namespace.DEFAULT.id(),

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TablePropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TablePropUtil.java
@@ -17,6 +17,9 @@
 package org.apache.accumulo.server.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.fate.zookeeper.ZooCache.TABLE_SETTING_CONFIG_PATTERN;
+
+import java.util.regex.Matcher;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.Property;
@@ -26,8 +29,12 @@ import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TablePropUtil {
+
+  private static final Logger log = LoggerFactory.getLogger(TablePropUtil.class);
 
   public static boolean setTableProperty(ServerContext context, TableId tableId, String property,
       String value) throws KeeperException, InterruptedException {
@@ -47,7 +54,10 @@ public class TablePropUtil {
     // create the zk node for this property and set it's data to the specified value
     String zPath = zkTablePath + "/" + property;
     zoo.putPersistentData(zPath, value.getBytes(UTF_8), NodeExistsPolicy.OVERWRITE);
-
+    updateTableConfigTrackingZnode(zPath, zoo);
+    if (log.isTraceEnabled()) {
+      log.trace("updateTableConfigTrackingZnode called in setTableProperty for " + zPath);
+    }
     return true;
   }
 
@@ -61,9 +71,43 @@ public class TablePropUtil {
       throws InterruptedException, KeeperException {
     String zPath = getTablePath(context.getZooKeeperRoot(), tableId) + "/" + property;
     context.getZooReaderWriter().recursiveDelete(zPath, NodeMissingPolicy.SKIP);
+    updateTableConfigTrackingZnode(zPath, context.getZooReaderWriter());
+    if (log.isTraceEnabled()) {
+      log.trace("updateTableConfigTrackingZnode called in removeTableProperty " + zPath);
+    }
   }
 
   private static String getTablePath(String zkRoot, TableId tableId) {
     return zkRoot + Constants.ZTABLES + "/" + tableId.canonical() + Constants.ZTABLE_CONF;
   }
+
+  /**
+   * Sets the table-config-version Zookeeper node value with the ZPath of the table configuration
+   * item that has just been created, updated or deleted. This triggers the NodeDataChanged event
+   * for the table-config-version which cause all the ZooCaches to be updated.
+   *
+   * @param zPath
+   *          The Zookeeper path to the table configuration being modified
+   * @param zoo
+   *          The ZooReaderWriter that will update the table-config-version
+   * @throws KeeperException
+   *           If the putPersistant data call this exception may be thrown
+   * @throws InterruptedException
+   *           If the putPersistant data call this exception may be thrown
+   */
+
+  private static void updateTableConfigTrackingZnode(String zPath, ZooReaderWriter zoo)
+      throws KeeperException, InterruptedException {
+
+    String pathPrefix;
+    Matcher configMatcher = TABLE_SETTING_CONFIG_PATTERN.matcher(zPath);
+    if (configMatcher.matches()) {
+      pathPrefix = configMatcher.group(1);
+      zoo.putPersistentData(pathPrefix + Constants.ZTABLE_CONFIG_VERSION, zPath.getBytes(UTF_8),
+          NodeExistsPolicy.OVERWRITE);
+
+    }
+
+  }
+
 }


### PR DESCRIPTION
@ivakegg  has reviewed this code and has recommended this pull request.  It is nearly an exact implementation of what @ctubbsii  has specified at the top of the Issue #1125. The solution has been tested in Fluo-uno and Fluo-muchos on EC-2.  It has been tested in the accumulo shell by using the 'config' command to change table properties and see the changes made effective. Other commands like 'createtable' and 'deletetable' and 'clonetable' have been tested to check that the system works as expected.  Accumulo-Testing 'cingest createtables' and 'cingest ingest' both run well.  It passes the  'mvn clean verify -Psunny' build.

The non-existence of the watchers has been verified using the ZooKeeper 'wchp' four letter word command.   These four letter commands need to be whitelisted in your zoo.cfg file by adding this line:  
 4lw.commands.whitelist=*
You need to stop and start Zookeeper to see the whitelisting commands come into effect. 
You run the 'wchp' four letter command from the shell like so:
echo wchp | nc localhost 2181 | grep 'conf/table\.
 
The only watchers remaining for table configuration are the ones  under /accumulo/{InstanceID}/namespaces.  We no longer see accumulation of table configuration item watchers as tables are created and deleted.  

This pull request should fix some system issues we have seen over the years in large systems. 