### PR TITLE
Close open BatchScanner's in SampleIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -146,57 +146,58 @@ public class SampleIT extends AccumuloClusterHarness {
       isoScanner.setSamplerConfiguration(SC1);
       isoScanner.setBatchSize(10);
 
-      BatchScanner bScanner = client.createBatchScanner(tableName);
-      bScanner.setSamplerConfiguration(SC1);
-      bScanner.setRanges(Arrays.asList(new Range()));
+      try (BatchScanner bScanner = client.createBatchScanner(tableName)) {
+        bScanner.setSamplerConfiguration(SC1);
+        bScanner.setRanges(Arrays.asList(new Range()));
 
-      check(expected, scanner, bScanner, isoScanner, csiScanner);
+        check(expected, scanner, bScanner, isoScanner, csiScanner);
 
-      client.tableOperations().flush(tableName, null, null, true);
+        client.tableOperations().flush(tableName, null, null, true);
 
-      Scanner oScanner = newOfflineScanner(client, tableName, clone, SC1);
-      check(expected, scanner, bScanner, isoScanner, csiScanner, oScanner);
+        Scanner oScanner = newOfflineScanner(client, tableName, clone, SC1);
+        check(expected, scanner, bScanner, isoScanner, csiScanner, oScanner);
 
-      // ensure non sample data can be scanned after scanning sample data
-      for (ScannerBase sb : Arrays.asList(scanner, bScanner, isoScanner, csiScanner, oScanner)) {
-        sb.clearSamplerConfiguration();
-        assertEquals(20000, Iterables.size(sb));
-        sb.setSamplerConfiguration(SC1);
+        // ensure non sample data can be scanned after scanning sample data
+        for (ScannerBase sb : Arrays.asList(scanner, bScanner, isoScanner, csiScanner, oScanner)) {
+          sb.clearSamplerConfiguration();
+          assertEquals(20000, Iterables.size(sb));
+          sb.setSamplerConfiguration(SC1);
+        }
+
+        expected.keySet().removeIf(k -> k.getRow().toString().equals(someRow));
+
+        expected.put(new Key(someRow, "cf1", "cq1", 8), new Value("42"));
+        expected.put(new Key(someRow, "cf1", "cq3", 8), new Value("suprise"));
+
+        Mutation m = new Mutation(someRow);
+
+        m.put("cf1", "cq1", 8, "42");
+        m.putDelete("cf1", "cq2", 8);
+        m.put("cf1", "cq3", 8, "suprise");
+
+        bw.addMutation(m);
+        bw.close();
+
+        check(expected, scanner, bScanner, isoScanner, csiScanner);
+
+        client.tableOperations().flush(tableName, null, null, true);
+
+        oScanner = newOfflineScanner(client, tableName, clone, SC1);
+        check(expected, scanner, bScanner, isoScanner, csiScanner, oScanner);
+
+        scanner.setRange(new Range(someRow));
+        isoScanner.setRange(new Range(someRow));
+        csiScanner.setRange(new Range(someRow));
+        oScanner.setRange(new Range(someRow));
+        bScanner.setRanges(Arrays.asList(new Range(someRow)));
+
+        expected.clear();
+
+        expected.put(new Key(someRow, "cf1", "cq1", 8), new Value("42"));
+        expected.put(new Key(someRow, "cf1", "cq3", 8), new Value("suprise"));
+
+        check(expected, scanner, bScanner, isoScanner, csiScanner, oScanner);
       }
-
-      expected.keySet().removeIf(k -> k.getRow().toString().equals(someRow));
-
-      expected.put(new Key(someRow, "cf1", "cq1", 8), new Value("42"));
-      expected.put(new Key(someRow, "cf1", "cq3", 8), new Value("suprise"));
-
-      Mutation m = new Mutation(someRow);
-
-      m.put("cf1", "cq1", 8, "42");
-      m.putDelete("cf1", "cq2", 8);
-      m.put("cf1", "cq3", 8, "suprise");
-
-      bw.addMutation(m);
-      bw.close();
-
-      check(expected, scanner, bScanner, isoScanner, csiScanner);
-
-      client.tableOperations().flush(tableName, null, null, true);
-
-      oScanner = newOfflineScanner(client, tableName, clone, SC1);
-      check(expected, scanner, bScanner, isoScanner, csiScanner, oScanner);
-
-      scanner.setRange(new Range(someRow));
-      isoScanner.setRange(new Range(someRow));
-      csiScanner.setRange(new Range(someRow));
-      oScanner.setRange(new Range(someRow));
-      bScanner.setRanges(Arrays.asList(new Range(someRow)));
-
-      expected.clear();
-
-      expected.put(new Key(someRow, "cf1", "cq1", 8), new Value("42"));
-      expected.put(new Key(someRow, "cf1", "cq3", 8), new Value("suprise"));
-
-      check(expected, scanner, bScanner, isoScanner, csiScanner, oScanner);
     }
   }
 
