### PR TITLE
Refactor use of ServerConfigurationFactory

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -121,7 +121,7 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   @Override
   public Configuration getConfiguration(TableId tableId) {
-    return new ConfigurationImpl(srvCtx.getServerConfFactory().getTableConfiguration(tableId));
+    return new ConfigurationImpl(srvCtx.getTableConfiguration(tableId));
   }
 
   @Override
@@ -138,8 +138,7 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
   @Override
   public <T> T instantiate(TableId tableId, String className, Class<T> base)
       throws ReflectiveOperationException, IOException {
-    String ctx =
-        srvCtx.getServerConfFactory().getTableConfiguration(tableId).get(Property.TABLE_CLASSPATH);
+    String ctx = srvCtx.getTableConfiguration(tableId).get(Property.TABLE_CLASSPATH);
     return ConfigurationTypeHelper.getClassInstance(ctx, className, base);
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -60,7 +60,6 @@ import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
 import org.apache.accumulo.server.security.SecurityOperation;
@@ -310,14 +309,13 @@ public class ClientServiceHandler implements ClientService.Iface {
   @Override
   public Map<String,String> getConfiguration(TInfo tinfo, TCredentials credentials,
       ConfigurationType type) throws TException {
-    ServerConfigurationFactory factory = context.getServerConfFactory();
     switch (type) {
       case CURRENT:
-        return conf(credentials, factory.getSystemConfiguration());
+        return conf(credentials, context.getConfiguration());
       case SITE:
-        return conf(credentials, factory.getSiteConfiguration());
+        return conf(credentials, context.getSiteConfiguration());
       case DEFAULT:
-        return conf(credentials, factory.getDefaultConfiguration());
+        return conf(credentials, context.getDefaultConfiguration());
     }
     throw new RuntimeException("Unexpected configuration type " + type);
   }
@@ -326,7 +324,7 @@ public class ClientServiceHandler implements ClientService.Iface {
   public Map<String,String> getTableConfiguration(TInfo tinfo, TCredentials credentials,
       String tableName) throws TException, ThriftTableOperationException {
     TableId tableId = checkTableId(context, tableName, null);
-    AccumuloConfiguration config = context.getServerConfFactory().getTableConfiguration(tableId);
+    AccumuloConfiguration config = context.getTableConfiguration(tableId);
     return conf(credentials, config);
   }
 
@@ -392,7 +390,7 @@ public class ClientServiceHandler implements ClientService.Iface {
     try {
       shouldMatch = loader.loadClass(interfaceMatch);
 
-      AccumuloConfiguration conf = context.getServerConfFactory().getTableConfiguration(tableId);
+      AccumuloConfiguration conf = context.getTableConfiguration(tableId);
 
       String context = conf.get(Property.TABLE_CLASSPATH);
 
@@ -427,8 +425,7 @@ public class ClientServiceHandler implements ClientService.Iface {
     try {
       shouldMatch = loader.loadClass(interfaceMatch);
 
-      AccumuloConfiguration conf =
-          context.getServerConfFactory().getNamespaceConfiguration(namespaceId);
+      AccumuloConfiguration conf = context.getNamespaceConfiguration(namespaceId);
 
       String context = conf.get(Property.TABLE_CLASSPATH);
 
@@ -489,8 +486,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       throw new ThriftTableOperationException(null, ns, null,
           TableOperationExceptionType.NAMESPACE_NOTFOUND, why);
     }
-    AccumuloConfiguration config =
-        context.getServerConfFactory().getNamespaceConfiguration(namespaceId);
+    AccumuloConfiguration config = context.getNamespaceConfiguration(namespaceId);
     return conf(credentials, config);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ConfigSanityCheck.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ConfigSanityCheck.java
@@ -29,7 +29,7 @@ public class ConfigSanityCheck implements KeywordExecutable {
 
   public static void main(String[] args) {
     try (var context = new ServerContext(SiteConfiguration.auto())) {
-      context.getServerConfFactory().getSystemConfiguration();
+      context.getConfiguration();
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -141,13 +141,6 @@ public class TableConfiguration extends AccumuloConfiguration {
   }
 
   /**
-   * returns the actual NamespaceConfiguration that corresponds to the current parent namespace.
-   */
-  public NamespaceConfiguration getNamespaceConfiguration() {
-    return context.getServerConfFactory().getNamespaceConfiguration(parent.namespaceId);
-  }
-
-  /**
    * Gets the parent configuration of this configuration.
    *
    * @return parent configuration

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
@@ -46,8 +46,7 @@ public class ZooConfiguration extends AccumuloConfiguration {
   private final Map<String,String> fixedProps = Collections.synchronizedMap(new HashMap<>());
   private final String propPathPrefix;
 
-  protected ZooConfiguration(ServerContext context, ZooCache propCache,
-      AccumuloConfiguration parent) {
+  public ZooConfiguration(ServerContext context, ZooCache propCache, AccumuloConfiguration parent) {
     this.context = context;
     this.propCache = propCache;
     this.parent = parent;

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -416,13 +416,12 @@ public class Initialize implements KeywordExecutable {
       // If they did not, fall back to the credentials present in accumulo.properties that the
       // servers will use themselves.
       try {
-        final var siteConf = context.getServerConfFactory().getSiteConfiguration();
-        if (siteConf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
+        if (siteConfig.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
           final UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
           // We don't have any valid creds to talk to HDFS
           if (!ugi.hasKerberosCredentials()) {
-            final String accumuloKeytab = siteConf.get(Property.GENERAL_KERBEROS_KEYTAB),
-                accumuloPrincipal = siteConf.get(Property.GENERAL_KERBEROS_PRINCIPAL);
+            final String accumuloKeytab = siteConfig.get(Property.GENERAL_KERBEROS_KEYTAB),
+                accumuloPrincipal = siteConfig.get(Property.GENERAL_KERBEROS_PRINCIPAL);
 
             // Fail if the site configuration doesn't contain appropriate credentials to login as
             // servers

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -329,15 +329,13 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
   public void init(ServerContext context) {
     super.init(context);
 
-    this.hrtlbConf =
-        context.getServerConfFactory().getSystemConfiguration().newDeriver(HrtlbConf::new);
+    this.hrtlbConf = context.getConfiguration().newDeriver(HrtlbConf::new);
 
     tablesRegExCache =
         CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build(new CacheLoader<>() {
           @Override
           public Deriver<Map<String,String>> load(TableId key) throws Exception {
-            return context.getServerConfFactory().getTableConfiguration(key)
-                .newDeriver(conf -> getRegexes(conf));
+            return context.getTableConfiguration(key).newDeriver(conf -> getRegexes(conf));
           }
         });
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
@@ -63,7 +63,7 @@ public class RegexGroupBalancer extends GroupBalancer {
 
   @Override
   protected long getWaitTime() {
-    Map<String,String> customProps = context.getServerConfFactory().getTableConfiguration(tableId)
+    Map<String,String> customProps = context.getTableConfiguration(tableId)
         .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     if (customProps.containsKey(WAIT_TIME_PROPERTY)) {
       return ConfigurationTypeHelper.getTimeInMillis(customProps.get(WAIT_TIME_PROPERTY));
@@ -75,7 +75,7 @@ public class RegexGroupBalancer extends GroupBalancer {
   @Override
   protected Function<KeyExtent,String> getPartitioner() {
 
-    Map<String,String> customProps = context.getServerConfFactory().getTableConfiguration(tableId)
+    Map<String,String> customProps = context.getTableConfiguration(tableId)
         .getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
     String regex = customProps.get(REGEX_PROPERTY);
     final String defaultGroup = customProps.get(DEFAUT_GROUP_PROPERTY);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -48,8 +48,7 @@ public class TableLoadBalancer extends TabletBalancer {
   private TabletBalancer constructNewBalancerForTable(String clazzName, TableId tableId)
       throws Exception {
     String context = null;
-    context = this.context.getServerConfFactory().getTableConfiguration(tableId)
-        .get(Property.TABLE_CLASSPATH);
+    context = this.context.getTableConfiguration(tableId).get(Property.TABLE_CLASSPATH);
     Class<? extends TabletBalancer> clazz;
     if (context != null && !context.equals(""))
       clazz = AccumuloVFSClassLoader.getContextManager().loadClass(context, clazzName,
@@ -65,8 +64,7 @@ public class TableLoadBalancer extends TabletBalancer {
     if (tableState == null)
       return null;
     if (tableState.equals(TableState.ONLINE))
-      return this.context.getServerConfFactory().getTableConfiguration(table)
-          .get(Property.TABLE_LOAD_BALANCER);
+      return this.context.getTableConfiguration(table).get(Property.TABLE_LOAD_BALANCER);
     return null;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicationUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/ReplicationUtil.java
@@ -124,7 +124,7 @@ public class ReplicationUtil {
         continue;
       }
 
-      TableConfiguration tableConf = context.getServerConfFactory().getTableConfiguration(localId);
+      TableConfiguration tableConf = context.getTableConfiguration(localId);
       if (tableConf == null) {
         log.trace("Could not get configuration for table {} (it no longer exists)", table);
         continue;

--- a/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
@@ -121,13 +121,6 @@ public class LargestFirstMemoryManager implements MemoryManager {
     }
   }
 
-  LargestFirstMemoryManager(long maxMemory, int maxConcurrentMincs, int numWaitingMultiplier) {
-    this();
-    this.maxMemory = maxMemory;
-    this.maxConcurrentMincs = maxConcurrentMincs;
-    this.numWaitingMultiplier = numWaitingMultiplier;
-  }
-
   @Override
   public void init(ServerConfiguration conf) {
     this.config = conf;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/LoginProperties.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/LoginProperties.java
@@ -46,7 +46,7 @@ public class LoginProperties implements KeywordExecutable {
   @Override
   public void execute(String[] args) throws Exception {
     try (var context = new ServerContext(SiteConfiguration.auto())) {
-      AccumuloConfiguration config = context.getServerConfFactory().getSystemConfiguration();
+      AccumuloConfiguration config = context.getConfiguration();
       Authenticator authenticator = AccumuloVFSClassLoader.getClassLoader()
           .loadClass(config.get(Property.INSTANCE_SECURITY_AUTHENTICATOR))
           .asSubclass(Authenticator.class).getDeclaredConstructor().newInstance();

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -54,7 +54,13 @@ public class HostRegexTableLoadBalancerReconfigurationTest
     replay(context1);
     final TestServerConfigurationFactory factory = new TestServerConfigurationFactory(context1);
     ServerContext context2 = createMockContext();
-    expect(context2.getServerConfFactory()).andReturn(factory).anyTimes();
+    expect(context2.getConfiguration()).andReturn(factory.getSystemConfiguration()).anyTimes();
+    expect(context2.getTableConfiguration(FOO.getId()))
+        .andReturn(factory.getTableConfiguration(FOO.getId())).anyTimes();
+    expect(context2.getTableConfiguration(BAR.getId()))
+        .andReturn(factory.getTableConfiguration(BAR.getId())).anyTimes();
+    expect(context2.getTableConfiguration(BAZ.getId()))
+        .andReturn(factory.getTableConfiguration(BAZ.getId())).anyTimes();
     replay(context2);
     init(context2);
     Map<KeyExtent,TServerInstance> unassigned = new HashMap<>();

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
@@ -62,7 +62,13 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
 
   private void initFactory(ServerConfigurationFactory factory) {
     ServerContext context = createMockContext();
-    expect(context.getServerConfFactory()).andReturn(factory).anyTimes();
+    expect(context.getConfiguration()).andReturn(factory.getSystemConfiguration()).anyTimes();
+    expect(context.getTableConfiguration(FOO.getId()))
+        .andReturn(factory.getTableConfiguration(FOO.getId())).anyTimes();
+    expect(context.getTableConfiguration(BAR.getId()))
+        .andReturn(factory.getTableConfiguration(BAR.getId())).anyTimes();
+    expect(context.getTableConfiguration(BAZ.getId()))
+        .andReturn(factory.getTableConfiguration(BAZ.getId())).anyTimes();
     replay(context);
     init(context);
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -99,7 +99,6 @@ import org.apache.accumulo.server.AbstractServer;
 import org.apache.accumulo.server.HighlyAvailableService;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerOpts;
-import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.log.WalStateManager;
 import org.apache.accumulo.server.log.WalStateManager.WalMarkerException;
@@ -275,8 +274,6 @@ public class Master extends AbstractServer
 
   private Future<Void> upgradeMetadataFuture;
 
-  private final ServerConfigurationFactory serverConfig;
-
   private MasterClientServiceHandler clientHandler;
 
   private int assignedOrHosted(TableId tableId) {
@@ -374,9 +371,8 @@ public class Master extends AbstractServer
   Master(ServerOpts opts, String[] args) throws IOException {
     super("master", opts, args);
     ServerContext context = super.getContext();
-    this.serverConfig = context.getServerConfFactory();
 
-    AccumuloConfiguration aconf = serverConfig.getSystemConfiguration();
+    AccumuloConfiguration aconf = context.getConfiguration();
 
     log.info("Version {}", Constants.VERSION);
     log.info("Instance {}", getInstanceID());
@@ -1589,10 +1585,6 @@ public class Master extends AbstractServer
 
   public EventCoordinator getEventCoordinator() {
     return nextEvent;
-  }
-
-  public ServerConfigurationFactory getConfigurationFactory() {
-    return serverConfig;
   }
 
   public VolumeManager getVolumeManager() {

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -211,8 +211,7 @@ abstract class TabletGroupWatcher extends Daemon {
             eventListener.waitForEvents(Master.TIME_TO_WAIT_BETWEEN_SCANS);
           }
           TableId tableId = tls.extent.getTableId();
-          TableConfiguration tableConf =
-              this.master.getConfigurationFactory().getTableConfiguration(tableId);
+          TableConfiguration tableConf = this.master.getContext().getTableConfiguration(tableId);
 
           MergeStats mergeStats = mergeStatsCache.get(tableId);
           if (mergeStats == null) {

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
@@ -115,7 +115,7 @@ public class WorkMaker {
         }
 
         // Get the table configuration for the table specified by the status record
-        tableConf = context.getServerConfFactory().getTableConfiguration(tableId);
+        tableConf = context.getTableConfiguration(tableId);
 
         // getTableConfiguration(String) returns null if the table no longer exists
         if (tableConf == null) {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableExport/WriteExportFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableExport/WriteExportFiles.java
@@ -262,7 +262,7 @@ class WriteExportFiles extends MasterRepo {
     Map<String,String> siteConfig = context.instanceOperations().getSiteConfiguration();
     Map<String,String> systemConfig = context.instanceOperations().getSystemConfiguration();
 
-    TableConfiguration tableConfig = context.getServerConfFactory().getTableConfiguration(tableID);
+    TableConfiguration tableConfig = context.getTableConfiguration(tableID);
 
     OutputStreamWriter osw = new OutputStreamWriter(dataOut, UTF_8);
 

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -306,9 +306,8 @@ public class Upgrader9to10 implements Upgrader {
         long maxTime = -1;
         try (FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
             .forFile(path.toString(), ns, ns.getConf(), context.getCryptoService())
-            .withTableConfiguration(
-                context.getServerConfFactory().getTableConfiguration(RootTable.ID))
-            .seekToBeginning().build()) {
+            .withTableConfiguration(context.getTableConfiguration(RootTable.ID)).seekToBeginning()
+            .build()) {
           while (reader.hasTop()) {
             maxTime = Math.max(maxTime, reader.getTopKey().getTimestamp());
             reader.next();

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -58,7 +58,6 @@ import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.ServerUtil;
-import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.security.SecurityUtil;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
@@ -84,7 +83,6 @@ import org.slf4j.LoggerFactory;
 public class TraceServer implements Watcher, AutoCloseable {
 
   private static final Logger log = LoggerFactory.getLogger(TraceServer.class);
-  private final ServerConfigurationFactory serverConfiguration;
   private final ServerContext context;
   private final TServer server;
   private final AtomicReference<BatchWriter> writer;
@@ -197,10 +195,9 @@ public class TraceServer implements Watcher, AutoCloseable {
 
   public TraceServer(ServerContext context, String hostname) throws Exception {
     this.context = context;
-    this.serverConfiguration = context.getServerConfFactory();
     log.info("Version {}", Constants.VERSION);
     log.info("Instance {}", context.getInstanceID());
-    AccumuloConfiguration conf = serverConfiguration.getSystemConfiguration();
+    AccumuloConfiguration conf = context.getConfiguration();
     tableName = conf.get(Property.TRACE_TABLE);
     accumuloClient = ensureTraceTableExists(conf);
 
@@ -306,8 +303,8 @@ public class TraceServer implements Watcher, AutoCloseable {
   }
 
   public void run() {
-    SimpleTimer.getInstance(serverConfiguration.getSystemConfiguration()).schedule(() -> flush(),
-        SCHEDULE_DELAY, SCHEDULE_PERIOD);
+    SimpleTimer.getInstance(context.getConfiguration()).schedule(() -> flush(), SCHEDULE_DELAY,
+        SCHEDULE_PERIOD);
     server.serve();
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -317,8 +317,7 @@ public class FileManager {
         // log.debug("Opening "+file + " path " + path);
         FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
             .forFile(path.toString(), ns, ns.getConf(), context.getCryptoService())
-            .withTableConfiguration(
-                context.getServerConfFactory().getTableConfiguration(tablet.getTableId()))
+            .withTableConfiguration(context.getTableConfiguration(tablet.getTableId()))
             .withCacheProvider(cacheProvider).withFileLenCache(fileLenCache).build();
         readersReserved.put(reader, file);
       } catch (Exception e) {
@@ -480,7 +479,7 @@ public class FileManager {
       this.tablet = tablet;
       this.cacheProvider = cacheProvider;
 
-      continueOnFailure = context.getServerConfFactory().getTableConfiguration(tablet.getTableId())
+      continueOnFailure = context.getTableConfiguration(tablet.getTableId())
           .getBoolean(Property.TABLE_FAILURES_IGNORE);
 
       if (tablet.isMeta()) {


### PR DESCRIPTION
Divided this PR into 2 commits:
~~1 - Deprecates the init method in MemoryManager that took ServerConfigurationFactory as a parameter.  Replace it with a method that takes ServerContext.  Updated Test to mock ServerContext.~~
2 -  Inline some of the methods of ServerConfigurationFactory into ServerContext to reduce references to it.  Removed sychronization on the methods now they are a part of ServerContext because i don't think its needed since each server should only have one instance.  This is just a first step into eliminating internal use of ServerConfigurationFactory.

Update: Broke out changes to MemoryManager in a separate branch.