### PR TITLE
Fixes #1488 - ManyWriteAheadLogsIT asserts open WALS equal to zero.

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -205,6 +205,8 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
       if (entry.getValue() == WalState.OPEN) {
         open++;
         allWalsSeen.add(entry.getKey());
+      } else {
+        log.error("The WalState is " + entry.getValue());// CLOSED or UNREFERENCED
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -213,7 +213,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           allWalsSeen.add(entry.getKey());
           foundWal = true;
         } else {
-          log.error("The WalState is " + entry.getValue());// CLOSED or UNREFERENCED
+          log.debug("The WalState for {} is {}", entry.getKey(), entry.getValue()); // CLOSED or UNREFERENCED
         }
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -220,7 +220,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
       if (!foundWal) {
         Thread.sleep(50);
         if (attempts % 50 == 0)
-          log.info("Has not found an open WAL in " + attempts + " attempts.");
+          log.debug("No open WALs found in {} attempts.", attempts);
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -198,13 +198,15 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
   }
 
   private void addOpenWals(ServerContext c, Set<String> allWalsSeen) throws Exception {
-    Map<String,WalState> wals = WALSunnyDayIT._getWals(c);
-    Set<Entry<String,WalState>> es = wals.entrySet();
+
     int open = 0;
-    int attempts = 1;
+    int attempts = 0;
     boolean foundWal = false;
 
     while (open == 0) {
+      attempts++;
+      Map<String,WalState> wals = WALSunnyDayIT._getWals(c);
+      Set<Entry<String,WalState>> es = wals.entrySet();
       for (Entry<String,WalState> entry : es) {
         if (entry.getValue() == WalState.OPEN) {
           open++;
@@ -213,13 +215,12 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
         } else {
           log.error("The WalState is " + entry.getValue());// CLOSED or UNREFERENCED
         }
+      }
 
-        if (!foundWal) {
-          attempts++;
-          Thread.sleep(50);
-          if (attempts % 50 == 0)
-            log.info("Has not found an open WAL in " + attempts + " attempts.");
-        }
+      if (!foundWal) {
+        Thread.sleep(50);
+        if (attempts % 50 == 0)
+          log.info("Has not found an open WAL in " + attempts + " attempts.");
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -224,7 +224,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
       }
     }
 
-    log.debug("It took " + attempts + " attempt(s) to find an open WAL");
+    log.debug("It took {} attempt(s) to find {} open WALs", attempts, open);
     assertTrue("Open WALs not in expected range " + open, open > 0 && open < 4);
   }
 


### PR DESCRIPTION
CLOSED and UNREFERENCE WALS (not OPEN) causing open == 0