### PR TITLE
Narrow default debug logging to only Accumulo

### DIFF
--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -75,13 +75,16 @@ appender.monitor.filter.threshold.level = warn
 logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = error
 
+logger.accumulo.name = org.apache.accumulo
+logger.accumulo.level = debug
+
 # uncomment for separate audit logs
 #logger.audit.name = org.apache.accumulo.audit
 #logger.audit.level = info
 #logger.audit.additivity = false
 #logger.audit.appenderRef.audit.ref = AuditLogFiles
 
-rootLogger.level = debug
+rootLogger.level = info
 rootLogger.appenderRef.console.ref = STDERR
 rootLogger.appenderRef.rolling.ref = LogFiles
 rootLogger.appenderRef.monitor.ref = MonitorLog

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
@@ -526,7 +526,7 @@ public final class Compression {
             // Somebody returns the compressor to CodecPool but is still using it.
             log.warn("Compressor obtained from CodecPool already finished()");
           } else {
-            log.debug("Got a compressor: {}", compressor.hashCode());
+            log.trace("Got a compressor: {}", compressor.hashCode());
           }
           // The following statement is necessary to get around bugs in 0.18 where a compressor is
           // referenced after it's
@@ -540,7 +540,7 @@ public final class Compression {
 
     public void returnCompressor(final Compressor compressor) {
       if (compressor != null) {
-        log.debug("Return a compressor: {}", compressor.hashCode());
+        log.trace("Return a compressor: {}", compressor.hashCode());
         CodecPool.returnCompressor(compressor);
       }
     }
@@ -554,7 +554,7 @@ public final class Compression {
             // Somebody returns the decompressor to CodecPool but is still using it.
             log.warn("Decompressor obtained from CodecPool already finished()");
           } else {
-            log.debug("Got a decompressor: {}", decompressor.hashCode());
+            log.trace("Got a decompressor: {}", decompressor.hashCode());
           }
           // The following statement is necessary to get around bugs in 0.18 where a decompressor is
           // referenced after
@@ -571,7 +571,7 @@ public final class Compression {
      */
     public void returnDecompressor(final Decompressor decompressor) {
       if (decompressor != null) {
-        log.debug("Returned a decompressor: {}", decompressor.hashCode());
+        log.trace("Returned a decompressor: {}", decompressor.hashCode());
         CodecPool.returnDecompressor(decompressor);
       }
     }


### PR DESCRIPTION
When running 2.1.0-SNAPSHOT locally I am seeing debug logs for lots of dependencies (like Hadoop and Guava) in the tserver logs.  This makes the default configuration unusable for me.  This change narrows the default config to only have debug logging for Accumulo and info for everything else.