### PR TITLE
Created TabletFile, TabletFileUtil & test. Fixes #1396

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -311,7 +311,6 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     for (TabletFile file : absFiles) {
       FileSystem fs =
           VolumeConfiguration.getVolume(file.getMetadataEntry(), conf, config).getFileSystem();
-      // TODO check if file.getMetadataEntry() is the correct path for FileSKVIterator
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
           .forFile(file.getMetadataEntry(), fs, conf, CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(acuTableConf).build();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -26,13 +26,12 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -59,6 +58,7 @@ import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SystemIteratorUtil;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
@@ -262,27 +262,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       throw new AccumuloException(
           " " + currentExtent + " is not previous extent " + tablet.getExtent());
 
-    // Old property is only used to resolve relative paths into absolute paths. For systems upgraded
-    // with relative paths, it's assumed that correct instance.dfs.{uri,dir} is still correct in the
-    // configuration
-    @SuppressWarnings("deprecation")
-    String tablesDir = config.get(Property.INSTANCE_DFS_DIR) + Constants.HDFS_TABLES_DIR;
-
-    List<String> absFiles = new ArrayList<>();
-    for (String relPath : tablet.getFiles()) {
-      if (relPath.contains(":")) {
-        absFiles.add(relPath);
-      } else {
-        // handle old-style relative paths
-        if (relPath.startsWith("..")) {
-          absFiles.add(tablesDir + relPath.substring(2));
-        } else {
-          absFiles.add(tablesDir + "/" + tableId + relPath);
-        }
-      }
-    }
-
-    iter = createIterator(tablet.getExtent(), absFiles);
+    iter = createIterator(tablet.getExtent(), tablet.getFiles());
     iter.seek(range, LocalityGroupUtil.families(options.fetchedColumns),
         options.fetchedColumns.size() != 0);
     currentExtent = tablet.getExtent();
@@ -296,7 +276,8 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     }
   }
 
-  private SortedKeyValueIterator<Key,Value> createIterator(KeyExtent extent, List<String> absFiles)
+  private SortedKeyValueIterator<Key,Value> createIterator(KeyExtent extent,
+      Collection<TabletFile> absFiles)
       throws TableNotFoundException, AccumuloException, IOException {
 
     // TODO share code w/ tablet - ACCUMULO-1303
@@ -327,10 +308,12 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     }
 
     // TODO need to close files - ACCUMULO-1303
