### PR TITLE
Create public API for loading iterators. Closes #1388

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -39,9 +39,12 @@ import org.apache.accumulo.core.client.rfile.RFile;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.LoadPlan;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.hadoop.io.Text;
@@ -956,6 +959,23 @@ public interface TableOperations {
    */
   Map<String,EnumSet<IteratorScope>> listIterators(String tableName)
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException;
+
+  /**
+   * Create a stack of iterators from what is in the provided table properties and with the scope.
+   * The specified source will be the bottom of the stack and the top SortedKeyValueIterator on the
+   * stack will be returned.
+   *
+   * @param tableProps
+   *          the properties of the table where the iterators are configured
+   * @param scope
+   *          the scope of the iterators
+   * @param source
+   *          the iterator at the start of the stack
+   * @return the SortedKeyValueIterator at the top of the stack
+   * @since 2.1
+   */
+  SortedKeyValueIterator<Key,Value> loadIterators(Iterable<Entry<String,String>> tableProps,
+      IteratorScope scope, SortedKeyValueIterator<Key,Value> source) throws IOException;
 
   /**
    * Check whether a given iterator configuration conflicts with existing configuration; in

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.core.clientImpl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,8 +34,15 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.IterConfigUtil;
+import org.apache.accumulo.core.conf.IterLoad;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 public abstract class TableOperationsHelper implements TableOperations {
 
@@ -231,5 +240,15 @@ public abstract class TableOperationsHelper implements TableOperations {
       }
     }
     return constraints;
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> loadIterators(Iterable<Entry<String,String>> tableProps,
+      IteratorScope scope, SortedKeyValueIterator<Key,Value> source) throws IOException {
+    AccumuloConfiguration tableConf = new ConfigurationCopy(tableProps);
+    IterLoad iterLoad =
+        IterConfigUtil.loadIterConf(scope, new ArrayList<>(), new HashMap<>(), tableConf)
+            .useAccumuloClassLoader(false);
+    return IterConfigUtil.loadIterators(source, iterLoad);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/IterConfigUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/IterConfigUtilTest.java
@@ -96,7 +96,7 @@ public class IterConfigUtilTest {
     }
   }
 
-  static class AddingIter extends WrappedIter {
+  public static class AddingIter extends WrappedIter {
 
     int amount = 1;
 


### PR DESCRIPTION
This method will load all the iterators configured in the provided properties and scope.  Placed method in TableOperations since it seemed similar to other iterator methods and uses table properties but is really just a static utility method.  

This implementation always uses the Java classloader by calling ```.useAccumuloClassLoader(false);```.  I wasn't sure if we want to provide an option for using the AccumuloVFSClassLoader.