### PR TITLE
Fixes #1542 - Created a randomIndex member of ThriftTransportPool 

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -19,8 +19,17 @@
 package org.apache.accumulo.core.clientImpl;
 
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;

--- a/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,7 @@ import org.slf4j.LoggerFactory;
 public class TransportCachingIT extends AccumuloClusterHarness {
   private static final Logger log = LoggerFactory.getLogger(TransportCachingIT.class);
   private static int ATTEMPTS = 0;
+  private static final SecureRandom random = new SecureRandom();
 
   @Test
   public void testCachedTransport() throws InterruptedException {
@@ -101,6 +103,8 @@ public class TransportCachingIT extends AccumuloClusterHarness {
       }
 
       ThriftTransportPool pool = ThriftTransportPool.getInstance();
+      pool.setRandomIndex(random.nextInt(servers.size()));
+
       TTransport first = null;
       while (first == null) {
         try {


### PR DESCRIPTION
for testing.   When the preferredCachedConnection was false the randomness of the selection of the server index caused inconsistent results in test.  The integrated test actually reveals something that needs to be corrected in the usage of ThriftTransportPool in general but I will let others decide that.  This change allows the TransportCachingIT to run 30 times consecutively without failure.  I haven't tried to go higher in count.