### PR TITLE
Turn off trim stacktrace on failsafe plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -966,6 +966,7 @@
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>
+            <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
I found this very useful when debugging failed ITs.  The failsafe plugin will trim stack traces by default, only showing the error message.