### PR TITLE
Optimize DatafileManager bulk import method

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -197,17 +197,12 @@ class DatafileManager {
     return inUse;
   }
 
-  public void importMapFiles(long tid, Map<TabletFile,DataFileValue> fileMap, boolean setTime)
+  public void importMapFiles(long tid, Map<TabletFile,DataFileValue> paths, boolean setTime)
       throws IOException {
 
     String bulkDir = null;
 
-    Map<TabletFile,DataFileValue> paths = new HashMap<>();
-    for (Entry<TabletFile,DataFileValue> entry : fileMap.entrySet())
-      paths.put(entry.getKey(), entry.getValue());
-
     for (TabletFile tpath : paths.keySet()) {
-
       boolean inTheRightDirectory = false;
       Path parent = tpath.getPath().getParent().getParent();
       for (String tablesDir : ServerConstants.getTablesDirs(tablet.getContext())) {


### PR DESCRIPTION
* Stop creating a second HashMap in DatafileManager when the calling
method in Tablet already creates a HashMap for this method

The only place this method is called is in Tablet [here](https://github.com/apache/accumulo/blob/7a2ab3bccb32e57cb6f82bdbf6c7d06ea887f876/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java#L2314).