### PR TITLE
Update dependency and plugin versions

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/ByteUtilsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/ByteUtilsTest.java
@@ -20,15 +20,11 @@ package org.apache.accumulo.core.clientImpl.lexicoder;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ByteUtilsTest {
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   private final byte[] empty = new byte[0];
   private final byte[] noSplits = "nosplits".getBytes();
@@ -93,8 +89,7 @@ public class ByteUtilsTest {
   @Test
   public void testIllegalArgument() {
     // incomplete bytes would cause an ArrayIndexOutOfBounds in the past
-    exception.expect(IllegalArgumentException.class);
     byte[] errorBytes = {0x01};
-    ByteUtils.unescape(errorBytes);
+    assertThrows(IllegalArgumentException.class, () -> ByteUtils.unescape(errorBytes));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
@@ -32,14 +33,9 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration.ScanExecutorConfig;
 import org.apache.accumulo.core.spi.scan.SimpleScanDispatcher;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class AccumuloConfigurationTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testGetPropertyByString() {
@@ -196,8 +192,7 @@ public class AccumuloConfigurationTest {
     expected1.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "a2", "asg34");
     assertEquals(expected1, pm1);
 
-    thrown.expect(UnsupportedOperationException.class);
-    pm1.put("k9", "v3");
+    assertThrows(UnsupportedOperationException.class, () -> pm1.put("k9", "v3"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
@@ -19,15 +19,14 @@
 package org.apache.accumulo.core.conf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ClientPropertyTest {
 
@@ -59,9 +58,6 @@ public class ClientPropertyTest {
     assertEquals("/path/to/keytab", ClientProperty.AUTH_TOKEN.getValue(props));
   }
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   @Test
   public void testTypes() {
     Properties props = new Properties();
@@ -81,7 +77,7 @@ public class ClientPropertyTest {
     value = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
     assertEquals(1234L, value.longValue());
 
-    exception.expect(IllegalStateException.class);
-    ClientProperty.BATCH_WRITER_LATENCY_MAX.getBytes(props);
+    assertThrows(IllegalStateException.class,
+        () -> ClientProperty.BATCH_WRITER_LATENCY_MAX.getBytes(props));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/PreAllocatedArrayTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PreAllocatedArrayTest.java
@@ -21,17 +21,13 @@ package org.apache.accumulo.core.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Iterator;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class PreAllocatedArrayTest {
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   /**
    * Test method for {@link org.apache.accumulo.core.util.PreAllocatedArray#PreAllocatedArray(int)}.
@@ -50,8 +46,7 @@ public class PreAllocatedArrayTest {
 
   @Test
   public void testPreAllocatedArray_Fail() {
-    exception.expect(IllegalArgumentException.class);
-    new PreAllocatedArray<String>(-5);
+    assertThrows(IllegalArgumentException.class, () -> new PreAllocatedArray<String>(-5));
   }
 
   /**
@@ -89,31 +84,27 @@ public class PreAllocatedArrayTest {
   public void testSetIndexHigh() {
     PreAllocatedArray<String> strings = new PreAllocatedArray<>(3);
     strings.set(2, "in bounds");
-    exception.expect(IndexOutOfBoundsException.class);
-    strings.set(3, "out of bounds");
+    assertThrows(IndexOutOfBoundsException.class, () -> strings.set(3, "out of bounds"));
   }
 
   @Test
   public void testSetIndexNegative() {
     PreAllocatedArray<String> strings = new PreAllocatedArray<>(3);
     strings.set(0, "in bounds");
-    exception.expect(IndexOutOfBoundsException.class);
-    strings.set(-3, "out of bounds");
+    assertThrows(IndexOutOfBoundsException.class, () -> strings.set(-3, "out of bounds"));
   }
 
   @Test
   public void testGetIndexHigh() {
     PreAllocatedArray<String> strings = new PreAllocatedArray<>(3);
     strings.get(2);
-    exception.expect(IndexOutOfBoundsException.class);
-    strings.get(3);
+    assertThrows(IndexOutOfBoundsException.class, () -> strings.get(3));
   }
 
   @Test
   public void testGetIndexNegative() {
     PreAllocatedArray<String> strings = new PreAllocatedArray<>(3);
     strings.get(0);
-    exception.expect(IndexOutOfBoundsException.class);
-    strings.get(-3);
+    assertThrows(IndexOutOfBoundsException.class, () -> strings.get(-3));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/UnsynchronizedBufferTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/UnsynchronizedBufferTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -28,14 +29,9 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.apache.hadoop.io.WritableUtils;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class UnsynchronizedBufferTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testByteBufferConstructor() {
@@ -57,8 +53,9 @@ public class UnsynchronizedBufferTest {
 
     buf = new byte[6];
     // the byte buffer has the extra byte, but should not be able to read it...
-    thrown.expect(ArrayIndexOutOfBoundsException.class);
-    ub.readBytes(buf);
+    final UnsynchronizedBuffer.Reader ub2 = ub;
+    final byte[] buf2 = buf;
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> ub2.readBytes(buf2));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/fate/util/RetryTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/util/RetryTest.java
@@ -25,8 +25,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 
@@ -38,9 +38,7 @@ import org.apache.accumulo.fate.util.Retry.NeedsTimeIncrement;
 import org.apache.accumulo.fate.util.Retry.RetryFactory;
 import org.easymock.EasyMock;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 
 public class RetryTest {
@@ -53,9 +51,6 @@ public class RetryTest {
   private static final long LOG_INTERVAL = 1000;
   private Retry unlimitedRetry;
   private static final TimeUnit MS = MILLISECONDS;
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Before
   public void setup() {
@@ -103,9 +98,7 @@ public class RetryTest {
     assertFalse(retry.canRetry());
 
     // Calling useRetry when canRetry returns false throws an exception
-    exception.expect(IllegalStateException.class);
-    retry.useRetry();
-    fail("previous command should have thrown IllegalStateException");
+    assertThrows(IllegalStateException.class, () -> retry.useRetry());
   }
 
   @Test
@@ -245,9 +238,8 @@ public class RetryTest {
     NeedsRetries builder = Retry.builder();
     builder.maxRetries(10);
     builder.maxRetries(0);
-    exception.expect(IllegalArgumentException.class);
-    builder.maxRetries(-1);
-    fail("Should not allow negative retries");
+    assertThrows("Should not allow negative retries", IllegalArgumentException.class,
+        () -> builder.maxRetries(-1));
   }
 
   @Test
@@ -260,9 +252,8 @@ public class RetryTest {
     builder.retryAfter(0, MILLISECONDS);
     builder.retryAfter(0, DAYS);
 
-    exception.expect(IllegalArgumentException.class);
-    builder.retryAfter(-1, NANOSECONDS);
-    fail("Should not allow negative wait times");
+    assertThrows("Should not allow negative wait times", IllegalArgumentException.class,
+        () -> builder.retryAfter(-1, NANOSECONDS));
   }
 
   @Test
@@ -275,9 +266,8 @@ public class RetryTest {
     builder.incrementBy(0, HOURS);
     builder.incrementBy(0, NANOSECONDS);
 
-    exception.expect(IllegalArgumentException.class);
-    builder.incrementBy(-1, NANOSECONDS);
-    fail("Should not allow negative increments");
+    assertThrows("Should not allow negative increments", IllegalArgumentException.class,
+        () -> builder.incrementBy(-1, NANOSECONDS));
   }
 
   @Test
@@ -287,9 +277,8 @@ public class RetryTest {
     builder.maxWait(15, MILLISECONDS);
     builder.maxWait(16, MILLISECONDS);
 
-    exception.expect(IllegalArgumentException.class);
-    builder.maxWait(14, MILLISECONDS);
-    fail("Max wait time should be greater than or equal to initial wait time");
+    assertThrows("Max wait time should be greater than or equal to initial wait time",
+        IllegalArgumentException.class, () -> builder.maxWait(14, MILLISECONDS));
   }
 
   @Test
@@ -303,9 +292,8 @@ public class RetryTest {
     builder.logInterval(0, HOURS);
     builder.logInterval(0, NANOSECONDS);
 
-    exception.expect(IllegalArgumentException.class);
-    builder.logInterval(-1, NANOSECONDS);
-    fail("Log interval must not be negative");
+    assertThrows("Log interval must not be negative", IllegalArgumentException.class,
+        () -> builder.logInterval(-1, NANOSECONDS));
   }
 
   @Test

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.mapred;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -43,7 +44,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 
 public class AccumuloInputFormatTest {
@@ -53,8 +53,6 @@ public class AccumuloInputFormatTest {
 
   @Rule
   public TestName test = new TestName();
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Before
   public void createJob() {
@@ -71,8 +69,8 @@ public class AccumuloInputFormatTest {
   public void testMissingTable() throws Exception {
     Properties clientProps =
         org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest.setupClientProperties();
-    exception.expect(IllegalArgumentException.class);
-    AccumuloInputFormat.configure().clientProperties(clientProps).store(new JobConf());
+    assertThrows(IllegalArgumentException.class,
+        () -> AccumuloInputFormat.configure().clientProperties(clientProps).store(new JobConf()));
   }
 
   /**

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.hadoop.mapreduce;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -42,13 +43,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class AccumuloInputFormatTest {
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   static Properties clientProperties;
 
@@ -71,8 +68,8 @@ public class AccumuloInputFormatTest {
   public void testMissingTable() throws Exception {
     Properties clientProps =
         org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormatTest.setupClientProperties();
-    exception.expect(IllegalArgumentException.class);
-    AccumuloInputFormat.configure().clientProperties(clientProps).store(Job.getInstance());
+    assertThrows(IllegalArgumentException.class, () -> AccumuloInputFormat.configure()
+        .clientProperties(clientProps).store(Job.getInstance()));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -115,9 +115,9 @@
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
     <!-- bouncycastle version for test dependencies -->
-    <bouncycastle.version>1.62</bouncycastle.version>
+    <bouncycastle.version>1.64</bouncycastle.version>
     <!-- Curator version -->
-    <curator.version>4.2.0</curator.version>
+    <curator.version>4.3.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <!-- extra release args for testing -->
@@ -126,27 +126,26 @@
     <failsafe.groups />
     <!-- surefire/failsafe plugin option -->
     <forkCount>1</forkCount>
-    <hadoop.version>3.1.2</hadoop.version>
-    <hk2.version>2.5.0</hk2.version>
+    <hadoop.version>3.2.1</hadoop.version>
+    <hk2.version>2.6.1</hk2.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.2.0-incubating</htrace.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
-    <jackson.version>2.10.0</jackson.version>
+    <jackson.version>2.10.3</jackson.version>
     <javax.el.version>3.0.1-b06</javax.el.version>
     <jaxb.version>2.3.0.1</jaxb.version>
-    <jersey.version>2.28</jersey.version>
-    <jetty.version>9.4.19.v20190610</jetty.version>
+    <jersey.version>2.30.1</jersey.version>
+    <jetty.version>9.4.27.v20200227</jetty.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <powermock.version>2.0.2</powermock.version>
+    <powermock.version>2.0.5</powermock.version>
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>
-    <slf4j.version>1.7.26</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
-    <spotbugs.version>3.1.12</spotbugs.version>
     <surefire.excludedGroups />
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <surefire.groups />
@@ -162,12 +161,12 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.72</version>
+        <version>1.78</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>classmate</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -202,22 +201,22 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>${spotbugs.version}</version>
+        <version>4.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
-        <version>1.0-rc5</version>
+        <version>1.0-rc6</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.5</version>
+        <version>2.8.6</version>
       </dependency>
       <dependency>
         <!-- this is a runtime dependency of guava, no longer included with guava as of 27.1 -->
@@ -228,7 +227,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.0-jre</version>
+        <version>28.2-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -248,7 +247,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
@@ -258,7 +257,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.12</version>
+        <version>1.14</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -318,7 +317,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>4.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.accumulo</groupId>
@@ -394,12 +393,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.3</version>
+        <version>4.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -424,12 +423,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.6</version>
+        <version>1.8</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
-        <version>2.3</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
@@ -470,6 +469,11 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-distcp</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdfs-client</artifactId>
         <version>${hadoop.version}</version>
       </dependency>
       <dependency>
@@ -554,7 +558,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>4.0.2</version>
+        <version>4.2</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -594,7 +598,7 @@
       <dependency>
         <groupId>org.freemarker</groupId>
         <artifactId>freemarker</artifactId>
-        <version>2.3.28</version>
+        <version>2.3.30</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
@@ -722,29 +726,19 @@
         <version>2.2.6</version>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>2.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>6.1.0.Final</version>
+        <version>6.1.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.25.0-GA</version>
+        <version>3.26.0-GA</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
-        <version>3.4.0.Final</version>
+        <version>3.4.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
@@ -774,7 +768,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -833,7 +827,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>${spotbugs.version}.1</version>
+          <version>3.1.12.1</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -910,6 +904,11 @@
               <arg>5</arg>
             </compilerArgs>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1062,14 +1061,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <!-- needed for Java 11 until maven-dependency-plugin 3.1.2 is released -->
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-dependency-analyzer</artifactId>
-            <version>1.11.1</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>analyze</id>
@@ -1083,6 +1074,7 @@
                 <usedUndeclaredDependency>org.apache.curator:curator-client:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-common:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-hdfs:*:*</usedUndeclaredDependency>
+                <usedUndeclaredDependency>org.apache.hadoop:hadoop-hdfs-client:*:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-mapreduce-client-core:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-auth:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.httpcomponents:httpcore:jar:*</usedUndeclaredDependency>
@@ -1266,7 +1258,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.29</version>
+            <version>8.30</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,11 @@
         <version>1.0-rc6</version>
       </dependency>
       <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.8.6</version>
@@ -268,6 +273,11 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>1.3.5</version>
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
@@ -429,6 +439,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
         <version>2.6.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
@@ -469,11 +485,6 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-distcp</artifactId>
-        <version>${hadoop.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-hdfs-client</artifactId>
         <version>${hadoop.version}</version>
       </dependency>
       <dependency>
@@ -554,6 +565,11 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
@@ -739,6 +755,11 @@
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
         <version>3.4.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.1</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
@@ -1074,7 +1095,6 @@
                 <usedUndeclaredDependency>org.apache.curator:curator-client:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-common:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-hdfs:*:*</usedUndeclaredDependency>
-                <usedUndeclaredDependency>org.apache.hadoop:hadoop-hdfs-client:*:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-mapreduce-client-core:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.hadoop:hadoop-auth:jar:*</usedUndeclaredDependency>
                 <usedUndeclaredDependency>org.apache.httpcomponents:httpcore:jar:*</usedUndeclaredDependency>
@@ -1161,6 +1181,7 @@
                 <requireJavaVersion>
                   <version>[11,)</version>
                 </requireJavaVersion>
+                <dependencyConvergence />
               </rules>
             </configuration>
           </execution>

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PerTableVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PerTableVolumeChooserTest.java
@@ -24,7 +24,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
@@ -33,9 +33,7 @@ import org.apache.accumulo.server.fs.VolumeChooser.VolumeChooserException;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironment.ChooserScope;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class PerTableVolumeChooserTest {
 
@@ -53,9 +51,6 @@ public class PerTableVolumeChooserTest {
   public static class MockChooser1 extends RandomVolumeChooser {}
 
   public static class MockChooser2 extends RandomVolumeChooser {}
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void before() {
@@ -126,9 +121,7 @@ public class PerTableVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    getTableDelegate();
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> getTableDelegate());
   }
 
   @Test
@@ -140,9 +133,7 @@ public class PerTableVolumeChooserTest {
         VolumeChooser.class)).andThrow(new RuntimeException());
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    getTableDelegate();
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> getTableDelegate());
   }
 
   @Test
@@ -179,9 +170,7 @@ public class PerTableVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    getDelegate(ChooserScope.LOGGER);
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> getDelegate(ChooserScope.LOGGER));
   }
 
   @Test
@@ -194,9 +183,7 @@ public class PerTableVolumeChooserTest {
         .andThrow(new RuntimeException());
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    getDelegate(ChooserScope.LOGGER);
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> getDelegate(ChooserScope.LOGGER));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
@@ -24,7 +24,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Set;
 
@@ -35,9 +35,7 @@ import org.apache.accumulo.server.fs.VolumeChooser.VolumeChooserException;
 import org.apache.accumulo.server.fs.VolumeChooserEnvironment.ChooserScope;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class PreferredVolumeChooserTest {
 
@@ -53,9 +51,6 @@ public class PreferredVolumeChooserTest {
   private Configuration tableConf;
   private Configuration systemConf;
   private PreferredVolumeChooser chooser;
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void before() {
@@ -118,9 +113,7 @@ public class PreferredVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    chooseForTable();
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> chooseForTable());
   }
 
   @Test
@@ -128,9 +121,7 @@ public class PreferredVolumeChooserTest {
     expect(tableConf.getTableCustom(TABLE_CUSTOM_SUFFIX)).andReturn(",").once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    chooseForTable();
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> chooseForTable());
   }
 
   @Test
@@ -140,9 +131,7 @@ public class PreferredVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    chooseForTable();
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> chooseForTable());
   }
 
   @Test
@@ -171,9 +160,7 @@ public class PreferredVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    choose(ChooserScope.LOGGER);
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> choose(ChooserScope.LOGGER));
   }
 
   @Test
@@ -182,9 +169,7 @@ public class PreferredVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    choose(ChooserScope.LOGGER);
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> choose(ChooserScope.LOGGER));
   }
 
   @Test
@@ -195,9 +180,7 @@ public class PreferredVolumeChooserTest {
         .once();
     replay(serviceEnv, tableConf, systemConf);
 
-    thrown.expect(VolumeChooserException.class);
-    choose(ChooserScope.LOGGER);
-    fail("should not reach");
+    assertThrows(VolumeChooserException.class, () -> choose(ChooserScope.LOGGER));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.tserver;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -65,7 +66,6 @@ import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -95,9 +95,6 @@ public class InMemoryMapTest {
       return sampleConfig;
     }
   }
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   public static ServerContext getServerContext() {
     Configuration hadoopConf = new Configuration();
@@ -799,9 +796,9 @@ public class InMemoryMapTest {
     iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
     assertEquals(expectedAll, readAll(iter));
 
-    iter = imm.skvIterator(sampleConfig1);
-    thrown.expect(SampleNotPresentException.class);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    final MemoryIterator iter2 = imm.skvIterator(sampleConfig1);
+    assertThrows(SampleNotPresentException.class,
+        () -> iter2.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false));
   }
 
   private TreeMap<Key,Value> readAll(SortedKeyValueIterator<Key,Value> iter) throws IOException {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactionPlanTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactionPlanTest.java
@@ -18,17 +18,14 @@
  */
 package org.apache.accumulo.tserver.compaction;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.Set;
 
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class CompactionPlanTest {
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testOverlappingInputAndDelete() {
@@ -44,8 +41,7 @@ public class CompactionPlanTest {
 
     Set<StoredTabletFile> allFiles = Set.of(fr1, fr2);
 
-    exception.expect(IllegalStateException.class);
-    cp1.validate(allFiles);
+    assertThrows(IllegalStateException.class, () -> cp1.validate(allFiles));
   }
 
   @Test
@@ -62,8 +58,7 @@ public class CompactionPlanTest {
 
     Set<StoredTabletFile> allFiles = Set.of(fr1, fr2);
 
-    exception.expect(IllegalStateException.class);
-    cp1.validate(allFiles);
+    assertThrows(IllegalStateException.class, () -> cp1.validate(allFiles));
   }
 
   @Test
@@ -80,8 +75,7 @@ public class CompactionPlanTest {
 
     Set<StoredTabletFile> allFiles = Set.of(fr1, fr2);
 
-    exception.expect(IllegalStateException.class);
-    cp1.validate(allFiles);
+    assertThrows(IllegalStateException.class, () -> cp1.validate(allFiles));
   }
 
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -24,6 +24,7 @@ import static org.apache.accumulo.tserver.logger.LogEvents.DEFINE_TABLET;
 import static org.apache.accumulo.tserver.logger.LogEvents.MUTATION;
 import static org.apache.accumulo.tserver.logger.LogEvents.OPEN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -57,7 +58,6 @@ import org.apache.hadoop.io.MapFile.Writer;
 import org.apache.hadoop.io.Text;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -73,9 +73,6 @@ public class SortedLogRecoveryTest {
   @Rule
   public TemporaryFolder tempFolder =
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   static class KeyValue implements Comparable<KeyValue> {
     public final LogFileKey key;
@@ -874,9 +871,8 @@ public class SortedLogRecoveryTest {
     Map<String,KeyValue[]> logs = new TreeMap<>();
     logs.put("entries1", entries1);
 
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("consecutive " + LogEvents.COMPACTION_FINISH.name());
-    recover(logs, extent);
+    var e = assertThrows(IllegalStateException.class, () -> recover(logs, extent));
+    assertTrue(e.getMessage().contains("consecutive " + LogEvents.COMPACTION_FINISH.name()));
   }
 
   @Test
@@ -996,8 +992,7 @@ public class SortedLogRecoveryTest {
     Map<String,KeyValue[]> logs = new TreeMap<>();
     logs.put("entries1", entries1);
 
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("not " + LogEvents.OPEN);
-    recover(logs, extent);
+    var e = assertThrows(IllegalStateException.class, () -> recover(logs, extent));
+    assertTrue(e.getMessage().contains("not " + LogEvents.OPEN));
   }
 }

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoader.java
@@ -265,21 +265,21 @@ public class AccumuloReloadingVFSClassLoader implements FileListener, ReloadingC
   @Override
   public void fileCreated(FileChangeEvent event) throws Exception {
     if (log.isDebugEnabled())
-      log.debug("{} created, recreating classloader", event.getFile().getURL());
+      log.debug("{} created, recreating classloader", event.getFileObject().getURL());
     scheduleRefresh();
   }
 
   @Override
   public void fileDeleted(FileChangeEvent event) throws Exception {
     if (log.isDebugEnabled())
-      log.debug("{} deleted, recreating classloader", event.getFile().getURL());
+      log.debug("{} deleted, recreating classloader", event.getFileObject().getURL());
     scheduleRefresh();
   }
 
   @Override
   public void fileChanged(FileChangeEvent event) throws Exception {
     if (log.isDebugEnabled())
-      log.debug("{} changed, recreating classloader", event.getFile().getURL());
+      log.debug("{} changed, recreating classloader", event.getFileObject().getURL());
     scheduleRefresh();
   }
 

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloReloadingVFSClassLoaderTest.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.start.classloader.vfs;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -171,9 +171,13 @@ public class AccumuloReloadingVFSClassLoaderTest {
     Object o2 = clazz2.getDeclaredConstructor().newInstance();
     assertEquals("Hello World!", o2.toString());
 
-    // This is true because they are loaded by the same classloader due to the new retry
-    assertTrue(clazz1.equals(clazz2));
-    assertFalse(o1.equals(o2));
+    // This is false because even though it's the same class, it's loaded from a different jar
+    // this is a change in behavior from previous versions of vfs2 where it would load the same
+    // class from different jars as though it was from the first jar
+    assertNotEquals(clazz1, clazz2);
+    assertNotSame(o1, o2);
+    assertEquals(clazz1.getName(), clazz2.getName());
+    assertEquals(o1.toString(), o2.toString());
 
     arvcl.close();
   }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -175,10 +175,6 @@
       <artifactId>easymock</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +67,7 @@ public class ClassLoaderIT extends AccumuloClusterHarness {
 
   @Before
   public void checkCluster() {
-    Assume.assumeThat(getClusterType(), CoreMatchers.is(ClusterType.MINI));
+    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
     MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) getCluster();
     rootPath = mac.getConfig().getDir().getAbsolutePath();
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
@@ -45,7 +45,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +67,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
 
   @Before
   public void checkCluster() throws Exception {
-    Assume.assumeThat(getClusterType(), CoreMatchers.is(ClusterType.MINI));
+    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
     MiniAccumuloClusterImpl.class.cast(getCluster());
     fs = FileSystem.get(cluster.getServerContext().getHadoopConf());
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.test.VerifyIngest.VerifyParams;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -59,7 +58,7 @@ public class TableIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    Assume.assumeThat(getClusterType(), CoreMatchers.is(ClusterType.MINI));
+    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
 
     AccumuloCluster cluster = getCluster();
     MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
@@ -19,6 +19,8 @@
 package org.apache.accumulo.test.rpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
@@ -27,13 +29,11 @@ import org.apache.accumulo.test.categories.SunnyDayTests;
 import org.apache.accumulo.test.rpc.thrift.SimpleThriftService;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 
@@ -45,9 +45,6 @@ public class ThriftBehaviorIT {
 
   @Rule
   public TestName testName = new TestName();
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   private SimpleThriftService.Client client;
   private SimpleThriftServiceHandler handler;
@@ -85,9 +82,8 @@ public class ThriftBehaviorIT {
 
   @Test
   public void echoFailHandler() throws TException {
-    exception.expect(TException.class);
-    exception.expectCause(IsInstanceOf.instanceOf(UnsupportedOperationException.class));
-    handler.echoFail(KITTY_MSG);
+    var e = assertThrows(TException.class, () -> handler.echoFail(KITTY_MSG));
+    assertTrue(e.getCause() instanceof UnsupportedOperationException);
   }
 
   @Test
@@ -104,8 +100,7 @@ public class ThriftBehaviorIT {
 
   @Test
   public void echoRuntimeFailHandler() {
-    exception.expect(UnsupportedOperationException.class);
-    handler.echoRuntimeFail(KITTY_MSG);
+    assertThrows(UnsupportedOperationException.class, () -> handler.echoRuntimeFail(KITTY_MSG));
   }
 
   @Test
@@ -132,9 +127,8 @@ public class ThriftBehaviorIT {
 
   @Test
   public void onewayFailHandler() throws TException {
-    exception.expect(TException.class);
-    exception.expectCause(IsInstanceOf.instanceOf(UnsupportedOperationException.class));
-    handler.onewayFail(KITTY_MSG);
+    var e = assertThrows(TException.class, () -> handler.onewayFail(KITTY_MSG));
+    assertTrue(e.getCause() instanceof UnsupportedOperationException);
   }
 
   @Test
@@ -146,8 +140,7 @@ public class ThriftBehaviorIT {
 
   @Test
   public void onewayRuntimeFailHandler() {
-    exception.expect(UnsupportedOperationException.class);
-    handler.onewayRuntimeFail(KITTY_MSG);
+    assertThrows(UnsupportedOperationException.class, () -> handler.onewayRuntimeFail(KITTY_MSG));
   }
 
   @Test


### PR DESCRIPTION
Fix warnings due to updated dependencies
 * Use new vfs2 method instead of deprecated one
 * Use assertThrows instead of ExpectedException
 * Remove hamcrest dependency, because it's not needed any more