### PR TITLE
Use isEmpty() rather than size()/length() checks.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -132,7 +132,7 @@ public class ConfigOpts extends Help {
       System.err.println(errMsg);
       throw new IllegalArgumentException(errMsg);
     }
-    if (getOverrides().size() > 0) {
+    if (!getOverrides().isEmpty()) {
       log.info("The following configuration was set on the command line:");
       for (Map.Entry<String,String> entry : getOverrides().entrySet()) {
         String key = entry.getKey();

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -166,7 +166,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
     @Override
     public void seek(final Range range, final Collection<ByteSequence> columnFamilies,
         final boolean inclusive) throws IOException {
-      if (!inclusive && columnFamilies.size() > 0) {
+      if (!inclusive && !columnFamilies.isEmpty()) {
         throw new IllegalArgumentException();
       }
       scanner.setRange(range);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloOutputFormat.java
@@ -557,7 +557,7 @@ public class AccumuloOutputFormat implements OutputFormat<Text,Mutation> {
           log.error("Not authorized to write to tables : " + tables);
         }
 
-        if (e.getConstraintViolationSummaries().size() > 0) {
+        if (!e.getConstraintViolationSummaries().isEmpty()) {
           log.error("Constraint violations : " + e.getConstraintViolationSummaries().size());
         }
         throw new IOException(e);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloOutputFormat.java
@@ -558,7 +558,7 @@ public class AccumuloOutputFormat extends OutputFormat<Text,Mutation> {
           log.error("Not authorized to write to tables : " + tables);
         }
 
-        if (e.getConstraintViolationSummaries().size() > 0) {
+        if (!e.getConstraintViolationSummaries().isEmpty()) {
           log.error("Constraint violations : " + e.getConstraintViolationSummaries().size());
         }
         throw new IOException(e);

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -189,7 +189,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
     }
 
     this.opts = opts;
-    if (opts.tableConfig != null && opts.tableConfig.size() > 0) {
+    if (opts.tableConfig != null && !opts.tableConfig.isEmpty()) {
       ConfigurationCopy tableCC = new ConfigurationCopy(DefaultConfiguration.getInstance());
       opts.tableConfig.forEach(tableCC::set);
       this.tableConf = tableCC;
@@ -377,7 +377,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
       }
 
       try {
-        if (opts.tableConfig != null && opts.tableConfig.size() > 0) {
+        if (opts.tableConfig != null && !opts.tableConfig.isEmpty()) {
           IterLoad il = IterConfigUtil.loadIterConf(IteratorScope.scan, serverSideIteratorList,
               serverSideIteratorOptions, tableConf);
           iterator = IterConfigUtil.loadIterators(iterator,
@@ -391,7 +391,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
         throw new RuntimeException(e);
       }
 
-      iterator.seek(getRange() == null ? EMPTY_RANGE : getRange(), families, families.size() != 0);
+      iterator.seek(getRange() == null ? EMPTY_RANGE : getRange(), families, !families.isEmpty());
       return new IteratorAdapter(iterator);
 
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
@@ -97,7 +97,7 @@ class RFileWriterBuilder implements RFile.OutputArguments, RFile.WriterFSOptions
     userProps.putAll(summarizerProps);
     userProps.putAll(samplerProps);
 
-    if (userProps.size() > 0) {
+    if (!userProps.isEmpty()) {
       acuconf = new ConfigurationCopy(Iterables.concat(acuconf, userProps.entrySet()));
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -279,7 +279,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
         }
       }
 
-      if (mutations2.size() > 0)
+      if (!mutations2.isEmpty())
         failedMutations.addAll(mutations2);
 
     } else {
@@ -309,7 +309,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
       binnedMutations.clear();
     }
 
-    if (failures.size() > 0)
+    if (!failures.isEmpty())
       queueRetry(failures, null);
 
     binnedMutations.forEach(this::queue);
@@ -340,7 +340,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     // result in bigger batches and less RPC overhead
 
     synchronized (serverQueue) {
-      if (serverQueue.queue.size() > 0)
+      if (!serverQueue.queue.isEmpty())
         threadPool.execute(new LoggingRunnable(log, Trace.wrap(task)));
       else
         serverQueue.taskQueued = false;
@@ -354,7 +354,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     var mutations = new ArrayList<TabletServerMutations<QCMutation>>();
     queue.drainTo(mutations);
 
-    if (mutations.size() == 0)
+    if (mutations.isEmpty())
       return null;
 
     if (mutations.size() == 1) {
@@ -388,7 +388,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     Runnable failureHandler = () -> {
       List<QCMutation> mutations = new ArrayList<>();
       failedMutations.drainTo(mutations);
-      if (mutations.size() > 0)
+      if (!mutations.isEmpty())
         queue(mutations);
     };
 
@@ -412,7 +412,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
       ConditionalMutation mut = mutations.next();
       count++;
 
-      if (mut.getConditions().size() == 0)
+      if (mut.getConditions().isEmpty())
         throw new IllegalArgumentException(
             "ConditionalMutation had no conditions " + new String(mut.getRow(), UTF_8));
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -116,7 +116,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
     List<String> results = new ArrayList<>();
     for (String candidate : cache.getChildren(path)) {
       var children = cache.getChildren(path + "/" + candidate);
-      if (children != null && children.size() > 0) {
+      if (children != null && !children.isEmpty()) {
         var copy = new ArrayList<>(children);
         Collections.sort(copy);
         var data = cache.get(path + "/" + candidate + "/" + copy.get(0));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/MasterClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/MasterClient.java
@@ -58,7 +58,7 @@ public class MasterClient {
 
     List<String> locations = context.getMasterLocations();
 
-    if (locations.size() == 0) {
+    if (locations.isEmpty()) {
       log.debug("No masters...");
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsHelper.java
@@ -171,7 +171,7 @@ public abstract class NamespaceOperationsHelper implements NamespaceOperations {
           }
         }
       }
-      if (optionConflicts.size() > 0)
+      if (!optionConflicts.isEmpty())
         throw new AccumuloException(new IllegalArgumentException(
             "iterator options conflict for " + setting.getName() + ": " + optionConflicts));
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
@@ -146,7 +146,7 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
           SecurityErrorCode.UNSUPPORTED_OPERATION);
     }
 
-    if (Namespaces.getTableIds(context, namespaceId).size() > 0) {
+    if (!Namespaces.getTableIds(context, namespaceId).isEmpty()) {
       throw new NamespaceNotEmptyException(namespaceId.canonical(), namespace, null);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -164,7 +164,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     this.context = context;
     this.range = range;
 
-    if (this.options.fetchedColumns.size() > 0) {
+    if (!this.options.fetchedColumns.isEmpty()) {
       this.range =
           range.bound(this.options.fetchedColumns.first(), this.options.fetchedColumns.last());
     }
@@ -265,7 +265,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
 
     iter = createIterator(tablet.getExtent(), tablet.getFiles());
     iter.seek(range, LocalityGroupUtil.families(options.fetchedColumns),
-        options.fetchedColumns.size() != 0);
+        !options.fetchedColumns.isEmpty());
     currentExtent = tablet.getExtent();
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ReplicationClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ReplicationClient.java
@@ -71,7 +71,7 @@ public class ReplicationClient {
   public static ReplicationCoordinator.Client getCoordinatorConnection(ClientContext context) {
     List<String> locations = context.getMasterLocations();
 
-    if (locations.size() == 0) {
+    if (locations.isEmpty()) {
       log.debug("No masters for replication to instance {}", context.getInstanceName());
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
@@ -80,7 +80,7 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
 
     this.reporter = reporter;
 
-    if (this.options.fetchedColumns.size() > 0) {
+    if (!this.options.fetchedColumns.isEmpty()) {
       range = range.bound(this.options.fetchedColumns.first(), this.options.fetchedColumns.last());
     }
 
@@ -154,7 +154,7 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
         Preconditions.checkState(!closed, "Scanner was closed");
         batch = ThriftScanner.scan(scanState.context, scanState, timeOut);
       }
-    } while (batch != null && batch.size() == 0);
+    } while (batch != null && batch.isEmpty());
 
     if (batch != null) {
       reporter.readBatch(this);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -73,7 +73,7 @@ public class ScannerOptions implements ScannerBase {
   @Override
   public synchronized void addScanIterator(IteratorSetting si) {
     checkArgument(si != null, "si is null");
-    if (serverSideIteratorList.size() == 0) {
+    if (serverSideIteratorList.isEmpty()) {
       serverSideIteratorList = new ArrayList<>();
     }
 
@@ -89,7 +89,7 @@ public class ScannerOptions implements ScannerBase {
 
     serverSideIteratorList.add(new IterInfo(si.getPriority(), si.getIteratorClass(), si.getName()));
 
-    if (serverSideIteratorOptions.size() == 0) {
+    if (serverSideIteratorOptions.isEmpty()) {
       serverSideIteratorOptions = new HashMap<>();
     }
     serverSideIteratorOptions.computeIfAbsent(si.getName(), k -> new HashMap<>())
@@ -100,7 +100,7 @@ public class ScannerOptions implements ScannerBase {
   public synchronized void removeScanIterator(String iteratorName) {
     checkArgument(iteratorName != null, "iteratorName is null");
     // if no iterators are set, we don't have it, so it is already removed
-    if (serverSideIteratorList.size() == 0) {
+    if (serverSideIteratorList.isEmpty()) {
       return;
     }
 
@@ -119,7 +119,7 @@ public class ScannerOptions implements ScannerBase {
     checkArgument(iteratorName != null, "iteratorName is null");
     checkArgument(key != null, "key is null");
     checkArgument(value != null, "value is null");
-    if (serverSideIteratorOptions.size() == 0) {
+    if (serverSideIteratorOptions.isEmpty()) {
       serverSideIteratorOptions = new HashMap<>();
     }
     serverSideIteratorOptions.computeIfAbsent(iteratorName, k -> new HashMap<>()).put(key, value);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
@@ -161,7 +161,7 @@ public abstract class TableOperationsHelper implements TableOperations {
           }
         }
       }
-      if (optionConflicts.size() > 0)
+      if (!optionConflicts.isEmpty())
         throw new AccumuloException(new IllegalArgumentException(
             "iterator options conflict for " + setting.getName() + ": " + optionConflicts));
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
@@ -194,7 +194,7 @@ public class TabletLocatorImpl extends TabletLocator {
       rLock.unlock();
     }
 
-    if (notInCache.size() > 0) {
+    if (!notInCache.isEmpty()) {
       Collections.sort(notInCache, (o1, o2) -> WritableComparator.compareBytes(o1.getRow(), 0,
           o1.getRow().length, o2.getRow(), 0, o2.getRow().length));
 
@@ -356,7 +356,7 @@ public class TabletLocatorImpl extends TabletLocator {
       rLock.unlock();
     }
 
-    if (failures.size() > 0) {
+    if (!failures.isEmpty()) {
       // sort failures by range start key
       Collections.sort(failures);
 
@@ -567,7 +567,7 @@ public class TabletLocatorImpl extends TabletLocator {
       er = MAX_TEXT;
     metaCache.put(er, tabletLocation);
 
-    if (badExtents.size() > 0)
+    if (!badExtents.isEmpty())
       removeOverlapping(badExtents, tabletLocation.tablet_extent);
   }
 
@@ -683,7 +683,7 @@ public class TabletLocatorImpl extends TabletLocator {
   private void processInvalidated(ClientContext context, LockCheckerSession lcSession)
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException {
 
-    if (badExtents.size() == 0)
+    if (badExtents.isEmpty())
       return;
 
     final boolean writeLockHeld = rwLock.isWriteLockedByCurrentThread();
@@ -691,7 +691,7 @@ public class TabletLocatorImpl extends TabletLocator {
       if (!writeLockHeld) {
         rLock.unlock();
         wLock.lock();
-        if (badExtents.size() == 0)
+        if (badExtents.isEmpty())
           return;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -91,7 +91,7 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
 
   @Override
   public void setRanges(Collection<Range> ranges) {
-    if (ranges == null || ranges.size() == 0) {
+    if (ranges == null || ranges.isEmpty()) {
       throw new IllegalArgumentException("ranges must be non null and contain at least 1 range");
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -125,7 +125,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     timedoutServers = Collections.synchronizedSet(new HashSet<>());
     this.timeout = timeout;
 
-    if (options.fetchedColumns.size() > 0) {
+    if (!options.fetchedColumns.isEmpty()) {
       ArrayList<Range> ranges2 = new ArrayList<>(ranges.size());
       for (Range range : ranges) {
         ranges2.add(range.bound(options.fetchedColumns.first(), options.fetchedColumns.last()));
@@ -235,7 +235,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       binnedRanges.clear();
       List<Range> failures = tabletLocator.binRanges(context, ranges, binnedRanges);
 
-      if (failures.size() > 0) {
+      if (!failures.isEmpty()) {
         // tried to only do table state checks when failures.size() == ranges.size(), however this
         // did
         // not work because nothing ever invalidated entries in the tabletLocator cache... so even
@@ -360,7 +360,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         }
         doLookup(context, tsLocation, tabletsRanges, tsFailures, unscanned, receiver, columns,
             options, authorizations, timeoutTracker);
-        if (tsFailures.size() > 0) {
+        if (!tsFailures.isEmpty()) {
           locator.invalidateCache(tsFailures.keySet());
           synchronized (failures) {
             failures.putAll(tsFailures);
@@ -399,7 +399,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         Thread.currentThread().setName(threadName);
         if (semaphore.tryAcquire(semaphoreSize)) {
           // finished processing all queries
-          if (fatalException == null && failures.size() > 0) {
+          if (fatalException == null && !failures.isEmpty()) {
             // there were some failures
             try {
               processFailures(failures, receiver, columns);
@@ -475,7 +475,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     Map<KeyExtent,List<Range>> failures = new HashMap<>();
 
-    if (timedoutServers.size() > 0) {
+    if (!timedoutServers.isEmpty()) {
       // go ahead and fail any timed out servers
       for (Iterator<Entry<String,Map<KeyExtent,List<Range>>>> iterator =
           binnedRanges.entrySet().iterator(); iterator.hasNext();) {
@@ -512,7 +512,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
           }
         }
 
-        if (tabletSubset.size() > 0) {
+        if (!tabletSubset.isEmpty()) {
           QueryTask queryTask =
               new QueryTask(tsLocation, tabletSubset, failures, receiver, columns);
           queryTasks.add(queryTask);
@@ -630,7 +630,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       Authorizations authorizations, TimeoutTracker timeoutTracker)
       throws IOException, AccumuloSecurityException, AccumuloServerException {
 
-    if (requested.size() == 0) {
+    if (requested.isEmpty()) {
       return;
     }
 
@@ -674,7 +674,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
             Translators.KET, new Translator.ListTranslator<>(Translators.RT));
 
         Map<String,String> execHints =
-            options.executionHints.size() == 0 ? null : options.executionHints;
+            options.executionHints.isEmpty() ? null : options.executionHints;
 
         InitialMultiScan imsr = client.startMultiScan(TraceUtil.traceInfo(), context.rpcCreds(),
             thriftTabletRanges, Translator.translate(columns, Translators.CT),
@@ -700,10 +700,10 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
           entries.add(new SimpleImmutableEntry<>(new Key(kv.key), new Value(kv.value)));
         }
 
-        if (entries.size() > 0)
+        if (!entries.isEmpty())
           receiver.receive(entries);
 
-        if (entries.size() > 0 || scanResult.fullScans.size() > 0)
+        if (!entries.isEmpty() || !scanResult.fullScans.isEmpty())
           timeoutTracker.madeProgress();
 
         trackScanning(failures, unscanned, scanResult);
@@ -735,10 +735,10 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
             entries.add(new SimpleImmutableEntry<>(new Key(kv.key), new Value(kv.value)));
           }
 
-          if (entries.size() > 0)
+          if (!entries.isEmpty())
             receiver.receive(entries);
 
-          if (entries.size() > 0 || scanResult.fullScans.size() > 0)
+          if (!entries.isEmpty() || !scanResult.fullScans.isEmpty())
             timeoutTracker.madeProgress();
 
           trackScanning(failures, unscanned, scanResult);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -477,7 +477,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
   // BEGIN code for handling unrecoverable errors
 
   private void updatedConstraintViolations(List<ConstraintViolationSummary> cvsList) {
-    if (cvsList.size() > 0) {
+    if (!cvsList.isEmpty()) {
       synchronized (this) {
         somethingFailed = true;
         violations.add(cvsList);
@@ -495,7 +495,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
   }
 
   private void updateAuthorizationFailures(Map<KeyExtent,SecurityErrorCode> authorizationFailures) {
-    if (authorizationFailures.size() > 0) {
+    if (!authorizationFailures.isEmpty()) {
 
       // was a table deleted?
       HashSet<TableId> tableIds = new HashSet<>();
@@ -677,7 +677,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
             ArrayList<Mutation> tableFailures = new ArrayList<>();
             locator.binMutations(context, tableMutations, binnedMutations, tableFailures);
 
-            if (tableFailures.size() > 0) {
+            if (!tableFailures.isEmpty()) {
               failedMutations.add(tableId, tableFailures);
 
               if (tableFailures.size() == tableMutations.size())
@@ -887,7 +887,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
     private MutationSet sendMutationsToTabletServer(String location,
         Map<KeyExtent,List<Mutation>> tabMuts, TimeoutTracker timeoutTracker)
         throws IOException, AccumuloSecurityException, AccumuloServerException {
-      if (tabMuts.size() == 0) {
+      if (tabMuts.isEmpty()) {
         return new MutationSet();
       }
       TInfo tinfo = TraceUtil.traceInfo();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletType.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletType.java
@@ -34,7 +34,7 @@ public enum TabletType {
   }
 
   public static TabletType type(Collection<KeyExtent> extents) {
-    if (extents.size() == 0)
+    if (extents.isEmpty())
       throw new IllegalArgumentException();
 
     TabletType ttype = null;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -215,7 +215,7 @@ public class ThriftScanner {
 
       this.batchTimeOut = batchTimeOut;
 
-      if (executionHints == null || executionHints.size() == 0)
+      if (executionHints == null || executionHints.isEmpty())
         this.executionHints = null; // avoid thrift serialization for empty map
       else
         this.executionHints = executionHints;
@@ -408,7 +408,7 @@ public class ThriftScanner {
         }
       }
 
-      if (results != null && results.size() == 0 && scanState.finished) {
+      if (results != null && results.isEmpty() && scanState.finished) {
         results = null;
       }
 
@@ -536,7 +536,7 @@ public class ThriftScanner {
 
       Key.decompress(sr.results);
 
-      if (sr.results.size() > 0 && !scanState.finished)
+      if (!sr.results.isEmpty() && !scanState.finished)
         scanState.range = new Range(new Key(sr.results.get(sr.results.size() - 1).key), false,
             scanState.range.getEndKey(), scanState.range.isEndKeyInclusive());
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -691,7 +691,7 @@ public class ThriftTransportPool {
       // randomly pick a server from the connection cache
       serversSet.retainAll(pool.getThriftTransportKeys());
 
-      if (serversSet.size() > 0) {
+      if (!serversSet.isEmpty()) {
         ArrayList<ThriftTransportKey> cachedServers = new ArrayList<>(serversSet);
         Collections.shuffle(cachedServers, random);
 
@@ -709,7 +709,7 @@ public class ThriftTransportPool {
 
     ConnectionPool pool = getConnectionPool();
     int retryCount = 0;
-    while (servers.size() > 0 && retryCount < 10) {
+    while (!servers.isEmpty() && retryCount < 10) {
 
       int index = random.nextInt(servers.size());
       ThriftTransportKey ttk = servers.get(index);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
@@ -733,7 +733,7 @@ public class InputConfigurator extends ConfiguratorBase {
         getInputTableConfigs(implementingClass, conf);
     try {
       AccumuloClient client = client(implementingClass, conf);
-      if (getInputTableConfigs(implementingClass, conf).size() == 0)
+      if (getInputTableConfigs(implementingClass, conf).isEmpty())
         throw new IOException("No table set.");
 
       String principal = getPrincipal(implementingClass, conf);

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientConfigGenerate.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientConfigGenerate.java
@@ -107,7 +107,7 @@ class ClientConfigGenerate {
       doc.print("| <a name=\"" + prop.getKey().replace(".", "_") + "\" class=\"prop\"></a> "
           + prop.getKey() + " | ");
       String defaultValue = sanitize(prop.getDefaultValue()).trim();
-      if (defaultValue.length() == 0) {
+      if (defaultValue.isEmpty()) {
         defaultValue = "*empty*";
       }
       doc.println(

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
@@ -93,7 +93,7 @@ class ConfigurationDocGen {
     doc.print(strike("**type:** " + prop.getType().name(), depr) + ", ");
     doc.print(strike("**zk mutable:** " + isZooKeeperMutable(prop), depr) + ", ");
     String defaultValue = sanitize(prop.getDefaultValue()).trim();
-    if (defaultValue.length() == 0) {
+    if (defaultValue.isEmpty()) {
       defaultValue = strike("**default value:** empty", depr);
     } else if (defaultValue.contains("\n")) {
       // deal with multi-line values, skip strikethrough of value

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
@@ -146,7 +146,7 @@ public class ConfigurationTypeHelper {
    * @return interpreted fraction as a decimal value
    */
   public static double getFraction(String str) {
-    if (str.length() > 0 && str.charAt(str.length() - 1) == '%')
+    if (!str.isEmpty() && str.charAt(str.length() - 1) == '%')
       return Double.parseDouble(str.substring(0, str.length() - 1)) / 100.0;
     return Double.parseDouble(str);
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -230,7 +230,7 @@ public enum PropertyType {
       }
       try {
         double d;
-        if (input.length() > 0 && input.charAt(input.length() - 1) == '%') {
+        if (!input.isEmpty() && input.charAt(input.length() - 1) == '%') {
           d = Double.parseDouble(input.substring(0, input.length() - 1));
         } else {
           d = Double.parseDouble(input);

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -1205,7 +1205,7 @@ public class Key implements WritableComparable<Key>, Cloneable {
 
     List<TKeyValue> tkvl = Arrays.asList(new TKeyValue[param.size()]);
 
-    if (param.size() > 0)
+    if (!param.isEmpty())
       tkvl.set(0, new TKeyValue(param.get(0).getKey().toThrift(),
           ByteBuffer.wrap(param.get(0).getValue().get())));
 

--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -451,7 +451,7 @@ public class Range implements WritableComparable<Range> {
    * @return list of merged ranges
    */
   public static List<Range> mergeOverlapping(Collection<Range> ranges) {
-    if (ranges.size() == 0)
+    if (ranges.isEmpty())
       return Collections.emptyList();
     if (ranges.size() == 1)
       return Collections.singletonList(ranges.iterator().next());

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
@@ -235,7 +235,7 @@ public final class TinyLfuBlockCache implements BlockCache {
   public CacheEntry getBlock(String blockName, Loader loader) {
     Map<String,Loader> deps = loader.getDependencies();
     Block block;
-    if (deps.size() == 0) {
+    if (deps.isEmpty()) {
       block = cache.get(blockName, k -> load(loader, Collections.emptyMap()));
     } else {
       // This code path exist to handle the case where dependencies may need to be loaded. Loading

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -575,7 +575,7 @@ public class MultiLevelIndex {
 
       out.writeInt(totalAdded);
       // save root node
-      if (levels.size() > 0) {
+      if (!levels.isEmpty()) {
         levels.get(levels.size() - 1).write(out);
       } else {
         new IndexBlock(0, 0).write(out);

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -202,7 +202,7 @@ public class RFile {
     public void updateColumnCount(Key key) {
 
       if (isDefaultLG && columnFamilies == null) {
-        if (previousColumnFamilies.size() > 0) {
+        if (!previousColumnFamilies.isEmpty()) {
           // only do this check when there are previous column families
           ByteSequence cf = key.getColumnFamilyData();
           if (previousColumnFamilies.contains(cf)) {
@@ -409,7 +409,7 @@ public class RFile {
         // called with true
         List<SampleEntry> subList = entries.subList(0, entries.size() - 1);
 
-        if (subList.size() > 0) {
+        if (!subList.isEmpty()) {
           for (SampleEntry se : subList) {
             lgr.append(se.key, se.val);
           }
@@ -887,7 +887,7 @@ public class RFile {
       if (closed)
         throw new IllegalStateException("Locality group reader closed");
 
-      if (columnFamilies.size() != 0 || inclusive)
+      if (!columnFamilies.isEmpty() || inclusive)
         throw new IllegalArgumentException("I do not know how to filter column families");
 
       if (interruptFlag != null && interruptFlag.get()) {
@@ -1486,7 +1486,7 @@ public class RFile {
         lgm.printInfo(false, includeIndexDetails);
       }
 
-      if (sampleGroups.size() > 0) {
+      if (!sampleGroups.isEmpty()) {
 
         System.out.println();
         System.out.printf("%-24s :\n", "Sample Configuration");
@@ -1505,7 +1505,7 @@ public class RFile {
       if (deepCopy)
         throw new RuntimeException("Calling setInterruptFlag on a deep copy is not supported");
 
-      if (deepCopies.size() != 0)
+      if (!deepCopies.isEmpty())
         throw new RuntimeException("Setting interrupt flag after calling deep copy not supported");
 
       setInterruptFlagInternal(flag);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -285,7 +285,7 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
       throw new IllegalArgumentException("Must specify " + COLUMNS_OPTION + " option");
 
     String encodedColumns = options.get(COLUMNS_OPTION);
-    if (encodedColumns.length() == 0)
+    if (encodedColumns.isEmpty())
       throw new IllegalArgumentException("The " + COLUMNS_OPTION + " must not be empty");
 
     combiners = new ColumnSet(Lists.newArrayList(Splitter.on(",").split(encodedColumns)));
@@ -356,7 +356,7 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
           "options must include " + ALL_OPTION + " or " + COLUMNS_OPTION);
 
     String encodedColumns = options.get(COLUMNS_OPTION);
-    if (encodedColumns.length() == 0)
+    if (encodedColumns.isEmpty())
       throw new IllegalArgumentException("empty columns specified in option " + COLUMNS_OPTION);
 
     for (String columns : Splitter.on(",").split(encodedColumns)) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/LargeRowFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/LargeRowFilter.java
@@ -116,7 +116,7 @@ public class LargeRowFilter implements SortedKeyValueIterator<Key,Value>, Option
     values.clear();
     currentPosition = 0;
 
-    while (source.hasTop() && keys.size() == 0) {
+    while (source.hasTop() && keys.isEmpty()) {
 
       addKeyValue(source.getTopKey(), source.getTopValue());
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
@@ -220,7 +220,7 @@ public class SummingArrayCombiner extends TypedValueCombiner<List<Long>> {
   public static class StringArrayEncoder extends AbstractEncoder<List<Long>> {
     @Override
     public byte[] encode(List<Long> la) {
-      if (la.size() == 0)
+      if (la.isEmpty())
         return new byte[] {};
       StringBuilder sb = new StringBuilder(Long.toString(la.get(0)));
       for (int i = 1; i < la.size(); i++) {
@@ -242,7 +242,7 @@ public class SummingArrayCombiner extends TypedValueCombiner<List<Long>> {
       String[] longstrs = new String(b, offset, len, UTF_8).split(",");
       List<Long> la = new ArrayList<>(longstrs.length);
       for (String s : longstrs) {
-        if (s.length() == 0)
+        if (s.isEmpty())
           la.add(0L);
         else
           try {

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
@@ -66,14 +66,14 @@ public class ColumnSet {
 
   public boolean contains(Key key) {
     // lookup column family and column qualifier
-    if (objectsCol.size() > 0) {
+    if (!objectsCol.isEmpty()) {
       lookupCol.set(key);
       if (objectsCol.contains(lookupCol))
         return true;
     }
 
     // lookup just column family
-    if (objectsCF.size() > 0) {
+    if (!objectsCF.isEmpty()) {
       lookupCF.set(key);
       return objectsCF.contains(lookupCF);
     }
@@ -82,7 +82,7 @@ public class ColumnSet {
   }
 
   public boolean isEmpty() {
-    return objectsCol.size() == 0 && objectsCF.size() == 0;
+    return objectsCol.isEmpty() && objectsCF.isEmpty();
   }
 
   public static String encodeColumns(Text columnFamily, Text columnQualifier) {

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnToClassMapping.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnToClassMapping.java
@@ -87,7 +87,7 @@ public class ColumnToClassMapping<K> {
     K obj = null;
 
     // lookup column family and column qualifier
-    if (objectsCol.size() > 0) {
+    if (!objectsCol.isEmpty()) {
       lookupCol.set(key);
       obj = objectsCol.get(lookupCol);
       if (obj != null) {
@@ -96,7 +96,7 @@ public class ColumnToClassMapping<K> {
     }
 
     // lookup just column family
-    if (objectsCF.size() > 0) {
+    if (!objectsCF.isEmpty()) {
       lookupCF.set(key);
       obj = objectsCF.get(lookupCF);
     }
@@ -105,6 +105,6 @@ public class ColumnToClassMapping<K> {
   }
 
   public boolean isEmpty() {
-    return objectsCol.size() == 0 && objectsCF.size() == 0;
+    return objectsCol.isEmpty() && objectsCF.isEmpty();
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnFamilySkippingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnFamilySkippingIterator.java
@@ -79,7 +79,7 @@ public class ColumnFamilySkippingIterator extends ServerSkippingIterator
           count = 0;
         }
       }
-    else if (colFamSet != null && colFamSet.size() > 0)
+    else if (colFamSet != null && !colFamSet.isEmpty())
       while (source.hasTop() && colFamSet.contains(source.getTopKey().getColumnFamilyData())) {
         if (count < 10) {
           source.next();

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/LocalityGroupIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/LocalityGroupIterator.java
@@ -164,7 +164,7 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
     hiter.clear();
 
     Set<ByteSequence> cfSet;
-    if (columnFamilies.size() > 0) {
+    if (!columnFamilies.isEmpty()) {
       if (columnFamilies instanceof Set<?>) {
         cfSet = (Set<ByteSequence>) columnFamilies;
       } else {
@@ -179,7 +179,7 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
     Collection<LocalityGroup> groups = Collections.emptyList();
 
     // if no column families specified, then include all groups unless !inclusive
-    if (cfSet.size() == 0) {
+    if (cfSet.isEmpty()) {
       if (!inclusive) {
         groups = lgContext.groups;
       }

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MapFileIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MapFileIterator.java
@@ -87,7 +87,7 @@ public class MapFileIterator implements FileSKVIterator {
   @Override
   public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
       throws IOException {
-    if (columnFamilies.size() != 0 || inclusive) {
+    if (!columnFamilies.isEmpty() || inclusive) {
       throw new IllegalArgumentException("I do not know how to filter column families");
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
@@ -192,7 +192,7 @@ public class MetadataLocationObtainer implements TabletLocationObtainer {
     try {
       TabletServerBatchReaderIterator.doLookup(context, tserver, tabletsRanges, failures, unscanned,
           rr, columns, opts, Authorizations.EMPTY);
-      if (failures.size() > 0) {
+      if (!failures.isEmpty()) {
         // invalidate extents in parents cache
         if (log.isTraceEnabled())
           log.trace("lookupTablets failed for {} extents", failures.size());

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
@@ -111,7 +111,7 @@ abstract class TableMetadataServicer extends MetadataServicer {
     SortedSet<KeyExtent> tabletsKeys = (SortedSet<KeyExtent>) tablets.keySet();
     // sanity check of metadata table entries
     // make sure tablets has no holes, and that it starts and ends w/ null
-    if (tabletsKeys.size() == 0)
+    if (tabletsKeys.isEmpty())
       throw new AccumuloException(
           "No entries found in metadata table for table " + getServicedTableId());
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -114,7 +114,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
           col.fetch(scanner);
         }
 
-        if (families.size() == 0 && qualifiers.size() == 0) {
+        if (families.isEmpty() && qualifiers.isEmpty()) {
           fetchedCols = EnumSet.allOf(ColumnType.class);
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -157,7 +157,7 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
     if (authsString.startsWith(HEADER)) {
       // it's the new format
       authsString = authsString.substring(HEADER.length());
-      if (authsString.length() > 0) {
+      if (!authsString.isEmpty()) {
         for (String encAuth : authsString.split(",")) {
           byte[] auth = Base64.getDecoder().decode(encAuth);
           auths.add(new ArrayByteSequence(auth));

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -312,7 +312,7 @@ public class Gatherer {
         client = ThriftUtil.getTServerClient(location, ctx);
         // partition files into smaller chunks so that not too many are sent to a tserver at once
         for (Map<TabletFile,List<TRowRange>> files : partition(allFiles, 500)) {
-          if (pfiles.failedFiles.size() > 0) {
+          if (!pfiles.failedFiles.isEmpty()) {
             // there was a previous failure on this tserver, so just fail the rest of the files
             pfiles.failedFiles.addAll(files.keySet());
             continue;
@@ -419,7 +419,7 @@ public class Gatherer {
       if (future.isDone()) {
         if (!future.isCancelled() && !future.isCompletedExceptionally()) {
           ProcessedFiles pf = _get();
-          if (pf.failedFiles.size() > 0) {
+          if (!pf.failedFiles.isEmpty()) {
             initiateProcessing(pf);
           }
         }
@@ -456,7 +456,7 @@ public class Gatherer {
         }
 
         ProcessedFiles pf = _get();
-        if (pf.failedFiles.size() == 0) {
+        if (pf.failedFiles.isEmpty()) {
           return true;
         } else {
           updateFuture();
@@ -470,7 +470,7 @@ public class Gatherer {
     public SummaryCollection get() throws InterruptedException, ExecutionException {
       CompletableFuture<ProcessedFiles> futureRef = updateFuture();
       ProcessedFiles processedFiles = futureRef.get();
-      while (processedFiles.failedFiles.size() > 0) {
+      while (!processedFiles.failedFiles.isEmpty()) {
         futureRef = updateFuture();
         processedFiles = futureRef.get();
       }
@@ -487,7 +487,7 @@ public class Gatherer {
       ProcessedFiles processedFiles = futureRef.get(Long.max(1, nanosLeft), TimeUnit.NANOSECONDS);
       t2 = System.nanoTime();
       nanosLeft -= (t2 - t1);
-      while (processedFiles.failedFiles.size() > 0) {
+      while (!processedFiles.failedFiles.isEmpty()) {
         futureRef = updateFuture();
         t1 = System.nanoTime();
         processedFiles = futureRef.get(Long.max(1, nanosLeft), TimeUnit.NANOSECONDS);

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarizerConfigurationUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarizerConfigurationUtil.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.dataImpl.thrift.TSummarizerConfiguration;
 public class SummarizerConfigurationUtil {
 
   public static Map<String,String> toTablePropertiesMap(List<SummarizerConfiguration> summarizers) {
-    if (summarizers.size() == 0) {
+    if (summarizers.isEmpty()) {
       return Collections.emptyMap();
     }
 
@@ -84,7 +84,7 @@ public class SummarizerConfigurationUtil {
 
   private static List<SummarizerConfiguration>
       getSummarizerConfigsFiltered(SortedMap<String,String> sprops) {
-    if (sprops.size() == 0) {
+    if (sprops.isEmpty()) {
       return Collections.emptyList();
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryCollection.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryCollection.java
@@ -108,7 +108,7 @@ public class SummaryCollection {
 
   SummaryCollection(Collection<FileSummary> initialEntries, boolean deleted) {
     if (deleted) {
-      Preconditions.checkArgument(initialEntries.size() == 0);
+      Preconditions.checkArgument(initialEntries.isEmpty());
     }
     mergedSummaries = new HashMap<>();
     for (FileSummary entry : initialEntries) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryWriter.java
@@ -148,7 +148,7 @@ public class SummaryWriter implements FileSKVWriter {
     List<SummarizerConfiguration> configs =
         SummarizerConfigurationUtil.getSummarizerConfigs(tableConfig);
 
-    if (configs.size() == 0) {
+    if (configs.isEmpty()) {
       return writer;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/CompletableFutureUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CompletableFutureUtil.java
@@ -30,7 +30,7 @@ public class CompletableFutureUtil {
   // results of their children when complete
   public static <T> CompletableFuture<T> merge(List<CompletableFuture<T>> futures,
       BiFunction<T,T,T> mergeFunc, Supplier<T> nothing) {
-    if (futures.size() == 0) {
+    if (futures.isEmpty()) {
       return CompletableFuture.completedFuture(nothing.get());
     }
     while (futures.size() > 1) {

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -70,7 +70,7 @@ public class LocalityGroupUtil {
    * @return An immutable set of columns
    */
   public static Set<ByteSequence> families(Collection<Column> columns) {
-    if (columns.size() == 0) {
+    if (columns.isEmpty()) {
       return EMPTY_CF_SET;
     }
     var builder = ImmutableSet.<ByteSequence>builder();
@@ -115,7 +115,7 @@ public class LocalityGroupUtil {
     Map<String,Set<ByteSequence>> result = new HashMap<>();
     String[] groups = acuconf.get(Property.TABLE_LOCALITY_GROUPS).split(",");
     for (String group : groups) {
-      if (group.length() > 0) {
+      if (!group.isEmpty()) {
         result.put(group, new HashSet<>());
       }
     }

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -404,8 +404,8 @@ public class AdminUtil<T> {
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
 
-    if (fateStatus.getDanglingHeldLocks().size() != 0
-        || fateStatus.getDanglingWaitingLocks().size() != 0) {
+    if (!fateStatus.getDanglingHeldLocks().isEmpty()
+        || !fateStatus.getDanglingWaitingLocks().isEmpty()) {
       fmt.format("%nThe following locks did not have an associated FATE operation%n");
       for (Entry<String,List<String>> entry : fateStatus.getDanglingHeldLocks().entrySet())
         fmt.format("txid: %s  locked: %s%n", entry.getKey(), entry.getValue());

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -142,7 +142,7 @@ public class ZooStore<T> implements TStore<T> {
         Collections.sort(txdirs);
 
         synchronized (this) {
-          if (txdirs.size() > 0 && txdirs.get(txdirs.size() - 1).compareTo(lastReserved) <= 0)
+          if (!txdirs.isEmpty() && txdirs.get(txdirs.size() - 1).compareTo(lastReserved) <= 0)
             lastReserved = "";
         }
 
@@ -191,7 +191,7 @@ public class ZooStore<T> implements TStore<T> {
         synchronized (this) {
           // suppress lgtm alert - synchronized variable is not always true
           if (events == statusChangeEvents) { // lgtm [java/constant-comparison]
-            if (defered.size() > 0) {
+            if (!defered.isEmpty()) {
               Long minTime = Collections.min(defered.values());
               long waitTime = minTime - System.currentTimeMillis();
               if (waitTime > 0)

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -566,7 +566,7 @@ public class ZooCache {
 
     List<String> children = getChildren(path);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       return null;
     }
 

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
@@ -414,7 +414,7 @@ public class ZooLock implements Watcher {
 
     List<String> children = zc.getChildren(lid.path);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       return false;
     }
 
@@ -433,7 +433,7 @@ public class ZooLock implements Watcher {
       throws KeeperException, InterruptedException {
     List<String> children = zk.getChildren(path, false);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       return null;
     }
 
@@ -449,7 +449,7 @@ public class ZooLock implements Watcher {
 
     List<String> children = zc.getChildren(path);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       return null;
     }
 
@@ -468,7 +468,7 @@ public class ZooLock implements Watcher {
   public static long getSessionId(ZooCache zc, String path) {
     List<String> children = zc.getChildren(path);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       return 0;
     }
 
@@ -495,7 +495,7 @@ public class ZooLock implements Watcher {
 
     children = zk.getChildren(path);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       throw new IllegalStateException("No lock is held at " + path);
     }
 
@@ -517,7 +517,7 @@ public class ZooLock implements Watcher {
 
     children = zk.getChildren(path);
 
-    if (children == null || children.size() == 0) {
+    if (children == null || children.isEmpty()) {
       throw new IllegalStateException("No lock is held at " + path);
     }
 

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooReaderWriter.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooReaderWriter.java
@@ -404,7 +404,7 @@ public class ZooReaderWriter extends ZooReader {
       try {
         List<String> children = getZooKeeper().getChildren(lockID.path, false);
 
-        if (children.size() == 0) {
+        if (children.isEmpty()) {
           return false;
         }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -480,7 +480,7 @@ public class TabletLocatorImplTest {
         }
       }
 
-      if (failures.size() > 0)
+      if (!failures.isEmpty())
         parent.invalidateCache(failures);
 
       return MetadataLocationObtainer.getMetadataLocationEntries(results).getLocations();
@@ -523,7 +523,7 @@ public class TabletLocatorImplTest {
     if (tabletData == null) {
       tabletData = new TreeMap<>();
       tablets.put(tablet, tabletData);
-    } else if (tabletData.size() > 0) {
+    } else if (!tabletData.isEmpty()) {
       throw new RuntimeException("Asked for empty tablet, but non empty tablet exists");
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -2205,8 +2205,8 @@ public class RFileTest {
 
         trf.closeWriter();
 
-        assertTrue(sampleDataLG1.size() > 0);
-        assertTrue(sampleDataLG2.size() > 0);
+        assertTrue(!sampleDataLG1.isEmpty());
+        assertTrue(!sampleDataLG2.isEmpty());
 
         trf.openReader(false);
         FileSKVIterator sample =

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -455,7 +455,7 @@ public class TransformingIteratorTest {
   private void checkExpected(Range range, Set<ByteSequence> families,
       TreeMap<Key,Value> expectedEntries) throws IOException {
 
-    titer.seek(range, families, families.size() != 0);
+    titer.seek(range, families, !families.isEmpty());
 
     while (titer.hasTop()) {
       Entry<Key,Value> expected = expectedEntries.pollFirstEntry();

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -237,7 +237,7 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
     }
 
     Map<String,String> executionHints = baseSplit.getExecutionHints();
-    if (executionHints == null || executionHints.size() == 0) {
+    if (executionHints == null || executionHints.isEmpty()) {
       executionHints = tableConfig.getExecutionHints();
     }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordWriter.java
@@ -194,7 +194,7 @@ public class AccumuloRecordWriter implements RecordWriter<Text,Mutation> {
         log.error("Not authorized to write to tables : " + tables);
       }
 
-      if (e.getConstraintViolationSummaries().size() > 0) {
+      if (!e.getConstraintViolationSummaries().isEmpty()) {
         log.error("Constraint violations : " + e.getConstraintViolationSummaries().size());
       }
       throw new IOException(e);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordWriter.java
@@ -195,7 +195,7 @@ public class AccumuloRecordWriter extends RecordWriter<Text,Mutation> {
         log.error("Not authorized to write to tables : " + tables);
       }
 
-      if (e.getConstraintViolationSummaries().size() > 0) {
+      if (!e.getConstraintViolationSummaries().isEmpty()) {
         log.error("Constraint violations : " + e.getConstraintViolationSummaries().size());
       }
       throw new IOException(e);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/FileOutputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/FileOutputFormatBuilderImpl.java
@@ -127,7 +127,7 @@ public class FileOutputFormatBuilderImpl<T> implements FileOutputFormatBuilder,
       FileOutputConfigurator.setReplication(callingClass, conf, replication.get());
     if (sampler.isPresent())
       FileOutputConfigurator.setSampler(callingClass, conf, sampler.get());
-    if (summarizers.size() > 0)
+    if (!summarizers.isEmpty())
       FileOutputConfigurator.setSummarizers(callingClass, conf,
           summarizers.toArray(new SummarizerConfiguration[0]));
   }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -96,7 +96,7 @@ public class InputFormatBuilderImpl<T>
   public InputFormatBuilder.InputFormatOptions<T> ranges(Collection<Range> ranges) {
     List<Range> newRanges =
         List.copyOf(Objects.requireNonNull(ranges, "Collection of ranges is null"));
-    if (newRanges.size() == 0) {
+    if (newRanges.isEmpty()) {
       throw new IllegalArgumentException("Specified collection of ranges is empty.");
     }
     tableConfigMap.get(currentTable).setRanges(newRanges);
@@ -108,7 +108,7 @@ public class InputFormatBuilderImpl<T>
       fetchColumns(Collection<IteratorSetting.Column> fetchColumns) {
     Collection<IteratorSetting.Column> newFetchColumns =
         List.copyOf(Objects.requireNonNull(fetchColumns, "Collection of fetch columns is null"));
-    if (newFetchColumns.size() == 0) {
+    if (newFetchColumns.isEmpty()) {
       throw new IllegalArgumentException("Specified collection of fetch columns is empty.");
     }
     tableConfigMap.get(currentTable).fetchColumns(newFetchColumns);
@@ -127,7 +127,7 @@ public class InputFormatBuilderImpl<T>
   public InputFormatBuilder.InputFormatOptions<T> executionHints(Map<String,String> hints) {
     Map<String,String> newHints =
         Map.copyOf(Objects.requireNonNull(hints, "Map of execution hints must not be null."));
-    if (newHints.size() == 0) {
+    if (newHints.isEmpty()) {
       throw new IllegalArgumentException("Specified map of execution hints is empty.");
     }
     tableConfigMap.get(currentTable).setExecutionHints(newHints);
@@ -194,7 +194,7 @@ public class InputFormatBuilderImpl<T>
 
   private void _store(Configuration conf) throws AccumuloException, AccumuloSecurityException {
     InputConfigurator.setClientProperties(callingClass, conf, clientProps, clientPropsPath);
-    if (tableConfigMap.size() == 0) {
+    if (tableConfigMap.isEmpty()) {
       throw new IllegalArgumentException("At least one Table must be configured for job.");
     }
     // if only one table use the single table configuration method
@@ -214,20 +214,20 @@ public class InputFormatBuilderImpl<T>
       if (config.getContext().isPresent()) {
         InputConfigurator.setClassLoaderContext(callingClass, conf, config.getContext().get());
       }
-      if (config.getRanges().size() > 0) {
+      if (!config.getRanges().isEmpty()) {
         InputConfigurator.setRanges(callingClass, conf, config.getRanges());
       }
-      if (config.getIterators().size() > 0) {
+      if (!config.getIterators().isEmpty()) {
         InputConfigurator.writeIteratorsToConf(callingClass, conf, config.getIterators());
       }
-      if (config.getFetchedColumns().size() > 0) {
+      if (!config.getFetchedColumns().isEmpty()) {
         InputConfigurator.fetchColumns(callingClass, conf, config.getFetchedColumns());
       }
       if (config.getSamplerConfiguration() != null) {
         InputConfigurator.setSamplerConfiguration(callingClass, conf,
             config.getSamplerConfiguration());
       }
-      if (config.getExecutionHints().size() > 0) {
+      if (!config.getExecutionHints().isEmpty()) {
         InputConfigurator.setExecutionHints(callingClass, conf, config.getExecutionHints());
       }
       InputConfigurator.setAutoAdjustRanges(callingClass, conf, config.shouldAutoAdjustRanges());

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/RangeInputSplit.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/RangeInputSplit.java
@@ -222,7 +222,7 @@ public class RangeInputSplit extends InputSplit implements Writable {
       new SamplerConfigurationImpl(samplerConfig).write(out);
     }
 
-    if (executionHints == null || executionHints.size() == 0) {
+    if (executionHints == null || executionHints.isEmpty()) {
       out.writeInt(0);
     } else {
       out.writeInt(executionHints.size());

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -734,7 +734,7 @@ public class InputConfigurator extends ConfiguratorBase {
       AccumuloClient client) throws IOException {
     Map<String,InputTableConfig> inputTableConfigs = getInputTableConfigs(implementingClass, conf);
     try {
-      if (getInputTableConfigs(implementingClass, conf).size() == 0)
+      if (getInputTableConfigs(implementingClass, conf).isEmpty())
         throw new IOException("No table set.");
 
       Properties props = getClientProperties(implementingClass, conf);

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
@@ -107,7 +107,7 @@ public class IsolatedDeepCopiesTestCase extends OutputVerifyingTestCase {
   }
 
   private <E> E getRandomElement(Collection<E> iterators) {
-    if (iterators == null || iterators.size() == 0)
+    if (iterators == null || iterators.isEmpty())
       throw new IllegalArgumentException("should not pass an empty collection");
     int num = random.nextInt(iterators.size());
     for (E e : iterators) {

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerConstants.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerConstants.java
@@ -144,7 +144,7 @@ public class ServerConstants {
       baseDirsList.add(baseDir);
     }
 
-    if (baseDirsList.size() == 0) {
+    if (baseDirsList.isEmpty()) {
       throw new RuntimeException("None of the configured paths are initialized.");
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -149,7 +149,7 @@ public class BulkImporter {
             }
             log.debug("Map file {} found to overlap {} tablets", mapFile,
                 tabletsToAssignMapFileTo.size());
-            if (tabletsToAssignMapFileTo.size() == 0) {
+            if (tabletsToAssignMapFileTo.isEmpty()) {
               List<KeyExtent> empty = Collections.emptyList();
               completeFailures.put(mapFile, empty);
             } else
@@ -179,7 +179,7 @@ public class BulkImporter {
         failureCount.put(entry.getKey(), 1);
 
       long sleepTime = 2 * 1000;
-      while (assignmentFailures.size() > 0) {
+      while (!assignmentFailures.isEmpty()) {
         sleepTime = Math.min(sleepTime * 2, 60 * 1000);
         locator.invalidateCache();
         // assumption about assignment failures is that it caused by a split
@@ -217,7 +217,7 @@ public class BulkImporter {
             timer.stop(Timers.QUERY_METADATA);
           }
 
-          if (tabletsToAssignMapFileTo.size() > 0)
+          if (!tabletsToAssignMapFileTo.isEmpty())
             assignments.put(entry.getKey(), tabletsToAssignMapFileTo);
         }
 
@@ -304,7 +304,7 @@ public class BulkImporter {
 
     Set<Entry<Path,List<KeyExtent>>> es = completeFailures.entrySet();
 
-    if (completeFailures.size() == 0)
+    if (completeFailures.isEmpty())
       return Collections.emptySet();
 
     log.debug("The following map files failed ");
@@ -760,7 +760,7 @@ public class BulkImporter {
       sb.append(String.format("# map files with failures : %,10d %6.2f%s%n",
           completeFailures.size(), completeFailures.size() * 100.0 / numUniqueMapFiles, "%"));
       sb.append(String.format("# failed failed map files : %,10d %s%n", failedFailures.size(),
-          failedFailures.size() > 0 ? " <-- THIS IS BAD" : ""));
+          !failedFailures.isEmpty() ? " <-- THIS IS BAD" : ""));
       sb.append(String.format("# of tablets              : %,10d%n", counts.size()));
       sb.append(String.format("# tablets imported to     : %,10d %6.2f%s%n", tabletsImportedTo,
           tabletsImportedTo * 100.0 / counts.size(), "%"));

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -63,7 +63,7 @@ public class VolumeUtil {
   }
 
   public static Path switchVolume(String path, FileType ft, List<Pair<Path,Path>> replacements) {
-    if (replacements.size() == 0) {
+    if (replacements.isEmpty()) {
       log.trace("Not switching volume because there are no replacements");
       return null;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -716,7 +716,7 @@ public class Initialize implements KeywordExecutable {
         System.exit(0);
       }
       instanceName = instanceName.trim();
-      if (instanceName.length() == 0) {
+      if (instanceName.isEmpty()) {
         continue;
       }
       instanceNamePath = getInstanceNamePrefix() + instanceName;
@@ -868,7 +868,7 @@ public class Initialize implements KeywordExecutable {
         .readLine("Your HDFS replication " + reason + " is not compatible with our default "
             + MetadataTable.NAME + " replication of 5. What do you want to set your "
             + MetadataTable.NAME + " replication to? (" + replication + ") ");
-    if (rep == null || rep.length() == 0) {
+    if (rep == null || rep.isEmpty()) {
       rep = Integer.toString(replication);
     } else {
       // Lets make sure it's a number

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -63,7 +63,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
 
   public TServerInstance getAssignment(SortedMap<TServerInstance,TabletServerStatus> locations,
       TServerInstance last) {
-    if (locations.size() == 0)
+    if (locations.isEmpty())
       return null;
 
     if (last != null) {
@@ -292,7 +292,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
   }
 
   static KeyExtent selectTablet(Map<KeyExtent,TabletStats> extents) {
-    if (extents.size() == 0)
+    if (extents.isEmpty())
       return null;
     KeyExtent mostRecentlySplit = null;
     long splitTime = 0;
@@ -335,9 +335,9 @@ public class DefaultLoadBalancer extends TabletBalancer {
   public long balance(SortedMap<TServerInstance,TabletServerStatus> current,
       Set<KeyExtent> migrations, List<TabletMigration> migrationsOut) {
     // do we have any servers?
-    if (current.size() > 0) {
+    if (!current.isEmpty()) {
       // Don't migrate if we have migrations in progress
-      if (migrations.size() == 0) {
+      if (migrations.isEmpty()) {
         resetBalancerErrors();
         if (getMigrations(current, migrationsOut))
           return 1 * 1000;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -133,7 +133,7 @@ public abstract class GroupBalancer extends TabletBalancer {
   public void getAssignments(SortedMap<TServerInstance,TabletServerStatus> current,
       Map<KeyExtent,TServerInstance> unassigned, Map<KeyExtent,TServerInstance> assignments) {
 
-    if (current.size() == 0) {
+    if (current.isEmpty()) {
       return;
     }
 
@@ -508,7 +508,7 @@ public abstract class GroupBalancer extends TabletBalancer {
       move.count--;
       if (move.count == 0) {
         srcMoves.remove(srcMoves.size() - 1);
-        if (srcMoves.size() == 0) {
+        if (srcMoves.isEmpty()) {
           moves.remove(src, group);
         }
       }
@@ -537,7 +537,7 @@ public abstract class GroupBalancer extends TabletBalancer {
     ArrayList<TServerInstance> serversToRemove = new ArrayList<>();
 
     for (TserverGroupInfo destTgi : tservers.values()) {
-      if (surplusExtra.size() == 0) {
+      if (surplusExtra.isEmpty()) {
         break;
       }
 
@@ -564,7 +564,7 @@ public abstract class GroupBalancer extends TabletBalancer {
           }
         }
 
-        if (serversToRemove.size() > 0) {
+        if (!serversToRemove.isEmpty()) {
           surplusExtra.columnKeySet().removeAll(serversToRemove);
         }
 
@@ -593,7 +593,7 @@ public abstract class GroupBalancer extends TabletBalancer {
     }
 
     balanceExtraMultiple(tservers, maxExtraGroups, moves, extraMultiple, false);
-    if (moves.size() < getMaxMigrations() && extraMultiple.size() > 0) {
+    if (moves.size() < getMaxMigrations() && !extraMultiple.isEmpty()) {
       // no place to move so must exceed maxExtra temporarily... subsequent balancer calls will
       // smooth things out
       balanceExtraMultiple(tservers, maxExtraGroups, moves, extraMultiple, true);
@@ -637,7 +637,7 @@ public abstract class GroupBalancer extends TabletBalancer {
           extraMultiple.remove(pair.getFirst(), pair.getSecond());
         }
 
-        if (extraMultiple.size() == 0 || moves.size() >= getMaxMigrations()) {
+        if (extraMultiple.isEmpty() || moves.size() >= getMaxMigrations()) {
           break;
         }
       }
@@ -661,7 +661,7 @@ public abstract class GroupBalancer extends TabletBalancer {
     ArrayList<TServerInstance> emptyServers = new ArrayList<>();
     ArrayList<Pair<String,TServerInstance>> emptyServerGroups = new ArrayList<>();
     for (TserverGroupInfo destTgi : tservers.values()) {
-      if (extraSurplus.size() == 0) {
+      if (extraSurplus.isEmpty()) {
         break;
       }
 
@@ -696,7 +696,7 @@ public abstract class GroupBalancer extends TabletBalancer {
           }
         }
 
-        if (emptyServers.size() > 0) {
+        if (!emptyServers.isEmpty()) {
           extraSurplus.columnKeySet().removeAll(emptyServers);
         }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -111,7 +111,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     Map<String,String> customProps =
         aconf.getAllPropertiesWithPrefix(Property.TABLE_ARBITRARY_PROP_PREFIX);
 
-    if (customProps != null && customProps.size() > 0) {
+    if (customProps != null && !customProps.isEmpty()) {
       for (Entry<String,String> customProp : customProps.entrySet()) {
         if (customProp.getKey().startsWith(HOST_BALANCER_PREFIX)) {
           if (customProp.getKey().equals(HOST_BALANCER_OOB_CHECK_KEY)
@@ -251,7 +251,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
         pools.add(e.getKey());
       }
     }
-    if (pools.size() == 0) {
+    if (pools.isEmpty()) {
       pools.add(DEFAULT_POOL);
     }
     return pools;
@@ -362,7 +362,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
       String tableName = tableIdToTableName.get(e.getKey());
       String poolName = getPoolNameForTable(tableName);
       SortedMap<TServerInstance,TabletServerStatus> currentView = pools.get(poolName);
-      if (currentView == null || currentView.size() == 0) {
+      if (currentView == null || currentView.isEmpty()) {
         LOG.warn("No tablet servers online for table {}, assigning within default pool", tableName);
         currentView = pools.get(DEFAULT_POOL);
         if (currentView == null) {
@@ -464,13 +464,13 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
       }
     }
 
-    if (migrationsOut.size() > 0) {
+    if (!migrationsOut.isEmpty()) {
       LOG.warn("Not balancing tables due to moving {} out of bounds tablets", migrationsOut.size());
       LOG.info("Migrating out of bounds tablets: {}", migrationsOut);
       return minBalanceTime;
     }
 
-    if (migrations != null && migrations.size() > 0) {
+    if (migrations != null && !migrations.isEmpty()) {
       if (migrations.size() >= myConf.maxOutstandingMigrations) {
         LOG.warn("Not balancing tables due to {} outstanding migrations", migrations.size());
         if (LOG.isTraceEnabled()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
@@ -121,7 +121,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
       return null;
     // parse "host:port[INSTANCE]"
     Set<TServerInstance> result = new HashSet<>();
-    if (servers.length() > 0) {
+    if (!servers.isEmpty()) {
       for (String part : servers.split(",")) {
         String[] parts = part.split("\\[", 2);
         String hostport = parts[0];

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityUtil.java
@@ -57,10 +57,10 @@ public class SecurityUtil {
    *          The Kerberos principal
    */
   public static void serverLogin(AccumuloConfiguration acuConf, String keyTab, String principal) {
-    if (keyTab == null || keyTab.length() == 0)
+    if (keyTab == null || keyTab.isEmpty())
       return;
 
-    if (principal == null || principal.length() == 0)
+    if (principal == null || principal.isEmpty())
       return;
 
     if (login(principal, keyTab)) {
@@ -89,8 +89,8 @@ public class SecurityUtil {
   static boolean login(String principalConfig, String keyTabPath) {
     try {
       String principalName = getServerPrincipal(principalConfig);
-      if (keyTabPath != null && principalName != null && keyTabPath.length() != 0
-          && principalName.length() != 0) {
+      if (keyTabPath != null && principalName != null && !keyTabPath.isEmpty()
+          && !principalName.isEmpty()) {
         log.info("Attempting to login with keytab as {}", principalName);
         UserGroupInformation.loginUserFromKeytab(principalName, keyTabPath);
         log.info("Succesfully logged in as user {}", principalName);

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -298,7 +298,7 @@ public class ZKPermHandler implements PermissionHandler {
     try {
       if (tablePerms.remove(permission)) {
         zooCache.clear();
-        if (tablePerms.size() == 0)
+        if (tablePerms.isEmpty())
           zoo.recursiveDelete(ZKUserPath + "/" + user + ZKUserTablePerms + "/" + table,
               NodeMissingPolicy.SKIP);
         else
@@ -329,7 +329,7 @@ public class ZKPermHandler implements PermissionHandler {
     try {
       if (namespacePerms.remove(permission)) {
         zooCache.clear();
-        if (namespacePerms.size() == 0)
+        if (namespacePerms.isEmpty())
           zoo.recursiveDelete(ZKUserPath + "/" + user + ZKUserNamespacePerms + "/" + namespace,
               NodeMissingPolicy.SKIP);
         else

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
@@ -95,7 +95,7 @@ public abstract class TabletTime {
       long currTime = RelativeTime.currentTimeMillis();
 
       synchronized (this) {
-        if (mutations.size() == 0)
+        if (mutations.isEmpty())
           return lastTime;
 
         currTime = updateTime(currTime);
@@ -170,7 +170,7 @@ public abstract class TabletTime {
 
     @Override
     public long setUpdateTimes(List<Mutation> mutations) {
-      if (mutations.size() == 0)
+      if (mutations.isEmpty())
         return getTime();
 
       long time = nextTime.getAndAdd(mutations.size());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -286,7 +286,7 @@ public class Admin implements KeywordExecutable {
 
     InstanceOperations io = context.instanceOperations();
 
-    if (args.size() == 0) {
+    if (args.isEmpty()) {
       args = io.getTabletServers();
     }
 
@@ -367,7 +367,7 @@ public class Admin implements KeywordExecutable {
 
   private static void stopTabletServer(final ClientContext context, List<String> servers,
       final boolean force) throws AccumuloException, AccumuloSecurityException {
-    if (context.getMasterLocations().size() == 0) {
+    if (context.getMasterLocations().isEmpty()) {
       log.info("No masters running. Not attempting safe unload of tserver.");
       return;
     }
@@ -483,7 +483,7 @@ public class Admin implements KeywordExecutable {
           printNameSpaceConfiguration(context, namespace, outputDirectory);
         }
       }
-      if (opts.tables.size() > 0) {
+      if (!opts.tables.isEmpty()) {
         for (String tableName : opts.tables) {
           printTableConfiguration(context, tableName, outputDirectory);
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -116,7 +116,7 @@ public class ChangeSecret {
         ephemerals.add(path);
       }
     });
-    if (ephemerals.size() > 0) {
+    if (!ephemerals.isEmpty()) {
       System.err.println("The following ephemeral nodes exist, something is still running:");
       for (String path : ephemerals) {
         System.err.println(path);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -47,7 +47,7 @@ public class CheckForMetadataProblems {
     // sanity check of metadata table entries
     // make sure tablets has no holes, and that it starts and ends w/ null
 
-    if (tablets.size() == 0) {
+    if (tablets.isEmpty()) {
       System.out.println("No entries found in metadata table for table " + tablename);
       sawProblems = true;
       return;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
@@ -102,7 +102,7 @@ public class ListInstances {
       for (UUID uuid : instancedIds) {
         printInstanceInfo(cache, null, uuid, printErrors);
       }
-    } else if (instancedIds.size() > 0) {
+    } else if (!instancedIds.isEmpty()) {
       System.out.println();
       System.out.println("INFO : " + instancedIds.size()
           + " unamed instances were not printed, run with --print-all to see all instances");

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -166,7 +166,7 @@ public class RemoveEntriesForMissingFiles {
     threadPool.shutdown();
 
     synchronized (processing) {
-      while (processing.size() > 0)
+      while (!processing.isEmpty())
         processing.wait();
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -143,7 +143,7 @@ public class VerifyTabletAssignments {
 
     while (!tp.awaitTermination(1, TimeUnit.HOURS)) {}
 
-    if (failures.size() > 0)
+    if (!failures.isEmpty())
       checkTable(context, opts, tableName, failures);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -104,7 +104,7 @@ public class ZooZap {
               zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
             } else {
               String path = tserversPath + "/" + child;
-              if (zoo.getChildren(path).size() > 0) {
+              if (!zoo.getChildren(path).isEmpty()) {
                 if (!ZooLock.deleteLock(zoo, path, "tserver")) {
                   message("Did not delete " + tserversPath + "/" + child, opts);
                 }

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -63,7 +63,7 @@ public class DistributedWorkQueue {
   private AtomicInteger numTask = new AtomicInteger(0);
 
   private void lookForWork(final Processor processor, List<String> children) {
-    if (children.size() == 0)
+    if (children.isEmpty())
       return;
 
     if (numTask.get() >= threadPool.getCorePoolSize())

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -152,7 +152,7 @@ public class ChaoticLoadBalancerTest {
     // Just want to make sure it gets some migrations, randomness prevents guarantee of a defined
     // amount, or even expected amount
     List<TabletMigration> migrationsOut = new ArrayList<>();
-    while (migrationsOut.size() != 0) {
+    while (!migrationsOut.isEmpty()) {
       balancer.balance(getAssignments(servers), migrations, migrationsOut);
     }
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -198,7 +198,7 @@ public class DefaultLoadBalancerTest {
     while (true) {
       List<TabletMigration> migrationsOut = new ArrayList<>();
       balancer.balance(getAssignments(servers), migrations, migrationsOut);
-      if (migrationsOut.size() == 0)
+      if (migrationsOut.isEmpty())
         break;
       for (TabletMigration migration : migrationsOut) {
         if (servers.get(migration.oldServer).extents.remove(migration.tablet))
@@ -240,7 +240,7 @@ public class DefaultLoadBalancerTest {
     while (true) {
       List<TabletMigration> migrationsOut = new ArrayList<>();
       balancer.balance(getAssignments(servers), migrations, migrationsOut);
-      if (migrationsOut.size() == 0)
+      if (migrationsOut.isEmpty())
         break;
       for (TabletMigration migration : migrationsOut) {
         if (servers.get(migration.oldServer).extents.remove(migration.tablet))

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -133,7 +133,7 @@ public class GroupBalancerTest {
           tabletLocs.put(tabletMigration.tablet, tabletMigration.newServer);
         }
 
-        if (migrationsOut.size() == 0) {
+        if (migrationsOut.isEmpty()) {
           break;
         }
       }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -298,7 +298,7 @@ public class GarbageCollectionAlgorithm {
 
       outOfMemory = getCandidates(gce, lastCandidate, candidates);
 
-      if (candidates.size() == 0)
+      if (candidates.isEmpty())
         break;
       else
         lastCandidate = candidates.get(candidates.size() - 1);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -791,7 +791,7 @@ public class Master extends AbstractServer
                         tserverSet.remove(server);
                       }
                     }
-                    if (currentServers.size() == 0) {
+                    if (currentServers.isEmpty()) {
                       setMasterState(MasterState.STOP);
                     }
                   }
@@ -884,7 +884,7 @@ public class Master extends AbstractServer
         migrations.put(m.tablet, m.newServer);
         log.debug("migration {}", m);
       }
-      if (migrationsOut.size() > 0) {
+      if (!migrationsOut.isEmpty()) {
         nextEvent.event("Migrating %d more tablets, %d total", migrationsOut.size(),
             migrations.size());
       } else {
@@ -1451,7 +1451,7 @@ public class Master extends AbstractServer
     if (!deleted.isEmpty() || !added.isEmpty()) {
       DeadServerList obit =
           new DeadServerList(getContext(), getZooKeeperRoot() + Constants.ZDEADTSERVERS);
-      if (added.size() > 0) {
+      if (!added.isEmpty()) {
         log.info("New servers: {}", added);
         for (TServerInstance up : added) {
           obit.delete(up.hostPort());
@@ -1469,7 +1469,7 @@ public class Master extends AbstractServer
 
       Set<TServerInstance> unexpected = new HashSet<>(deleted);
       unexpected.removeAll(this.serversToShutdown);
-      if (unexpected.size() > 0) {
+      if (!unexpected.isEmpty()) {
         if (stillMaster() && !getMasterGoalState().equals(MasterGoalState.CLEAN_STOP)) {
           log.warn("Lost servers {}", unexpected);
         }
@@ -1616,7 +1616,7 @@ public class Master extends AbstractServer
         } catch (InterruptedException e) {
           log.debug(e.toString(), e);
         }
-      } while (displayUnassigned() > 0 || migrations.size() > 0
+      } while (displayUnassigned() > 0 || !migrations.isEmpty()
           || eventCounter != nextEvent.waitForEvents(0, 0));
     }
   }

--- a/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -162,7 +162,7 @@ abstract class TabletGroupWatcher extends Daemon {
           currentTServers.put(entry, this.master.tserverStatus.get(entry));
         }
 
-        if (currentTServers.size() == 0) {
+        if (currentTServers.isEmpty()) {
           eventListener.waitForEvents(Master.TIME_TO_WAIT_BETWEEN_SCANS);
           synchronized (this) {
             lastScanServers = ImmutableSortedSet.of();
@@ -430,11 +430,11 @@ abstract class TabletGroupWatcher extends Daemon {
           future.put(entry.getKey(), entry.getValue());
         }
       }
-      if (future.size() > 0 && assigned.size() > 0) {
+      if (!future.isEmpty() && !assigned.isEmpty()) {
         Master.log.warn("Found a tablet assigned and hosted, attempting to repair");
-      } else if (future.size() > 1 && assigned.size() == 0) {
+      } else if (future.size() > 1 && assigned.isEmpty()) {
         Master.log.warn("Found a tablet assigned to multiple servers, attempting to repair");
-      } else if (future.size() == 0 && assigned.size() > 1) {
+      } else if (future.isEmpty() && assigned.size() > 1) {
         Master.log.warn("Found a tablet hosted on multiple servers, attempting to repair");
       } else {
         Master.log.info("Attempted a repair, but nothing seems to be obviously wrong. {} {}",
@@ -869,7 +869,7 @@ abstract class TabletGroupWatcher extends Daemon {
         Master.log.warn("Load balancer failed to assign any tablets");
     }
 
-    if (assignments.size() > 0) {
+    if (!assignments.isEmpty()) {
       Master.log.info(String.format("Assigning %d tablets", assignments.size()));
       store.setFutureLocations(assignments);
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CopyFailed.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CopyFailed.java
@@ -145,7 +145,7 @@ class CopyFailed extends MasterRepo {
       log.debug(FateTxId.formatTid(tid) + " renamed " + orig + " to " + dest + ": import failed");
     }
 
-    if (loadedFailures.size() > 0) {
+    if (!loadedFailures.isEmpty()) {
       DistributedWorkQueue bifCopyQueue = new DistributedWorkQueue(
           Constants.ZROOT + "/" + master.getInstanceID() + Constants.ZBULK_FAILED_COPYQ,
           master.getConfiguration());

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/LoadFiles.java
@@ -85,7 +85,7 @@ class LoadFiles extends MasterRepo {
 
   @Override
   public long isReady(long tid, Master master) {
-    if (master.onlineTabletServers().size() == 0)
+    if (master.onlineTabletServers().isEmpty())
       return 500;
     return 0;
   }
@@ -128,14 +128,14 @@ class LoadFiles extends MasterRepo {
       filesToLoad.add(f.getPath().toString());
 
     final int RETRIES = Math.max(1, conf.getCount(Property.MASTER_BULK_RETRIES));
-    for (int attempt = 0; attempt < RETRIES && filesToLoad.size() > 0; attempt++) {
+    for (int attempt = 0; attempt < RETRIES && !filesToLoad.isEmpty(); attempt++) {
       List<Future<Void>> results = new ArrayList<>();
 
-      if (master.onlineTabletServers().size() == 0)
+      if (master.onlineTabletServers().isEmpty())
         log.warn("There are no tablet server to process bulk import, waiting (tid = "
             + FateTxId.formatTid(tid) + ")");
 
-      while (master.onlineTabletServers().size() == 0) {
+      while (master.onlineTabletServers().isEmpty()) {
         sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
       }
 
@@ -154,7 +154,7 @@ class LoadFiles extends MasterRepo {
             subset.add(t);
           }
         });
-        if (subset.size() == 0) {
+        if (subset.isEmpty()) {
           log.warn("There are no tablet servers online that match supplied regex: {}",
               conf.get(Property.MASTER_BULK_TSERVER_REGEX));
         }
@@ -195,7 +195,7 @@ class LoadFiles extends MasterRepo {
         f.get();
       }
       filesToLoad.removeAll(loaded);
-      if (filesToLoad.size() > 0) {
+      if (!filesToLoad.isEmpty()) {
         log.debug(FateTxId.formatTid(tid) + " attempt " + (attempt + 1) + " "
             + sampleList(filesToLoad, 10) + " failed");
         sleepUninterruptibly(100, TimeUnit.MILLISECONDS);

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -89,7 +89,7 @@ class LoadFiles extends MasterRepo {
 
   @Override
   public long isReady(long tid, Master master) throws Exception {
-    if (master.onlineTabletServers().size() == 0) {
+    if (master.onlineTabletServers().isEmpty()) {
       log.warn("There are no tablet server to process bulkDir import, waiting (tid = "
           + FateTxId.formatTid(tid) + ")");
       return 100;

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
@@ -91,7 +91,7 @@ public class PrepBulkImport extends MasterRepo {
     if (!Utils.getReadLock(master, bulkInfo.tableId, tid).tryLock())
       return 100;
 
-    if (master.onlineTabletServers().size() == 0)
+    if (master.onlineTabletServers().isEmpty())
       return 500;
     Tables.clearCache(master.getContext());
 

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/compact/CompactRange.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/compact/CompactRange.java
@@ -70,7 +70,7 @@ public class CompactRange extends MasterRepo {
     this.startRow = startRow.length == 0 ? null : startRow;
     this.endRow = endRow.length == 0 ? null : endRow;
 
-    if (iterators.size() > 0
+    if (!iterators.isEmpty()
         || !compactionStrategy.equals(CompactionStrategyConfigUtil.DEFAULT_STRATEGY)) {
       this.config = WritableUtils.toByteArray(
           new UserCompactionConfig(this.startRow, this.endRow, iterators, compactionStrategy));

--- a/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -230,7 +230,7 @@ public class Upgrader9to10 implements Upgrader {
 
     String[] parts = str.split("[|]", 2);
     HostAndPort address = HostAndPort.fromString(parts[0]);
-    if (parts.length > 1 && parts[1] != null && parts[1].length() > 0) {
+    if (parts.length > 1 && parts[1] != null && !parts[1].isEmpty()) {
       return new TServerInstance(address, parts[1]);
     } else {
       // a 1.2 location specification: DO NOT WANT

--- a/server/master/src/test/java/org/apache/accumulo/master/metrics/fate/ZooKeeperTestingServer.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/metrics/fate/ZooKeeperTestingServer.java
@@ -125,7 +125,7 @@ public class ZooKeeperTestingServer {
       String path = "";
 
       for (String p : paths) {
-        if (p.length() > 0) {
+        if (!p.isEmpty()) {
           path = path + slash + p;
           log.debug("building default paths, creating node {}", path);
           zoo.create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);

--- a/server/master/src/test/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/master/src/test/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -62,7 +62,7 @@ public class PrepBulkImportTest {
 
     }
 
-    extents.add(nke(rows.size() == 0 ? null : rows.get(rows.size() - 1), null));
+    extents.add(nke(rows.isEmpty() ? null : rows.get(rows.size() - 1), null));
 
     return extents;
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -393,7 +393,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       ZooReaderWriter zk = context.getZooReaderWriter();
       String path = context.getZooKeeperRoot() + Constants.ZGC_LOCK;
       List<String> locks = zk.getChildren(path, null);
-      if (locks != null && locks.size() > 0) {
+      if (locks != null && !locks.isEmpty()) {
         Collections.sort(locks);
         address = new ServerServices(new String(zk.getData(path + "/" + locks.get(0), null), UTF_8))
             .getAddress(Service.GC_CLIENT);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/master/MasterResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/master/MasterResource.java
@@ -102,7 +102,7 @@ public class MasterResource {
       List<String> masters = monitor.getContext().getMasterLocations();
 
       String master =
-          masters.size() == 0 ? "Down" : AddressUtil.parseAddress(masters.get(0), false).getHost();
+          masters.isEmpty() ? "Down" : AddressUtil.parseAddress(masters.get(0), false).getHost();
       int onlineTabletServers = mmi.tServerInfo.size();
       int totalTabletServers = tservers.size();
       int tablets = monitor.getTotalTabletCount();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/status/StatusResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/status/StatusResource.java
@@ -66,7 +66,7 @@ public class StatusResource {
       }
 
       List<String> masters = monitor.getContext().getMasterLocations();
-      masterStatus = masters.size() == 0 ? Status.ERROR : Status.OK;
+      masterStatus = masters.isEmpty() ? Status.ERROR : Status.OK;
 
       int tServerUp = mmi.getTServerInfoSize();
       int tServerDown = mmi.getDeadTabletServersSize();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
@@ -305,7 +305,7 @@ public class TracesResource {
         conf.getAllPropertiesWithPrefix(Property.TRACE_TOKEN_PROPERTY_PREFIX);
     // May be null
     String keytab = loginMap.get(Property.TRACE_TOKEN_PROPERTY_PREFIX.getKey() + "keytab");
-    if (keytab == null || keytab.length() == 0) {
+    if (keytab == null || keytab.isEmpty()) {
       keytab = conf.getPath(Property.GENERAL_KERBEROS_KEYTAB);
     }
 

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -380,15 +380,15 @@ public class TraceServer implements Watcher, AutoCloseable {
         Map<String,String> loginMap =
             acuConf.getAllPropertiesWithPrefix(Property.TRACE_TOKEN_PROPERTY_PREFIX);
         String keyTab = loginMap.get(Property.TRACE_TOKEN_PROPERTY_PREFIX.getKey() + "keytab");
-        if (keyTab == null || keyTab.length() == 0) {
+        if (keyTab == null || keyTab.isEmpty()) {
           keyTab = acuConf.getPath(Property.GENERAL_KERBEROS_KEYTAB);
         }
-        if (keyTab == null || keyTab.length() == 0) {
+        if (keyTab == null || keyTab.isEmpty()) {
           return;
         }
 
         String principalConfig = acuConf.get(Property.TRACE_USER);
-        if (principalConfig == null || principalConfig.length() == 0) {
+        if (principalConfig == null || principalConfig.isEmpty()) {
           return;
         }
 

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
@@ -89,7 +89,7 @@ public class ZooTraceClient extends AsyncSpanReceiver<String,Client> implements 
 
   @Override
   protected synchronized String getSpanKey(Map<String,String> data) {
-    if (hosts.size() > 0) {
+    if (!hosts.isEmpty()) {
       return hosts.get(random.nextInt(hosts.size()));
     }
     return null;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -84,8 +84,8 @@ class AssignmentHandler implements Runnable {
             return;
           }
 
-          if (unopenedOverlapping.size() != 1 || openingOverlapping.size() > 0
-              || onlineOverlapping.size() > 0) {
+          if (unopenedOverlapping.size() != 1 || !openingOverlapping.isEmpty()
+              || !onlineOverlapping.isEmpty()) {
             throw new IllegalStateException(
                 "overlaps assigned " + extent + " " + !server.unopenedTablets.contains(extent) + " "
                     + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/CompactionQueue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/CompactionQueue.java
@@ -44,7 +44,7 @@ class CompactionQueue extends AbstractQueue<TraceRunnable> implements BlockingQu
 
   @Override
   public synchronized TraceRunnable poll() {
-    if (task.size() == 0)
+    if (task.isEmpty())
       return null;
 
     TraceRunnable min = Collections.min(task, ELEMENT_COMPARATOR);
@@ -60,7 +60,7 @@ class CompactionQueue extends AbstractQueue<TraceRunnable> implements BlockingQu
 
   @Override
   public synchronized TraceRunnable peek() {
-    if (task.size() == 0)
+    if (task.isEmpty())
       return null;
 
     return Collections.min(task, ELEMENT_COMPARATOR);
@@ -88,7 +88,7 @@ class CompactionQueue extends AbstractQueue<TraceRunnable> implements BlockingQu
 
   @Override
   public synchronized TraceRunnable take() throws InterruptedException {
-    while (task.size() == 0) {
+    while (task.isEmpty()) {
       wait();
     }
 
@@ -97,11 +97,11 @@ class CompactionQueue extends AbstractQueue<TraceRunnable> implements BlockingQu
 
   @Override
   public synchronized TraceRunnable poll(long timeout, TimeUnit unit) throws InterruptedException {
-    if (task.size() == 0) {
+    if (task.isEmpty()) {
       wait(unit.toMillis(timeout));
     }
 
-    if (task.size() == 0)
+    if (task.isEmpty())
       return null;
 
     return poll();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ConditionalMutationSet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ConditionalMutationSet.java
@@ -59,7 +59,7 @@ public class ConditionalMutationSet {
       List<ServerConditionalMutation> deferred = new ArrayList<>();
       filter.defer(scml, okMutations, deferred);
 
-      if (deferred.size() > 0) {
+      if (!deferred.isEmpty()) {
         scml.clear();
         scml.addAll(okMutations);
         List<ServerConditionalMutation> l = deferredMutations.get(entry.getKey());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -146,7 +146,7 @@ public class FileManager {
             }
           }
 
-          if (ofl.size() == 0) {
+          if (ofl.isEmpty()) {
             iter.remove();
           }
         }
@@ -211,7 +211,7 @@ public class FileManager {
         throw new RuntimeException("Failed to remove open reader that should have been there");
       }
 
-      if (ofl.size() == 0) {
+      if (ofl.isEmpty()) {
         openFiles.remove(or.fileName);
       }
 
@@ -240,10 +240,10 @@ public class FileManager {
     List<String> filesToOpen = Collections.emptyList();
     for (String file : files) {
       List<OpenReader> ofl = openFiles.get(file);
-      if (ofl != null && ofl.size() > 0) {
+      if (ofl != null && !ofl.isEmpty()) {
         OpenReader openReader = ofl.remove(ofl.size() - 1);
         readersReserved.put(openReader.reader, file);
-        if (ofl.size() == 0) {
+        if (ofl.isEmpty()) {
           openFiles.remove(file);
         }
       } else {
@@ -263,7 +263,7 @@ public class FileManager {
       throw new IllegalArgumentException("requested files exceeds max open");
     }
 
-    if (files.size() == 0) {
+    if (files.isEmpty()) {
       return Collections.emptyMap();
     }
 
@@ -571,7 +571,7 @@ public class FileManager {
     }
 
     public synchronized void reattach(SamplerConfigurationImpl samplerConfig) throws IOException {
-      if (tabletReservedReaders.size() != 0)
+      if (!tabletReservedReaders.isEmpty())
         throw new IllegalStateException();
 
       List<String> files = dataSources.stream().map(x -> x.file).collect(Collectors.toList());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -142,7 +142,7 @@ public class InMemoryMap {
     SimpleMap allMap;
     SimpleMap sampleMap;
 
-    if (lggroups.size() == 0) {
+    if (lggroups.isEmpty()) {
       allMap = newMap(useNativeMap);
       sampleMap = newMap(useNativeMap);
       mapType = useNativeMap ? TYPE_NATIVE_MAP_WRAPPER : TYPE_DEFAULT_MAP;
@@ -357,7 +357,7 @@ public class InMemoryMap {
         partitioner.partition(mutations, partitioned);
 
         for (int i = 0; i < partitioned.length; i++) {
-          if (partitioned.get(i).size() > 0) {
+          if (!partitioned.get(i).isEmpty()) {
             maps[i].mutate(partitioned.get(i), kvCount);
             for (Mutation m : partitioned.get(i))
               kvCount += m.getUpdates().size();
@@ -735,11 +735,11 @@ public class InMemoryMap {
 
     long t1 = System.currentTimeMillis();
 
-    while (activeIters.size() > 0 && System.currentTimeMillis() - t1 < waitTime) {
+    while (!activeIters.isEmpty() && System.currentTimeMillis() - t1 < waitTime) {
       sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
     }
 
-    if (activeIters.size() > 0) {
+    if (!activeIters.isEmpty()) {
       // dump memmap exactly as is to a tmp file on disk, and switch scans to that temp file
       try {
         Configuration conf = context.getHadoopConf();
@@ -795,7 +795,7 @@ public class InMemoryMap {
       } catch (IOException ioe) {
         log.error("Failed to create mem dump file", ioe);
 
-        while (activeIters.size() > 0) {
+        while (!activeIters.isEmpty()) {
           sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
         }
       }
@@ -825,7 +825,7 @@ public class InMemoryMap {
   }
 
   private void dumpLocalityGroup(FileSKVWriter out, InterruptibleIterator iter) throws IOException {
-    while (iter.hasTop() && activeIters.size() > 0) {
+    while (iter.hasTop() && !activeIters.isEmpty()) {
       // RFile does not support MemKey, so we move the kv count into the value only for the RFile.
       // There is no need to change the MemKey to a normal key because the kvCount info gets lost
       // when it is written

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -220,7 +220,7 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
       allocatedNativeMaps = new HashSet<>();
 
       Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-        if (allocatedNativeMaps.size() > 0) {
+        if (!allocatedNativeMaps.isEmpty()) {
           log.info("There are {} allocated native maps", allocatedNativeMaps.size());
         }
         log.debug("{} native maps were allocated", totalAllocations);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -555,7 +555,7 @@ public class TabletServer extends AbstractServer {
   private HostAndPort getMasterAddress() {
     try {
       List<String> locations = getContext().getMasterLocations();
-      if (locations.size() == 0) {
+      if (locations.isEmpty()) {
         return null;
       }
       return HostAndPort.fromString(locations.get(0));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -624,7 +624,7 @@ public class TabletServerResourceManager {
 
         try {
           if (mma != null && mma.tabletsToMinorCompact != null
-              && mma.tabletsToMinorCompact.size() > 0) {
+              && !mma.tabletsToMinorCompact.isEmpty()) {
             for (KeyExtent keyExtent : mma.tabletsToMinorCompact) {
               TabletStateImpl tabletReport = tabletReportsCopy.get(keyExtent);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
@@ -726,7 +726,7 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
       }
     }
 
-    if (!containsMetadataTablet && us.queuedMutations.size() > 0) {
+    if (!containsMetadataTablet && !us.queuedMutations.isEmpty()) {
       server.resourceManager.waitUntilCommitsAreEnabled();
     }
 
@@ -737,7 +737,7 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
         Durability durability =
             DurabilityImpl.resolveDurabilty(us.durability, tablet.getDurability());
         List<Mutation> mutations = entry.getValue();
-        if (mutations.size() > 0) {
+        if (!mutations.isEmpty()) {
           try {
             server.updateMetrics.addMutationArraySize(mutations.size());
 
@@ -884,18 +884,18 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
               us.flushTime / 1000.0, us.prepareTimes.sum() / 1000.0, us.walogTimes.sum() / 1000.0,
               us.commitTimes.sum() / 1000.0));
     }
-    if (us.failures.size() > 0) {
+    if (!us.failures.isEmpty()) {
       Entry<KeyExtent,Long> first = us.failures.entrySet().iterator().next();
       log.debug(String.format("Failures: %d, first extent %s successful commits: %d",
           us.failures.size(), first.getKey().toString(), first.getValue()));
     }
     List<ConstraintViolationSummary> violations = us.violations.asList();
-    if (violations.size() > 0) {
+    if (!violations.isEmpty()) {
       ConstraintViolationSummary first = us.violations.asList().iterator().next();
       log.debug(String.format("Violations: %d, first %s occurs %d", violations.size(),
           first.violationDescription, first.numberOfViolatingMutations));
     }
-    if (us.authFailures.size() > 0) {
+    if (!us.authFailures.isEmpty()) {
       KeyExtent first = us.authFailures.keySet().iterator().next();
       log.debug(String.format("Authentication Failures: %d, first %s", us.authFailures.size(),
           first.toString()));
@@ -1016,7 +1016,7 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
         try {
           tablet.checkConditions(checker, cs.auths, cs.interruptFlag);
 
-          if (okMutations.size() > 0) {
+          if (!okMutations.isEmpty()) {
             entry.setValue(okMutations);
           } else {
             iter.remove();
@@ -1087,7 +1087,7 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
     }
 
     try (TraceScope walSpan = Trace.startSpan("wal")) {
-      while (loggables.size() > 0) {
+      while (!loggables.isEmpty()) {
         try {
           long t1 = System.currentTimeMillis();
           server.logger.logManyTablets(loggables);
@@ -1221,7 +1221,7 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
       Map<KeyExtent,List<ServerConditionalMutation>> deferred =
           conditionalUpdate(cs, updates, results, symbols);
 
-      while (deferred.size() > 0) {
+      while (!deferred.isEmpty()) {
         deferred = conditionalUpdate(cs, deferred, results, symbols);
       }
 
@@ -1414,7 +1414,7 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
             // ignore self, for error logging
             all.remove(extent);
 
-            if (all.size() > 0) {
+            if (!all.isEmpty()) {
               log.error("Tablet {} overlaps previously assigned {} {} {}", extent,
                   unopenedOverlapping, openingOverlapping, onlineOverlapping + " " + all);
             }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/WriteTracker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/WriteTracker.java
@@ -87,7 +87,7 @@ class WriteTracker {
   }
 
   public long startWrite(Set<Tablet> keySet) {
-    if (keySet.size() == 0)
+    if (keySet.isEmpty())
       return -1;
 
     List<KeyExtent> extents = new ArrayList<>(keySet.size());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategy.java
@@ -81,7 +81,7 @@ public class ConfigurableCompactionStrategy extends CompactionStrategy {
       gatherCalled = true;
       Collection<SummarizerConfiguration> configs =
           SummarizerConfiguration.fromTableProperties(request.getTableProperties());
-      if (configs.size() == 0) {
+      if (configs.isEmpty()) {
         summaryConfigured = false;
       } else {
         Set<SummarizerConfiguration> configsSet = configs instanceof Set
@@ -128,7 +128,7 @@ public class ConfigurableCompactionStrategy extends CompactionStrategy {
       if (!gatherCalled) {
         Collection<SummarizerConfiguration> configs =
             SummarizerConfiguration.fromTableProperties(request.getTableProperties());
-        return configs.size() > 0;
+        return !configs.isEmpty();
       }
 
       if (!summaryConfigured) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -545,7 +545,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     }
 
     // expect workq should be empty at this point
-    if (workQueue.size() != 0) {
+    if (!workQueue.isEmpty()) {
       log.error("WAL work queue not empty after sync thread exited");
       throw new IllegalStateException("WAL work queue not empty after sync thread exited");
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -500,7 +500,7 @@ public class TabletServerLogger {
    * Log mutations. This method expects mutations that have a durability other than NONE.
    */
   public void logManyTablets(Map<CommitSession,TabletMutations> loggables) throws IOException {
-    if (loggables.size() == 0)
+    if (loggables.isEmpty())
       return;
 
     write(loggables.keySet(), false, logger -> logger.logManyTablets(loggables.values()),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
@@ -65,7 +65,7 @@ public class LogFileValue implements Writable {
   }
 
   public static String format(LogFileValue lfv, int maxMutations) {
-    if (lfv.mutations.size() == 0)
+    if (lfv.mutations.isEmpty())
       return "";
     StringBuilder builder = new StringBuilder();
     builder.append(lfv.mutations.size() + " mutations:\n");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
@@ -131,7 +131,7 @@ public class LookupTask extends ScanTask<MultiScanResult> {
 
         bytesAdded += lookupResult.bytesAdded;
 
-        if (lookupResult.unfinishedRanges.size() > 0) {
+        if (!lookupResult.unfinishedRanges.isEmpty()) {
           if (lookupResult.closed) {
             failures.put(entry.getKey(), lookupResult.unfinishedRanges);
           } else {
@@ -165,7 +165,7 @@ public class LookupTask extends ScanTask<MultiScanResult> {
       }
       // add results to queue
       addResult(new MultiScanResult(retResults, retFailures, retFullScans, retPartScan,
-          retPartNextKey, partNextKeyInclusive, session.queries.size() != 0));
+          retPartNextKey, partNextKeyInclusive, !session.queries.isEmpty()));
     } catch (IterationInterruptedException iie) {
       if (!isCancelled()) {
         log.warn("Iteration interrupted, when scan not cancelled", iie);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionInfo.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionInfo.java
@@ -75,7 +75,7 @@ public class CompactionInfo {
     CompactionType type;
 
     if (compactor.hasIMM())
-      if (compactor.getFilesToCompact().size() > 0)
+      if (!compactor.getFilesToCompact().isEmpty())
         type = CompactionType.MERGE;
       else
         type = CompactionType.MINOR;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -142,7 +142,7 @@ class DatafileManager {
         tablet.notifyAll();
     }
 
-    if (filesToDelete.size() > 0) {
+    if (!filesToDelete.isEmpty()) {
       log.debug("Removing scan refs from metadata {} {}", tablet.getExtent(), filesToDelete);
       MetadataTableUtil.removeScanFiles(tablet.getExtent(), filesToDelete, tablet.getContext(),
           tablet.getTabletServer().getLock());
@@ -150,7 +150,7 @@ class DatafileManager {
   }
 
   void removeFilesAfterScan(Set<StoredTabletFile> scanFiles) {
-    if (scanFiles.size() == 0)
+    if (scanFiles.isEmpty())
       return;
 
     Set<StoredTabletFile> filesToDelete = new HashSet<>();
@@ -164,7 +164,7 @@ class DatafileManager {
       }
     }
 
-    if (filesToDelete.size() > 0) {
+    if (!filesToDelete.isEmpty()) {
       log.debug("Removing scan refs from metadata {} {}", tablet.getExtent(), filesToDelete);
       MetadataTableUtil.removeScanFiles(tablet.getExtent(), filesToDelete, tablet.getContext(),
           tablet.getTabletServer().getLock());
@@ -231,7 +231,7 @@ class DatafileManager {
 
     synchronized (bulkFileImportLock) {
 
-      if (paths.size() > 0) {
+      if (!paths.isEmpty()) {
         long bulkTime = Long.MIN_VALUE;
         if (setTime) {
           for (DataFileValue dfv : paths.values()) {
@@ -283,7 +283,7 @@ class DatafileManager {
     // largest file is returned for merging.. the following check mostly
     // avoids this case, except for the case where major compactions fail or
     // are canceled
-    if (majorCompactingFiles.size() > 0 && datafileSizes.size() == maxFiles)
+    if (!majorCompactingFiles.isEmpty() && datafileSizes.size() == maxFiles)
       return null;
 
     if (datafileSizes.size() >= maxFiles) {
@@ -474,7 +474,7 @@ class DatafileManager {
   }
 
   public void reserveMajorCompactingFiles(Collection<StoredTabletFile> files) {
-    if (majorCompactingFiles.size() != 0)
+    if (!majorCompactingFiles.isEmpty())
       throw new IllegalStateException("Major compacting files not empty " + majorCompactingFiles);
 
     if (mergingMinorCompactionFile != null && files.contains(mergingMinorCompactionFile))
@@ -545,7 +545,7 @@ class DatafileManager {
 
     // known consistency issue between minor and major compactions - see ACCUMULO-18
     Set<StoredTabletFile> filesInUseByScans = waitForScansToFinish(oldDatafiles);
-    if (filesInUseByScans.size() > 0)
+    if (!filesInUseByScans.isEmpty())
       log.debug("Adding scan refs to metadata {} {}", extent, filesInUseByScans);
     MasterMetadataUtil.replaceDatafiles(tablet.getContext(), extent, oldDatafiles,
         filesInUseByScans, newFile, compactionId, dfv,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -193,7 +193,7 @@ class ScanDataSource implements DataSource {
 
       ParsedIteratorConfig pic =
           tablet.getTableConfiguration().getParsedIteratorConfig(IteratorScope.scan);
-      if (scanParams.getSsiList().size() == 0 && scanParams.getSsio().size() == 0) {
+      if (scanParams.getSsiList().isEmpty() && scanParams.getSsio().isEmpty()) {
         // No scan time iterator options were set, so can just use the pre-parsed table iterator
         // options.
         iterInfos = pic.getIterInfo();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -493,7 +493,7 @@ public class Tablet {
     boolean tabletClosed = false;
 
     Set<ByteSequence> cfset = null;
-    if (scanParams.getColumnSet().size() > 0) {
+    if (!scanParams.getColumnSet().isEmpty()) {
       cfset = LocalityGroupUtil.families(scanParams.getColumnSet());
     }
 
@@ -655,7 +655,7 @@ public class Tablet {
   public LookupResult lookup(List<Range> ranges, List<KVEntry> results, ScanParameters scanParams,
       long maxResultSize, AtomicBoolean interruptFlag) throws IOException {
 
-    if (ranges.size() == 0) {
+    if (ranges.isEmpty()) {
       return new LookupResult();
     }
 
@@ -728,7 +728,7 @@ public class Tablet {
       iter.enableYielding(yield);
     }
 
-    if (scanParams.getColumnSet().size() == 0) {
+    if (scanParams.getColumnSet().isEmpty()) {
       iter.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
     } else {
       iter.seek(range, LocalityGroupUtil.families(scanParams.getColumnSet()), true);
@@ -777,7 +777,7 @@ public class Tablet {
     } else if (!iter.hasTop()) {
       // end of tablet has been reached
       continueKey = null;
-      if (results.size() == 0) {
+      if (results.isEmpty()) {
         results = null;
       }
     }
@@ -1300,7 +1300,7 @@ public class Tablet {
     }
 
     // wait for reads and writes to complete
-    while (writesInProgress > 0 || activeScans.size() > 0) {
+    while (writesInProgress > 0 || !activeScans.isEmpty()) {
       try {
         this.wait(50);
       } catch (InterruptedException e) {
@@ -1374,7 +1374,7 @@ public class Tablet {
       Pair<List<LogEntry>,SortedMap<StoredTabletFile,DataFileValue>> fileLog =
           MetadataTableUtil.getFileAndLogEntries(context, extent);
 
-      if (fileLog.getFirst().size() != 0) {
+      if (!fileLog.getFirst().isEmpty()) {
         String msg = "Closed tablet " + extent + " has walog entries in " + MetadataTable.NAME + " "
             + fileLog.getFirst();
         log.error(msg);
@@ -1394,7 +1394,7 @@ public class Tablet {
 
     }
 
-    if (otherLogs.size() != 0 || currentLogs.size() != 0 || referencedLogs.size() != 0) {
+    if (!otherLogs.isEmpty() || !currentLogs.isEmpty() || !referencedLogs.isEmpty()) {
       String msg = "Closed tablet " + extent + " has walog entries in memory currentLogs = "
           + currentLogs + "  otherLogs = " + otherLogs + " refererncedLogs = " + referencedLogs;
       log.error(msg);
@@ -1536,7 +1536,7 @@ public class Tablet {
 
       Text text = mid.getRow();
       SortedMap<Double,Key> firstHalf = keys.headMap(.5);
-      if (firstHalf.size() > 0) {
+      if (!firstHalf.isEmpty()) {
         Text beforeMid = firstHalf.get(firstHalf.lastKey()).getRow();
         Text shorter = new Text();
         int trunc = longestCommonLength(text, beforeMid);
@@ -1836,7 +1836,7 @@ public class Tablet {
         Set<StoredTabletFile> smallestFiles = removeSmallest(filesToCompact, numToCompact);
 
         TabletFile newFile =
-            getNextMapFilename((filesToCompact.size() == 0 && !propogateDeletes) ? "A" : "C");
+            getNextMapFilename((filesToCompact.isEmpty() && !propogateDeletes) ? "A" : "C");
         TabletFile compactTmpName = new TabletFile(new Path(newFile.getMetaInsert() + "_tmp"));
 
         AccumuloConfiguration tableConf = createCompactionConfiguration(tableConfiguration, plan);
@@ -1895,21 +1895,20 @@ public class Tablet {
           if (lastBatch && plan != null && plan.deleteFiles != null) {
             smallestFiles.addAll(plan.deleteFiles);
           }
-          StoredTabletFile newTabletFile =
-              getDatafileManager().bringMajorCompactionOnline(smallestFiles, compactTmpName,
-                  newFile, filesToCompact.size() == 0 && compactionId != null
-                      ? compactionId.getFirst() : null,
-                  new DataFileValue(mcs.getFileSize(), mcs.getEntriesWritten()));
+          StoredTabletFile newTabletFile = getDatafileManager().bringMajorCompactionOnline(
+              smallestFiles, compactTmpName, newFile,
+              filesToCompact.isEmpty() && compactionId != null ? compactionId.getFirst() : null,
+              new DataFileValue(mcs.getFileSize(), mcs.getEntriesWritten()));
 
           // when major compaction produces a file w/ zero entries, it will be deleted... do not
           // want to add the deleted file
-          if (filesToCompact.size() > 0 && mcs.getEntriesWritten() > 0) {
+          if (!filesToCompact.isEmpty() && mcs.getEntriesWritten() > 0) {
             filesToCompact.put(newTabletFile,
                 new DataFileValue(mcs.getFileSize(), mcs.getEntriesWritten()));
           }
         }
 
-      } while (filesToCompact.size() > 0);
+      } while (!filesToCompact.isEmpty());
       return majCStats;
     } finally {
       synchronized (Tablet.this) {
@@ -1970,7 +1969,7 @@ public class Tablet {
     }
 
     Set<StoredTabletFile> smallestFiles = new HashSet<>();
-    while (smallestFiles.size() < maxFilesToCompact && fileHeap.size() > 0) {
+    while (smallestFiles.size() < maxFilesToCompact && !fileHeap.isEmpty()) {
       Pair<StoredTabletFile,Long> pair = fileHeap.remove();
       filesToCompact.remove(pair.getFirst());
       smallestFiles.add(pair.getFirst());
@@ -2104,7 +2103,7 @@ public class Tablet {
   }
 
   public boolean isMajorCompactionQueued() {
-    return majorCompactionQueued.size() > 0;
+    return !majorCompactionQueued.isEmpty();
   }
 
   public TreeMap<KeyExtent,TabletData> split(byte[] sp) throws IOException {
@@ -2446,7 +2445,7 @@ public class Tablet {
       // finishClearingUnusedLogs() calls rebuildReferencedLogs(). See the comments in
       // rebuildReferencedLogs() for more info.
 
-      if (unusedLogs.size() > 0) {
+      if (!unusedLogs.isEmpty()) {
         removingLogs = true;
       }
     }
@@ -2510,14 +2509,14 @@ public class Tablet {
           if (addToOther) {
             throw new IllegalStateException("Adding to other logs for mincFinish on " + extent);
           }
-          if (otherLogs.size() != 0) {
+          if (!otherLogs.isEmpty()) {
             throw new IllegalStateException("Expect other logs to be 0 when minC finish, but its "
                 + otherLogs + " for " + extent);
           }
 
           // when writing a minc finish event, there is no need to add the log to metadata
           // if nothing has been logged for the tablet since the minor compaction started
-          if (currentLogs.size() == 0) {
+          if (currentLogs.isEmpty()) {
             return !releaseLock;
           }
         }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -590,7 +590,7 @@ public class InMemoryMapTest {
         mutate(imm, row, "cf2:cq2", 5, "v" + ((2 * r) + 1), sampler, expectedSample, expectedAll);
       }
 
-      assertTrue(expectedSample.size() > 0);
+      assertTrue(!expectedSample.isEmpty());
 
       MemoryIterator iter1 = imm.skvIterator(sampleConfig);
       MemoryIterator iter2 = imm.skvIterator(null);
@@ -673,7 +673,7 @@ public class InMemoryMapTest {
       mutate(imm, row, "cf2:cq2", 5, "v" + ((2 * r) + 1), sampler, expectedSample, expectedAll);
     }
 
-    assertTrue(expectedSample.size() > 0);
+    assertTrue(!expectedSample.isEmpty());
 
     MemoryIterator miter = imm.skvIterator(sampleConfig1);
     AtomicBoolean iFlag = new AtomicBoolean(false);

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -711,7 +711,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     fields = fields.length > 1 ? Arrays.copyOfRange(fields, 1, fields.length) : new String[] {};
 
     Command sc = null;
-    if (command.length() > 0) {
+    if (!command.isEmpty()) {
       try {
         // Obtain the command from the command table
         sc = commandFactory.get(command);
@@ -1048,7 +1048,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
           if (peek != null) {
             reader.println(peek);
             if (paginate) {
-              linesPrinted += peek.length() == 0 ? 0 : Math.ceil(peek.length() * 1.0 / termWidth);
+              linesPrinted += peek.isEmpty() ? 0 : Math.ceil(peek.length() * 1.0 / termWidth);
 
               // check if displaying the next line would result in
               // scrolling off the screen

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellCompletor.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellCompletor.java
@@ -67,7 +67,7 @@ public class ShellCompletor implements Completer {
     boolean end_space = buffer.endsWith(" ");
 
     // tabbing with no text
-    if (buffer.length() == 0) {
+    if (buffer.isEmpty()) {
       candidates.addAll(root.getSubcommandNames());
       return 0;
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionIterator.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionIterator.java
@@ -94,7 +94,7 @@ class ActiveCompactionIterator implements Iterator<String> {
         compactions.add(tserver + " ERROR " + e.getMessage());
       }
 
-      if (compactions.size() > 0) {
+      if (!compactions.isEmpty()) {
         break;
       }
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveScanIterator.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveScanIterator.java
@@ -56,7 +56,7 @@ class ActiveScanIterator implements Iterator<String> {
         scans.add(tserver + " ERROR " + e.getMessage());
       }
 
-      if (scans.size() > 0) {
+      if (!scans.isEmpty()) {
         break;
       }
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CompactCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CompactCommand.java
@@ -152,7 +152,7 @@ public class CompactCommand extends TableOperation {
     Map<String,String> configurableCompactOpt = getConfigurableCompactionStrategyOpts(cl);
 
     if (cl.hasOption(strategyOpt.getOpt())) {
-      if (configurableCompactOpt.size() > 0)
+      if (!configurableCompactOpt.isEmpty())
         throw new IllegalArgumentException(
             "Can not specify compaction strategy with file selection and file output options.");
 
@@ -164,7 +164,7 @@ public class CompactCommand extends TableOperation {
       compactionConfig.setCompactionStrategy(csc);
     }
 
-    if (configurableCompactOpt.size() > 0) {
+    if (!configurableCompactOpt.isEmpty()) {
       CompactionStrategyConfig csc = new CompactionStrategyConfig(
           "org.apache.accumulo.tserver.compaction.strategies.ConfigurableCompactionStrategy");
       csc.setOptions(configurableCompactOpt);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -213,7 +213,7 @@ public class CreateTableCommand extends Command {
       final Shell shellState, NewTableConfiguration ntc) {
     EnumSet<IteratorScope> scopeEnumSet;
     IteratorSetting iteratorSetting;
-    if (shellState.iteratorProfiles.size() == 0)
+    if (shellState.iteratorProfiles.isEmpty())
       throw new IllegalArgumentException("No shell iterator profiles have been created.");
     String[] options = cl.getOptionValues(createTableOptIteratorProps.getOpt());
     for (String profileInfo : options) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteScanIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteScanIterCommand.java
@@ -65,7 +65,7 @@ public class DeleteScanIterCommand extends Command {
         } else {
           Shell.log.info("Removed scan iterator {} from table {} ({} left)", name, tableName,
               shellState.scanIteratorOptions.get(tableName).size());
-          if (shellState.scanIteratorOptions.get(tableName).size() == 0) {
+          if (shellState.scanIteratorOptions.get(tableName).isEmpty()) {
             shellState.scanIteratorOptions.remove(tableName);
           }
         }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
@@ -125,7 +125,7 @@ public class InsertCommand extends Command {
         lines.add("\t\t" + cvs);
       }
 
-      if (lines.size() == 0 || e.getUnknownExceptions() > 0) {
+      if (lines.isEmpty() || e.getUnknownExceptions() > 0) {
         // must always print something
         lines.add(" " + e.getClass().getName() + " : " + e.getMessage());
         if (e.getCause() != null)

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListShellIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListShellIterCommand.java
@@ -36,7 +36,7 @@ public class ListShellIterCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws Exception {
-    if (shellState.iteratorProfiles.size() == 0)
+    if (shellState.iteratorProfiles.isEmpty())
       return 0;
 
     final StringBuilder sb = new StringBuilder();

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -285,7 +285,7 @@ public class SetIterCommand extends Command {
                 input = new String(input);
               }
 
-              if (input.length() == 0)
+              if (input.isEmpty())
                 break;
 
               String[] sa = input.split(" ", 2);

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -126,7 +126,7 @@ public class AccumuloClassLoader {
       justification = "class path configuration is controlled by admin, not unchecked user input")
   private static void addUrl(String classpath, ArrayList<URL> urls) throws MalformedURLException {
     classpath = classpath.trim();
-    if (classpath.length() == 0)
+    if (classpath.isEmpty())
       return;
 
     classpath = replaceEnvVars(classpath, System.getenv());

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -147,7 +147,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
       System.out.println(s);
     }
     System.out.println("End of captured audit messages for step " + stepName);
-    if (result.size() > 0)
+    if (!result.isEmpty())
       lastAuditTimestamp = (result.get(result.size() - 1)).substring(0, 23);
 
     return result;

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
@@ -133,7 +133,7 @@ public class BulkImportMonitoringIT extends ConfigurableMacBase {
         stats = getCluster().getMasterMonitorInfo();
       }
       log.info(stats.bulkImports.toString());
-      assertTrue(stats.bulkImports.size() > 0);
+      assertTrue(!stats.bulkImports.isEmpty());
       // look for exception
       for (Future<Object> err : errs) {
         err.get();

--- a/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/DetectDeadTabletServersIT.java
@@ -77,7 +77,7 @@ public class DetectDeadTabletServersIT extends ConfigurableMacBase {
       assertEquals(1, stats.badTServers.size() + stats.deadTabletServers.size());
       while (true) {
         stats = getStats(c);
-        if (stats.deadTabletServers.size() != 0) {
+        if (!stats.deadTabletServers.isEmpty()) {
           break;
         }
         UtilWaitThread.sleep(500);

--- a/test/src/main/java/org/apache/accumulo/test/GetMasterStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/GetMasterStats.java
@@ -60,14 +60,14 @@ public class GetMasterStats {
     }
     out(0, "State: " + stats.state.name());
     out(0, "Goal State: " + stats.goalState.name());
-    if (stats.serversShuttingDown != null && stats.serversShuttingDown.size() > 0) {
+    if (stats.serversShuttingDown != null && !stats.serversShuttingDown.isEmpty()) {
       out(0, "Servers to shutdown");
       for (String server : stats.serversShuttingDown) {
         out(1, "%s", server);
       }
     }
     out(0, "Unassigned tablets: %d", stats.unassignedTablets);
-    if (stats.badTServers != null && stats.badTServers.size() > 0) {
+    if (stats.badTServers != null && !stats.badTServers.isEmpty()) {
       out(0, "Bad servers");
 
       for (Entry<String,Byte> entry : stats.badTServers.entrySet()) {
@@ -86,7 +86,7 @@ public class GetMasterStats {
       out(2, "Bulk state %s", bulk.state);
       out(2, "Bulk start %s", bulk.startTime);
     }
-    if (stats.tableMap != null && stats.tableMap.size() > 0) {
+    if (stats.tableMap != null && !stats.tableMap.isEmpty()) {
       out(0, "Tables");
       for (Entry<String,TableInfo> entry : stats.tableMap.entrySet()) {
         TableInfo v = entry.getValue();
@@ -99,7 +99,7 @@ public class GetMasterStats {
         out(2, "Query Rate: %.2f", v.queryRate);
       }
     }
-    if (stats.tServerInfo != null && stats.tServerInfo.size() > 0) {
+    if (stats.tServerInfo != null && !stats.tServerInfo.isEmpty()) {
       out(0, "Tablet Servers");
       long now = System.currentTimeMillis();
       for (TabletServerStatus server : stats.tServerInfo) {
@@ -115,7 +115,7 @@ public class GetMasterStats {
         if (server.holdTime > 0) {
           out(2, "Hold Time: %d", server.holdTime);
         }
-        if (server.tableMap != null && server.tableMap.size() > 0) {
+        if (server.tableMap != null && !server.tableMap.isEmpty()) {
           out(2, "Tables");
           for (Entry<String,TableInfo> status : server.tableMap.entrySet()) {
             TableInfo info = status.getValue();

--- a/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
@@ -242,11 +242,11 @@ public class LargeSplitRowIT extends ConfigurableMacBase {
       client.tableOperations().flush(tableName, new Text(), new Text("z"), true);
 
       // Make sure a split occurs
-      while (client.tableOperations().listSplits(tableName).size() == 0) {
+      while (client.tableOperations().listSplits(tableName).isEmpty()) {
         Thread.sleep(250);
       }
 
-      assertTrue(client.tableOperations().listSplits(tableName).size() > 0);
+      assertTrue(!client.tableOperations().listSplits(tableName).isEmpty());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -177,7 +177,7 @@ public class ShellIT extends SharedMiniClusterBase {
   void assertGoodExit(String s, boolean stringPresent) {
     Shell.log.debug("{}", output.get());
     assertEquals(shell.getExitCode(), 0);
-    if (s.length() > 0) {
+    if (!s.isEmpty()) {
       assertEquals(s + " present in " + output.get() + " was not " + stringPresent, stringPresent,
           output.get().contains(s));
     }
@@ -186,7 +186,7 @@ public class ShellIT extends SharedMiniClusterBase {
   void assertBadExit(String s, boolean stringPresent) {
     Shell.log.debug("{}", output.get());
     assertTrue(shell.getExitCode() > 0);
-    if (s.length() > 0) {
+    if (!s.isEmpty()) {
       assertEquals(s + " present in " + output.get() + " was not " + stringPresent, stringPresent,
           output.get().contains(s));
     }

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -254,7 +254,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
         assertEquals(errorMsg, 0, shell.getExitCode());
       }
 
-      if (s.length() > 0)
+      if (!s.isEmpty())
         assertEquals(s + " present in " + output.get() + " was not " + stringPresent, stringPresent,
             output.get().contains(s));
     }
@@ -266,7 +266,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
         assertTrue(errorMsg, shell.getExitCode() > 0);
       }
 
-      if (s.length() > 0)
+      if (!s.isEmpty())
         assertEquals(s + " present in " + output.get() + " was not " + stringPresent, stringPresent,
             output.get().contains(s));
       shell.resetExitCode();

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -363,7 +363,7 @@ public class TestIngest {
       try {
         bw.close();
       } catch (MutationsRejectedException e) {
-        if (e.getSecurityErrorCodes().size() > 0) {
+        if (!e.getSecurityErrorCodes().isEmpty()) {
           for (Entry<TabletId,Set<SecurityErrorCode>> entry : e.getSecurityErrorCodes()
               .entrySet()) {
             System.err.println("ERROR : Not authorized to write to : " + entry.getKey() + " due to "
@@ -371,7 +371,7 @@ public class TestIngest {
           }
         }
 
-        if (e.getConstraintViolationSummaries().size() > 0) {
+        if (!e.getConstraintViolationSummaries().isEmpty()) {
           for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
             System.err.println("ERROR : Constraint violates : " + cvs);
           }

--- a/test/src/main/java/org/apache/accumulo/test/TestRandomDeletes.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestRandomDeletes.java
@@ -119,7 +119,7 @@ public class TestRandomDeletes {
 
     Set<RowColumn> current = scanAll(opts);
     current.removeAll(rows);
-    if (current.size() > 0) {
+    if (!current.isEmpty()) {
       throw new RuntimeException(current.size() + " records not deleted");
     }
     return result;

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -69,7 +69,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
     Collection<ProcessReference> monitors = cluster.getProcesses().get(ServerType.MONITOR);
     // Need to start one monitor and let it become active.
-    if (monitors == null || monitors.size() == 0) {
+    if (monitors == null || monitors.isEmpty()) {
       getClusterControl().start(ServerType.MONITOR, "localhost");
     }
 
@@ -144,7 +144,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
         try {
           List<String> locks =
               reader.getChildren(Constants.ZROOT + "/" + instanceID + Constants.ZMASTER_LOCK);
-          if (locks.size() > 0) {
+          if (!locks.isEmpty()) {
             break;
           }
         } catch (Exception e) {
@@ -206,7 +206,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
         try {
           List<String> locks =
               reader.getChildren(Constants.ZROOT + "/" + instanceID + Constants.ZGC_LOCK);
-          if (locks.size() > 0) {
+          if (!locks.isEmpty()) {
             break;
           }
         } catch (Exception e) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -228,7 +228,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
       }
       long t2 = System.currentTimeMillis();
 
-      if (expected.size() > 0) {
+      if (!expected.isEmpty()) {
         throw new Exception("Did not get all expected values " + expected.size());
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -81,7 +81,7 @@ public class CacheTestWriter {
           String child = UUID.randomUUID().toString();
           zk.putPersistentData(rootDir + "/dir/" + child, new byte[0], NodeExistsPolicy.SKIP);
           children.add(child);
-        } else if (children.size() > 0) {
+        } else if (!children.isEmpty()) {
           int index = r.nextInt(children.size());
           String child = children.remove(index);
           zk.recursiveDelete(rootDir + "/dir/" + child, NodeMissingPolicy.FAIL);

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -268,7 +268,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
           continue;
         }
 
-        if (locks != null && locks.size() > 0) {
+        if (locks != null && !locks.isEmpty()) {
           Collections.sort(locks);
 
           String lockPath = path + "/" + locks.get(0);

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -531,8 +531,8 @@ public class KerberosIT extends AccumuloITBase {
               client.securityOperations().getDelegationToken(new DelegationTokenConfig());
 
           assertTrue("Could not get tables with delegation token",
-              mac.createAccumuloClient(rootUser.getPrincipal(), token).tableOperations().list()
-                  .size() > 0);
+              !mac.createAccumuloClient(rootUser.getPrincipal(), token).tableOperations().list()
+                  .isEmpty());
 
           return token;
         });
@@ -548,7 +548,7 @@ public class KerberosIT extends AccumuloITBase {
       AccumuloClient client = mac.createAccumuloClient(rootUser.getPrincipal(), delegationToken1);
 
       assertTrue("Could not get tables with delegation token",
-          client.tableOperations().list().size() > 0);
+          !client.tableOperations().list().isEmpty());
 
       return null;
     });
@@ -565,8 +565,8 @@ public class KerberosIT extends AccumuloITBase {
               client.securityOperations().getDelegationToken(new DelegationTokenConfig());
 
           assertTrue("Could not get tables with delegation token",
-              mac.createAccumuloClient(rootUser.getPrincipal(), token).tableOperations().list()
-                  .size() > 0);
+              !mac.createAccumuloClient(rootUser.getPrincipal(), token).tableOperations().list()
+                  .isEmpty());
 
           return token;
         });

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterMetricsIT.java
@@ -213,7 +213,7 @@ public class MasterMetricsIT extends AccumuloClusterHarness {
 
       Map<String,String> results = metricsTail.parseLine("");
 
-      if (results != null && results.size() > 0
+      if (results != null && !results.isEmpty()
           && Long.parseLong(results.get("currentFateOps")) >= tableCount) {
         log.info("Found required number of fate operations");
         return results;

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -86,7 +86,7 @@ public class MetadataIT extends AccumuloClusterHarness {
           files2.add(entry.getKey().getColumnQualifier().toString());
 
         // flush of metadata table should change file set in root table
-        assertTrue(files2.size() > 0);
+        assertTrue(!files2.isEmpty());
         assertNotEquals(files1, files2);
 
         c.tableOperations().compact(MetadataTable.NAME, null, null, false, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -654,7 +654,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
             m.put("a", "b", "c");
             bw.addMutation(m);
           } catch (MutationsRejectedException e1) {
-            if (e1.getSecurityErrorCodes().size() > 0)
+            if (!e1.getSecurityErrorCodes().isEmpty())
               throw new AccumuloSecurityException(test_user_client.whoami(),
                   org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode.PERMISSION_DENIED,
                   e1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
@@ -169,7 +169,7 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
   private boolean checkGroup(Table<String,String,MutableInt> groupLocationCounts, String group,
       int min, int max, int tsevers) {
     Collection<MutableInt> counts = groupLocationCounts.row(group).values();
-    if (counts.size() == 0) {
+    if (counts.isEmpty()) {
       return min == 0 && max == 0 && tsevers == 0;
     }
     return min == Collections.min(counts).intValue() && max == Collections.max(counts).intValue()

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionBlockVerifyIT.java
@@ -147,7 +147,7 @@ public class SessionBlockVerifyIT extends ScanSessionTimeOutIT {
         for (ActiveScan scan : scans) {
           // only here to minimize chance of seeing meta extent scans
 
-          if (tableName.equals(scan.getTable()) && scan.getSsiList().size() > 0) {
+          if (tableName.equals(scan.getTable()) && !scan.getSsiList().isEmpty()) {
             assertEquals("Not the expected iterator", 1, scan.getSsiList().size());
             assertTrue("Not the expected iterator",
                 scan.getSsiList().iterator().next().contains("SlowIterator"));

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -235,7 +235,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
         throw new Exception(" " + lowBulkFiles + " != " + highBulkFiles + " " + low + " " + high);
       }
 
-      if (lowBulkFiles.size() == 0) {
+      if (lowBulkFiles.isEmpty()) {
         throw new Exception(" no bulk files " + low);
       }
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/VisibilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/VisibilityIT.java
@@ -325,7 +325,7 @@ public class VisibilityIT extends AccumuloClusterHarness {
       }
     }
 
-    if (valuesSeen.size() != 0) {
+    if (!valuesSeen.isEmpty()) {
       throw new Exception("Saw more values than expected " + valuesSeen);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -467,7 +467,7 @@ public class CollectTabletStats {
           .forFile(file.getPathStr(), ns, ns.getConf(), CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(aconf).build();
       Range range = new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true);
-      reader.seek(range, columnSet, columnSet.size() != 0);
+      reader.seek(range, columnSet, !columnSet.isEmpty());
       while (reader.hasTop() && !range.afterEndKey(reader.getTopKey())) {
         count++;
         reader.next();
@@ -510,7 +510,7 @@ public class CollectTabletStats {
     HashSet<ByteSequence> columnSet = createColumnBSS(columns);
 
     reader.seek(new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true), columnSet,
-        columnSet.size() != 0);
+        !columnSet.isEmpty());
 
     int count = 0;
 


### PR DESCRIPTION
Per SonarQube recommendations:
Using Collection.size() to test for emptiness works, but using Collection.isEmpty() makes the code more readable and can be more performant. The time complexity of any isEmpty() method implementation should be O(1) whereas some implementations of size() can be O(n).