### PR TITLE
Removed duplicate 'if' condition in TabletLocatorImpl.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocatorImpl.java
@@ -548,12 +548,6 @@ public class TabletLocatorImpl extends TabletLocator {
           "Cannot add null locations to cache " + tableId + "  " + tabletLocation.tablet_extent);
     }
 
-    if (!tabletLocation.tablet_extent.getTableId().equals(tableId)) {
-      // sanity check
-      throw new IllegalStateException("Cannot add other table ids to locations cache " + tableId
-          + "  " + tabletLocation.tablet_extent);
-    }
-
     // clear out any overlapping extents in cache
     removeOverlapping(metaCache, tabletLocation.tablet_extent);
 


### PR DESCRIPTION
The 'updateCache' method within TabletLocatorImpl.java contains two identical 'if' conditions, both of which throw 'IllegalStateExceptions'. I removed the second, given that it would never be reached if the
condition is true. Even though the conditional checks are identical, the message provided to the exceptions differ. I kept the first since that would be the one presented to the user if this condition was satisfied.