### PR TITLE
Drop obscuring overrides in thrift client code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
@@ -90,7 +90,7 @@ public class ServerClient {
       CT client = null;
       String server = null;
       try {
-        Pair<String,CT> pair = ServerClient.getConnection(context, factory);
+        Pair<String,CT> pair = ServerClient.getConnection(context, factory, true);
         server = pair.getFirst();
         client = pair.getSecond();
         return exec.execute(client);
@@ -112,7 +112,8 @@ public class ServerClient {
       ClientService.Client client = null;
       String server = null;
       try {
-        Pair<String,Client> pair = ServerClient.getConnection(context);
+        Pair<String,Client> pair =
+            ServerClient.getConnection(context, new ClientService.Client.Factory(), true);
         server = pair.getFirst();
         client = pair.getSecond();
         exec.execute(client);
@@ -131,31 +132,11 @@ public class ServerClient {
 
   static volatile boolean warnedAboutTServersBeingDown = false;
 
-  public static Pair<String,ClientService.Client> getConnection(ClientContext context)
-      throws TTransportException {
-    return getConnection(context, true);
-  }
-
   public static <CT extends TServiceClient> Pair<String,CT> getConnection(ClientContext context,
-      TServiceClientFactory<CT> factory) throws TTransportException {
-    return getConnection(context, factory, true, context.getClientTimeoutInMillis());
-  }
-
-  public static Pair<String,ClientService.Client> getConnection(ClientContext context,
-      boolean preferCachedConnections) throws TTransportException {
-    return getConnection(context, preferCachedConnections, context.getClientTimeoutInMillis());
-  }
-
-  public static Pair<String,ClientService.Client> getConnection(ClientContext context,
-      boolean preferCachedConnections, long rpcTimeout) throws TTransportException {
-    return getConnection(context, new ClientService.Client.Factory(), preferCachedConnections,
-        rpcTimeout);
-  }
-
-  public static <CT extends TServiceClient> Pair<String,CT> getConnection(ClientContext context,
-      TServiceClientFactory<CT> factory, boolean preferCachedConnections, long rpcTimeout)
+      TServiceClientFactory<CT> factory, boolean preferCachedConnections)
       throws TTransportException {
     checkArgument(context != null, "context is null");
+    long rpcTimeout = context.getClientTimeoutInMillis();
     // create list of servers
     ArrayList<ThriftTransportKey> servers = new ArrayList<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -86,6 +86,7 @@ import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.client.summary.Summary;
 import org.apache.accumulo.core.clientImpl.TabletLocator.TabletLocation;
 import org.apache.accumulo.core.clientImpl.bulk.BulkImport;
+import org.apache.accumulo.core.clientImpl.thrift.ClientService;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService.Client;
 import org.apache.accumulo.core.clientImpl.thrift.TDiskUsage;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException;
@@ -1431,7 +1432,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         // this operation may us a lot of memory... its likely that connections to tabletservers
         // hosting metadata tablets will be cached, so do not use cached
         // connections
-        pair = ServerClient.getConnection(context, false);
+        pair = ServerClient.getConnection(context, new ClientService.Client.Factory(), false);
         diskUsages = pair.getSecond().getDiskUsage(tableNames, context.rpcCreds());
       } catch (ThriftTableOperationException e) {
         switch (e.getType()) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -645,10 +645,7 @@ public class ThriftTransportPool {
 
   public TTransport getTransport(HostAndPort location, long milliseconds, ClientContext context)
       throws TTransportException {
-    return getTransport(new ThriftTransportKey(location, milliseconds, context));
-  }
-
-  private TTransport getTransport(ThriftTransportKey cacheKey) throws TTransportException {
+    ThriftTransportKey cacheKey = new ThriftTransportKey(location, milliseconds, context);
     // compute hash code outside of lock, this lowers the time the lock is held
     cacheKey.precomputeHashCode();
 


### PR DESCRIPTION
* Inline method overrides only called once or twice. They obscure actual
method calls and bloat the code