### PR TITLE
Fix #1663 - Missing metrics files running CI tests

### DIFF
--- a/assemble/conf/templates/hadoop-metrics2-accumulo.properties
+++ b/assemble/conf/templates/hadoop-metrics2-accumulo.properties
@@ -46,6 +46,11 @@
 # accumulo.sink.file-thrift.context=thrift
 # accumulo.sink.file-thrift.filename=thrift.metrics
 
+# File sink for gc metrics
+# accumulo.sink.file-gc.class=org.apache.hadoop.metrics2.sink.FileSink
+# accumulo.sink.file-gc.context=accgc
+# accumulo.sink.file-gc.filename=accgc.metrics
+
 #
 # Configure Graphite
 #

--- a/pom.xml
+++ b/pom.xml
@@ -658,9 +658,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
-            <excludes>
-              <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
-            </excludes>
             <archive>
               <manifestEntries>
                 <Sealed>true</Sealed>

--- a/pom.xml
+++ b/pom.xml
@@ -658,6 +658,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
+            <excludes>
+              <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
+            </excludes>
             <archive>
               <manifestEntries>
                 <Sealed>true</Sealed>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -275,7 +275,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
+            <exclude>src/main/resources/hadoop-metrics2-accumulo.properties</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -275,7 +275,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>src/main/resources/hadoop-metrics2-accumulo.properties</exclude>
+            <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -277,12 +277,6 @@
           <excludes>
             <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
           </excludes>
-          <archive>
-            <manifestEntries>
-              <Sealed>true</Sealed>
-              <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
-            </manifestEntries>
-          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -270,6 +270,21 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
+          </excludes>
+          <archive>
+            <manifestEntries>
+              <Sealed>true</Sealed>
+              <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -275,7 +275,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>**/hadoop-metrics2-accumulo.properties</exclude>
+            <exclude>hadoop-metrics2-accumulo.properties</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
- excluded hadoop-metrics2-accumulo.properties from jar plugin
- added gc metrics config sample to template