### PR TITLE
Always stop transport pool closer thread #1449

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -389,7 +389,7 @@ public class ThriftTransportPool {
   private class Closer implements Runnable {
 
     private void closeConnections() throws InterruptedException {
-      while (true) {
+      while (!getConnectionPool().shutdown) {
         closeExpiredConnections();
         Thread.sleep(500);
       }


### PR DESCRIPTION
The thrift transport pool closer thread was only stopping when shutdown
and there were connections to close.  If there was nothing to close, it
would keep running when shutdown.  This was causing test to hang.  Made
it always stop when shutdown.