### PR TITLE
Remove negations in 'isEmpty' and 'if' statements.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -340,10 +340,10 @@ class ConditionalWriterImpl implements ConditionalWriter {
     // result in bigger batches and less RPC overhead
 
     synchronized (serverQueue) {
-      if (!serverQueue.queue.isEmpty())
-        threadPool.execute(new LoggingRunnable(log, Trace.wrap(task)));
-      else
+      if (serverQueue.queue.isEmpty())
         serverQueue.taskQueued = false;
+      else
+        threadPool.execute(new LoggingRunnable(log, Trace.wrap(task)));
     }
 
   }
@@ -488,11 +488,11 @@ class ConditionalWriterImpl implements ConditionalWriter {
         if (sid.reserved)
           throw new IllegalStateException();
 
-        if (!sid.isActive()) {
-          cachedSessionIDs.remove(location);
-        } else {
+        if (sid.isActive()) {
           sid.reserved = true;
           return sid;
+        } else {
+          cachedSessionIDs.remove(location);
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -235,7 +235,9 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       binnedRanges.clear();
       List<Range> failures = tabletLocator.binRanges(context, ranges, binnedRanges);
 
-      if (!failures.isEmpty()) {
+      if (failures.isEmpty()) {
+        break;
+      } else {
         // tried to only do table state checks when failures.size() == ranges.size(), however this
         // did
         // not work because nothing ever invalidated entries in the tabletLocator cache... so even
@@ -260,8 +262,6 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         } catch (InterruptedException e) {
           throw new RuntimeException(e);
         }
-      } else {
-        break;
       }
 
     }
@@ -382,10 +382,10 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         log.debug("AccumuloSecurityException thrown", e);
 
         Tables.clearCache(context);
-        if (!Tables.exists(context, tableId))
-          fatalException = new TableDeletedException(tableId.canonical());
-        else
+        if (Tables.exists(context, tableId))
           fatalException = e;
+        else
+          fatalException = new TableDeletedException(tableId.canonical());
       } catch (SampleNotPresentException e) {
         fatalException = e;
       } catch (Throwable t) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -291,15 +291,15 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
       ports = new int[1];
       try {
         int port = Integer.parseInt(portString);
-        if (port != 0) {
+        if (port == 0) {
+          ports[0] = port;
+        } else {
           if (port < 1024 || port > 65535) {
             log.error("Invalid port number {}; Using default {}", port, property.getDefaultValue());
             ports[0] = Integer.parseInt(property.getDefaultValue());
           } else {
             ports[0] = port;
           }
-        } else {
-          ports[0] = port;
         }
       } catch (NumberFormatException e1) {
         throw new IllegalArgumentException("Invalid port syntax. Must be a single positive "

--- a/core/src/main/java/org/apache/accumulo/core/cryptoImpl/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/cryptoImpl/AESCryptoService.java
@@ -353,10 +353,11 @@ public class AESCryptoService implements CryptoService {
       void incrementIV(byte[] iv, int i) {
         iv[i]++;
         if (iv[i] == 0) {
-          if (i != 0) {
-            incrementIV(iv, i - 1);
-          } else
+          if (i == 0)
             return;
+          else {
+            incrementIV(iv, i - 1);
+          }
         }
 
       }

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -1565,9 +1565,7 @@ public class Mutation implements Writable {
     entries = WritableUtils.readVInt(in);
 
     boolean valuesPresent = (first & 0x01) == 0x01;
-    if (!valuesPresent) {
-      values = null;
-    } else {
+    if (valuesPresent) {
       values = new ArrayList<>();
       int numValues = WritableUtils.readVInt(in);
       for (int i = 0; i < numValues; i++) {
@@ -1576,6 +1574,8 @@ public class Mutation implements Writable {
         in.readFully(val);
         values.add(val);
       }
+    } else {
+      values = null;
     }
 
     if ((first & 0x02) == 0x02) {
@@ -1605,9 +1605,7 @@ public class Mutation implements Writable {
 
     List<byte[]> localValues;
     boolean valuesPresent = in.readBoolean();
-    if (!valuesPresent) {
-      localValues = null;
-    } else {
+    if (valuesPresent) {
       localValues = new ArrayList<>();
       int numValues = in.readInt();
       for (int i = 0; i < numValues; i++) {
@@ -1616,6 +1614,8 @@ public class Mutation implements Writable {
         in.readFully(val);
         localValues.add(val);
       }
+    } else {
+      localValues = null;
     }
 
     // convert data to new format

--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -684,18 +684,18 @@ public class Range implements WritableComparable<Range> {
   public void readFields(DataInput in) throws IOException {
     infiniteStartKey = in.readBoolean();
     infiniteStopKey = in.readBoolean();
-    if (!infiniteStartKey) {
+    if (infiniteStartKey) {
+      start = null;
+    } else {
       start = new Key();
       start.readFields(in);
-    } else {
-      start = null;
     }
 
-    if (!infiniteStopKey) {
+    if (infiniteStopKey) {
+      stop = null;
+    } else {
       stop = new Key();
       stop.readFields(in);
-    } else {
-      stop = null;
     }
 
     startKeyInclusive = in.readBoolean();

--- a/core/src/main/java/org/apache/accumulo/core/data/Value.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Value.java
@@ -106,11 +106,11 @@ public class Value implements WritableComparable<Object> {
    */
   public Value(byte[] bytes, boolean copy) {
     requireNonNull(bytes);
-    if (!copy) {
-      this.value = bytes;
-    } else {
+    if (copy) {
       this.value = new byte[bytes.length];
       System.arraycopy(bytes, 0, this.value, 0, bytes.length);
+    } else {
+      this.value = bytes;
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -256,10 +256,10 @@ public class BloomFilterLayer {
         } catch (NoSuchMetaStoreException nsme) {
           // file does not have a bloom filter, ignore it
         } catch (IOException ioe) {
-          if (!closed)
-            LOG.warn("Can't open BloomFilter", ioe);
-          else
+          if (closed)
             LOG.debug("Can't open BloomFilter, file closed : {}", ioe.getMessage());
+          else
+            LOG.warn("Can't open BloomFilter", ioe);
 
           bloomFilter = null;
         } catch (ClassNotFoundException e) {
@@ -269,10 +269,10 @@ public class BloomFilterLayer {
           LOG.error("Could not instantiate KeyFunctor: " + sanitize(ClassName), e);
           bloomFilter = null;
         } catch (RuntimeException rte) {
-          if (!closed)
-            throw rte;
-          else
+          if (closed)
             LOG.debug("Can't open BloomFilter, RTE after closed ", rte);
+          else
+            throw rte;
         } finally {
           if (in != null) {
             try {
@@ -372,11 +372,11 @@ public class BloomFilterLayer {
     public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
         throws IOException {
 
-      if (!bfl.probablyHasKey(range)) {
-        checkSuper = false;
-      } else {
+      if (bfl.probablyHasKey(range)) {
         reader.seek(range, columnFamilies, inclusive);
         checkSuper = true;
+      } else {
+        checkSuper = false;
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -187,13 +187,13 @@ public class CachableBlockFile {
           tmpReader = new BCFile.Reader(serializedMetadata, fsIn, conf, cryptoService);
         }
 
-        if (!bcfr.compareAndSet(null, tmpReader)) {
+        if (bcfr.compareAndSet(null, tmpReader)) {
+          fin = fsIn;
+          return tmpReader;
+        } else {
           fsIn.close();
           tmpReader.close();
           return bcfr.get();
-        } else {
-          fin = fsIn;
-          return tmpReader;
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -575,10 +575,10 @@ public class MultiLevelIndex {
 
       out.writeInt(totalAdded);
       // save root node
-      if (!levels.isEmpty()) {
-        levels.get(levels.size() - 1).write(out);
-      } else {
+      if (levels.isEmpty()) {
         new IndexBlock(0, 0).write(out);
+      } else {
+        levels.get(levels.size() - 1).write(out);
       }
 
     }
@@ -719,10 +719,10 @@ public class MultiLevelIndex {
         if (node == null)
           return false;
 
-        if (!liter.hasNext()) {
-          return node.indexBlock.hasNext();
-        } else {
+        if (liter.hasNext()) {
           return true;
+        } else {
+          return node.indexBlock.hasNext();
         }
 
       }
@@ -754,10 +754,10 @@ public class MultiLevelIndex {
         if (node == null)
           return false;
 
-        if (!liter.hasPrevious()) {
-          return node.indexBlock.getOffset() > 0;
-        } else {
+        if (liter.hasPrevious()) {
           return true;
+        } else {
+          return node.indexBlock.getOffset() > 0;
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/PrintInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/PrintInfo.java
@@ -323,11 +323,11 @@ public class PrintInfo implements KeywordExecutable {
       long cryptoParamOffset = fsDis.readLong();
       fsDis.seek(cryptoParamOffset);
       byte[] cryptoParams = CryptoUtils.readParams(fsDis);
-      if (!Arrays.equals(noCryptoBytes, cryptoParams)) {
+      if (Arrays.equals(noCryptoBytes, cryptoParams)) {
+        System.out.println("No on disk encryption detected.");
+      } else {
         System.out.println("Encrypted with Params: "
             + Key.toPrintableString(cryptoParams, 0, cryptoParams.length, cryptoParams.length));
-      } else {
-        System.out.println("No on disk encryption detected.");
       }
     } catch (IOException ioe) {
       log.error("Error reading crypto params", ioe);

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -1001,9 +1001,7 @@ public class RFile {
 
         reset();
 
-        if (!iiter.hasNext()) {
-          // past the last key
-        } else {
+        if (iiter.hasNext()) {
 
           // if the index contains the same key multiple times, then go to the
           // earliest index entry containing the key
@@ -1061,6 +1059,8 @@ public class RFile {
           // set rk when everything above is successful, if exception
           // occurs rk will not be set
           rk = skippr.rk;
+        } else {
+          // past the last key
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
@@ -95,14 +95,13 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
 
         // determine where to seek to, but don't go beyond the user-specified range
         Key nextKey = source.getTopKey().followingKey(PartialKey.ROW);
-        if (!latestRange.afterEndKey(nextKey))
+        if (latestRange.afterEndKey(nextKey)) {
+          finished = true;
+          break;
+        } else
           source.seek(
               new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()),
               latestColumnFamilies, latestInclusive);
-        else {
-          finished = true;
-          break;
-        }
       }
     }
     lastRowFound = source.hasTop() ? source.getTopKey().getRow(lastRowFound) : null;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/OrIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/OrIterator.java
@@ -135,7 +135,9 @@ public class OrIterator implements SortedKeyValueIterator<Key,Value>, OptionDesc
      */
     public void seek(Range originalRange) throws IOException {
       // the infinite start key is equivalent to a null startKey on the Range.
-      if (!originalRange.isInfiniteStartKey()) {
+      if (originalRange.isInfiniteStartKey()) {
+        currentRange = originalRange;
+      } else {
         Key originalStartKey = originalRange.getStartKey();
         // Pivot the provided range into the range for this term
         Key newKey = new Key(originalStartKey.getRow(), term, originalStartKey.getColumnQualifier(),
@@ -143,8 +145,6 @@ public class OrIterator implements SortedKeyValueIterator<Key,Value>, OptionDesc
         // Construct the new range, preserving the other attributes on the provided range.
         currentRange = new Range(newKey, originalRange.isStartKeyInclusive(),
             originalRange.getEndKey(), originalRange.isEndKeyInclusive());
-      } else {
-        currentRange = originalRange;
       }
       LOG.trace("Seeking {} to {}", this, currentRange);
       iter.seek(currentRange, seekColfams, true);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
@@ -180,12 +180,12 @@ public abstract class SeekingFilter extends WrappingIterator {
             f.advance == AdvanceResult.USE_HINT ? getNextKeyHint(src.getTopKey(), src.getTopValue())
                 : " (none)");
       }
-      if (f.accept != negate) {
+      if (f.accept == negate) {
+        advanceSource(src, f.advance);
+      } else {
         // advance will be processed when next is called
         advance = f.advance;
         break;
-      } else {
-        advanceSource(src, f.advance);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
@@ -145,9 +145,7 @@ public class ColumnSet {
 
     // very inefficient code
     for (int i = 0; i < sb.length; i++) {
-      if (sb[i] != '%') {
-        t.append(new byte[] {sb[i]}, 0, 1);
-      } else {
+      if (sb[i] == '%') {
         int x = ++i;
         int y = ++i;
         if (y < sb.length) {
@@ -159,6 +157,8 @@ public class ColumnSet {
           throw new IllegalArgumentException("Invalid characters in encoded string (" + s + ")."
               + " Expected two characters after '%'");
         }
+      } else {
+        t.append(new byte[] {sb[i]}, 0, 1);
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/HeapIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/HeapIterator.java
@@ -72,15 +72,7 @@ public abstract class HeapIterator implements SortedKeyValueIterator<Key,Value> 
     }
 
     topIdx.next();
-    if (!topIdx.hasTop()) {
-      if (nextKey == null) {
-        // No iterators left
-        topIdx = null;
-        return;
-      }
-
-      pullReferencesFromHeap();
-    } else {
+    if (topIdx.hasTop()) {
       if (nextKey == null) {
         // topIdx is the only iterator
         return;
@@ -96,15 +88,23 @@ public abstract class HeapIterator implements SortedKeyValueIterator<Key,Value> 
         topIdx = nextTopIdx;
         nextKey = heap.peek().getTopKey();
       }
+    } else {
+      if (nextKey == null) {
+        // No iterators left
+        topIdx = null;
+        return;
+      }
+
+      pullReferencesFromHeap();
     }
   }
 
   private void pullReferencesFromHeap() {
     topIdx = heap.remove();
-    if (!heap.isEmpty()) {
-      nextKey = heap.peek().getTopKey();
-    } else {
+    if (heap.isEmpty()) {
       nextKey = null;
+    } else {
+      nextKey = heap.peek().getTopKey();
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/LocalityGroupIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/LocalityGroupIterator.java
@@ -164,15 +164,15 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
     hiter.clear();
 
     Set<ByteSequence> cfSet;
-    if (!columnFamilies.isEmpty()) {
+    if (columnFamilies.isEmpty()) {
+      cfSet = Collections.emptySet();
+    } else {
       if (columnFamilies instanceof Set<?>) {
         cfSet = (Set<ByteSequence>) columnFamilies;
       } else {
         cfSet = new HashSet<>();
         cfSet.addAll(columnFamilies);
       }
-    } else {
-      cfSet = Collections.emptySet();
     }
 
     // determine the set of groups to use

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
@@ -86,7 +86,18 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
       return false;
     }
 
-    if (!curr.getTableId().equals(prev.getTableId())) {
+    if (curr.getTableId().equals(prev.getTableId())) {
+      if (prev.getEndRow() == null) {
+        throw new IllegalStateException("Null end row for tablet in middle of table: "
+            + prev.getExtent() + " " + curr.getExtent());
+      }
+
+      if (curr.getPrevEndRow() == null || !prev.getEndRow().equals(curr.getPrevEndRow())) {
+        log.debug("Tablets end row and prev end row not equals {} {} ", prev.getExtent(),
+            curr.getExtent());
+        return false;
+      }
+    } else {
       if (prev.getEndRow() != null) {
         log.debug("Non-null end row for last tablet in table: " + prev.getExtent() + " "
             + curr.getExtent());
@@ -95,17 +106,6 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
 
       if (curr.getPrevEndRow() != null) {
         log.debug("First tablet for table had prev end row {} {} ", prev.getExtent(),
-            curr.getExtent());
-        return false;
-      }
-    } else {
-      if (prev.getEndRow() == null) {
-        throw new IllegalStateException("Null end row for tablet in middle of table: "
-            + prev.getExtent() + " " + curr.getExtent());
-      }
-
-      if (curr.getPrevEndRow() == null || !prev.getEndRow().equals(curr.getPrevEndRow())) {
-        log.debug("Tablets end row and prev end row not equals {} {} ", prev.getExtent(),
             curr.getExtent());
         return false;
       }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
@@ -95,12 +95,12 @@ public class SslConnectionParams {
   private static String passwordFromConf(AccumuloConfiguration conf, String defaultPassword,
       Property passwordOverrideProperty) {
     String keystorePassword = conf.get(passwordOverrideProperty);
-    if (!keystorePassword.isEmpty()) {
+    if (keystorePassword.isEmpty()) {
+      keystorePassword = defaultPassword;
+    } else {
       if (log.isTraceEnabled())
         log.trace("Using explicit SSL private key password from {}",
             passwordOverrideProperty.getKey());
-    } else {
-      keystorePassword = defaultPassword;
     }
     return keystorePassword;
   }

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -398,7 +398,9 @@ class SummarySerializer {
   static SummarySerializer load(SummarizerConfiguration sconf, DataInputStream in)
       throws IOException {
     boolean exceededMaxSize = in.readBoolean();
-    if (!exceededMaxSize) {
+    if (exceededMaxSize) {
+      return new SummarySerializer(sconf);
+    } else {
       WritableUtils.readVInt(in);
       // load symbol table
       int numSymbols = WritableUtils.readVInt(in);
@@ -414,8 +416,6 @@ class SummarySerializer {
       }
 
       return new SummarySerializer(sconf, allSummaries);
-    } else {
-      return new SummarySerializer(sconf);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/ShardedTableDistributionFormatter.java
@@ -47,11 +47,12 @@ public class ShardedTableDistributionFormatter extends AggregatingFormatter {
       // Parse the day out of the row
       int semicolon = row.indexOf(";");
       String day = null;
-      if (semicolon != -1) {
+      if (semicolon == -1)
+        day = "NULL    ";
+      else {
         semicolon++;
         day = row.substring(semicolon, semicolon + 8);
-      } else
-        day = "NULL    ";
+      }
       String server = entry.getValue().toString();
       countsByDay.computeIfAbsent(day, k -> new HashSet<>());
       countsByDay.get(day).add(server);

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -162,11 +162,12 @@ public class ZooStore<T> implements TStore<T> {
               else
                 continue;
             }
-            if (!reserved.contains(tid)) {
+            if (reserved.contains(tid))
+              continue;
+            else {
               reserved.add(tid);
               lastReserved = txdir;
-            } else
-              continue;
+            }
           }
 
           // have reserved id, status should not change
@@ -191,13 +192,14 @@ public class ZooStore<T> implements TStore<T> {
         synchronized (this) {
           // suppress lgtm alert - synchronized variable is not always true
           if (events == statusChangeEvents) { // lgtm [java/constant-comparison]
-            if (!defered.isEmpty()) {
+            if (defered.isEmpty())
+              this.wait(5000);
+            else {
               Long minTime = Collections.min(defered.values());
               long waitTime = minTime - System.currentTimeMillis();
               if (waitTime > 0)
                 this.wait(Math.min(waitTime, 5000));
-            } else
-              this.wait(5000);
+            }
           }
         }
       }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooReaderWriter.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooReaderWriter.java
@@ -234,7 +234,7 @@ public class ZooReaderWriter extends ZooReader {
   public void recursiveCopyPersistent(String source, String destination, NodeExistsPolicy policy)
       throws KeeperException, InterruptedException {
     Stat stat = null;
-    if (!(getStatus(getZooKeeper(), getRetryFactory(), source) != null))
+    if (getStatus(getZooKeeper(), getRetryFactory(), source) == null)
       throw KeeperException.create(Code.NONODE, source);
     if (getStatus(getZooKeeper(), getRetryFactory(), destination) != null) {
       switch (policy) {

--- a/core/src/test/java/org/apache/accumulo/core/data/OldMutation.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/OldMutation.java
@@ -454,9 +454,7 @@ public class OldMutation implements Writable {
     entries = in.readInt();
 
     boolean valuesPresent = in.readBoolean();
-    if (!valuesPresent) {
-      values = null;
-    } else {
+    if (valuesPresent) {
       values = new ArrayList<>();
       int numValues = in.readInt();
       for (int i = 0; i < numValues; i++) {
@@ -465,6 +463,8 @@ public class OldMutation implements Writable {
         in.readFully(val);
         values.add(val);
       }
+    } else {
+      values = null;
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -275,10 +275,10 @@ public class MultiThreadedRFileTest {
 
       for (Throwable t : threadExceptions) {
         String msg = t.getClass() + " : " + t.getMessage();
-        if (!messages.containsKey(msg)) {
-          messages.put(msg, new MutableInt(1));
-        } else {
+        if (messages.containsKey(msg)) {
           messages.get(msg).increment();
+        } else {
+          messages.put(msg, new MutableInt(1));
         }
         StringWriter string = new StringWriter();
         PrintWriter writer = new PrintWriter(string);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -877,10 +877,10 @@ public class CombinerTest {
     assertEquals(expected, readAll(ai));
 
     long logSize = CombinerTestUtil.cacheSize();
-    if (!expectedLog) {
-      assertEquals("Expected 0 log messages, but got : " + logSize, 0, logSize);
-    } else {
+    if (expectedLog) {
       assertTrue("Expected >0 log messages, but got : " + logSize, logSize > 0);
+    } else {
+      assertEquals("Expected 0 log messages, but got : " + logSize, 0, logSize);
     }
   }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/ConfiguratorBase.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/ConfiguratorBase.java
@@ -106,7 +106,9 @@ public class ConfiguratorBase {
     String propString;
     String clientPropsFile =
         conf.get(enumToConfKey(implementingClass, ClientOpts.CLIENT_PROPS_FILE), "");
-    if (!clientPropsFile.isEmpty()) {
+    if (clientPropsFile.isEmpty()) {
+      propString = conf.get(enumToConfKey(implementingClass, ClientOpts.CLIENT_PROPS), "");
+    } else {
       try (InputStream inputStream = DistributedCacheHelper.openCachedFile(clientPropsFile,
           cachedClientPropsFileName(implementingClass), conf)) {
 
@@ -120,8 +122,6 @@ public class ConfiguratorBase {
       } catch (IOException e) {
         throw new IllegalStateException("Error closing client properties file stream", e);
       }
-    } else {
-      propString = conf.get(enumToConfKey(implementingClass, ClientOpts.CLIENT_PROPS), "");
     }
     Properties props = new Properties();
     if (!propString.isEmpty()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -760,7 +760,7 @@ public class BulkImporter {
       sb.append(String.format("# map files with failures : %,10d %6.2f%s%n",
           completeFailures.size(), completeFailures.size() * 100.0 / numUniqueMapFiles, "%"));
       sb.append(String.format("# failed failed map files : %,10d %s%n", failedFailures.size(),
-          !failedFailures.isEmpty() ? " <-- THIS IS BAD" : ""));
+          failedFailures.isEmpty() ? "" : " <-- THIS IS BAD"));
       sb.append(String.format("# of tablets              : %,10d%n", counts.size()));
       sb.append(String.format("# tablets imported to     : %,10d %6.2f%s%n", tabletsImportedTo,
           tabletsImportedTo * 100.0 / counts.size(), "%"));

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/NamespaceConfiguration.java
@@ -108,11 +108,11 @@ public class NamespaceConfiguration extends AccumuloConfiguration {
   public String get(Property property) {
     String key = property.getKey();
     AccumuloConfiguration getParent;
-    if (!(namespaceId.equals(Namespace.ACCUMULO.id()) && isIteratorOrConstraint(key))) {
-      getParent = parent;
-    } else {
+    if (namespaceId.equals(Namespace.ACCUMULO.id()) && isIteratorOrConstraint(key)) {
       // ignore iterators from parent if system namespace
       getParent = null;
+    } else {
+      getParent = parent;
     }
     return getPropCacheAccessor().get(property, getPath(), getParent);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -142,13 +142,13 @@ public class MetadataConstraints implements Constraint {
       }
     }
 
-    if (!containsSemiC) {
-      // see if last row char is <
-      if (row.length == 0 || row[row.length - 1] != '<') {
+    if (containsSemiC) {
+      if (row.length == 0) {
         violations = addIfNotPresent(violations, 4);
       }
     } else {
-      if (row.length == 0) {
+      // see if last row char is <
+      if (row.length == 0 || row[row.length - 1] != '<') {
         violations = addIfNotPresent(violations, 4);
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -335,7 +335,9 @@ public class DefaultLoadBalancer extends TabletBalancer {
   public long balance(SortedMap<TServerInstance,TabletServerStatus> current,
       Set<KeyExtent> migrations, List<TabletMigration> migrationsOut) {
     // do we have any servers?
-    if (!current.isEmpty()) {
+    if (current.isEmpty()) {
+      constraintNotMet(NO_SERVERS);
+    } else {
       // Don't migrate if we have migrations in progress
       if (migrations.isEmpty()) {
         resetBalancerErrors();
@@ -345,8 +347,6 @@ public class DefaultLoadBalancer extends TabletBalancer {
         outstandingMigrations.migrations = migrations;
         constraintNotMet(outstandingMigrations);
       }
-    } else {
-      constraintNotMet(NO_SERVERS);
     }
     return 5 * 1000;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
@@ -193,14 +193,14 @@ public abstract class TabletBalancer {
    * provided logging handler more often than TIME_BETWEEN_BALANCER_WARNINGS
    */
   protected void constraintNotMet(BalancerProblem cause) {
-    if (!stuck) {
-      stuck = true;
-      stuckNotificationTime = System.currentTimeMillis();
-    } else {
+    if (stuck) {
       if ((System.currentTimeMillis() - stuckNotificationTime) > TIME_BETWEEN_BALANCER_WARNINGS) {
         cause.run();
         stuckNotificationTime = System.currentTimeMillis();
       }
+    } else {
+      stuck = true;
+      stuckNotificationTime = System.currentTimeMillis();
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/StatusCombiner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/StatusCombiner.java
@@ -113,14 +113,14 @@ public class StatusCombiner extends TypedValueCombiner<Status> {
       // Avoid creation of a new builder and message when we only have one
       // message to reduce
       if (combined == null) {
-        if (!iter.hasNext()) {
+        if (iter.hasNext()) {
+          combined = Status.newBuilder();
+        } else {
           if (log.isTraceEnabled()) {
             log.trace("Returned single value: {} {}", key.toStringNoTruncate(),
                 ProtobufUtil.toString(status));
           }
           return status;
-        } else {
-          combined = Status.newBuilder();
         }
       }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributor.java
@@ -68,11 +68,7 @@ public class ZooAuthenticationKeyDistributor {
       return;
     }
 
-    if (!zk.exists(baseNode)) {
-      if (!zk.putPrivatePersistentData(baseNode, new byte[0], NodeExistsPolicy.FAIL)) {
-        throw new AssertionError("Got false from putPrivatePersistentData method");
-      }
-    } else {
+    if (zk.exists(baseNode)) {
       List<ACL> acls = zk.getACL(baseNode, new Stat());
       if (acls.size() == 1) {
         ACL actualAcl = acls.get(0), expectedAcl = ZooUtil.PRIVATE.get(0);
@@ -90,6 +86,10 @@ public class ZooAuthenticationKeyDistributor {
       log.error("Expected {} to have ACLs {} but was {}", baseNode, ZooUtil.PRIVATE, acls);
       throw new IllegalStateException(
           "Delegation token secret key node in ZooKeeper is not protected.");
+    } else {
+      if (!zk.putPrivatePersistentData(baseNode, new byte[0], NodeExistsPolicy.FAIL)) {
+        throw new AssertionError("Got false from putPrivatePersistentData method");
+      }
     }
 
     initialized.set(true);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -129,11 +129,7 @@ public class MasterMetadataUtil {
     try (ScannerImpl scanner2 = new ScannerImpl(context, MetadataTable.ID, Authorizations.EMPTY)) {
       scanner2.setRange(new Range(prevRowKey, prevRowKey.followingKey(PartialKey.ROW)));
 
-      if (!scanner2.iterator().hasNext()) {
-        log.info("Rolling back incomplete split {} {}", metadataEntry, metadataPrevEndRow);
-        MetadataTableUtil.rollBackSplit(metadataEntry, oper, context, lock);
-        return new KeyExtent(metadataEntry, oper);
-      } else {
+      if (scanner2.iterator().hasNext()) {
         log.info("Finishing incomplete split {} {}", metadataEntry, metadataPrevEndRow);
 
         List<StoredTabletFile> highDatafilesToRemove = new ArrayList<>();
@@ -164,6 +160,10 @@ public class MasterMetadataUtil {
             context, lock);
 
         return new KeyExtent(metadataEntry, KeyExtent.encodePrevEndRow(metadataPrevEndRow));
+      } else {
+        log.info("Rolling back incomplete split {} {}", metadataEntry, metadataPrevEndRow);
+        MetadataTableUtil.rollBackSplit(metadataEntry, oper, context, lock);
+        return new KeyExtent(metadataEntry, oper);
       }
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -564,7 +564,12 @@ public class MetadataTableUtil {
       if (cloneSuccessful)
         continue;
 
-      if (!srcFiles.containsAll(cloneFiles)) {
+      if (srcFiles.containsAll(cloneFiles)) {
+        // write out marker that this tablet was successfully cloned
+        Mutation m = new Mutation(cloneTablet.getExtent().getMetadataEntry());
+        m.put(ClonedColumnFamily.NAME, new Text(""), new Value("OK"));
+        bw.addMutation(m);
+      } else {
         // delete existing cloned tablet entry
         Mutation m = new Mutation(cloneTablet.getExtent().getMetadataEntry());
 
@@ -579,11 +584,6 @@ public class MetadataTableUtil {
           bw.addMutation(createCloneMutation(srcTableId, tableId, st.getKeyValues()));
 
         rewrites++;
-      } else {
-        // write out marker that this tablet was successfully cloned
-        Mutation m = new Mutation(cloneTablet.getExtent().getMetadataEntry());
-        m.put(ClonedColumnFamily.NAME, new Text(""), new Value("OK"));
-        bw.addMutation(m);
       }
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -91,7 +91,11 @@ public class RemoveEntriesForMissingFiles {
     @SuppressWarnings("unchecked")
     public void run() {
       try {
-        if (!fs.exists(path)) {
+        if (fs.exists(path)) {
+          synchronized (processing) {
+            cache.put(path, path);
+          }
+        } else {
           missing.incrementAndGet();
 
           Mutation m = new Mutation(key.getRow());
@@ -101,10 +105,6 @@ public class RemoveEntriesForMissingFiles {
             System.out.println("Reference " + path + " removed from " + key.getRow());
           } else {
             System.out.println("File " + path + " is missing");
-          }
-        } else {
-          synchronized (processing) {
-            cache.put(path, path);
           }
         }
       } catch (Exception e) {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -168,7 +168,18 @@ public class GarbageCollectionAlgorithm {
     while (iter.hasNext()) {
       Reference ref = iter.next();
 
-      if (!ref.isDir) {
+      if (ref.isDir) {
+        String tableID = ref.id.toString();
+        String dirName = ref.ref;
+        ServerColumnFamily.validateDirCol(dirName);
+
+        String dir = "/" + tableID + "/" + dirName;
+
+        dir = makeRelative(dir, 2);
+
+        if (candidateMap.remove(dir) != null)
+          log.debug("Candidate was still in use: {}", dir);
+      } else {
 
         String reference = ref.ref;
         if (reference.startsWith("/")) {
@@ -188,17 +199,6 @@ public class GarbageCollectionAlgorithm {
         if (candidateMap.remove(dir) != null)
           log.debug("Candidate was still in use: {}", reference);
 
-      } else {
-        String tableID = ref.id.toString();
-        String dirName = ref.ref;
-        ServerColumnFamily.validateDirCol(dirName);
-
-        String dir = "/" + tableID + "/" + dirName;
-
-        dir = makeRelative(dir, 2);
-
-        if (candidateMap.remove(dir) != null)
-          log.debug("Candidate was still in use: {}", dir);
       }
     }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -884,13 +884,13 @@ public class Master extends AbstractServer
         migrations.put(m.tablet, m.newServer);
         log.debug("migration {}", m);
       }
-      if (!migrationsOut.isEmpty()) {
-        nextEvent.event("Migrating %d more tablets, %d total", migrationsOut.size(),
-            migrations.size());
-      } else {
+      if (migrationsOut.isEmpty()) {
         synchronized (balancedNotifier) {
           balancedNotifier.notifyAll();
         }
+      } else {
+        nextEvent.event("Migrating %d more tablets, %d total", migrationsOut.size(),
+            migrations.size());
       }
       return wait;
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -573,11 +573,11 @@ public class MasterClientServiceHandler extends FateServiceHandler
         }
 
         // Skip files that we didn't observe when we started (new files/data)
-        if (!relevantLogs.contains(file)) {
+        if (relevantLogs.contains(file)) {
+          drainLog.trace("Found file that we *do* care about {}", file);
+        } else {
           drainLog.trace("Found file that we didn't care about {}", file);
           continue;
-        } else {
-          drainLog.trace("Found file that we *do* care about {}", file);
         }
 
         try {

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
@@ -129,12 +129,12 @@ public class WorkMaker {
         // If we have targets, we need to make a work record
         // TODO Don't replicate if it's a only a newFile entry (nothing to replicate yet)
         // -- Another scanner over the WorkSection can make this relatively cheap
-        if (!replicationTargets.isEmpty()) {
+        if (replicationTargets.isEmpty()) {
+          log.warn("No configured targets for table with ID {}", tableId);
+        } else {
           try (TraceScope workSpan = Trace.startSpan("createWorkMutations")) {
             addWorkRecord(file, entry.getValue(), replicationTargets, tableId);
           }
-        } else {
-          log.warn("No configured targets for table with ID {}", tableId);
         }
       }
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/state/MergeStats.java
@@ -153,12 +153,7 @@ public class MergeStats {
       }
     }
     if (state == MergeState.WAITING_FOR_OFFLINE) {
-      if (chopped != needsToBeChopped) {
-        log.warn("Unexpected state: chopped tablets should be {} was {} merge {}", needsToBeChopped,
-            chopped, info.getExtent());
-        // Perhaps a split occurred after we chopped, but before we went offline: start over
-        state = MergeState.WAITING_FOR_CHOPPED;
-      } else {
+      if (chopped == needsToBeChopped) {
         log.info("{} tablets are chopped, {} are offline {}", chopped, unassigned,
             info.getExtent());
         if (unassigned == total) {
@@ -170,6 +165,11 @@ public class MergeStats {
           log.info("Waiting for {} unassigned tablets to be {} {}", unassigned, total,
               info.getExtent());
         }
+      } else {
+        log.warn("Unexpected state: chopped tablets should be {} was {} merge {}", needsToBeChopped,
+            chopped, info.getExtent());
+        // Perhaps a split occurred after we chopped, but before we went offline: start over
+        state = MergeState.WAITING_FOR_CHOPPED;
       }
     }
     if (state == MergeState.MERGING) {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/clone/FinishCloneTable.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/clone/FinishCloneTable.java
@@ -47,10 +47,10 @@ class FinishCloneTable extends MasterRepo {
     // may never create files.. therefore there is no need to consume namenode space w/ directories
     // that are not used... tablet will create directories as needed
 
-    if (!cloneInfo.keepOffline) {
-      environment.getTableManager().transitionTableState(cloneInfo.tableId, TableState.ONLINE);
-    } else {
+    if (cloneInfo.keepOffline) {
       environment.getTableManager().transitionTableState(cloneInfo.tableId, TableState.OFFLINE);
+    } else {
+      environment.getTableManager().transitionTableState(cloneInfo.tableId, TableState.ONLINE);
     }
 
     Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, tid, false);

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -63,10 +63,7 @@ public class EmbeddedWebServer {
   private static AbstractConnectionFactory[] getConnectionFactories(AccumuloConfiguration conf,
       boolean secure) {
     HttpConnectionFactory httpFactory = new HttpConnectionFactory();
-    if (!secure) {
-      LOG.debug("Not configuring Jetty to use TLS");
-      return new AbstractConnectionFactory[] {httpFactory};
-    } else {
+    if (secure) {
       LOG.debug("Configuring Jetty to use TLS");
       final SslContextFactory sslContextFactory = new SslContextFactory.Server();
       // If the key password is the same as the keystore password, we don't
@@ -101,6 +98,9 @@ public class EmbeddedWebServer {
       SslConnectionFactory sslFactory =
           new SslConnectionFactory(sslContextFactory, httpFactory.getProtocol());
       return new AbstractConnectionFactory[] {sslFactory, httpFactory};
+    } else {
+      LOG.debug("Not configuring Jetty to use TLS");
+      return new AbstractConnectionFactory[] {httpFactory};
     }
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
@@ -320,7 +320,9 @@ public class TracesResource {
       principal = conf.get(Property.TRACE_USER);
     }
 
-    if (!saslEnabled) {
+    if (saslEnabled) {
+      at = null;
+    } else {
       if (loginMap.isEmpty()) {
         Property p = Property.TRACE_PASSWORD;
         at = new PasswordToken(conf.get(p).getBytes(UTF_8));
@@ -336,8 +338,6 @@ public class TracesResource {
         token.init(props);
         at = token;
       }
-    } else {
-      at = null;
     }
 
     java.util.Properties props = monitor.getContext().getProperties();

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -365,13 +365,7 @@ public class TraceServer implements Watcher, AutoCloseable {
       Class<? extends AuthenticationToken> traceTokenType = AccumuloVFSClassLoader.getClassLoader()
           .loadClass(acuConf.get(Property.TRACE_TOKEN_TYPE)).asSubclass(AuthenticationToken.class);
 
-      if (!(KerberosToken.class.isAssignableFrom(traceTokenType))) {
-        // We're not using Kerberos to talk to Accumulo, but we might still need it for talking to
-        // HDFS/ZK for
-        // instance information.
-        log.info("Handling login under the assumption that Accumulo users are not using Kerberos.");
-        SecurityUtil.serverLogin(acuConf);
-      } else {
+      if (KerberosToken.class.isAssignableFrom(traceTokenType)) {
         // We're using Kerberos to talk to Accumulo, so check for trace user specific auth details.
         // We presume this same user will have the needed access for the service to interact with
         // HDFS/ZK for
@@ -394,6 +388,12 @@ public class TraceServer implements Watcher, AutoCloseable {
 
         log.info("Attempting to login as {} with {}", principalConfig, keyTab);
         SecurityUtil.serverLogin(acuConf, keyTab, principalConfig);
+      } else {
+        // We're not using Kerberos to talk to Accumulo, but we might still need it for talking to
+        // HDFS/ZK for
+        // instance information.
+        log.info("Handling login under the assumption that Accumulo users are not using Kerberos.");
+        SecurityUtil.serverLogin(acuConf);
       }
     } catch (IOException | ClassNotFoundException exception) {
       final String msg =

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -203,7 +203,9 @@ class AssignmentHandler implements Runnable {
       server.releaseRecoveryMemory(extent);
     }
 
-    if (!successful) {
+    if (successful) {
+      server.enqueueMasterMessage(new TabletStatusMessage(TabletLoadState.LOADED, extent));
+    } else {
       synchronized (server.unopenedTablets) {
         synchronized (server.openingTablets) {
           server.openingTablets.remove(extent);
@@ -231,8 +233,6 @@ class AssignmentHandler implements Runnable {
           }
         }
       }, reschedule);
-    } else {
-      server.enqueueMasterMessage(new TabletStatusMessage(TabletLoadState.LOADED, extent));
     }
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -640,11 +640,11 @@ public class TabletServerResourceManager {
                   synchronized (tabletReports) {
                     TabletStateImpl latestReport = tabletReports.remove(keyExtent);
                     if (latestReport != null) {
-                      if (latestReport.getTablet() != tablet) {
+                      if (latestReport.getTablet() == tablet) {
+                        log.debug("Cleaned up report for closed tablet {}", keyExtent);
+                      } else {
                         // different tablet instance => put it back
                         tabletReports.put(keyExtent, latestReport);
-                      } else {
-                        log.debug("Cleaned up report for closed tablet {}", keyExtent);
                       }
                     }
                   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
@@ -1016,10 +1016,10 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
         try {
           tablet.checkConditions(checker, cs.auths, cs.interruptFlag);
 
-          if (!okMutations.isEmpty()) {
-            entry.setValue(okMutations);
-          } else {
+          if (okMutations.isEmpty()) {
             iter.remove();
+          } else {
+            entry.setValue(okMutations);
           }
         } catch (TabletClosedException | IterationInterruptedException | TooManyFilesException e) {
           // clear anything added while checking conditions.

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -143,11 +143,11 @@ public class SortedLogRecovery {
 
     for (Path wal : recoveryLogs) {
       int tabletId = findMaxTabletId(extent, Collections.singletonList(wal));
-      if (tabletId != -1) {
+      if (tabletId == -1) {
+        log.debug("Did not find tablet {} in recovery log {}", extent, wal.getName());
+      } else {
         logsThatDefineTablet.computeIfAbsent(tabletId, k -> new ArrayList<>()).add(wal);
         log.debug("Found tablet {} with id {} in recovery log {}", extent, tabletId, wal.getName());
-      } else {
-        log.debug("Did not find tablet {} in recovery log {}", extent, wal.getName());
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayer.java
@@ -107,10 +107,10 @@ public class BatchWriterReplicationReplayer implements AccumuloReplicationReplay
               long timestamp;
 
               // If the update doesn't have a timestamp, pull it from the ServerMutation
-              if (!update.hasTimestamp()) {
-                timestamp = origServer.getSystemTimestamp();
-              } else {
+              if (update.hasTimestamp()) {
                 timestamp = update.getTimestamp();
+              } else {
+                timestamp = origServer.getSystemTimestamp();
               }
 
               // TODO ACCUMULO-2937 cache the CVs

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
@@ -131,7 +131,9 @@ public class LookupTask extends ScanTask<MultiScanResult> {
 
         bytesAdded += lookupResult.bytesAdded;
 
-        if (!lookupResult.unfinishedRanges.isEmpty()) {
+        if (lookupResult.unfinishedRanges.isEmpty()) {
+          fullScans.add(entry.getKey());
+        } else {
           if (lookupResult.closed) {
             failures.put(entry.getKey(), lookupResult.unfinishedRanges);
           } else {
@@ -140,8 +142,6 @@ public class LookupTask extends ScanTask<MultiScanResult> {
             partNextKey = lookupResult.unfinishedRanges.get(0).getStartKey();
             partNextKeyInclusive = lookupResult.unfinishedRanges.get(0).isStartKeyInclusive();
           }
-        } else {
-          fullScans.add(entry.getKey());
         }
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -370,10 +370,10 @@ public class Compactor implements Callable<CompactionStats> {
 
       itr.seek(extent.toDataRange(), columnFamilies, inclusive);
 
-      if (!inclusive) {
-        mfw.startDefaultLocalityGroup();
-      } else {
+      if (inclusive) {
         mfw.startNewLocalityGroup(lgName, columnFamilies);
+      } else {
+        mfw.startDefaultLocalityGroup();
       }
 
       try (TraceScope write = Trace.startSpan("write")) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -88,7 +88,9 @@ class ScanDataSource implements DataSource {
 
   @Override
   public DataSource getNewDataSource() {
-    if (!isCurrent()) {
+    if (isCurrent())
+      return this;
+    else {
       // log.debug("Switching data sources during a scan");
       if (memIters != null) {
         tablet.getTabletMemory().returnIterators(memIters);
@@ -104,8 +106,7 @@ class ScanDataSource implements DataSource {
       iter = null;
 
       return this;
-    } else
-      return this;
+    }
   }
 
   @Override
@@ -185,9 +186,7 @@ class ScanDataSource implements DataSource {
         SystemIteratorUtil.setupSystemScanIterators(statsIterator, scanParams.getColumnSet(),
             scanParams.getAuthorizations(), defaultLabels, tablet.getTableConfiguration());
 
-    if (!loadIters) {
-      return visFilter;
-    } else {
+    if (loadIters) {
       List<IterInfo> iterInfos;
       Map<String,Map<String,String>> iterOpts;
 
@@ -225,6 +224,8 @@ class ScanDataSource implements DataSource {
       IterLoad il = new IterLoad().iters(iterInfos).iterOpts(iterOpts).iterEnv(iterEnv)
           .useAccumuloClassLoader(true).context(context);
       return iterEnv.getTopLevelIterator(IterConfigUtil.loadIterators(visFilter, il));
+    } else {
+      return visFilter;
     }
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -787,13 +787,13 @@ public class SortedLogRecoveryTest {
     filesSet.addAll(Arrays.asList(tabletFiles));
     List<Mutation> mutations = recover(logs, filesSet, extent);
 
-    if (!startMatches) {
+    if (startMatches) {
+      assertEquals(1, mutations.size());
+      assertEquals(m2, mutations.get(0));
+    } else {
       assertEquals(2, mutations.size());
       assertEquals(m1, mutations.get(0));
       assertEquals(m2, mutations.get(1));
-    } else {
-      assertEquals(1, mutations.size());
-      assertEquals(m2, mutations.get(0));
     }
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -711,7 +711,10 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     fields = fields.length > 1 ? Arrays.copyOfRange(fields, 1, fields.length) : new String[] {};
 
     Command sc = null;
-    if (!command.isEmpty()) {
+    if (command.isEmpty()) {
+      ++exitCode;
+      printException(new BadArgumentException("Unrecognized empty command", command, -1));
+    } else {
       try {
         // Obtain the command from the command table
         sc = commandFactory.get(command);
@@ -801,9 +804,6 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         ++exitCode;
         printException(e);
       }
-    } else {
-      ++exitCode;
-      printException(new BadArgumentException("Unrecognized empty command", command, -1));
     }
     reader.flush();
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/Token.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Token.java
@@ -84,12 +84,12 @@ public class Token {
       Token t = iter.next();
       Set<String> subset = t.getCommandNames();
       for (String s : subset) {
-        if (!t.getCaseSensitive()) {
-          if (s.toLowerCase().startsWith(startsWith.toLowerCase())) {
+        if (t.getCaseSensitive()) {
+          if (s.startsWith(startsWith)) {
             set.add(s);
           }
         } else {
-          if (s.startsWith(startsWith)) {
+          if (s.toLowerCase().startsWith(startsWith.toLowerCase())) {
             set.add(s);
           }
         }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteScanIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteScanIterCommand.java
@@ -60,14 +60,14 @@ public class DeleteScanIterCommand extends Command {
             break;
           }
         }
-        if (!found) {
-          Shell.log.info("No iterator named {} found for table {}", name, tableName);
-        } else {
+        if (found) {
           Shell.log.info("Removed scan iterator {} from table {} ({} left)", name, tableName,
               shellState.scanIteratorOptions.get(tableName).size());
           if (shellState.scanIteratorOptions.get(tableName).isEmpty()) {
             shellState.scanIteratorOptions.remove(tableName);
           }
+        } else {
+          Shell.log.info("No iterator named {} found for table {}", name, tableName);
         }
       } else {
         Shell.log.info("No iterator named {} found for table {}", name, tableName);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteShellIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteShellIterCommand.java
@@ -52,11 +52,11 @@ public class DeleteShellIterCommand extends Command {
             break;
           }
         }
-        if (!found) {
-          Shell.log.info("No iterator named {} found", name);
-        } else {
+        if (found) {
           Shell.log.info("Removed iterator {} from profile {} ( left)", name, profile,
               iterSettings.size());
+        } else {
+          Shell.log.info("No iterator named {} found", name);
         }
       }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -66,13 +66,7 @@ public class GetSplitsCommand extends Command {
 
     try (PrintLine p =
         outputFile == null ? new PrintShell(shellState.getReader()) : new PrintFile(outputFile)) {
-      if (!verbose) {
-        for (Text row : maxSplits > 0
-            ? shellState.getAccumuloClient().tableOperations().listSplits(tableName, maxSplits)
-            : shellState.getAccumuloClient().tableOperations().listSplits(tableName)) {
-          p.print(encode(encode, row));
-        }
-      } else {
+      if (verbose) {
         String systemTableToCheck =
             MetadataTable.NAME.equals(tableName) ? RootTable.NAME : MetadataTable.NAME;
         final Scanner scanner =
@@ -93,6 +87,12 @@ public class GetSplitsCommand extends Command {
                 er == null ? ") Default Tablet " : "]");
             p.print(line);
           }
+        }
+      } else {
+        for (Text row : maxSplits > 0
+            ? shellState.getAccumuloClient().tableOperations().listSplits(tableName, maxSplits)
+            : shellState.getAccumuloClient().tableOperations().listSplits(tableName)) {
+          p.print(encode(encode, row));
         }
       }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/RenameNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/RenameNamespaceCommand.java
@@ -46,7 +46,7 @@ public class RenameNamespaceCommand extends Command {
     String newer = cl.getArgs()[1];
     boolean resetContext = false;
     TableId currentTableId = null;
-    if (!(shellState.getTableName() == null) && !shellState.getTableName().isEmpty()) {
+    if (shellState.getTableName() != null && !shellState.getTableName().isEmpty()) {
       NamespaceId namespaceId = Namespaces.getNamespaceId(shellState.getContext(), old);
       List<TableId> tableIds = Namespaces.getTableIds(shellState.getContext(), namespaceId);
       currentTableId = Tables.getTableId(shellState.getContext(), shellState.getTableName());

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -296,7 +296,7 @@ public class ScriptCommand extends Command {
       } else if (cl.hasOption(object.getOpt())) {
         String objectMethod = cl.getOptionValue(object.getOpt());
         String[] parts = objectMethod.split(":");
-        if (!(parts.length == 2)) {
+        if (parts.length != 2) {
           shellState.printException(new Exception("Object and Method must be supplied"));
           return;
         }

--- a/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
@@ -270,15 +270,15 @@ public class VerifyIngest {
       throw new AccumuloException("saw " + errors + " errors ");
     }
 
-    if (expectedRow != (params.rows + params.startRow)) {
-      throw new AccumuloException("Did not read expected number of rows. Saw "
-          + (expectedRow - params.startRow) + " expected " + params.rows);
-    } else {
+    if (expectedRow == (params.rows + params.startRow)) {
       System.out.printf(
           "%,12d records read | %,8d records/sec | %,12d bytes read |"
               + " %,8d bytes/sec | %6.3f secs   %n",
           recsRead, (int) ((recsRead) / ((t2 - t1) / 1000.0)), bytesRead,
           (int) (bytesRead / ((t2 - t1) / 1000.0)), (t2 - t1) / 1000.0);
+    } else {
+      throw new AccumuloException("Did not read expected number of rows. Saw "
+          + (expectedRow - params.startRow) + " expected " + params.rows);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -103,11 +103,11 @@ public class CacheTestWriter {
 
           byte[] data = Long.toString(r.nextLong(), 16).getBytes(UTF_8);
 
-          if (!dataSExists) {
+          if (dataSExists) {
+            zk.putPersistentData(rootDir + "/dataS", data, NodeExistsPolicy.OVERWRITE);
+          } else {
             zk.putPersistentData(rootDir + "/dataS", data, NodeExistsPolicy.SKIP);
             dataSExists = true;
-          } else {
-            zk.putPersistentData(rootDir + "/dataS", data, NodeExistsPolicy.OVERWRITE);
           }
 
           expectedData.put(rootDir + "/dataS", new String(data, UTF_8));

--- a/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
@@ -106,7 +106,11 @@ public class YieldingIterator extends WrappingIterator {
     log.info("start YieldingIterator.seek: " + getTopValue() + " with range " + range);
     boolean yielded = false;
 
-    if (!range.isStartKeyInclusive()) {
+    if (range.isStartKeyInclusive()) {
+      // must be a new scan so re-initialize the counters
+      log.info("reseting counters");
+      resetCounters();
+    } else {
       rebuilds.incrementAndGet();
 
       // yield on every other seek call.
@@ -120,10 +124,6 @@ public class YieldingIterator extends WrappingIterator {
             .yield(range.getStartKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
         log.info("end YieldingIterator.next: yielded at " + range.getStartKey());
       }
-    } else {
-      // must be a new scan so re-initialize the counters
-      log.info("reseting counters");
-      resetCounters();
     }
 
     // if not yielding, then simply pass on the call to the source

--- a/test/src/test/java/org/apache/accumulo/test/metrics/MetricsFileTailerTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/metrics/MetricsFileTailerTest.java
@@ -66,15 +66,15 @@ public class MetricsFileTailerTest {
 
     int count = 0;
     while (count++ < 5) {
-      if (lastUpdate != tailer.getLastUpdate()) {
+      if (lastUpdate == tailer.getLastUpdate()) {
+        log.trace("no change");
+      } else {
         lastUpdate = tailer.getLastUpdate();
         log.trace("{} - {}", tailer.getLastUpdate(), tailer.getLast());
         if (SUCCESS.compareTo(tailer.getLast()) == 0) {
           passed = Boolean.TRUE;
           break;
         }
-      } else {
-        log.trace("no change");
       }
       try {
         Thread.sleep(5_000);


### PR DESCRIPTION
This is a follow-up to #1590. After updating code to use isEmpty() this ticket re-factors to switch order of statements to remove the negation. Additionally 'if' statement negations were re-factored. A couple of cases where a statement contained double negations were updated also. The intent is to increase the clarity of the statements.

This update should not alter the behaviour of the code. Hopefully it results in more readable code. Since this is primarily a stylistic update if there is opposition to it then it can be ignored and the
ticket can be closed.