### PR TITLE
Fixes #1464 - SimpleThreadPool for importtable

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -251,6 +251,9 @@ public enum Property {
   MASTER_BULK_RENAME_THREADS("master.bulk.rename.threadpool.size", "20", PropertyType.COUNT,
       "The number of threads to use when moving user files to bulk ingest "
           + "directories under accumulo control"),
+  MASTER_IMPORTTABLE_RENAME_THREADS("master.importtable.rename.threadpool.size", "20",
+      PropertyType.COUNT,
+      "The number of threads to use when renaming user files when importing a table."),
   MASTER_BULK_TSERVER_REGEX("master.bulk.tserver.regex", "", PropertyType.STRING,
       "Regular expression that defines the set of Tablet Servers that will perform bulk imports"),
   MASTER_MINTHREADS("master.server.threads.minimum", "20", PropertyType.COUNT,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -248,6 +248,10 @@ public enum Property {
       "The number of threads to use when coordinating a bulk import."),
   MASTER_BULK_TIMEOUT("master.bulk.timeout", "5m", PropertyType.TIMEDURATION,
       "The time to wait for a tablet server to process a bulk import request"),
+  MASTER_RENAME_THREADS("master.rename.threadpool.size", "20", PropertyType.COUNT,
+      "The number of threads to use when renaming user files during table import or bulk ingest."),
+  @Deprecated
+  @ReplacedBy(property = MASTER_RENAME_THREADS)
   MASTER_BULK_RENAME_THREADS("master.bulk.rename.threadpool.size", "20", PropertyType.COUNT,
       "The number of threads to use when moving user files to bulk ingest "
           + "directories under accumulo control"),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -253,11 +253,8 @@ public enum Property {
   @Deprecated
   @ReplacedBy(property = MASTER_RENAME_THREADS)
   MASTER_BULK_RENAME_THREADS("master.bulk.rename.threadpool.size", "20", PropertyType.COUNT,
-      "The number of threads to use when moving user files to bulk ingest "
+      "This property is deprecated since 2.1.0. The number of threads to use when moving user files to bulk ingest "
           + "directories under accumulo control"),
-  MASTER_IMPORTTABLE_RENAME_THREADS("master.importtable.rename.threadpool.size", "20",
-      PropertyType.COUNT,
-      "The number of threads to use when renaming user files when importing a table."),
   MASTER_BULK_TSERVER_REGEX("master.bulk.tserver.regex", "", PropertyType.STRING,
       "Regular expression that defines the set of Tablet Servers that will perform bulk imports"),
   MASTER_MINTHREADS("master.server.threads.minimum", "20", PropertyType.COUNT,

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/BulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/BulkImport.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationExcepti
 import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.file.FileOperations;
@@ -201,7 +202,10 @@ public class BulkImport extends MasterRepo {
 
     final UniqueNameAllocator namer = master.getUniqueNameAllocator();
 
-    int workerCount = master.getConfiguration().getCount(Property.MASTER_BULK_RENAME_THREADS);
+    AccumuloConfiguration serverConfig = master.getConfiguration();
+    @SuppressWarnings("deprecation")
+    int workerCount = serverConfig.getCount(
+        serverConfig.resolve(Property.MASTER_RENAME_THREADS, Property.MASTER_BULK_RENAME_THREADS));
     SimpleThreadPool workers = new SimpleThreadPool(workerCount, "bulk move");
     List<Future<Exception>> results = new ArrayList<>();
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/MoveExportedFiles.java
@@ -62,8 +62,7 @@ class MoveExportedFiles extends MasterRepo {
   public Repo<Master> call(long tid, Master master) throws Exception {
     String fmtTid = FateTxId.formatTid(tid);
 
-    int workerCount =
-        master.getConfiguration().getCount(Property.MASTER_IMPORTTABLE_RENAME_THREADS);
+    int workerCount = master.getConfiguration().getCount(Property.MASTER_RENAME_THREADS);
     SimpleThreadPool workers = new SimpleThreadPool(workerCount, "importtable rename");
     List<Future<Boolean>> results = new ArrayList<>();
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/MoveExportedFiles.java
@@ -18,17 +18,24 @@
  */
 package org.apache.accumulo.master.tableOps.tableImport;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.util.SimpleThreadPool;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
@@ -53,53 +60,88 @@ class MoveExportedFiles extends MasterRepo {
 
   @Override
   public Repo<Master> call(long tid, Master master) throws Exception {
-    try {
-      VolumeManager fs = master.getVolumeManager();
+    String fmtTid = FateTxId.formatTid(tid);
 
-      Map<String,String> fileNameMappings = PopulateMetadataTable.readMappingFile(fs, tableInfo);
+    int workerCount =
+        master.getConfiguration().getCount(Property.MASTER_IMPORTTABLE_RENAME_THREADS);
+    SimpleThreadPool workers = new SimpleThreadPool(workerCount, "importtable rename");
+    List<Future<Boolean>> results = new ArrayList<>();
 
-      FileStatus[] exportedFiles = fs.listStatus(new Path(tableInfo.exportDir));
-      FileStatus[] importedFiles = fs.listStatus(new Path(tableInfo.importDir));
+    VolumeManager fs = master.getVolumeManager();
 
-      Function<FileStatus,String> fileStatusName = fstat -> fstat.getPath().getName();
+    Map<String,String> fileNameMappings = PopulateMetadataTable.readMappingFile(fs, tableInfo);
 
-      Set<String> importing = Arrays.stream(exportedFiles).map(fileStatusName)
-          .map(fileNameMappings::get).collect(Collectors.toSet());
+    FileStatus[] exportedFiles = fs.listStatus(new Path(tableInfo.exportDir));
+    FileStatus[] importedFiles = fs.listStatus(new Path(tableInfo.importDir));
 
-      Set<String> imported =
-          Arrays.stream(importedFiles).map(fileStatusName).collect(Collectors.toSet());
+    Function<FileStatus,String> fileStatusName = fstat -> fstat.getPath().getName();
 
-      if (log.isDebugEnabled()) {
-        log.debug("Files already present in imported (target) directory: {}",
-            imported.stream().collect(Collectors.joining(",")));
-      }
+    Set<String> importing = Arrays.stream(exportedFiles).map(fileStatusName)
+        .map(fileNameMappings::get).collect(Collectors.toSet());
 
-      Set<String> missingFiles = Sets.difference(new HashSet<String>(fileNameMappings.values()),
-          new HashSet<String>(Sets.union(importing, imported)));
+    Set<String> imported =
+        Arrays.stream(importedFiles).map(fileStatusName).collect(Collectors.toSet());
 
-      if (!missingFiles.isEmpty()) {
-        throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(),
-            tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-            "Missing source files corresponding to files "
-                + missingFiles.stream().collect(Collectors.joining(",")));
-      }
+    if (log.isDebugEnabled()) {
+      log.debug("{} files already present in imported (target) directory: {}", fmtTid,
+          imported.stream().collect(Collectors.joining(",")));
+    }
 
-      for (FileStatus fileStatus : exportedFiles) {
-        String newName = fileNameMappings.get(fileStatus.getPath().getName());
+    Set<String> missingFiles = Sets.difference(new HashSet<String>(fileNameMappings.values()),
+        new HashSet<String>(Sets.union(importing, imported)));
 
-        if (newName != null) {
-          Path newPath = new Path(tableInfo.importDir, newName);
-          log.debug("Renaming file {} to {}", fileStatus.getPath(), newPath);
-          fs.rename(fileStatus.getPath(), newPath);
-        }
-      }
-
-      return new FinishImportTable(tableInfo);
-    } catch (IOException ioe) {
-      log.warn("{}", ioe.getMessage(), ioe);
+    if (!missingFiles.isEmpty()) {
       throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(),
           tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,
-          "Error renaming files " + ioe.getMessage());
+          "Missing source files corresponding to files "
+              + missingFiles.stream().collect(Collectors.joining(",")));
     }
+
+    for (FileStatus fileStatus : exportedFiles) {
+      Path originalPath = fileStatus.getPath();
+      String newName = fileNameMappings.get(originalPath.getName());
+
+      results.add(workers.submit(() -> {
+        boolean success = true;
+
+        // Need to exclude any other files which may be present in the exported directory
+        if (newName != null) {
+          Path newPath = new Path(tableInfo.importDir, newName);
+
+          // No try-catch here, as we do not expect any "benign" exceptions. Prior code already
+          // accounts for files which were already moved. So anything returned by the rename
+          // operation would be truly unexpected
+          success = fs.rename(originalPath, newPath);
+
+          if (!success) {
+            log.error("{} rename operation returned false. orig: {} new: {}", fmtTid, originalPath,
+                newPath);
+          } else if (log.isTraceEnabled()) {
+            log.trace("{} moved {} to {}", fmtTid, originalPath, newPath);
+          }
+        } else {
+          log.debug("{} not moving (unmapped) file {}", fmtTid, originalPath);
+        }
+
+        return success;
+      }));
+    }
+
+    workers.shutdown();
+    while (!workers.awaitTermination(1000L, TimeUnit.MILLISECONDS)) {}
+
+    for (Future<Boolean> future : results) {
+      try {
+        if (!future.get()) {
+          throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(), null,
+              TableOperation.IMPORT, TableOperationExceptionType.OTHER, "Failed to import files");
+        }
+      } catch (ExecutionException ee) {
+        throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(), null,
+            TableOperation.IMPORT, TableOperationExceptionType.OTHER, ee.getCause().getMessage());
+      }
+    }
+
+    return new FinishImportTable(tableInfo);
   }
 }


### PR DESCRIPTION
Improves performance as calls to fs.rename are now made in parallel
from multiple threads within a SimpleThreadPool. Thread pool size is
controlled by new property master.importtable.rename.threadpool.size