### PR TITLE
Streamline passing scan parameters within tserver

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -280,6 +280,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
+import com.google.common.collect.Collections2;
 
 public class TabletServer extends AbstractServer {
 
@@ -840,15 +841,8 @@ public class TabletServer extends AbstractServer {
         writeTracker.waitForWrites(TabletType.type(batch.keySet()));
       }
 
-      Set<Column> columnSet;
-      if (tcolumns.isEmpty()) {
-        columnSet = Collections.emptySet();
-      } else {
-        columnSet = new HashSet<Column>();
-        for (TColumn tcolumn : tcolumns) {
-          columnSet.add(new Column(tcolumn));
-        }
-      }
+      Set<Column> columnSet = tcolumns.isEmpty() ? Collections.emptySet()
+          : new HashSet<Column>(Collections2.transform(tcolumns, Column::new));
 
       ScanParameters scanParams =
           new ScanParameters(-1, new Authorizations(authorizations), columnSet, ssiList, ssio,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
@@ -115,9 +115,8 @@ public class LookupTask extends ScanTask<MultiScanResult> {
           if (isCancelled())
             interruptFlag.set(true);
 
-          lookupResult = tablet.lookup(entry.getValue(), session.columnSet, session.auths, results,
-              maxResultsSize - bytesAdded, session.ssiList, session.ssio, interruptFlag,
-              session.samplerConfig, session.batchTimeOut, session.context);
+          lookupResult = tablet.lookup(entry.getValue(), results, session.scanParams,
+              maxResultsSize - bytesAdded, interruptFlag);
 
           // if the tablet was closed it it possible that the
           // interrupt flag was set.... do not want it set for

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
@@ -16,12 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.tserver.tablet;
+package org.apache.accumulo.tserver.scan;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.Column;
@@ -29,31 +28,29 @@ import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 
-final class ScanOptions {
+/**
+ * Information needed to execute a scan inside a tablet
+ */
+public final class ScanParameters {
 
   private final Authorizations authorizations;
-  private final byte[] defaultLabels;
   private final Set<Column> columnSet;
   private final List<IterInfo> ssiList;
   private final Map<String,Map<String,String>> ssio;
-  private final AtomicBoolean interruptFlag;
-  private final int num;
+  private final int maxEntries;
   private final boolean isolated;
-  private SamplerConfiguration samplerConfig;
+  private final SamplerConfiguration samplerConfig;
   private final long batchTimeOut;
-  private String classLoaderContext;
+  private final String classLoaderContext;
 
-  ScanOptions(int num, Authorizations authorizations, byte[] defaultLabels, Set<Column> columnSet,
-      List<IterInfo> ssiList, Map<String,Map<String,String>> ssio, AtomicBoolean interruptFlag,
-      boolean isolated, SamplerConfiguration samplerConfig, long batchTimeOut,
-      String classLoaderContext) {
-    this.num = num;
+  public ScanParameters(int maxEntries, Authorizations authorizations, Set<Column> columnSet,
+      List<IterInfo> ssiList, Map<String,Map<String,String>> ssio, boolean isolated,
+      SamplerConfiguration samplerConfig, long batchTimeOut, String classLoaderContext) {
+    this.maxEntries = maxEntries;
     this.authorizations = authorizations;
-    this.defaultLabels = defaultLabels;
     this.columnSet = columnSet;
     this.ssiList = ssiList;
     this.ssio = ssio;
-    this.interruptFlag = interruptFlag;
     this.isolated = isolated;
     this.samplerConfig = samplerConfig;
     this.batchTimeOut = batchTimeOut;
@@ -62,10 +59,6 @@ final class ScanOptions {
 
   public Authorizations getAuthorizations() {
     return authorizations;
-  }
-
-  public byte[] getDefaultLabels() {
-    return defaultLabels;
   }
 
   public Set<Column> getColumnSet() {
@@ -80,12 +73,8 @@ final class ScanOptions {
     return ssio;
   }
 
-  public AtomicBoolean getInterruptFlag() {
-    return interruptFlag;
-  }
-
-  public int getNum() {
-    return num;
+  public int getMaxEntries() {
+    return maxEntries;
   }
 
   public boolean isIsolated() {
@@ -114,9 +103,9 @@ final class ScanOptions {
     buf.append(", batchTimeOut=").append(this.batchTimeOut);
     buf.append(", context=").append(this.classLoaderContext);
     buf.append(", columns=").append(this.columnSet);
-    buf.append(", interruptFlag=").append(this.interruptFlag);
     buf.append(", isolated=").append(this.isolated);
-    buf.append(", num=").append(this.num);
+    buf.append(", maxEntries=").append(this.maxEntries);
+    buf.append(", num=").append(this.maxEntries);
     buf.append(", samplerConfig=").append(this.samplerConfig);
     buf.append("]");
     return buf.toString();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/MultiScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/MultiScanSession.java
@@ -18,26 +18,20 @@
  */
 package org.apache.accumulo.tserver.session;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
 import org.apache.accumulo.core.dataImpl.thrift.MultiScanResult;
-import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
+import org.apache.accumulo.tserver.scan.ScanParameters;
 import org.apache.accumulo.tserver.scan.ScanTask;
 
 public class MultiScanSession extends ScanSession {
   public final KeyExtent threadPoolExtent;
   public final Map<KeyExtent,List<Range>> queries;
-  public final SamplerConfiguration samplerConfig;
-  public final long batchTimeOut;
-  public final String context;
 
   // stats
   public int numRanges;
@@ -48,16 +42,12 @@ public class MultiScanSession extends ScanSession {
   public volatile ScanTask<MultiScanResult> lookupTask;
 
   public MultiScanSession(TCredentials credentials, KeyExtent threadPoolExtent,
-      Map<KeyExtent,List<Range>> queries, List<IterInfo> ssiList,
-      Map<String,Map<String,String>> ssio, Authorizations authorizations,
-      SamplerConfiguration samplerConfig, long batchTimeOut, String context,
+      Map<KeyExtent,List<Range>> queries, ScanParameters scanParams,
+
       Map<String,String> executionHints) {
-    super(credentials, new HashSet<>(), ssiList, ssio, authorizations, executionHints);
+    super(credentials, scanParams, executionHints);
     this.queries = queries;
     this.threadPoolExtent = threadPoolExtent;
-    this.samplerConfig = samplerConfig;
-    this.batchTimeOut = batchTimeOut;
-    this.context = context;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/ScanSession.java
@@ -20,20 +20,18 @@ package org.apache.accumulo.tserver.session;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
-import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.spi.common.IteratorConfiguration;
 import org.apache.accumulo.core.spi.common.Stats;
 import org.apache.accumulo.core.spi.scan.ScanInfo;
 import org.apache.accumulo.core.util.Stat;
+import org.apache.accumulo.tserver.scan.ScanParameters;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -71,20 +69,13 @@ public abstract class ScanSession extends Session implements ScanInfo {
   private Stat idleStats = new Stat();
   public Stat runStats = new Stat();
 
-  public final HashSet<Column> columnSet;
-  public final List<IterInfo> ssiList;
-  public final Map<String,Map<String,String>> ssio;
-  public final Authorizations auths;
+  public final ScanParameters scanParams;
   private Map<String,String> executionHints;
 
-  ScanSession(TCredentials credentials, HashSet<Column> cols, List<IterInfo> ssiList,
-      Map<String,Map<String,String>> ssio, Authorizations auths,
+  ScanSession(TCredentials credentials, ScanParameters scanParams,
       Map<String,String> executionHints) {
     super(credentials);
-    this.columnSet = cols;
-    this.ssiList = ssiList;
-    this.ssio = ssio;
-    this.auths = auths;
+    this.scanParams = scanParams;
     if (executionHints == null) {
       this.executionHints = Collections.emptyMap();
     } else {
@@ -123,7 +114,7 @@ public abstract class ScanSession extends Session implements ScanInfo {
 
   @Override
   public Set<Column> getFetchedColumns() {
-    return Collections.unmodifiableSet(columnSet);
+    return Collections.unmodifiableSet(scanParams.getColumnSet());
   }
 
   private class IterConfImpl implements IteratorConfiguration {
@@ -151,7 +142,7 @@ public abstract class ScanSession extends Session implements ScanInfo {
 
     @Override
     public Map<String,String> getOptions() {
-      Map<String,String> opts = ssio.get(ii.iterName);
+      Map<String,String> opts = scanParams.getSsio().get(ii.iterName);
       return opts == null || opts.isEmpty() ? Collections.emptyMap()
           : Collections.unmodifiableMap(opts);
     }
@@ -159,7 +150,7 @@ public abstract class ScanSession extends Session implements ScanInfo {
 
   @Override
   public Collection<IteratorConfiguration> getClientScanIterators() {
-    return Lists.transform(ssiList, IterConfImpl::new);
+    return Lists.transform(scanParams.getSsiList(), IterConfImpl::new);
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -387,11 +387,13 @@ public class SessionManager {
           }
         }
 
+        var params = ss.scanParams;
         ActiveScan activeScan =
             new ActiveScan(ss.client, ss.getUser(), ss.extent.getTableId().canonical(),
                 ct - ss.startTime, ct - ss.lastAccessTime, ScanType.SINGLE, state,
-                ss.extent.toThrift(), Translator.translate(ss.columnSet, Translators.CT),
-                ss.ssiList, ss.ssio, ss.auths.getAuthorizationsBB(), ss.context);
+                ss.extent.toThrift(), Translator.translate(params.getColumnSet(), Translators.CT),
+                params.getSsiList(), params.getSsio(),
+                params.getAuthorizations().getAuthorizationsBB(), params.getClassLoaderContext());
 
         // scanId added by ACCUMULO-2641 is an optional thrift argument and not available in
         // ActiveScan constructor
@@ -421,11 +423,13 @@ public class SessionManager {
           }
         }
 
+        var params = mss.scanParams;
         activeScans.add(new ActiveScan(mss.client, mss.getUser(),
             mss.threadPoolExtent.getTableId().canonical(), ct - mss.startTime,
             ct - mss.lastAccessTime, ScanType.BATCH, state, mss.threadPoolExtent.toThrift(),
-            Translator.translate(mss.columnSet, Translators.CT), mss.ssiList, mss.ssio,
-            mss.auths.getAuthorizationsBB(), mss.context));
+            Translator.translate(params.getColumnSet(), Translators.CT), params.getSsiList(),
+            params.getSsio(), params.getAuthorizations().getAuthorizationsBB(),
+            params.getClassLoaderContext()));
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
@@ -18,17 +18,13 @@
  */
 package org.apache.accumulo.tserver.session;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
-import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
+import org.apache.accumulo.tserver.scan.ScanParameters;
 import org.apache.accumulo.tserver.scan.ScanTask;
 import org.apache.accumulo.tserver.tablet.ScanBatch;
 import org.apache.accumulo.tserver.tablet.Scanner;
@@ -41,18 +37,12 @@ public class SingleScanSession extends ScanSession {
   public volatile ScanTask<ScanBatch> nextBatchTask;
   public Scanner scanner;
   public final long readaheadThreshold;
-  public final long batchTimeOut;
-  public final String context;
 
-  public SingleScanSession(TCredentials credentials, KeyExtent extent, HashSet<Column> columnSet,
-      List<IterInfo> ssiList, Map<String,Map<String,String>> ssio, Authorizations authorizations,
-      long readaheadThreshold, long batchTimeOut, String context,
-      Map<String,String> executionHints) {
-    super(credentials, columnSet, ssiList, ssio, authorizations, executionHints);
+  public SingleScanSession(TCredentials credentials, KeyExtent extent, ScanParameters scanParams,
+      long readaheadThreshold, Map<String,String> executionHints) {
+    super(credentials, scanParams, executionHints);
     this.extent = extent;
     this.readaheadThreshold = readaheadThreshold;
-    this.batchTimeOut = batchTimeOut;
-    this.context = context;
   }
 
   @Override


### PR DESCRIPTION
While working on #1383 I found it difficult to get caching parameters
from one part of the tserver to another for a scan.  The difficulty was
caused by many methods with many parameters that were mostly the same.
This commit changes the code to pass a single object around.

I decided to make these changes separate from #1383 inorder to make it
easier to review the changes for #1383.