### PR TITLE
Remove miniDFS from HalfDeadTServerIT

### DIFF
--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -17,9 +17,6 @@
 # under the License.
 #
 
-## Log4j2 file that configures logging for all Accumulo services
-## The system properties referenced below are configured by accumulo-env.sh
-
 status = info
 dest = err
 name = AccumuloITLoggingProperties
@@ -68,6 +65,9 @@ logger.12.level =  info
 
 logger.13.name = org.apache.zookeeper.ClientCnxn
 logger.13.level = fatal
+
+logger.13b.name = org.apache.zookeeper.ClientCnxnSocket
+logger.13b.level = warn
 
 logger.14.name = org.apache.zookeeper.ZooKeeper
 logger.14.level = warn

--- a/test/src/test/c/fake_disk_failure.c
+++ b/test/src/test/c/fake_disk_failure.c
@@ -25,7 +25,6 @@
 static
 void test_pause() {
   static char trickFile[1024] = "";
-  static char pid[10] = "";
   if (trickFile[0] == '\0') {
     strcpy(trickFile, getenv("TRICK_FILE"));
   }


### PR DESCRIPTION
Remove use of miniDFS from IT, because sometimes miniDFS is slow to
start up, and it causes the IT to time out. It is not needed for the
test, since the test case works fine on LocalFileSystem-based DFS.

Use java.util.scanner to clean up boilerplate BufferedReader stuffs.

Suppress some spammy ZK logs in IT log4j2 config.

Add prefix to DumpOutput class in HalfDeadTServerIT to help troubleshoot
the IT in future.