### PR TITLE
Replace use of equals() with Object.equals()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/DiskUsage.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/DiskUsage.java
@@ -48,16 +48,12 @@ public class DiskUsage {
 
     DiskUsage diskUsage = (DiskUsage) o;
 
-    if (!Objects.equals(tables, diskUsage.tables))
-      return false;
-    return Objects.equals(usage, diskUsage.usage);
+    return Objects.equals(tables, diskUsage.tables) && Objects.equals(usage, diskUsage.usage);
   }
 
   @Override
   public int hashCode() {
-    int result = tables != null ? tables.hashCode() : 0;
-    result = 31 * result + (usage != null ? usage.hashCode() : 0);
-    return result;
+    return Objects.hash(tables, usage);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/DiskUsage.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/DiskUsage.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client.admin;
 
+import java.util.Objects;
 import java.util.SortedSet;
 
 public class DiskUsage {
@@ -47,9 +48,9 @@ public class DiskUsage {
 
     DiskUsage diskUsage = (DiskUsage) o;
 
-    if (tables != null ? !tables.equals(diskUsage.tables) : diskUsage.tables != null)
+    if (!Objects.equals(tables, diskUsage.tables))
       return false;
-    return usage != null ? usage.equals(diskUsage.usage) : diskUsage.usage == null;
+    return Objects.equals(usage, diskUsage.usage);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputTableConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputTableConfig.java
@@ -378,38 +378,17 @@ public class InputTableConfig implements Writable {
       return true;
     if (o == null || getClass() != o.getClass())
       return false;
-
     InputTableConfig that = (InputTableConfig) o;
-
-    if (autoAdjustRanges != that.autoAdjustRanges)
-      return false;
-    if (offlineScan != that.offlineScan)
-      return false;
-    if (useIsolatedScanners != that.useIsolatedScanners)
-      return false;
-    if (useLocalIterators != that.useLocalIterators)
-      return false;
-    if (!Objects.equals(columns, that.columns))
-      return false;
-    if (!Objects.equals(iterators, that.iterators))
-      return false;
-    if (!Objects.equals(ranges, that.ranges))
-      return false;
-    if (!Objects.equals(samplerConfig, that.samplerConfig))
-      return false;
-    return true;
+    return autoAdjustRanges == that.autoAdjustRanges && useLocalIterators == that.useLocalIterators
+        && useIsolatedScanners == that.useIsolatedScanners && offlineScan == that.offlineScan
+        && Objects.equals(iterators, that.iterators) && Objects.equals(ranges, that.ranges)
+        && Objects.equals(columns, that.columns)
+        && Objects.equals(samplerConfig, that.samplerConfig);
   }
 
   @Override
   public int hashCode() {
-    int result = 31 * (iterators != null ? iterators.hashCode() : 0);
-    result = 31 * result + (ranges != null ? ranges.hashCode() : 0);
-    result = 31 * result + (columns != null ? columns.hashCode() : 0);
-    result = 31 * result + (autoAdjustRanges ? 1 : 0);
-    result = 31 * result + (useLocalIterators ? 1 : 0);
-    result = 31 * result + (useIsolatedScanners ? 1 : 0);
-    result = 31 * result + (offlineScan ? 1 : 0);
-    result = 31 * result + (samplerConfig == null ? 0 : samplerConfig.hashCode());
-    return result;
+    return Objects.hash(iterators, ranges, columns, autoAdjustRanges, useLocalIterators,
+        useIsolatedScanners, offlineScan, samplerConfig);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputTableConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/InputTableConfig.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.accumulo.core.client.ClientSideIteratorScanner;
 import org.apache.accumulo.core.client.IsolatedScanner;
@@ -388,14 +389,13 @@ public class InputTableConfig implements Writable {
       return false;
     if (useLocalIterators != that.useLocalIterators)
       return false;
-    if (columns != null ? !columns.equals(that.columns) : that.columns != null)
+    if (!Objects.equals(columns, that.columns))
       return false;
-    if (iterators != null ? !iterators.equals(that.iterators) : that.iterators != null)
+    if (!Objects.equals(iterators, that.iterators))
       return false;
-    if (ranges != null ? !ranges.equals(that.ranges) : that.ranges != null)
+    if (!Objects.equals(ranges, that.ranges))
       return false;
-    if (samplerConfig != null ? !samplerConfig.equals(that.samplerConfig)
-        : that.samplerConfig != null)
+    if (!Objects.equals(samplerConfig, that.samplerConfig))
       return false;
     return true;
   }

--- a/core/src/main/java/org/apache/accumulo/core/data/Condition.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Condition.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -324,10 +325,10 @@ public class Condition {
     if (!(c.cv.equals(cv))) {
       return false;
     }
-    if (!(c.val == null ? val == null : c.val.equals(val))) {
+    if (!(Objects.equals(c.val, val))) {
       return false;
     }
-    if (!(c.ts == null ? ts == null : c.ts.equals(ts))) {
+    if (!(Objects.equals(c.ts, ts))) {
       return false;
     }
     return Arrays.equals(c.iterators, iterators);

--- a/core/src/main/java/org/apache/accumulo/core/data/Condition.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Condition.java
@@ -309,41 +309,20 @@ public class Condition {
 
   @Override
   public boolean equals(Object o) {
-    if (o == this) {
+    if (this == o)
       return true;
-    }
-    if (o == null || !(o instanceof Condition)) {
+    if (o == null || getClass() != o.getClass())
       return false;
-    }
-    Condition c = (Condition) o;
-    if (!(c.cf.equals(cf))) {
-      return false;
-    }
-    if (!(c.cq.equals(cq))) {
-      return false;
-    }
-    if (!(c.cv.equals(cv))) {
-      return false;
-    }
-    if (!(Objects.equals(c.val, val))) {
-      return false;
-    }
-    if (!(Objects.equals(c.ts, ts))) {
-      return false;
-    }
-    return Arrays.equals(c.iterators, iterators);
+    Condition condition = (Condition) o;
+    return Objects.equals(cf, condition.cf) && Objects.equals(cq, condition.cq)
+        && Objects.equals(cv, condition.cv) && Objects.equals(val, condition.val)
+        && Objects.equals(ts, condition.ts) && Arrays.equals(iterators, condition.iterators);
   }
 
   @Override
   public int hashCode() {
-    int result = 17;
-    result = 31 * result + cf.hashCode();
-    result = 31 * result + cq.hashCode();
-    result = 31 * result + cv.hashCode();
-    result = 31 * result + (val == null ? 0 : val.hashCode());
-    result = 31 * result + (ts == null ? 0 : ts.hashCode());
+    int result = Objects.hash(cf, cq, cv, val, ts);
     result = 31 * result + Arrays.hashCode(iterators);
     return result;
   }
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/data/Condition.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Condition.java
@@ -311,7 +311,7 @@ public class Condition {
   public boolean equals(Object o) {
     if (this == o)
       return true;
-    if (o == null || getClass() != o.getClass())
+    if (o == null || !(o instanceof Condition))
       return false;
     Condition condition = (Condition) o;
     return Objects.equals(cf, condition.cf) && Objects.equals(cq, condition.cq)


### PR DESCRIPTION
Utilize newer Java language features to simplfy code by using Object.equals() rather than equals().