### PR TITLE
Support multiple tservers / node in accumulo-service

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -100,45 +100,29 @@ function get_ip() {
   echo "$ip_addr"
 }
 
-function set_last_instance_id() {
-  if [[ "$service" == "tserver" ]]; then
-    last_instance_id=${NUM_TSERVERS:-1}
-  else
-    last_instance_id=1
-  fi
-}
-
-function set_service_instance_if_needed() {
-  if [[ "$service" == "tserver" && ${NUM_TSERVERS:-1} > 1 ]]; then
-    export ACCUMULO_SERVICE_INSTANCE=$inst_id
-    service_instance_cmd="export ACCUMULO_SERVICE_INSTANCE=${inst_id};"
-  else
-    export ACCUMULO_SERVICE_INSTANCE=
-    service_instance_cmd=
-  fi
-}
-
 function control_service() {
-  set_last_instance_id
+  host="$1"
+  service="$2"
+  control_cmd="$3"
+
+  local last_instance_id; last_instance_id=1
+  [[ "$service" == "tserver" ]] && last_instance_id=${NUM_TSERVERS:-1}
 
   for (( inst_id=1; inst_id<=last_instance_id; inst_id++ ))
   do
-    set_service_instance_if_needed
+    ACCUMULO_SERVICE_INSTANCE=""
+    [[ "$service" == "tserver" && ${NUM_TSERVERS:-1} -gt 1 ]] && ACCUMULO_SERVICE_INSTANCE=${inst_id}
 
-    if [[ $host == localhost || $host = "$(hostname -s)" || $host = "$(hostname -f)" || $host = $(get_ip) ]] ; then
-      "${bin}/accumulo-service" "$service" "$control_cmd"
+    if [[ $host == localhost || $host == "$(hostname -s)" || $host == "$(hostname -f)" || $host == $(get_ip) ]] ; then
+      ACCUMULO_SERVICE_INSTANCE="${ACCUMULO_SERVICE_INSTANCE}" "${bin}/accumulo-service" "$service" "$control_cmd"
     else
-      $SSH "$host" "bash -c '${service_instance_cmd} ${bin}/accumulo-service \"$service\" \"$control_cmd\"'"
+      $SSH "$host" "bash -c 'ACCUMULO_SERVICE_INSTANCE=${ACCUMULO_SERVICE_INSTANCE} ${bin}/accumulo-service \"$service\" \"$control_cmd\"'"
     fi
   done
 }
 
 function start_service() {
-  host="$1"
-  service="$2"
-  control_cmd="start"
-
-  control_service
+  control_service "$@" start
 }
 
 function start_tservers() {
@@ -218,11 +202,7 @@ function start_here() {
 }
 
 function end_service() {
-  host="$1"
-  service="$2"
-  control_cmd="$3"
-
-  control_service
+  control_service "$@"
 }
 
 function stop_service() {

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -100,15 +100,45 @@ function get_ip() {
   echo "$ip_addr"
 }
 
+function set_last_instance_id() {
+  if [[ "$service" == "tserver" ]]; then
+    last_instance_id=${NUM_TSERVERS:-1}
+  else
+    last_instance_id=1
+  fi
+}
+
+function set_service_instance_if_needed() {
+  if [[ "$service" == "tserver" && ${NUM_TSERVERS:-1} > 1 ]]; then
+    export ACCUMULO_SERVICE_INSTANCE=$inst_id
+    service_instance_cmd="export ACCUMULO_SERVICE_INSTANCE=${inst_id};"
+  else
+    export ACCUMULO_SERVICE_INSTANCE=
+    service_instance_cmd=
+  fi
+}
+
+function control_service() {
+  set_last_instance_id
+
+  for (( inst_id=1; inst_id<=last_instance_id; inst_id++ ))
+  do
+    set_service_instance_if_needed
+
+    if [[ $host == localhost || $host = "$(hostname -s)" || $host = "$(hostname -f)" || $host = $(get_ip) ]] ; then
+      "${bin}/accumulo-service" "$service" "$control_cmd"
+    else
+      $SSH "$host" "bash -c '${service_instance_cmd} ${bin}/accumulo-service \"$service\" \"$control_cmd\"'"
+    fi
+  done
+}
+
 function start_service() {
   host="$1"
   service="$2"
+  control_cmd="start"
 
-  if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
-    "${bin}/accumulo-service" "$service" start
-  else
-    $SSH "$host" "bash -c '${bin}/accumulo-service \"$service\" start'"
-  fi
+  control_service
 }
 
 function start_tservers() {
@@ -190,12 +220,9 @@ function start_here() {
 function end_service() {
   host="$1"
   service="$2"
-  end_cmd="$3"
-  if [[ $host == localhost || $host = "$(hostname -s)" || $host = "$(hostname -f)" || $host = $(get_ip) ]] ; then
-    "${bin}/accumulo-service" "$service" "$end_cmd"
-  else
-    $SSH "$host" "bash -c '${bin}/accumulo-service \"$service\" \"$end_cmd\"'"
-  fi
+  control_cmd="$3"
+
+  control_service
 }
 
 function stop_service() {

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -71,8 +71,8 @@ function start_service() {
     "${bin}/accumulo" org.apache.accumulo.master.state.SetGoalState NORMAL
   fi
 
-  outfile="${ACCUMULO_LOG_DIR}/${service}_${host}.out"
-  errfile="${ACCUMULO_LOG_DIR}/${service}_${host}.err"
+  outfile="${ACCUMULO_LOG_DIR}/${service}${ACCUMULO_SERVICE_INSTANCE}_${host}.out"
+  errfile="${ACCUMULO_LOG_DIR}/${service}${ACCUMULO_SERVICE_INSTANCE}_${host}.err"
   rotate_log "$outfile"
   rotate_log "$errfile"
 
@@ -137,7 +137,7 @@ function main() {
     host=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
   fi 
   service="$1"
-  pid_file="${ACCUMULO_PID_DIR}/accumulo-${service}.pid"
+  pid_file="${ACCUMULO_PID_DIR}/accumulo-${service}${ACCUMULO_SERVICE_INSTANCE}.pid"
   case "$service" in
     gc|master|monitor|tserver|tracer)
       if [[ -z $2 ]]; then

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -89,6 +89,7 @@ esac
 JAVA_OPTS=("${JAVA_OPTS[@]}"
   "-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
   "-Daccumulo.application=${cmd}${ACCUMULO_SERVICE_INSTANCE}_$(hostname)"
+  "-Daccumulo.metrics.service.instance=${ACCUMULO_SERVICE_INSTANCE}"
   "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
 )
 


### PR DESCRIPTION
If NUM_TSERVERS is defined (typically by adding it in accumulo-env.sh
this modification to accumulo-service enables trivial support for
running more than 1 tserver per node. Of course, the corresponding
changes in accumulo.properties (tserver.port.search and
replication.receipt.service.port) are still needed.