### PR TITLE
add erasure coding and storage policy to table/namespace settings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -156,6 +156,15 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import org.apache.hadoop.io.erasurecode.ErasureCodeConstants;
+
 public class Constants {
 
   public static final String VERSION = FilteredConstants.VERSION;
@@ -117,4 +119,12 @@ public class Constants {
 
   public static final int MAX_TABLE_NAME_LEN = 1024;
   public static final int MAX_NAMESPACE_LEN = 1024;
+
+  // used to indicate normal hdfs replication, rather than erasure coding
+  public static final String HDFS_REPLICATION = ErasureCodeConstants.REPLICATION_POLICY_NAME;
+
+  // added in hadoop 3.1, but need to support compilation against
+  // hadoop 3.0. replace with HdfsConstants.PROVIDED_STORAGE_POLICY_NAME
+  // when 3.0 support is not longer required.
+  public static final String PROVIDED_STORAGE_POLICY_NAME = "PROVIDED";
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -970,12 +970,19 @@ public class TableOperationsImpl extends TableOperationsHelper {
     }
   }
 
+  private boolean validPropertyValue(final String property, final String value) {
+    Property p = Property.getPropertyByKey(property);
+    return p == null || p.getType().isValidFormat(value);
+  }
+
   @Override
   public void setProperty(final String tableName, final String property, final String value)
       throws AccumuloException, AccumuloSecurityException {
     checkArgument(tableName != null, "tableName is null");
     checkArgument(property != null, "property is null");
     checkArgument(value != null, "value is null");
+    checkArgument(Property.isValidTablePropertyKey(property), "invalid per-table property");
+    checkArgument(validPropertyValue(property, value), "improper value for property");
     try {
       setPropertyNoChecks(tableName, property, value);
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.util.format.DefaultFormatter;
 import org.apache.accumulo.core.util.interpret.DefaultScanInterpreter;
 import org.apache.accumulo.start.classloader.AccumuloClassLoader;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -829,6 +830,32 @@ public enum Property {
           + " need fast seeks within the timestamp range of a column. When setting this to fail, "
           + "also consider configuring the `" + NoDeleteConstraint.class.getName() + "` "
           + "constraint."),
+  @Experimental
+  TABLE_STORAGE_POLICY("table.hdfs.policy.storage", HdfsConstants.HOT_STORAGE_POLICY_NAME,
+      PropertyType.STORAGE_POLICY,
+      "HDFS Storage policy to apply to the directory tree holding the tablets for the "
+          + "table.  Can be one of '" + HdfsConstants.HOT_STORAGE_POLICY_NAME + "', '"
+          + HdfsConstants.WARM_STORAGE_POLICY_NAME + "', '" + HdfsConstants.COLD_STORAGE_POLICY_NAME
+          + "', '" + HdfsConstants.ONESSD_STORAGE_POLICY_NAME + "', '"
+          + HdfsConstants.ALLSSD_STORAGE_POLICY_NAME + "' or '"
+          + Constants.PROVIDED_STORAGE_POLICY_NAME + "'. '"
+          + HdfsConstants.MEMORY_STORAGE_POLICY_NAME
+          + "' is also available, but since it cannot guarantee data is written to disk in the event "
+          + "of a power failure, it is not recommended for use.  There is also some confusion"
+          + "in the documentation about the performance of '"
+          + HdfsConstants.MEMORY_STORAGE_POLICY_NAME + "' when more than one "
+          + "replicant is specified.  Also note, that only '"
+          + HdfsConstants.HOT_STORAGE_POLICY_NAME + "', '" + HdfsConstants.COLD_STORAGE_POLICY_NAME
+          + "', and '" + HdfsConstants.ALLSSD_STORAGE_POLICY_NAME
+          + "' make sense when using erasure coding."),
+  @Experimental
+  TABLE_CODING_POLICY("table.hdfs.policy.encoding", Constants.HDFS_REPLICATION, PropertyType.STRING,
+      "The HDFS erasure coding (EC) policy to apply to the directory tree holding the tablets "
+          + "for the table.  The default of '" + Constants.HDFS_REPLICATION
+          + "' uses standard HDFS block replication, "
+          + "subject to defaults set elsewhere.  Other policies will vary depending on the HDFS "
+          + "configuration.  'RS-6-3-64k' seems to be a good balance between scan performance and "
+          + "random seek latency."),
 
   // VFS ClassLoader properties
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -28,9 +28,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.lang3.Range;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 
 import com.google.common.base.Preconditions;
 
@@ -134,7 +136,14 @@ public enum PropertyType {
   BOOLEAN("boolean", in(false, null, "true", "false"),
       "Has a value of either 'true' or 'false' (case-insensitive)"),
 
-  URI("uri", x -> true, "A valid URI");
+  URI("uri", x -> true, "A valid URI"),
+
+  STORAGE_POLICY("storage policy",
+      in(true, HdfsConstants.HOT_STORAGE_POLICY_NAME, HdfsConstants.COLD_STORAGE_POLICY_NAME,
+          HdfsConstants.WARM_STORAGE_POLICY_NAME, HdfsConstants.ALLSSD_STORAGE_POLICY_NAME,
+          HdfsConstants.ONESSD_STORAGE_POLICY_NAME, HdfsConstants.MEMORY_STORAGE_POLICY_NAME,
+          Constants.PROVIDED_STORAGE_POLICY_NAME),
+      "One of 'HOT', 'COLD', 'WARM', 'ALLSSD', 'ONESSD', 'LAZY_PERSIST', or 'PROVIDED'");
 
   private String shortname, format;
   // Field is transient because enums are Serializable, but Predicates aren't necessarily,

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImplTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.accumulo.core.clientImpl;
+
+import static org.powermock.api.easymock.PowerMock.createPartialMock;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.NamespaceNotFoundException;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.PropertyType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NamespaceOperationsImpl.class)
+public class NamespaceOperationsImplTest {
+  private NamespaceOperationsImpl namespaceOpsImpl;
+
+  @Before
+  public void setup() {
+    namespaceOpsImpl = createPartialMock(NamespaceOperationsImpl.class, "setPropertyNoChecks",
+        "checkLocalityGroups");
+
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setNullNamespaceThrowsExcept()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    namespaceOpsImpl.setProperty(null, Property.INSTANCE_VOLUMES.getKey(), "none");
+  }
+
+  @SuppressFBWarnings(value = "NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS",
+      justification = "testing null value")
+  @Test(expected = IllegalArgumentException.class)
+  public void setNullKeyThrowsExcept()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    namespaceOpsImpl.setProperty("foo", null, "none");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setNullValueThrowsExcept()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    namespaceOpsImpl.setProperty(null, Property.INSTANCE_VOLUMES.getKey(), null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setInvalidKeyThrowsExcept()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    namespaceOpsImpl.setProperty("foo", "nosuchproperty", "none");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setInvalidValueThrowsExcept()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    namespaceOpsImpl.setProperty("foo", Property.TABLE_STORAGE_POLICY.getKey(), "SPICY");
+  }
+
+  @Test
+  public void testSetDefaults()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    for (Property p : Property.values()) {
+      // only need to test table properties
+      if (p.getType().equals(PropertyType.PREFIX) || !Property.isValidTablePropertyKey(p.getKey()))
+        continue;
+
+      namespaceOpsImpl.setProperty("foo", p.getKey(), p.getDefaultValue());
+    }
+  }
+
+  @Test
+  public void setCustomProperty()
+      throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
+    namespaceOpsImpl.setProperty("foo", "table.custom.myproperty", "foo");
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsImplTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.accumulo.core.clientImpl;
+
+import static org.powermock.api.easymock.PowerMock.createPartialMock;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.PropertyType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(TableOperationsImpl.class)
+public class TableOperationsImplTest {
+  private TableOperationsImpl tableOpsImpl;
+
+  @Before
+  public void setup() {
+    tableOpsImpl =
+        createPartialMock(TableOperationsImpl.class, "setPropertyNoChecks", "checkLocalityGroups");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setNullTableNameThrowsExcept() throws AccumuloException, AccumuloSecurityException {
+    tableOpsImpl.setProperty(null, Property.INSTANCE_VOLUMES.getKey(), "none");
+  }
+
+  @SuppressFBWarnings(value = "NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS",
+      justification = "testing null value")
+  @Test(expected = IllegalArgumentException.class)
+  public void setNullKeyThrowsExcept() throws AccumuloException, AccumuloSecurityException {
+    tableOpsImpl.setProperty("foo", null, "none");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setNullValueThrowsExcept() throws AccumuloException, AccumuloSecurityException {
+    tableOpsImpl.setProperty(null, Property.INSTANCE_VOLUMES.getKey(), null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setInvalidKeyThrowsExcept() throws AccumuloException, AccumuloSecurityException {
+    tableOpsImpl.setProperty("foo", "nosuchproperty", "none");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setInvalidValueThrowsExcept() throws AccumuloException, AccumuloSecurityException {
+    tableOpsImpl.setProperty("foo", Property.TABLE_STORAGE_POLICY.getKey(), "SPICY");
+  }
+
+  @Test
+  public void testSetDefaults() throws AccumuloException, AccumuloSecurityException {
+    for (Property p : Property.values()) {
+      // only need to test table properties
+      if (p.getType().equals(PropertyType.PREFIX) || !Property.isValidTablePropertyKey(p.getKey()))
+        continue;
+
+      tableOpsImpl.setProperty("foo", p.getKey(), p.getDefaultValue());
+    }
+  }
+
+  @Test
+  public void setCustomProperty() throws Exception {
+    tableOpsImpl.setProperty("foo", "table.custom.myproperty", "foo");
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.Constants;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -208,4 +210,12 @@ public class PropertyTypeTest {
     valid(null, "", "hdfs://hostname", "file:///path/", "hdfs://example.com:port/path");
   }
 
+  @Test
+  public void testTypeSTORAGE_POLICY() {
+    valid(HdfsConstants.HOT_STORAGE_POLICY_NAME, HdfsConstants.COLD_STORAGE_POLICY_NAME,
+        HdfsConstants.WARM_STORAGE_POLICY_NAME, HdfsConstants.ALLSSD_STORAGE_POLICY_NAME,
+        HdfsConstants.ONESSD_STORAGE_POLICY_NAME, HdfsConstants.MEMORY_STORAGE_POLICY_NAME,
+        Constants.PROVIDED_STORAGE_POLICY_NAME);
+    invalid(null, "SPICY");
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.ServerConstants;
+import org.apache.accumulo.server.util.Policies;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -141,6 +142,13 @@ public interface VolumeManager extends AutoCloseable {
 
   // forward to the appropriate FileSystem object
   boolean mkdirs(Path path, FsPermission permission) throws IOException;
+
+  // forward to the appropriate FileSystem object
+  boolean mkdirs(Path path, Policies policies) throws IOException;
+
+  // check and correct storage policy and encoding for path if supported
+  // by underlying FileSystem
+  void checkDirPolicies(Path path, Policies policies) throws IOException;
 
   // forward to the appropriate FileSystem object
   FSDataInputStream open(Path path) throws IOException;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ConvertTablePolicy.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ConvertTablePolicy.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.accumulo.server.util;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.NamespaceNotFoundException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.clientImpl.Namespaces;
+import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.server.ServerConstants;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.cli.ServerUtilOpts;
+import org.apache.accumulo.server.fs.VolumeChooserEnvironment;
+import org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+
+import com.beust.jcommander.Parameter;
+
+/**
+ * Utility to sync HDFS table directories with configured storage and erasure coding policies. After
+ * changing table.hdfs.policy.storage or table.hdfs.policy.encoding, this tool can be run to change
+ * the policies for the directories of the affected tables.
+ *
+ * The "-t" flag can be used to pass a comma separated list of tables to update, or the "-ns" flag
+ * can be used to specify that all tables in the given namespace are to be converted.
+ *
+ * If the "-compact" flag is passed, then each table will be compacted to complete the conversion of
+ * the RFiles.
+ *
+ * If the "-offline" flag is passed, then each table is taken offline before the conversion, and
+ * brought back online after.
+ */
+public class ConvertTablePolicy {
+  private static class ConvertOpts extends ServerUtilOpts {
+    @Parameter(names = {"-ns", "--namespace"}, description = "Namespace to convert")
+    String namespace = null;
+    @Parameter(names = {"-t", "-table", "--table"},
+        description = "Comma separated list of tables to convert")
+    String table = null;
+    @Parameter(names = {"-compact", "--compact"},
+        description = "Perform table compaction after conversion")
+    boolean doCompact = false;
+    @Parameter(names = {"-offline", "--offline"},
+        description = "Take table offline before conversion, and bring online after")
+    boolean takeOffline = false;
+    @Parameter(names = {"-sp", "-storagepolicy", "--storagepolicy"},
+        description = "If set, set storage policy for table(s) or namespace to given value")
+    String storagePolicy = null;
+    @Parameter(names = {"-ep", "-encodingpolicy", "--encodingpolicy"},
+        description = "If set, set encoding policy for table(s) or namespace to given value")
+    String encodingPolicy = null;
+  }
+
+  private static void checkDirPoliciesRecursively(ServerContext ctx, Path path, Policies policies)
+      throws IOException {
+    var vm = ctx.getVolumeManager();
+    var fs = vm.getFileSystemByPath(path);
+
+    // only need to do checks if HDFS
+    if (fs instanceof DistributedFileSystem) {
+      // check toplevel
+      vm.checkDirPolicies(path, policies);
+
+      // and then check children
+      // TODO does the directory tree for a table ever get more than one level deep?
+      var fstats = fs.listStatus(path);
+      for (FileStatus fstat : fstats) {
+        if (fstat.isDirectory()) {
+          vm.checkDirPolicies(fstat.getPath(), policies);
+        }
+      }
+    }
+  }
+
+  private static void updateTable(TableId tableId, ServerContext ctx) throws IOException {
+    VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironmentImpl(tableId, null, ctx);
+
+    System.out.println("  convert table...");
+
+    // find all volumes table could live on
+    var volumes = ctx.getVolumeManager().choosable(chooserEnv, ServerConstants.getBaseUris(ctx));
+
+    // and ensure each is changed to the appropriate policies
+    var policies =
+        Policies.getPoliciesForTable(ctx.getServerConfFactory().getTableConfiguration(tableId));
+
+    boolean sawError = false;
+    for (String volume : volumes) {
+      String tableDir = volume + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + tableId;
+      System.out.println("    converting table directory " + tableDir + " to ("
+          + policies.getStoragePolicy() + ", " + policies.getEncodingPolicy() + ")");
+      try {
+        checkDirPoliciesRecursively(ctx, new Path(tableDir), policies);
+      } catch (FileNotFoundException fnfe) {
+        System.err.println("path " + tableDir + " does not exist...continuing");
+      } catch (IOException ioe) {
+        // catch for this volume and continue
+        System.err.println("error setting policies for tableId=" + tableId);
+        System.err.println(ioe.getMessage());
+        sawError = true;
+      }
+    }
+
+    if (sawError)
+      throw new IOException("trouble setting table policies for tableId=" + tableId);
+
+    System.out.println("  done");
+  }
+
+  private static void offlineTable(AccumuloClient client, String table) throws Exception {
+    System.out.print("  take table offline...");
+    System.out.flush();
+    client.tableOperations().offline(table, true);
+    System.out.println("done");
+  }
+
+  private static void onlineTable(AccumuloClient client, String table) throws Exception {
+    System.out.print("  bring table online...");
+    System.out.flush();
+    client.tableOperations().online(table, true);
+    System.out.println("done");
+  }
+
+  private static void doTables(ConvertOpts opts, AccumuloClient client) {
+    var serverContext = opts.getServerContext();
+
+    StringTokenizer tok = new StringTokenizer(opts.table, ",", false);
+    while (tok.hasMoreTokens()) {
+      String tab = tok.nextToken().trim();
+      System.out.println("converting table " + tab);
+
+      // set storage policy if requested
+      if (opts.storagePolicy != null && !opts.storagePolicy.isEmpty()) {
+        try {
+          client.tableOperations().setProperty(tab, Property.TABLE_STORAGE_POLICY.getKey(),
+              opts.storagePolicy);
+        } catch (Exception e) {
+          System.err.println("error setting storage policy");
+          System.err.println(e.getMessage());
+          System.exit(1);
+        }
+      }
+
+      // set encoding policy if requested
+      if (opts.encodingPolicy != null && !opts.encodingPolicy.isEmpty()) {
+        try {
+          client.tableOperations().setProperty(tab, Property.TABLE_CODING_POLICY.getKey(),
+              opts.encodingPolicy);
+        } catch (Exception e) {
+          System.err.println("error setting encoding policy");
+          System.err.println(e.getMessage());
+          System.exit(1);
+        }
+      }
+
+      try {
+        TableId tid = Tables.getTableId(serverContext, tab);
+
+        if (opts.takeOffline)
+          offlineTable(client, tab);
+
+        updateTable(tid, serverContext);
+
+        if (opts.takeOffline)
+          onlineTable(client, tab);
+
+        if (opts.doCompact) {
+          System.out.println("  starting compaction");
+          client.tableOperations().compact(tab, null, null, true, false);
+        }
+      } catch (TableNotFoundException te) {
+        System.err.println("no such table " + tab);
+        System.err.println("skipping");
+      } catch (IOException ioe) {
+        System.err.println(ioe.getMessage());
+      } catch (Exception ex) {
+        System.err.println("error converting table " + tab);
+        System.err.println(ex.getMessage());
+      }
+    }
+  }
+
+  private static void doNamespace(ConvertOpts opts, AccumuloClient client) {
+    var serverContext = opts.getServerContext();
+
+    List<TableId> tableIds = null;
+    try {
+      NamespaceId nsid = Namespaces.getNamespaceId(serverContext, opts.namespace);
+      tableIds = Namespaces.getTableIds(serverContext, nsid);
+    } catch (NamespaceNotFoundException nfe) {
+      System.err.println("no such namespace " + opts.namespace);
+      System.err.println("exiting");
+      System.exit(1);
+    }
+
+    // set storage policy if requested
+    if (opts.storagePolicy != null && !opts.storagePolicy.isEmpty()) {
+      try {
+        client.namespaceOperations().setProperty(opts.namespace,
+            Property.TABLE_STORAGE_POLICY.getKey(), opts.storagePolicy);
+      } catch (Exception e) {
+        System.err.println("error setting storage policy");
+        System.err.println(e.getMessage());
+        System.exit(1);
+      }
+    }
+
+    // set encoding policy if requested
+    if (opts.encodingPolicy != null && !opts.encodingPolicy.isEmpty()) {
+      try {
+        client.namespaceOperations().setProperty(opts.namespace,
+            Property.TABLE_CODING_POLICY.getKey(), opts.encodingPolicy);
+      } catch (Exception e) {
+        System.err.println("error setting encoding policy");
+        System.err.println(e.getMessage());
+        System.exit(1);
+      }
+    }
+
+    for (TableId tid : tableIds) {
+      try {
+        String tabName = Tables.getTableName(serverContext, tid);
+        System.out.println("converting table " + tabName);
+
+        if (opts.takeOffline)
+          offlineTable(client, tabName);
+
+        updateTable(tid, serverContext);
+
+        if (opts.takeOffline)
+          onlineTable(client, tabName);
+
+        if (opts.doCompact) {
+          try {
+            System.out.println("  starting compaction");
+            client.tableOperations().compact(tabName, null, null, true, false);
+          } catch (Exception e) {
+            System.err.println("error compacting tableid " + tid);
+            System.err.println(e.getMessage());
+            System.err.println("not compacting");
+          }
+        }
+      } catch (IOException | TableNotFoundException ioe) {
+        System.err.println(ioe.getMessage());
+      } catch (Exception e) {
+        System.err.println("error converting table");
+        System.err.println(e.getMessage());
+      }
+    }
+  }
+
+  public static void main(String[] args) {
+    ConvertOpts opts = new ConvertOpts();
+    opts.parseArgs(ConvertTablePolicy.class.getName(), args);
+
+    if (opts.namespace != null && opts.table != null) {
+      System.err.println("can only use one of -ns or -t");
+      return;
+    }
+
+    if (opts.namespace == null && opts.table == null) {
+      System.err.println("must specify one of -ns or -t");
+      return;
+    }
+
+    if (opts.storagePolicy != null) {
+      Property p = Property.getPropertyByKey(Property.TABLE_STORAGE_POLICY.getKey());
+      if (!p.getType().isValidFormat(opts.storagePolicy)) {
+        System.err.println("invalid storage policy: " + opts.storagePolicy);
+        return;
+      }
+
+      if (opts.encodingPolicy != null && !opts.encodingPolicy.equals(Constants.HDFS_REPLICATION)) {
+        if (!opts.storagePolicy.equals(HdfsConstants.HOT_STORAGE_POLICY_NAME)
+            && !opts.storagePolicy.equals(HdfsConstants.COLD_STORAGE_POLICY_NAME)
+            && !opts.storagePolicy.equals(HdfsConstants.ALLSSD_STORAGE_POLICY_NAME)) {
+          System.err.println(
+              "storage policy " + opts.storagePolicy + " is inconsistent with erasure coding");
+          return;
+        }
+      }
+    }
+
+    try (AccumuloClient client = Accumulo.newClient().from(opts.getClientProps()).build()) {
+      if (opts.namespace != null) {
+        doNamespace(opts, client);
+      } else if (opts.table != null) {
+        doTables(opts, client);
+      }
+    }
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Policies.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Policies.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.accumulo.server.util;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.server.conf.NamespaceConfiguration;
+import org.apache.accumulo.server.conf.TableConfiguration;
+
+public class Policies {
+  private String storagePolicy;
+  private String encodingPolicy;
+
+  private Policies(String storage, String encoding) {
+    storagePolicy = storage;
+    encodingPolicy = encoding;
+  }
+
+  public String getEncodingPolicy() {
+    return encodingPolicy;
+  }
+
+  public String getStoragePolicy() {
+    return storagePolicy;
+  }
+
+  public static Policies getPoliciesForTable(TableConfiguration tableConf) {
+    var storagePolicy = tableConf.get(Property.TABLE_STORAGE_POLICY);
+    var encoding = tableConf.get(Property.TABLE_CODING_POLICY);
+    return new Policies(storagePolicy, encoding);
+  }
+
+  public static Policies getPoliciesForNamespace(NamespaceConfiguration namespaceConf) {
+    var storagePolicy = namespaceConf.get(Property.TABLE_STORAGE_POLICY);
+    var encoding = namespaceConf.get(Property.TABLE_CODING_POLICY);
+    return new Policies(storagePolicy, encoding);
+  }
+}


### PR DESCRIPTION
First attempt at adding two table properties: table.hdfs.policy.encoding and table.hdfs.policy.storage.  The first is used to control the erasure coding policy used for tablet directories, the second controls the HDFS storage policy.  The intent is to make it easy to tune HDFS performance on a per-table basis.  For instance, frequently used tables with strict row lookup latency requirements could be configured to use HOT storage and default replication, while tables with archival data could be marked COLD and use erasure coding to save space.

The basic concept of operation here is to replace calls to VolumeManager.mkdirs(Path) with a new version of mkdirs that takes the table's storage and encoding policies as arguments.  After creating the directory, a new method VolumeManager.checkDirPolicies() is called which will do the necessary HDFS calls to set the policies on the tablet directories.  When the policy properties are changed via the client, a "property changed" FATE operation is sent to the master, which then calls checkDirPolicies() for the affected tablet directories.
 
This is very much a work-in-progress, and I'm not at all sure this is a) desired, or b) the correct approach.  I'm particularly worried about my use of FATE to enact the policy changes.  In an earlier iteration I used the ConfigurationObserver.propertiesChanged() override to let each tablet keep the policies on disk synced with the properties.  This mechanism disappeared in 2.1, so that's when I switched to using FATE.  I'm not sure this is the right way to go about this, and I'm also not sure the way I'm doing the table and namespace locking is correct.

This also lacks any sort of testing code. I'm assuming this would need a mix of unit tests in the accumulo tree, and then some live testing in accumulo-tests.  Any tips on this would be appreciated.