### PR TITLE
Create bulkRename method in VolumeManager

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -150,8 +150,11 @@ public interface VolumeManager extends AutoCloseable {
   // volumes
   boolean rename(Path path, Path newPath) throws IOException;
 
-  // rename lots of files at once in a thread pool
-  // returns once all the threads have completed
+  /**
+   * Rename lots of files at once in a thread pool and return once all the threads have completed.
+   * This operation should be idempotent to allow calling multiple times in the case of a partial
+   * completion.
+   */
   void bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize, String poolName,
       String transactionId) throws IOException;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -22,9 +22,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.ServerConstants;
@@ -148,6 +152,11 @@ public interface VolumeManager extends AutoCloseable {
   // forward to the appropriate FileSystem object, throws an exception if the paths are in different
   // volumes
   boolean rename(Path path, Path newPath) throws IOException;
+
+  // rename lots of files at once in a thread pool
+  // returns the results once all the threads have completed
+  List<Future<Boolean>> bulkRename(Map<Path,Path> oldToNewPathMap, SimpleThreadPool workerPool,
+      String transactionId) throws Exception;
 
   // forward to the appropriate FileSystem object
   boolean moveToTrash(Path sourcePath) throws IOException;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.server.ServerConstants;
@@ -155,7 +154,7 @@ public interface VolumeManager extends AutoCloseable {
 
   // rename lots of files at once in a thread pool
   // returns the results once all the threads have completed
-  List<Future<Boolean>> bulkRename(Map<Path,Path> oldToNewPathMap, SimpleThreadPool workerPool,
+  List<Future<Boolean>> bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize, String poolName,
       String transactionId) throws Exception;
 
   // forward to the appropriate FileSystem object

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -22,10 +22,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.volume.Volume;
@@ -153,9 +151,9 @@ public interface VolumeManager extends AutoCloseable {
   boolean rename(Path path, Path newPath) throws IOException;
 
   // rename lots of files at once in a thread pool
-  // returns the results once all the threads have completed
-  List<Future<Boolean>> bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize, String poolName,
-      String transactionId) throws Exception;
+  // returns once all the threads have completed
+  void bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize, String poolName,
+      String transactionId) throws IOException;
 
   // forward to the appropriate FileSystem object
   boolean moveToTrash(Path sourcePath) throws IOException;

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -295,9 +295,10 @@ public class VolumeManagerImpl implements VolumeManager {
   }
 
   @Override
-  public List<Future<Boolean>> bulkRename(Map<Path,Path> oldToNewPathMap,
-      SimpleThreadPool workerPool, String transactionId) throws InterruptedException {
+  public List<Future<Boolean>> bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize,
+      String poolName, String transactionId) throws InterruptedException {
     List<Future<Boolean>> results = new ArrayList<>();
+    SimpleThreadPool workerPool = new SimpleThreadPool(poolSize, poolName);
     oldToNewPathMap.forEach((oldPath, newPath) -> results.add(workerPool.submit(() -> {
       boolean success;
       try {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -315,9 +315,8 @@ public class VolumeManagerImpl implements VolumeManager {
             transactionId, oldPath, newPath, e);
         success = true;
       }
-      if (!success) {
-        log.error("Rename operation {} returned false. orig: {} new: {}", transactionId, oldPath,
-            newPath);
+      if (!success && (!exists(newPath) || exists(oldPath))) {
+          throw new IOException("Rename operation "+transactionId+" returned false. orig: "+oldPath+" new: "+newPath);
       } else if (log.isTraceEnabled()) {
         log.trace("{} moved {} to {}", transactionId, oldPath, newPath);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -316,7 +316,8 @@ public class VolumeManagerImpl implements VolumeManager {
         success = true;
       }
       if (!success && (!exists(newPath) || exists(oldPath))) {
-          throw new IOException("Rename operation "+transactionId+" returned false. orig: "+oldPath+" new: "+newPath);
+        throw new IOException("Rename operation " + transactionId + " returned false. orig: "
+            + oldPath + " new: " + newPath);
       } else if (log.isTraceEnabled()) {
         log.trace("{} moved {} to {}", transactionId, oldPath, newPath);
       }

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/BulkImportMove.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/BulkImportMove.java
@@ -32,7 +32,6 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.master.state.tables.TableState;
-import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -120,7 +119,7 @@ class BulkImportMove extends MasterRepo {
       Path newPath = new Path(bulkDir, renameEntry.getValue());
       oldToNewMap.put(originalPath, newPath);
     }
-    results = fs.bulkRename(oldToNewMap, new SimpleThreadPool(workerCount, "bulkDir move"), fmtTid);
+    results = fs.bulkRename(oldToNewMap, workerCount, "bulkDir move", fmtTid);
 
     for (Future<Boolean> future : results) {
       try {

--- a/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/MoveExportedFiles.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/tableOps/tableImport/MoveExportedFiles.java
@@ -33,7 +33,6 @@ import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationExcepti
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.util.SimpleThreadPool;
 import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -110,8 +109,8 @@ class MoveExportedFiles extends MasterRepo {
         }
       }
     }
-    List<Future<Boolean>> results = fs.bulkRename(oldToNewPaths,
-        new SimpleThreadPool(workerCount, "importtable rename"), fmtTid);
+    List<Future<Boolean>> results =
+        fs.bulkRename(oldToNewPaths, workerCount, "importtable rename", fmtTid);
 
     for (Future<Boolean> future : results) {
       try {


### PR DESCRIPTION
* Refactor fate code in BulkImportMove (bulkVer2) and MoveExportedFiles to call the
new method for handling renames of lots of files
* Work related to #1620 
* Made bulkRename method return the list of completed Futures so FATE operations can handle errors accordingly