### PR TITLE
Clean up tablet event logging #1316

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.logging;
+
+public class Logging {
+  public static final String PREFIX = "org.apache.accumulo.logs.";
+}

--- a/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
@@ -17,5 +17,5 @@
 package org.apache.accumulo.core.logging;
 
 public class Logging {
-  public static final String PREFIX = "org.apache.accumulo.logs.";
+  public static final String PREFIX = "org.apache.accumulo.";
 }

--- a/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
@@ -1,21 +1,32 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.accumulo.core.logging;
 
+/**
+ * @see org.apache.accumulo.core.logging
+ */
 public class Logging {
+  /**
+   * Prefix for all log messages in logical logging namespaces. When chosing suffixes, try to avoid
+   * existing source package names like {@code core}. This prefix was chosen to make it easy to
+   * configure all Accumulo logging for loggers using fully qualified class names and logical
+   * loggers.
+   */
   public static final String PREFIX = "org.apache.accumulo.";
 }

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.accumulo.core.logging;
 
@@ -29,7 +31,12 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// logs messages about a tablets internal state, like its location, set of files, metadata... operations that cut across multiple tablets should go elsewhere
+/**
+ * This class contains source for logs messages about a tablets internal state, like its location,
+ * set of files, metadata.
+ *
+ * @see org.apache.accumulo.core.logging
+ */
 public class TabletLogger {
 
   private static final String PREFIX = Logging.PREFIX + "tablet.";
@@ -37,7 +44,7 @@ public class TabletLogger {
   private static final Logger locLog = LoggerFactory.getLogger(PREFIX + "location");
   private static final Logger fileLog = LoggerFactory.getLogger(PREFIX + "files");
   private static final Logger recoveryLog = LoggerFactory.getLogger(PREFIX + "recovery");
-  private static final Logger walsLog = LoggerFactory.getLogger(PREFIX + "wals");
+  private static final Logger walsLog = LoggerFactory.getLogger(PREFIX + "walogs");
 
   /**
    * A decision was made to assign a tablet to a tablet server process. Accumulo will stick to this

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.core.logging;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.tabletserver.log.LogEntry;
+import org.apache.accumulo.core.util.HostAndPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// logs messages about a tablets internal state, like its location, set of files, metadata... operations that cut across multiple tablets should go elsewhere
+public class TabletLogger {
+
+  private static final String PREFIX = Logging.PREFIX + "tablet.";
+
+  private static final Logger locLog = LoggerFactory.getLogger(PREFIX + "location");
+  private static final Logger fileLog = LoggerFactory.getLogger(PREFIX + "files");
+  private static final Logger recoveryLog = LoggerFactory.getLogger(PREFIX + "recovery");
+  private static final Logger walsLog = LoggerFactory.getLogger(PREFIX + "wals");
+
+  /**
+   * A decision was made to assign a tablet to a tablet server process. Accumulo will stick to this
+   * decision until the tablet server loads the tablet or dies.
+   */
+  public static void assigned(KeyExtent extent, Ample.TServer server) {
+    locLog.debug("Assigned {} to {}", extent, server);
+  }
+
+  /**
+   * A tablet server has received an assignment message from master and queued the tablet for
+   * loading.
+   */
+  public static void loading(KeyExtent extent, Ample.TServer server) {
+    locLog.debug("Loading {} on {}", extent, server);
+  }
+
+  public static void suspended(KeyExtent extent, HostAndPort server, long time, TimeUnit timeUnit,
+      int numWalogs) {
+    locLog.debug("Suspended {} to {} at {} ms with {} walogs", extent, server,
+        timeUnit.toMillis(time), numWalogs);
+  }
+
+  public static void unsuspended(KeyExtent extent) {
+    locLog.debug("Unsuspended " + extent);
+  }
+
+  public static void loaded(KeyExtent extent, Ample.TServer server) {
+    locLog.debug("Loaded {} on {}", extent, server);
+  }
+
+  public static void unassigned(KeyExtent extent, int logCount) {
+    locLog.debug("Unassigned {} with {} walogs", extent, logCount);
+  }
+
+  public static void split(KeyExtent parent, KeyExtent lowChild, KeyExtent highChild,
+      Ample.TServer server) {
+    locLog.debug("Split {} into {} and {} on {}", parent, lowChild, highChild, server);
+  }
+
+  /**
+   * Called when a tablet's current assignment state does not match the goal state.
+   */
+  public static void missassigned(KeyExtent extent, String goalState, String currentState,
+      Ample.TServer future, Ample.TServer current, int walogs) {
+    // usually this is only called when the states are not equal, but for the root tablet this
+    // method is currently always called
+    if (!goalState.equals(currentState)) {
+      locLog.trace("Miss-assigned {} goal:{} current:{} future:{} location:{} walogs:{}", extent,
+          goalState, currentState, future, current, walogs);
+    }
+  }
+
+  public static void compacted(KeyExtent extent, Collection<? extends Ample.FileMeta> inputs,
+      Ample.FileMeta output) {
+    fileLog.debug("Compacted {} created {} from {}", extent, output, inputs);
+  }
+
+  public static void flushed(KeyExtent extent, Ample.FileMeta absMergeFile,
+      Ample.FileMeta newDatafile) {
+    if (absMergeFile == null)
+      fileLog.debug("Flushed {} created {} from [memory]", extent, newDatafile);
+    else
+      fileLog.debug("Flushed {} created {} from [memory,{}]", extent, newDatafile, absMergeFile);
+  }
+
+  public static void bulkImported(KeyExtent extent, Ample.FileMeta file) {
+    fileLog.debug("Imported {} {}  ", extent, file);
+  }
+
+  public static void recovering(KeyExtent extent, List<LogEntry> logEntries) {
+    if (recoveryLog.isDebugEnabled()) {
+      List<String> logIds = logEntries.stream().map(LogEntry::getUniqueID).collect(toList());
+      recoveryLog.debug("For {} recovering data from walogs: {}", extent, logIds);
+    }
+  }
+
+  public static void recovered(KeyExtent extent, List<LogEntry> logEntries, long numMutation,
+      long numEntries) {
+    recoveryLog.info("For {} recovered {} mutations creating {} entries from {} walogs", extent,
+        numMutation, numEntries, logEntries.size());
+  }
+
+  public static boolean isWalRefLoggingEnabled() {
+    return walsLog.isTraceEnabled();
+  }
+
+  /**
+   * Called when the set of write ahead logs a tablet currently has unflushed data in changes.
+   */
+  public static void walRefsChanged(KeyExtent extent, Collection<String> refsSupplier) {
+    walsLog.trace("{} has unflushed data in wals: {} ", extent, refsSupplier);
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/logging/package-info.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * This package exist to provide a central place in Accumulo's source code for important log
+ * messages. This allows Accumulo's users to look in one place in the source code to see whats
+ * available. It also allows user to diff this directory across Accumulo releases to see what has
+ * changed, which enable them to update automated parsing.
+ *
+ * <p>
+ * The log messages in this package exist within a logical namespace independently from source code
+ * package names. This convention allows user to track logical events like changes to tablet files
+ * where the code making those changes may exist in many different packages and classes.
+ *
+ * <p>
+ * Since users may have automation for parsing log messages, please be mindful of this when making
+ * changes to log messages in bug fix releases.
+ */
+package org.apache.accumulo.core.logging;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -95,6 +95,16 @@ public interface Ample {
         throw new UnsupportedOperationException();
       return id;
     }
+
+    public static DataLevel of(TableId tableId) {
+      if (tableId.equals(RootTable.ID)) {
+        return DataLevel.ROOT;
+      } else if (tableId.equals(MetadataTable.ID)) {
+        return DataLevel.METADATA;
+      } else {
+        return DataLevel.USER;
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -203,17 +203,9 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
     @Override
     public TableRangeOptions forTable(TableId tableId) {
-      if (tableId.equals(RootTable.ID)) {
-        this.level = DataLevel.ROOT;
-      } else if (tableId.equals(MetadataTable.ID)) {
-        this.level = DataLevel.METADATA;
-      } else {
-        this.level = DataLevel.USER;
-      }
-
+      this.level = DataLevel.of(tableId);
       this.tableId = tableId;
       this.range = TabletsSection.getRange(tableId);
-
       return this;
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/Assignment.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/Assignment.java
@@ -19,25 +19,13 @@
 package org.apache.accumulo.server.master.state;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.util.HostAndPort;
 
-public class Assignment implements Ample.TServer {
+public class Assignment {
   public KeyExtent tablet;
   public TServerInstance server;
 
   public Assignment(KeyExtent tablet, TServerInstance server) {
     this.tablet = tablet;
     this.server = server;
-  }
-
-  @Override
-  public HostAndPort getLocation() {
-    return server.getLocation();
-  }
-
-  @Override
-  public String getSession() {
-    return server.getSession();
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/LoggingTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/LoggingTabletStateStore.java
@@ -26,6 +26,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.hadoop.fs.Path;
 
+/**
+ * Wraps a tablet state store and logs important events.
+ */
 class LoggingTabletStateStore implements TabletStateStore {
 
   private TabletStateStore wrapped;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/LoggingTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/LoggingTabletStateStore.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.master.state;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.logging.TabletLogger;
+import org.apache.hadoop.fs.Path;
+
+class LoggingTabletStateStore implements TabletStateStore {
+
+  private TabletStateStore wrapped;
+
+  LoggingTabletStateStore(TabletStateStore tss) {
+    this.wrapped = tss;
+  }
+
+  @Override
+  public String name() {
+    return wrapped.name();
+  }
+
+  @Override
+  public ClosableIterator<TabletLocationState> iterator() {
+    return wrapped.iterator();
+  }
+
+  @Override
+  public void setFutureLocations(Collection<Assignment> assignments)
+      throws DistributedStoreException {
+    wrapped.setFutureLocations(assignments);
+    assignments.forEach(assignment -> TabletLogger.assigned(assignment.tablet, assignment.server));
+  }
+
+  @Override
+  public void setLocations(Collection<Assignment> assignments) throws DistributedStoreException {
+    wrapped.setLocations(assignments);
+    assignments.forEach(assignment -> TabletLogger.loaded(assignment.tablet, assignment.server));
+  }
+
+  @Override
+  public void unassign(Collection<TabletLocationState> tablets,
+      Map<TServerInstance,List<Path>> logsForDeadServers) throws DistributedStoreException {
+    wrapped.unassign(tablets, logsForDeadServers);
+
+    if (logsForDeadServers == null)
+      logsForDeadServers = Map.of();
+
+    for (TabletLocationState tls : tablets) {
+      TabletLogger.unassigned(tls.extent, logsForDeadServers.size());
+    }
+  }
+
+  @Override
+  public void suspend(Collection<TabletLocationState> tablets,
+      Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
+      throws DistributedStoreException {
+    wrapped.suspend(tablets, logsForDeadServers, suspensionTimestamp);
+
+    if (logsForDeadServers == null)
+      logsForDeadServers = Map.of();
+
+    for (TabletLocationState tls : tablets) {
+      TabletLogger.suspended(tls.extent, tls.current.getLocation(), suspensionTimestamp,
+          TimeUnit.MILLISECONDS, logsForDeadServers.size());
+    }
+  }
+
+  @Override
+  public void unsuspend(Collection<TabletLocationState> tablets) throws DistributedStoreException {
+    wrapped.unsuspend(tablets);
+    for (TabletLocationState tls : tablets) {
+      TabletLogger.unsuspended(tls.extent);
+    }
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -31,10 +31,9 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
-import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.fs.Path;
 
-public class MetaDataStateStore extends TabletStateStore {
+class MetaDataStateStore implements TabletStateStore {
 
   private static final int THREADS = 4;
   private static final int LATENCY = 1000;
@@ -50,16 +49,8 @@ public class MetaDataStateStore extends TabletStateStore {
     this.targetTableName = targetTableName;
   }
 
-  public MetaDataStateStore(ClientContext context, CurrentState state) {
+  MetaDataStateStore(ClientContext context, CurrentState state) {
     this(context, state, MetadataTable.NAME);
-  }
-
-  protected MetaDataStateStore(ServerContext context, String tableName) {
-    this(context, null, tableName);
-  }
-
-  public MetaDataStateStore(ServerContext context) {
-    this(context, MetadataTable.NAME);
   }
 
   @Override
@@ -125,11 +116,17 @@ public class MetaDataStateStore extends TabletStateStore {
   @Override
   public void unassign(Collection<TabletLocationState> tablets,
       Map<TServerInstance,List<Path>> logsForDeadServers) throws DistributedStoreException {
-    suspend(tablets, logsForDeadServers, -1);
+    unassign(tablets, logsForDeadServers, -1);
   }
 
   @Override
   public void suspend(Collection<TabletLocationState> tablets,
+      Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
+      throws DistributedStoreException {
+    unassign(tablets, logsForDeadServers, suspensionTimestamp);
+  }
+
+  private void unassign(Collection<TabletLocationState> tablets,
       Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
       throws DistributedStoreException {
     BatchWriter writer = createBatchWriter();

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/RootTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/RootTabletStateStore.java
@@ -21,16 +21,11 @@ package org.apache.accumulo.server.master.state;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
-import org.apache.accumulo.server.ServerContext;
 
-public class RootTabletStateStore extends MetaDataStateStore {
+class RootTabletStateStore extends MetaDataStateStore {
 
-  public RootTabletStateStore(ClientContext context, CurrentState state) {
+  RootTabletStateStore(ClientContext context, CurrentState state) {
     super(context, state, RootTable.NAME);
-  }
-
-  public RootTabletStateStore(ServerContext context) {
-    super(context, RootTable.NAME);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateStore.java
@@ -31,33 +31,30 @@ import org.apache.hadoop.fs.Path;
 
 /**
  * Interface for storing information about tablet assignments. There are three implementations:
- *
- * ZooTabletStateStore: information about the root tablet is stored in ZooKeeper MetaDataStateStore:
- * information about the other tablets are stored in the metadata table
  */
 public interface TabletStateStore extends Iterable<TabletLocationState> {
 
   /**
    * Identifying name for this tablet state store.
    */
-  public abstract String name();
+  String name();
 
   /**
    * Scan the information about the tablets covered by this store
    */
   @Override
-  public abstract ClosableIterator<TabletLocationState> iterator();
+  ClosableIterator<TabletLocationState> iterator();
 
   /**
    * Store the assigned locations in the data store.
    */
-  public abstract void setFutureLocations(Collection<Assignment> assignments)
+  void setFutureLocations(Collection<Assignment> assignments)
       throws DistributedStoreException;
 
   /**
    * Tablet servers will update the data store with the location when they bring the tablet online
    */
-  public abstract void setLocations(Collection<Assignment> assignments)
+  void setLocations(Collection<Assignment> assignments)
       throws DistributedStoreException;
 
   /**
@@ -68,21 +65,21 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
    * @param logsForDeadServers
    *          a cache of logs in use by servers when they died
    */
-  public abstract void unassign(Collection<TabletLocationState> tablets,
+  void unassign(Collection<TabletLocationState> tablets,
       Map<TServerInstance,List<Path>> logsForDeadServers) throws DistributedStoreException;
 
   /**
    * Mark tablets as having no known or future location, but desiring to be returned to their
    * previous tserver.
    */
-  public abstract void suspend(Collection<TabletLocationState> tablets,
+  void suspend(Collection<TabletLocationState> tablets,
       Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
       throws DistributedStoreException;
 
   /**
    * Remove a suspension marker for a collection of tablets, moving them to being simply unassigned.
    */
-  public abstract void unsuspend(Collection<TabletLocationState> tablets)
+  void unsuspend(Collection<TabletLocationState> tablets)
       throws DistributedStoreException;
 
   public static void unassign(ServerContext context, TabletLocationState tls,

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateStore.java
@@ -48,14 +48,12 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
   /**
    * Store the assigned locations in the data store.
    */
-  void setFutureLocations(Collection<Assignment> assignments)
-      throws DistributedStoreException;
+  void setFutureLocations(Collection<Assignment> assignments) throws DistributedStoreException;
 
   /**
    * Tablet servers will update the data store with the location when they bring the tablet online
    */
-  void setLocations(Collection<Assignment> assignments)
-      throws DistributedStoreException;
+  void setLocations(Collection<Assignment> assignments) throws DistributedStoreException;
 
   /**
    * Mark the tablets as having no known or future location.
@@ -79,8 +77,7 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
   /**
    * Remove a suspension marker for a collection of tablets, moving them to being simply unassigned.
    */
-  void unsuspend(Collection<TabletLocationState> tablets)
-      throws DistributedStoreException;
+  void unsuspend(Collection<TabletLocationState> tablets) throws DistributedStoreException;
 
   public static void unassign(ServerContext context, TabletLocationState tls,
       Map<TServerInstance,List<Path>> logsForDeadServers) throws DistributedStoreException {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/ZooTabletStateStore.java
@@ -35,12 +35,12 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ZooTabletStateStore extends TabletStateStore {
+class ZooTabletStateStore implements TabletStateStore {
 
   private static final Logger log = LoggerFactory.getLogger(ZooTabletStateStore.class);
   private final Ample ample;
 
-  public ZooTabletStateStore(Ample ample) {
+  ZooTabletStateStore(Ample ample) {
     this.ample = ample;
   }
 
@@ -86,7 +86,6 @@ public class ZooTabletStateStore extends TabletStateStore {
 
           TabletLocationState result = new TabletLocationState(RootTable.EXTENT, futureSession,
               currentSession, lastSession, null, logs, false);
-          log.debug("Returning root tablet state: {}", result);
           return result;
         } catch (Exception ex) {
           throw new RuntimeException(ex);
@@ -113,7 +112,7 @@ public class ZooTabletStateStore extends TabletStateStore {
       throw new IllegalArgumentException("You can only store the root tablet location");
 
     TabletMutator tabletMutator = ample.mutateTablet(assignment.tablet);
-    tabletMutator.putLocation(assignment, LocationType.FUTURE);
+    tabletMutator.putLocation(assignment.server, LocationType.FUTURE);
     tabletMutator.mutate();
   }
 
@@ -126,8 +125,8 @@ public class ZooTabletStateStore extends TabletStateStore {
       throw new IllegalArgumentException("You can only store the root tablet location");
 
     TabletMutator tabletMutator = ample.mutateTablet(assignment.tablet);
-    tabletMutator.putLocation(assignment, LocationType.CURRENT);
-    tabletMutator.deleteLocation(assignment, LocationType.FUTURE);
+    tabletMutator.putLocation(assignment.server, LocationType.CURRENT);
+    tabletMutator.deleteLocation(assignment.server, LocationType.FUTURE);
 
     tabletMutator.mutate();
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
@@ -39,7 +40,7 @@ import org.apache.accumulo.server.master.state.MetaDataTableScanner;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.master.state.TabletState;
-import org.apache.accumulo.server.master.state.ZooTabletStateStore;
+import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.htrace.TraceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +74,7 @@ public class FindOfflineTablets {
     scanning.set(true);
 
     Iterator<TabletLocationState> zooScanner =
-        new ZooTabletStateStore(context.getAmple()).iterator();
+        TabletStateStore.getStoreForLevel(DataLevel.ROOT, context).iterator();
 
     int offline = 0;
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/RootTabletStateStoreTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.master.state;
+package org.apache.accumulo.server.master.state;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -35,12 +35,7 @@ import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.util.HostAndPort;
-import org.apache.accumulo.server.master.state.Assignment;
-import org.apache.accumulo.server.master.state.DistributedStoreException;
-import org.apache.accumulo.server.master.state.TServerInstance;
-import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.master.state.TabletLocationState.BadLocationStateException;
-import org.apache.accumulo.server.master.state.ZooTabletStateStore;
 import org.apache.accumulo.server.metadata.TabletMutatorBase;
 import org.junit.Test;
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.gc.thrift.GCStatus;
 import org.apache.accumulo.core.gc.thrift.GcCycleStats;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
@@ -50,12 +51,10 @@ import org.apache.accumulo.server.log.WalStateManager;
 import org.apache.accumulo.server.log.WalStateManager.WalMarkerException;
 import org.apache.accumulo.server.log.WalStateManager.WalState;
 import org.apache.accumulo.server.master.LiveTServerSet;
-import org.apache.accumulo.server.master.state.MetaDataStateStore;
-import org.apache.accumulo.server.master.state.RootTabletStateStore;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
 import org.apache.accumulo.server.master.state.TabletState;
-import org.apache.accumulo.server.master.state.ZooTabletStateStore;
+import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
@@ -94,8 +93,10 @@ public class GarbageCollectWriteAheadLogs {
     this.useTrash = useTrash;
     this.liveServers = liveServers;
     this.walMarker = new WalStateManager(context);
-    this.store = () -> Iterators.concat(new ZooTabletStateStore(context.getAmple()).iterator(),
-        new RootTabletStateStore(context).iterator(), new MetaDataStateStore(context).iterator());
+    this.store = () -> Iterators.concat(
+        TabletStateStore.getStoreForLevel(DataLevel.ROOT, context).iterator(),
+        TabletStateStore.getStoreForLevel(DataLevel.METADATA, context).iterator(),
+        TabletStateStore.getStoreForLevel(DataLevel.USER, context).iterator());
   }
 
   /**

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -52,6 +52,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.master.thrift.MasterState;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
@@ -99,8 +100,6 @@ import com.google.common.collect.Iterators;
 
 abstract class TabletGroupWatcher extends Daemon {
   // Constants used to make sure assignment logging isn't excessive in quantity or size
-  private static final String ASSIGNMENT_BUFFER_SEPARATOR = ", ";
-  private static final int ASSIGNMENT_BUFFER_MAX_LENGTH = 4096;
 
   private final Master master;
   private final TabletStateStore store;
@@ -194,17 +193,9 @@ abstract class TabletGroupWatcher extends Daemon {
             continue;
           }
 
-          // this can get spammy during merges
-          if (currentMerges.isEmpty()) {
-            Master.log.debug("{} location State: {}", store.name(), tls);
-          }
-
           // ignore entries for tables that do not exist in zookeeper
           if (master.getTableManager().getTableState(tls.extent.getTableId()) == null)
             continue;
-
-          if (Master.log.isTraceEnabled())
-            Master.log.trace("{} walogs {}", tls, tls.walogs.size());
 
           // Don't overwhelm the tablet servers with work
           if (unassigned.size() + unloaded
@@ -234,9 +225,10 @@ abstract class TabletGroupWatcher extends Daemon {
           TabletGoalState goal = this.master.getGoalState(tls, mergeStats.getMergeInfo());
           TServerInstance server = tls.getServer();
           TabletState state = tls.getState(currentTServers.keySet());
-          if (Master.log.isTraceEnabled()) {
-            Master.log.trace("Goal state {} current {} for {}", goal, state, tls.extent);
-          }
+
+          TabletLogger.missassigned(tls.extent, goal.toString(), state.toString(), tls.future,
+              tls.current, tls.walogs.size());
+
           stats.update(tableId, state);
           mergeStats.update(tls.extent, state, tls.chopped, !tls.walogs.isEmpty());
           sendChopRequest(mergeStats.getMergeInfo(), state, tls);
@@ -854,7 +846,6 @@ abstract class TabletGroupWatcher extends Daemon {
 
     if (!currentTServers.isEmpty()) {
       Map<KeyExtent,TServerInstance> assignedOut = new HashMap<>();
-      final StringBuilder builder = new StringBuilder(64);
       this.master.tabletBalancer.getAssignments(Collections.unmodifiableSortedMap(currentTServers),
           Collections.unmodifiableMap(unassigned), assignedOut);
       for (Entry<KeyExtent,TServerInstance> assignment : assignedOut.entrySet()) {
@@ -867,19 +858,6 @@ abstract class TabletGroupWatcher extends Daemon {
               continue;
             }
 
-            if (builder.length() > 0) {
-              builder.append(ASSIGNMENT_BUFFER_SEPARATOR);
-            }
-
-            builder.append(assignment);
-
-            // Don't let the log message get too gigantic
-            if (builder.length() > ASSIGNMENT_BUFFER_MAX_LENGTH) {
-              builder.append("]");
-              Master.log.debug("{} assigning tablets: [{}", store.name(), builder);
-              builder.setLength(0);
-            }
-
             assignments.add(new Assignment(assignment.getKey(), assignment.getValue()));
           }
         } else {
@@ -887,12 +865,6 @@ abstract class TabletGroupWatcher extends Daemon {
               "{} load balancer assigning tablet that was not nominated for assignment {}",
               store.name(), assignment.getKey());
         }
-      }
-
-      if (builder.length() > 0) {
-        // Make sure to log any leftover assignments
-        builder.append("]");
-        Master.log.debug("{} assigning tablets: [{}", store.name(), builder);
       }
 
       if (!unassigned.isEmpty() && assignedOut.isEmpty())

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -248,7 +248,7 @@ public class Compactor implements Callable<CompactionStats> {
         throw ex;
       }
 
-      log.debug(String.format(
+      log.trace(String.format(
           "Compaction %s %,d read | %,d written | %,6d entries/sec"
               + " | %,6.3f secs | %,12d bytes | %9.3f byte/sec",
           extent, majCStats.getEntriesRead(), majCStats.getEntriesWritten(),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.replication.ReplicationConfigurationUtil;
 import org.apache.accumulo.core.util.MapCounter;
@@ -277,8 +278,7 @@ class DatafileManager {
     }
 
     for (Entry<FileRef,DataFileValue> entry : paths.entrySet()) {
-      log.debug("TABLET_HIST {} import {} {}", tablet.getExtent(), entry.getKey(),
-          entry.getValue());
+      TabletLogger.bulkImported(tablet.getExtent(), entry.getKey());
     }
   }
 
@@ -476,13 +476,12 @@ class DatafileManager {
     // must do this after list of files in memory is updated above
     removeFilesAfterScan(filesInUseByScans);
 
-    if (absMergeFile != null)
-      log.debug("TABLET_HIST {} MinC [{},memory] -> {}", tablet.getExtent(), absMergeFile,
-          newDatafile);
-    else
-      log.debug("TABLET_HIST {} MinC [memory] -> {}", tablet.getExtent(), newDatafile);
-    log.debug(String.format("MinC finish lock %.2f secs %s", (t2 - t1) / 1000.0,
-        tablet.getExtent().toString()));
+    TabletLogger.flushed(tablet.getExtent(), absMergeFile, newDatafile);
+
+    if (log.isTraceEnabled()) {
+      log.trace(String.format("MinC finish lock %.2f secs %s", (t2 - t1) / 1000.0,
+          tablet.getExtent().toString()));
+    }
     long splitSize = tablet.getTableConfiguration().getAsBytes(Property.TABLE_SPLIT_THRESHOLD);
     if (dfv.getSize() > splitSize) {
       log.debug(String.format("Minor Compaction wrote out file larger than split threshold."
@@ -568,8 +567,11 @@ class DatafileManager {
         tablet.getTabletServer().getLock());
     removeFilesAfterScan(filesInUseByScans);
 
-    log.debug(String.format("MajC finish lock %.2f secs", (t2 - t1) / 1000.0));
-    log.debug("TABLET_HIST {} MajC  --> {}", oldDatafiles, newDatafile);
+    if (log.isTraceEnabled()) {
+      log.trace(String.format("MajC finish lock %.2f secs", (t2 - t1) / 1000.0));
+    }
+
+    TabletLogger.compacted(extent, oldDatafiles, newDatafile);
   }
 
   public SortedMap<FileRef,DataFileValue> getDatafileSizes() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -111,7 +111,7 @@ public class MinorCompactor extends Compactor {
   @Override
   public CompactionStats call() {
     final String outputFileName = getOutputFile();
-    log.debug("Begin minor compaction {} {}", outputFileName, getExtent());
+    log.trace("Begin minor compaction {} {}", outputFileName, getExtent());
 
     // output to new MapFile with a temporary name
     int sleepTime = 100;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.tserver.tablet;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.ByteArrayInputStream;
@@ -73,6 +74,7 @@ import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.YieldCallback;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator;
+import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.core.master.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.MetadataTable;
@@ -365,7 +367,7 @@ public class Tablet {
     tabletMemory = new TabletMemory(this);
 
     if (!logEntries.isEmpty()) {
-      log.info("Starting Write-Ahead Log recovery for {}", this.extent);
+      TabletLogger.recovering(extent, logEntries);
       final AtomicLong entriesUsedOnTablet = new AtomicLong(0);
       // track max time from walog entries without timestamps
       final AtomicLong maxTime = new AtomicLong(Long.MIN_VALUE);
@@ -429,9 +431,8 @@ public class Tablet {
 
       rebuildReferencedLogs();
 
-      log.info(
-          "Write-Ahead Log recovery complete for {} ({} mutations applied, {} entries created)",
-          this.extent, entriesUsedOnTablet.get(), getTabletMemory().getNumEntries());
+      TabletLogger.recovered(extent, logEntries, entriesUsedOnTablet.get(),
+          getTabletMemory().getNumEntries());
     }
 
     String contextName = tableConfiguration.get(Property.TABLE_CLASSPATH);
@@ -454,8 +455,6 @@ public class Tablet {
       // look for any temp files hanging around
       removeOldTemporaryFiles();
     }
-
-    log.debug("TABLET_HIST {} opened", extent);
   }
 
   public ServerContext getContext() {
@@ -1238,7 +1237,7 @@ public class Tablet {
           + ". State not saved and requested minor compactions queue");
     }
 
-    log.debug("initiateClose(saveState={} queueMinC={} disableWrites={}) {}", saveState, queueMinC,
+    log.trace("initiateClose(saveState={} queueMinC={} disableWrites={}) {}", saveState, queueMinC,
         disableWrites, getExtent());
 
     MinorCompactionTask mct = null;
@@ -1309,7 +1308,7 @@ public class Tablet {
       throw new IllegalStateException("Bad close state " + closeState + " on tablet " + extent);
     }
 
-    log.debug("completeClose(saveState={} completeClose={}) {}", saveState, completeClose, extent);
+    log.trace("completeClose(saveState={} completeClose={}) {}", saveState, completeClose, extent);
 
     // ensure this method is only called once, also guards against multiple
     // threads entering the method at the same time
@@ -1374,8 +1373,6 @@ public class Tablet {
 
     // close map files
     getTabletResources().close();
-
-    log.debug("TABLET_HIST {} closed", extent);
 
     if (completeClose) {
       closeState = CloseState.COMPLETE;
@@ -1807,7 +1804,7 @@ public class Tablet {
 
     try {
 
-      log.debug(String.format("MajC initiate lock %.2f secs, wait %.2f secs", (t3 - t2) / 1000.0,
+      log.trace(String.format("MajC initiate lock %.2f secs, wait %.2f secs", (t3 - t2) / 1000.0,
           (t2 - t1) / 1000.0));
 
       if (updateCompactionID) {
@@ -2223,7 +2220,7 @@ public class Tablet {
       MetadataTableUtil.finishSplit(high, highDatafileSizes, highDatafilesToRemove,
           getTabletServer().getContext(), getTabletServer().getLock());
 
-      log.debug("TABLET_HIST {} split {} {}", extent, low, high);
+      TabletLogger.split(extent, low, high, getTabletServer().getTabletSession());
 
       newTablets.put(high, new TabletData(dirName, highDatafileSizes, time, lastFlushID,
           lastCompactID, lastLocation, bulkImported));
@@ -2390,10 +2387,18 @@ public class Tablet {
      * Ensuring referencedLogs accurately tracks these sets ensures in use walogs are not GCed.
      */
 
+    var prev = referencedLogs;
+
     var builder = ImmutableSet.<DfsLogger>builder();
     builder.addAll(currentLogs);
     builder.addAll(otherLogs);
     referencedLogs = builder.build();
+
+    if (TabletLogger.isWalRefLoggingEnabled() && !prev.equals(referencedLogs)) {
+      TabletLogger.walRefsChanged(extent,
+          referencedLogs.stream().map(DfsLogger::getPath).map(Path::getName).collect(toList()));
+    }
+
   }
 
   public void removeInUseLogs(Set<DfsLogger> candidates) {
@@ -2472,15 +2477,15 @@ public class Tablet {
 
     // do debug logging outside tablet lock
     for (String logger : otherLogsCopy) {
-      log.debug("Logs for memory compacted: {} {}", getExtent(), logger);
+      log.trace("Logs for memory compacted: {} {}", getExtent(), logger);
     }
 
     for (String logger : currentLogsCopy) {
-      log.debug("Logs for current memory: {} {}", getExtent(), logger);
+      log.trace("Logs for current memory: {} {}", getExtent(), logger);
     }
 
     for (String logger : unusedLogs) {
-      log.debug("Logs to be destroyed: {} {}", getExtent(), logger);
+      log.trace("Logs to be destroyed: {} {}", getExtent(), logger);
     }
 
     return unusedLogs;

--- a/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
@@ -36,16 +36,16 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.master.state.ClosableIterator;
-import org.apache.accumulo.server.master.state.MetaDataStateStore;
-import org.apache.accumulo.server.master.state.RootTabletStateStore;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.RawLocalFileSystem;
@@ -87,7 +87,7 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
       // scan the metadata table and get the two table location states
       Set<TServerInstance> states = new HashSet<>();
       Set<TabletLocationState> oldLocations = new HashSet<>();
-      MetaDataStateStore store = new MetaDataStateStore(context, null);
+      TabletStateStore store = TabletStateStore.getStoreForLevel(DataLevel.USER, context);
       while (states.size() < 2) {
         UtilWaitThread.sleep(250);
         oldLocations.clear();
@@ -147,11 +147,11 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
       moved.current.putLocation(assignment);
       bw.addMutation(assignment);
       bw.close();
-      waitForCleanStore(new RootTabletStateStore(context, null));
+      waitForCleanStore(TabletStateStore.getStoreForLevel(DataLevel.METADATA, context));
     }
   }
 
-  private void waitForCleanStore(MetaDataStateStore store) {
+  private void waitForCleanStore(TabletStateStore store) {
     while (true) {
       try (ClosableIterator<TabletLocationState> iter = store.iterator()) {
         Iterators.size(iter);

--- a/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
@@ -38,6 +38,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.MasterState;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
@@ -49,9 +50,9 @@ import org.apache.accumulo.server.master.state.Assignment;
 import org.apache.accumulo.server.master.state.CurrentState;
 import org.apache.accumulo.server.master.state.MergeInfo;
 import org.apache.accumulo.server.master.state.MergeState;
-import org.apache.accumulo.server.master.state.MetaDataStateStore;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
@@ -142,7 +143,8 @@ public class MergeStateIT extends ConfigurableMacBase {
               MergeInfo.Operation.MERGE));
 
       // Verify the tablet state: hosted, and count
-      MetaDataStateStore metaDataStateStore = new MetaDataStateStore(context, state);
+      TabletStateStore metaDataStateStore =
+          TabletStateStore.getStoreForLevel(DataLevel.USER, context);
       int count = 0;
       for (TabletLocationState tss : metaDataStateStore) {
         if (tss != null)
@@ -208,7 +210,7 @@ public class MergeStateIT extends ConfigurableMacBase {
     }
   }
 
-  private MergeStats scan(MockCurrentState state, MetaDataStateStore metaDataStateStore) {
+  private MergeStats scan(MockCurrentState state, TabletStateStore metaDataStateStore) {
     MergeStats stats = new MergeStats(state.mergeInfo);
     stats.getMergeInfo().setState(MergeState.WAITING_FOR_OFFLINE);
     for (TabletLocationState tss : metaDataStateStore) {

--- a/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
@@ -55,6 +55,7 @@ import org.apache.accumulo.core.dataImpl.thrift.TSummaryRequest;
 import org.apache.accumulo.core.dataImpl.thrift.UpdateErrors;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.tabletserver.thrift.ActiveCompaction;
 import org.apache.accumulo.core.tabletserver.thrift.ActiveScan;
@@ -70,10 +71,10 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.client.ClientServiceHandler;
 import org.apache.accumulo.server.master.state.Assignment;
-import org.apache.accumulo.server.master.state.MetaDataStateStore;
 import org.apache.accumulo.server.master.state.MetaDataTableScanner;
 import org.apache.accumulo.server.master.state.TServerInstance;
 import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletStateStore;
 import org.apache.accumulo.server.metrics.Metrics;
 import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftServerType;
@@ -322,7 +323,7 @@ public class NullTserver {
       }
     }
     // point them to this server
-    MetaDataStateStore store = new MetaDataStateStore(context);
+    TabletStateStore store = TabletStateStore.getStoreForLevel(DataLevel.USER, context);
     store.setLocations(assignments);
 
     while (true) {


### PR DESCRIPTION
Centralized in code logging related to tablet files and location.
Removed and supressed redundant logging, with the goal of logging a
single message for an event like assignment or compaction.