### PR TITLE
Make ITs override defaultTimeoutSeconds

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/BalanceFasterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BalanceFasterIT.java
@@ -55,12 +55,17 @@ public class BalanceFasterIT extends ConfigurableMacBase {
     cfg.setNumTservers(3);
   }
 
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 90;
+  }
+
   @BeforeClass
   static public void checkMR() {
     assumeFalse(IntegrationTestMapReduce.isMapReduce());
   }
 
-  @Test(timeout = 90 * 1000)
+  @Test
   public void test() throws Exception {
     // create a table, add a bunch of splits
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/GarbageCollectWALIT.java
@@ -48,7 +48,12 @@ public class GarbageCollectWALIT extends ConfigurableMacBase {
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 3 * 60;
+  }
+
+  @Test
   public void test() throws Exception {
     // not yet, please
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
@@ -59,8 +59,13 @@ public class LargeSplitRowIT extends ConfigurableMacBase {
     cfg.setSiteConfig(siteConfig);
   }
 
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 60;
+  }
+
   // User added split
-  @Test(timeout = 60 * 1000)
+  @Test
   public void userAddedSplit() throws Exception {
 
     log.info("User added split");

--- a/test/src/main/java/org/apache/accumulo/test/ManySplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ManySplitIT.java
@@ -48,12 +48,17 @@ public class ManySplitIT extends ConfigurableMacBase {
 
   final int SPLITS = 10_000;
 
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
   @BeforeClass
   static public void checkMR() {
     assumeFalse(IntegrationTestMapReduce.isMapReduce());
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void test() throws Exception {
     assumeFalse(IntegrationTestMapReduce.isMapReduce());
 

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -41,7 +41,6 @@ import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
 
 import com.google.common.collect.Iterators;
 
@@ -52,6 +51,11 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
     cfg.setNumTservers(1);
     cfg.setProperty(Property.TSERV_SCAN_MAX_OPENFILES, "2");
     cfg.setProperty(Property.TABLE_BLOCKCACHE_ENABLED, "false");
+  }
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 2 * 60;
   }
 
   private static Thread slowScan(final Connector c, final String tableName,
@@ -79,7 +83,6 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
     return thread;
   }
 
-  @Test(timeout = 2 * 60 * 1000)
   public void test() throws Exception {
     final String tableName = getUniqueNames(1)[0];
     final Connector c = getConnector();

--- a/test/src/main/java/org/apache/accumulo/test/MetaRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaRecoveryIT.java
@@ -54,7 +54,12 @@ public class MetaRecoveryIT extends ConfigurableMacBase {
     cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "1048576");
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
+  @Test
   public void test() throws Exception {
     String[] tables = getUniqueNames(10);
     Connector c = getConnector();

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -53,7 +53,12 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
+  @Test
   public void testRecoveryOverMultipleTables() throws Exception {
     final int N = 3;
     final Connector c = getConnector();

--- a/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanFlushWithTimeIT.java
@@ -45,7 +45,12 @@ public class ScanFlushWithTimeIT extends AccumuloClusterHarness {
 
   private static final Logger log = LoggerFactory.getLogger(ScanFlushWithTimeIT.class);
 
-  @Test(timeout = 30 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 30;
+  }
+
+  @Test
   public void test() throws Exception {
     log.info("Creating table");
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1349,7 +1349,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     }
   }
 
-  // @Test(timeout = 45000)
+  @Test
   public void history() throws Exception {
     final String table = name.getMethodName();
 

--- a/test/src/main/java/org/apache/accumulo/test/TabletServerGivesUpIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TabletServerGivesUpIT.java
@@ -44,7 +44,12 @@ public class TabletServerGivesUpIT extends ConfigurableMacBase {
     cfg.setProperty(Property.TSERV_WALOG_TOLERATED_MAXIMUM_WAIT_DURATION, "0s");
   }
 
-  @Test(timeout = 45 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 45;
+  }
+
+  @Test
   public void test() throws Exception {
     final Connector conn = this.getConnector();
     // Yes, there's a tabletserver

--- a/test/src/main/java/org/apache/accumulo/test/TabletServerHdfsRestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TabletServerHdfsRestartIT.java
@@ -42,7 +42,12 @@ public class TabletServerHdfsRestartIT extends ConfigurableMacBase {
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
   }
 
-  @Test(timeout = 2 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 2 * 60;
+  }
+
+  @Test
   public void test() throws Exception {
     final Connector conn = this.getConnector();
     // Yes, there's a tabletserver

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -49,11 +49,16 @@ public class TotalQueuedIT extends ConfigurableMacBase {
     cfg.useMiniDFS();
   }
 
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
   int SMALL_QUEUE_SIZE = 100000;
   int LARGE_QUEUE_SIZE = SMALL_QUEUE_SIZE * 10;
   static final long N = 1000000;
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void test() throws Exception {
     Random random = new Random();
     Connector c = getConnector();

--- a/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
@@ -65,7 +65,12 @@ public class UnusedWALIT extends ConfigurableMacBase {
     hadoopCoreSite.set("fs.namenode.fs-limits.min-block-size", Long.toString(logSize));
   }
 
-  @Test(timeout = 2 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 2 * 60;
+  }
+
+  @Test
   public void test() throws Exception {
     // don't want this bad boy cleaning up walog entries
     getCluster().getClusterControl().stop(ServerType.GARBAGE_COLLECTOR);

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -69,7 +69,12 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
+  @Test
   public void testSerializedRecovery() throws Exception {
     // make a table with many splits
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
@@ -67,7 +67,7 @@ public class DeleteRowsIT extends AccumuloClusterHarness {
     ROWS.add("{");
   }
 
-  @Test(timeout = 5 * 60 * 1000)
+  @Test
   public void testDeleteAllRows() throws Exception {
     Connector c = getConnector();
     String[] tableNames = this.getUniqueNames(20);

--- a/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
@@ -59,6 +59,11 @@ public class DurabilityIT extends ConfigurableMacBase {
     cfg.setNumTservers(1);
   }
 
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 4 * 60;
+  }
+
   @BeforeClass
   static public void checkMR() {
     assumeFalse(IntegrationTestMapReduce.isMapReduce());
@@ -93,7 +98,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     tableOps.create(tableName);
   }
 
-  @Test(timeout = 2 * 60 * 1000)
+  @Test
   public void testWriteSpeed() throws Exception {
     TableOperations tableOps = getConnector().tableOperations();
     String tableNames[] = init();
@@ -117,7 +122,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     assertTrue("no durability should be faster than log", t2 > t3);
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void testSync() throws Exception {
     String tableNames[] = init();
     // sync table should lose nothing
@@ -127,7 +132,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     cleanup(tableNames);
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void testFlush() throws Exception {
     String tableNames[] = init();
     // flush table won't lose anything since we're not losing power/dfs
@@ -137,7 +142,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     cleanup(tableNames);
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void testLog() throws Exception {
     String tableNames[] = init();
     // we're probably going to lose something the the log setting
@@ -148,7 +153,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     cleanup(tableNames);
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void testNone() throws Exception {
     String tableNames[] = init();
     // probably won't get any data back without logging
@@ -159,7 +164,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     cleanup(tableNames);
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void testIncreaseDurability() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];
@@ -183,7 +188,7 @@ public class DurabilityIT extends ConfigurableMacBase {
     return result;
   }
 
-  @Test(timeout = 4 * 60 * 1000)
+  @Test
   public void testMetaDurability() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
@@ -50,7 +50,12 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
     cfg.setNumTservers(4);
   }
 
-  @Test(timeout = 120000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 2 * 60;
+  }
+
+  @Test
   public void testBalancing() throws Exception {
     Connector conn = getConnector();
     String tablename = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
@@ -49,7 +49,12 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
   }
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 3 * 60;
+  }
+
+  @Test
   public void nondurableTableHasDurableWrites() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];
@@ -66,7 +71,7 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     assertEquals(10, count(tableName));
   }
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Test
   public void durableTableLosesNonDurableWrites() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];
@@ -97,7 +102,7 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     bw.close();
   }
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Test
   public void testConditionDurability() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];
@@ -115,7 +120,7 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
     assertEquals(0, count(tableName));
   }
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Test
   public void testConditionDurability2() throws Exception {
     Connector c = getConnector();
     String tableName = getUniqueNames(1)[0];

--- a/test/src/main/java/org/apache/accumulo/test/performance/RollWALPerformanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/RollWALPerformanceIT.java
@@ -59,6 +59,11 @@ public class RollWALPerformanceIT extends ConfigurableMacBase {
     cfg.useMiniDFS(true);
   }
 
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 20 * 60;
+  }
+
   private long ingest() throws Exception {
     final Connector c = getConnector();
     final String tableName = getUniqueNames(1)[0];
@@ -122,7 +127,7 @@ public class RollWALPerformanceIT extends ConfigurableMacBase {
     assertTrue(percent < 125.);
   }
 
-  @Test(timeout = 20 * 60 * 1000)
+  @Test
   public void testWalPerformance() throws Exception {
     testWalPerformanceOnce();
   }

--- a/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
@@ -268,7 +268,7 @@ public class GarbageCollectorCommunicatesWithTServersIT extends ConfigurableMacB
         fileToStatusAfterMinc);
   }
 
-  @Test(timeout = 2 * 60 * 1000)
+  @Test
   public void testUnreferencedWalInTserverIsClosed() throws Exception {
     final String[] names = getUniqueNames(2);
     // `table` will be replicated, `otherTable` is only used to roll the WAL on the tserver

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiInstanceReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiInstanceReplicationIT.java
@@ -159,7 +159,7 @@ public class MultiInstanceReplicationIT extends ConfigurableMacBase {
     }
   }
 
-  @Test(timeout = 10 * 60 * 1000)
+  @Test
   public void dataWasReplicatedToThePeer() throws Exception {
     MiniAccumuloConfigImpl peerCfg = new MiniAccumuloConfigImpl(
         createTestDir(this.getClass().getName() + "_" + this.testName.getMethodName() + "_peer"),

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationRandomWalkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationRandomWalkIT.java
@@ -40,7 +40,12 @@ public class ReplicationRandomWalkIT extends ConfigurableMacBase {
     cfg.setNumTservers(1);
   }
 
-  @Test(timeout = 5 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 5 * 60;
+  }
+
+  @Test
   public void runReplicationRandomWalkStep() throws Exception {
     Replication r = new Replication();
 


### PR DESCRIPTION
* Some ITs were setting timeout using junit, instead of the miniaccumulo
method defaultTimeoutSeconds which allows use of system prop timeout.factor