### PR TITLE
Use more precise imports for MetadataSchema

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ReplicationOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ReplicationOperationsImpl.java
@@ -39,8 +39,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
@@ -150,7 +150,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
 
     // Get the WALs currently referenced by the table
     BatchScanner metaBs = context.createBatchScanner(MetadataTable.NAME, Authorizations.EMPTY, 4);
-    metaBs.setRanges(Collections.singleton(MetadataSchema.TabletsSection.getRange(tableId)));
+    metaBs.setRanges(Collections.singleton(TabletsSection.getRange(tableId)));
     metaBs.fetchColumnFamily(LogColumnFamily.NAME);
     Set<String> wals = new HashSet<>();
     try {

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -46,6 +46,7 @@ import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.BinaryComparable;
@@ -300,7 +301,7 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
 
   public static Mutation getPrevRowUpdateMutation(KeyExtent ke) {
     Mutation m = new Mutation(ke.getMetadataEntry());
-    TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.put(m, encodePrevEndRow(ke.getPrevEndRow()));
+    TabletColumnFamily.PREV_ROW_COLUMN.put(m, encodePrevEndRow(ke.getPrevEndRow()));
     return m;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
@@ -53,7 +53,9 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.core.util.TextUtil;
@@ -70,9 +72,8 @@ public class MetadataLocationObtainer implements TabletLocationObtainer {
   public MetadataLocationObtainer() {
 
     locCols = new TreeSet<>();
-    locCols.add(
-        new Column(TextUtil.getBytes(TabletsSection.CurrentLocationColumnFamily.NAME), null, null));
-    locCols.add(TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.toColumn());
+    locCols.add(new Column(TextUtil.getBytes(CurrentLocationColumnFamily.NAME), null, null));
+    locCols.add(TabletColumnFamily.PREV_ROW_COLUMN.toColumn());
     columns = new ArrayList<>(locCols);
   }
 
@@ -241,14 +242,14 @@ public class MetadataLocationObtainer implements TabletLocationObtainer {
       colq = key.getColumnQualifier(colq);
 
       // interpret the row id as a key extent
-      if (colf.equals(TabletsSection.CurrentLocationColumnFamily.NAME)
-          || colf.equals(TabletsSection.FutureLocationColumnFamily.NAME)) {
+      if (colf.equals(CurrentLocationColumnFamily.NAME)
+          || colf.equals(FutureLocationColumnFamily.NAME)) {
         if (location != null) {
           throw new IllegalStateException("Tablet has multiple locations : " + lastRowFromKey);
         }
         location = new Text(val.toString());
         session = new Text(colq);
-      } else if (TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
+      } else if (TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
         prevRow = new Value(val);
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
@@ -32,6 +32,8 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 
@@ -66,8 +68,8 @@ abstract class TableMetadataServicer extends MetadataServicer {
 
     Scanner scanner = context.createScanner(getServicingTableName(), Authorizations.EMPTY);
 
-    TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-    scanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
+    TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
+    scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
 
     // position at first entry in metadata table for given table
     scanner.setRange(TabletsSection.getRange(getServicedTableId()));
@@ -93,12 +95,12 @@ abstract class TableMetadataServicer extends MetadataServicer {
       colf = entry.getKey().getColumnFamily(colf);
       colq = entry.getKey().getColumnQualifier(colq);
 
-      if (TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
+      if (TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
         currentKeyExtent = new KeyExtent(entry.getKey().getRow(), entry.getValue());
         tablets.put(currentKeyExtent, location);
         currentKeyExtent = null;
         location = null;
-      } else if (colf.equals(TabletsSection.CurrentLocationColumnFamily.NAME)) {
+      } else if (colf.equals(CurrentLocationColumnFamily.NAME)) {
         location = entry.getValue().toString();
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.TableId;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 
@@ -57,15 +57,15 @@ public class TabletFile implements Comparable<TabletFile> {
 
     // use Path object to step backwards from the filename through all the parts
     this.fileName = metaPath.getName();
-    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(fileName);
+    ServerColumnFamily.validateDirCol(fileName);
 
     Path tabletDirPath = Objects.requireNonNull(metaPath.getParent(), errorMsg);
     this.tabletDir = tabletDirPath.getName();
-    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tabletDir);
+    ServerColumnFamily.validateDirCol(tabletDir);
 
     Path tableIdPath = Objects.requireNonNull(tabletDirPath.getParent(), errorMsg);
     this.tableId = TableId.of(tableIdPath.getName());
-    MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(tableId.canonical());
+    ServerColumnFamily.validateDirCol(tableId.canonical());
 
     Path tablePath = Objects.requireNonNull(tableIdPath.getParent(), errorMsg);
     String tpString = "/" + tablePath.getName();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
@@ -35,8 +35,9 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.hadoop.io.Text;
@@ -53,9 +54,9 @@ public class RootTabletMetadata {
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
   private static final ByteSequence CURR_LOC_FAM =
-      new ArrayByteSequence(TabletsSection.CurrentLocationColumnFamily.STR_NAME);
+      new ArrayByteSequence(CurrentLocationColumnFamily.STR_NAME);
   private static final ByteSequence FUTURE_LOC_FAM =
-      new ArrayByteSequence(TabletsSection.FutureLocationColumnFamily.STR_NAME);
+      new ArrayByteSequence(FutureLocationColumnFamily.STR_NAME);
 
   private TreeMap<Key,Value> entries = new TreeMap<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/tabletserver/log/LogEntry.java
+++ b/core/src/main/java/org/apache/accumulo/core/tabletserver/log/LogEntry.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
@@ -104,7 +104,7 @@ public class LogEntry {
   }
 
   public Text getColumnFamily() {
-    return MetadataSchema.TabletsSection.LogColumnFamily.NAME;
+    return LogColumnFamily.NAME;
   }
 
   public String getUniqueID() {

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -51,7 +51,8 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataLocationObtainer;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -539,7 +540,7 @@ public class TabletLocatorImplTest {
     }
 
     Text mr = ke.getMetadataEntry();
-    Key lk = new Key(mr, TabletsSection.CurrentLocationColumnFamily.NAME, new Text(instance));
+    Key lk = new Key(mr, CurrentLocationColumnFamily.NAME, new Text(instance));
     tabletData.remove(lk);
 
   }
@@ -557,12 +558,12 @@ public class TabletLocatorImplTest {
     if (location != null) {
       if (instance == null)
         instance = "";
-      Key lk = new Key(mr, TabletsSection.CurrentLocationColumnFamily.NAME, new Text(instance));
+      Key lk = new Key(mr, CurrentLocationColumnFamily.NAME, new Text(instance));
       tabletData.put(lk, new Value(location));
     }
 
-    Key pk = new Key(mr, TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
-        TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier());
+    Key pk = new Key(mr, TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
+        TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier());
     tabletData.put(pk, per);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -78,9 +78,9 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
 import org.apache.accumulo.core.spi.cache.BlockCacheManager;
@@ -2336,25 +2336,22 @@ public class RFileTest {
 
     // mfw.startDefaultLocalityGroup();
 
-    Text tableExtent = new Text(TabletsSection.getRow(MetadataTable.ID,
-        MetadataSchema.TabletsSection.getRange().getEndKey().getRow()));
+    Text tableExtent = new Text(
+        TabletsSection.getRow(MetadataTable.ID, TabletsSection.getRange().getEndKey().getRow()));
 
     // table tablet's directory
-    Key tableDirKey =
-        new Key(tableExtent, TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
-            TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier(), 0);
+    Key tableDirKey = new Key(tableExtent, ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
+        ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier(), 0);
     mfw.append(tableDirKey, new Value(/* TABLE_TABLETS_TABLET_DIR */"/table_info"));
 
     // table tablet time
-    Key tableTimeKey =
-        new Key(tableExtent, TabletsSection.ServerColumnFamily.TIME_COLUMN.getColumnFamily(),
-            TabletsSection.ServerColumnFamily.TIME_COLUMN.getColumnQualifier(), 0);
+    Key tableTimeKey = new Key(tableExtent, ServerColumnFamily.TIME_COLUMN.getColumnFamily(),
+        ServerColumnFamily.TIME_COLUMN.getColumnQualifier(), 0);
     mfw.append(tableTimeKey, new Value(/* TabletTime.LOGICAL_TIME_ID */'L' + "0"));
 
     // table tablet's prevRow
-    Key tablePrevRowKey =
-        new Key(tableExtent, TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
-            TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier(), 0);
+    Key tablePrevRowKey = new Key(tableExtent, TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
+        TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier(), 0);
     mfw.append(tablePrevRowKey, KeyExtent.encodePrevEndRow(null));
 
     // ----------] default tablet info
@@ -2362,22 +2359,21 @@ public class RFileTest {
 
     // default's directory
     Key defaultDirKey =
-        new Key(defaultExtent, TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
-            TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier(), 0);
+        new Key(defaultExtent, ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
+            ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier(), 0);
     mfw.append(defaultDirKey, new Value(ServerColumnFamily.DEFAULT_TABLET_DIR_NAME));
 
     // default's time
-    Key defaultTimeKey =
-        new Key(defaultExtent, TabletsSection.ServerColumnFamily.TIME_COLUMN.getColumnFamily(),
-            TabletsSection.ServerColumnFamily.TIME_COLUMN.getColumnQualifier(), 0);
+    Key defaultTimeKey = new Key(defaultExtent, ServerColumnFamily.TIME_COLUMN.getColumnFamily(),
+        ServerColumnFamily.TIME_COLUMN.getColumnQualifier(), 0);
     mfw.append(defaultTimeKey, new Value(/* TabletTime.LOGICAL_TIME_ID */'L' + "0"));
 
     // default's prevRow
     Key defaultPrevRowKey =
-        new Key(defaultExtent, TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
-            TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier(), 0);
+        new Key(defaultExtent, TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
+            TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier(), 0);
     mfw.append(defaultPrevRowKey,
-        KeyExtent.encodePrevEndRow(MetadataSchema.TabletsSection.getRange().getEndKey().getRow()));
+        KeyExtent.encodePrevEndRow(TabletsSection.getRange().getEndKey().getRow()));
 
     testRfile.closeWriter();
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/DeleteMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/DeleteMetadataTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.metadata.schema;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.junit.Test;
 
 public class DeleteMetadataTest {
@@ -27,11 +28,9 @@ public class DeleteMetadataTest {
   @Test
   public void encodeRowTest() {
     String path = "/dir/testpath";
-    assertEquals(path,
-        MetadataSchema.DeletesSection.decodeRow(MetadataSchema.DeletesSection.encodeRow(path)));
+    assertEquals(path, DeletesSection.decodeRow(DeletesSection.encodeRow(path)));
     path = "hdfs://localhost:8020/dir/r+/1_table/f$%#";
-    assertEquals(path,
-        MetadataSchema.DeletesSection.decodeRow(MetadataSchema.DeletesSection.encodeRow(path)));
+    assertEquals(path, DeletesSection.decodeRow(DeletesSection.encodeRow(path)));
 
   }
 }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -64,7 +64,10 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
@@ -90,7 +93,7 @@ public class InputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum ScanOpts {
+  public enum ScanOpts {
     TABLE_NAME,
     AUTHORIZATIONS,
     RANGES,
@@ -107,7 +110,7 @@ public class InputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum Features {
+  public enum Features {
     AUTO_ADJUST_RANGES,
     SCAN_ISOLATION,
     USE_LOCAL_ITERATORS,
@@ -851,10 +854,10 @@ public class InputConfigurator extends ConfiguratorBase {
       Range metadataRange =
           new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
       Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-      MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.LastLocationColumnFamily.NAME);
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.FutureLocationColumnFamily.NAME);
+      TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
+      scanner.fetchColumnFamily(LastLocationColumnFamily.NAME);
+      scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
+      scanner.fetchColumnFamily(FutureLocationColumnFamily.NAME);
       scanner.setRange(metadataRange);
 
       RowIterator rowIter = new RowIterator(scanner);
@@ -869,19 +872,16 @@ public class InputConfigurator extends ConfiguratorBase {
           Map.Entry<Key,Value> entry = row.next();
           Key key = entry.getKey();
 
-          if (key.getColumnFamily()
-              .equals(MetadataSchema.TabletsSection.LastLocationColumnFamily.NAME)) {
+          if (key.getColumnFamily().equals(LastLocationColumnFamily.NAME)) {
             last = entry.getValue().toString();
           }
 
-          if (key.getColumnFamily()
-              .equals(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME)
-              || key.getColumnFamily()
-                  .equals(MetadataSchema.TabletsSection.FutureLocationColumnFamily.NAME)) {
+          if (key.getColumnFamily().equals(CurrentLocationColumnFamily.NAME)
+              || key.getColumnFamily().equals(FutureLocationColumnFamily.NAME)) {
             location = entry.getValue().toString();
           }
 
-          if (MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
+          if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
             extent = new KeyExtent(key.getRow(), entry.getValue());
           }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -35,13 +35,18 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ClonedColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.core.util.cleaner.CleanerUtil;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
@@ -69,22 +74,29 @@ public class MetadataConstraints implements Constraint {
     }
   }
 
+  // @formatter:off
   private static final HashSet<ColumnFQ> validColumnQuals =
-      new HashSet<>(Arrays.asList(TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN,
-          TabletsSection.TabletColumnFamily.OLD_PREV_ROW_COLUMN,
-          TabletsSection.SuspendLocationColumn.SUSPEND_COLUMN,
-          TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN,
-          TabletsSection.TabletColumnFamily.SPLIT_RATIO_COLUMN,
-          TabletsSection.ServerColumnFamily.TIME_COLUMN,
-          TabletsSection.ServerColumnFamily.LOCK_COLUMN,
-          TabletsSection.ServerColumnFamily.FLUSH_COLUMN,
-          TabletsSection.ServerColumnFamily.COMPACT_COLUMN));
+      new HashSet<>(Arrays.asList(TabletColumnFamily.PREV_ROW_COLUMN,
+          TabletColumnFamily.OLD_PREV_ROW_COLUMN,
+          SuspendLocationColumn.SUSPEND_COLUMN,
+          ServerColumnFamily.DIRECTORY_COLUMN,
+          TabletColumnFamily.SPLIT_RATIO_COLUMN,
+          ServerColumnFamily.TIME_COLUMN,
+          ServerColumnFamily.LOCK_COLUMN,
+          ServerColumnFamily.FLUSH_COLUMN,
+          ServerColumnFamily.COMPACT_COLUMN));
 
-  private static final HashSet<Text> validColumnFams = new HashSet<>(Arrays.asList(
-      TabletsSection.BulkFileColumnFamily.NAME, LogColumnFamily.NAME, ScanFileColumnFamily.NAME,
-      DataFileColumnFamily.NAME, TabletsSection.CurrentLocationColumnFamily.NAME,
-      TabletsSection.LastLocationColumnFamily.NAME, TabletsSection.FutureLocationColumnFamily.NAME,
-      ChoppedColumnFamily.NAME, ClonedColumnFamily.NAME));
+  private static final HashSet<Text> validColumnFams =
+      new HashSet<>(Arrays.asList(BulkFileColumnFamily.NAME,
+          LogColumnFamily.NAME,
+          ScanFileColumnFamily.NAME,
+          DataFileColumnFamily.NAME,
+          CurrentLocationColumnFamily.NAME,
+          LastLocationColumnFamily.NAME,
+          FutureLocationColumnFamily.NAME,
+          ChoppedColumnFamily.NAME,
+          ClonedColumnFamily.NAME));
+  // @formatter:on
 
   private static boolean isValidColumn(ColumnUpdate cu) {
 
@@ -192,7 +204,7 @@ public class MetadataConstraints implements Constraint {
         }
       } else if (columnFamily.equals(ScanFileColumnFamily.NAME)) {
 
-      } else if (columnFamily.equals(TabletsSection.BulkFileColumnFamily.NAME)) {
+      } else if (columnFamily.equals(BulkFileColumnFamily.NAME)) {
         if (!columnUpdate.isDeleted() && !checkedBulk) {
           // splits, which also write the time reference, are allowed to write this reference even
           // when
@@ -214,15 +226,14 @@ public class MetadataConstraints implements Constraint {
           int otherTidCount = 0;
 
           for (ColumnUpdate update : mutation.getUpdates()) {
-            if (new ColumnFQ(update).equals(TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN)) {
+            if (new ColumnFQ(update).equals(ServerColumnFamily.DIRECTORY_COLUMN)) {
               isSplitMutation = true;
             } else if (new Text(update.getColumnFamily())
-                .equals(TabletsSection.CurrentLocationColumnFamily.NAME)) {
+                .equals(CurrentLocationColumnFamily.NAME)) {
               isLocationMutation = true;
             } else if (new Text(update.getColumnFamily()).equals(DataFileColumnFamily.NAME)) {
               dataFiles.add(new Text(update.getColumnQualifier()));
-            } else if (new Text(update.getColumnFamily())
-                .equals(TabletsSection.BulkFileColumnFamily.NAME)) {
+            } else if (new Text(update.getColumnFamily()).equals(BulkFileColumnFamily.NAME)) {
               loadedFiles.add(new Text(update.getColumnQualifier()));
 
               if (!new String(update.getValue(), UTF_8).equals(tidString)) {
@@ -249,8 +260,7 @@ public class MetadataConstraints implements Constraint {
       } else {
         if (!isValidColumn(columnUpdate)) {
           violations = addViolation(violations, 2);
-        } else if (new ColumnFQ(columnUpdate)
-            .equals(TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN)
+        } else if (new ColumnFQ(columnUpdate).equals(TabletColumnFamily.PREV_ROW_COLUMN)
             && columnUpdate.getValue().length > 0
             && (violations == null || !violations.contains((short) 4))) {
           KeyExtent ke = new KeyExtent(new Text(mutation.getRow()), (Text) null);
@@ -263,8 +273,7 @@ public class MetadataConstraints implements Constraint {
           if (!prevEndRowLessThanEndRow) {
             violations = addViolation(violations, 3);
           }
-        } else if (new ColumnFQ(columnUpdate)
-            .equals(TabletsSection.ServerColumnFamily.LOCK_COLUMN)) {
+        } else if (new ColumnFQ(columnUpdate).equals(ServerColumnFamily.LOCK_COLUMN)) {
           if (zooCache == null) {
             zooCache = new ZooCache(context.getZooReaderWriter(), null);
             CleanerUtil.zooCacheClearer(this, zooCache);

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilter.java
@@ -29,7 +29,6 @@ import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
@@ -52,7 +51,7 @@ public class MetadataBulkLoadFilter extends Filter {
 
   @Override
   public boolean accept(Key k, Value v) {
-    if (!k.isDeleted() && k.compareColumnFamily(TabletsSection.BulkFileColumnFamily.NAME) == 0) {
+    if (!k.isDeleted() && k.compareColumnFamily(BulkFileColumnFamily.NAME) == 0) {
       long txid = BulkFileColumnFamily.getBulkLoadTid(v);
 
       Status status = bulkTxStatusCache.get(txid);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.hadoop.fs.Path;
 
@@ -55,8 +55,7 @@ class MetaDataStateStore implements TabletStateStore {
 
   @Override
   public ClosableIterator<TabletLocationState> iterator() {
-    return new MetaDataTableScanner(context, MetadataSchema.TabletsSection.getRange(), state,
-        targetTableName);
+    return new MetaDataTableScanner(context, TabletsSection.getRange(), state, targetTableName);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/RootTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/RootTabletStateStore.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.server.master.state;
 
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 
 class RootTabletStateStore extends MetaDataStateStore {
 
@@ -30,8 +30,7 @@ class RootTabletStateStore extends MetaDataStateStore {
 
   @Override
   public ClosableIterator<TabletLocationState> iterator() {
-    return new MetaDataTableScanner(context, MetadataSchema.TabletsSection.getRange(), state,
-        RootTable.NAME);
+    return new MetaDataTableScanner(context, TabletsSection.getRange(), state, RootTable.NAME);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TServerInstance.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TServerInstance.java
@@ -28,7 +28,9 @@ import java.io.Serializable;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -82,27 +84,27 @@ public class TServerInstance implements Ample.TServer, Comparable<TServerInstanc
   }
 
   public void putLocation(Mutation m) {
-    m.put(TabletsSection.CurrentLocationColumnFamily.NAME, asColumnQualifier(), asMutationValue());
+    m.put(CurrentLocationColumnFamily.NAME, asColumnQualifier(), asMutationValue());
   }
 
   public void putFutureLocation(Mutation m) {
-    m.put(TabletsSection.FutureLocationColumnFamily.NAME, asColumnQualifier(), asMutationValue());
+    m.put(FutureLocationColumnFamily.NAME, asColumnQualifier(), asMutationValue());
   }
 
   public void putLastLocation(Mutation m) {
-    m.put(TabletsSection.LastLocationColumnFamily.NAME, asColumnQualifier(), asMutationValue());
+    m.put(LastLocationColumnFamily.NAME, asColumnQualifier(), asMutationValue());
   }
 
   public void clearLastLocation(Mutation m) {
-    m.putDelete(TabletsSection.LastLocationColumnFamily.NAME, asColumnQualifier());
+    m.putDelete(LastLocationColumnFamily.NAME, asColumnQualifier());
   }
 
   public void clearFutureLocation(Mutation m) {
-    m.putDelete(TabletsSection.FutureLocationColumnFamily.NAME, asColumnQualifier());
+    m.putDelete(FutureLocationColumnFamily.NAME, asColumnQualifier());
   }
 
   public void clearLocation(Mutation m) {
-    m.putDelete(TabletsSection.CurrentLocationColumnFamily.NAME, asColumnQualifier());
+    m.putDelete(CurrentLocationColumnFamily.NAME, asColumnQualifier());
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.metadata.TabletFileUtil;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.AmpleImpl;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.SkewedKeyValue;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
@@ -144,6 +145,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     }
   }
 
+  @Override
   public Iterator<String> getGcCandidates(DataLevel level, String continuePoint) {
     if (level == DataLevel.ROOT) {
       byte[] json = context.getZooCache()
@@ -171,7 +173,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       }
       scanner.setRange(range);
       return StreamSupport.stream(scanner.spliterator(), false)
-          .filter(entry -> entry.getValue().equals(DeletesSection.SkewedKeyValue.NAME))
+          .filter(entry -> entry.getValue().equals(SkewedKeyValue.NAME))
           .map(entry -> DeletesSection.decodeRow(entry.getKey().getRow().toString())).iterator();
     } else {
       throw new IllegalArgumentException();
@@ -204,7 +206,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
   private static Mutation createDelMutation(String path) {
     Mutation delFlag = new Mutation(new Text(DeletesSection.encodeRow(path)));
-    delFlag.put(EMPTY_TEXT, EMPTY_TEXT, DeletesSection.SkewedKeyValue.NAME);
+    delFlag.put(EMPTY_TEXT, EMPTY_TEXT, SkewedKeyValue.NAME);
     return delFlag;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -33,8 +33,9 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.hadoop.io.Text;
@@ -103,9 +104,9 @@ public class CheckForMetadataProblems {
 
       Scanner scanner = client.createScanner(tableNameToCheck, Authorizations.EMPTY);
 
-      scanner.setRange(MetadataSchema.TabletsSection.getRange());
-      TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-      scanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
+      scanner.setRange(TabletsSection.getRange());
+      TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
+      scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
 
       Text colf = new Text();
       Text colq = new Text();
@@ -136,11 +137,11 @@ public class CheckForMetadataProblems {
           tables.put(tableName, tablets);
         }
 
-        if (TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
+        if (TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
           KeyExtent tabletKe = new KeyExtent(entry.getKey().getRow(), entry.getValue());
           tablets.add(tabletKe);
           justLoc = false;
-        } else if (colf.equals(TabletsSection.CurrentLocationColumnFamily.NAME)) {
+        } else if (colf.equals(CurrentLocationColumnFamily.NAME)) {
           if (justLoc) {
             System.out.println("Problem at key " + entry.getKey());
             sawProblems = true;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.master.LiveTServerSet;
@@ -87,7 +87,7 @@ public class FindOfflineTablets {
 
     System.out.println("Scanning " + RootTable.NAME);
     Iterator<TabletLocationState> rootScanner =
-        new MetaDataTableScanner(context, MetadataSchema.TabletsSection.getRange(), RootTable.NAME);
+        new MetaDataTableScanner(context, TabletsSection.getRange(), RootTable.NAME);
     if ((offline = checkTablets(context, rootScanner, tservers)) > 0)
       return offline;
 
@@ -96,7 +96,7 @@ public class FindOfflineTablets {
 
     System.out.println("Scanning " + MetadataTable.NAME);
 
-    Range range = MetadataSchema.TabletsSection.getRange();
+    Range range = TabletsSection.getRange();
     if (tableName != null) {
       TableId tableId = Tables.getTableId(context, tableName);
       range = new KeyExtent(tableId, null, null).toMetadataRange();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/LocalityCheck.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/LocalityCheck.java
@@ -30,8 +30,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TabletFileUtil;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -53,9 +53,9 @@ public class LocalityCheck {
       try (AccumuloClient accumuloClient =
           Accumulo.newClient().from(opts.getClientProps()).build()) {
         Scanner scanner = accumuloClient.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-        scanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
+        scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
         scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-        scanner.setRange(MetadataSchema.TabletsSection.getRange());
+        scanner.setRange(TabletsSection.getRange());
 
         Map<String,Long> totalBlocks = new HashMap<>();
         Map<String,Long> localBlocks = new HashMap<>();
@@ -63,7 +63,7 @@ public class LocalityCheck {
 
         for (Entry<Key,Value> entry : scanner) {
           Key key = entry.getKey();
-          if (key.compareColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME) == 0) {
+          if (key.compareColumnFamily(CurrentLocationColumnFamily.NAME) == 0) {
             String location = entry.getValue().toString();
             String[] parts = location.split(":");
             String host = parts[0];

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -41,7 +41,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TabletFileUtil;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.ServerContext;
@@ -182,11 +182,10 @@ public class RemoveEntriesForMissingFiles {
   }
 
   static int checkAllTables(ServerContext context, boolean fix) throws Exception {
-    int missing =
-        checkTable(context, RootTable.NAME, MetadataSchema.TabletsSection.getRange(), fix);
+    int missing = checkTable(context, RootTable.NAME, TabletsSection.getRange(), fix);
 
     if (missing == 0)
-      return checkTable(context, MetadataTable.NAME, MetadataSchema.TabletsSection.getRange(), fix);
+      return checkTable(context, MetadataTable.NAME, TabletsSection.getRange(), fix);
     else
       return missing;
   }
@@ -195,7 +194,7 @@ public class RemoveEntriesForMissingFiles {
     if (tableName.equals(RootTable.NAME)) {
       throw new IllegalArgumentException("Can not check root table");
     } else if (tableName.equals(MetadataTable.NAME)) {
-      return checkTable(context, RootTable.NAME, MetadataSchema.TabletsSection.getRange(), fix);
+      return checkTable(context, RootTable.NAME, TabletsSection.getRange(), fix);
     } else {
       TableId tableId = Tables.getTableId(context, tableName);
       Range range = new KeyExtent(tableId, null, null).toMetadataRange();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.tabletserver.thrift.ConstraintViolationException;
@@ -106,8 +105,7 @@ public class ReplicationTableUtil {
       // Set our combiner and combine all columns
       // Need to set the combiner beneath versioning since we don't want to turn it off
       IteratorSetting setting = new IteratorSetting(9, COMBINER_NAME, StatusCombiner.class);
-      Combiner.setColumns(setting,
-          Collections.singletonList(new Column(MetadataSchema.ReplicationSection.COLF)));
+      Combiner.setColumns(setting, Collections.singletonList(new Column(ReplicationSection.COLF)));
       try {
         tops.attachIterator(tableName, setting);
       } catch (AccumuloSecurityException | AccumuloException | TableNotFoundException e) {
@@ -191,7 +189,7 @@ public class ReplicationTableUtil {
 
   private static Mutation createUpdateMutation(Text row, Value v, KeyExtent extent) {
     Mutation m = new Mutation(row);
-    m.put(MetadataSchema.ReplicationSection.COLF, new Text(extent.getTableId().canonical()), v);
+    m.put(ReplicationSection.COLF, new Text(extent.getTableId().canonical()), v);
     return m;
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilterTest.java
@@ -31,8 +31,9 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
@@ -82,26 +83,26 @@ public class MetadataBulkLoadFilterTest {
     TreeMap<Key,Value> expected = new TreeMap<>();
 
     // following should not be deleted by filter
-    put(tm1, "2;m", TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN, "/t1");
+    put(tm1, "2;m", ServerColumnFamily.DIRECTORY_COLUMN, "/t1");
     put(tm1, "2;m", DataFileColumnFamily.NAME, "/t1/file1",
         new DataFileValue(1, 1).encodeAsString());
-    put(tm1, "2;m", TabletsSection.BulkFileColumnFamily.NAME, "/t1/file1", "5");
-    put(tm1, "2;m", TabletsSection.BulkFileColumnFamily.NAME, "/t1/file3", "7");
-    put(tm1, "2;m", TabletsSection.BulkFileColumnFamily.NAME, "/t1/file4", "9");
-    put(tm1, "2<", TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN, "/t2");
+    put(tm1, "2;m", BulkFileColumnFamily.NAME, "/t1/file1", "5");
+    put(tm1, "2;m", BulkFileColumnFamily.NAME, "/t1/file3", "7");
+    put(tm1, "2;m", BulkFileColumnFamily.NAME, "/t1/file4", "9");
+    put(tm1, "2<", ServerColumnFamily.DIRECTORY_COLUMN, "/t2");
     put(tm1, "2<", DataFileColumnFamily.NAME, "/t2/file2",
         new DataFileValue(1, 1).encodeAsString());
-    put(tm1, "2<", TabletsSection.BulkFileColumnFamily.NAME, "/t2/file6", "5");
-    put(tm1, "2<", TabletsSection.BulkFileColumnFamily.NAME, "/t2/file7", "7");
-    put(tm1, "2<", TabletsSection.BulkFileColumnFamily.NAME, "/t2/file8", "9");
-    put(tm1, "2<", TabletsSection.BulkFileColumnFamily.NAME, "/t2/fileC", null);
+    put(tm1, "2<", BulkFileColumnFamily.NAME, "/t2/file6", "5");
+    put(tm1, "2<", BulkFileColumnFamily.NAME, "/t2/file7", "7");
+    put(tm1, "2<", BulkFileColumnFamily.NAME, "/t2/file8", "9");
+    put(tm1, "2<", BulkFileColumnFamily.NAME, "/t2/fileC", null);
 
     expected.putAll(tm1);
 
     // the following should be deleted by filter
-    put(tm1, "2;m", TabletsSection.BulkFileColumnFamily.NAME, "/t1/file5", "8");
-    put(tm1, "2<", TabletsSection.BulkFileColumnFamily.NAME, "/t2/file9", "8");
-    put(tm1, "2<", TabletsSection.BulkFileColumnFamily.NAME, "/t2/fileA", "2");
+    put(tm1, "2;m", BulkFileColumnFamily.NAME, "/t1/file5", "8");
+    put(tm1, "2<", BulkFileColumnFamily.NAME, "/t2/file9", "8");
+    put(tm1, "2<", BulkFileColumnFamily.NAME, "/t2/fileA", "2");
 
     SystemIteratorEnvironment env = EasyMock.createMock(SystemIteratorEnvironment.class);
     EasyMock.expect(env.getServerContext()).andReturn(null);

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.server.replication.StatusCombiner;
@@ -98,14 +97,15 @@ public class ReplicationTableUtilTest {
     assertEquals(1, mutations.size());
     Mutation m = mutations.get(0);
 
-    assertEquals(MetadataSchema.ReplicationSection.getRowPrefix()
-        + "file:/home/user/accumulo/wal/server+port/" + uuid, new Text(m.getRow()).toString());
+    assertEquals(
+        ReplicationSection.getRowPrefix() + "file:/home/user/accumulo/wal/server+port/" + uuid,
+        new Text(m.getRow()).toString());
 
     List<ColumnUpdate> updates = m.getUpdates();
     assertEquals(1, updates.size());
     ColumnUpdate update = updates.get(0);
 
-    assertEquals(MetadataSchema.ReplicationSection.COLF, new Text(update.getColumnFamily()));
+    assertEquals(ReplicationSection.COLF, new Text(update.getColumnFamily()));
     assertEquals("1", new Text(update.getColumnQualifier()).toString());
     assertEquals(StatusUtil.fileCreatedValue(createdTime), new Value(update.getValue()));
   }
@@ -123,12 +123,11 @@ public class ReplicationTableUtilTest {
     Mutation m =
         ReplicationTableUtil.createUpdateMutation(filePath, ProtobufUtil.toValue(stat), extent);
 
-    assertEquals(new Text(MetadataSchema.ReplicationSection.getRowPrefix() + row),
-        new Text(m.getRow()));
+    assertEquals(new Text(ReplicationSection.getRowPrefix() + row), new Text(m.getRow()));
     assertEquals(1, m.getUpdates().size());
     ColumnUpdate col = m.getUpdates().get(0);
 
-    assertEquals(MetadataSchema.ReplicationSection.COLF, new Text(col.getColumnFamily()));
+    assertEquals(ReplicationSection.COLF, new Text(col.getColumnFamily()));
     assertEquals(extent.getTableId().canonical(), new Text(col.getColumnQualifier()).toString());
     assertEquals(0, col.getColumnVisibility().length);
     assertArrayEquals(stat.toByteArray(), col.getValue());

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.gc.thrift.GCStatus;
 import org.apache.accumulo.core.gc.thrift.GcCycleStats;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.replication.ReplicationTableOfflineException;
@@ -343,11 +343,11 @@ public class GarbageCollectWriteAheadLogs {
       }
 
       final Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-      scanner.fetchColumnFamily(MetadataSchema.ReplicationSection.COLF);
-      scanner.setRange(MetadataSchema.ReplicationSection.getRange());
+      scanner.fetchColumnFamily(ReplicationSection.COLF);
+      scanner.setRange(ReplicationSection.getRange());
       for (Entry<Key,Value> entry : scanner) {
         Text file = new Text();
-        MetadataSchema.ReplicationSection.getFile(entry.getKey(), file);
+        ReplicationSection.getFile(entry.getKey(), file);
         UUID id = path2uuid(new Path(file.toString()));
         candidates.remove(id);
         log.info("Ignore closed log " + id + " because it is being replicated");

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -58,7 +58,7 @@ import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TabletFileUtil;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.BlipSection;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
@@ -236,10 +236,10 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
       IsolatedScanner scanner =
           new IsolatedScanner(getContext().createScanner(level.metaTable(), Authorizations.EMPTY));
 
-      scanner.setRange(MetadataSchema.BlipSection.getRange());
+      scanner.setRange(BlipSection.getRange());
 
       return Iterators.transform(scanner.iterator(), entry -> entry.getKey().getRow().toString()
-          .substring(MetadataSchema.BlipSection.getRowPrefix().length()));
+          .substring(BlipSection.getRowPrefix().length()));
     }
 
     @Override

--- a/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/replication/CloseWriteAheadLogReferences.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.security.Authorizations;
@@ -160,7 +159,7 @@ public class CloseWriteAheadLogReferences implements Runnable {
         }
 
         // Ignore things that aren't completely replicated as we can't delete those anyways
-        MetadataSchema.ReplicationSection.getFile(entry.getKey(), replFileText);
+        ReplicationSection.getFile(entry.getKey(), replFileText);
         String replFile = replFileText.toString();
         boolean isClosed = closedWals.contains(replFile);
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -33,7 +33,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.gc.thrift.GCStatus;
 import org.apache.accumulo.core.gc.thrift.GcCycleStats;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.replication.ReplicationSchema;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.security.Authorizations;
@@ -176,9 +176,9 @@ public class GarbageCollectWriteAheadLogsTest {
 
     EasyMock.expect(context.createScanner(MetadataTable.NAME, Authorizations.EMPTY))
         .andReturn(mscanner);
-    mscanner.fetchColumnFamily(MetadataSchema.ReplicationSection.COLF);
+    mscanner.fetchColumnFamily(ReplicationSection.COLF);
     EasyMock.expectLastCall().once();
-    mscanner.setRange(MetadataSchema.ReplicationSection.getRange());
+    mscanner.setRange(ReplicationSection.getRange());
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(emptyKV);
     EasyMock.expect(fs.deleteRecursively(path)).andReturn(true).once();
@@ -224,9 +224,9 @@ public class GarbageCollectWriteAheadLogsTest {
 
     EasyMock.expect(context.createScanner(MetadataTable.NAME, Authorizations.EMPTY))
         .andReturn(mscanner);
-    mscanner.fetchColumnFamily(MetadataSchema.ReplicationSection.COLF);
+    mscanner.fetchColumnFamily(ReplicationSection.COLF);
     EasyMock.expectLastCall().once();
-    mscanner.setRange(MetadataSchema.ReplicationSection.getRange());
+    mscanner.setRange(ReplicationSection.getRange());
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(emptyKV);
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
@@ -249,8 +249,8 @@ public class GarbageCollectWriteAheadLogsTest {
     LiveTServerSet tserverSet = EasyMock.createMock(LiveTServerSet.class);
     Scanner mscanner = EasyMock.createMock(Scanner.class);
     Scanner rscanner = EasyMock.createMock(Scanner.class);
-    String row = MetadataSchema.ReplicationSection.getRowPrefix() + path;
-    String colf = MetadataSchema.ReplicationSection.COLF.toString();
+    String row = ReplicationSection.getRowPrefix() + path;
+    String colf = ReplicationSection.COLF.toString();
     String colq = "1";
     Map<Key,Value> replicationWork =
         Collections.singletonMap(new Key(row, colf, colq), new Value(new byte[0]));
@@ -272,9 +272,9 @@ public class GarbageCollectWriteAheadLogsTest {
 
     EasyMock.expect(context.createScanner(MetadataTable.NAME, Authorizations.EMPTY))
         .andReturn(mscanner);
-    mscanner.fetchColumnFamily(MetadataSchema.ReplicationSection.COLF);
+    mscanner.fetchColumnFamily(ReplicationSection.COLF);
     EasyMock.expectLastCall().once();
-    mscanner.setRange(MetadataSchema.ReplicationSection.getRange());
+    mscanner.setRange(ReplicationSection.getRange());
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(replicationWork.entrySet().iterator());
     EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);

--- a/server/manager/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Master.java
@@ -72,7 +72,7 @@ import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.replication.thrift.ReplicationCoordinator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.tabletserver.thrift.TUnloadTabletGoal;
@@ -674,7 +674,7 @@ public class Master extends AbstractServer
     private void cleanupNonexistentMigrations(final AccumuloClient accumuloClient)
         throws TableNotFoundException {
       Scanner scanner = accumuloClient.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-      TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
+      TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       Set<KeyExtent> found = new HashSet<>();
       for (Entry<Key,Value> entry : scanner) {
         KeyExtent extent = new KeyExtent(entry.getKey().getRow(), entry.getValue());

--- a/server/manager/src/main/java/org/apache/accumulo/master/replication/StatusMaker.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/replication/StatusMaker.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationSchema.OrderSection;
@@ -113,8 +112,8 @@ public class StatusMaker {
           }
         }
         // Extract the useful bits from the status key
-        MetadataSchema.ReplicationSection.getFile(entry.getKey(), file);
-        TableId tableId = MetadataSchema.ReplicationSection.getTableId(entry.getKey());
+        ReplicationSection.getFile(entry.getKey(), file);
+        TableId tableId = ReplicationSection.getTableId(entry.getKey());
 
         Status status;
         try {
@@ -276,7 +275,7 @@ public class StatusMaker {
 
     Status status = Status.newBuilder().setCreatedTime(createdTime).build();
     Mutation m = new Mutation(new Text(ReplicationSection.getRowPrefix() + file));
-    m.put(MetadataSchema.ReplicationSection.COLF, new Text(tableId), ProtobufUtil.toValue(status));
+    m.put(ReplicationSection.COLF, new Text(tableId), ProtobufUtil.toValue(status));
     replicationWriter.addMutation(m);
     replicationWriter.flush();
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/state/MergeStats.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
@@ -95,9 +94,7 @@ public class MergeStats {
     if (info.needsToBeChopped(ke)) {
       this.needsToBeChopped++;
       if (chopped) {
-        if (state.equals(TabletState.HOSTED)) {
-          this.chopped++;
-        } else if (!hasWALs) {
+        if (state.equals(TabletState.HOSTED) || !hasWALs) {
           this.chopped++;
         }
       }
@@ -204,7 +201,7 @@ public class MergeStats {
     TableId tableId = extent.getTableId();
     Text first = TabletsSection.getRow(tableId, start);
     Range range = new Range(first, false, null, true);
-    scanner.setRange(range.clip(MetadataSchema.TabletsSection.getRange()));
+    scanner.setRange(range.clip(TabletsSection.getRange()));
     KeyExtent prevExtent = null;
 
     log.debug("Scanning range {}", range);

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CopyFailed.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CopyFailed.java
@@ -38,7 +38,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TabletFileUtil;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.FateTxId;
@@ -123,7 +122,7 @@ class CopyFailed extends MasterRepo {
     try (Scanner mscanner =
         new IsolatedScanner(client.createScanner(MetadataTable.NAME, Authorizations.EMPTY))) {
       mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
-      mscanner.fetchColumnFamily(TabletsSection.BulkFileColumnFamily.NAME);
+      mscanner.fetchColumnFamily(BulkFileColumnFamily.NAME);
 
       for (Entry<Key,Value> entry : mscanner) {
         if (BulkFileColumnFamily.getBulkLoadTid(entry.getValue()) == tid) {

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.fate.Repo;
@@ -91,9 +90,8 @@ class PopulateMetadata extends MasterRepo {
       Mutation mut = new KeyExtent(tableId, split, prevSplit).getPrevRowUpdateMutation();
       dirValue = (split == null) ? new Value(ServerColumnFamily.DEFAULT_TABLET_DIR_NAME)
           : new Value(data.get(split));
-      MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut, dirValue);
-      MetadataSchema.TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut,
-          new Value(new MetadataTime(0, timeType).encode()));
+      ServerColumnFamily.DIRECTORY_COLUMN.put(mut, dirValue);
+      ServerColumnFamily.TIME_COLUMN.put(mut, new Value(new MetadataTime(0, timeType).encode()));
       MetadataTableUtil.putLockID(ctx, lock, mut);
       prevSplit = split;
       bw.addMutation(mut);

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/delete/CleanUp.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.user.GrepIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.Repo;
@@ -129,8 +129,8 @@ class CleanUp extends MasterRepo {
       AccumuloClient client = master.getContext();
       try (BatchScanner bs =
           client.createBatchScanner(MetadataTable.NAME, Authorizations.EMPTY, 8)) {
-        Range allTables = MetadataSchema.TabletsSection.getRange();
-        Range tableRange = MetadataSchema.TabletsSection.getRange(tableId);
+        Range allTables = TabletsSection.getRange();
+        Range tableRange = TabletsSection.getRange(tableId);
         Range beforeTable =
             new Range(allTables.getStartKey(), true, tableRange.getStartKey(), false);
         Range afterTable = new Range(tableRange.getEndKey(), false, allTables.getEndKey(), true);

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableExport/WriteExportFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableExport/WriteExportFiles.java
@@ -51,9 +51,12 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TabletFileUtil;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -103,8 +106,8 @@ class WriteExportFiles extends MasterRepo {
     metaScanner.setRange(new KeyExtent(tableInfo.tableID, null, null).toMetadataRange());
 
     // scan for locations
-    metaScanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
-    metaScanner.fetchColumnFamily(TabletsSection.FutureLocationColumnFamily.NAME);
+    metaScanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
+    metaScanner.fetchColumnFamily(FutureLocationColumnFamily.NAME);
 
     if (metaScanner.iterator().hasNext()) {
       return 500;
@@ -223,8 +226,8 @@ class WriteExportFiles extends MasterRepo {
 
     Scanner metaScanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-    TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);
-    TabletsSection.ServerColumnFamily.TIME_COLUMN.fetch(metaScanner);
+    TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);
+    ServerColumnFamily.TIME_COLUMN.fetch(metaScanner);
     metaScanner.setRange(new KeyExtent(tableID, null, null).toMetadataRange());
 
     for (Entry<Key,Value> entry : metaScanner) {

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableImport/PopulateMetadataTable.java
@@ -41,8 +41,9 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
@@ -152,7 +153,7 @@ class PopulateMetadataTable extends MasterRepo {
                   UTF_8);
 
               m = new Mutation(metadataRow);
-              TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value(tabletDir));
+              ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value(tabletDir));
               currentRow = metadataRow;
             }
 
@@ -166,13 +167,12 @@ class PopulateMetadataTable extends MasterRepo {
                   UTF_8);
 
               m = new Mutation(metadataRow);
-              TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value(tabletDir));
+              ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value(tabletDir));
             }
 
             m.put(key.getColumnFamily(), cq, val);
 
-            if (endRow == null
-                && TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
+            if (endRow == null && TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
               mbw.addMutation(m);
               break; // its the last column in the last row
             }

--- a/server/manager/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -59,7 +59,9 @@ import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.SkewedKeyValue;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
@@ -103,7 +105,7 @@ public class Upgrader9to10 implements Upgrader {
   public static final String ZROOT_TABLET_WALOGS = ZROOT_TABLET + "/walogs";
   public static final String ZROOT_TABLET_CURRENT_LOGS = ZROOT_TABLET + "/current_logs";
   public static final String ZROOT_TABLET_PATH = ZROOT_TABLET + "/dir";
-  public static final Value UPGRADED = MetadataSchema.DeletesSection.SkewedKeyValue.NAME;
+  public static final Value UPGRADED = SkewedKeyValue.NAME;
   public static final String OLD_DELETE_PREFIX = "~del";
 
   // effectively an 8MB batch size, since this number is the number of Chars
@@ -480,7 +482,7 @@ public class Upgrader9to10 implements Upgrader {
    */
   private Iterator<String> getOldCandidates(ServerContext ctx, String tableName)
       throws TableNotFoundException {
-    Range range = MetadataSchema.DeletesSection.getRange();
+    Range range = DeletesSection.getRange();
     Scanner scanner = ctx.createScanner(tableName, Authorizations.EMPTY);
     scanner.setRange(range);
     return StreamSupport.stream(scanner.spliterator(), false)
@@ -564,7 +566,7 @@ public class Upgrader9to10 implements Upgrader {
     try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY);
         BatchWriter writer = c.createBatchWriter(tableName)) {
 
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
         Key key = entry.getKey();
         String metaEntry = key.getColumnQualifier().toString();
@@ -609,7 +611,7 @@ public class Upgrader9to10 implements Upgrader {
 
     try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
       log.info("Looking for relative paths in {}", tableName);
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
         Key key = entry.getKey();
         String metaEntry = key.getColumnQualifier().toString();

--- a/server/manager/src/test/java/org/apache/accumulo/master/upgrade/Upgrader9to10Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/master/upgrade/Upgrader9to10Test.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.gc.GcVolumeUtil;
@@ -152,7 +152,7 @@ public class Upgrader9to10Test {
     expect(scanner.iterator()).andReturn(map.entrySet().iterator()).anyTimes();
 
     // void methods
-    scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+    scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     expectLastCall().anyTimes();
     scanner.close();
     expectLastCall().anyTimes();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -29,7 +29,10 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.util.ColumnFQ;
@@ -88,11 +91,11 @@ public class CheckTabletMetadataTest {
 
     TreeMap<Key,Value> tabletMeta = new TreeMap<>();
 
-    put(tabletMeta, "1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN,
+    put(tabletMeta, "1<", TabletColumnFamily.PREV_ROW_COLUMN,
         KeyExtent.encodePrevEndRow(null).get());
-    put(tabletMeta, "1<", TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN, "t1".getBytes());
-    put(tabletMeta, "1<", TabletsSection.ServerColumnFamily.TIME_COLUMN, "M0".getBytes());
-    put(tabletMeta, "1<", TabletsSection.FutureLocationColumnFamily.NAME, "4", "127.0.0.1:9997");
+    put(tabletMeta, "1<", ServerColumnFamily.DIRECTORY_COLUMN, "t1".getBytes());
+    put(tabletMeta, "1<", ServerColumnFamily.TIME_COLUMN, "M0".getBytes());
+    put(tabletMeta, "1<", FutureLocationColumnFamily.NAME, "4", "127.0.0.1:9997");
 
     TServerInstance tsi = new TServerInstance("127.0.0.1:9997", 4);
 
@@ -110,30 +113,27 @@ public class CheckTabletMetadataTest {
 
     assertFail(tabletMeta, new KeyExtent(TableId.of("1"), new Text("r"), new Text("m")), tsi);
 
-    assertFail(tabletMeta, ke, tsi,
-        newKey("1<", TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", TabletColumnFamily.PREV_ROW_COLUMN));
 
-    assertFail(tabletMeta, ke, tsi,
-        newKey("1<", TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", ServerColumnFamily.DIRECTORY_COLUMN));
 
-    assertFail(tabletMeta, ke, tsi, newKey("1<", TabletsSection.ServerColumnFamily.TIME_COLUMN));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", ServerColumnFamily.TIME_COLUMN));
 
-    assertFail(tabletMeta, ke, tsi,
-        newKey("1<", TabletsSection.FutureLocationColumnFamily.NAME, "4"));
+    assertFail(tabletMeta, ke, tsi, newKey("1<", FutureLocationColumnFamily.NAME, "4"));
 
     TreeMap<Key,Value> copy = new TreeMap<>(tabletMeta);
-    put(copy, "1<", TabletsSection.CurrentLocationColumnFamily.NAME, "4", "127.0.0.1:9997");
+    put(copy, "1<", CurrentLocationColumnFamily.NAME, "4", "127.0.0.1:9997");
     assertFail(copy, ke, tsi);
-    assertFail(copy, ke, tsi, newKey("1<", TabletsSection.FutureLocationColumnFamily.NAME, "4"));
+    assertFail(copy, ke, tsi, newKey("1<", FutureLocationColumnFamily.NAME, "4"));
 
     copy = new TreeMap<>(tabletMeta);
-    put(copy, "1<", TabletsSection.CurrentLocationColumnFamily.NAME, "5", "127.0.0.1:9998");
+    put(copy, "1<", CurrentLocationColumnFamily.NAME, "5", "127.0.0.1:9998");
     assertFail(copy, ke, tsi);
-    put(copy, "1<", TabletsSection.CurrentLocationColumnFamily.NAME, "6", "127.0.0.1:9999");
+    put(copy, "1<", CurrentLocationColumnFamily.NAME, "6", "127.0.0.1:9999");
     assertFail(copy, ke, tsi);
 
     copy = new TreeMap<>(tabletMeta);
-    put(copy, "1<", TabletsSection.FutureLocationColumnFamily.NAME, "5", "127.0.0.1:9998");
+    put(copy, "1<", FutureLocationColumnFamily.NAME, "5", "127.0.0.1:9998");
     assertFail(copy, ke, tsi);
 
     assertFail(new TreeMap<>(), ke, tsi);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.core.util.format.DefaultFormatter;
@@ -71,14 +71,14 @@ public class GetSplitsCommand extends Command {
             MetadataTable.NAME.equals(tableName) ? RootTable.NAME : MetadataTable.NAME;
         final Scanner scanner =
             shellState.getAccumuloClient().createScanner(systemTableToCheck, Authorizations.EMPTY);
-        TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
+        TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
         final Text start =
             new Text(shellState.getAccumuloClient().tableOperations().tableIdMap().get(tableName));
         final Text end = new Text(start);
         end.append(new byte[] {'<'}, 0, 1);
         scanner.setRange(new Range(start, end));
         for (final Entry<Key,Value> next : scanner) {
-          if (TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(next.getKey())) {
+          if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(next.getKey())) {
             KeyExtent extent = new KeyExtent(next.getKey().getRow(), next.getValue());
             final String pr = encode(encode, extent.getPrevEndRow());
             final String er = encode(encode, extent.getEndRow());

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
@@ -175,7 +175,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
       log.info("Verifying that delete markers were deleted");
       // look for delete markers
       try (Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-        scanner.setRange(MetadataSchema.DeletesSection.getRange());
+        scanner.setRange(DeletesSection.getRange());
         for (Entry<Key,Value> entry : scanner) {
           String row = entry.getKey().getRow().toString();
           if (!row.contains("/" + tableId + "/")) {

--- a/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
@@ -36,7 +36,8 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -139,8 +140,8 @@ public class CleanWalIT extends AccumuloClusterHarness {
   private int countLogs(AccumuloClient client) throws TableNotFoundException {
     int count = 0;
     try (Scanner scanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.LogColumnFamily.NAME);
-      scanner.setRange(MetadataSchema.TabletsSection.getRange());
+      scanner.fetchColumnFamily(LogColumnFamily.NAME);
+      scanner.setRange(TabletsSection.getRange());
       for (Entry<Key,Value> entry : scanner) {
         log.debug("Saw {}={}", entry.getKey(), entry.getValue());
         count++;

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -35,8 +35,9 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletDeletedException;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -55,8 +56,8 @@ public class CloneIT extends AccumuloClusterHarness {
       KeyExtent ke = new KeyExtent(TableId.of("0"), null, null);
       Mutation mut = ke.getPrevRowUpdateMutation();
 
-      TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
-      TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value("/default_tablet"));
+      ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
+      ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value("/default_tablet"));
 
       try (BatchWriter bw1 = client.createBatchWriter(tableName)) {
         bw1.addMutation(mut);
@@ -83,8 +84,8 @@ public class CloneIT extends AccumuloClusterHarness {
       KeyExtent ke = new KeyExtent(TableId.of("0"), null, null);
       Mutation mut = ke.getPrevRowUpdateMutation();
 
-      TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
-      TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value("/default_tablet"));
+      ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
+      ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value("/default_tablet"));
       mut.put(DataFileColumnFamily.NAME.toString(), filePrefix + "/default_tablet/0_0.rf",
           new DataFileValue(1, 200).encodeAsString());
 
@@ -232,9 +233,9 @@ public class CloneIT extends AccumuloClusterHarness {
     KeyExtent ke = new KeyExtent(TableId.of(tid), endRow == null ? null : new Text(endRow),
         prevRow == null ? null : new Text(prevRow));
     Mutation mut = new Mutation(ke.getMetadataEntry());
-    TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
-    TabletsSection.ServerColumnFamily.TIME_COLUMN.putDelete(mut);
-    TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.putDelete(mut);
+    TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
+    ServerColumnFamily.TIME_COLUMN.putDelete(mut);
+    ServerColumnFamily.DIRECTORY_COLUMN.putDelete(mut);
     mut.putDelete(DataFileColumnFamily.NAME.toString(), file);
 
     return mut;
@@ -246,8 +247,8 @@ public class CloneIT extends AccumuloClusterHarness {
         prevRow == null ? null : new Text(prevRow));
     Mutation mut = ke.getPrevRowUpdateMutation();
 
-    TabletsSection.ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
-    TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value(dir));
+    ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
+    ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value(dir));
     mut.put(DataFileColumnFamily.NAME.toString(), file,
         new DataFileValue(10, 200).encodeAsString());
 

--- a/test/src/main/java/org/apache/accumulo/test/ConfigurableMajorCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConfigurableMajorCompactionIT.java
@@ -31,7 +31,8 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -106,8 +107,8 @@ public class ConfigurableMajorCompactionIT extends ConfigurableMacBase {
 
   private int countFiles(AccumuloClient client) throws Exception {
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.setRange(MetadataSchema.TabletsSection.getRange());
-      s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      s.setRange(TabletsSection.getRange());
+      s.fetchColumnFamily(DataFileColumnFamily.NAME);
       return Iterators.size(s.iterator());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
@@ -146,7 +146,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       log.info("{} is offline", tableName);
 
-      Text row = MetadataSchema.TabletsSection.getRow(tableId, null);
+      Text row = TabletsSection.getRow(tableId, null);
       Mutation m = new Mutation(row);
       m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 
@@ -206,7 +206,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       log.info("{} is offline", tableName);
 
-      Text row = MetadataSchema.TabletsSection.getRow(tableId, null);
+      Text row = TabletsSection.getRow(tableId, null);
       Mutation m = new Mutation(row);
       m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 

--- a/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -90,7 +90,7 @@ public class RecoveryCompactionsAreFlushesIT extends AccumuloClusterHarness {
 
       // ensure that the recovery was not a merging minor compaction
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-        s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+        s.fetchColumnFamily(DataFileColumnFamily.NAME);
         for (Entry<Key,Value> entry : s) {
           String filename = entry.getKey().getColumnQualifier().toString();
           String[] parts = filename.split("/");

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -36,8 +36,10 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -58,7 +60,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
     String tableId = client.tableOperations().tableIdMap().get(tablename);
     try (Scanner scanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       scanner.setRange(new Range(new Text(tableId + ";"), new Text(tableId + "<")));
-      scanner.fetchColumnFamily(TabletsSection.CurrentLocationColumnFamily.NAME);
+      scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       return Iterators.size(scanner.iterator()) == 0;
     }
   }
@@ -95,10 +97,8 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
         KeyExtent extent = new KeyExtent(tableId, null, new Text("b"));
         Mutation m = extent.getPrevRowUpdateMutation();
 
-        TabletsSection.TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m,
-            new Value(Double.toString(0.5)));
-        TabletsSection.TabletColumnFamily.OLD_PREV_ROW_COLUMN.put(m,
-            KeyExtent.encodePrevEndRow(null));
+        TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m, new Value(Double.toString(0.5)));
+        TabletColumnFamily.OLD_PREV_ROW_COLUMN.put(m, KeyExtent.encodePrevEndRow(null));
         try (BatchWriter bw = client.createBatchWriter(MetadataTable.NAME)) {
           bw.addMutation(m);
 
@@ -111,8 +111,8 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
 
               KeyExtent extent2 = new KeyExtent(tableId, new Text("b"), null);
               m = extent2.getPrevRowUpdateMutation();
-              TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("t2"));
-              TabletsSection.ServerColumnFamily.TIME_COLUMN.put(m, new Value("M0"));
+              ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("t2"));
+              ServerColumnFamily.TIME_COLUMN.put(m, new Value("M0"));
 
               for (Entry<Key,Value> entry : scanner) {
                 m.put(DataFileColumnFamily.NAME, entry.getKey().getColumnQualifier(),

--- a/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
@@ -47,6 +47,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.fs.PerTableVolumeChooser;
@@ -252,7 +253,7 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     TreeSet<String> volumesSeen = new TreeSet<>();
     try (Scanner scanner = accumuloClient.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       scanner.setRange(tableRange);
-      scanner.fetchColumnFamily(TabletsSection.LogColumnFamily.NAME);
+      scanner.fetchColumnFamily(LogColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
         boolean inVolume = false;
         for (String volume : volumes) {

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -58,7 +58,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -304,7 +303,7 @@ public class VolumeIT extends ConfigurableMacBase {
 
     TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
     try (Scanner metaScanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      metaScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       metaScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
 
       int[] counts = new int[paths.length];

--- a/test/src/main/java/org/apache/accumulo/test/WaitForBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/WaitForBalanceIT.java
@@ -34,7 +34,9 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.io.Text;
@@ -75,17 +77,15 @@ public class WaitForBalanceIT extends ConfigurableMacBase {
     int offline = 0;
     for (String tableName : new String[] {MetadataTable.NAME, RootTable.NAME}) {
       try (Scanner s = c.createScanner(tableName, Authorizations.EMPTY)) {
-        s.setRange(MetadataSchema.TabletsSection.getRange());
-        s.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
-        MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
+        s.setRange(TabletsSection.getRange());
+        s.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
+        TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
         String location = null;
         for (Entry<Key,Value> entry : s) {
           Key key = entry.getKey();
-          if (key.getColumnFamily()
-              .equals(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME)) {
+          if (key.getColumnFamily().equals(CurrentLocationColumnFamily.NAME)) {
             location = key.getColumnQualifier().toString();
-          } else if (MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN
-              .hasColumns(key)) {
+          } else if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
             if (location == null) {
               offline++;
             } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/CleanTmpIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CleanTmpIT.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
@@ -90,7 +90,7 @@ public class CleanTmpIT extends ConfigurableMacBase {
       Path file;
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         s.setRange(Range.prefix(id));
-        s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+        s.fetchColumnFamily(DataFileColumnFamily.NAME);
         Entry<Key,Value> entry = Iterables.getOnlyElement(s);
         file = new Path(entry.getKey().getColumnQualifier().toString());
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -54,7 +54,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
@@ -137,8 +138,8 @@ public class CloneTestIT extends AccumuloClusterHarness {
   private void checkMetadata(String table, AccumuloClient client) throws Exception {
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
 
-      s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
-      MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
+      s.fetchColumnFamily(DataFileColumnFamily.NAME);
+      ServerColumnFamily.DIRECTORY_COLUMN.fetch(s);
       String tableId = client.tableOperations().tableIdMap().get(table);
 
       assertNotNull("Could not get table id for " + table, tableId);
@@ -154,16 +155,13 @@ public class CloneTestIT extends AccumuloClusterHarness {
         k.getColumnFamily(cf);
         k.getColumnQualifier(cq);
 
-        if (cf.equals(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME)) {
+        if (cf.equals(DataFileColumnFamily.NAME)) {
           Path p = new Path(cq.toString());
           FileSystem fs = cluster.getFileSystem();
           assertTrue("File does not exist: " + p, fs.exists(p));
-        } else if (cf.equals(
-            MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily())) {
+        } else if (cf.equals(ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily())) {
           assertEquals("Saw unexpected cq",
-              MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN
-                  .getColumnQualifier(),
-              cq);
+              ServerColumnFamily.DIRECTORY_COLUMN.getColumnQualifier(), cq);
 
           String dirName = entry.getValue().toString();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -33,7 +33,8 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -173,8 +174,8 @@ public class CompactionIT extends AccumuloClusterHarness {
 
   private int countFiles(AccumuloClient c) throws Exception {
     try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.fetchColumnFamily(new Text(MetadataSchema.TabletsSection.TabletColumnFamily.NAME));
-      s.fetchColumnFamily(new Text(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME));
+      s.fetchColumnFamily(new Text(TabletColumnFamily.NAME));
+      s.fetchColumnFamily(new Text(DataFileColumnFamily.NAME));
       return Iterators.size(s.iterator());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableCompactionIT.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -187,7 +187,7 @@ public class ConfigurableCompactionIT extends ConfigurableMacBase {
 
   private int countFiles(AccumuloClient c) throws Exception {
     try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      s.fetchColumnFamily(DataFileColumnFamily.NAME);
       return Iterators.size(s.iterator());
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FunctionalTestUtils.java
@@ -47,7 +47,9 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.AdminUtil;
 import org.apache.accumulo.fate.AdminUtil.FateStatus;
@@ -67,8 +69,8 @@ public class FunctionalTestUtils {
   public static int countRFiles(AccumuloClient c, String tableName) throws Exception {
     try (Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       TableId tableId = TableId.of(c.tableOperations().tableIdMap().get(tableName));
-      scanner.setRange(MetadataSchema.TabletsSection.getRange(tableId));
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      scanner.setRange(TabletsSection.getRange(tableId));
+      scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       return Iterators.size(scanner.iterator());
     }
   }
@@ -78,8 +80,8 @@ public class FunctionalTestUtils {
     try (Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       String tableId = c.tableOperations().tableIdMap().get(tableName);
       scanner.setRange(new Range(new Text(tableId + ";"), true, new Text(tableId + "<"), true));
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
-      MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
+      scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
+      TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
 
       HashMap<Text,Integer> tabletFileCounts = new HashMap<>();
 
@@ -90,8 +92,7 @@ public class FunctionalTestUtils {
         Integer count = tabletFileCounts.get(row);
         if (count == null)
           count = 0;
-        if (entry.getKey().getColumnFamily()
-            .equals(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME)) {
+        if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
           count = count + 1;
         }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -44,7 +44,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.SkewedKeyValue;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.util.ServerServices;
@@ -189,7 +190,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
   }
 
   private Mutation createDelMutation(String path, String cf, String cq, String val) {
-    Text row = new Text(MetadataSchema.DeletesSection.encodeRow(path));
+    Text row = new Text(DeletesSection.encodeRow(path));
     Mutation delFlag = new Mutation(row);
     delFlag.put(cf, cq, val);
     return delFlag;
@@ -219,8 +220,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
         // path is invalid but value is expected - only way the invalid entry will come through
         // processing and
         // show up to produce error in output to allow while loop to end
-        bw.addMutation(
-            createDelMutation("/", "", "", MetadataSchema.DeletesSection.SkewedKeyValue.STR_NAME));
+        bw.addMutation(createDelMutation("/", "", "", SkewedKeyValue.STR_NAME));
       }
 
       ProcessInfo gc = cluster.exec(SimpleGarbageCollector.class);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -40,7 +40,9 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -71,8 +73,8 @@ public class MetadataIT extends AccumuloClusterHarness {
       c.tableOperations().create(tableNames[0]);
 
       try (Scanner rootScanner = c.createScanner(RootTable.NAME, Authorizations.EMPTY)) {
-        rootScanner.setRange(MetadataSchema.TabletsSection.getRange());
-        rootScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+        rootScanner.setRange(TabletsSection.getRange());
+        rootScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
 
         Set<String> files1 = new HashSet<>();
         for (Entry<Key,Value> entry : rootScanner)
@@ -115,7 +117,7 @@ public class MetadataIT extends AccumuloClusterHarness {
       }
       c.tableOperations().merge(MetadataTable.NAME, null, null);
       try (Scanner s = c.createScanner(RootTable.NAME, Authorizations.EMPTY)) {
-        s.setRange(MetadataSchema.DeletesSection.getRange());
+        s.setRange(DeletesSection.getRange());
         while (Iterators.size(s.iterator()) == 0) {
           sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RegexGroupBalanceIT.java
@@ -36,7 +36,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.master.balancer.RegexGroupBalancer;
@@ -179,9 +180,9 @@ public class RegexGroupBalanceIT extends ConfigurableMacBase {
   private Table<String,String,MutableInt> getCounts(AccumuloClient client, String tablename)
       throws TableNotFoundException {
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
+      s.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tablename));
-      s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+      s.setRange(TabletsSection.getRange(tableId));
 
       Table<String,String,MutableInt> groupLocationCounts = HashBasedTable.create();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -143,7 +143,7 @@ public class SplitIT extends AccumuloClusterHarness {
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         KeyExtent extent = new KeyExtent(id, null, null);
         s.setRange(extent.toMetadataRange());
-        MetadataSchema.TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
+        TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
         int count = 0;
         int shortened = 0;
         for (Entry<Key,Value> entry : s) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -49,8 +49,13 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
@@ -250,17 +255,17 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
       scanner.setRange(extent.toMetadataRange());
 
       HashSet<ColumnFQ> expectedColumns = new HashSet<>();
-      expectedColumns.add(TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN);
-      expectedColumns.add(TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN);
-      expectedColumns.add(TabletsSection.ServerColumnFamily.TIME_COLUMN);
-      expectedColumns.add(TabletsSection.ServerColumnFamily.LOCK_COLUMN);
+      expectedColumns.add(ServerColumnFamily.DIRECTORY_COLUMN);
+      expectedColumns.add(TabletColumnFamily.PREV_ROW_COLUMN);
+      expectedColumns.add(ServerColumnFamily.TIME_COLUMN);
+      expectedColumns.add(ServerColumnFamily.LOCK_COLUMN);
 
       HashSet<Text> expectedColumnFamilies = new HashSet<>();
       expectedColumnFamilies.add(DataFileColumnFamily.NAME);
-      expectedColumnFamilies.add(TabletsSection.FutureLocationColumnFamily.NAME);
-      expectedColumnFamilies.add(TabletsSection.CurrentLocationColumnFamily.NAME);
-      expectedColumnFamilies.add(TabletsSection.LastLocationColumnFamily.NAME);
-      expectedColumnFamilies.add(TabletsSection.BulkFileColumnFamily.NAME);
+      expectedColumnFamilies.add(FutureLocationColumnFamily.NAME);
+      expectedColumnFamilies.add(CurrentLocationColumnFamily.NAME);
+      expectedColumnFamilies.add(LastLocationColumnFamily.NAME);
+      expectedColumnFamilies.add(BulkFileColumnFamily.NAME);
 
       Iterator<Entry<Key,Value>> iter = scanner.iterator();
 
@@ -275,7 +280,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
               "Tablet " + extent + " contained unexpected " + MetadataTable.NAME + " entry " + key);
         }
 
-        if (TabletsSection.TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
+        if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
           sawPer = true;
           if (!new KeyExtent(key.getRow(), entry.getValue()).equals(extent)) {
             throw new Exception("Unexpected prev end row " + entry);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
@@ -76,7 +76,7 @@ public class TableIT extends AccumuloClusterHarness {
       TableId id = TableId.of(to.tableIdMap().get(tableName));
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         s.setRange(new KeyExtent(id, null, null).toMetadataRange());
-        s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+        s.fetchColumnFamily(DataFileColumnFamily.NAME);
         assertTrue(Iterators.size(s.iterator()) > 0);
 
         FileSystem fs = getCluster().getFileSystem();

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -54,7 +54,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.state.tables.TableState;
 import org.apache.accumulo.core.master.thrift.MasterState;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
@@ -155,8 +155,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
     TableId tableIdToModify =
         TableId.of(client.tableOperations().tableIdMap().get(tableNameToModify));
     Mutation m = new Mutation(new KeyExtent(tableIdToModify, null, null).getMetadataEntry());
-    m.put(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME, new Text("1234567"),
-        new Value("fake:9005"));
+    m.put(CurrentLocationColumnFamily.NAME, new Text("1234567"), new Value("fake:9005"));
     try (BatchWriter bw = client.createBatchWriter(table)) {
       bw.addMutation(m);
     }
@@ -168,7 +167,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
         TableId.of(client.tableOperations().tableIdMap().get(tableNameToModify));
     try (Scanner scanner = client.createScanner(table, Authorizations.EMPTY)) {
       scanner.setRange(new KeyExtent(tableIdToModify, null, null).toMetadataRange());
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
+      scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       Entry<Key,Value> entry = scanner.iterator().next();
       Mutation m = new Mutation(entry.getKey().getRow());
       m.putDelete(entry.getKey().getColumnFamily(), entry.getKey().getColumnQualifier(),
@@ -189,7 +188,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
         client.createBatchDeleter(table, Authorizations.EMPTY, 1, new BatchWriterConfig());
     deleter.setRanges(
         Collections.singleton(new KeyExtent(tableIdToModify, null, null).toMetadataRange()));
-    deleter.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
+    deleter.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
     deleter.delete();
     deleter.close();
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.master.state.SetGoalState;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterControl;
@@ -144,7 +145,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       sleepUninterruptibly(5, TimeUnit.SECONDS);
       Map<KeyExtent,List<String>> markers = getRecoveryMarkers(c);
       // log.debug("markers " + markers);
-      assertEquals("one tablet should have markers", 1, markers.keySet().size());
+      assertEquals("one tablet should have markers", 1, markers.size());
       assertEquals("tableId of the keyExtent should be 1", "1",
           markers.keySet().iterator().next().getTableId().canonical());
 
@@ -199,11 +200,11 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
     try (Scanner root = c.createScanner(RootTable.NAME, EMPTY);
         Scanner meta = c.createScanner(MetadataTable.NAME, EMPTY)) {
       root.setRange(TabletsSection.getRange());
-      root.fetchColumnFamily(TabletsSection.LogColumnFamily.NAME);
+      root.fetchColumnFamily(LogColumnFamily.NAME);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(root);
 
       meta.setRange(TabletsSection.getRange());
-      meta.fetchColumnFamily(TabletsSection.LogColumnFamily.NAME);
+      meta.fetchColumnFamily(LogColumnFamily.NAME);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(meta);
 
       List<String> logs = new ArrayList<>();
@@ -211,7 +212,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       while (both.hasNext()) {
         Entry<Key,Value> entry = both.next();
         Key key = entry.getKey();
-        if (key.getColumnFamily().equals(TabletsSection.LogColumnFamily.NAME)) {
+        if (key.getColumnFamily().equals(LogColumnFamily.NAME)) {
           logs.add(key.getColumnQualifier().toString());
         }
         if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key) && !logs.isEmpty()) {

--- a/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
@@ -46,7 +46,9 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationTable;
 import org.apache.accumulo.core.rpc.ThriftUtil;
@@ -136,9 +138,9 @@ public class GarbageCollectorCommunicatesWithTServersIT extends ConfigurableMacB
 
     Set<String> rfiles = new HashSet<>();
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      Range r = MetadataSchema.TabletsSection.getRange(tableId);
+      Range r = TabletsSection.getRange(tableId);
       s.setRange(r);
-      s.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
+      s.fetchColumnFamily(DataFileColumnFamily.NAME);
 
       for (Entry<Key,Value> entry : s) {
         log.debug("Reading RFiles: {}={}", entry.getKey().toStringNoTruncate(), entry.getValue());
@@ -164,13 +166,13 @@ public class GarbageCollectorCommunicatesWithTServersIT extends ConfigurableMacB
 
     Map<String,Status> fileToStatus = new HashMap<>();
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      Range r = MetadataSchema.ReplicationSection.getRange();
+      Range r = ReplicationSection.getRange();
       s.setRange(r);
-      s.fetchColumn(MetadataSchema.ReplicationSection.COLF, new Text(tableId));
+      s.fetchColumn(ReplicationSection.COLF, new Text(tableId));
 
       for (Entry<Key,Value> entry : s) {
         Text file = new Text();
-        MetadataSchema.ReplicationSection.getFile(entry.getKey(), file);
+        ReplicationSection.getFile(entry.getKey(), file);
         Status status = Status.parseFrom(entry.getValue().get());
         log.info("Got status for {}: {}", file, ProtobufUtil.toString(status));
         fileToStatus.put(file.toString(), status);

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -68,9 +68,9 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iteratorsImpl.conf.ColumnSet;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
@@ -156,8 +156,8 @@ public class ReplicationIT extends ConfigurableMacBase {
     // Map of server to tableId
     Multimap<TServerInstance,TableId> serverToTableID = HashMultimap.create();
     try (Scanner scanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      scanner.setRange(MetadataSchema.TabletsSection.getRange());
-      scanner.fetchColumnFamily(MetadataSchema.TabletsSection.CurrentLocationColumnFamily.NAME);
+      scanner.setRange(TabletsSection.getRange());
+      scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
         var tServer = new TServerInstance(entry.getValue(), entry.getKey().getColumnQualifier());
         TableId tableId = KeyExtent.tableOfMetadataRow(entry.getKey().getRow());
@@ -487,7 +487,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       List<Entry<Key,Value>> records = new ArrayList<>();
 
       try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-        s.setRange(MetadataSchema.ReplicationSection.getRange());
+        s.setRange(ReplicationSection.getRange());
         for (Entry<Key,Value> metadata : s) {
           records.add(metadata);
           log.debug("Meta: {} => {}", metadata.getKey().toStringNoTruncate(), metadata.getValue());
@@ -781,7 +781,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       }
 
       try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-        s.fetchColumnFamily(TabletsSection.LogColumnFamily.NAME);
+        s.fetchColumnFamily(LogColumnFamily.NAME);
         s.setRange(TabletsSection.getRange(tableId));
         Set<String> wals = new HashSet<>();
         for (Entry<Key,Value> entry : s) {

--- a/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/StatusCombinerMacIT.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
@@ -96,7 +96,7 @@ public class StatusCombinerMacIT extends SharedMiniClusterBase {
         String key = Property.TABLE_ITERATOR_PREFIX.getKey() + scope.name() + "."
             + ReplicationTableUtil.COMBINER_NAME + ".opt.columns";
         assertTrue("Properties did not contain key : " + key, properties.containsKey(key));
-        assertEquals(MetadataSchema.ReplicationSection.COLF.toString(), properties.get(key));
+        assertEquals(ReplicationSection.COLF.toString(), properties.get(key));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
@@ -42,7 +42,9 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
@@ -164,14 +166,14 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
 
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
 
-      s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+      s.setRange(TabletsSection.getRange(tableId));
       for (Entry<Key,Value> entry : s) {
         System.out.println(entry.getKey().toStringNoTruncate() + " " + entry.getValue());
       }
     }
 
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.setRange(MetadataSchema.ReplicationSection.getRange());
+      s.setRange(ReplicationSection.getRange());
       for (Entry<Key,Value> entry : s) {
         System.out.println(entry.getKey().toStringNoTruncate() + " "
             + ProtobufUtil.toString(Status.parseFrom(entry.getValue().get())));
@@ -186,13 +188,13 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
       KeyExtent extent = new KeyExtent(tableId, null, null);
       try (BatchWriter bw = client.createBatchWriter(MetadataTable.NAME)) {
         Mutation m = new Mutation(extent.getMetadataEntry());
-        m.put(MetadataSchema.TabletsSection.LogColumnFamily.NAME,
-            new Text("localhost:12345/" + walUri), new Value(walUri + "|1"));
+        m.put(LogColumnFamily.NAME, new Text("localhost:12345/" + walUri),
+            new Value(walUri + "|1"));
         bw.addMutation(m);
 
         // Add a replication entry for our fake WAL
-        m = new Mutation(MetadataSchema.ReplicationSection.getRowPrefix() + new Path(walUri));
-        m.put(MetadataSchema.ReplicationSection.COLF, new Text(tableId.canonical()),
+        m = new Mutation(ReplicationSection.getRowPrefix() + new Path(walUri));
+        m.put(ReplicationSection.COLF, new Text(tableId.canonical()),
             new Value(StatusUtil.fileCreated(System.currentTimeMillis()).toByteArray()));
         bw.addMutation(m);
       }
@@ -201,14 +203,14 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     }
 
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+      s.setRange(TabletsSection.getRange(tableId));
       for (Entry<Key,Value> entry : s) {
         log.info("{} {}", entry.getKey().toStringNoTruncate(), entry.getValue());
       }
     }
 
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.setRange(MetadataSchema.ReplicationSection.getRange());
+      s.setRange(ReplicationSection.getRange());
       for (Entry<Key,Value> entry : s) {
         log.info("{} {}", entry.getKey().toStringNoTruncate(),
             ProtobufUtil.toString(Status.parseFrom(entry.getValue().get())));
@@ -223,14 +225,14 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
     }
 
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.setRange(MetadataSchema.TabletsSection.getRange(tableId));
+      s.setRange(TabletsSection.getRange(tableId));
       for (Entry<Key,Value> entry : s) {
         log.info("{} {}", entry.getKey().toStringNoTruncate(), entry.getValue());
       }
     }
 
     try (Scanner s = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-      s.setRange(MetadataSchema.ReplicationSection.getRange());
+      s.setRange(ReplicationSection.getRange());
       for (Entry<Key,Value> entry : s) {
         Status status = Status.parseFrom(entry.getValue().get());
         log.info("{} {}", entry.getKey().toStringNoTruncate(), ProtobufUtil.toString(status));

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgrade9to10TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgrade9to10TestIT.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.schema.Ample;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
@@ -138,7 +138,7 @@ public class GCUpgrade9to10TestIT extends ConfigurableMacBase {
       Map<String,String> expected = addEntries(c, level.metaTable(), numberOfEntries, longpathname);
       assertEquals(numberOfEntries + numberOfEntries / 10, expected.size());
 
-      Range range = MetadataSchema.DeletesSection.getRange();
+      Range range = DeletesSection.getRange();
 
       sleepUninterruptibly(1, TimeUnit.SECONDS);
       try (Scanner scanner = c.createScanner(level.metaTable(), Authorizations.EMPTY)) {
@@ -184,7 +184,7 @@ public class GCUpgrade9to10TestIT extends ConfigurableMacBase {
       sleepUninterruptibly(1, TimeUnit.SECONDS);
       upgrader.upgradeFileDeletes(getServerContext(), level);
       sleepUninterruptibly(1, TimeUnit.SECONDS);
-      Range range = MetadataSchema.DeletesSection.getRange();
+      Range range = DeletesSection.getRange();
 
       try (Scanner scanner = c.createScanner(level.metaTable(), Authorizations.EMPTY)) {
         Map<String,String> actual = new HashMap<>();
@@ -226,8 +226,7 @@ public class GCUpgrade9to10TestIT extends ConfigurableMacBase {
             String.format("hdfs://localhost:8020/accumulo/tables/5a/t-%08x/%s", i, filename);
         Mutation delFlag = createOldDelMutation(longpath, "", "", "");
         bw.addMutation(delFlag);
-        expected.put(MetadataSchema.DeletesSection.encodeRow(longpath),
-            Upgrader9to10.UPGRADED.toString());
+        expected.put(DeletesSection.encodeRow(longpath), Upgrader9to10.UPGRADED.toString());
       }
 
       // create directory delete entries
@@ -241,8 +240,7 @@ public class GCUpgrade9to10TestIT extends ConfigurableMacBase {
         Mutation delFlag = createOldDelMutation(longpath, "", "", "");
         bw.addMutation(delFlag);
         expected.put(
-            MetadataSchema.DeletesSection
-                .encodeRow(GcVolumeUtil.getDeleteTabletOnAllVolumesUri(tableId, dirName)),
+            DeletesSection.encodeRow(GcVolumeUtil.getDeleteTabletOnAllVolumesUri(tableId, dirName)),
             Upgrader9to10.UPGRADED.toString());
       }
 


### PR DESCRIPTION
Shorten some code lines (for readability) by having longer, more
specific, imports for MetadataSchema classes.

(I noticed that some of these would be beneficial to make consistent and shorter while working in other code, and thought I'd pause to take care of this globally, as a separate action, first.)