### PR TITLE
Bump spotbugs to 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -848,7 +848,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>3.1.12.1</version>
+          <version>4.0.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>


### PR DESCRIPTION
Newer spotbugs release uses newer version of asm, required for parsing
class files created with newer JDK versions. Spotbugs 4.0.0 supports at
least Java 13, possibly up to 15.