-    for (String file : absFiles) {
-      FileSystem fs = VolumeConfiguration.getVolume(file, conf, config).getFileSystem();
+    for (TabletFile file : absFiles) {
+      FileSystem fs =
+          VolumeConfiguration.getVolume(file.getMetadataEntry(), conf, config).getFileSystem();
+      // TODO check if file.getMetadataEntry() is the correct path for FileSKVIterator
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
-          .forFile(file, fs, conf, CryptoServiceFactory.newDefaultInstance())
+          .forFile(file.getMetadataEntry(), fs, conf, CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(acuTableConf).build();
       if (scannerSamplerConfigImpl != null) {
         reader = reader.getSample(scannerSamplerConfigImpl);

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -457,12 +457,6 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     return ke.getTableId();
   }
 
-  public static TableId tableIdOfMetadataRow(Text row) {
-    KeyExtent ke = new KeyExtent();
-    ke.decodeMetadataRow(row);
-    return ke.getTableId();
-  }
-
   public boolean contains(final ByteSequence bsrow) {
     if (bsrow == null) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -457,6 +457,12 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     return ke.getTableId();
   }
 
+  public static TableId tableIdOfMetadataRow(Text row) {
+    KeyExtent ke = new KeyExtent();
+    ke.decodeMetadataRow(row);
+    return ke.getTableId();
+  }
+
   public boolean contains(final ByteSequence bsrow) {
     if (bsrow == null) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
@@ -18,14 +18,13 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 
 /**
- * Object representing a tablet file entry in the metadata table. Keeps a string of exact entry of
- * the column qualifier of the
+ * Object representing a tablet file entry in the metadata table. Keeps a string of the exact entry
+ * of what is in the metadata table for the column qualifier of the
  * {@link org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily}
  * Validates the full URI form: "hdfs://1.2.3.4/accumulo/tables/2a/t-0003/C0004.rf"
  */
@@ -54,7 +53,7 @@ public class TabletFile implements Comparable<TabletFile> {
     this.tableId = TableId.of(tableIdPath.getName());
     // TODO validate tableId
 
-    Path volumePath = TabletFileUtil.getVolumeFromFullPath(metadataPath, Constants.HDFS_TABLES_DIR);
+    Path volumePath = TabletFileUtil.getVolumeFromFullPath(metadataPath, "tables");
     TabletFileUtil.validateVolume(volumePath);
     this.volume = volumePath.toString();
   }
@@ -89,7 +88,23 @@ public class TabletFile implements Comparable<TabletFile> {
 
   @Override
   public int compareTo(TabletFile o) {
-    return metadataEntry.compareTo(o.getMetadataEntry());
+    if (metadataEntry.equals(o.metadataEntry)) {
+      return 0;
+    } else {
+      return metadataEntry.compareTo(o.getMetadataEntry());
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof TabletFile)
+      return metadataEntry.equals(((TabletFile) obj).getMetadataEntry());
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return metadataEntry.hashCode();
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
@@ -60,7 +60,7 @@ public class TabletFile implements Comparable<TabletFile> {
     MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tableId.canonical());
 
     Path volumePath = Objects.requireNonNull(
-        TabletFileUtil.getVolumeFromFullPath(metaPath, "tables"), "Volume " + errorMsg);
+        TabletFileUtil.getVolumeFromFullPath(metaPath, "tables"), "Volume" + errorMsg);
     this.volume = volumePath.toString();
 
     this.suffix = tableId.canonical() + "/" + tabletDir + "/" + fileName;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+
+/**
+ * Object representing a tablet file entry in the metadata table. Keeps a string of exact entry of
+ * the column qualifier of the
+ * {@link org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily}
+ * Validates the full URI form: "hdfs://1.2.3.4/accumulo/tables/2a/t-0003/C0004.rf"
+ */
+public class TabletFile implements Comparable<TabletFile> {
+  private String volume; // hdfs://1.2.3.4/accumulo
+  // /tables/
+  private TableId tableId; // 2a
+  private String tabletDir; // t-0003
+  private String fileName; // C0004.rf
+
+  // exact string that is stored the metadata table
+  private String metadataEntry;
+  private Path metadataPath;
+
+  public TabletFile(String metadataEntry) {
+    this.metadataPath = new Path(metadataEntry);
+    this.metadataEntry = metadataEntry;
+    this.fileName = metadataPath.getName();
+    // TODO validate filename
+
+    Path tabletDirPath = metadataPath.getParent();
+    this.tabletDir = tabletDirPath.getName();
+    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tabletDir);
+
+    Path tableIdPath = tabletDirPath.getParent();
+    this.tableId = TableId.of(tableIdPath.getName());
+    // TODO validate tableId
+
+    Path volumePath = TabletFileUtil.getVolumeFromFullPath(metadataPath, Constants.HDFS_TABLES_DIR);
+    TabletFileUtil.validateVolume(volumePath);
+    this.volume = volumePath.toString();
+  }
+
+  public String getVolume() {
+    return volume;
+  }
+
+  public TableId getTableId() {
+    return tableId;
+  }
+
+  public String getTabletDir() {
+    return tabletDir;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public String getMetadataEntry() {
+    return metadataEntry;
+  }
+
+  public Text meta() {
+    return new Text(metadataEntry);
+  }
+
+  public Path path() {
+    return metadataPath;
+  }
+
+  @Override
+  public int compareTo(TabletFile o) {
+    return metadataEntry.compareTo(o.getMetadataEntry());
+  }
+
+  @Override
+  public String toString() {
+    return metadataEntry;
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
@@ -41,7 +41,7 @@ public class TabletFile implements Comparable<TabletFile> {
 
   public TabletFile(String metadataEntry) {
     this.metadataPath = new Path(metadataEntry);
-    this.metadataEntry = metadataEntry;
+    this.metadataEntry = Objects.requireNonNull(metadataEntry);
     this.fileName = metadataPath.getName();
     // TODO validate filename
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFile.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
+import java.util.Objects;
+
 import org.apache.accumulo.core.data.TableId;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
@@ -29,19 +31,19 @@ import org.apache.hadoop.io.Text;
  * Validates the full URI form: "hdfs://1.2.3.4/accumulo/tables/2a/t-0003/C0004.rf"
  */
 public class TabletFile implements Comparable<TabletFile> {
-  private String volume; // hdfs://1.2.3.4/accumulo
+  private final String volume; // hdfs://1.2.3.4/accumulo
   // /tables/
-  private TableId tableId; // 2a
-  private String tabletDir; // t-0003
-  private String fileName; // C0004.rf
+  private final TableId tableId; // 2a
+  private final String tabletDir; // t-0003
+  private final String fileName; // C0004.rf
 
   // exact string that is stored the metadata table
-  private String metadataEntry;
-  private Path metadataPath;
+  private final String metadataEntry;
+  private final Path metadataPath;
 
   public TabletFile(String metadataEntry) {
-    this.metadataPath = new Path(metadataEntry);
     this.metadataEntry = Objects.requireNonNull(metadataEntry);
+    this.metadataPath = new Path(metadataEntry);
     this.fileName = metadataPath.getName();
     // TODO validate filename
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
@@ -18,9 +18,68 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
+import java.util.Objects;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.fs.Path;
 
 public class TabletFileUtil {
+
+  /**
+   * Create a TabletFile, handling different types of entries from the metadata table.
+   */
+  public static TabletFile newTabletFile(String metadataEntry, Key key) {
+    Objects.requireNonNull(metadataEntry);
+    String errorMsg = " is missing from tablet file metadata entry: " + metadataEntry;
+
+    Path metaPath;
+    boolean isAbsolutePath = false;
+    if (metadataEntry.contains(":"))
+      isAbsolutePath = true;
+
+    if (isAbsolutePath) {
+      metaPath = new Path(metadataEntry);
+    } else {
+      metaPath = resolveRelativePath(metadataEntry, key);
+    }
+
+    // use Path object to step backwards from the filename through all the parts
+    String fileName = metaPath.getName();
+    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(fileName);
+
+    Path tabletDirPath = Objects.requireNonNull(metaPath.getParent(), "Tablet dir" + errorMsg);
+    String tabletDir = tabletDirPath.getName();
+    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tabletDir);
+
+    Path tableIdPath = Objects.requireNonNull(tabletDirPath.getParent(), "Table ID" + errorMsg);
+    TableId tableId = TableId.of(tableIdPath.getName());
+    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tableId.canonical());
+
+    TabletFile tabletFile = new TabletFile(metadataEntry, tableId, tabletDir, fileName);
+
+    Path volumePath = TabletFileUtil.getVolumeFromFullPath(metaPath, "tables");
+    if (volumePath != null) {
+      tabletFile.setVolume(volumePath.toString());
+    }
+    return tabletFile;
+  }
+
+  /**
+   * Resolve one of the two relative paths: "../2a/t-0003/C0004.rf" or "/t-0003/C0004.rf"
+   */
+  private static Path resolveRelativePath(String metadataEntry, Key key) {
+    // handle old-style relative paths
+    if (metadataEntry.startsWith("..")) {
+      // resolve style "../2a/t-0003/C0004.rf"
+      return new Path(metadataEntry.substring(2));
+    } else {
+      // resolve style "/t-0003/C0004.rf"
+      TableId tableId = KeyExtent.tableIdOfMetadataRow(key.getRow());
+      return new Path(tableId.canonical() + metadataEntry);
+    }
+  }
 
   public static Path getVolumeFromFullPath(Path path, String dir) {
     String pathString = path.toString();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
@@ -18,43 +18,9 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
-import java.util.Objects;
-
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.TableId;
 import org.apache.hadoop.fs.Path;
 
 public class TabletFileUtil {
-
-  /**
-   * Create a TabletFile, handling different types of entries from the metadata table.
-   */
-  public static TabletFile newTabletFile(String metadataEntry, Key key) {
-    Objects.requireNonNull(metadataEntry);
-    String errorMsg = " is missing from tablet file metadata entry: " + metadataEntry;
-
-    Path metaPath = new Path(metadataEntry);
-
-    // use Path object to step backwards from the filename through all the parts
-    String fileName = metaPath.getName();
-    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(fileName);
-
-    Path tabletDirPath = Objects.requireNonNull(metaPath.getParent(), "Tablet dir" + errorMsg);
-    String tabletDir = tabletDirPath.getName();
-    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tabletDir);
-
-    Path tableIdPath = Objects.requireNonNull(tabletDirPath.getParent(), "Table ID" + errorMsg);
-    TableId tableId = TableId.of(tableIdPath.getName());
-    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tableId.canonical());
-
-    TabletFile tabletFile = new TabletFile(metadataEntry, tableId, tabletDir, fileName);
-
-    Path volumePath = TabletFileUtil.getVolumeFromFullPath(metaPath, "tables");
-    if (volumePath != null) {
-      tabletFile.setVolume(volumePath.toString());
-    }
-    return tabletFile;
-  }
 
   public static Path getVolumeFromFullPath(Path path, String dir) {
     String pathString = path.toString();
@@ -86,14 +52,5 @@ public class TabletFileUtil {
     if (path.contains(":"))
       throw new IllegalArgumentException(path + " is absolute, but does not contain " + dir);
     return -1;
-  }
-
-  // TODO validate volume
-  public static void validateVolume(Path path) {
-    if (path != null) {
-      if (path.toString().contains(":"))
-        return;
-    }
-    throw new IllegalArgumentException("Invalid Volume in path: " + path);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import org.apache.hadoop.fs.Path;
+
+public class TabletFileUtil {
+
+  public static Path getVolumeFromFullPath(Path path, String dir) {
+    String pathString = path.toString();
+
+    int eopi = endOfVolumeIndex(pathString, dir);
+    if (eopi != -1)
+      return new Path(pathString.substring(0, eopi + 1));
+
+    return null;
+  }
+
+  public static Path removeVolumeFromFullPath(Path path, String dir) {
+    String pathString = path.toString();
+
+    int eopi = endOfVolumeIndex(pathString, dir);
+    if (eopi != -1)
+      return new Path(pathString.substring(eopi + 1));
+
+    return null;
+  }
+
+  public static int endOfVolumeIndex(String path, String dir) {
+    // Strip off the suffix that starts with the FileType (e.g. tables, wal, etc)
+    int dirIndex = path.indexOf('/' + dir);
+    if (dirIndex != -1) {
+      return dirIndex;
+    }
+
+    if (path.contains(":"))
+      throw new IllegalArgumentException(path + " is absolute, but does not contain " + dir);
+    return -1;
+  }
+
+  // TODO validate volume
+  public static void validateVolume(Path path) {
+    if (path != null) {
+      if (path.toString().contains(":"))
+        return;
+    }
+    throw new IllegalArgumentException("Invalid Volume in path: " + path);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileUtil.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.fs.Path;
 
 public class TabletFileUtil {
@@ -34,16 +33,7 @@ public class TabletFileUtil {
     Objects.requireNonNull(metadataEntry);
     String errorMsg = " is missing from tablet file metadata entry: " + metadataEntry;
 
-    Path metaPath;
-    boolean isAbsolutePath = false;
-    if (metadataEntry.contains(":"))
-      isAbsolutePath = true;
-
-    if (isAbsolutePath) {
-      metaPath = new Path(metadataEntry);
-    } else {
-      metaPath = resolveRelativePath(metadataEntry, key);
-    }
+    Path metaPath = new Path(metadataEntry);
 
     // use Path object to step backwards from the filename through all the parts
     String fileName = metaPath.getName();
@@ -64,21 +54,6 @@ public class TabletFileUtil {
       tabletFile.setVolume(volumePath.toString());
     }
     return tabletFile;
-  }
-
-  /**
-   * Resolve one of the two relative paths: "../2a/t-0003/C0004.rf" or "/t-0003/C0004.rf"
-   */
-  private static Path resolveRelativePath(String metadataEntry, Key key) {
-    // handle old-style relative paths
-    if (metadataEntry.startsWith("..")) {
-      // resolve style "../2a/t-0003/C0004.rf"
-      return new Path(metadataEntry.substring(2));
-    } else {
-      // resolve style "/t-0003/C0004.rf"
-      TableId tableId = KeyExtent.tableIdOfMetadataRow(key.getRow());
-      return new Path(tableId.canonical() + metadataEntry);
-    }
   }
 
   public static Path getVolumeFromFullPath(Path path, String dir) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -342,7 +342,7 @@ public class TabletMetadata {
           }
           break;
         case DataFileColumnFamily.STR_NAME:
-          filesBuilder.put(TabletFileUtil.newTabletFile(qual, key), new DataFileValue(val));
+          filesBuilder.put(new TabletFile(qual), new DataFileValue(val));
           break;
         case BulkFileColumnFamily.STR_NAME:
           loadedFilesBuilder.put(qual, BulkFileColumnFamily.getBulkLoadTid(val));
@@ -357,7 +357,7 @@ public class TabletMetadata {
           te.last = new Location(val, qual, LocationType.LAST);
           break;
         case ScanFileColumnFamily.STR_NAME:
-          scansBuilder.add(TabletFileUtil.newTabletFile(qual, key));
+          scansBuilder.add(new TabletFile(qual));
           break;
         case ClonedColumnFamily.STR_NAME:
           te.cloned = val;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -75,8 +75,8 @@ public class TabletMetadata {
   private boolean sawOldPrevEndRow = false;
   private Text endRow;
   private Location location;
-  private Map<String,DataFileValue> files;
-  private List<String> scans;
+  private Map<TabletFile,DataFileValue> files;
+  private List<TabletFile> scans;
   private Map<String,Long> loadedFiles;
   private EnumSet<ColumnType> fetchedCols;
   private KeyExtent extent;
@@ -214,12 +214,12 @@ public class TabletMetadata {
     return last;
   }
 
-  public Collection<String> getFiles() {
+  public Collection<TabletFile> getFiles() {
     ensureFetched(ColumnType.FILES);
     return files.keySet();
   }
 
-  public Map<String,DataFileValue> getFilesMap() {
+  public Map<TabletFile,DataFileValue> getFilesMap() {
     ensureFetched(ColumnType.FILES);
     return files;
   }
@@ -229,7 +229,7 @@ public class TabletMetadata {
     return logs;
   }
 
-  public List<String> getScans() {
+  public List<TabletFile> getScans() {
     ensureFetched(ColumnType.SCANS);
     return scans;
   }
@@ -280,8 +280,8 @@ public class TabletMetadata {
       kvBuilder = ImmutableSortedMap.naturalOrder();
     }
 
-    var filesBuilder = ImmutableMap.<String,DataFileValue>builder();
-    var scansBuilder = ImmutableList.<String>builder();
+    var filesBuilder = ImmutableMap.<TabletFile,DataFileValue>builder();
+    var scansBuilder = ImmutableList.<TabletFile>builder();
     var logsBuilder = ImmutableList.<LogEntry>builder();
     final var loadedFilesBuilder = ImmutableMap.<String,Long>builder();
     ByteSequence row = null;
@@ -342,7 +342,7 @@ public class TabletMetadata {
           }
           break;
         case DataFileColumnFamily.STR_NAME:
-          filesBuilder.put(qual, new DataFileValue(val));
+          filesBuilder.put(TabletFileUtil.newTabletFile(qual, key), new DataFileValue(val));
           break;
         case BulkFileColumnFamily.STR_NAME:
           loadedFilesBuilder.put(qual, BulkFileColumnFamily.getBulkLoadTid(val));
@@ -357,7 +357,7 @@ public class TabletMetadata {
           te.last = new Location(val, qual, LocationType.LAST);
           break;
         case ScanFileColumnFamily.STR_NAME:
-          scansBuilder.add(qual);
+          scansBuilder.add(TabletFileUtil.newTabletFile(qual, key));
           break;
         case ClonedColumnFamily.STR_NAME:
           te.cloned = val;

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -60,6 +60,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.TRowRange;
 import org.apache.accumulo.core.dataImpl.thrift.TSummaries;
 import org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest;
+import org.apache.accumulo.core.metadata.schema.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.rpc.ThriftUtil;
@@ -175,10 +176,10 @@ public class Gatherer {
     Map<String,List<TabletMetadata>> files = new HashMap<>();
 
     for (TabletMetadata tm : tmi) {
-      for (String file : tm.getFiles()) {
-        if (fileSelector.test(file)) {
+      for (TabletFile file : tm.getFiles()) {
+        if (fileSelector.test(file.getMetadataEntry())) {
           // TODO push this filtering to server side and possibly use batch scanner
-          files.computeIfAbsent(file, s -> new ArrayList<>()).add(tm);
+          files.computeIfAbsent(file.getMetadataEntry(), s -> new ArrayList<>()).add(tm);
         }
       }
     }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TabletFileTest {
+
+  @Test
+  // metadataEntry = "hdfs://1.2.3.4/accumulo/tables/2a/t-0003/C0004.rf"
+  public void testFullPath() {
+    String volume = "hdfs://1.2.3.4/accumulo";
+    String id = "2a";
+    String dir = "t-0003";
+    String filename = "C0004.rf";
+    String metadataEntry = volume + "/tables/" + id + "/" + dir + "/" + filename;
+    TabletFile tabletFile = new TabletFile(metadataEntry);
+
+    assertEquals(volume, tabletFile.getVolume());
+    assertEquals(id, tabletFile.getTableId().canonical());
+    assertEquals(dir, tabletFile.getTabletDir());
+    assertEquals(filename, tabletFile.getFileName());
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.metadata.schema;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.accumulo.core.data.Key;
@@ -33,15 +32,13 @@ public class TabletFileTest {
 
   private void test(String metadataEntry, Key key, TableId tableId, String tabletDir,
       String fileName) {
-    TabletFile parsedTabletFile = TabletFileUtil.newTabletFile(metadataEntry, key);
-    TabletFile tabletFile = new TabletFile(metadataEntry, tableId, tabletDir, fileName);
+    TabletFile tabletFile = new TabletFile(metadataEntry);
 
     assertEquals(metadataEntry, tabletFile.getMetadataEntry());
     assertEquals(tableId, tabletFile.getTableId());
     assertEquals(tabletDir, tabletFile.getTabletDir());
     assertEquals(fileName, tabletFile.getFileName());
-    assertTrue("Parsed tabletFile not equal to constructed one",
-        tabletFile.equals(parsedTabletFile));
+
   }
 
   @Test
@@ -82,10 +79,9 @@ public class TabletFileTest {
     String filename = "C0004.rf";
     String metadataEntry = volume + "/tables/" + id + "/" + dir + "/" + filename;
 
-    TabletFile tabletFile = TabletFileUtil.newTabletFile(metadataEntry, null);
+    TabletFile tabletFile = new TabletFile(metadataEntry);
 
-    assertTrue(tabletFile.getVolume().isPresent());
-    assertEquals(volume, tabletFile.getVolume().get());
+    assertEquals(volume, tabletFile.getVolume());
     assertEquals(id, tabletFile.getTableId().canonical());
     assertEquals(dir, tabletFile.getTabletDir());
     assertEquals(filename, tabletFile.getFileName());

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -18,25 +18,77 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
+import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.KeyBuilder;
+import org.apache.accumulo.core.data.TableId;
 import org.junit.Test;
 
 public class TabletFileTest {
 
+  private void test(String metadataEntry, Key key, TableId tableId, String tabletDir,
+      String fileName) {
+    TabletFile parsedTabletFile = TabletFileUtil.newTabletFile(metadataEntry, key);
+    TabletFile tabletFile = new TabletFile(metadataEntry, tableId, tabletDir, fileName);
+
+    assertEquals(metadataEntry, tabletFile.getMetadataEntry());
+    assertEquals(tableId, tabletFile.getTableId());
+    assertEquals(tabletDir, tabletFile.getTabletDir());
+    assertEquals(fileName, tabletFile.getFileName());
+    assertTrue("Parsed tabletFile not equal to constructed one",
+        tabletFile.equals(parsedTabletFile));
+  }
+
+  @Test
+  public void testValidPaths() {
+    KeyBuilder.ColumnQualifierStep rowFamily =
+        Key.builder().row("2a<").family(DataFileColumnFamily.STR_NAME);
+    test("../2a/t-0003/C0004.rf", rowFamily.qualifier("../2a/t-0003/C0004.rf").build(),
+        TableId.of("2a"), "t-0003", "C0004.rf");
+    test("/t-0003/C0004.rf", rowFamily.qualifier("/t-0003/C0004.rf").build(), TableId.of("2a"),
+        "t-0003", "C0004.rf");
+    test("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf", rowFamily
+        .qualifier("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf").build(),
+        TableId.of("2a"), "default_tablet", "F0000070.rf");
+  }
+
+  @Test
+  public void testBadPaths() {
+    try {
+      test("C0004.rf", Key.builder().row("2a<").family(DataFileColumnFamily.STR_NAME)
+          .qualifier("C0004.rf").build(), TableId.of("2a"), "t-0003", "C0004.rf");
+      fail("Failed to throw error on bad path");
+    } catch (NullPointerException e) {}
+
+    // 2a< srv:dir
+    try {
+      test("dir", Key.builder().row("2a<").family(ServerColumnFamily.STR_NAME)
+          .qualifier(ServerColumnFamily.DIRECTORY_QUAL).build(), TableId.of("2a"), "", "");
+      fail("Failed to throw error on bad path");
+    } catch (NullPointerException e) {}
+  }
+
   @Test
   // metadataEntry = "hdfs://1.2.3.4/accumulo/tables/2a/t-0003/C0004.rf"
-  public void testFullPath() {
+  public void testFullPathWithVolume() {
     String volume = "hdfs://1.2.3.4/accumulo";
     String id = "2a";
     String dir = "t-0003";
     String filename = "C0004.rf";
     String metadataEntry = volume + "/tables/" + id + "/" + dir + "/" + filename;
-    TabletFile tabletFile = new TabletFile(metadataEntry);
 
-    assertEquals(volume, tabletFile.getVolume());
+    TabletFile tabletFile = TabletFileUtil.newTabletFile(metadataEntry, null);
+
+    assertTrue(tabletFile.getVolume().isPresent());
+    assertEquals(volume, tabletFile.getVolume().get());
     assertEquals(id, tabletFile.getTableId().canonical());
     assertEquals(dir, tabletFile.getTabletDir());
     assertEquals(filename, tabletFile.getFileName());
   }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -18,19 +18,15 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
-import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
-import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.KeyBuilder;
 import org.apache.accumulo.core.data.TableId;
 import org.junit.Test;
 
 public class TabletFileTest {
 
-  private void test(String metadataEntry, Key key, TableId tableId, String tabletDir,
+  private void test(String metadataEntry, TableId tableId, String tabletDir,
       String fileName) {
     TabletFile tabletFile = new TabletFile(metadataEntry);
 
@@ -43,29 +39,22 @@ public class TabletFileTest {
 
   @Test
   public void testValidPaths() {
-    KeyBuilder.ColumnQualifierStep rowFamily =
-        Key.builder().row("2a<").family(DataFileColumnFamily.STR_NAME);
-    test("../2a/t-0003/C0004.rf", rowFamily.qualifier("../2a/t-0003/C0004.rf").build(),
-        TableId.of("2a"), "t-0003", "C0004.rf");
-    test("/t-0003/C0004.rf", rowFamily.qualifier("/t-0003/C0004.rf").build(), TableId.of("2a"),
-        "t-0003", "C0004.rf");
-    test("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf", rowFamily
-        .qualifier("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf").build(),
+    test("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf",
         TableId.of("2a"), "default_tablet", "F0000070.rf");
+    test("hdfs://nn1:9000/accumulo/tables/5a/t-0005/C0009.rf",
+            TableId.of("5a"), "t-0005", "C0009.rf");
   }
 
   @Test
   public void testBadPaths() {
     try {
-      test("C0004.rf", Key.builder().row("2a<").family(DataFileColumnFamily.STR_NAME)
-          .qualifier("C0004.rf").build(), TableId.of("2a"), "t-0003", "C0004.rf");
+      test("C0004.rf", TableId.of("2a"), "t-0003", "C0004.rf");
       fail("Failed to throw error on bad path");
     } catch (NullPointerException e) {}
 
     // 2a< srv:dir
     try {
-      test("dir", Key.builder().row("2a<").family(ServerColumnFamily.STR_NAME)
-          .qualifier(ServerColumnFamily.DIRECTORY_QUAL).build(), TableId.of("2a"), "", "");
+      test("dir", TableId.of("2a"), "", "");
       fail("Failed to throw error on bad path");
     } catch (NullPointerException e) {}
   }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -72,8 +72,8 @@ public class TabletMetadataTest {
     mutation.at().family(ClonedColumnFamily.NAME).qualifier("").put("OK");
 
     DataFileValue dfv1 = new DataFileValue(555, 23);
-    TabletFile tf1 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/df1.rf", null);
-    TabletFile tf2 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/df2.rf", null);
+    TabletFile tf1 = new TabletFile("hdfs://nn1/acc/tables/1/t-0001/df1.rf");
+    TabletFile tf2 = new TabletFile("hdfs://nn1/acc/tables/1/t-0001/df2.rf");
     mutation.at().family(DataFileColumnFamily.NAME).qualifier(tf1.getMetadataEntry())
         .put(dfv1.encode());
     DataFileValue dfv2 = new DataFileValue(234, 13);
@@ -91,8 +91,8 @@ public class TabletMetadataTest {
     mutation.at().family(le2.getColumnFamily()).qualifier(le2.getColumnQualifier())
         .timestamp(le2.timestamp).put(le2.getValue());
 
-    TabletFile sf1 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/sf1.rf", null);
-    TabletFile sf2 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/sf2.rf", null);
+    TabletFile sf1 = new TabletFile("hdfs://nn1/acc/tables/1/t-0001/sf1.rf");
+    TabletFile sf2 = new TabletFile("hdfs://nn1/acc/tables/1/t-0001/sf2.rf");
     mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf1.getMetadataEntry()).put("");
     mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf2.getMetadataEntry()).put("");
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -72,9 +72,13 @@ public class TabletMetadataTest {
     mutation.at().family(ClonedColumnFamily.NAME).qualifier("").put("OK");
 
     DataFileValue dfv1 = new DataFileValue(555, 23);
-    mutation.at().family(DataFileColumnFamily.NAME).qualifier("df1").put(dfv1.encode());
+    TabletFile tf1 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/df1.rf", null);
+    TabletFile tf2 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/df2.rf", null);
+    mutation.at().family(DataFileColumnFamily.NAME).qualifier(tf1.getMetadataEntry())
+        .put(dfv1.encode());
     DataFileValue dfv2 = new DataFileValue(234, 13);
-    mutation.at().family(DataFileColumnFamily.NAME).qualifier("df2").put(dfv2.encode());
+    mutation.at().family(DataFileColumnFamily.NAME).qualifier(tf2.getMetadataEntry())
+        .put(dfv2.encode());
 
     mutation.at().family(CurrentLocationColumnFamily.NAME).qualifier("s001").put("server1:8555");
 
@@ -87,8 +91,10 @@ public class TabletMetadataTest {
     mutation.at().family(le2.getColumnFamily()).qualifier(le2.getColumnQualifier())
         .timestamp(le2.timestamp).put(le2.getValue());
 
-    mutation.at().family(ScanFileColumnFamily.NAME).qualifier("sf1").put("");
-    mutation.at().family(ScanFileColumnFamily.NAME).qualifier("sf2").put("");
+    TabletFile sf1 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/sf1.rf", null);
+    TabletFile sf2 = TabletFileUtil.newTabletFile("hdfs://nn1/acc/tables/1/t-0001/sf2.rf", null);
+    mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf1.getMetadataEntry()).put("");
+    mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf2.getMetadataEntry()).put("");
 
     SortedMap<Key,Value> rowMap = toRowMap(mutation);
 
@@ -100,8 +106,8 @@ public class TabletMetadataTest {
     assertEquals("t-0001757", tm.getDirName());
     assertEquals(extent.getEndRow(), tm.getEndRow());
     assertEquals(extent, tm.getExtent());
-    assertEquals(Set.of("df1", "df2"), Set.copyOf(tm.getFiles()));
-    assertEquals(Map.of("df1", dfv1, "df2", dfv2), tm.getFilesMap());
+    assertEquals(Set.of(tf1, tf2), Set.copyOf(tm.getFiles()));
+    assertEquals(Map.of(tf1, dfv1, tf2, dfv2), tm.getFilesMap());
     assertEquals(6L, tm.getFlushId().getAsLong());
     assertEquals(rowMap, tm.getKeyValues());
     assertEquals(Map.of("bf1", 56L, "bf2", 59L), tm.getLoaded());
@@ -118,7 +124,7 @@ public class TabletMetadataTest {
     assertEquals(extent.getTableId(), tm.getTableId());
     assertTrue(tm.sawPrevEndRow());
     assertEquals("M123456789", tm.getTime().encode());
-    assertEquals(Set.of("sf1", "sf2"), Set.copyOf(tm.getScans()));
+    assertEquals(Set.of(sf1, sf2), Set.copyOf(tm.getScans()));
   }
 
   @Test

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -75,6 +75,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Cl
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
+import org.apache.accumulo.core.metadata.schema.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
@@ -422,7 +423,8 @@ public class MetadataTableUtil {
     result.addAll(tablet.getLogs());
 
     tablet.getFilesMap().forEach((k, v) -> {
-      sizes.put(new FileRef(k, fs.getFullPath(tablet.getTableId(), k)), v);
+      sizes.put(new FileRef(k.getMetadataEntry(),
+          fs.getFullPath(tablet.getTableId(), k.getMetadataEntry())), v);
     });
 
     return new Pair<>(result, sizes);
@@ -436,9 +438,11 @@ public class MetadataTableUtil {
     tablet.mutate();
   }
 
-  private static void getFiles(Set<String> files, Collection<String> tabletFiles,
+  private static void getFiles(Set<String> files, Collection<TabletFile> tabletFiles,
       TableId srcTableId) {
-    for (String file : tabletFiles) {
+    for (TabletFile tfile : tabletFiles) {
+      String file = tfile.getMetadataEntry();
+      // TODO why are we creating relative paths??
       if (srcTableId != null && !file.startsWith("../") && !file.contains(":")) {
         file = "../" + srcTableId + file;
       }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -257,7 +257,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
       Stream<Reference> refStream = tabletStream.flatMap(tm -> {
         Stream<Reference> refs = Stream.concat(tm.getFiles().stream(), tm.getScans().stream())
-            .map(f -> new Reference(tm.getTableId(), f, false));
+            .map(f -> new Reference(tm.getTableId(), f.getMetadataEntry(), false));
         if (tm.getDirName() != null) {
           refs =
               Stream.concat(refs, Stream.of(new Reference(tm.getTableId(), tm.getDirName(), true)));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -58,13 +58,14 @@ public class TabletData {
     this.flushID = meta.getFlushId().orElse(-1);
     this.directoryName = meta.getDirName();
     this.logEntries.addAll(meta.getLogs());
-    meta.getScans().forEach(path -> scanFiles.add(new FileRef(fs, path, meta.getTableId())));
+    meta.getScans().forEach(tabletFile -> scanFiles
+        .add(new FileRef(fs, tabletFile.getMetadataEntry(), meta.getTableId())));
 
     if (meta.getLast() != null)
       this.lastLocation = new TServerInstance(meta.getLast());
 
-    meta.getFilesMap().forEach((path, dfv) -> {
-      dataFiles.put(new FileRef(fs, path, meta.getTableId()), dfv);
+    meta.getFilesMap().forEach((tabletFile, dfv) -> {
+      dataFiles.put(new FileRef(fs, tabletFile.getMetadataEntry(), meta.getTableId()), dfv);
     });
 
     meta.getLoaded().forEach((path, txid) -> {

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -60,6 +60,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.TabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -476,9 +477,9 @@ public class VolumeIT extends ConfigurableMacBase {
 
       // check that root tablet is not on volume 1
       int count = 0;
-      for (String file : ((ClientContext) client).getAmple().readTablet(RootTable.EXTENT)
+      for (TabletFile file : ((ClientContext) client).getAmple().readTablet(RootTable.EXTENT)
           .getFiles()) {
-        assertTrue(file.startsWith(v2.toString()));
+        assertTrue(file.getMetadataEntry().startsWith(v2.toString()));
         count++;
       }
 
@@ -546,9 +547,10 @@ public class VolumeIT extends ConfigurableMacBase {
 
     // check that root tablet is not on volume 1 or 2
     int count = 0;
-    for (String file : ((ClientContext) client).getAmple().readTablet(RootTable.EXTENT)
+    for (TabletFile file : ((ClientContext) client).getAmple().readTablet(RootTable.EXTENT)
         .getFiles()) {
-      assertTrue(file.startsWith(v8.toString()) || file.startsWith(v9.toString()));
+      assertTrue(file.getMetadataEntry().startsWith(v8.toString())
+          || file.getMetadataEntry().startsWith(v9.toString()));
       count++;
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -439,8 +439,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
       for (TabletMetadata tablet : tablets) {
         assertTrue(tablet.getLoaded().isEmpty());
 
-        Set<String> fileHashes =
-            tablet.getFiles().stream().map(f -> hash(f)).collect(Collectors.toSet());
+        Set<String> fileHashes = tablet.getFiles().stream().map(f -> hash(f.getMetadataEntry()))
+            .collect(Collectors.toSet());
 
         String endRow = tablet.getEndRow() == null ? "null" : tablet.getEndRow().toString();
 


### PR DESCRIPTION
Putting this up for early review before I go too much further.  I began replacing FileRef with TabletFile in another branch.

TabletFileUtil was created to hold the shared code that VolumeManager is also using. Not sure if that's the best name or place but it had to be in core if TabletFile is going to be in core.