### PR TITLE
Replace Collections.sort() with List.sort()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
@@ -195,7 +195,7 @@ public class TabletLocatorImpl extends TabletLocator {
     }
 
     if (!notInCache.isEmpty()) {
-      Collections.sort(notInCache, (o1, o2) -> WritableComparator.compareBytes(o1.getRow(), 0,
+      notInCache.sort((o1, o2) -> WritableComparator.compareBytes(o1.getRow(), 0,
           o1.getRow().length, o2.getRow(), 0, o2.getRow().length));
 
       wLock.lock();

--- a/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
@@ -123,7 +123,7 @@ public class IterConfigUtil {
       }
     }
 
-    Collections.sort(iterators, ITER_INFO_COMPARATOR);
+    iterators.sort(ITER_INFO_COMPARATOR);
     return iterators;
   }
 
@@ -133,7 +133,7 @@ public class IterConfigUtil {
       Map<String,Map<String,String>> ssio) {
     destList.addAll(tableIters);
     destList.addAll(ssi);
-    Collections.sort(destList, ITER_INFO_COMPARATOR);
+    destList.sort(ITER_INFO_COMPARATOR);
 
     Set<Entry<String,Map<String,String>>> es = tableOpts.entrySet();
     for (Entry<String,Map<String,String>> entry : es) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -23,7 +23,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -365,7 +364,7 @@ public abstract class TransformingIterator extends WrappingIterator implements O
     }
 
     if (!keys.isEmpty()) {
-      Collections.sort(keys, keyComparator);
+      keys.sort(keyComparator);
       keyPos = 0;
     }
   }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -494,7 +494,7 @@ public class ZooStore<T> implements TStore<T> {
       }
 
       ops = new ArrayList<>(ops);
-      Collections.sort(ops, Collections.reverseOrder());
+      ops.sort(Collections.reverseOrder());
 
       ArrayList<ReadOnlyRepo<T>> dops = new ArrayList<>();
 

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/LexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/LexicoderTest.java
@@ -45,7 +45,7 @@ public abstract class LexicoderTest {
     }
 
     if (comp != null)
-      Collections.sort(list, comp);
+      list.sort(comp);
     else
       Collections.sort(list);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -2224,7 +2224,7 @@ public class RFileTest {
         allSampleData.addAll(sampleDataLG1);
         allSampleData.addAll(sampleDataLG2);
 
-        Collections.sort(allSampleData, Comparator.comparing(Entry::getKey));
+        allSampleData.sort(Comparator.comparing(Entry::getKey));
 
         checkSample(sample, allSampleData, newColFamByteSequence("dataA", "metaA"), true);
         checkSample(sample, allSampleData, EMPTY_COL_FAMS, false);

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizerTest.java
@@ -67,7 +67,7 @@ public class HintScanPrioritizerTest {
           }
         });
 
-    Collections.sort(scans, comparator);
+    scans.sort(comparator);
 
     assertEquals("i", scans.get(0).testId);
     assertEquals("e", scans.get(1).testId);

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/IdleRatioScanPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/IdleRatioScanPrioritizerTest.java
@@ -64,7 +64,7 @@ public class IdleRatioScanPrioritizerTest {
           }
         });
 
-    Collections.sort(scans, comparator);
+    scans.sort(comparator);
 
     assertEquals("b", scans.get(0).testId);
     assertEquals("a", scans.get(1).testId);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -152,7 +152,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
       }
 
       // order from low to high
