### PR TITLE
Skip restricted ports in TServer port search

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 
@@ -225,6 +226,72 @@ public class TServerUtilsTest {
       server = address.getServer();
       assertNotNull(server);
       assertEquals(port[1], address.getAddress().getPort());
+    } finally {
+      if (null != server) {
+        TServerUtils.stopTServer(server);
+      }
+
+    }
+  }
+
+  @SuppressFBWarnings(value = "UNENCRYPTED_SERVER_SOCKET", justification = "socket for testing")
+  @Test
+  public void testStartServerNonDefaultPorts() throws Exception {
+    TServer server = null;
+
+    // This test finds 6 free ports in more-or-less a contiguous way and then
+    // uses those port numbers to Accumulo services in the below (ascending) sequence
+    // 0. TServer default client port (this test binds to this port to force a port search)
+    // 1. GC
+    // 2. Master
+    // 3. Monitor
+    // 4. Master Replication Coordinator
+    // 5. One free port - this is the one that we expect the TServer to finally use
+    int[] ports = findTwoFreeSequentialPorts(1024);
+    int tserverDefaultPort = ports[0];
+    ((ConfigurationCopy) factory.getSystemConfiguration()).set(Property.TSERV_CLIENTPORT,
+        Integer.toString(tserverDefaultPort));
+    int gcPort = ports[1];
+    ((ConfigurationCopy) factory.getSystemConfiguration()).set(Property.GC_PORT,
+        Integer.toString(gcPort));
+
+    ports = findTwoFreeSequentialPorts(gcPort + 1);
+    int masterPort = ports[0];
+    ((ConfigurationCopy) factory.getSystemConfiguration()).set(Property.MASTER_CLIENTPORT,
+        Integer.toString(masterPort));
+    int monitorPort = ports[1];
+    ((ConfigurationCopy) factory.getSystemConfiguration()).set(Property.MONITOR_PORT,
+        Integer.toString(monitorPort));
+
+    ports = findTwoFreeSequentialPorts(monitorPort + 1);
+    int masterReplCoordPort = ports[0];
+    ((ConfigurationCopy) factory.getSystemConfiguration())
+        .set(Property.MASTER_REPLICATION_COORDINATOR_PORT, Integer.toString(masterReplCoordPort));
+    int tserverFinalPort = ports[1];
+
+    ((ConfigurationCopy) factory.getSystemConfiguration()).set(Property.TSERV_PORTSEARCH, "true");
+
+    // Ensure that the TServer client port we set above is NOT in the reserved ports
+    Map<Integer,Property> reservedPorts =
+        TServerUtils.getReservedPorts(factory.getSystemConfiguration());
+    assertTrue(!reservedPorts.keySet().contains(tserverDefaultPort));
+
+    // Ensure that all the ports we assigned (GC, Master, Monitor) are included in the reserved
+    // ports as returned by TServerUtils
+    assertTrue(reservedPorts.keySet().contains(gcPort));
+    assertTrue(reservedPorts.keySet().contains(masterPort));
+    assertTrue(reservedPorts.keySet().contains(monitorPort));
+    assertTrue(reservedPorts.keySet().contains(masterReplCoordPort));
+
+    InetAddress addr = InetAddress.getByName("localhost");
+    try (ServerSocket s = new ServerSocket(tserverDefaultPort, 50, addr)) {
+      ServerAddress address = startServer();
+      assertNotNull(address);
+      server = address.getServer();
+      assertNotNull(server);
+
+      // Finally ensure that the TServer is using the last port (i.e. port search worked)
+      assertTrue(address.getAddress().getPort() == tserverFinalPort);
     } finally {
       if (null != server) {
         TServerUtils.stopTServer(server);


### PR DESCRIPTION
Fixes #1573. Includes debug logging for ports being skipped. This has been tested by running 4 TableServer instances on a single node using Uno. Debug logs added in this PR are below, clearly showing the reserved ports being skipped:
```
2020-03-28T15:04:31,877 [rpc.TServerUtils] WARN : Error attempting to create server at 0.0.0.0:9997. Error: Could not create ServerSocket on address /0.0.0.0:9997.
2020-03-28T15:04:31,883 [rpc.TServerUtils] DEBUG: Adding port 9999 to list of restricted ports
2020-03-28T15:04:31,884 [rpc.TServerUtils] DEBUG: Adding port 10001 to list of restricted ports
2020-03-28T15:04:31,884 [rpc.TServerUtils] DEBUG: Adding port 9997 to list of restricted ports
2020-03-28T15:04:31,884 [rpc.TServerUtils] DEBUG: Adding port 9998 to list of restricted ports
2020-03-28T15:04:31,884 [rpc.TServerUtils] DEBUG: Adding port 9995 to list of restricted ports
2020-03-28T15:04:31,884 [rpc.TServerUtils] DEBUG: Adding port 12234 to list of restricted ports
2020-03-28T15:04:31,886 [rpc.TServerUtils] DEBUG: Adding port 0 to list of restricted ports
2020-03-28T15:04:31,886 [rpc.TServerUtils] DEBUG: During port search, skipping port 9998 as it is reserved for another service
2020-03-28T15:04:31,886 [rpc.TServerUtils] DEBUG: During port search, skipping port 9999 as it is reserved for another service
2020-03-28T15:04:31,886 [rpc.TServerUtils] DEBUG: Instantiating unsecure custom half-async Thrift server
2020-03-28T15:04:31,887 [rpc.TServerUtils] WARN : Error attempting to create server at 0.0.0.0:10000. Error: Could not create ServerSocket on address /0.0.0.0:10000.
2020-03-28T15:04:31,887 [rpc.TServerUtils] INFO : Unable to use port 10000, retrying. (Thread Name = Thrift Client Server)
2020-03-28T15:04:31,887 [rpc.TServerUtils] DEBUG: During port search, skipping port 10001 as it is reserved for another service
2020-03-28T15:04:31,887 [rpc.TServerUtils] DEBUG: Instantiating unsecure custom half-async Thrift server
2020-03-28T15:04:31,887 [rpc.TServerUtils] WARN : Error attempting to create server at 0.0.0.0:10002. Error: Could not create ServerSocket on address /0.0.0.0:10002.
2020-03-28T15:04:31,887 [rpc.TServerUtils] INFO : Unable to use port 10002, retrying. (Thread Name = Thrift Client Server)
2020-03-28T15:04:31,887 [rpc.TServerUtils] DEBUG: Instantiating unsecure custom half-async Thrift server
2020-03-28T15:04:31,909 [tserver.TabletServer] INFO : address = ubdev:10003
```