### PR TITLE
Reduce Path obj creation with VolumeUtil

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFileUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFileUtil.java
@@ -37,4 +37,11 @@ public class TabletFileUtil {
     }
     return p.toString();
   }
+
+  public static Path validate(Path path) {
+    if (path.toUri().getScheme() == null) {
+      throw new IllegalArgumentException("Invalid path provided, no scheme in " + path);
+    }
+    return path;
+  }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
@@ -49,11 +49,11 @@ public class VolumeUtilTest {
         .add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a/accumulo")));
     replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b/accumulo")));
 
-    assertEquals("viewfs:/a/accumulo/tables/t-00000/C000.rf", VolumeUtil
+    assertEquals(new Path("viewfs:/a/accumulo/tables/t-00000/C000.rf"), VolumeUtil
         .switchVolume("hdfs://nn1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/a/accumulo/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/a/accumulo/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1:9000/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/b/accumulo/tables/t-00000/C000.rf", VolumeUtil
+    assertEquals(new Path("viewfs:/b/accumulo/tables/t-00000/C000.rf"), VolumeUtil
         .switchVolume("hdfs://nn2/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
     assertNull(VolumeUtil.switchVolume("viewfs:/a/accumulo/tables/t-00000/C000.rf", FileType.TABLE,
         replacements));
@@ -68,11 +68,11 @@ public class VolumeUtilTest {
     replacements
         .add(new Pair<>(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/b/accumulo")));
 
-    assertEquals("viewfs:/a/accumulo/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/a/accumulo/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1/d1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/a/accumulo/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/a/accumulo/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1:9000/d1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/b/accumulo/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/b/accumulo/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn2/d2/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
     assertNull(VolumeUtil.switchVolume("viewfs:/a/accumulo/tables/t-00000/C000.rf", FileType.TABLE,
         replacements));
@@ -89,11 +89,11 @@ public class VolumeUtilTest {
     replacements.add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/a")));
     replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/b")));
 
-    assertEquals("viewfs:/a/tables/t-00000/C000.rf", VolumeUtil
+    assertEquals(new Path("viewfs:/a/tables/t-00000/C000.rf"), VolumeUtil
         .switchVolume("hdfs://nn1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/a/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/a/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1:9000/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/b/tables/t-00000/C000.rf", VolumeUtil
+    assertEquals(new Path("viewfs:/b/tables/t-00000/C000.rf"), VolumeUtil
         .switchVolume("hdfs://nn2/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
     assertNull(
         VolumeUtil.switchVolume("viewfs:/a/tables/t-00000/C000.rf", FileType.TABLE, replacements));
@@ -105,11 +105,11 @@ public class VolumeUtilTest {
     replacements.add(new Pair<>(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/a")));
     replacements.add(new Pair<>(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/b")));
 
-    assertEquals("viewfs:/a/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/a/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1/d1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/a/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/a/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1:9000/d1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/b/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/b/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn2/d2/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
     assertNull(
         VolumeUtil.switchVolume("viewfs:/a/tables/t-00000/C000.rf", FileType.TABLE, replacements));
@@ -127,11 +127,11 @@ public class VolumeUtilTest {
         .add(new Pair<>(new Path("hdfs://nn1:9000/accumulo"), new Path("viewfs:/path1/path2")));
     replacements.add(new Pair<>(new Path("hdfs://nn2/accumulo"), new Path("viewfs:/path3")));
 
-    assertEquals("viewfs:/path1/path2/tables/t-00000/C000.rf", VolumeUtil
+    assertEquals(new Path("viewfs:/path1/path2/tables/t-00000/C000.rf"), VolumeUtil
         .switchVolume("hdfs://nn1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/path1/path2/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/path1/path2/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1:9000/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/path3/tables/t-00000/C000.rf", VolumeUtil
+    assertEquals(new Path("viewfs:/path3/tables/t-00000/C000.rf"), VolumeUtil
         .switchVolume("hdfs://nn2/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
     assertNull(VolumeUtil.switchVolume("viewfs:/path1/path2/tables/t-00000/C000.rf", FileType.TABLE,
         replacements));
@@ -145,11 +145,11 @@ public class VolumeUtilTest {
         .add(new Pair<>(new Path("hdfs://nn1:9000/d1/accumulo"), new Path("viewfs:/path1/path2")));
     replacements.add(new Pair<>(new Path("hdfs://nn2/d2/accumulo"), new Path("viewfs:/path3")));
 
-    assertEquals("viewfs:/path1/path2/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/path1/path2/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1/d1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/path1/path2/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/path1/path2/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn1:9000/d1/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
-    assertEquals("viewfs:/path3/tables/t-00000/C000.rf", VolumeUtil.switchVolume(
+    assertEquals(new Path("viewfs:/path3/tables/t-00000/C000.rf"), VolumeUtil.switchVolume(
         "hdfs://nn2/d2/accumulo/tables/t-00000/C000.rf", FileType.TABLE, replacements));
     assertNull(VolumeUtil.switchVolume("viewfs:/path1/path2/tables/t-00000/C000.rf", FileType.TABLE,
         replacements));
@@ -167,7 +167,7 @@ public class VolumeUtilTest {
 
     FileType ft = FileType.TABLE;
 
-    assertEquals("file:/foo/v8/tables/+r/root_tablet",
+    assertEquals(new Path("file:/foo/v8/tables/+r/root_tablet"),
         VolumeUtil.switchVolume("file:/foo/v1/tables/+r/root_tablet", ft, replacements));
   }
 }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -309,7 +309,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
           try {
             Path fullPath;
-            String switchedDelete = VolumeUtil.switchVolume(delete, FileType.TABLE, replacements);
+            Path switchedDelete = VolumeUtil.switchVolume(delete, FileType.TABLE, replacements);
             if (switchedDelete != null) {
               // actually replacing the volumes in the metadata table would be tricky because the
               // entries would be different rows. So it could not be
@@ -320,7 +320,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
               // of deleting something that should not be deleted. Must not change value of delete
               // variable because thats whats stored in metadata table.
               log.debug("Volume replaced {} -> {}", delete, switchedDelete);
-              fullPath = new Path(TabletFileUtil.validate(switchedDelete));
+              fullPath = TabletFileUtil.validate(switchedDelete);
             } else {
               fullPath = new Path(TabletFileUtil.validate(delete));
             }

--- a/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/recovery/RecoveryManager.java
@@ -156,14 +156,14 @@ public class RecoveryManager {
     for (Collection<String> logs : walogs) {
       for (String walog : logs) {
 
-        String switchedWalog = VolumeUtil.switchVolume(walog, FileType.WAL, ServerConstants
+        Path switchedWalog = VolumeUtil.switchVolume(walog, FileType.WAL, ServerConstants
             .getVolumeReplacements(master.getConfiguration(), master.getContext().getHadoopConf()));
         if (switchedWalog != null) {
           // replaces the volume used for sorting, but do not change entry in metadata table. When
           // the tablet loads it will change the metadata table entry. If
           // the tablet has the same replacement config, then it will find the sorted log.
           log.info("Volume replaced {} -> {}", walog, switchedWalog);
-          walog = switchedWalog;
+          walog = switchedWalog.toString();
         }
 
         String[] parts = walog.split("/");


### PR DESCRIPTION
* Make VolumeUtil.switchVolume() return the Path object it created
instead of returning a string. This allows callers to use the Path
object or call toString if one is needed. There are a few cases where
the string returned was used to create another Path object