### PR TITLE
Remove errorprone profile from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1633,40 +1633,6 @@
       </properties>
     </profile>
     <profile>
-      <!-- This profile uses the google errorprone compiler to enforce use of the Override
-      annotation where needed. Auto-generated code is not checked. -->
-      <id>use-errorprone</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <compilerArgs>
-                <arg>-XepDisableAllChecks</arg>
-                <arg>-Xep:MissingOverride:ERROR</arg>
-                <arg>-XepExcludedPaths:.*/(proto|thrift|generated-sources)/.*</arg>
-              </compilerArgs>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>2.3.1</version>
-              </dependency>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>sec-bugs</id>
       <build>
         <plugins>


### PR DESCRIPTION
Removed errorprone profile from pom.xml as it currently does not work with jdks above 8 using maven. May re-introduce in the future if the status changes.