### PR TITLE
#1385 Ensure Namespace.READ is sufficient for fast-failure checks in new

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -964,6 +964,32 @@ public class NamespacesIT extends SharedMiniClusterBase {
   }
 
   @Test
+  public void validatePermissions() throws Exception {
+    // Create namespace.
+    c.namespaceOperations().create(namespace);
+
+    assertTrue(c.securityOperations().hasNamespacePermission(c.whoami(), namespace,
+        NamespacePermission.READ));
+    c.securityOperations().revokeNamespacePermission(c.whoami(), namespace,
+        NamespacePermission.READ);
+    assertFalse(c.securityOperations().hasNamespacePermission(c.whoami(), namespace,
+        NamespacePermission.READ));
+    c.securityOperations().grantNamespacePermission(c.whoami(), namespace,
+        NamespacePermission.READ);
+    assertTrue(c.securityOperations().hasNamespacePermission(c.whoami(), namespace,
+        NamespacePermission.READ));
+
+    c.namespaceOperations().delete(namespace);
+
+    assertSecurityException(SecurityErrorCode.NAMESPACE_DOESNT_EXIST, () -> c.securityOperations()
+        .hasNamespacePermission(c.whoami(), namespace, NamespacePermission.READ));
+    assertSecurityException(SecurityErrorCode.NAMESPACE_DOESNT_EXIST, () -> c.securityOperations()
+        .grantNamespacePermission(c.whoami(), namespace, NamespacePermission.READ));
+    assertSecurityException(SecurityErrorCode.NAMESPACE_DOESNT_EXIST, () -> c.securityOperations()
+        .revokeNamespacePermission(c.whoami(), namespace, NamespacePermission.READ));
+  }
+
+  @Test
   public void verifyTableOperationsExceptions() throws Exception {
     String tableName = namespace + ".1";
     IteratorSetting setting = new IteratorSetting(200, VersioningIterator.class);


### PR DESCRIPTION
For ticket #1385 ------- I added the Namespace.READ fix from ticket #1371 to the new accumulo-hadoop MapReduce module code. Before the fix, InputConfigurator.validatePermissions only checks whether the user has Table.READ permission. Now, access may also be allowed if the user has Namespace.READ instead.