### PR TITLE
Fixes #1525 - remove lines added in b67d3f9 in VolumeUtil

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -187,8 +187,7 @@ public class VolumeUtil {
       VolumeManager vm, KeyExtent extent, TabletFiles tabletFiles, boolean replicate)
       throws IOException {
     List<Pair<Path,Path>> replacements = ServerConstants.getVolumeReplacements();
-    if (replacements.isEmpty())
-      return tabletFiles;
+
     log.trace("Using volume replacements: " + replacements);
 
     List<LogEntry> logsToRemove = new ArrayList<>();


### PR DESCRIPTION
I bisected the commits in 1.9 and found commit that broke VolumeIT.  It was:
7513626cc Optimize Tablet volume replacement (#1505)