### PR TITLE
Fix #1582 Ignore VSCode IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml
+.vscode/
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -1056,6 +1056,8 @@
               <exclude>nbproject/**</exclude>
               <exclude>nb-configuration.xml</exclude>
               <exclude>nbactions.xml</exclude>
+              <exclude>.vscode/**</exclude>
+              <exclude>.factorypath</exclude>
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
Added VSCode resources to .gitignore and apache-rat excludes (#1582)