### PR TITLE
Fixes #1220  -  Removes ZooKeeper watches on table configs when table is deleted.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -118,5 +118,4 @@ public class Constants {
   public static final String HDFS_TABLES_DIR = "/tables";
 
   public static final int DEFAULT_VISIBILITY_CACHE_SIZE = 1000;
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -118,4 +118,5 @@ public class Constants {
   public static final String HDFS_TABLES_DIR = "/tables";
 
   public static final int DEFAULT_VISIBILITY_CACHE_SIZE = 1000;
+
 }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -156,10 +156,8 @@ public class ZooCache {
       }
 
       switch (event.getType()) {
-        case NodeDataChanged:
         case NodeChildrenChanged:
-          if (event.getPath().endsWith("conf")
-              && event.getType().equals(Event.EventType.NodeChildrenChanged)) {
+          if (event.getPath().endsWith("conf")) {
             try {
               clear(event.getPath());
               getZooKeeper().exists(event.getPath(), watcher);
@@ -172,6 +170,7 @@ public class ZooCache {
               log.error("could not reset watcher on parent node: " + event.getPath());
             }
           }
+        case NodeDataChanged:
         case NodeCreated:
         case NodeDeleted:
           remove(event.getPath());

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -499,7 +499,7 @@ public class ZooCache {
       try {
         stat = zooKeeper.exists(zPath, false);
       } catch (KeeperException.BadVersionException | KeeperException.NoNodeException e1) {
-        throw new ConcurrentModificationException();
+        throw e1;
       }
 
       if (stat != null) {

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -22,6 +22,7 @@ import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -67,7 +68,7 @@ public class ZooCache {
   private final HashMap<String,byte[]> cache;
   private final HashMap<String,ZcStat> statCache;
   private final HashMap<String,List<String>> childrenCache;
-  private final HashMap<String,Boolean> znodeExists = new HashMap<>();
+  private final HashSet<String> znodeExists = new HashSet<>();
 
   private final ZooReader zReader;
   private final SecureRandom secureRandom = new SecureRandom();
@@ -173,9 +174,9 @@ public class ZooCache {
               try {
                 clear(event.getPath());
                 getZooKeeper().exists(event.getPath(), watcher);
-                 if (log.isTraceEnabled()) {
-                    log.trace("NodeChildrenChanged: resetting watcher for " + event.getPath());
-                 }
+                if (log.isTraceEnabled()) {
+                  log.trace("NodeChildrenChanged: resetting watcher for " + event.getPath());
+                }
               } catch (KeeperException | InterruptedException e) {
                 log.error("could not reset watcher on parent node: " + event.getPath());
               }
@@ -488,7 +489,7 @@ public class ZooCache {
 
     boolean watched = true;
 
-    if (znodeExists.containsKey(zPath))
+    if (znodeExists.contains(zPath))
       return watched;
 
     Matcher configMatcher = TABLE_SETTING_CONFIG_PATTERN.matcher(zPath);
@@ -504,7 +505,7 @@ public class ZooCache {
       if (stat != null) {
         watched = true;
         synchronized (znodeExists) {
-          znodeExists.put(zPath, true);
+          znodeExists.add(zPath);
         }
       } else {
         watched = false;

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -158,6 +158,20 @@ public class ZooCache {
       switch (event.getType()) {
         case NodeDataChanged:
         case NodeChildrenChanged:
+          if (event.getPath().endsWith("conf")
+              && event.getType().equals(Event.EventType.NodeChildrenChanged)) {
+            try {
+              clear(event.getPath());
+              getZooKeeper().exists(event.getPath(), watcher);
+              if (log.isTraceEnabled()) {
+                log.trace("NodeChildrenChanged: resetting watcher for " + event.getPath());
+                if (externalWatcher != null)
+                  log.trace("external watcher with process this zpath also " + event.getPath());
+              }
+            } catch (KeeperException | InterruptedException e) {
+              log.error("could not reset watcher on parent node: " + event.getPath());
+            }
+          }
         case NodeCreated:
         case NodeDeleted:
           remove(event.getPath());

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -172,13 +172,14 @@ public class ZooCache {
             Matcher confDirMatcher = TABLE_CONFIG_DIR_PATTERN.matcher(event.getPath());
             if (confDirMatcher.matches()) {
               try {
+                // If a table config parameter without a watch on it is deleted
+                // this is how it gets cleared from ZooCache
                 clear(event.getPath());
                 getZooKeeper().exists(event.getPath(), watcher);
-                if (log.isTraceEnabled()) {
-                  log.trace("NodeChildrenChanged: resetting watcher for " + event.getPath());
-                }
+                log.info("NodeChildrenChanged: resetting watcher for " + event.getPath());
+
               } catch (KeeperException | InterruptedException e) {
-                log.error("could not reset watcher on parent node: " + event.getPath());
+                log.error("Could not reset watcher on parent node: " + event.getPath());
               }
             }
           }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -472,7 +472,9 @@ public class ZooCache {
 
       if (stat != null) {
         watched = true;
-        znodeExists.put(zPath, true);
+        synchronized (znodeExists) {
+          znodeExists.put(zPath, true);
+        }
       } else {
         watched = false;
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -21,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -46,7 +45,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -253,13 +251,9 @@ public class TableManager {
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_STATE,
           NodeMissingPolicy.SKIP);
       String tableConfigPath = zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_CONF;
-      List<String> tableConfigs = zoo.getZooKeeper().getChildren(tableConfigPath, false);
-      for (String tableConfig : tableConfigs) {
-        log.trace("Deleting the table config " + tableConfigPath + "/" + tableConfig);
-        org.apache.zookeeper.data.Stat stat =
-            zoo.getZooKeeper().exists(tableConfigPath + "/" + tableConfig, false);
-      }
-
+      // The line below removes all the watches on the table configuration items from the Zookeeper
+      // server
+      zoo.getZooKeeper().getChildren(tableConfigPath, false);
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId, NodeMissingPolicy.SKIP);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.accumulo.server.tables;
 
@@ -250,10 +252,6 @@ public class TableManager {
       tableStateCache.remove(tableId);
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_STATE,
           NodeMissingPolicy.SKIP);
-      String tableConfigPath = zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_CONF;
-      // The line below removes all the watches on the table configuration items from the Zookeeper
-      // server
-      zoo.getZooKeeper().getChildren(tableConfigPath, false);
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId, NodeMissingPolicy.SKIP);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -258,7 +258,6 @@ public class TableManager {
         log.trace("Deleting the table config " + tableConfigPath + "/" + tableConfig);
         org.apache.zookeeper.data.Stat stat =
             zoo.getZooKeeper().exists(tableConfigPath + "/" + tableConfig, false);
-        zoo.getZooKeeper().delete(tableConfigPath + "/" + tableConfig, stat.getVersion());
       }
 
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId, NodeMissingPolicy.SKIP);

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -45,6 +46,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -250,6 +252,15 @@ public class TableManager {
       tableStateCache.remove(tableId);
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_STATE,
           NodeMissingPolicy.SKIP);
+      String tableConfigPath = zkRoot + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_CONF;
+      List<String> tableConfigs = zoo.getZooKeeper().getChildren(tableConfigPath, false);
+      for (String tableConfig : tableConfigs) {
+        log.trace("Deleting the table config " + tableConfigPath + "/" + tableConfig);
+        org.apache.zookeeper.data.Stat stat =
+            zoo.getZooKeeper().exists(tableConfigPath + "/" + tableConfig, false);
+        zoo.getZooKeeper().delete(tableConfigPath + "/" + tableConfig, stat.getVersion());
+      }
+
       zoo.recursiveDelete(zkRoot + Constants.ZTABLES + "/" + tableId, NodeMissingPolicy.SKIP);
     }
   }


### PR DESCRIPTION
This stops the number of watchers in Zookeeper from growing without a limit and ultimately crashing ZooKeeper.  You have to whitelist the wchp four letter command in ZooKeeper to verify watches are actually removed when tables are deleted.  You have to add this line to the zoo.cfg command to whitelist the four letter commands:  4lw.commands.whitelist=*  

This command will show you the table configurations in ZooKeeper that have watches on them:
'echo wchp | nc localhost 2181 | grep 'conf/table\.''

This pull request can't be done with the one for #1225.  
