### PR TITLE
Update ListVolumesUsed to support root table metadata (#1350)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -195,6 +195,13 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     }
 
     @Override
+    public Options forLevel(DataLevel level) {
+      this.level = level;
+      this.range = TabletsSection.getRange();
+      return this;
+    }
+
+    @Override
     public TableRangeOptions forTable(TableId tableId) {
       if (tableId.equals(RootTable.ID)) {
         this.level = DataLevel.ROOT;
@@ -265,6 +272,11 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
   }
 
   public interface TableOptions {
+
+    /**
+     * Read all of the tablet metadata for this level.
+     */
+    Options forLevel(DataLevel level);
 
     /**
      * Get the tablet metadata for this extents end row. This should only ever return a single

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -116,7 +116,7 @@ public class ListVolumesUsed {
     try {
       listTable(Ample.DataLevel.ROOT, context);
     } catch (UnsupportedOperationException ex) {
-      // print nothing if no table name exists
+      System.out.println("\tNo volumes present");
     }
     System.out.println();
     listTable(Ample.DataLevel.METADATA, context);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -26,10 +26,8 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.server.ServerContext;
@@ -63,22 +61,6 @@ public class ListVolumesUsed {
     volumes.add(getLogURI(logEntry.filename));
   }
 
-  private static void listZookeeper(ServerContext context) throws Exception {
-    System.out.println("Listing volumes referenced in zookeeper");
-    TreeSet<String> volumes = new TreeSet<>();
-
-    TabletMetadata rootMeta = context.getAmple().readTablet(RootTable.EXTENT);
-
-    for (LogEntry logEntry : rootMeta.getLogs()) {
-      getLogURIs(volumes, logEntry);
-    }
-
-    for (String volume : volumes) {
-      System.out.println("\tVolume : " + volume);
-    }
-
-  }
-
   private static void listTable(Ample.DataLevel level, ServerContext context) throws Exception {
 
     System.out.println("Listing volumes referenced in " + level + " tablets section");
@@ -107,7 +89,7 @@ public class ListVolumesUsed {
     }
 
     System.out.println("Listing volumes referenced in " + level
-        + " deletes section (volume replacement occurrs at deletion time)");
+        + " deletes section (volume replacement occurs at deletion time)");
     volumes.clear();
 
     Iterator<String> delPaths = context.getAmple().getGcCandidates(level, "");
@@ -131,7 +113,11 @@ public class ListVolumesUsed {
   }
 
   public static void listVolumes(ServerContext context) throws Exception {
-    listZookeeper(context);
+    try {
+      listTable(Ample.DataLevel.ROOT, context);
+    } catch (UnsupportedOperationException ex) {
+      // print nothing if no table name exists
+    }
     System.out.println();
     listTable(Ample.DataLevel.METADATA, context);
     System.out.println();


### PR DESCRIPTION
With changes in #1313 the root tablet file metadata is no different from
any other tablet. Given that fact, ListVolumesUsed has been updated to
remove the specialized code that it had for zookeeper and instead make
use of the Ample API for interfacing with zookeeper.