### PR TITLE
 Fix check for Standalone properties file. Fixes #1168 

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -63,19 +63,19 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
         try {
           reader = new FileReader(f);
         } catch (FileNotFoundException e) {
-          log.warn("Could not read properties from specified file: {}", propertyFile, e);
+          throw new RuntimeException("Could not read properties from specified file: " + propertyFile, e);
         }
 
         if (reader != null) {
           try {
             fileProperties.load(reader);
           } catch (IOException e) {
-            log.warn("Could not load properties from specified file: {}", propertyFile, e);
+            throw new RuntimeException("Could not load properties from specified file: " + propertyFile, e);
           } finally {
             try {
               reader.close();
             } catch (IOException e) {
-              log.warn("Could not close reader", e);
+              throw new RuntimeException("Could not close reader", e);
             }
           }
 
@@ -83,10 +83,10 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
           clientConf = fileProperties.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
         }
       } else {
-        log.debug("Property file ({}) is not a readable file", propertyFile);
+        throw new RuntimeException("Property file (" + propertyFile + ") is not a readable file");
       }
     } else {
-      log.debug("No properties file found in {}", ACCUMULO_IT_PROPERTIES_FILE);
+      throw new RuntimeException("No properties file found in " + ACCUMULO_IT_PROPERTIES_FILE);
     }
 
     if (clusterTypeValue == null) {

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -57,36 +57,16 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
     if (propertyFile != null) {
       // Check for properties provided in a file
       File f = new File(propertyFile);
-      if (f.exists() && f.isFile() && f.canRead()) {
-        Properties fileProperties = new Properties();
-        FileReader reader = null;
-        try {
-          reader = new FileReader(f);
-        } catch (FileNotFoundException e) {
-          throw new RuntimeException("Could not read properties from specified file: " + propertyFile, e);
-        }
-
-        if (reader != null) {
-          try {
-            fileProperties.load(reader);
-          } catch (IOException e) {
-            throw new RuntimeException("Could not load properties from specified file: " + propertyFile, e);
-          } finally {
-            try {
-              reader.close();
-            } catch (IOException e) {
-              throw new RuntimeException("Could not close reader", e);
-            }
-          }
-
-          clusterTypeValue = fileProperties.getProperty(ACCUMULO_CLUSTER_TYPE_KEY);
-          clientConf = fileProperties.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
-        }
-      } else {
-        throw new RuntimeException("Property file (" + propertyFile + ") is not a readable file");
+      Properties fileProperties = new Properties();
+      try (FileReader reader = new FileReader(f)) {
+        fileProperties.load(reader);
+        clusterTypeValue = fileProperties.getProperty(ACCUMULO_CLUSTER_TYPE_KEY);
+        clientConf = fileProperties.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
+      } catch (IOException e) {
+        throw new RuntimeException("Could not read properties from file: " + propertyFile, e);
       }
     } else {
-      throw new RuntimeException("No properties file found in " + ACCUMULO_IT_PROPERTIES_FILE);
+      log.debug("No properties file found in {}", ACCUMULO_IT_PROPERTIES_FILE);
     }
 
     if (clusterTypeValue == null) {


### PR DESCRIPTION
Revert the revert for #1189 and cleanup the check to only throw error when appropriate.