@@ -421,52 +422,53 @@ public class SampleIT extends AccumuloClusterHarness {
       Scanner isoScanner = new IsolatedScanner(client.createScanner(tableName));
       isoScanner.setBatchSize(10);
       Scanner csiScanner = new ClientSideIteratorScanner(client.createScanner(tableName));
-      BatchScanner bScanner = client.createBatchScanner(tableName);
-      bScanner.setRanges(Arrays.asList(new Range()));
+      try (BatchScanner bScanner = client.createBatchScanner(tableName)) {
+        bScanner.setRanges(Arrays.asList(new Range()));
 
-      // ensure sample not present exception occurs when sampling is not configured
-      assertSampleNotPresent(SC1, scanner, isoScanner, bScanner, csiScanner);
+        // ensure sample not present exception occurs when sampling is not configured
+        assertSampleNotPresent(SC1, scanner, isoScanner, bScanner, csiScanner);
 
-      client.tableOperations().flush(tableName, null, null, true);
+        client.tableOperations().flush(tableName, null, null, true);
 
-      Scanner oScanner = newOfflineScanner(client, tableName, clone, SC1);
-      assertSampleNotPresent(SC1, scanner, isoScanner, bScanner, csiScanner, oScanner);
+        Scanner oScanner = newOfflineScanner(client, tableName, clone, SC1);
+        assertSampleNotPresent(SC1, scanner, isoScanner, bScanner, csiScanner, oScanner);
 
-      // configure sampling, however there exist an rfile w/o sample data... so should still see
-      // sample not present exception
+        // configure sampling, however there exist an rfile w/o sample data... so should still see
+        // sample not present exception
 
-      updateSamplingConfig(client, tableName, SC1);
+        updateSamplingConfig(client, tableName, SC1);
 
-      // create clone with new config
-      oScanner = newOfflineScanner(client, tableName, clone, SC1);
+        // create clone with new config
+        oScanner = newOfflineScanner(client, tableName, clone, SC1);
 
-      assertSampleNotPresent(SC1, scanner, isoScanner, bScanner, csiScanner, oScanner);
+        assertSampleNotPresent(SC1, scanner, isoScanner, bScanner, csiScanner, oScanner);
 
-      // create rfile with sample data present
-      client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
+        // create rfile with sample data present
+        client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
 
-      // should be able to scan sample now
-      oScanner = newOfflineScanner(client, tableName, clone, SC1);
-      setSamplerConfig(SC1, scanner, csiScanner, isoScanner, bScanner, oScanner);
-      check(expected, scanner, isoScanner, bScanner, csiScanner, oScanner);
+        // should be able to scan sample now
+        oScanner = newOfflineScanner(client, tableName, clone, SC1);
+        setSamplerConfig(SC1, scanner, csiScanner, isoScanner, bScanner, oScanner);
+        check(expected, scanner, isoScanner, bScanner, csiScanner, oScanner);
 
-      // change sampling config
-      updateSamplingConfig(client, tableName, SC2);
+        // change sampling config
+        updateSamplingConfig(client, tableName, SC2);
 
-      // create clone with new config
-      oScanner = newOfflineScanner(client, tableName, clone, SC2);
+        // create clone with new config
+        oScanner = newOfflineScanner(client, tableName, clone, SC2);
 
-      // rfile should have different sample config than table, and scan should not work
-      assertSampleNotPresent(SC2, scanner, isoScanner, bScanner, csiScanner, oScanner);
+        // rfile should have different sample config than table, and scan should not work
+        assertSampleNotPresent(SC2, scanner, isoScanner, bScanner, csiScanner, oScanner);
 
-      // create rfile that has same sample data as table config
-      client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
+        // create rfile that has same sample data as table config
+        client.tableOperations().compact(tableName, new CompactionConfig().setWait(true));
 
-      // should be able to scan sample now
-      updateExpected(SC2, expected);
-      oScanner = newOfflineScanner(client, tableName, clone, SC2);
-      setSamplerConfig(SC2, scanner, csiScanner, isoScanner, bScanner, oScanner);
-      check(expected, scanner, isoScanner, bScanner, csiScanner, oScanner);
+        // should be able to scan sample now
+        updateExpected(SC2, expected);
+        oScanner = newOfflineScanner(client, tableName, clone, SC2);
+        setSamplerConfig(SC2, scanner, csiScanner, isoScanner, bScanner, oScanner);
+        check(expected, scanner, isoScanner, bScanner, csiScanner, oScanner);
+      }
     }
   }
 


### PR DESCRIPTION
While updating another issue I noted two occasions where created BatchScanner's were not closed properly. This update closes them to remove the exception output that appeared in the test output.