### PR TITLE
Validate ClientOpts instance name and Zookeeper paths

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
@@ -402,7 +402,10 @@ public class ClientOpts extends Help {
       return cachedClientConfig = clientConfig.withInstance(UUID.fromString(instanceIDFromFile))
           .withZkHosts(zookeepers);
     }
-    return cachedClientConfig = clientConfig.withInstance(instance).withZkHosts(zookeepers);
-  }
 
+    if (instance != null && zookeepers != null)
+      return cachedClientConfig = clientConfig.withInstance(instance).withZkHosts(zookeepers);
+    else
+      return clientConfig;
+  }
 }


### PR DESCRIPTION
Only override instance name and ZK paths if those were specified by caller.