### PR TITLE
Remove java flags for CMS java garbage collector

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -65,9 +65,6 @@ export CLASSPATH
 
 ## JVM options set for all processes. Extra options can be passed in by setting ACCUMULO_JAVA_OPTS to an array of options.
 JAVA_OPTS=("${ACCUMULO_JAVA_OPTS[@]}"
-  '-XX:+UseConcMarkSweepGC'
-  '-XX:CMSInitiatingOccupancyFraction=75'
-  '-XX:+CMSClassUnloadingEnabled'
   '-XX:OnOutOfMemoryError=kill -9 %p'
   '-XX:-OmitStackTraceInFastThrow'
   '-Djava.net.preferIPv4Stack=true'

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -217,8 +217,6 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     }
     // @formatter:off
     argList.addAll(Arrays.asList(
-        "-XX:+UseConcMarkSweepGC",
-        "-XX:CMSInitiatingOccupancyFraction=75",
         "-Dapple.awt.UIElement=true",
         "-Djava.net.preferIPv4Stack=true",
         "-XX:+PerfDisableSharedMem",


### PR DESCRIPTION
* Concurrent Mark Sweep (CMS) garbage collector is deprecated in Java
  9 and later, and will likely be removed in a future version
* This change removes the explicit use of a specific java garbage
  collector, instead relying on users to configure their own in their
  environment, as appropriate for their circumstances
* If users do not set their JVM garbage collector explicitly, then we
  shouldn't override default Java behavior with our own preferred
  default, which may be worse than Java's defaults