### PR TITLE
Remove an workaround profile exists in core/pom.xml file since the related issue had been already fixed.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -383,21 +383,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <!-- workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=541772 -->
-      <id>m2e</id>
-      <activation>
-        <property>
-          <name>m2e.version</name>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client-runtime</artifactId>
-          <scope>compile</scope>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
According to the link https://bugs.eclipse.org/bugs/show_bug.cgi?id=541772#c30, I observed that such issue had already been fixed in 4.12M1 release. The workaround for this profile is not needed in my opinion.
I suggest to remove this profile.

The workaround profile:
https://github.com/apache/accumulo/blob/07bc9d329ea0b8da9a577863acfe009910e189cd/core/pom.xml#L386-L401
