### PR TITLE
Ignore IntelliJ IDE .ipr and .iws files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 /.pydevproject
 /.idea
 /*.iml
+/*.ipr
+/*.iws
 /nbproject/
 /nbactions.xml
 /nb-configuration.xml


### PR DESCRIPTION
-  Added the JetBrains IDE `*.ipr` and `*.iws` with are generated by IntelliJ.


---
Signed-off-by: ben <git@benjamin.ie>