### PR TITLE
Use single map method where possible.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.client.mapred;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -47,7 +46,6 @@ import org.apache.accumulo.core.clientImpl.DelegationTokenImpl;
 import org.apache.accumulo.core.clientImpl.mapreduce.lib.OutputConfigurator;
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
@@ -552,13 +550,9 @@ public class AccumuloOutputFormat implements OutputFormat<Text,Mutation> {
       } catch (MutationsRejectedException e) {
         if (!e.getSecurityErrorCodes().isEmpty()) {
           HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-          for (Entry<TabletId,Set<SecurityErrorCode>> ke : e.getSecurityErrorCodes().entrySet()) {
+          for (var ke : e.getSecurityErrorCodes().entrySet()) {
             String tableId = ke.getKey().getTableId().toString();
-            Set<SecurityErrorCode> secCodes = tables.get(tableId);
-            if (secCodes == null) {
-              secCodes = new HashSet<>();
-              tables.put(tableId, secCodes);
-            }
+            Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
             secCodes.addAll(ke.getValue());
           }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
@@ -549,13 +549,11 @@ public class AccumuloOutputFormat implements OutputFormat<Text,Mutation> {
         mtbw.close();
       } catch (MutationsRejectedException e) {
         if (!e.getSecurityErrorCodes().isEmpty()) {
-          HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-          for (var ke : e.getSecurityErrorCodes().entrySet()) {
-            String tableId = ke.getKey().getTableId().toString();
-            Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
-            secCodes.addAll(ke.getValue());
-          }
-
+          var tables = new HashMap<String,Set<SecurityErrorCode>>();
+          e.getSecurityErrorCodes().forEach((tabletId, secSet) -> {
+            var tableId = tabletId.getTableId().toString();
+            tables.computeIfAbsent(tableId, p -> new HashSet<>()).addAll(secSet);
+          });
           log.error("Not authorized to write to tables : " + tables);
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.client.mapreduce;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -47,7 +46,6 @@ import org.apache.accumulo.core.clientImpl.DelegationTokenImpl;
 import org.apache.accumulo.core.clientImpl.mapreduce.lib.OutputConfigurator;
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
@@ -553,13 +551,9 @@ public class AccumuloOutputFormat extends OutputFormat<Text,Mutation> {
       } catch (MutationsRejectedException e) {
         if (!e.getSecurityErrorCodes().isEmpty()) {
           HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-          for (Entry<TabletId,Set<SecurityErrorCode>> ke : e.getSecurityErrorCodes().entrySet()) {
+          for (var ke : e.getSecurityErrorCodes().entrySet()) {
             String tableId = ke.getKey().getTableId().toString();
-            Set<SecurityErrorCode> secCodes = tables.get(tableId);
-            if (secCodes == null) {
-              secCodes = new HashSet<>();
-              tables.put(tableId, secCodes);
-            }
+            Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
             secCodes.addAll(ke.getValue());
           }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
@@ -550,13 +550,11 @@ public class AccumuloOutputFormat extends OutputFormat<Text,Mutation> {
         mtbw.close();
       } catch (MutationsRejectedException e) {
         if (!e.getSecurityErrorCodes().isEmpty()) {
-          HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-          for (var ke : e.getSecurityErrorCodes().entrySet()) {
-            String tableId = ke.getKey().getTableId().toString();
-            Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
-            secCodes.addAll(ke.getValue());
-          }
-
+          var tables = new HashMap<String,Set<SecurityErrorCode>>();
+          e.getSecurityErrorCodes().forEach((tabletId, secSet) -> {
+            var tableId = tabletId.getTableId().toString();
+            tables.computeIfAbsent(tableId, p -> new HashSet<>()).addAll(secSet);
+          });
           log.error("Not authorized to write to tables : " + tables);
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -92,11 +92,8 @@ public class ScannerOptions implements ScannerBase {
     if (serverSideIteratorOptions.size() == 0) {
       serverSideIteratorOptions = new HashMap<>();
     }
-
-    Map<String,String> opts =
-        serverSideIteratorOptions.computeIfAbsent(si.getName(), k -> new HashMap<>());
-
-    opts.putAll(si.getOptions());
+    serverSideIteratorOptions.computeIfAbsent(si.getName(), k -> new HashMap<>())
+        .putAll(si.getOptions());
   }
 
   @Override
@@ -125,11 +122,7 @@ public class ScannerOptions implements ScannerBase {
     if (serverSideIteratorOptions.size() == 0) {
       serverSideIteratorOptions = new HashMap<>();
     }
-
-    Map<String,String> opts =
-        serverSideIteratorOptions.computeIfAbsent(iteratorName, k -> new HashMap<>());
-
-    opts.put(key, value);
+    serverSideIteratorOptions.computeIfAbsent(iteratorName, k -> new HashMap<>()).put(key, value);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -93,12 +93,9 @@ public class ScannerOptions implements ScannerBase {
       serverSideIteratorOptions = new HashMap<>();
     }
 
-    Map<String,String> opts = serverSideIteratorOptions.get(si.getName());
+    Map<String,String> opts =
+        serverSideIteratorOptions.computeIfAbsent(si.getName(), k -> new HashMap<>());
 
-    if (opts == null) {
-      opts = new HashMap<>();
-      serverSideIteratorOptions.put(si.getName(), opts);
-    }
     opts.putAll(si.getOptions());
   }
 
@@ -129,12 +126,9 @@ public class ScannerOptions implements ScannerBase {
       serverSideIteratorOptions = new HashMap<>();
     }
 
-    Map<String,String> opts = serverSideIteratorOptions.get(iteratorName);
+    Map<String,String> opts =
+        serverSideIteratorOptions.computeIfAbsent(iteratorName, k -> new HashMap<>());
 
-    if (opts == null) {
-      opts = new HashMap<>();
-      serverSideIteratorOptions.put(iteratorName, opts);
-    }
     opts.put(key, value);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1716,13 +1716,11 @@ public class TableOperationsImpl extends TableOperationsHelper {
       if (groupedByRanges == null) {
         Map<Range,List<TabletId>> tmp = new HashMap<>();
 
-        for (var entry : groupedByTablets.entrySet()) {
-          for (Range range : entry.getValue()) {
-            List<TabletId> tablets = tmp.computeIfAbsent(range, k -> new ArrayList<>());
-
-            tablets.add(entry.getKey());
+        groupedByTablets.forEach((table, rangeList) -> {
+          for (Range range : rangeList) {
+            tmp.computeIfAbsent(range, k -> new ArrayList<>()).add(table);
           }
-        }
+        });
 
         Map<Range,List<TabletId>> tmp2 = new HashMap<>();
         for (Entry<Range,List<TabletId>> entry : tmp.entrySet()) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1716,13 +1716,9 @@ public class TableOperationsImpl extends TableOperationsHelper {
       if (groupedByRanges == null) {
         Map<Range,List<TabletId>> tmp = new HashMap<>();
 
-        for (Entry<TabletId,List<Range>> entry : groupedByTablets.entrySet()) {
+        for (var entry : groupedByTablets.entrySet()) {
           for (Range range : entry.getValue()) {
-            List<TabletId> tablets = tmp.get(range);
-            if (tablets == null) {
-              tablets = new ArrayList<>();
-              tmp.put(range, tablets);
-            }
+            List<TabletId> tablets = tmp.computeIfAbsent(range, k -> new ArrayList<>());
 
             tablets.add(entry.getKey());
           }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
@@ -730,12 +730,8 @@ public class TabletLocatorImpl extends TabletLocator {
 
   protected static void addRange(Map<String,Map<KeyExtent,List<Range>>> binnedRanges,
       String location, KeyExtent ke, Range range) {
-    Map<KeyExtent,List<Range>> tablets =
-        binnedRanges.computeIfAbsent(location, k -> new HashMap<>());
-
-    List<Range> tabletsRanges = tablets.computeIfAbsent(ke, k -> new ArrayList<>());
-
-    tabletsRanges.add(range);
+    binnedRanges.computeIfAbsent(location, k -> new HashMap<>())
+        .computeIfAbsent(ke, k -> new ArrayList<>()).add(range);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
@@ -730,17 +730,10 @@ public class TabletLocatorImpl extends TabletLocator {
 
   protected static void addRange(Map<String,Map<KeyExtent,List<Range>>> binnedRanges,
       String location, KeyExtent ke, Range range) {
-    Map<KeyExtent,List<Range>> tablets = binnedRanges.get(location);
-    if (tablets == null) {
-      tablets = new HashMap<>();
-      binnedRanges.put(location, tablets);
-    }
+    Map<KeyExtent,List<Range>> tablets =
+        binnedRanges.computeIfAbsent(location, k -> new HashMap<>());
 
-    List<Range> tabletsRanges = tablets.get(ke);
-    if (tabletsRanges == null) {
-      tabletsRanges = new ArrayList<>();
-      tablets.put(ke, tabletsRanges);
-    }
+    List<Range> tabletsRanges = tablets.computeIfAbsent(ke, k -> new ArrayList<>());
 
     tabletsRanges.add(range);
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -517,10 +517,9 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
   private void mergeAuthorizationFailures(Map<KeyExtent,Set<SecurityErrorCode>> source,
       Map<KeyExtent,SecurityErrorCode> addition) {
-    for (var entry : addition.entrySet()) {
-      Set<SecurityErrorCode> secs = source.computeIfAbsent(entry.getKey(), k -> new HashSet<>());
-      secs.add(entry.getValue());
-    }
+    addition.forEach((ke, sec) -> {
+      source.computeIfAbsent(ke, p -> new HashSet<>()).add(sec);
+    });
   }
 
   private synchronized void updateServerErrors(String server, Exception e) {
@@ -1006,10 +1005,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
     }
 
     void addMutation(TableId table, Mutation mutation) {
-      List<Mutation> tabMutList = mutations.computeIfAbsent(table, k -> new ArrayList<>());
-
-      tabMutList.add(mutation);
-
+      mutations.computeIfAbsent(table, k -> new ArrayList<>()).add(mutation);
       memoryUsed += mutation.estimatedMemoryUsed();
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -517,12 +517,8 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
   private void mergeAuthorizationFailures(Map<KeyExtent,Set<SecurityErrorCode>> source,
       Map<KeyExtent,SecurityErrorCode> addition) {
-    for (Entry<KeyExtent,SecurityErrorCode> entry : addition.entrySet()) {
-      Set<SecurityErrorCode> secs = source.get(entry.getKey());
-      if (secs == null) {
-        secs = new HashSet<>();
-        source.put(entry.getKey(), secs);
-      }
+    for (var entry : addition.entrySet()) {
+      Set<SecurityErrorCode> secs = source.computeIfAbsent(entry.getKey(), k -> new HashSet<>());
       secs.add(entry.getValue());
     }
   }
@@ -1010,11 +1006,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
     }
 
     void addMutation(TableId table, Mutation mutation) {
-      List<Mutation> tabMutList = mutations.get(table);
-      if (tabMutList == null) {
-        tabMutList = new ArrayList<>();
-        mutations.put(table, tabMutList);
-      }
+      List<Mutation> tabMutList = mutations.computeIfAbsent(table, k -> new ArrayList<>());
 
       tabMutList.add(mutation);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
@@ -892,17 +892,10 @@ public class InputConfigurator extends ConfiguratorBase {
           throw new AccumuloException(" " + lastExtent + " is not previous extent " + extent);
         }
 
-        Map<KeyExtent,List<Range>> tabletRanges = binnedRanges.get(last);
-        if (tabletRanges == null) {
-          tabletRanges = new HashMap<>();
-          binnedRanges.put(last, tabletRanges);
-        }
+        Map<KeyExtent,List<Range>> tabletRanges =
+            binnedRanges.computeIfAbsent(last, k -> new HashMap<>());
 
-        List<Range> rangeList = tabletRanges.get(extent);
-        if (rangeList == null) {
-          rangeList = new ArrayList<>();
-          tabletRanges.put(extent, rangeList);
-        }
+        List<Range> rangeList = tabletRanges.computeIfAbsent(extent, k -> new ArrayList<>());
 
         rangeList.add(range);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
@@ -892,12 +892,8 @@ public class InputConfigurator extends ConfiguratorBase {
           throw new AccumuloException(" " + lastExtent + " is not previous extent " + extent);
         }
 
-        Map<KeyExtent,List<Range>> tabletRanges =
-            binnedRanges.computeIfAbsent(last, k -> new HashMap<>());
-
-        List<Range> rangeList = tabletRanges.computeIfAbsent(extent, k -> new ArrayList<>());
-
-        rangeList.add(range);
+        binnedRanges.computeIfAbsent(last, k -> new HashMap<>())
+            .computeIfAbsent(extent, k -> new ArrayList<>()).add(range);
 
         if (extent.getEndRow() == null
             || range.afterEndKey(new Key(extent.getEndRow()).followingKey(PartialKey.ROW))) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
@@ -116,9 +116,7 @@ public class IterConfigUtil {
         String iterName = suffixSplit[0];
         String optName = suffixSplit[2];
 
-        Map<String,String> options = allOptions.computeIfAbsent(iterName, k -> new HashMap<>());
-
-        options.put(optName, entry.getValue());
+        allOptions.computeIfAbsent(iterName, k -> new HashMap<>()).put(optName, entry.getValue());
 
       } else {
         throw new IllegalArgumentException("Invalid iterator format: " + entry.getKey());

--- a/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
@@ -116,11 +116,7 @@ public class IterConfigUtil {
         String iterName = suffixSplit[0];
         String optName = suffixSplit[2];
 
-        Map<String,String> options = allOptions.get(iterName);
-        if (options == null) {
-          options = new HashMap<>();
-          allOptions.put(iterName, options);
-        }
+        Map<String,String> options = allOptions.computeIfAbsent(iterName, k -> new HashMap<>());
 
         options.put(optName, entry.getValue());
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/PrintInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/PrintInfo.java
@@ -249,7 +249,7 @@ public class PrintInfo implements KeywordExecutable {
         if (opts.formatterClazz != null) {
           final Class<? extends BiFunction<Key,Value,String>> formatterClass =
               getFormatter(opts.formatterClazz);
-          formatter = formatterClass.newInstance();
+          formatter = formatterClass.getConstructor().newInstance();
         } else if (opts.fullKeys) {
           formatter = (key, value) -> key.toStringNoTruncate() + " -> " + value;
         } else if (opts.dump) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilter.java
@@ -52,11 +52,7 @@ public class ColumnSliceFilter extends Filter {
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
       IteratorEnvironment env) throws IOException {
     super.init(source, options, env);
-    if (options.containsKey(START_BOUND)) {
-      startBound = options.get(START_BOUND);
-    } else {
-      startBound = null;
-    }
+    startBound = options.getOrDefault(START_BOUND, null);
 
     if (options.containsKey(START_INCLUSIVE)) {
       startInclusive = Boolean.parseBoolean(options.get(START_INCLUSIVE));
@@ -64,11 +60,7 @@ public class ColumnSliceFilter extends Filter {
       startInclusive = true;
     }
 
-    if (options.containsKey(END_BOUND)) {
-      endBound = options.get(END_BOUND);
-    } else {
-      endBound = null;
-    }
+    endBound = options.getOrDefault(END_BOUND, null);
 
     if (options.containsKey(END_INCLUSIVE)) {
       endInclusive = Boolean.parseBoolean(options.get(END_INCLUSIVE));

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilter.java
@@ -54,19 +54,13 @@ public class ColumnSliceFilter extends Filter {
     super.init(source, options, env);
     startBound = options.getOrDefault(START_BOUND, null);
 
-    if (options.containsKey(START_INCLUSIVE)) {
-      startInclusive = Boolean.parseBoolean(options.get(START_INCLUSIVE));
-    } else {
-      startInclusive = true;
-    }
+    startInclusive = options.containsKey(START_INCLUSIVE)
+        ? Boolean.parseBoolean(options.get(START_INCLUSIVE)) : true;
 
     endBound = options.getOrDefault(END_BOUND, null);
 
-    if (options.containsKey(END_INCLUSIVE)) {
-      endInclusive = Boolean.parseBoolean(options.get(END_INCLUSIVE));
-    } else {
-      endInclusive = false;
-    }
+    endInclusive = options.containsKey(END_INCLUSIVE)
+        ? Boolean.parseBoolean(options.get(END_INCLUSIVE)) : false;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
@@ -40,18 +40,16 @@ public class ColumnQualifierFilter extends ServerFilter {
     this.columnFamilies = new HashSet<>();
     this.columnsQualifiers = new HashMap<>();
 
-    for (Column col : columns) {
+    columns.forEach(col -> {
       if (col.columnQualifier != null) {
-        ArrayByteSequence cq = new ArrayByteSequence(col.columnQualifier);
-        HashSet<ByteSequence> cfset =
-            this.columnsQualifiers.computeIfAbsent(cq, k -> new HashSet<>());
-
-        cfset.add(new ArrayByteSequence(col.columnFamily));
+        this.columnsQualifiers
+            .computeIfAbsent(new ArrayByteSequence(col.columnQualifier), k -> new HashSet<>())
+            .add(new ArrayByteSequence(col.columnFamily));
       } else {
         // this whole column family should pass
         columnFamilies.add(new ArrayByteSequence(col.columnFamily));
       }
-    }
+    });
   }
 
   private ColumnQualifierFilter(SortedKeyValueIterator<Key,Value> iterator,

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
@@ -43,11 +43,8 @@ public class ColumnQualifierFilter extends ServerFilter {
     for (Column col : columns) {
       if (col.columnQualifier != null) {
         ArrayByteSequence cq = new ArrayByteSequence(col.columnQualifier);
-        HashSet<ByteSequence> cfset = this.columnsQualifiers.get(cq);
-        if (cfset == null) {
-          cfset = new HashSet<>();
-          this.columnsQualifiers.put(cq, cfset);
-        }
+        HashSet<ByteSequence> cfset =
+            this.columnsQualifiers.computeIfAbsent(cq, k -> new HashSet<>());
 
         cfset.add(new ArrayByteSequence(col.columnFamily));
       } else {

--- a/core/src/main/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatter.java
@@ -53,8 +53,7 @@ public class ShardedTableDistributionFormatter extends AggregatingFormatter {
       } else
         day = "NULL    ";
       String server = entry.getValue().toString();
-      if (countsByDay.get(day) == null)
-        countsByDay.put(day, new HashSet<>());
+      countsByDay.computeIfAbsent(day, k -> new HashSet<>());
       countsByDay.get(day).add(server);
     }
   }

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -301,11 +301,8 @@ public class AdminUtil<T> {
               }
             }
 
-            List<String> tables = locks.get(Long.parseLong(lda[1], 16));
-            if (tables == null) {
-              tables = new ArrayList<>();
-              locks.put(Long.parseLong(lda[1], 16), tables);
-            }
+            List<String> tables =
+                locks.computeIfAbsent(Long.parseLong(lda[1], 16), k -> new ArrayList<>());
 
             tables.add(lda[0].charAt(0) + ":" + id);
 

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -301,10 +301,8 @@ public class AdminUtil<T> {
               }
             }
 
-            List<String> tables =
-                locks.computeIfAbsent(Long.parseLong(lda[1], 16), k -> new ArrayList<>());
-
-            tables.add(lda[0].charAt(0) + ":" + id);
+            locks.computeIfAbsent(Long.parseLong(lda[1], 16), k -> new ArrayList<>())
+                .add(lda[0].charAt(0) + ":" + id);
 
           } catch (Exception e) {
             log.error("{}", e.getMessage(), e);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -296,11 +296,8 @@ public class TabletLocatorImplTest {
       String server = (String) ol[1];
       KeyExtent ke = (KeyExtent) ol[2];
 
-      Map<KeyExtent,List<String>> tb = emb.computeIfAbsent(server, k -> new HashMap<>());
-
-      List<String> rl = tb.computeIfAbsent(ke, k -> new ArrayList<>());
-
-      rl.add(row);
+      emb.computeIfAbsent(server, k -> new HashMap<>()).computeIfAbsent(ke, k -> new ArrayList<>())
+          .add(row);
     }
 
     return emb;

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -296,17 +296,9 @@ public class TabletLocatorImplTest {
       String server = (String) ol[1];
       KeyExtent ke = (KeyExtent) ol[2];
 
-      Map<KeyExtent,List<String>> tb = emb.get(server);
-      if (tb == null) {
-        tb = new HashMap<>();
-        emb.put(server, tb);
-      }
+      Map<KeyExtent,List<String>> tb = emb.computeIfAbsent(server, k -> new HashMap<>());
 
-      List<String> rl = tb.get(ke);
-      if (rl == null) {
-        rl = new ArrayList<>();
-        tb.put(ke, rl);
-      }
+      List<String> rl = tb.computeIfAbsent(ke, k -> new ArrayList<>());
 
       rl.add(row);
     }
@@ -527,11 +519,8 @@ public class TabletLocatorImplTest {
   }
 
   static void createEmptyTablet(TServers tservers, String server, KeyExtent tablet) {
-    Map<KeyExtent,SortedMap<Key,Value>> tablets = tservers.tservers.get(server);
-    if (tablets == null) {
-      tablets = new HashMap<>();
-      tservers.tservers.put(server, tablets);
-    }
+    Map<KeyExtent,SortedMap<Key,Value>> tablets =
+        tservers.tservers.computeIfAbsent(server, k -> new HashMap<>());
 
     SortedMap<Key,Value> tabletData = tablets.get(tablet);
     if (tabletData == null) {
@@ -562,17 +551,10 @@ public class TabletLocatorImplTest {
 
   static void setLocation(TServers tservers, String server, KeyExtent tablet, KeyExtent ke,
       String location, String instance) {
-    Map<KeyExtent,SortedMap<Key,Value>> tablets = tservers.tservers.get(server);
-    if (tablets == null) {
-      tablets = new HashMap<>();
-      tservers.tservers.put(server, tablets);
-    }
+    Map<KeyExtent,SortedMap<Key,Value>> tablets =
+        tservers.tservers.computeIfAbsent(server, k -> new HashMap<>());
 
-    SortedMap<Key,Value> tabletData = tablets.get(tablet);
-    if (tabletData == null) {
-      tabletData = new TreeMap<>();
-      tablets.put(tablet, tabletData);
-    }
+    SortedMap<Key,Value> tabletData = tablets.computeIfAbsent(tablet, k -> new TreeMap<>());
 
     Text mr = ke.getMetadataEntry();
     Value per = KeyExtent.encodePrevEndRow(ke.getPrevEndRow());

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
@@ -185,12 +185,11 @@ public class AccumuloRecordWriter implements RecordWriter<Text,Mutation> {
       mtbw.close();
     } catch (MutationsRejectedException e) {
       if (!e.getSecurityErrorCodes().isEmpty()) {
-        HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-        for (var ke : e.getSecurityErrorCodes().entrySet()) {
-          String tableId = ke.getKey().getTableId().toString();
-          Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
-          secCodes.addAll(ke.getValue());
-        }
+        var tables = new HashMap<String,Set<SecurityErrorCode>>();
+        e.getSecurityErrorCodes().forEach((tabletId, secSet) -> {
+          String tableId = tabletId.getTableId().toString();
+          tables.computeIfAbsent(tableId, p -> new HashSet<>()).addAll(secSet);
+        });
 
         log.error("Not authorized to write to tables : " + tables);
       }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.hadoopImpl.mapred;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -35,7 +34,6 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.hadoop.mapred.AccumuloOutputFormat;
 import org.apache.accumulo.hadoopImpl.mapreduce.lib.OutputConfigurator;
@@ -188,13 +186,9 @@ public class AccumuloRecordWriter implements RecordWriter<Text,Mutation> {
     } catch (MutationsRejectedException e) {
       if (!e.getSecurityErrorCodes().isEmpty()) {
         HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-        for (Map.Entry<TabletId,Set<SecurityErrorCode>> ke : e.getSecurityErrorCodes().entrySet()) {
+        for (var ke : e.getSecurityErrorCodes().entrySet()) {
           String tableId = ke.getKey().getTableId().toString();
-          Set<SecurityErrorCode> secCodes = tables.get(tableId);
-          if (secCodes == null) {
-            secCodes = new HashSet<>();
-            tables.put(tableId, secCodes);
-          }
+          Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
           secCodes.addAll(ke.getValue());
         }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
@@ -189,8 +189,7 @@ public class AccumuloRecordWriter extends RecordWriter<Text,Mutation> {
         HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
         for (var ke : e.getSecurityErrorCodes().entrySet()) {
           String tableId = ke.getKey().getTableId().toString();
-          Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
-          secCodes.addAll(ke.getValue());
+          tables.computeIfAbsent(tableId, k -> new HashSet<>()).addAll(ke.getValue());
         }
 
         log.error("Not authorized to write to tables : " + tables);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.hadoopImpl.mapreduce;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -35,7 +34,6 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.hadoop.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.hadoopImpl.mapreduce.lib.OutputConfigurator;
@@ -189,13 +187,9 @@ public class AccumuloRecordWriter extends RecordWriter<Text,Mutation> {
     } catch (MutationsRejectedException e) {
       if (!e.getSecurityErrorCodes().isEmpty()) {
         HashMap<String,Set<SecurityErrorCode>> tables = new HashMap<>();
-        for (Map.Entry<TabletId,Set<SecurityErrorCode>> ke : e.getSecurityErrorCodes().entrySet()) {
+        for (var ke : e.getSecurityErrorCodes().entrySet()) {
           String tableId = ke.getKey().getTableId().toString();
-          Set<SecurityErrorCode> secCodes = tables.get(tableId);
-          if (secCodes == null) {
-            secCodes = new HashSet<>();
-            tables.put(tableId, secCodes);
-          }
+          Set<SecurityErrorCode> secCodes = tables.computeIfAbsent(tableId, k -> new HashSet<>());
           secCodes.addAll(ke.getValue());
         }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -880,12 +880,8 @@ public class InputConfigurator extends ConfiguratorBase {
           throw new AccumuloException(" " + lastExtent + " is not previous extent " + extent);
         }
 
-        Map<KeyExtent,List<Range>> tabletRanges =
-            binnedRanges.computeIfAbsent(last, k -> new HashMap<>());
-
-        List<Range> rangeList = tabletRanges.computeIfAbsent(extent, k -> new ArrayList<>());
-
-        rangeList.add(range);
+        binnedRanges.computeIfAbsent(last, k -> new HashMap<>())
+            .computeIfAbsent(extent, k -> new ArrayList<>()).add(range);
 
         if (extent.getEndRow() == null
             || range.afterEndKey(new Key(extent.getEndRow()).followingKey(PartialKey.ROW))) {

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -880,17 +880,10 @@ public class InputConfigurator extends ConfiguratorBase {
           throw new AccumuloException(" " + lastExtent + " is not previous extent " + extent);
         }
 
-        Map<KeyExtent,List<Range>> tabletRanges = binnedRanges.get(last);
-        if (tabletRanges == null) {
-          tabletRanges = new HashMap<>();
-          binnedRanges.put(last, tabletRanges);
-        }
+        Map<KeyExtent,List<Range>> tabletRanges =
+            binnedRanges.computeIfAbsent(last, k -> new HashMap<>());
 
-        List<Range> rangeList = tabletRanges.get(extent);
-        if (rangeList == null) {
-          rangeList = new ArrayList<>();
-          tabletRanges.put(extent, rangeList);
-        }
+        List<Range> rangeList = tabletRanges.computeIfAbsent(extent, k -> new ArrayList<>());
 
         rangeList.add(range);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -465,12 +465,8 @@ public class BulkImporter {
         List<PathSize> mapFiles = assignmentsPerTablet.get(ke);
         synchronized (assignmentFailures) {
           for (PathSize pathSize : mapFiles) {
-            List<KeyExtent> existingFailures = assignmentFailures.get(pathSize.path);
-            if (existingFailures == null) {
-              existingFailures = new ArrayList<>();
-              assignmentFailures.put(pathSize.path, existingFailures);
-            }
-
+            List<KeyExtent> existingFailures =
+                assignmentFailures.computeIfAbsent(pathSize.path, k -> new ArrayList<>());
             existingFailures.add(ke);
           }
         }
@@ -525,12 +521,8 @@ public class BulkImporter {
       List<AssignmentInfo> tabletsToAssignMapFileTo = entry.getValue();
 
       for (AssignmentInfo ai : tabletsToAssignMapFileTo) {
-        List<PathSize> mapFiles = assignmentsPerTablet.get(ai.ke);
-        if (mapFiles == null) {
-          mapFiles = new ArrayList<>();
-          assignmentsPerTablet.put(ai.ke, mapFiles);
-        }
-
+        List<PathSize> mapFiles =
+            assignmentsPerTablet.computeIfAbsent(ai.ke, k -> new ArrayList<>());
         mapFiles.add(new PathSize(mapFile, ai.estSize));
       }
     }
@@ -548,12 +540,8 @@ public class BulkImporter {
       if (location == null) {
         for (PathSize pathSize : entry.getValue()) {
           synchronized (assignmentFailures) {
-            List<KeyExtent> failures = assignmentFailures.get(pathSize.path);
-            if (failures == null) {
-              failures = new ArrayList<>();
-              assignmentFailures.put(pathSize.path, failures);
-            }
-
+            List<KeyExtent> failures =
+                assignmentFailures.computeIfAbsent(pathSize.path, k -> new ArrayList<>());
             failures.add(ke);
           }
         }
@@ -565,12 +553,8 @@ public class BulkImporter {
         continue;
       }
 
-      Map<KeyExtent,List<PathSize>> apt = assignmentsPerTabletServer.get(location);
-      if (apt == null) {
-        apt = new TreeMap<>();
-        assignmentsPerTabletServer.put(location, apt);
-      }
-
+      Map<KeyExtent,List<PathSize>> apt =
+          assignmentsPerTabletServer.computeIfAbsent(location, k -> new TreeMap<>());
       apt.put(entry.getKey(), entry.getValue());
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
@@ -197,10 +197,7 @@ public class WalStateManager {
       String path = root();
       for (String child : zoo.getChildren(path)) {
         TServerInstance inst = new TServerInstance(child);
-        List<UUID> logs = result.get(inst);
-        if (logs == null) {
-          result.put(inst, logs = new ArrayList<>());
-        }
+        List<UUID> logs = result.computeIfAbsent(inst, k -> new ArrayList<>());
 
         // This function is called by the Accumulo GC which deletes WAL markers. Therefore we do not
         // expect the following call to fail because the WAL info in ZK was deleted.

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -223,10 +223,9 @@ public class DefaultLoadBalancer extends TabletBalancer {
         // look for an uneven table count
         int biggestDifference = 0;
         TableId biggestDifferenceTable = null;
-        for (Entry<TableId,Integer> tableEntry : tooMuchMap.entrySet()) {
+        for (var tableEntry : tooMuchMap.entrySet()) {
           TableId tableID = tableEntry.getKey();
-          if (tooLittleMap.get(tableID) == null)
-            tooLittleMap.put(tableID, 0);
+          tooLittleMap.putIfAbsent(tableID, 0);
           int diff = tableEntry.getValue() - tooLittleMap.get(tableID);
           if (diff > biggestDifference) {
             biggestDifference = diff;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -351,13 +351,9 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     Map<String,SortedMap<TServerInstance,TabletServerStatus>> pools = splitCurrentByRegex(current);
     // group the unassigned into tables
     Map<TableId,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
-    for (Entry<KeyExtent,TServerInstance> e : unassigned.entrySet()) {
+    for (var e : unassigned.entrySet()) {
       Map<KeyExtent,TServerInstance> tableUnassigned =
-          groupedUnassigned.get(e.getKey().getTableId());
-      if (tableUnassigned == null) {
-        tableUnassigned = new HashMap<>();
-        groupedUnassigned.put(e.getKey().getTableId(), tableUnassigned);
-      }
+          groupedUnassigned.computeIfAbsent(e.getKey().getTableId(), k -> new HashMap<>());
       tableUnassigned.put(e.getKey(), e.getValue());
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -351,11 +351,10 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     Map<String,SortedMap<TServerInstance,TabletServerStatus>> pools = splitCurrentByRegex(current);
     // group the unassigned into tables
     Map<TableId,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
-    for (var e : unassigned.entrySet()) {
-      Map<KeyExtent,TServerInstance> tableUnassigned =
-          groupedUnassigned.computeIfAbsent(e.getKey().getTableId(), k -> new HashMap<>());
-      tableUnassigned.put(e.getKey(), e.getValue());
-    }
+    unassigned.forEach((keyExtent, tServerInstance) -> {
+      groupedUnassigned.computeIfAbsent(keyExtent.getTableId(), p -> new HashMap<>()).put(keyExtent,
+          tServerInstance);
+    });
 
     Map<TableId,String> tableIdToTableName = createdTableNameMap(getTableOperations().tableIdMap());
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -118,13 +118,9 @@ public class TableLoadBalancer extends TabletBalancer {
       Map<KeyExtent,TServerInstance> unassigned, Map<KeyExtent,TServerInstance> assignments) {
     // separate the unassigned into tables
     Map<TableId,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
-    for (Entry<KeyExtent,TServerInstance> e : unassigned.entrySet()) {
+    for (var e : unassigned.entrySet()) {
       Map<KeyExtent,TServerInstance> tableUnassigned =
-          groupedUnassigned.get(e.getKey().getTableId());
-      if (tableUnassigned == null) {
-        tableUnassigned = new HashMap<>();
-        groupedUnassigned.put(e.getKey().getTableId(), tableUnassigned);
-      }
+          groupedUnassigned.computeIfAbsent(e.getKey().getTableId(), k -> new HashMap<>());
       tableUnassigned.put(e.getKey(), e.getValue());
     }
     for (Entry<TableId,Map<KeyExtent,TServerInstance>> e : groupedUnassigned.entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -118,11 +118,11 @@ public class TableLoadBalancer extends TabletBalancer {
       Map<KeyExtent,TServerInstance> unassigned, Map<KeyExtent,TServerInstance> assignments) {
     // separate the unassigned into tables
     Map<TableId,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
-    for (var e : unassigned.entrySet()) {
-      Map<KeyExtent,TServerInstance> tableUnassigned =
-          groupedUnassigned.computeIfAbsent(e.getKey().getTableId(), k -> new HashMap<>());
-      tableUnassigned.put(e.getKey(), e.getValue());
-    }
+    unassigned.forEach((keyExtent, tServerInstance) -> {
+      groupedUnassigned.computeIfAbsent(keyExtent.getTableId(), p -> new HashMap<>()).put(keyExtent,
+          tServerInstance);
+    });
+
     for (Entry<TableId,Map<KeyExtent,TServerInstance>> e : groupedUnassigned.entrySet()) {
       Map<KeyExtent,TServerInstance> newAssignments = new HashMap<>();
       getBalancerForTable(e.getKey()).getAssignments(current, e.getValue(), newAssignments);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -717,11 +717,7 @@ public class MetadataTableUtil {
 
       Text row = entry.getKey().getRow();
 
-      SortedMap<ColumnFQ,Value> colVals = tabletEntries.get(row);
-      if (colVals == null) {
-        colVals = new TreeMap<>();
-        tabletEntries.put(row, colVals);
-      }
+      SortedMap<ColumnFQ,Value> colVals = tabletEntries.computeIfAbsent(row, k -> new TreeMap<>());
 
       colVals.put(currentKey, entry.getValue());
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -717,9 +717,7 @@ public class MetadataTableUtil {
 
       Text row = entry.getKey().getRow();
 
-      SortedMap<ColumnFQ,Value> colVals = tabletEntries.computeIfAbsent(row, k -> new TreeMap<>());
-
-      colVals.put(currentKey, entry.getValue());
+      tabletEntries.computeIfAbsent(row, k -> new TreeMap<>()).put(currentKey, entry.getValue());
     }
 
     return tabletEntries;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -112,11 +112,8 @@ public class VerifyTabletAssignments {
 
       if (loc != null) {
         final HostAndPort parsedLoc = HostAndPort.fromString(loc);
-        List<KeyExtent> extentList = extentsPerServer.get(parsedLoc);
-        if (extentList == null) {
-          extentList = new ArrayList<>();
-          extentsPerServer.put(parsedLoc, extentList);
-        }
+        List<KeyExtent> extentList =
+            extentsPerServer.computeIfAbsent(parsedLoc, k -> new ArrayList<>());
 
         if (check == null || check.contains(keyExtent))
           extentList.add(keyExtent);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -271,13 +271,12 @@ public class DefaultLoadBalancerTest {
     if (expectedCounts != null) {
       for (FakeTServer server : servers.values()) {
         Map<String,Integer> counts = new HashMap<>();
-        for (KeyExtent extent : server.extents) {
+        for (var extent : server.extents) {
           String t = extent.getTableId().canonical();
-          if (counts.get(t) == null)
-            counts.put(t, 0);
+          counts.putIfAbsent(t, 0);
           counts.put(t, counts.get(t) + 1);
         }
-        for (Entry<String,Integer> entry : counts.entrySet()) {
+        for (var entry : counts.entrySet()) {
           assertEquals(expectedCounts.get(entry.getKey()), counts.get(entry.getKey()));
         }
       }

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/SequentialWorkAssigner.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/SequentialWorkAssigner.java
@@ -104,11 +104,8 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       log.debug("In progress replication of {} from table with ID {} to peer {}", filename,
           sourceTableId, peerName);
 
-      Map<TableId,String> replicationForPeer = queuedWorkByPeerName.get(peerName);
-      if (replicationForPeer == null) {
-        replicationForPeer = new HashMap<>();
-        queuedWorkByPeerName.put(peerName, replicationForPeer);
-      }
+      Map<TableId,String> replicationForPeer =
+          queuedWorkByPeerName.computeIfAbsent(peerName, k -> new HashMap<>());
 
       replicationForPeer.put(sourceTableId, work);
     }
@@ -173,11 +170,8 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
   @Override
   protected boolean queueWork(Path path, ReplicationTarget target) {
     String queueKey = DistributedWorkQueueWorkAssignerHelper.getQueueKey(path.getName(), target);
-    Map<TableId,String> workForPeer = this.queuedWorkByPeerName.get(target.getPeerName());
-    if (workForPeer == null) {
-      workForPeer = new HashMap<>();
-      this.queuedWorkByPeerName.put(target.getPeerName(), workForPeer);
-    }
+    Map<TableId,String> workForPeer =
+        this.queuedWorkByPeerName.computeIfAbsent(target.getPeerName(), k -> new HashMap<>());
 
     String queuedWork = workForPeer.get(target.getSourceTableId());
     if (queuedWork == null) {

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/SequentialWorkAssigner.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/SequentialWorkAssigner.java
@@ -104,10 +104,7 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       log.debug("In progress replication of {} from table with ID {} to peer {}", filename,
           sourceTableId, peerName);
 
-      Map<TableId,String> replicationForPeer =
-          queuedWorkByPeerName.computeIfAbsent(peerName, k -> new HashMap<>());
-
-      replicationForPeer.put(sourceTableId, work);
+      queuedWorkByPeerName.computeIfAbsent(peerName, k -> new HashMap<>()).put(sourceTableId, work);
     }
   }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/namespace/create/SetupNamespacePermissions.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/namespace/create/SetupNamespacePermissions.java
@@ -41,7 +41,7 @@ class SetupNamespacePermissions extends MasterRepo {
   public Repo<Master> call(long tid, Master env) throws Exception {
     // give all namespace permissions to the creator
     SecurityOperation security = AuditedSecurityOperation.getInstance(env.getContext());
-    for (NamespacePermission permission : NamespacePermission.values()) {
+    for (var permission : NamespacePermission.values()) {
       try {
         security.grantNamespacePermission(env.getContext().rpcCreds(), namespaceInfo.user,
             namespaceInfo.namespaceId, permission);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -221,12 +221,7 @@ public class FileManager {
   }
 
   private static <T> List<T> getFileList(String file, Map<String,List<T>> files) {
-    List<T> ofl = files.get(file);
-    if (ofl == null) {
-      ofl = new ArrayList<>();
-      files.put(file, ofl);
-    }
-
+    List<T> ofl = files.computeIfAbsent(file, k -> new ArrayList<>());
     return ofl;
   }
 
@@ -594,15 +589,10 @@ public class FileManager {
 
       Map<FileSKVIterator,String> newlyReservedReaders = openFiles(files);
       Map<String,List<FileSKVIterator>> map = new HashMap<>();
-      for (Entry<FileSKVIterator,String> entry : newlyReservedReaders.entrySet()) {
+      for (var entry : newlyReservedReaders.entrySet()) {
         FileSKVIterator reader = entry.getKey();
         String fileName = entry.getValue();
-        List<FileSKVIterator> list = map.get(fileName);
-        if (list == null) {
-          list = new LinkedList<>();
-          map.put(fileName, list);
-        }
-
+        List<FileSKVIterator> list = map.computeIfAbsent(fileName, k -> new LinkedList<>());
         list.add(reader);
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -221,8 +221,7 @@ public class FileManager {
   }
 
   private static <T> List<T> getFileList(String file, Map<String,List<T>> files) {
-    List<T> ofl = files.computeIfAbsent(file, k -> new ArrayList<>());
-    return ofl;
+    return files.computeIfAbsent(file, k -> new ArrayList<>());
   }
 
   private void closeReaders(Collection<FileSKVIterator> filesToClose) {
@@ -589,12 +588,9 @@ public class FileManager {
 
       Map<FileSKVIterator,String> newlyReservedReaders = openFiles(files);
       Map<String,List<FileSKVIterator>> map = new HashMap<>();
-      for (var entry : newlyReservedReaders.entrySet()) {
-        FileSKVIterator reader = entry.getKey();
-        String fileName = entry.getValue();
-        List<FileSKVIterator> list = map.computeIfAbsent(fileName, k -> new LinkedList<>());
-        list.add(reader);
-      }
+      newlyReservedReaders.forEach((reader, fileName) -> {
+        map.computeIfAbsent(fileName, k -> new LinkedList<>()).add(reader);
+      });
 
       for (FileDataSource fds : dataSources) {
         FileSKVIterator source = map.get(fds.file).remove(0);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -144,12 +144,8 @@ public class SortedLogRecovery {
     for (Path wal : recoveryLogs) {
       int tabletId = findMaxTabletId(extent, Collections.singletonList(wal));
       if (tabletId != -1) {
-        List<Path> perIdList = logsThatDefineTablet.get(tabletId);
-        if (perIdList == null) {
-          perIdList = new ArrayList<>();
-          logsThatDefineTablet.put(tabletId, perIdList);
-
-        }
+        List<Path> perIdList =
+            logsThatDefineTablet.computeIfAbsent(tabletId, k -> new ArrayList<>());
         perIdList.add(wal);
         log.debug("Found tablet {} with id {} in recovery log {}", extent, tabletId, wal.getName());
       } else {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -144,9 +144,7 @@ public class SortedLogRecovery {
     for (Path wal : recoveryLogs) {
       int tabletId = findMaxTabletId(extent, Collections.singletonList(wal));
       if (tabletId != -1) {
-        List<Path> perIdList =
-            logsThatDefineTablet.computeIfAbsent(tabletId, k -> new ArrayList<>());
-        perIdList.add(wal);
+        logsThatDefineTablet.computeIfAbsent(tabletId, k -> new ArrayList<>()).add(wal);
         log.debug("Found tablet {} with id {} in recovery log {}", extent, tabletId, wal.getName());
       } else {
         log.debug("Did not find tablet {} in recovery log {}", extent, wal.getName());

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetScanIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetScanIterCommand.java
@@ -59,11 +59,8 @@ public class SetScanIterCommand extends SetIterCommand {
 
     options.values().removeIf(v -> v == null || v.isEmpty());
 
-    List<IteratorSetting> tableScanIterators = shellState.scanIteratorOptions.get(tableName);
-    if (tableScanIterators == null) {
-      tableScanIterators = new ArrayList<>();
-      shellState.scanIteratorOptions.put(tableName, tableScanIterators);
-    }
+    List<IteratorSetting> tableScanIterators =
+        shellState.scanIteratorOptions.computeIfAbsent(tableName, k -> new ArrayList<>());
     final IteratorSetting setting = new IteratorSetting(priority, name, classname);
     setting.addOptions(options);
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetShellIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetShellIterCommand.java
@@ -53,11 +53,8 @@ public class SetShellIterCommand extends SetIterCommand {
 
     options.values().removeIf(v -> v == null || v.isEmpty());
 
-    List<IteratorSetting> tableScanIterators = shellState.iteratorProfiles.get(profile);
-    if (tableScanIterators == null) {
-      tableScanIterators = new ArrayList<>();
-      shellState.iteratorProfiles.put(profile, tableScanIterators);
-    }
+    List<IteratorSetting> tableScanIterators =
+        shellState.iteratorProfiles.computeIfAbsent(profile, k -> new ArrayList<>());
     final IteratorSetting setting = new IteratorSetting(priority, name, classname);
     setting.addOptions(options);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -213,7 +213,8 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           allWalsSeen.add(entry.getKey());
           foundWal = true;
         } else {
-          log.debug("The WalState for {} is {}", entry.getKey(), entry.getValue()); // CLOSED or UNREFERENCED
+          log.debug("The WalState for {} is {}", entry.getKey(), entry.getValue()); // CLOSED or
+                                                                                    // UNREFERENCED
         }
       }
 


### PR DESCRIPTION
Replace common usage patterns of java.util.Map with Java 8 methods such as computeIfAbsent(), putIfAbsent(), etc.