-      Collections.sort(totals, Collections.reverseOrder());
+      totals.sort(Collections.reverseOrder());
       int even = total / totals.size();
       int numServersOverEven = total % totals.size();
 

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceDump.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceDump.java
@@ -23,7 +23,6 @@ import static java.lang.Math.min;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
@@ -72,7 +71,7 @@ public class TraceDump {
 
   public static List<RemoteSpan> sortByStart(Collection<RemoteSpan> spans) {
     List<RemoteSpan> spanList = new ArrayList<>(spans);
-    Collections.sort(spanList, (o1, o2) -> (int) (o1.start - o2.start));
+    spanList.sort((o1, o2) -> (int) (o1.start - o2.start));
     return spanList;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/CompactionQueue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/CompactionQueue.java
@@ -119,7 +119,7 @@ class CompactionQueue extends AbstractQueue<TraceRunnable> implements BlockingQu
 
   @Override
   public synchronized int drainTo(Collection<? super TraceRunnable> c, int maxElements) {
-    Collections.sort(task, ELEMENT_COMPARATOR);
+    task.sort(ELEMENT_COMPARATOR);
 
     int num = Math.min(task.size(), maxElements);
 
@@ -134,7 +134,7 @@ class CompactionQueue extends AbstractQueue<TraceRunnable> implements BlockingQu
 
   @Override
   public synchronized Iterator<TraceRunnable> iterator() {
-    Collections.sort(task, ELEMENT_COMPARATOR);
+    task.sort(ELEMENT_COMPARATOR);
 
     return task.iterator();
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ConditionalMutationSet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ConditionalMutationSet.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.tserver;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -81,7 +80,7 @@ public class ConditionalMutationSet {
 
   static void sortConditionalMutations(Map<KeyExtent,List<ServerConditionalMutation>> updates) {
     for (Entry<KeyExtent,List<ServerConditionalMutation>> entry : updates.entrySet()) {
-      Collections.sort(entry.getValue(), (o1, o2) -> WritableComparator.compareBytes(o1.getRow(), 0,
+      entry.getValue().sort((o1, o2) -> WritableComparator.compareBytes(o1.getRow(), 0,
           o1.getRow().length, o2.getRow(), 0, o2.getRow().length));
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1159,7 +1159,7 @@ public class TabletServer extends AbstractServer {
       Set<String> tabletFiles, MutationReceiver mutationReceiver) throws IOException {
     List<Path> recoveryLogs = new ArrayList<>();
     List<LogEntry> sorted = new ArrayList<>(logEntries);
-    Collections.sort(sorted, (e1, e2) -> (int) (e1.timestamp - e2.timestamp));
+    sorted.sort((e1, e2) -> (int) (e1.timestamp - e2.timestamp));
     for (LogEntry entry : sorted) {
       Path recovery = null;
       Path finished = RecoveryPath.getRecoveryPath(new Path(entry.filename));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategy.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.tserver.compaction;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,7 @@ public class DefaultCompactionStrategy extends CompactionStrategy {
         files.add(new CompactionFile(entry.getKey(), entry.getValue().getSize()));
       }
 
-      Collections.sort(files, Comparator.comparingLong(CompactionFile::getSize)
+      files.sort(Comparator.comparingLong(CompactionFile::getSize)
           .thenComparing(CompactionFile::getFile).reversed());
 
       for (CompactionFile file : files) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -182,7 +182,7 @@ public class LogSorter {
       try (MapFile.Writer output = new MapFile.Writer(ns.getConf(), ns.makeQualified(path),
           MapFile.Writer.keyClass(LogFileKey.class),
           MapFile.Writer.valueClass(LogFileValue.class))) {
-        Collections.sort(buffer, Comparator.comparing(Pair::getFirst));
+        buffer.sort(Comparator.comparing(Pair::getFirst));
         for (Pair<LogFileKey,LogFileValue> entry : buffer) {
           output.append(entry.getFirst(), entry.getSecond());
         }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -25,7 +25,6 @@ import java.io.DataInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -400,8 +399,7 @@ public class DefaultCompactionStrategyTest {
     void print() {
       List<Entry<StoredTabletFile,DataFileValue>> entries = new ArrayList<>(files.entrySet());
 
-      Collections.sort(entries,
-          (e1, e2) -> Long.compare(e2.getValue().getSize(), e1.getValue().getSize()));
+      entries.sort((e1, e2) -> Long.compare(e2.getValue().getSize(), e1.getValue().getSize()));
 
       for (Entry<StoredTabletFile,DataFileValue> entry : entries) {
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionIterator.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionIterator.java
@@ -65,7 +65,7 @@ class ActiveCompactionIterator implements Iterator<String> {
 
         acl = new ArrayList<>(acl);
 
-        Collections.sort(acl, (o1, o2) -> (int) (o2.getAge() - o1.getAge()));
+        acl.sort((o1, o2) -> (int) (o2.getAge() - o1.getAge()));
 
         for (ActiveCompaction ac : acl) {
           String output = ac.getOutputFile();

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetAuthsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetAuthsCommand.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.shell.commands;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -54,7 +53,7 @@ public class GetAuthsCommand extends Command {
     for (byte[] auth : auths) {
       list.add(new String(auth));
     }
-    Collections.sort(list, String.CASE_INSENSITIVE_ORDER);
+    list.sort(String.CASE_INSENSITIVE_ORDER);
     return list;
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -494,7 +494,7 @@ public class NativeMapIT {
     for (int i = 0; i < 2; i++) {
 
       // sort data
-      Collections.sort(testData, Comparator.comparing(Pair::getFirst));
+      testData.sort(Comparator.comparing(Pair::getFirst));
 
       // verify
       Iterator<Entry<Key,Value>> iter1 = nm.iterator();


### PR DESCRIPTION
As of JDK 1.8, calls to Collections.sort(list, comparator) can be replaced with List.sort(comparator).