### PR TITLE
Added detailed trace logging for FATE #1316

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.accumulo.core.logging;
+
+import static org.apache.accumulo.fate.FateTxId.formatTid;
+
+import java.io.Serializable;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.accumulo.fate.ReadOnlyRepo;
+import org.apache.accumulo.fate.Repo;
+import org.apache.accumulo.fate.StackOverflowException;
+import org.apache.accumulo.fate.TStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FateLogger {
+  private static final String PREFIX = Logging.PREFIX + "fate.";
+
+  // Logs all mutations to FATEs persistent storage. Enabling this logger could help debug
+  // reproducible problems with FATE transactions.
+  private static final Logger storeLog = LoggerFactory.getLogger(PREFIX + "store");
+
+  public static <T> TStore<T> wrap(TStore<T> store, Function<Repo<T>,String> toLogString) {
+
+    // only logging operations that change the persisted data, not operations that only read data
+    return new TStore<T>() {
+
+      @Override
+      public long reserve() {
+        return store.reserve();
+      }
+
+      @Override
+      public void reserve(long tid) {
+        store.reserve(tid);
+      }
+
+      @Override
+      public void unreserve(long tid, long deferTime) {
+        store.unreserve(tid, deferTime);
+      }
+
+      @Override
+      public List<ReadOnlyRepo<T>> getStack(long tid) {
+        return store.getStack(tid);
+      }
+
+      @Override
+      public TStatus getStatus(long tid) {
+        return store.getStatus(tid);
+      }
+
+      @Override
+      public TStatus waitForStatusChange(long tid, EnumSet<TStatus> expected) {
+        return store.waitForStatusChange(tid, expected);
+      }
+
+      @Override
+      public Serializable getProperty(long tid, String prop) {
+        return store.getProperty(tid, prop);
+      }
+
+      @Override
+      public List<Long> list() {
+        return store.list();
+      }
+
+      @Override
+      public long create() {
+        long tid = store.create();
+        if (storeLog.isTraceEnabled())
+          storeLog.trace("created {}", formatTid(tid));
+        return tid;
+      }
+
+      @Override
+      public Repo<T> top(long tid) {
+        return store.top(tid);
+      }
+
+      @Override
+      public void push(long tid, Repo<T> repo) throws StackOverflowException {
+        store.push(tid, repo);
+        storeLog.trace("pushed {} {}", formatTid(tid), toLogString.apply(repo));
+      }
+
+      @Override
+      public void pop(long tid) {
+        store.pop(tid);
+        if (storeLog.isTraceEnabled())
+          storeLog.trace("popped {}", formatTid(tid));
+      }
+
+      @Override
+      public void setStatus(long tid, TStatus status) {
+        store.setStatus(tid, status);
+        if (storeLog.isTraceEnabled())
+          storeLog.trace("setStatus {} {}", formatTid(tid), status);
+      }
+
+      @Override
+      public void setProperty(long tid, String prop, Serializable val) {
+        store.setProperty(tid, prop, val);
+        if (storeLog.isTraceEnabled())
+          storeLog.trace("setProperty {} {} {}", formatTid(tid), prop, val);
+      }
+
+      @Override
+      public void delete(long tid) {
+        store.delete(tid);
+        if (storeLog.isTraceEnabled())
+          storeLog.trace("deleted {}", formatTid(tid));
+      }
+    };
+  }
+}

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -101,7 +101,8 @@ public class FateLogger {
       @Override
       public void push(long tid, Repo<T> repo) throws StackOverflowException {
         store.push(tid, repo);
-        storeLog.trace("pushed {} {}", formatTid(tid), toLogString.apply(repo));
+        if (storeLog.isTraceEnabled())
+          storeLog.trace("pushed {} {}", formatTid(tid), toLogString.apply(repo));
       }
 
       @Override

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -213,7 +213,7 @@ public class Fate<T> {
    * <p>
    * Note: Users of this class should call {@link #startTransactionRunners(int)} to launch the
    * worker threads after creating a Fate object.
-   * 
+   *
    * @param toLogStrFunc
    *          A function that converts Repo to Strings that are suitable for logging
    */

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -25,7 +25,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
+import org.apache.accumulo.core.logging.FateLogger;
 import org.apache.accumulo.core.util.ShutdownUtil;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.util.LoggingRunnable;
@@ -211,9 +213,12 @@ public class Fate<T> {
    * <p>
    * Note: Users of this class should call {@link #startTransactionRunners(int)} to launch the
    * worker threads after creating a Fate object.
+   * 
+   * @param toLogStrFunc
+   *          A function that converts Repo to Strings that are suitable for logging
    */
-  public Fate(T environment, TStore<T> store) {
-    this.store = store;
+  public Fate(T environment, TStore<T> store, Function<Repo<T>,String> toLogStrFunc) {
+    this.store = FateLogger.wrap(store, toLogStrFunc);
     this.environment = environment;
   }
 
@@ -251,6 +256,7 @@ public class Fate<T> {
             // this should not happen
             throw new RuntimeException(e);
           }
+
         }
 
         if (autoCleanUp)

--- a/server/master/pom.xml
+++ b/server/master/pom.xml
@@ -41,6 +41,10 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -93,6 +93,7 @@ import org.apache.accumulo.master.replication.MasterReplicationCoordinator;
 import org.apache.accumulo.master.replication.ReplicationDriver;
 import org.apache.accumulo.master.replication.WorkDriver;
 import org.apache.accumulo.master.state.TableCounts;
+import org.apache.accumulo.master.tableOps.TraceRepo;
 import org.apache.accumulo.master.upgrade.UpgradeCoordinator;
 import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.HighlyAvailableService;
@@ -1117,7 +1118,7 @@ public class Master extends AbstractServer
 
       int threads = getConfiguration().getCount(Property.MASTER_FATE_THREADPOOL_SIZE);
 
-      fate = new Fate<>(this, store);
+      fate = new Fate<>(this, store, TraceRepo::toLogString);
       fate.startTransactionRunners(threads);
 
       SimpleTimer.getInstance(getConfiguration()).schedule(() -> store.ageOff(), 63000, 63000);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/TraceRepo.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/TraceRepo.java
@@ -21,7 +21,10 @@ package org.apache.accumulo.master.tableOps;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.fate.Repo;
+import org.apache.accumulo.master.Master;
 import org.apache.htrace.TraceScope;
+
+import com.google.gson.Gson;
 
 public class TraceRepo<T> implements Repo<T> {
 
@@ -72,4 +75,19 @@ public class TraceRepo<T> implements Repo<T> {
     return repo.getReturn();
   }
 
+  /**
+   * @return string version of Repo that is suitable for logging
+   */
+  public static String toLogString(Repo<Master> repo) {
+    if (repo instanceof TraceRepo) {
+      // There are two reasons the repo is unwrapped. First I could not figure out how to get this
+      // to work with Gson. Gson kept serializing nothing for the generic pointer TraceRepo.repo.
+      // Second I thought this information was not useful for logging.
+      repo = ((TraceRepo<Master>) repo).repo;
+    }
+
+    // Inorder for Gson to work with generic types, the following passes repo.getClass() to Gson.
+    // See the Gson javadoc for more info.
+    return repo.getClass() + " " + new Gson().toJson(repo, repo.getClass());
+  }
 }


### PR DESCRIPTION
This change add detailed trace logging for FATE.  To enable this add the following to `log4j-service.properties`

```
log4j.logger.org.apache.accumulo.fate.store=TRACE
```

The following is logging output when trace is enabled for create table FATE transaction.

```
2020-02-20 15:59:54,574 [fate.store] TRACE: created FATE[38dabaad752bd105]
2020-02-20 15:59:54,623 [fate.store] TRACE: pushed FATE[38dabaad752bd105] class org.apache.accumulo.master.tableOps.create.CreateTable {"tableInfo":{"tableName":"test99","namespaceId":{"canonical":"+default"},"timeType":"MILLIS","user":"root","initialTableState":"ONLINE","initialSplitSize":0,"props":{"table.iterator.majc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.constraint.1":"org.apache.accumulo.core.constraints.DefaultKeySizeConstraint","table.iterator.scan.vers.opt.maxVersions":"1","table.iterator.minc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.iterator.majc.vers.opt.maxVersions":"1","table.iterator.minc.vers.opt.maxVersions":"1","table.iterator.scan.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator"}}}
2020-02-20 15:59:54,629 [fate.store] TRACE: setProperty FATE[38dabaad752bd105] debug CreateTable
2020-02-20 15:59:54,637 [fate.store] TRACE: setStatus FATE[38dabaad752bd105] IN_PROGRESS
2020-02-20 15:59:54,688 [fate.store] TRACE: pushed FATE[38dabaad752bd105] class org.apache.accumulo.master.tableOps.create.SetupPermissions {"tableInfo":{"tableName":"test99","tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"timeType":"MILLIS","user":"root","initialTableState":"ONLINE","initialSplitSize":0,"props":{"table.iterator.majc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.constraint.1":"org.apache.accumulo.core.constraints.DefaultKeySizeConstraint","table.iterator.scan.vers.opt.maxVersions":"1","table.iterator.minc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.iterator.majc.vers.opt.maxVersions":"1","table.iterator.minc.vers.opt.maxVersions":"1","table.iterator.scan.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator"}}}
2020-02-20 15:59:54,763 [fate.store] TRACE: pushed FATE[38dabaad752bd105] class org.apache.accumulo.master.tableOps.create.PopulateZookeeper {"tableInfo":{"tableName":"test99","tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"timeType":"MILLIS","user":"root","initialTableState":"ONLINE","initialSplitSize":0,"props":{"table.iterator.majc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.constraint.1":"org.apache.accumulo.core.constraints.DefaultKeySizeConstraint","table.iterator.scan.vers.opt.maxVersions":"1","table.iterator.minc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.iterator.majc.vers.opt.maxVersions":"1","table.iterator.minc.vers.opt.maxVersions":"1","table.iterator.scan.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator"}}}
2020-02-20 15:59:54,895 [fate.store] TRACE: pushed FATE[38dabaad752bd105] class org.apache.accumulo.master.tableOps.create.ChooseDir {"tableInfo":{"tableName":"test99","tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"timeType":"MILLIS","user":"root","initialTableState":"ONLINE","initialSplitSize":0,"props":{"table.iterator.majc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.constraint.1":"org.apache.accumulo.core.constraints.DefaultKeySizeConstraint","table.iterator.scan.vers.opt.maxVersions":"1","table.iterator.minc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.iterator.majc.vers.opt.maxVersions":"1","table.iterator.minc.vers.opt.maxVersions":"1","table.iterator.scan.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator"}}}
2020-02-20 15:59:54,906 [fate.store] TRACE: pushed FATE[38dabaad752bd105] class org.apache.accumulo.master.tableOps.create.PopulateMetadata {"tableInfo":{"tableName":"test99","tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"timeType":"MILLIS","user":"root","initialTableState":"ONLINE","initialSplitSize":0,"props":{"table.iterator.majc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.constraint.1":"org.apache.accumulo.core.constraints.DefaultKeySizeConstraint","table.iterator.scan.vers.opt.maxVersions":"1","table.iterator.minc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.iterator.majc.vers.opt.maxVersions":"1","table.iterator.minc.vers.opt.maxVersions":"1","table.iterator.scan.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator"}}}
2020-02-20 15:59:54,959 [fate.store] TRACE: pushed FATE[38dabaad752bd105] class org.apache.accumulo.master.tableOps.create.FinishCreateTable {"tableInfo":{"tableName":"test99","tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"timeType":"MILLIS","user":"root","initialTableState":"ONLINE","initialSplitSize":0,"props":{"table.iterator.majc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.constraint.1":"org.apache.accumulo.core.constraints.DefaultKeySizeConstraint","table.iterator.scan.vers.opt.maxVersions":"1","table.iterator.minc.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator","table.iterator.majc.vers.opt.maxVersions":"1","table.iterator.minc.vers.opt.maxVersions":"1","table.iterator.scan.vers":"20,org.apache.accumulo.core.iterators.user.VersioningIterator"}}}
2020-02-20 15:59:54,997 [fate.store] TRACE: setProperty FATE[38dabaad752bd105] return 2
2020-02-20 15:59:55,005 [fate.store] TRACE: setStatus FATE[38dabaad752bd105] SUCCESSFUL
2020-02-20 15:59:55,013 [fate.store] TRACE: popped FATE[38dabaad752bd105]
2020-02-20 15:59:55,019 [fate.store] TRACE: popped FATE[38dabaad752bd105]
2020-02-20 15:59:55,025 [fate.store] TRACE: popped FATE[38dabaad752bd105]
2020-02-20 15:59:55,031 [fate.store] TRACE: popped FATE[38dabaad752bd105]
2020-02-20 15:59:55,038 [fate.store] TRACE: popped FATE[38dabaad752bd105]
2020-02-20 15:59:55,045 [fate.store] TRACE: popped FATE[38dabaad752bd105]
2020-02-20 15:59:55,080 [fate.store] TRACE: deleted FATE[38dabaad752bd105]
```

The following is for rename table

```
2020-02-20 16:00:01,607 [fate.store] TRACE: created FATE[6ba118b80b85ba43]
2020-02-20 16:00:01,617 [fate.store] TRACE: pushed FATE[6ba118b80b85ba43] class org.apache.accumulo.master.tableOps.rename.RenameTable {"tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"oldTableName":"test99","newTableName":"test999"}
2020-02-20 16:00:01,622 [fate.store] TRACE: setProperty FATE[6ba118b80b85ba43] debug RenameTable
2020-02-20 16:00:01,631 [fate.store] TRACE: setStatus FATE[6ba118b80b85ba43] IN_PROGRESS
2020-02-20 16:00:01,699 [fate.store] TRACE: setStatus FATE[6ba118b80b85ba43] SUCCESSFUL
2020-02-20 16:00:01,705 [fate.store] TRACE: popped FATE[6ba118b80b85ba43]
2020-02-20 16:00:01,719 [fate.store] TRACE: deleted FATE[6ba118b80b85ba43]
```

The following is for delete table.

```
2020-02-20 16:00:07,884 [fate.store] TRACE: created FATE[321b6d88d8be627b]
2020-02-20 16:00:07,894 [fate.store] TRACE: pushed FATE[321b6d88d8be627b] class org.apache.accumulo.master.tableOps.delete.DeleteTable {"tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"}}
2020-02-20 16:00:07,899 [fate.store] TRACE: setProperty FATE[321b6d88d8be627b] debug DeleteTable
2020-02-20 16:00:07,908 [fate.store] TRACE: setStatus FATE[321b6d88d8be627b] IN_PROGRESS
2020-02-20 16:00:07,955 [fate.store] TRACE: pushed FATE[321b6d88d8be627b] class org.apache.accumulo.master.tableOps.delete.CleanUp {"tableId":{"canonical":"2"},"namespaceId":{"canonical":"+default"},"creationTime":1582214407948}
2020-02-20 16:00:08,306 [fate.store] TRACE: setStatus FATE[321b6d88d8be627b] SUCCESSFUL
2020-02-20 16:00:08,312 [fate.store] TRACE: popped FATE[321b6d88d8be627b]
2020-02-20 16:00:08,318 [fate.store] TRACE: popped FATE[321b6d88d8be627b]
2020-02-20 16:00:08,331 [fate.store] TRACE: deleted FATE[321b6d88d8be627b]
```

Seeing this output makes me wish we stored FATE Repos in Zookeeper as JSon instead of using java serialization because whats in ZK would be human readable.