### PR TITLE
Perform lease recovery for wasb filesystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,6 +500,11 @@
         <version>${hadoop.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-azure</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.htrace</groupId>
         <artifactId>htrace-core</artifactId>
         <version>${htrace.version}</version>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -81,6 +81,10 @@
       <artifactId>hadoop-client-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-azure</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.htrace</groupId>
       <artifactId>htrace-core</artifactId>
     </dependency>


### PR DESCRIPTION
This patch passes a basic test of writing 1 k/v, killing accumulo, and restarting accumulo. I am not sure if it is correctly handling the case where acquireLease throws an exception.