### PR TITLE
Use Long.compare() to compare longs values.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -998,12 +998,7 @@ public class Key implements WritableComparable<Key>, Cloneable {
       return result;
 
     // check for matching timestamp
-    if (timestamp < other.timestamp)
-      result = 1;
-    else if (timestamp > other.timestamp)
-      result = -1;
-    else
-      result = 0;
+    result = Long.compare(other.timestamp, timestamp);
 
     if (result != 0 || part.equals(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME))
       return result;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -82,13 +82,7 @@ public class FileManager {
 
     @Override
     public int compareTo(OpenReader o) {
-      if (releaseTime < o.releaseTime) {
-        return -1;
-      } else if (releaseTime > o.releaseTime) {
-        return 1;
-      } else {
-        return 0;
-      }
+      return Long.compare(releaseTime, o.releaseTime);
     }
 
     @Override


### PR DESCRIPTION
Make use of the Long.compare() method, introduced in JDK 7, to compare longs instead of more verbose constructs.