### PR TITLE
Use sets instead of arrays for volumes

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/InterfaceEvolutionWarner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/InterfaceEvolutionWarner.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.fs;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InterfaceEvolutionWarner {
+
+  private static final Logger LOG = LoggerFactory.getLogger("accumulo.api.evolution");
+  private static final ConcurrentHashMap<String,Boolean> classesWarned = new ConcurrentHashMap<>();
+
+  static void warnOnce(Class<?> userClass, Class<?> interfaceClass, String interfaceMethod,
+      String version) {
+    String userClassName = userClass.getName();
+    String interfaceSignature = interfaceClass.getName() + "#" + interfaceMethod;
+    // don't warn multiple times for the same user class and interface method signature
+    String key = userClassName + ":" + interfaceSignature;
+    if (classesWarned.putIfAbsent(key, Boolean.TRUE) == null) {
+      LOG.warn("{} must override {} by {}", userClassName, interfaceSignature, version);
+    }
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.server.fs;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.core.data.TableId;
@@ -52,14 +53,14 @@ public class PerTableVolumeChooser implements VolumeChooser {
       getCustomPropertySuffix(ChooserScope.DEFAULT);
 
   @Override
-  public String choose(VolumeChooserEnvironment env, String[] options)
+  public String choose(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
     log.trace("{}.choose", getClass().getSimpleName());
     return getDelegateChooser(env).choose(env, options);
   }
 
   @Override
-  public String[] choosable(VolumeChooserEnvironment env, String[] options)
+  public Set<String> choosable(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
     return getDelegateChooser(env).choosable(env, options);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PreferredVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PreferredVolumeChooser.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.fs;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,7 +48,7 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
       getCustomPropertySuffix(ChooserScope.DEFAULT);
 
   @Override
-  public String choose(VolumeChooserEnvironment env, String[] options)
+  public String choose(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
     log.trace("{}.choose", getClass().getSimpleName());
     // Randomly choose the volume from the preferred volumes
@@ -57,20 +58,21 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
   }
 
   @Override
-  public String[] choosable(VolumeChooserEnvironment env, String[] options)
+  public Set<String> choosable(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
     return getPreferredVolumes(env, options);
   }
 
   // visible (not private) for testing
-  String[] getPreferredVolumes(VolumeChooserEnvironment env, String[] options) {
+  Set<String> getPreferredVolumes(VolumeChooserEnvironment env, Set<String> options) {
     if (env.getScope() == ChooserScope.TABLE) {
       return getPreferredVolumesForTable(env, options);
     }
     return getPreferredVolumesForScope(env, options);
   }
 
-  private String[] getPreferredVolumesForTable(VolumeChooserEnvironment env, String[] options) {
+  private Set<String> getPreferredVolumesForTable(VolumeChooserEnvironment env,
+      Set<String> options) {
     log.trace("Looking up property {} + for Table id: {}", TABLE_CUSTOM_SUFFIX, env.getTableId());
 
     String preferredVolumes =
@@ -86,15 +88,15 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
     // throw an error if volumes not specified or empty
     if (preferredVolumes == null || preferredVolumes.isEmpty()) {
       String msg = "Property " + TABLE_CUSTOM_SUFFIX + " or " + DEFAULT_SCOPED_PREFERRED_VOLUMES
-          + " must be a subset of " + Arrays.toString(options) + " to use the "
-          + getClass().getSimpleName();
+          + " must be a subset of " + options + " to use the " + getClass().getSimpleName();
       throw new VolumeChooserException(msg);
     }
 
     return parsePreferred(TABLE_CUSTOM_SUFFIX, preferredVolumes, options);
   }
 
-  private String[] getPreferredVolumesForScope(VolumeChooserEnvironment env, String[] options) {
+  private Set<String> getPreferredVolumesForScope(VolumeChooserEnvironment env,
+      Set<String> options) {
     ChooserScope scope = env.getScope();
     String property = getCustomPropertySuffix(scope);
     log.trace("Looking up property {} for scope: {}", property, scope);
@@ -112,8 +114,7 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
       // volumes
       if (preferredVolumes == null || preferredVolumes.isEmpty()) {
         String msg = "Property " + property + " or " + DEFAULT_SCOPED_PREFERRED_VOLUMES
-            + " must be a subset of " + Arrays.toString(options) + " to use the "
-            + getClass().getSimpleName();
+            + " must be a subset of " + options + " to use the " + getClass().getSimpleName();
         throw new VolumeChooserException(msg);
       }
 
@@ -123,7 +124,8 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
     return parsePreferred(property, preferredVolumes, options);
   }
 
-  private String[] parsePreferred(String property, String preferredVolumes, String[] options) {
+  private Set<String> parsePreferred(String property, String preferredVolumes,
+      Set<String> options) {
     log.trace("Found {} = {}", property, preferredVolumes);
 
     Set<String> preferred =
@@ -135,12 +137,11 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
     }
     // preferred volumes should also exist in the original options (typically, from
     // instance.volumes)
-    Set<String> optionsList = Arrays.stream(options).collect(Collectors.toSet());
-    if (!preferred.stream().allMatch(optionsList::contains)) {
-      String msg = "Some volumes in " + preferred + " are not valid volumes from " + optionsList;
+    if (Collections.disjoint(preferred, options)) {
+      String msg = "Some volumes in " + preferred + " are not valid volumes from " + options;
       throw new VolumeChooserException(msg);
     }
 
-    return preferred.toArray(new String[preferred.size()]);
+    return preferred;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/RandomVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/RandomVolumeChooser.java
@@ -20,18 +20,20 @@ package org.apache.accumulo.server.fs;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import java.util.Set;
 
 public class RandomVolumeChooser implements VolumeChooser {
   protected final Random random = new SecureRandom();
 
   @Override
-  public String choose(VolumeChooserEnvironment env, String[] options)
+  public String choose(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
-    return options[random.nextInt(options.length)];
+    String[] optionsArray = options.toArray(new String[0]);
+    return optionsArray[random.nextInt(optionsArray.length)];
   }
 
   @Override
-  public String[] choosable(VolumeChooserEnvironment env, String[] options)
+  public Set<String> choosable(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
     return options;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/SpaceAwareVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/SpaceAwareVolumeChooser.java
@@ -19,10 +19,9 @@
 package org.apache.accumulo.server.fs;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.NavigableMap;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -48,24 +47,21 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
 
   // Default time to wait in ms. Defaults to 5 min
   private long defaultComputationCacheDuration = 300000;
-  private LoadingCache<List<String>,WeightedRandomCollection> choiceCache = null;
+  private LoadingCache<Set<String>,WeightedRandomCollection> choiceCache = null;
 
   private static final Logger log = LoggerFactory.getLogger(SpaceAwareVolumeChooser.class);
 
   @Override
-  public String choose(VolumeChooserEnvironment env, String[] options)
+  public String choose(VolumeChooserEnvironment env, Set<String> options)
       throws VolumeChooserException {
-
-    options = getPreferredVolumes(env, options);
-
     try {
-      return getCache(env).get(Arrays.asList(options)).next();
+      return getCache(env).get(getPreferredVolumes(env, options)).next();
     } catch (ExecutionException e) {
       throw new IllegalStateException("Execution exception when attempting to cache choice", e);
     }
   }
 
-  private synchronized LoadingCache<List<String>,WeightedRandomCollection>
+  private synchronized LoadingCache<Set<String>,WeightedRandomCollection>
       getCache(VolumeChooserEnvironment env) {
 
     if (choiceCache == null) {
@@ -78,7 +74,7 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
           .expireAfterWrite(computationCacheDuration, TimeUnit.MILLISECONDS)
           .build(new CacheLoader<>() {
             @Override
-            public WeightedRandomCollection load(List<String> key) {
+            public WeightedRandomCollection load(Set<String> key) {
               return new WeightedRandomCollection(key, env, random);
             }
           });
@@ -92,7 +88,7 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
     private final Random random;
     private double total = 0;
 
-    public WeightedRandomCollection(List<String> options, VolumeChooserEnvironment env,
+    public WeightedRandomCollection(Set<String> options, VolumeChooserEnvironment env,
         Random random) {
       this.random = random;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collection;
+import java.util.Set;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.volume.Volume;
@@ -130,7 +131,7 @@ public interface VolumeManager {
   Volume getVolumeByPath(Path path);
 
   // return the item in options that is in the same volume as source
-  Path matchingFileSystem(Path source, String[] options);
+  Path matchingFileSystem(Path source, Set<String> options);
 
   // forward to the appropriate FileSystem object
   FileStatus[] listStatus(Path path) throws IOException;
@@ -164,10 +165,10 @@ public interface VolumeManager {
   ContentSummary getContentSummary(Path dir) throws IOException;
 
   // decide on which of the given locations to create a new file
-  String choose(VolumeChooserEnvironment env, String[] options);
+  String choose(VolumeChooserEnvironment env, Set<String> options);
 
   // return all valid locations to create a new file
-  String[] choosable(VolumeChooserEnvironment env, String[] options);
+  Set<String> choosable(VolumeChooserEnvironment env, Set<String> options);
 
   // are sync and flush supported for the given path
   boolean canSyncAndFlush(Path path);

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -38,7 +39,6 @@ import org.apache.accumulo.core.volume.NonConfiguredVolume;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.fs.VolumeChooser.VolumeChooserException;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.CreateFlag;
@@ -385,10 +385,10 @@ public class VolumeManagerImpl implements VolumeManager {
   }
 
   @Override
-  public Path matchingFileSystem(Path source, String[] options) {
+  public Path matchingFileSystem(Path source, Set<String> options) {
     try {
       if (ViewFSUtils.isViewFS(source, hadoopConf)) {
-        return ViewFSUtils.matchingFileSystem(source, options, hadoopConf);
+        return ViewFSUtils.matchingFileSystem(source, options.toArray(new String[0]), hadoopConf);
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -413,11 +413,10 @@ public class VolumeManagerImpl implements VolumeManager {
   }
 
   @Override
-  public String choose(VolumeChooserEnvironment env, String[] options) {
+  public String choose(VolumeChooserEnvironment env, Set<String> options) {
     final String choice;
     choice = chooser.choose(env, options);
-
-    if (!(ArrayUtils.contains(options, choice))) {
+    if (!options.contains(choice)) {
       String msg = "The configured volume chooser, '" + chooser.getClass()
           + "', or one of its delegates returned a volume not in the set of options provided";
       throw new VolumeChooserException(msg);
@@ -427,11 +426,11 @@ public class VolumeManagerImpl implements VolumeManager {
   }
 
   @Override
-  public String[] choosable(VolumeChooserEnvironment env, String[] options) {
-    final String[] choices = chooser.choosable(env, options);
+  public Set<String> choosable(VolumeChooserEnvironment env, Set<String> options) {
+    final Set<String> choices = chooser.choosable(env, options);
 
     for (String choice : choices) {
-      if (!(ArrayUtils.contains(options, choice))) {
+      if (!options.contains(choice)) {
         String msg = "The configured volume chooser, '" + chooser.getClass()
             + "', or one of its delegates returned a volume not in the set of options provided";
         throw new VolumeChooserException(msg);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -361,7 +361,7 @@ public class Initialize implements KeywordExecutable {
 
     UUID uuid = UUID.randomUUID();
     // the actual disk locations of the root table and tablets
-    String[] configuredVolumes = VolumeConfiguration.getVolumeUris(siteConfig, hadoopConf);
+    Set<String> configuredVolumes = VolumeConfiguration.getVolumeUris(siteConfig, hadoopConf);
     String instanceName = instanceNamePath.substring(getInstanceNamePrefix().length());
     ServerContext serverContext = new ServerContext(siteConfig, instanceName, uuid.toString());
     VolumeChooserEnvironment chooserEnv =
@@ -483,7 +483,7 @@ public class Initialize implements KeywordExecutable {
     }
   }
 
-  private static void initDirs(VolumeManager fs, UUID uuid, String[] baseDirs, boolean print)
+  private static void initDirs(VolumeManager fs, UUID uuid, Set<String> baseDirs, boolean print)
       throws IOException {
     for (String baseDir : baseDirs) {
       fs.mkdirs(new Path(new Path(baseDir, ServerConstants.VERSION_DIR),
@@ -892,14 +892,13 @@ public class Initialize implements KeywordExecutable {
   private static void addVolumes(VolumeManager fs, SiteConfiguration siteConfig,
       Configuration hadoopConf) throws IOException {
 
-    String[] volumeURIs = VolumeConfiguration.getVolumeUris(siteConfig, hadoopConf);
+    Set<String> volumeURIs = VolumeConfiguration.getVolumeUris(siteConfig, hadoopConf);
 
-    HashSet<String> initializedDirs = new HashSet<>();
-    initializedDirs.addAll(
-        Arrays.asList(ServerConstants.checkBaseUris(siteConfig, hadoopConf, volumeURIs, true)));
+    Set<String> initializedDirs =
+        ServerConstants.checkBaseUris(siteConfig, hadoopConf, volumeURIs, true);
 
     HashSet<String> uinitializedDirs = new HashSet<>();
-    uinitializedDirs.addAll(Arrays.asList(volumeURIs));
+    uinitializedDirs.addAll(volumeURIs);
     uinitializedDirs.removeAll(initializedDirs);
 
     Path aBasePath = new Path(initializedDirs.iterator().next());
@@ -925,7 +924,7 @@ public class Initialize implements KeywordExecutable {
           + ServerUtil.getAccumuloPersistentVersion(fs));
     }
 
-    initDirs(fs, uuid, uinitializedDirs.toArray(new String[uinitializedDirs.size()]), true);
+    initDirs(fs, uuid, uinitializedDirs, true);
   }
 
   static class Opts extends Help {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooKeeperMain.java
@@ -68,7 +68,7 @@ public class ZooKeeperMain implements KeywordExecutable {
     opts.parseArgs(ZooKeeperMain.class.getName(), args);
     try (var context = new ServerContext(SiteConfiguration.auto())) {
       FileSystem fs = context.getVolumeManager().getDefaultVolume().getFileSystem();
-      String baseDir = ServerConstants.getBaseUris(context)[0];
+      String baseDir = ServerConstants.getBaseUris(context).iterator().next();
       System.out.println("Using " + fs.makeQualified(new Path(baseDir + "/instance_id"))
           + " to lookup accumulo instance");
       if (opts.servers == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -75,7 +75,7 @@ public class ZooZap {
       SecurityUtil.serverLogin(siteConf);
     }
 
-    String volDir = VolumeConfiguration.getVolumeUris(siteConf, hadoopConf)[0];
+    String volDir = VolumeConfiguration.getVolumeUris(siteConf, hadoopConf).iterator().next();
     Path instanceDir = new Path(volDir, "instance_id");
     String iid = VolumeManager.getInstanceIDFromHdfs(instanceDir, siteConf, hadoopConf);
     ZooReaderWriter zoo = new ZooReaderWriter(siteConf);

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerConstantsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerConstantsTest.java
@@ -23,10 +23,12 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -75,50 +77,45 @@ public class ServerConstantsTest {
         Arrays.asList(ServerConstants.DATA_VERSION, ServerConstants.DATA_VERSION, null)));
   }
 
-  private void verifyAllPass(ArrayList<String> paths) {
-    assertEquals(paths, Arrays.asList(ServerConstants.checkBaseUris(conf, hadoopConf,
-        paths.toArray(new String[paths.size()]), true)));
-    assertEquals(paths, Arrays.asList(ServerConstants.checkBaseUris(conf, hadoopConf,
-        paths.toArray(new String[paths.size()]), false)));
+  private void verifyAllPass(Set<String> paths) {
+    assertEquals(paths, ServerConstants.checkBaseUris(conf, hadoopConf, paths, true));
+    assertEquals(paths, ServerConstants.checkBaseUris(conf, hadoopConf, paths, false));
   }
 
-  private void verifySomePass(ArrayList<String> paths) {
-    assertEquals(paths.subList(0, 2), Arrays.asList(ServerConstants.checkBaseUris(conf, hadoopConf,
-        paths.toArray(new String[paths.size()]), true)));
+  private void verifySomePass(Set<String> paths) {
+    Set<String> subset = paths.stream().limit(2).collect(Collectors.toSet());
+    assertEquals(subset, ServerConstants.checkBaseUris(conf, hadoopConf, paths, true));
     try {
-      ServerConstants.checkBaseUris(conf, hadoopConf, paths.toArray(new String[paths.size()]),
-          false);
+      ServerConstants.checkBaseUris(conf, hadoopConf, paths, false);
       fail();
     } catch (Exception e) {
       // ignored
     }
   }
 
-  private void verifyError(ArrayList<String> paths) {
+  private void verifyError(Set<String> paths) {
     try {
-      ServerConstants.checkBaseUris(conf, hadoopConf, paths.toArray(new String[paths.size()]),
-          true);
+      ServerConstants.checkBaseUris(conf, hadoopConf, paths, true);
       fail();
     } catch (Exception e) {
       // ignored
     }
 
     try {
-      ServerConstants.checkBaseUris(conf, hadoopConf, paths.toArray(new String[paths.size()]),
-          false);
+      ServerConstants.checkBaseUris(conf, hadoopConf, paths, false);
       fail();
     } catch (Exception e) {
       // ignored
     }
   }
 
-  private ArrayList<String> init(File newFile, List<String> uuids, List<Integer> dataVersions)
+  private Set<String> init(File newFile, List<String> uuids, List<Integer> dataVersions)
       throws IllegalArgumentException, IOException {
     String base = newFile.toURI().toString();
 
     LocalFileSystem fs = FileSystem.getLocal(new Configuration());
 
-    ArrayList<String> accumuloPaths = new ArrayList<>();
+    LinkedHashSet<String> accumuloPaths = new LinkedHashSet<>();
 
     for (int i = 0; i < uuids.size(); i++) {
       String volume = "v" + i;

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
@@ -23,10 +23,10 @@ import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
+import java.util.Set;
 
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
@@ -47,7 +47,7 @@ public class PreferredVolumeChooserTest {
     return "volume.preferred." + scope.name().toLowerCase();
   }
 
-  private static final String[] ALL_OPTIONS = {"1", "2", "3"};
+  private static final Set<String> ALL_OPTIONS = Set.of("1", "2", "3");
 
   private ServiceEnvironment serviceEnv;
   private Configuration tableConf;
@@ -74,7 +74,7 @@ public class PreferredVolumeChooserTest {
     verify(serviceEnv, tableConf, systemConf);
   }
 
-  private String[] chooseForTable() {
+  private Set<String> chooseForTable() {
     VolumeChooserEnvironment env =
         new VolumeChooserEnvironmentImpl(TableId.of("testTable"), null, null) {
           @Override
@@ -85,7 +85,7 @@ public class PreferredVolumeChooserTest {
     return chooser.getPreferredVolumes(env, ALL_OPTIONS);
   }
 
-  private String[] choose(ChooserScope scope) {
+  private Set<String> choose(ChooserScope scope) {
     VolumeChooserEnvironment env = new VolumeChooserEnvironmentImpl(scope, null) {
       @Override
       public ServiceEnvironment getServiceEnv() {
@@ -99,10 +99,7 @@ public class PreferredVolumeChooserTest {
   public void testTableScopeUsingTableProperty() {
     expect(tableConf.getTableCustom(TABLE_CUSTOM_SUFFIX)).andReturn("2,1");
     replay(serviceEnv, tableConf, systemConf);
-
-    String[] volumes = chooseForTable();
-    Arrays.sort(volumes);
-    assertArrayEquals(new String[] {"1", "2"}, volumes);
+    assertEquals(Set.of("1", "2"), chooseForTable());
   }
 
   @Test
@@ -111,10 +108,7 @@ public class PreferredVolumeChooserTest {
     expect(systemConf.getCustom(getCustomPropertySuffix(ChooserScope.DEFAULT))).andReturn("3,2")
         .once();
     replay(serviceEnv, tableConf, systemConf);
-
-    String[] volumes = chooseForTable();
-    Arrays.sort(volumes);
-    assertArrayEquals(new String[] {"2", "3"}, volumes);
+    assertEquals(Set.of("2", "3"), chooseForTable());
   }
 
   @Test
@@ -156,10 +150,7 @@ public class PreferredVolumeChooserTest {
     expect(systemConf.getCustom(getCustomPropertySuffix(ChooserScope.LOGGER))).andReturn("2,1")
         .once();
     replay(serviceEnv, tableConf, systemConf);
-
-    String[] volumes = choose(ChooserScope.LOGGER);
-    Arrays.sort(volumes);
-    assertArrayEquals(new String[] {"1", "2"}, volumes);
+    assertEquals(Set.of("1", "2"), choose(ChooserScope.LOGGER));
   }
 
   @Test
@@ -169,10 +160,7 @@ public class PreferredVolumeChooserTest {
     expect(systemConf.getCustom(getCustomPropertySuffix(ChooserScope.DEFAULT))).andReturn("3,2")
         .once();
     replay(serviceEnv, tableConf, systemConf);
-
-    String[] volumes = choose(ChooserScope.LOGGER);
-    Arrays.sort(volumes);
-    assertArrayEquals(new String[] {"2", "3"}, volumes);
+    assertEquals(Set.of("2", "3"), choose(ChooserScope.LOGGER));
   }
 
   @Test
@@ -217,10 +205,7 @@ public class PreferredVolumeChooserTest {
     expect(systemConf.getCustom(getCustomPropertySuffix(ChooserScope.INIT))).andReturn("2,1")
         .once();
     replay(serviceEnv, tableConf, systemConf);
-
-    String[] volumes = choose(ChooserScope.INIT);
-    Arrays.sort(volumes);
-    assertArrayEquals(new String[] {"1", "2"}, volumes);
+    assertEquals(Set.of("1", "2"), choose(ChooserScope.INIT));
   }
 
   @Test
@@ -229,10 +214,7 @@ public class PreferredVolumeChooserTest {
     expect(systemConf.getCustom(getCustomPropertySuffix(ChooserScope.DEFAULT))).andReturn("3,2")
         .once();
     replay(serviceEnv, tableConf, systemConf);
-
-    String[] volumes = choose(ChooserScope.INIT);
-    Arrays.sort(volumes);
-    assertArrayEquals(new String[] {"2", "3"}, volumes);
+    assertEquals(Set.of("2", "3"), choose(ChooserScope.INIT));
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/SpaceAwareVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/SpaceAwareVolumeChooserTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.fs;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
@@ -50,7 +51,7 @@ public class SpaceAwareVolumeChooserTest {
   String volumeTwo = "hdfs://nn2:8020/applications/accumulo/tables";
 
   // Different volumes with different paths
-  String[] tableDirs = {volumeOne, volumeTwo};
+  Set<String> tableDirs = Set.of(volumeOne, volumeTwo);
 
   int vol1Count = 0;
   int vol2Count = 0;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/CreateImportDir.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/CreateImportDir.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.master.tableOps.tableImport;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.fate.Repo;
@@ -47,10 +47,9 @@ class CreateImportDir extends MasterRepo {
     UniqueNameAllocator namer = master.getContext().getUniqueNameAllocator();
 
     Path exportDir = new Path(tableInfo.exportDir);
-    String[] tableDirs = ServerConstants.getTablesDirs(master.getContext());
+    Set<String> tableDirs = ServerConstants.getTablesDirs(master.getContext());
 
-    log.info("Looking for matching filesystem for " + exportDir + " from options "
-        + Arrays.toString(tableDirs));
+    log.info("Looking for matching filesystem for " + exportDir + " from options " + tableDirs);
     Path base = master.getFileSystem().matchingFileSystem(exportDir, tableDirs);
     if (base == null) {
       throw new IOException(tableInfo.exportDir + " is not in a volume configured for Accumulo");

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/CreateImportDir.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/CreateImportDir.java
@@ -49,7 +49,7 @@ class CreateImportDir extends MasterRepo {
     Path exportDir = new Path(tableInfo.exportDir);
     Set<String> tableDirs = ServerConstants.getTablesDirs(master.getContext());
 
-    log.info("Looking for matching filesystem for " + exportDir + " from options " + tableDirs);
+    log.info("Looking for matching filesystem for {} from options {}", exportDir, tableDirs);
     Path base = master.getFileSystem().matchingFileSystem(exportDir, tableDirs);
     if (base == null) {
       throw new IOException(tableInfo.exportDir + " is not in a volume configured for Accumulo");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -3006,11 +3006,11 @@ public class TabletServer extends AbstractServer {
   private void checkWalCanSync(ServerContext context) {
     VolumeChooserEnvironment chooserEnv =
         new VolumeChooserEnvironmentImpl(VolumeChooserEnvironment.ChooserScope.LOGGER, context);
-    String[] prefixes;
+    Set<String> prefixes;
     var options = ServerConstants.getBaseUris(context);
     try {
       prefixes = fs.choosable(chooserEnv, options);
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       log.warn("Unable to determine if WAL directories ({}) support sync or flush. "
           + "Data loss may occur.", Arrays.asList(options), e);
       return;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -63,7 +63,6 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.fate.util.LoggingRunnable;
 import org.apache.accumulo.server.ServerConstants;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.server.fs.VolumeChooserEnvironment;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironment.ChooserScope;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironmentImpl;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -425,8 +424,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     log.debug("DfsLogger.open() begin");
     VolumeManager fs = conf.getFileSystem();
 
-    VolumeChooserEnvironment chooserEnv =
-        new VolumeChooserEnvironmentImpl(ChooserScope.LOGGER, context);
+    var chooserEnv = new VolumeChooserEnvironmentImpl(ChooserScope.LOGGER, context);
     logPath = fs.choose(chooserEnv, ServerConstants.getBaseUris(context)) + Path.SEPARATOR
         + ServerConstants.WAL_DIR + Path.SEPARATOR + logger + Path.SEPARATOR + filename;
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.tserver;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.volume.Volume;
@@ -133,7 +134,7 @@ public class TabletServerSyncCheckTest {
     }
 
     @Override
-    public Path matchingFileSystem(Path source, String[] options) {
+    public Path matchingFileSystem(Path source, Set<String> options) {
       return null;
     }
 
@@ -183,7 +184,7 @@ public class TabletServerSyncCheckTest {
     }
 
     @Override
-    public String choose(VolumeChooserEnvironment env, String[] options) {
+    public String choose(VolumeChooserEnvironment env, Set<String> options) {
       return null;
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/FairVolumeChooser.java
+++ b/test/src/main/java/org/apache/accumulo/test/FairVolumeChooser.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.server.fs.VolumeChooser;
@@ -32,25 +33,26 @@ public class FairVolumeChooser implements VolumeChooser {
       new ConcurrentHashMap<>();
 
   @Override
-  public String choose(VolumeChooserEnvironment env, String[] options) {
+  public String choose(VolumeChooserEnvironment env, Set<String> options) {
     int currentChoice;
-    Integer lastChoice = optionLengthToLastChoice.get(options.length);
+    String[] optionsArray = options.toArray(new String[0]);
+    Integer lastChoice = optionLengthToLastChoice.get(optionsArray.length);
     if (lastChoice == null) {
       currentChoice = 0;
     } else {
       currentChoice = lastChoice + 1;
-      if (currentChoice >= options.length) {
+      if (currentChoice >= optionsArray.length) {
         currentChoice = 0;
       }
     }
 
-    optionLengthToLastChoice.put(options.length, currentChoice);
+    optionLengthToLastChoice.put(optionsArray.length, currentChoice);
 
-    return options[currentChoice];
+    return optionsArray[currentChoice];
   }
 
   @Override
-  public String[] choosable(VolumeChooserEnvironment env, String[] options) {
+  public Set<String> choosable(VolumeChooserEnvironment env, Set<String> options) {
     return options;
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -152,8 +152,8 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
       KeyExtent extent = extents[i];
 
       String dirName = "dir_" + i;
-      String tdir =
-          ServerConstants.getTablesDirs(context)[0] + "/" + extent.getTableId() + "/" + dirName;
+      String tdir = ServerConstants.getTablesDirs(context).iterator().next() + "/"
+          + extent.getTableId() + "/" + dirName;
       MetadataTableUtil.addTablet(extent, dirName, context, TimeType.LOGICAL, zl);
       SortedMap<TabletFile,DataFileValue> mapFiles = new TreeMap<>();
       mapFiles.put(new TabletFile(new Path(tdir + "/" + RFile.EXTENSION + "_000_000")),


### PR DESCRIPTION
Originally ACCUMULO-3376, this change replaces the use of `String[]`
with `Set<String>` throughout the VolumeChooser and VolumeManager code.
This makes the API for VolumeChooser a bit more friendly, making it
easier to use Streams and lambdas to filter and transform volumes
throughout the code.

This change also adds some more sanity checks on the instance volumes
configuration (checking for empty list and duplicates).

This also includes a utility to warn about planned API changes in
internal pluggable code (such as the VolumeChooser), but without being
too spammy.

Update the default `VolumeChooser.choosable()` to return the full set of
volumes, so that all are checked for flush and sync support on tserver
startup. This choosable mechanism is a bit dubious anyway, because
choosers could make different decisions over time (in response to
configuration changes, for example) than they do at startup. So,
defaulting to checking for the maximal set seems like a better strategy
out-of-the-box.

Make ServerConstants.baseUris unmodifiable.