### PR TITLE
Fix FateConcurrencyIT periodic failures

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -335,7 +335,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
    * compaction ratio in order to ensure the amount of data rewriting is logarithmic.
    *
    * <p>
-   * A set of files meets the compaction ratio when the largestFileinSet * compactionRatio <
+   * A set of files meets the compaction ratio when the largestFileinSet * compactionRatio &lt;
    * sumOfFileSizesInSet. This algorithm grows the set of small files until it meets the compaction
    * ratio, then keeps growing it while it continues to meet the ratio. Once a set does not meet the
    * compaction ratio, the last set that did is returned. Growing the set of small files means

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
@@ -105,10 +105,9 @@ public class MiniAccumuloRunner {
     System.out.println();
     System.out.println("# Configuration normally placed in accumulo.properties can be added using"
         + " a site.* prefix.");
-    System.out.println(
-        "# For example the following line will set tserver.compaction.major.concurrent.max");
+    System.out.println("# For example the following line will set tserver.compaction.major.delay");
     System.out.println();
-    System.out.println("#site.tserver.compaction.major.concurrent.max=4");
+    System.out.println("#site.tserver.compaction.major.delay=60s");
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterMetricsIT.java
@@ -150,7 +150,8 @@ public class MasterMetricsIT extends AccumuloClusterHarness {
 
     for (int i = 0; i < tableCount; i++) {
       String uniqueName = getUniqueNames(1)[0] + "_" + i;
-      SlowOps gen = new SlowOps(accumuloClient, uniqueName, maxWait, tableCount);
+      SlowOps.setExpectedCompactions(accumuloClient, tableCount);
+      SlowOps gen = new SlowOps(accumuloClient, uniqueName, maxWait);
       tables.add(gen);
       gen.startCompactTask();
     }


### PR DESCRIPTION
This patch fixes periodic FateConcurrencyIT failures due to insufficient
threads available for concurrent compactions, caused by the introduction
of the property
'tserver.compaction.major.service.default.planner.opts.executors' to
replace 'tserver.compaction.major.concurrent.max'.

This change now sets a sufficient number of executors to run the test
consistenly, when one tserver tries to compact 3 or 4 of the 4 total
tables, and the other is responsible for compacting only 0 or 1.

Additionally:

* Fix a javadoc issue for the improper use of less-than symbol in
  DefaultCompactionPlanner
* Use a non-deprecated property as an example in MiniAccumuloRunner
  instead of the deprecated 'tserver.compaction.major.concurrent.max'
* Set instance-wide compaction property only once instead of each time a
  SlowOps object is constructed
* Inline unneeded private SlowOps constructor
* Fix typo in FateConcurrencyIT javadoc
* Use Streams to simplify code logic
* Avoid creating unused SlowOps in `@Before` method in FateConcurrencyIT
* Clean up use of TimeUnits and conversions (using nano in an additional
  place, and variables which are named to indicate they are millis)