### PR TITLE
Temporarily cache existence of recovery wals

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -178,7 +178,8 @@ public class Master extends AccumuloServerContext
 
   final static int ONE_SECOND = 1000;
   final static long TIME_TO_WAIT_BETWEEN_SCANS = 60 * ONE_SECOND;
-  final static long TIME_TO_CACHE_RECOVERY_WAL_EXISTENCE = 20 * ONE_SECOND;
+  // made this less than TIME_TO_WAIT_BETWEEN_SCANS, so that the cache is cleared between cycles
+  final static long TIME_TO_CACHE_RECOVERY_WAL_EXISTENCE = (3 * TIME_TO_WAIT_BETWEEN_SCANS) / 4;
   final private static long TIME_BETWEEN_MIGRATION_CLEANUPS = 5 * 60 * ONE_SECOND;
   final static long WAIT_BETWEEN_ERRORS = ONE_SECOND;
   final private static long DEFAULT_WAIT_FOR_WATCHER = 10 * ONE_SECOND;

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -178,6 +178,7 @@ public class Master extends AccumuloServerContext
 
   final static int ONE_SECOND = 1000;
   final static long TIME_TO_WAIT_BETWEEN_SCANS = 60 * ONE_SECOND;
+  final static long TIME_TO_CACHE_RECOVERY_WAL_EXISTENCE = 20 * ONE_SECOND;
   final private static long TIME_BETWEEN_MIGRATION_CLEANUPS = 5 * 60 * ONE_SECOND;
   final static long WAIT_BETWEEN_ERRORS = ONE_SECOND;
   final private static long DEFAULT_WAIT_FOR_WATCHER = 10 * ONE_SECOND;
@@ -1242,7 +1243,7 @@ public class Master extends AccumuloServerContext
 
     getMasterLock(zroot + Constants.ZMASTER_LOCK);
 
-    recoveryManager = new RecoveryManager(this);
+    recoveryManager = new RecoveryManager(this, TIME_TO_CACHE_RECOVERY_WAL_EXISTENCE);
 
     TableManager.getInstance().addObserver(this);
 

--- a/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
@@ -73,7 +73,7 @@ public class RecoveryManager {
     this.master = master;
     existenceCache =
         CacheBuilder.newBuilder().expireAfterWrite(timeToCacheExistsInMillis, TimeUnit.MILLISECONDS)
-            .maximumWeight(10000000).weigher(new Weigher<Path,Boolean>() {
+            .maximumWeight(10_000_000).weigher(new Weigher<Path,Boolean>() {
               @Override
               public int weigh(Path path, Boolean exist) {
                 return path.toString().length();

--- a/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
@@ -26,6 +26,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +53,10 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.Weigher;
+
 public class RecoveryManager {
 
   private static final Logger log = LoggerFactory.getLogger(RecoveryManager.class);
@@ -58,12 +64,22 @@ public class RecoveryManager {
   private Map<String,Long> recoveryDelay = new HashMap<>();
   private Set<String> closeTasksQueued = new HashSet<>();
   private Set<String> sortsQueued = new HashSet<>();
+  private Cache<Path,Boolean> existenceCache;
   private ScheduledExecutorService executor;
   private Master master;
   private ZooCache zooCache;
 
-  public RecoveryManager(Master master) {
+  public RecoveryManager(Master master, long timeToCacheExistsInMillis) {
     this.master = master;
+    existenceCache =
+        CacheBuilder.newBuilder().expireAfterWrite(timeToCacheExistsInMillis, TimeUnit.MILLISECONDS)
+            .maximumWeight(10000000).weigher(new Weigher<Path,Boolean>() {
+              @Override
+              public int weigh(Path path, Boolean exist) {
+                return path.toString().length();
+              }
+            }).build();
+
     executor = Executors.newScheduledThreadPool(4, new NamingThreadFactory("Walog sort starter "));
     zooCache = new ZooCache();
     try {
@@ -132,6 +148,19 @@ public class RecoveryManager {
     log.info("Created zookeeper entry " + path + " with data " + work);
   }
 
+  private boolean exists(final Path path) throws IOException {
+    try {
+      return existenceCache.get(path, new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          return master.getFileSystem().exists(path);
+        }
+      });
+    } catch (ExecutionException e) {
+      throw new IOException(e);
+    }
+  }
+
   public boolean recoverLogs(KeyExtent extent, Collection<Collection<String>> walogs)
       throws IOException {
     boolean recoveryNeeded = false;
@@ -168,7 +197,7 @@ public class RecoveryManager {
           }
         }
 
-        if (master.getFileSystem().exists(SortedLogState.getFinishedMarkerPath(dest))) {
+        if (exists(SortedLogState.getFinishedMarkerPath(dest))) {
           synchronized (this) {
             closeTasksQueued.remove(sortId);
             recoveryDelay.remove(sortId);

--- a/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
@@ -183,6 +183,7 @@ public class RecoveryManager {
         String filename = master.getFileSystem().getFullPath(FileType.WAL, walog).toString();
         String dest =
             RecoveryPath.getRecoveryPath(master.getFileSystem(), new Path(filename)).toString();
+        log.debug("Recovering " + filename + " to " + dest);
 
         boolean sortQueued;
         synchronized (this) {

--- a/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
@@ -183,7 +183,6 @@ public class RecoveryManager {
         String filename = master.getFileSystem().getFullPath(FileType.WAL, walog).toString();
         String dest =
             RecoveryPath.getRecoveryPath(master.getFileSystem(), new Path(filename)).toString();
-        log.debug("Recovering " + filename + " to " + dest);
 
         boolean sortQueued;
         synchronized (this) {


### PR DESCRIPTION
For the case where a lot of tablet servers died, the master was
frequently checking for the existence of a recovery log for each tablet.
Its very likely that many tablets point to the same recovery logs and
the existence checks are redundant.  This patch caches the result of
existence checks for a short period.