### PR TITLE
Clean up KeyExtent

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveCompactionImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveCompactionImpl.java
@@ -46,12 +46,12 @@ public class ActiveCompactionImpl extends ActiveCompaction {
 
   @Override
   public String getTable() throws TableNotFoundException {
-    return Tables.getTableName(context, new KeyExtent(tac.getExtent()).getTableId());
+    return Tables.getTableName(context, KeyExtent.fromThrift(tac.getExtent()).tableId());
   }
 
   @Override
   public TabletId getTablet() {
-    return new TabletIdImpl(new KeyExtent(tac.getExtent()));
+    return new TabletIdImpl(KeyExtent.fromThrift(tac.getExtent()));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveScanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ActiveScanImpl.java
@@ -67,7 +67,7 @@ public class ActiveScanImpl extends ActiveScan {
     this.tableName = Tables.getTableName(context, TableId.of(activeScan.tableId));
     this.type = ScanType.valueOf(activeScan.getType().name());
     this.state = ScanState.valueOf(activeScan.state.name());
-    this.extent = new KeyExtent(activeScan.extent);
+    this.extent = KeyExtent.fromThrift(activeScan.extent);
     this.authorizations = new Authorizations(activeScan.authorizations);
 
     this.columns = new ArrayList<>(activeScan.columns.size());

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -222,20 +222,20 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       else
         startRow = new Text();
 
-      nextRange = new Range(TabletsSection.getRow(tableId, startRow), true, null, false);
+      nextRange = new Range(TabletsSection.encodeRow(tableId, startRow), true, null, false);
     } else {
 
-      if (currentExtent.getEndRow() == null) {
+      if (currentExtent.endRow() == null) {
         iter = null;
         return;
       }
 
-      if (range.afterEndKey(new Key(currentExtent.getEndRow()).followingKey(PartialKey.ROW))) {
+      if (range.afterEndKey(new Key(currentExtent.endRow()).followingKey(PartialKey.ROW))) {
         iter = null;
         return;
       }
 
-      nextRange = new Range(currentExtent.getMetadataEntry(), false, null, false);
+      nextRange = new Range(currentExtent.toMetaRow(), false, null, false);
     }
 
     TabletMetadata tablet = getTabletFiles(nextRange);
@@ -254,7 +254,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       tablet = getTabletFiles(nextRange);
     }
 
-    if (!tablet.getExtent().getTableId().equals(tableId)) {
+    if (!tablet.getExtent().tableId().equals(tableId)) {
       throw new AccumuloException(
           " did not find tablets for table " + tableId + " " + tablet.getExtent());
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -689,8 +689,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
     ArrayList<Text> endRows = new ArrayList<>(tabletLocations.size());
 
     for (KeyExtent ke : tabletLocations.keySet())
-      if (ke.getEndRow() != null)
-        endRows.add(ke.getEndRow());
+      if (ke.endRow() != null)
+        endRows.add(ke.endRow());
 
     return endRows;
 
@@ -1176,8 +1176,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
       if (unmergedExtents.size() >= 2) {
         KeyExtent first = unmergedExtents.removeFirst();
         KeyExtent second = unmergedExtents.removeFirst();
-        first.setEndRow(second.getEndRow());
-        mergedExtents.add(first);
+        KeyExtent merged = new KeyExtent(first.tableId(), second.endRow(), first.prevEndRow());
+        mergedExtents.add(merged);
       } else {
         mergedExtents.addAll(unmergedExtents);
         unmergedExtents.clear();
@@ -1282,7 +1282,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
       Range range;
       if (startRow == null || lastRow == null)
-        range = new KeyExtent(tableId, null, null).toMetadataRange();
+        range = new KeyExtent(tableId, null, null).toMetaRange();
       else
         range = new Range(startRow, lastRow);
 
@@ -1306,16 +1306,16 @@ public class TableOperationsImpl extends TableOperationsHelper {
             && (loc == null || loc.getType() == LocationType.FUTURE))
             || (expectedState == TableState.OFFLINE && loc != null)) {
           if (continueRow == null)
-            continueRow = tablet.getExtent().getMetadataEntry();
+            continueRow = tablet.getExtent().toMetaRow();
           waitFor++;
-          lastRow = tablet.getExtent().getMetadataEntry();
+          lastRow = tablet.getExtent().toMetaRow();
 
           if (loc != null) {
             serverCounts.increment(loc.getId(), 1);
           }
         }
 
-        if (!tablet.getExtent().getTableId().equals(tableId)) {
+        if (!tablet.getExtent().tableId().equals(tableId)) {
           throw new AccumuloException(
               "Saw unexpected table Id " + tableId + " " + tablet.getExtent());
         }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -545,7 +545,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     // remove partial scan from unscanned
     if (scanResult.partScan != null) {
-      KeyExtent ke = new KeyExtent(scanResult.partScan);
+      KeyExtent ke = KeyExtent.fromThrift(scanResult.partScan);
       Key nextKey = new Key(scanResult.partNextKey);
 
       ListIterator<Range> iterator = unscanned.get(ke).listIterator();
@@ -640,7 +640,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       for (Range range : entry.getValue()) {
         ranges.add(new Range(range));
       }
-      unscanned.put(new KeyExtent(entry.getKey()), ranges);
+      unscanned.put(KeyExtent.copyOf(entry.getKey()), ranges);
     }
 
     timeoutTracker.startingScan();
@@ -766,7 +766,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       log.debug("Server : " + server + " msg : " + e.getMessage(), e);
       String tableInfo = "?";
       if (e.getExtent() != null) {
-        TableId tableId = new KeyExtent(e.getExtent()).getTableId();
+        TableId tableId = KeyExtent.fromThrift(e.getExtent()).tableId();
         tableInfo = Tables.getPrintableTableInfoFromId(context, tableId);
       }
       String message = "Table " + tableInfo + " does not have sampling configured or built";

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -500,7 +500,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
       // was a table deleted?
       HashSet<TableId> tableIds = new HashSet<>();
       for (KeyExtent ke : authorizationFailures.keySet())
-        tableIds.add(ke.getTableId());
+        tableIds.add(ke.tableId());
 
       Tables.clearCache(context);
       for (TableId tableId : tableIds)
@@ -602,7 +602,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
     synchronized void add(TabletServerMutations<Mutation> tsm) {
       init();
-      tsm.getMutations().forEach((ke, muts) -> recentFailures.addAll(ke.getTableId(), muts));
+      tsm.getMutations().forEach((ke, muts) -> recentFailures.addAll(ke.tableId(), muts));
     }
 
     @Override
@@ -826,7 +826,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
           Set<TableId> tableIds = new TreeSet<>();
           for (Map.Entry<KeyExtent,List<Mutation>> entry : mutationBatch.entrySet()) {
             count += entry.getValue().size();
-            tableIds.add(entry.getKey().getTableId());
+            tableIds.add(entry.getKey().tableId());
           }
 
           String msg = "sending " + String.format("%,d", count) + " mutations to "
@@ -872,7 +872,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
           HashSet<TableId> tables = new HashSet<>();
           for (KeyExtent ke : mutationBatch.keySet())
-            tables.add(ke.getTableId());
+            tables.add(ke.tableId());
 
           for (TableId table : tables)
             getLocator(table).invalidateCache(context, location);
@@ -913,8 +913,8 @@ public class TabletServerBatchWriter implements AutoCloseable {
               client.update(tinfo, context.rpcCreds(), entry.getKey().toThrift(),
                   entry.getValue().get(0).toThrift(), DurabilityImpl.toThrift(durability));
             } catch (NotServingTabletException e) {
-              allFailures.addAll(entry.getKey().getTableId(), entry.getValue());
-              getLocator(entry.getKey().getTableId()).invalidateCache(entry.getKey());
+              allFailures.addAll(entry.getKey().tableId(), entry.getValue());
+              getLocator(entry.getKey().tableId()).invalidateCache(entry.getKey());
             } catch (ConstraintViolationException e) {
               updatedConstraintViolations(
                   Translator.translate(e.violationSummaries, Translators.TCVST));
@@ -958,7 +958,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
               int numCommitted = (int) (long) entry.getValue();
               totalCommitted += numCommitted;
 
-              TableId tableId = failedExtent.getTableId();
+              TableId tableId = failedExtent.tableId();
 
               getLocator(tableId).invalidateCache(failedExtent);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -105,7 +105,7 @@ public class ThriftScanner {
       try {
         // not reading whole rows (or stopping on row boundaries) so there is no need to enable
         // isolation below
-        ScanState scanState = new ScanState(context, extent.getTableId(), authorizations, range,
+        ScanState scanState = new ScanState(context, extent.tableId(), authorizations, range,
             fetchedColumns, size, serverSideIteratorList, serverSideIteratorOptions, false,
             Constants.SCANNER_DEFAULT_READAHEAD_THRESHOLD, null, batchTimeOut, classLoaderContext,
             null);
@@ -289,7 +289,7 @@ public class ThriftScanner {
               if (scanState.range.getStartKey() != null
                   && dataRange.afterEndKey(scanState.range.getStartKey())) {
                 // go to the next tablet
-                scanState.startRow = loc.tablet_extent.getEndRow();
+                scanState.startRow = loc.tablet_extent.endRow();
                 scanState.skipStartRow = true;
                 loc = null;
               } else if (scanState.range.getEndKey() != null
@@ -441,7 +441,7 @@ public class ThriftScanner {
 
       if (scanState.scanID == null) {
         Thread.currentThread().setName("Starting scan tserver=" + loc.tablet_location + " tableId="
-            + loc.tablet_extent.getTableId());
+            + loc.tablet_extent.tableId());
 
         if (log.isTraceEnabled()) {
           String msg = "Starting scan tserver=" + loc.tablet_location + " tablet="
@@ -502,7 +502,7 @@ public class ThriftScanner {
       } else {
         // log.debug("No more : tab end row = "+loc.tablet_extent.getEndRow()+" range =
         // "+scanState.range);
-        if (loc.tablet_extent.getEndRow() == null) {
+        if (loc.tablet_extent.endRow() == null) {
           scanState.finished = true;
 
           if (timer != null) {
@@ -513,8 +513,8 @@ public class ThriftScanner {
           }
 
         } else if (scanState.range.getEndKey() == null || !scanState.range
-            .afterEndKey(new Key(loc.tablet_extent.getEndRow()).followingKey(PartialKey.ROW))) {
-          scanState.startRow = loc.tablet_extent.getEndRow();
+            .afterEndKey(new Key(loc.tablet_extent.endRow()).followingKey(PartialKey.ROW))) {
+          scanState.startRow = loc.tablet_extent.endRow();
           scanState.skipStartRow = true;
 
           if (timer != null) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Translator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Translator.java
@@ -43,7 +43,7 @@ public abstract class Translator<IT,OT> {
   public static class TKeyExtentTranslator extends Translator<TKeyExtent,KeyExtent> {
     @Override
     public KeyExtent translate(TKeyExtent input) {
-      return new KeyExtent(input);
+      return KeyExtent.fromThrift(input);
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/Bulk.java
@@ -221,7 +221,7 @@ public class Bulk {
   }
 
   public static Tablet toTablet(KeyExtent keyExtent) {
-    return new Tablet(keyExtent.getEndRow(), keyExtent.getPrevEndRow());
+    return new Tablet(keyExtent.endRow(), keyExtent.prevEndRow());
   }
 
   public static KeyExtent toKeyExtent(TableId tableId, Tablet tablet) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -340,7 +340,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
       KeyExtent extent = extentCache.lookup(row);
       // log.debug(filename + " found row " + row + " at location " + tabletLocation);
       result.add(extent);
-      row = extent.getEndRow();
+      row = extent.endRow();
       if (row != null && (endRow == null || row.compareTo(endRow) < 0)) {
         row = nextRow(row);
       } else
@@ -467,8 +467,8 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
 
         extents.add(extent);
 
-        while (!extent.contains(endRow) && extent.getEndRow() != null) {
-          extent = kec.lookup(nextRow(extent.getEndRow()));
+        while (!extent.contains(endRow) && extent.endRow() != null) {
+          extent = kec.lookup(nextRow(extent.endRow()));
           extents.add(extent);
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -73,14 +73,14 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
   }
 
   private boolean inCache(KeyExtent e) {
-    return Objects.equals(e, extents.get(e.getEndRow() == null ? MAX : e.getEndRow()));
+    return Objects.equals(e, extents.get(e.endRow() == null ? MAX : e.endRow()));
   }
 
   @VisibleForTesting
   protected void updateCache(KeyExtent e) {
-    Text prevRow = e.getPrevEndRow() == null ? new Text() : e.getPrevEndRow();
-    Text endRow = e.getEndRow() == null ? MAX : e.getEndRow();
-    extents.subMap(prevRow, e.getPrevEndRow() == null, endRow, true).clear();
+    Text prevRow = e.prevEndRow() == null ? new Text() : e.prevEndRow();
+    Text endRow = e.endRow() == null ? MAX : e.endRow();
+    extents.subMap(prevRow, e.prevEndRow() == null, endRow, true).clear();
     extents.put(endRow, e);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/InputConfigurator.java
@@ -845,7 +845,7 @@ public class InputConfigurator extends ConfiguratorBase {
         startRow = new Text();
 
       Range metadataRange =
-          new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
+          new Range(new KeyExtent(tableId, startRow, null).toMetaRow(), true, null, false);
       Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       scanner.fetchColumnFamily(LastLocationColumnFamily.NAME);
@@ -875,7 +875,7 @@ public class InputConfigurator extends ConfiguratorBase {
           }
 
           if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
-            extent = new KeyExtent(key.getRow(), entry.getValue());
+            extent = KeyExtent.fromMetaPrevRow(entry);
           }
 
         }
@@ -883,7 +883,7 @@ public class InputConfigurator extends ConfiguratorBase {
         if (location != null)
           return null;
 
-        if (!extent.getTableId().equals(tableId)) {
+        if (!extent.tableId().equals(tableId)) {
           throw new AccumuloException("Saw unexpected table Id " + tableId + " " + extent);
         }
 
@@ -894,8 +894,8 @@ public class InputConfigurator extends ConfiguratorBase {
         binnedRanges.computeIfAbsent(last, k -> new HashMap<>())
             .computeIfAbsent(extent, k -> new ArrayList<>()).add(range);
 
-        if (extent.getEndRow() == null
-            || range.afterEndKey(new Key(extent.getEndRow()).followingKey(PartialKey.ROW))) {
+        if (extent.endRow() == null
+            || range.afterEndKey(new Key(extent.endRow()).followingKey(PartialKey.ROW))) {
           break;
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -124,7 +124,7 @@ public class Range implements WritableComparable<Range> {
    * @param endRow
    *          ending row; set to null for positive infinity
    * @param endRowInclusive
-   *          true to include start row, false to skip
+   *          true to include end row, false to skip
    * @throws IllegalArgumentException
    *           if end row is before start row
    */

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.dataImpl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -26,7 +27,6 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map.Entry;
@@ -37,8 +37,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
 
-import org.apache.accumulo.core.data.ByteSequence;
-import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
@@ -48,312 +47,234 @@ import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.BinaryComparable;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableComparable;
 
 /**
  * keeps track of information needed to identify a tablet
  */
-public class KeyExtent implements WritableComparable<KeyExtent> {
+public class KeyExtent implements Comparable<KeyExtent> {
 
-  private TableId tableId;
-  private Text textEndRow;
-  private Text textPrevEndRow;
+  private final TableId tableId;
+  private final Text endRow;
+  private final Text prevEndRow;
 
-  private static final TableId EMPTY_ID = TableId.of("");
+  // lazily computed, as needed
+  private volatile int hashCode = 0;
+
   private static final Text EMPTY_TEXT = new Text("");
 
-  private void check() {
-
-    if (getTableId() == null)
-      throw new IllegalArgumentException("null table id not allowed");
-
-    if (getEndRow() == null || getPrevEndRow() == null)
-      return;
-
-    if (getPrevEndRow().compareTo(getEndRow()) >= 0) {
-      throw new IllegalArgumentException(
-          "prevEndRow (" + getPrevEndRow() + ") >= endRow (" + getEndRow() + ")");
-    }
-  }
+  // The last tablet in a table has no end row, so null sorts last for end row; similarly, the first
+  // tablet has no previous end row, so null sorts first for previous end row
+  private static final Comparator<KeyExtent> COMPARATOR = Comparator.comparing(KeyExtent::tableId)
+      .thenComparing(KeyExtent::endRow, Comparator.nullsLast(Text::compareTo))
+      .thenComparing(KeyExtent::prevEndRow, Comparator.nullsFirst(Text::compareTo));
 
   /**
-   * Default constructor
+   * Create a new KeyExtent from its components.
    *
+   * @param table
+   *          the ID for the table
+   * @param endRow
+   *          the last row in this tablet, or null if this is the last tablet in this table
+   * @param prevEndRow
+   *          the last row in the immediately preceding tablet for the table, or null if this
+   *          represents the first tablet in this table
    */
-  public KeyExtent() {
-    this.setTableId(EMPTY_ID);
-    this.setEndRow(new Text(), false, false);
-    this.setPrevEndRow(new Text(), false, false);
-  }
-
   public KeyExtent(TableId table, Text endRow, Text prevEndRow) {
-    this.setTableId(table);
-    this.setEndRow(endRow, false, true);
-    this.setPrevEndRow(prevEndRow, false, true);
-
-    check();
-  }
-
-  public KeyExtent(KeyExtent extent) {
-    // extent has already deduped table id, so there is no need to do it again
-    this.tableId = extent.tableId;
-    this.setEndRow(extent.getEndRow(), false, true);
-    this.setPrevEndRow(extent.getPrevEndRow(), false, true);
-
-    check();
-  }
-
-  public KeyExtent(TKeyExtent tke) {
-    this.setTableId(TableId.of(new String(ByteBufferUtil.toBytes(tke.table), UTF_8)));
-    this.setEndRow(tke.endRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.endRow)), false,
-        false);
-    this.setPrevEndRow(
-        tke.prevEndRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.prevEndRow)), false,
-        false);
-
-    check();
+    tableId = requireNonNull(table, "null table ID not allowed");
+    if (endRow != null && prevEndRow != null && prevEndRow.compareTo(endRow) >= 0) {
+      throw new IllegalArgumentException(
+          "prevEndRow (" + prevEndRow + ") >= endRow (" + endRow + ")");
+    }
+    this.endRow = endRow == null ? null : new Text(endRow);
+    this.prevEndRow = prevEndRow == null ? null : new Text(prevEndRow);
   }
 
   /**
-   * Returns a String representing this extent's entry in the Metadata table
+   * Create a copy of a provided KeyExtent.
    *
+   * @param original
+   *          the KeyExtent to copy
    */
-  public Text getMetadataEntry() {
-    return TabletsSection.getRow(getTableId(), getEndRow());
-  }
-
-  // constructor for loading extents from metadata rows
-  public KeyExtent(Text flattenedExtent, Value prevEndRow) {
-    decodeMetadataRow(flattenedExtent);
-
-    // decode the prev row
-    this.setPrevEndRow(decodePrevEndRow(prevEndRow), false, true);
-
-    check();
-  }
-
-  // recreates an encoded extent from a string representation
-  // this encoding is what is stored as the row id of the metadata table
-  public KeyExtent(Text flattenedExtent, Text prevEndRow) {
-
-    decodeMetadataRow(flattenedExtent);
-
-    this.setPrevEndRow(null, false, false);
-    if (prevEndRow != null)
-      this.setPrevEndRow(prevEndRow, false, true);
-
-    check();
+  public static KeyExtent copyOf(KeyExtent original) {
+    return new KeyExtent(original.tableId(), original.endRow(), original.prevEndRow());
   }
 
   /**
-   * Sets the extents table id
+   * Create a KeyExtent from its Thrift form.
    *
+   * @param tke
+   *          the KeyExtent in its Thrift object form
    */
-  public void setTableId(TableId tId) {
-    Objects.requireNonNull(tId, "null table id not allowed");
-
-    this.tableId = tId;
-
-    hashCode = 0;
+  public static KeyExtent fromThrift(TKeyExtent tke) {
+    TableId tableId = TableId.of(new String(ByteBufferUtil.toBytes(tke.table), UTF_8));
+    Text endRow = tke.endRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.endRow));
+    Text prevEndRow =
+        tke.prevEndRow == null ? null : new Text(ByteBufferUtil.toBytes(tke.prevEndRow));
+    return new KeyExtent(tableId, endRow, prevEndRow);
   }
 
   /**
-   * Returns the extent's table id
-   *
+   * Convert to Thrift form.
    */
-  public TableId getTableId() {
+  public TKeyExtent toThrift() {
+    return new TKeyExtent(ByteBuffer.wrap(tableId().canonical().getBytes(UTF_8)),
+        endRow() == null ? null : TextUtil.getByteBuffer(endRow()),
+        prevEndRow() == null ? null : TextUtil.getByteBuffer(prevEndRow()));
+  }
+
+  /**
+   * Create a KeyExtent from a metadata previous end row entry.
+   *
+   * @param prevRowEntry
+   *          a provided previous end row entry from the metadata table, stored in the
+   *          <code>{@value TabletColumnFamily#STR_NAME}</code> column family and
+   *          <code>{@value TabletColumnFamily#PREV_ROW_QUAL}</code> column. If the individual
+   *          components are needed, consider {@link #KeyExtent(TableId, Text, Text)} or
+   *          {@link #fromMetaRow(Text, Text)} instead.
+   */
+  public static KeyExtent fromMetaPrevRow(Entry<Key,Value> prevRowEntry) {
+    return fromMetaRow(prevRowEntry.getKey().getRow(),
+        TabletColumnFamily.decodePrevEndRow(prevRowEntry.getValue()));
+  }
+
+  /**
+   * Create a KeyExtent from the table ID and the end row encoded in the row field of a tablet's
+   * metadata entry, with no previous end row.
+   *
+   * @param encodedMetadataRow
+   *          the encoded <code>tableId</code> and <code>endRow</code> from a metadata entry, as in
+   *          <code>entry.getKey().getRow()</code> or from
+   *          {@link TabletsSection#encodeRow(TableId, Text)}
+   */
+  public static KeyExtent fromMetaRow(Text encodedMetadataRow) {
+    return fromMetaRow(encodedMetadataRow, (Text) null);
+  }
+
+  /**
+   * Create a KeyExtent from the table ID and the end row encoded in the row field of a tablet's
+   * metadata entry, along with a previous end row.
+   *
+   * @param encodedMetadataRow
+   *          the encoded <code>tableId</code> and <code>endRow</code> from a metadata entry, as in
+   *          <code>entry.getKey().getRow()</code> or from
+   *          {@link TabletsSection#encodeRow(TableId, Text)}
+   * @param prevEndRow
+   *          the unencoded previous end row (a copy will be made)
+   */
+  public static KeyExtent fromMetaRow(Text encodedMetadataRow, Text prevEndRow) {
+    Pair<TableId,Text> tableIdAndEndRow = TabletsSection.decodeRow(encodedMetadataRow);
+    TableId tableId = tableIdAndEndRow.getFirst();
+    Text endRow = tableIdAndEndRow.getSecond();
+    return new KeyExtent(tableId, endRow, prevEndRow);
+  }
+
+  /**
+   * Return a serialized form of the table ID and end row for this extent, in a form suitable for
+   * use in the row portion of metadata entries for the tablet this extent represents.
+   */
+  public Text toMetaRow() {
+    return TabletsSection.encodeRow(tableId(), endRow());
+  }
+
+  /**
+   * Return the extent's table ID.
+   */
+  public TableId tableId() {
     return tableId;
-  }
-
-  private void setEndRow(Text endRow, boolean check, boolean copy) {
-    if (endRow != null)
-      if (copy)
-        this.textEndRow = new Text(endRow);
-      else
-        this.textEndRow = endRow;
-    else
-      this.textEndRow = null;
-
-    hashCode = 0;
-    if (check)
-      check();
-  }
-
-  /**
-   * Sets this extent's end row
-   *
-   */
-  public void setEndRow(Text endRow) {
-    setEndRow(endRow, true, true);
   }
 
   /**
    * Returns this extent's end row
-   *
    */
-  public Text getEndRow() {
-    return textEndRow;
+  public Text endRow() {
+    return endRow;
   }
 
   /**
    * Return the previous extent's end row
-   *
    */
-  public Text getPrevEndRow() {
-    return textPrevEndRow;
-  }
-
-  private void setPrevEndRow(Text prevEndRow, boolean check, boolean copy) {
-    if (prevEndRow != null)
-      if (copy)
-        this.textPrevEndRow = new Text(prevEndRow);
-      else
-        this.textPrevEndRow = prevEndRow;
-    else
-      this.textPrevEndRow = null;
-
-    hashCode = 0;
-    if (check)
-      check();
+  public Text prevEndRow() {
+    return prevEndRow;
   }
 
   /**
-   * Sets the previous extent's end row
+   * Create a KeyExtent from a serialized form.
    *
+   * @see #writeTo(DataOutput)
    */
-  public void setPrevEndRow(Text prevEndRow) {
-    setPrevEndRow(prevEndRow, true, true);
-  }
-
-  @Override
-  public void readFields(DataInput in) throws IOException {
+  public static KeyExtent readFrom(DataInput in) throws IOException {
     Text tid = new Text();
     tid.readFields(in);
-    setTableId(TableId.of(tid.toString()));
+    TableId tableId = TableId.of(tid.toString());
+    Text endRow = null;
+    Text prevEndRow = null;
     boolean hasRow = in.readBoolean();
     if (hasRow) {
-      Text er = new Text();
-      er.readFields(in);
-      setEndRow(er, false, false);
-    } else {
-      setEndRow(null, false, false);
+      endRow = new Text();
+      endRow.readFields(in);
     }
     boolean hasPrevRow = in.readBoolean();
     if (hasPrevRow) {
-      Text per = new Text();
-      per.readFields(in);
-      setPrevEndRow(per, false, true);
-    } else {
-      setPrevEndRow(null);
+      prevEndRow = new Text();
+      prevEndRow.readFields(in);
     }
-
-    hashCode = 0;
-    check();
-  }
-
-  @Override
-  public void write(DataOutput out) throws IOException {
-    new Text(getTableId().canonical()).write(out);
-    if (getEndRow() != null) {
-      out.writeBoolean(true);
-      getEndRow().write(out);
-    } else {
-      out.writeBoolean(false);
-    }
-    if (getPrevEndRow() != null) {
-      out.writeBoolean(true);
-      getPrevEndRow().write(out);
-    } else {
-      out.writeBoolean(false);
-    }
+    return new KeyExtent(tableId, endRow, prevEndRow);
   }
 
   /**
-   * Returns a String representing the previous extent's entry in the Metadata table
+   * Serialize this KeyExtent.
    *
+   * @see #readFrom(DataInput)
    */
-  public Mutation getPrevRowUpdateMutation() {
-    return getPrevRowUpdateMutation(this);
-  }
-
-  public static Text decodePrevEndRow(Value ibw) {
-    Text per = null;
-
-    if (ibw.get()[0] != 0) {
-      per = new Text();
-      per.set(ibw.get(), 1, ibw.get().length - 1);
+  public void writeTo(DataOutput out) throws IOException {
+    new Text(tableId().canonical()).write(out);
+    if (endRow() != null) {
+      out.writeBoolean(true);
+      endRow().write(out);
+    } else {
+      out.writeBoolean(false);
     }
-
-    return per;
+    if (prevEndRow() != null) {
+      out.writeBoolean(true);
+      prevEndRow().write(out);
+    } else {
+      out.writeBoolean(false);
+    }
   }
-
-  public static Value encodePrevEndRow(Text per) {
-    if (per == null)
-      return new Value(new byte[] {0});
-    byte[] b = new byte[per.getLength() + 1];
-    b[0] = 1;
-    System.arraycopy(per.getBytes(), 0, b, 1, per.getLength());
-    return new Value(b);
-  }
-
-  public static Mutation getPrevRowUpdateMutation(KeyExtent ke) {
-    Mutation m = new Mutation(ke.getMetadataEntry());
-    TabletColumnFamily.PREV_ROW_COLUMN.put(m, encodePrevEndRow(ke.getPrevEndRow()));
-    return m;
-  }
-
-  // The last tablet in a table has no end row, so null sorts last for end row; similarly, the first
-  // tablet has no previous end row, so null sorts first for previous end row
-  private static final Comparator<KeyExtent> COMPARATOR =
-      Comparator.comparing(KeyExtent::getTableId)
-          .thenComparing(KeyExtent::getEndRow, Comparator.nullsLast(Text::compareTo))
-          .thenComparing(KeyExtent::getPrevEndRow, Comparator.nullsFirst(Text::compareTo));
 
   @Override
   public int compareTo(KeyExtent other) {
     return COMPARATOR.compare(this, other);
   }
 
-  private int hashCode = 0;
-
   @Override
   public int hashCode() {
-    if (hashCode != 0)
+    // lazily compute hash code, if needed
+    if (hashCode != 0) {
       return hashCode;
-
-    int prevEndRowHash = 0;
-    int endRowHash = 0;
-    if (this.getEndRow() != null) {
-      endRowHash = this.getEndRow().hashCode();
     }
-
-    if (this.getPrevEndRow() != null) {
-      prevEndRowHash = this.getPrevEndRow().hashCode();
-    }
-
-    hashCode = getTableId().hashCode() + endRowHash + prevEndRowHash;
+    int tmpHashCode = tableId().hashCode();
+    tmpHashCode += endRow() == null ? 0 : endRow().hashCode();
+    tmpHashCode += prevEndRow() == null ? 0 : prevEndRow().hashCode();
+    hashCode = tmpHashCode;
     return hashCode;
-  }
-
-  private boolean equals(Text t1, Text t2) {
-    if (t1 == null || t2 == null)
-      return t1 == t2;
-
-    return t1.equals(t2);
   }
 
   @Override
   public boolean equals(Object o) {
-    if (o == this)
+    if (o == this) {
       return true;
-    if (!(o instanceof KeyExtent))
+    }
+    if (!(o instanceof KeyExtent)) {
       return false;
+    }
     KeyExtent oke = (KeyExtent) o;
-    return tableId.equals(oke.tableId) && equals(textEndRow, oke.textEndRow)
-        && equals(textPrevEndRow, oke.textPrevEndRow);
+    return tableId().equals(oke.tableId()) && Objects.equals(endRow(), oke.endRow())
+        && Objects.equals(prevEndRow(), oke.prevEndRow());
   }
 
   @Override
@@ -361,251 +282,135 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     String endRowString;
     String prevEndRowString;
     String tableIdString =
-        getTableId().canonical().replaceAll(";", "\\\\;").replaceAll("\\\\", "\\\\\\\\");
+        tableId().canonical().replaceAll(";", "\\\\;").replaceAll("\\\\", "\\\\\\\\");
 
-    if (getEndRow() == null)
+    if (endRow() == null) {
       endRowString = "<";
-    else
-      endRowString = ";" + TextUtil.truncate(getEndRow()).toString().replaceAll(";", "\\\\;")
+    } else {
+      endRowString = ";" + TextUtil.truncate(endRow()).toString().replaceAll(";", "\\\\;")
           .replaceAll("\\\\", "\\\\\\\\");
+    }
 
-    if (getPrevEndRow() == null)
+    if (prevEndRow() == null) {
       prevEndRowString = "<";
-    else
-      prevEndRowString = ";" + TextUtil.truncate(getPrevEndRow()).toString()
-          .replaceAll(";", "\\\\;").replaceAll("\\\\", "\\\\\\\\");
+    } else {
+      prevEndRowString = ";" + TextUtil.truncate(prevEndRow()).toString().replaceAll(";", "\\\\;")
+          .replaceAll("\\\\", "\\\\\\\\");
+    }
 
     return tableIdString + endRowString + prevEndRowString;
   }
 
+  /**
+   * Retrieve a unique identifier for this tablet that is useful for logging, without revealing the
+   * contents of the end row and previous end row.
+   */
   public UUID getUUID() {
-    try {
-
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      DataOutputStream dos = new DataOutputStream(baos);
-
+    try (var baos = new ByteArrayOutputStream(); var dos = new DataOutputStream(baos)) {
       // to get a unique hash it is important to encode the data
       // like it is being serialized
-
-      this.write(dos);
-
-      dos.close();
-
+      writeTo(dos);
       return UUID.nameUUIDFromBytes(baos.toByteArray());
-
-    } catch (IOException e) {
-      // should not happen since we are writing to memory
-      throw new RuntimeException(e);
+    } catch (IOException impossible) {
+      // impossible when ByteArrayOutputStream is backing the DataOutputStream
+      throw new AssertionError(impossible);
     }
   }
 
-  // note: this is only the encoding of the table id and the last row, not the prev row
   /**
-   * Populates the extent's fields based on a flatted extent
+   * Determine if another KeyExtent is wholly contained within the range of this one. * @param oke
    *
+   * @return true if and only if the provided KeyExtent is contained within the range of this one
    */
-  private void decodeMetadataRow(Text flattenedExtent) {
-    int semiPos = -1;
-    int ltPos = -1;
-
-    for (int i = 0; i < flattenedExtent.getLength(); i++) {
-      if (flattenedExtent.getBytes()[i] == ';' && semiPos < 0) {
-        // want the position of the first semicolon
-        semiPos = i;
-      }
-
-      if (flattenedExtent.getBytes()[i] == '<') {
-        ltPos = i;
-      }
-    }
-
-    if (semiPos < 0 && ltPos < 0) {
-      throw new IllegalArgumentException(
-          "Metadata row does not contain ; or <  " + flattenedExtent);
-    }
-
-    if (semiPos < 0) {
-
-      if (ltPos != flattenedExtent.getLength() - 1) {
-        throw new IllegalArgumentException(
-            "< must come at end of Metadata row  " + flattenedExtent);
-      }
-
-      String decodedString = new String(
-          Arrays.copyOfRange(flattenedExtent.getBytes(), 0, flattenedExtent.getLength() - 1),
-          UTF_8);
-      TableId tableId = TableId.of(decodedString);
-      this.setTableId(tableId);
-      this.setEndRow(null, false, false);
-    } else {
-
-      TableId tableId =
-          TableId.of(new String(Arrays.copyOfRange(flattenedExtent.getBytes(), 0, semiPos), UTF_8));
-
-      Text endRow = new Text();
-      endRow.set(flattenedExtent.getBytes(), semiPos + 1,
-          flattenedExtent.getLength() - (semiPos + 1));
-
-      this.setTableId(tableId);
-
-      this.setEndRow(endRow, false, false);
-    }
-  }
-
-  public static TableId tableOfMetadataRow(Text row) {
-    KeyExtent ke = new KeyExtent();
-    ke.decodeMetadataRow(row);
-    return ke.getTableId();
-  }
-
   public boolean contains(KeyExtent oke) {
-    boolean containsPrevRow = getPrevEndRow() == null
-        || (oke.getPrevEndRow() != null && getPrevEndRow().compareTo(oke.getPrevEndRow()) <= 0);
-    boolean containsEndRow = getEndRow() == null
-        || (oke.getEndRow() != null && getEndRow().compareTo(oke.getEndRow()) >= 0);
+    // true if this prev row is before the other
+    boolean containsPrevRow = prevEndRow() == null
+        || (oke.prevEndRow() != null && prevEndRow().compareTo(oke.prevEndRow()) <= 0);
+    // true if this end row is after the other
+    boolean containsEndRow =
+        endRow() == null || (oke.endRow() != null && endRow().compareTo(oke.endRow()) >= 0);
     return containsPrevRow && containsEndRow;
   }
 
-  public boolean contains(final ByteSequence bsrow) {
-    if (bsrow == null) {
-      throw new IllegalArgumentException(
-          "Passing null to contains is ambiguous, could be in first or last extent of table");
-    }
-
-    BinaryComparable row = new BinaryComparable() {
-
-      @Override
-      public int getLength() {
-        return bsrow.length();
-      }
-
-      @Override
-      public byte[] getBytes() {
-        if (bsrow.isBackedByArray() && bsrow.offset() == 0)
-          return bsrow.getBackingArray();
-
-        return bsrow.toArray();
-      }
-    };
-
-    return (this.getPrevEndRow() == null || this.getPrevEndRow().compareTo(row) < 0)
-        && (this.getEndRow() == null || this.getEndRow().compareTo(row) >= 0);
-  }
-
+  /**
+   * Determine if the provided row is contained within the range of this KeyExtent.
+   *
+   * @return true if and only if the provided row is contained within the range of this one
+   */
   public boolean contains(BinaryComparable row) {
     if (row == null) {
       throw new IllegalArgumentException(
           "Passing null to contains is ambiguous, could be in first or last extent of table");
     }
-
-    return (this.getPrevEndRow() == null || this.getPrevEndRow().compareTo(row) < 0)
-        && (this.getEndRow() == null || this.getEndRow().compareTo(row) >= 0);
+    return (prevEndRow() == null || prevEndRow().compareTo(row) < 0)
+        && (endRow() == null || endRow().compareTo(row) >= 0);
   }
 
+  /**
+   * Compute a representation of this extent as a Range suitable for scanning this extent's table
+   * and retrieving all data between this extent's previous end row (exclusive) and its end row
+   * (inclusive) in that table (or another table in the same range, since the returned range does
+   * not specify the table to scan).
+   *
+   * <p>
+   * For example, if this extent represented a range of data from <code>A</code> to <code>Z</code>
+   * for table <code>T</code>, the resulting Range could be used to scan table <code>T</code>'s data
+   * in the exclusive-inclusive range <code>(A,Z]</code>, or the same range in another table,
+   * <code>T2</code>.
+   */
   public Range toDataRange() {
-    return new Range(getPrevEndRow(), false, getEndRow(), true);
+    return new Range(prevEndRow(), false, endRow(), true);
   }
 
-  public Range toMetadataRange() {
-
+  /**
+   * Compute a representation of this extent as a Range suitable for scanning the corresponding
+   * metadata table for this extent's table, and retrieving all the metadata for the table's tablets
+   * between this extent's previous end row (exclusive) and its end row (inclusive) in that table.
+   *
+   * <p>
+   * For example, if this extent represented a range of data from <code>A</code> to <code>Z</code>
+   * for a user table, <code>T</code>, this would compute the range to scan
+   * <code>accumulo.metadata</code> that would include all the the metadata for <code>T</code>'s
+   * tablets that contain data in the range <code>(A,Z]</code>.
+   */
+  public Range toMetaRange() {
     Text metadataPrevRow =
-        TabletsSection.getRow(getTableId(), getPrevEndRow() == null ? EMPTY_TEXT : getPrevEndRow());
-
-    return new Range(metadataPrevRow, getPrevEndRow() == null, getMetadataEntry(), true);
+        TabletsSection.encodeRow(tableId(), prevEndRow() == null ? EMPTY_TEXT : prevEndRow());
+    return new Range(metadataPrevRow, prevEndRow() == null, toMetaRow(), true);
   }
 
-  public static SortedSet<KeyExtent> findChildren(KeyExtent ke, SortedSet<KeyExtent> tablets) {
-
-    SortedSet<KeyExtent> children = null;
-
-    for (KeyExtent tabletKe : tablets) {
-
-      if (ke.getPrevEndRow() == tabletKe.getPrevEndRow()
-          || ke.getPrevEndRow() != null && tabletKe.getPrevEndRow() != null
-              && tabletKe.getPrevEndRow().compareTo(ke.getPrevEndRow()) == 0) {
-        children = new TreeSet<>();
-      }
-
-      if (children != null) {
-        children.add(tabletKe);
-      }
-
-      if (ke.getEndRow() == tabletKe.getEndRow() || ke.getEndRow() != null
-          && tabletKe.getEndRow() != null && tabletKe.getEndRow().compareTo(ke.getEndRow()) == 0) {
-        return children;
-      }
-    }
-
-    return new TreeSet<>();
-  }
-
-  public static KeyExtent findContainingExtent(KeyExtent extent, SortedSet<KeyExtent> extents) {
-
-    KeyExtent lookupExtent = new KeyExtent(extent);
-    lookupExtent.setPrevEndRow(null);
-
-    SortedSet<KeyExtent> tailSet = extents.tailSet(lookupExtent);
-
-    if (tailSet.isEmpty()) {
-      return null;
-    }
-
-    KeyExtent first = tailSet.first();
-
-    if (first.getTableId().compareTo(extent.getTableId()) != 0) {
-      return null;
-    }
-
-    if (first.getPrevEndRow() == null) {
-      return first;
-    }
-
-    if (extent.getPrevEndRow() == null) {
-      return null;
-    }
-
-    if (extent.getPrevEndRow().compareTo(first.getPrevEndRow()) >= 0)
-      return first;
-    return null;
-  }
-
-  private static boolean startsAfter(KeyExtent nke, KeyExtent ke) {
-
-    int tiCmp = ke.getTableId().compareTo(nke.getTableId());
-
-    if (tiCmp > 0) {
-      return true;
-    }
-
-    return ke.getPrevEndRow() != null && nke.getEndRow() != null
-        && ke.getPrevEndRow().compareTo(nke.getEndRow()) >= 0;
+  private boolean startsAfter(KeyExtent other) {
+    KeyExtent nke = requireNonNull(other);
+    return tableId().compareTo(nke.tableId()) > 0 || (prevEndRow() != null && nke.endRow() != null
+        && prevEndRow().compareTo(nke.endRow()) >= 0);
   }
 
   private static Text rowAfterPrevRow(KeyExtent nke) {
-    Text row = new Text(nke.getPrevEndRow());
+    Text row = new Text(nke.prevEndRow());
     row.append(new byte[] {0}, 0, 1);
     return row;
   }
 
   // Some duplication with TabletLocatorImpl
   public static Set<KeyExtent> findOverlapping(KeyExtent nke, SortedSet<KeyExtent> extents) {
-    if (nke == null || extents == null || extents.isEmpty())
+    if (nke == null || extents == null || extents.isEmpty()) {
       return Collections.emptySet();
+    }
 
     SortedSet<KeyExtent> start;
 
-    if (nke.getPrevEndRow() != null) {
+    if (nke.prevEndRow() != null) {
       Text row = rowAfterPrevRow(nke);
-      KeyExtent lookupKey = new KeyExtent(nke.getTableId(), row, null);
+      KeyExtent lookupKey = new KeyExtent(nke.tableId(), row, null);
       start = extents.tailSet(lookupKey);
     } else {
-      KeyExtent lookupKey = new KeyExtent(nke.getTableId(), new Text(), null);
+      KeyExtent lookupKey = new KeyExtent(nke.tableId(), new Text(), null);
       start = extents.tailSet(lookupKey);
     }
 
     TreeSet<KeyExtent> result = new TreeSet<>();
     for (KeyExtent ke : start) {
-      if (startsAfter(nke, ke)) {
+      if (ke.startsAfter(nke)) {
         break;
       }
       result.add(ke);
@@ -621,24 +426,25 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
 
   // Specialization of findOverlapping(KeyExtent, SortedSet<KeyExtent> to work with SortedMap
   public static Set<KeyExtent> findOverlapping(KeyExtent nke, SortedMap<KeyExtent,?> extents) {
-    if (nke == null || extents == null || extents.isEmpty())
+    if (nke == null || extents == null || extents.isEmpty()) {
       return Collections.emptySet();
+    }
 
     SortedMap<KeyExtent,?> start;
 
-    if (nke.getPrevEndRow() != null) {
+    if (nke.prevEndRow() != null) {
       Text row = rowAfterPrevRow(nke);
-      KeyExtent lookupKey = new KeyExtent(nke.getTableId(), row, null);
+      KeyExtent lookupKey = new KeyExtent(nke.tableId(), row, null);
       start = extents.tailMap(lookupKey);
     } else {
-      KeyExtent lookupKey = new KeyExtent(nke.getTableId(), new Text(), null);
+      KeyExtent lookupKey = new KeyExtent(nke.tableId(), new Text(), null);
       start = extents.tailMap(lookupKey);
     }
 
     TreeSet<KeyExtent> result = new TreeSet<>();
     for (Entry<KeyExtent,?> entry : start.entrySet()) {
       KeyExtent ke = entry.getKey();
-      if (startsAfter(nke, ke)) {
+      if (ke.startsAfter(nke)) {
         break;
       }
       result.add(ke);
@@ -646,37 +452,24 @@ public class KeyExtent implements WritableComparable<KeyExtent> {
     return result;
   }
 
-  public static Text getMetadataEntry(KeyExtent extent) {
-    return TabletsSection.getRow(extent.getTableId(), extent.getEndRow());
-  }
-
-  public TKeyExtent toThrift() {
-    return new TKeyExtent(ByteBuffer.wrap(tableId.canonical().getBytes(UTF_8)),
-        textEndRow == null ? null : TextUtil.getByteBuffer(textEndRow),
-        textPrevEndRow == null ? null : TextUtil.getByteBuffer(textPrevEndRow));
-  }
-
   public boolean isPreviousExtent(KeyExtent prevExtent) {
-    if (prevExtent == null)
-      return getPrevEndRow() == null;
-
-    if (!prevExtent.getTableId().equals(getTableId()))
+    if (prevExtent == null) {
+      return prevEndRow() == null;
+    }
+    if (!prevExtent.tableId().equals(tableId())) {
       throw new IllegalArgumentException("Cannot compare across tables " + prevExtent + " " + this);
-
-    if (prevExtent.getEndRow() == null)
+    }
+    if (prevExtent.endRow() == null || prevEndRow() == null) {
       return false;
-
-    if (getPrevEndRow() == null)
-      return false;
-
-    return prevExtent.getEndRow().equals(getPrevEndRow());
+    }
+    return prevExtent.endRow().equals(prevEndRow());
   }
 
   public boolean isMeta() {
-    return getTableId().equals(MetadataTable.ID) || isRootTablet();
+    return tableId().equals(MetadataTable.ID) || isRootTablet();
   }
 
   public boolean isRootTablet() {
-    return getTableId().equals(RootTable.ID);
+    return tableId().equals(RootTable.ID);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/TabletIdImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/TabletIdImpl.java
@@ -37,17 +37,17 @@ public class TabletIdImpl implements TabletId {
 
   @Override
   public Text getTableId() {
-    return new Text(ke.getTableId().canonical());
+    return new Text(ke.tableId().canonical());
   }
 
   @Override
   public Text getEndRow() {
-    return ke.getEndRow();
+    return ke.endRow();
   }
 
   @Override
   public Text getPrevEndRow() {
-    return ke.getPrevEndRow();
+    return ke.prevEndRow();
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MultiIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/MultiIterator.java
@@ -84,7 +84,7 @@ public class MultiIterator extends HeapIterator {
   }
 
   public MultiIterator(List<SortedKeyValueIterator<Key,Value>> iters2, KeyExtent extent) {
-    this(iters2, new Range(extent.getPrevEndRow(), false, extent.getEndRow(), true), false);
+    this(iters2, new Range(extent.prevEndRow(), false, extent.endRow(), true), false);
   }
 
   public MultiIterator(List<SortedKeyValueIterator<Key,Value>> readers, boolean init) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/RootTable.java
@@ -46,6 +46,6 @@ public class RootTable {
 
   public static final KeyExtent EXTENT = new KeyExtent(ID, null, null);
   public static final KeyExtent OLD_EXTENT =
-      new KeyExtent(MetadataTable.ID, TabletsSection.getRow(MetadataTable.ID, null), null);
+      new KeyExtent(MetadataTable.ID, TabletsSection.encodeRow(MetadataTable.ID, null), null);
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TableMetadataServicer.java
@@ -96,7 +96,7 @@ abstract class TableMetadataServicer extends MetadataServicer {
       colq = entry.getKey().getColumnQualifier(colq);
 
       if (TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
-        currentKeyExtent = new KeyExtent(entry.getKey().getRow(), entry.getValue());
+        currentKeyExtent = KeyExtent.fromMetaPrevRow(entry);
         tablets.put(currentKeyExtent, location);
         currentKeyExtent = null;
         location = null;
@@ -117,28 +117,28 @@ abstract class TableMetadataServicer extends MetadataServicer {
       throw new AccumuloException(
           "No entries found in metadata table for table " + getServicedTableId());
 
-    if (tabletsKeys.first().getPrevEndRow() != null)
+    if (tabletsKeys.first().prevEndRow() != null)
       throw new AccumuloException("Problem with metadata table, first entry for table "
           + getServicedTableId() + "- " + tabletsKeys.first() + " - has non null prev end row");
 
-    if (tabletsKeys.last().getEndRow() != null)
+    if (tabletsKeys.last().endRow() != null)
       throw new AccumuloException("Problem with metadata table, last entry for table "
           + getServicedTableId() + "- " + tabletsKeys.first() + " - has non null end row");
 
     Iterator<KeyExtent> tabIter = tabletsKeys.iterator();
-    Text lastEndRow = tabIter.next().getEndRow();
+    Text lastEndRow = tabIter.next().endRow();
     while (tabIter.hasNext()) {
       KeyExtent tabke = tabIter.next();
 
-      if (tabke.getPrevEndRow() == null)
+      if (tabke.prevEndRow() == null)
         throw new AccumuloException(
             "Problem with metadata table, it has null prev end row in middle of table " + tabke);
 
-      if (!tabke.getPrevEndRow().equals(lastEndRow))
+      if (!tabke.prevEndRow().equals(lastEndRow))
         throw new AccumuloException("Problem with metadata table, it has a hole "
-            + tabke.getPrevEndRow() + " != " + lastEndRow);
+            + tabke.prevEndRow() + " != " + lastEndRow);
 
-      lastEndRow = tabke.getEndRow();
+      lastEndRow = tabke.endRow();
     }
 
     // end METADATA table sanity check

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/LinkingIterator.java
@@ -69,7 +69,7 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
     // Always expect the default tablet to exist for a table. The following checks for the case when
     // the default tablet was not seen when it should have been seen.
     if (!hasNext && prevTablet != null && prevTablet.getEndRow() != null) {
-      Text defaultTabletRow = TabletsSection.getRow(prevTablet.getTableId(), null);
+      Text defaultTabletRow = TabletsSection.encodeRow(prevTablet.getTableId(), null);
       if (range.contains(new Key(defaultTabletRow))) {
         throw new IllegalStateException(
             "Scan range incudled default tablet, but did not see default tablet.  Last tablet seen : "
@@ -120,7 +120,7 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
       source = iteratorFactory.apply(range);
     } else {
       // get the metadata table row for the previous tablet
-      Text prevMetaRow = TabletsSection.getRow(prevTablet.getTableId(), prevTablet.getEndRow());
+      Text prevMetaRow = TabletsSection.encodeRow(prevTablet.getTableId(), prevTablet.getEndRow());
 
       // ensure the previous tablet still exists in the metadata table
       if (Iterators.size(iteratorFactory.apply(new Range(prevMetaRow))) == 0) {
@@ -153,8 +153,8 @@ public class LinkingIterator implements Iterator<TabletMetadata> {
 
           KeyExtent extent = tmp.getExtent();
 
-          if (extent.getPrevEndRow() != null) {
-            prevMetaRow = TabletsSection.getRow(extent.getTableId(), extent.getPrevEndRow());
+          if (extent.prevEndRow() != null) {
+            prevMetaRow = TabletsSection.encodeRow(extent.tableId(), extent.prevEndRow());
           }
 
           // If the first tablet seen has a prev endrow within the range it means a preceding tablet

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Cu
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.hadoop.io.Text;
 
@@ -73,7 +74,7 @@ public class RootTabletMetadata {
    * Apply a metadata table mutation to update internal json.
    */
   public void update(Mutation m) {
-    Preconditions.checkArgument(new Text(m.getRow()).equals(RootTable.EXTENT.getMetadataEntry()));
+    Preconditions.checkArgument(new Text(m.getRow()).equals(RootTable.EXTENT.toMetaRow()));
 
     m.getUpdates().forEach(cup -> {
       Preconditions.checkArgument(!cup.hasTimestamp());
@@ -150,7 +151,7 @@ public class RootTabletMetadata {
 
     Preconditions.checkArgument(gd.version == 1);
 
-    String row = RootTable.EXTENT.getMetadataEntry().toString();
+    String row = RootTable.EXTENT.toMetaRow().toString();
 
     TreeMap<Key,Value> entries = new TreeMap<>();
 
@@ -182,7 +183,7 @@ public class RootTabletMetadata {
    */
   public static byte[] getInitialJson(String dirName, String file) {
     ServerColumnFamily.validateDirCol(dirName);
-    Mutation mutation = RootTable.EXTENT.getPrevRowUpdateMutation();
+    Mutation mutation = TabletColumnFamily.createPrevRowMutation(RootTable.EXTENT);
     ServerColumnFamily.DIRECTORY_COLUMN.put(mutation, new Value(dirName));
 
     mutation.put(DataFileColumnFamily.STR_NAME, file, new DataFileValue(0, 0).encodeAsValue());

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -301,9 +301,9 @@ public class TabletMetadata {
 
       if (row == null) {
         row = key.getRowData();
-        KeyExtent ke = new KeyExtent(key.getRow(), (Text) null);
-        te.endRow = ke.getEndRow();
-        te.tableId = ke.getTableId();
+        KeyExtent ke = KeyExtent.fromMetaRow(key.getRow());
+        te.endRow = ke.endRow();
+        te.tableId = ke.tableId();
       } else if (!row.equals(key.getRowData())) {
         throw new IllegalArgumentException(
             "Input contains more than one row : " + row + " " + key.getRowData());
@@ -313,11 +313,11 @@ public class TabletMetadata {
         case TabletColumnFamily.STR_NAME:
           switch (qual) {
             case PREV_ROW_QUAL:
-              te.prevEndRow = KeyExtent.decodePrevEndRow(kv.getValue());
+              te.prevEndRow = TabletColumnFamily.decodePrevEndRow(kv.getValue());
               te.sawPrevEndRow = true;
               break;
             case OLD_PREV_ROW_QUAL:
-              te.oldPrevEndRow = KeyExtent.decodePrevEndRow(kv.getValue());
+              te.oldPrevEndRow = TabletColumnFamily.decodePrevEndRow(kv.getValue());
               te.sawOldPrevEndRow = true;
               break;
             case SPLIT_RATIO_QUAL:

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -211,8 +211,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
     @Override
     public Options forTablet(KeyExtent extent) {
-      forTable(extent.getTableId());
-      this.range = new Range(extent.getMetadataEntry());
+      forTable(extent.tableId());
+      this.range = new Range(extent.toMetaRow());
       return this;
     }
 
@@ -224,7 +224,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
     @Override
     public Options overlapping(Text startRow, Text endRow) {
-      this.range = new KeyExtent(tableId, null, startRow).toMetadataRange();
+      this.range = new KeyExtent(tableId, null, startRow).toMetaRange();
       this.endRow = endRow;
       return this;
     }

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -632,8 +632,8 @@ public class Gatherer {
     private Text endRow;
 
     public RowRange(KeyExtent ke) {
-      this.startRow = ke.getPrevEndRow();
-      this.endRow = ke.getEndRow();
+      this.startRow = ke.prevEndRow();
+      this.endRow = ke.endRow();
     }
 
     public RowRange(TRowRange trr) {

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -216,8 +216,8 @@ public class Merge {
   protected void merge(AccumuloClient client, String table, List<Size> sizes, int numToMerge)
       throws MergeException {
     try {
-      Text start = sizes.get(0).extent.getPrevEndRow();
-      Text end = sizes.get(numToMerge - 1).extent.getEndRow();
+      Text start = sizes.get(0).extent.prevEndRow();
+      Text end = sizes.get(numToMerge - 1).extent.endRow();
       message("Merging %d tablets from (%s to %s]", numToMerge, start == null ? "-inf" : start,
           end == null ? "+inf" : end);
       client.tableOperations().merge(table, start, end);
@@ -236,7 +236,7 @@ public class Merge {
       ClientContext context = (ClientContext) client;
       tableId = Tables.getTableId(context, tablename);
       tablets = TabletsMetadata.builder().scanMetadataTable()
-          .overRange(new KeyExtent(tableId, end, start).toMetadataRange()).fetch(FILES, PREV_ROW)
+          .overRange(new KeyExtent(tableId, end, start).toMetaRange()).fetch(FILES, PREV_ROW)
           .build(context);
     } catch (Exception e) {
       throw new MergeException(e);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -61,7 +61,7 @@ import org.junit.Test;
 public class TabletLocatorImplTest {
 
   private static final KeyExtent RTE = RootTable.EXTENT;
-  private static final KeyExtent MTE = new KeyExtent(MetadataTable.ID, null, RTE.getEndRow());
+  private static final KeyExtent MTE = new KeyExtent(MetadataTable.ID, null, RTE.endRow());
 
   static KeyExtent nke(String t, String er, String per) {
     return new KeyExtent(TableId.of(t), er == null ? null : new Text(er),
@@ -126,10 +126,10 @@ public class TabletLocatorImplTest {
     TreeMap<Text,TabletLocation> mc = new TreeMap<>(TabletLocatorImpl.END_ROW_COMPARATOR);
 
     for (Entry<KeyExtent,TabletLocation> entry : mcke.entrySet()) {
-      if (entry.getKey().getEndRow() == null)
+      if (entry.getKey().endRow() == null)
         mc.put(TabletLocatorImpl.MAX_TEXT, entry.getValue());
       else
-        mc.put(entry.getKey().getEndRow(), entry.getValue());
+        mc.put(entry.getKey().endRow(), entry.getValue());
     }
 
     return mc;
@@ -539,7 +539,7 @@ public class TabletLocatorImplTest {
       return;
     }
 
-    Text mr = ke.getMetadataEntry();
+    Text mr = ke.toMetaRow();
     Key lk = new Key(mr, CurrentLocationColumnFamily.NAME, new Text(instance));
     tabletData.remove(lk);
 
@@ -552,8 +552,8 @@ public class TabletLocatorImplTest {
 
     SortedMap<Key,Value> tabletData = tablets.computeIfAbsent(tablet, k -> new TreeMap<>());
 
-    Text mr = ke.getMetadataEntry();
-    Value per = KeyExtent.encodePrevEndRow(ke.getPrevEndRow());
+    Text mr = ke.toMetaRow();
+    Value per = TabletColumnFamily.encodePrevEndRow(ke.prevEndRow());
 
     if (location != null) {
       if (instance == null)
@@ -689,8 +689,8 @@ public class TabletLocatorImplTest {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver3");
 
     // simulate the metadata table splitting
-    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, tab1e21.getMetadataEntry(), RTE.getEndRow());
-    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, tab1e21.getMetadataEntry());
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, tab1e21.toMetaRow(), RTE.endRow());
+    KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, tab1e21.toMetaRow());
 
     setLocation(tservers, "tserver4", RTE, mte1, "tserver5");
     setLocation(tservers, "tserver4", RTE, mte2, "tserver6");
@@ -728,9 +728,8 @@ public class TabletLocatorImplTest {
     locateTabletTest(tab1TabletCache, "r", tab1e22, "tserver9");
 
     // simulate a hole in the metadata, caused by a partial split
-    KeyExtent mte11 = new KeyExtent(MetadataTable.ID, tab1e1.getMetadataEntry(), RTE.getEndRow());
-    KeyExtent mte12 =
-        new KeyExtent(MetadataTable.ID, tab1e21.getMetadataEntry(), tab1e1.getMetadataEntry());
+    KeyExtent mte11 = new KeyExtent(MetadataTable.ID, tab1e1.toMetaRow(), RTE.endRow());
+    KeyExtent mte12 = new KeyExtent(MetadataTable.ID, tab1e21.toMetaRow(), tab1e1.toMetaRow());
     deleteServer(tservers, "tserver10");
     setLocation(tservers, "tserver4", RTE, mte12, "tserver10");
     setLocation(tservers, "tserver10", mte12, tab1e21, "tserver12");
@@ -1181,7 +1180,7 @@ public class TabletLocatorImplTest {
   @Test
   public void testBug1() throws Exception {
     // a bug that occurred while running continuous ingest
-    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("0;0bc"), RTE.getEndRow());
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("0;0bc"), RTE.endRow());
     KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, new Text("0;0bc"));
 
     TServers tservers = new TServers();
@@ -1210,7 +1209,7 @@ public class TabletLocatorImplTest {
   @Test
   public void testBug2() throws Exception {
     // a bug that occurred while running a functional test
-    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("~"), RTE.getEndRow());
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("~"), RTE.endRow());
     KeyExtent mte2 = new KeyExtent(MetadataTable.ID, null, new Text("~"));
 
     TServers tservers = new TServers();
@@ -1238,7 +1237,7 @@ public class TabletLocatorImplTest {
   // being merged away, caused locating tablets to fail
   @Test
   public void testBug3() throws Exception {
-    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("1;c"), RTE.getEndRow());
+    KeyExtent mte1 = new KeyExtent(MetadataTable.ID, new Text("1;c"), RTE.endRow());
     KeyExtent mte2 = new KeyExtent(MetadataTable.ID, new Text("1;f"), new Text("1;c"));
     KeyExtent mte3 = new KeyExtent(MetadataTable.ID, new Text("1;j"), new Text("1;f"));
     KeyExtent mte4 = new KeyExtent(MetadataTable.ID, new Text("1;r"), new Text("1;j"));

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyExtentTest.java
@@ -55,123 +55,27 @@ public class KeyExtentTest {
   public void testDecodingMetadataRow() {
     Text flattenedExtent = new Text("foo;bar");
 
-    ke = new KeyExtent(flattenedExtent, (Text) null);
+    ke = KeyExtent.fromMetaRow(flattenedExtent);
 
-    assertEquals(new Text("bar"), ke.getEndRow());
-    assertEquals("foo", ke.getTableId().canonical());
-    assertNull(ke.getPrevEndRow());
+    assertEquals(new Text("bar"), ke.endRow());
+    assertEquals("foo", ke.tableId().canonical());
+    assertNull(ke.prevEndRow());
 
     flattenedExtent = new Text("foo<");
 
-    ke = new KeyExtent(flattenedExtent, (Text) null);
+    ke = KeyExtent.fromMetaRow(flattenedExtent);
 
-    assertNull(ke.getEndRow());
-    assertEquals("foo", ke.getTableId().canonical());
-    assertNull(ke.getPrevEndRow());
+    assertNull(ke.endRow());
+    assertEquals("foo", ke.tableId().canonical());
+    assertNull(ke.prevEndRow());
 
     flattenedExtent = new Text("foo;bar;");
 
-    ke = new KeyExtent(flattenedExtent, (Text) null);
+    ke = KeyExtent.fromMetaRow(flattenedExtent);
 
-    assertEquals(new Text("bar;"), ke.getEndRow());
-    assertEquals("foo", ke.getTableId().canonical());
-    assertNull(ke.getPrevEndRow());
-
-  }
-
-  @Test
-  public void testFindContainingExtents() {
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, null), set0));
-    assertNull(KeyExtent.findContainingExtent(nke("t", "1", "0"), set0));
-    assertNull(KeyExtent.findContainingExtent(nke("t", "1", null), set0));
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, "0"), set0));
-
-    TreeSet<KeyExtent> set1 = new TreeSet<>();
-
-    set1.add(nke("t", null, null));
-
-    assertEquals(nke("t", null, null), KeyExtent.findContainingExtent(nke("t", null, null), set1));
-    assertEquals(nke("t", null, null), KeyExtent.findContainingExtent(nke("t", "1", "0"), set1));
-    assertEquals(nke("t", null, null), KeyExtent.findContainingExtent(nke("t", "1", null), set1));
-    assertEquals(nke("t", null, null), KeyExtent.findContainingExtent(nke("t", null, "0"), set1));
-
-    TreeSet<KeyExtent> set2 = new TreeSet<>();
-
-    set2.add(nke("t", "g", null));
-    set2.add(nke("t", null, "g"));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, null), set2));
-    assertEquals(nke("t", "g", null), KeyExtent.findContainingExtent(nke("t", "c", "a"), set2));
-    assertEquals(nke("t", "g", null), KeyExtent.findContainingExtent(nke("t", "c", null), set2));
-
-    assertEquals(nke("t", "g", null), KeyExtent.findContainingExtent(nke("t", "g", "a"), set2));
-    assertEquals(nke("t", "g", null), KeyExtent.findContainingExtent(nke("t", "g", null), set2));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", "h", "a"), set2));
-    assertNull(KeyExtent.findContainingExtent(nke("t", "h", null), set2));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", "z", "f"), set2));
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, "f"), set2));
-
-    assertEquals(nke("t", null, "g"), KeyExtent.findContainingExtent(nke("t", "z", "g"), set2));
-    assertEquals(nke("t", null, "g"), KeyExtent.findContainingExtent(nke("t", null, "g"), set2));
-
-    assertEquals(nke("t", null, "g"), KeyExtent.findContainingExtent(nke("t", "z", "h"), set2));
-    assertEquals(nke("t", null, "g"), KeyExtent.findContainingExtent(nke("t", null, "h"), set2));
-
-    TreeSet<KeyExtent> set3 = new TreeSet<>();
-
-    set3.add(nke("t", "g", null));
-    set3.add(nke("t", "s", "g"));
-    set3.add(nke("t", null, "s"));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, null), set3));
-
-    assertEquals(nke("t", "g", null), KeyExtent.findContainingExtent(nke("t", "g", null), set3));
-    assertEquals(nke("t", "s", "g"), KeyExtent.findContainingExtent(nke("t", "s", "g"), set3));
-    assertEquals(nke("t", null, "s"), KeyExtent.findContainingExtent(nke("t", null, "s"), set3));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", "t", "g"), set3));
-    assertNull(KeyExtent.findContainingExtent(nke("t", "t", "f"), set3));
-    assertNull(KeyExtent.findContainingExtent(nke("t", "s", "f"), set3));
-
-    assertEquals(nke("t", "s", "g"), KeyExtent.findContainingExtent(nke("t", "r", "h"), set3));
-    assertEquals(nke("t", "s", "g"), KeyExtent.findContainingExtent(nke("t", "s", "h"), set3));
-    assertEquals(nke("t", "s", "g"), KeyExtent.findContainingExtent(nke("t", "r", "g"), set3));
-
-    assertEquals(nke("t", null, "s"), KeyExtent.findContainingExtent(nke("t", null, "t"), set3));
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, "r"), set3));
-
-    assertEquals(nke("t", "g", null), KeyExtent.findContainingExtent(nke("t", "f", null), set3));
-    assertNull(KeyExtent.findContainingExtent(nke("t", "h", null), set3));
-
-    TreeSet<KeyExtent> set4 = new TreeSet<>();
-
-    set4.add(nke("t1", "d", null));
-    set4.add(nke("t1", "q", "d"));
-    set4.add(nke("t1", null, "q"));
-    set4.add(nke("t2", "g", null));
-    set4.add(nke("t2", "s", "g"));
-    set4.add(nke("t2", null, "s"));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", null, null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("z", null, null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("t11", null, null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("t1", null, null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("t2", null, null), set4));
-
-    assertNull(KeyExtent.findContainingExtent(nke("t", "g", null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("z", "g", null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("t11", "g", null), set4));
-    assertNull(KeyExtent.findContainingExtent(nke("t1", "g", null), set4));
-
-    assertEquals(nke("t2", "g", null), KeyExtent.findContainingExtent(nke("t2", "g", null), set4));
-    assertEquals(nke("t2", "s", "g"), KeyExtent.findContainingExtent(nke("t2", "s", "g"), set4));
-    assertEquals(nke("t2", null, "s"), KeyExtent.findContainingExtent(nke("t2", null, "s"), set4));
-
-    assertEquals(nke("t1", "d", null), KeyExtent.findContainingExtent(nke("t1", "d", null), set4));
-    assertEquals(nke("t1", "q", "d"), KeyExtent.findContainingExtent(nke("t1", "q", "d"), set4));
-    assertEquals(nke("t1", null, "q"), KeyExtent.findContainingExtent(nke("t1", null, "q"), set4));
+    assertEquals(new Text("bar;"), ke.endRow());
+    assertEquals("foo", ke.tableId().canonical());
+    assertNull(ke.prevEndRow());
 
   }
 
@@ -277,22 +181,12 @@ public class KeyExtentTest {
   }
 
   private KeyExtent writeAndReadFields(KeyExtent in) throws IOException {
-    KeyExtent out = new KeyExtent();
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    in.write(new DataOutputStream(baos));
+    in.writeTo(new DataOutputStream(baos));
 
     ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-    out.readFields(new DataInputStream(bais));
-
-    return out;
+    return KeyExtent.readFrom(new DataInputStream(bais));
   }
 
-  @Test
-  public void testDecodeEncode() {
-    assertNull(KeyExtent.decodePrevEndRow(KeyExtent.encodePrevEndRow(null)));
-
-    Text x = new Text();
-    assertEquals(x, KeyExtent.decodePrevEndRow(KeyExtent.encodePrevEndRow(x)));
-  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -229,39 +229,37 @@ public class RangeTest {
   @Test
   public void testMergeOverlapping22() {
 
-    Range ke1 = new KeyExtent(TableId.of("tab1"), new Text("Bank"), null).toMetadataRange();
+    Range ke1 = new KeyExtent(TableId.of("tab1"), new Text("Bank"), null).toMetaRange();
     Range ke2 =
-        new KeyExtent(TableId.of("tab1"), new Text("Fails"), new Text("Bank")).toMetadataRange();
-    Range ke3 =
-        new KeyExtent(TableId.of("tab1"), new Text("Sam"), new Text("Fails")).toMetadataRange();
-    Range ke4 =
-        new KeyExtent(TableId.of("tab1"), new Text("bails"), new Text("Sam")).toMetadataRange();
-    Range ke5 = new KeyExtent(TableId.of("tab1"), null, new Text("bails")).toMetadataRange();
+        new KeyExtent(TableId.of("tab1"), new Text("Fails"), new Text("Bank")).toMetaRange();
+    Range ke3 = new KeyExtent(TableId.of("tab1"), new Text("Sam"), new Text("Fails")).toMetaRange();
+    Range ke4 = new KeyExtent(TableId.of("tab1"), new Text("bails"), new Text("Sam")).toMetaRange();
+    Range ke5 = new KeyExtent(TableId.of("tab1"), null, new Text("bails")).toMetaRange();
 
     List<Range> rl = newRangeList(ke1, ke2, ke3, ke4, ke5);
     List<Range> expected =
-        newRangeList(new KeyExtent(TableId.of("tab1"), null, null).toMetadataRange());
+        newRangeList(new KeyExtent(TableId.of("tab1"), null, null).toMetaRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke1, ke2, ke4, ke5);
     expected =
-        newRangeList(new KeyExtent(TableId.of("tab1"), new Text("Fails"), null).toMetadataRange(),
-            new KeyExtent(TableId.of("tab1"), null, new Text("Sam")).toMetadataRange());
+        newRangeList(new KeyExtent(TableId.of("tab1"), new Text("Fails"), null).toMetaRange(),
+            new KeyExtent(TableId.of("tab1"), null, new Text("Sam")).toMetaRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke2, ke3, ke4, ke5);
     expected =
-        newRangeList(new KeyExtent(TableId.of("tab1"), null, new Text("Bank")).toMetadataRange());
+        newRangeList(new KeyExtent(TableId.of("tab1"), null, new Text("Bank")).toMetaRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke1, ke2, ke3, ke4);
     expected =
-        newRangeList(new KeyExtent(TableId.of("tab1"), new Text("bails"), null).toMetadataRange());
+        newRangeList(new KeyExtent(TableId.of("tab1"), new Text("bails"), null).toMetaRange());
     check(Range.mergeOverlapping(rl), expected);
 
     rl = newRangeList(ke2, ke3, ke4);
     expected = newRangeList(
-        new KeyExtent(TableId.of("tab1"), new Text("bails"), new Text("Bank")).toMetadataRange());
+        new KeyExtent(TableId.of("tab1"), new Text("bails"), new Text("Bank")).toMetaRange());
 
     check(Range.mergeOverlapping(rl), expected);
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -64,7 +64,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheConfiguration;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheManagerFactory;
@@ -2337,7 +2336,7 @@ public class RFileTest {
     // mfw.startDefaultLocalityGroup();
 
     Text tableExtent = new Text(
-        TabletsSection.getRow(MetadataTable.ID, TabletsSection.getRange().getEndKey().getRow()));
+        TabletsSection.encodeRow(MetadataTable.ID, TabletsSection.getRange().getEndKey().getRow()));
 
     // table tablet's directory
     Key tableDirKey = new Key(tableExtent, ServerColumnFamily.DIRECTORY_COLUMN.getColumnFamily(),
@@ -2352,10 +2351,10 @@ public class RFileTest {
     // table tablet's prevRow
     Key tablePrevRowKey = new Key(tableExtent, TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
         TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier(), 0);
-    mfw.append(tablePrevRowKey, KeyExtent.encodePrevEndRow(null));
+    mfw.append(tablePrevRowKey, TabletColumnFamily.encodePrevEndRow(null));
 
     // ----------] default tablet info
-    Text defaultExtent = new Text(TabletsSection.getRow(MetadataTable.ID, null));
+    Text defaultExtent = new Text(TabletsSection.encodeRow(MetadataTable.ID, null));
 
     // default's directory
     Key defaultDirKey =
@@ -2373,7 +2372,7 @@ public class RFileTest {
         new Key(defaultExtent, TabletColumnFamily.PREV_ROW_COLUMN.getColumnFamily(),
             TabletColumnFamily.PREV_ROW_COLUMN.getColumnQualifier(), 0);
     mfw.append(defaultPrevRowKey,
-        KeyExtent.encodePrevEndRow(TabletsSection.getRange().getEndKey().getRow()));
+        TabletColumnFamily.encodePrevEndRow(TabletsSection.getRange().getEndKey().getRow()));
 
     testRfile.closeWriter();
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/LinkingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/LinkingIteratorTest.java
@@ -54,8 +54,7 @@ public class LinkingIteratorTest {
     @Override
     public Iterator<TabletMetadata> apply(Range range) {
       Stream<TabletMetadata> stream = count++ == 0 ? initial.stream() : subsequent.stream();
-      return stream.filter(tm -> range.contains(new Key(tm.getExtent().getMetadataEntry())))
-          .iterator();
+      return stream.filter(tm -> range.contains(new Key(tm.getExtent().toMetaRow()))).iterator();
     }
   }
 
@@ -132,13 +131,13 @@ public class LinkingIteratorTest {
 
     check(tablets2, new IterFactory(tablets1, tablets2), TableId.of("4"));
     check(tablets2, new IterFactory(tablets1, tablets2),
-        new KeyExtent(TableId.of("4"), null, new Text("e")).toMetadataRange());
+        new KeyExtent(TableId.of("4"), null, new Text("e")).toMetaRange());
 
     // following should not care about missing tablet
     check(tablets1, new IterFactory(tablets1, tablets2),
-        new KeyExtent(TableId.of("4"), null, new Text("g")).toMetadataRange());
+        new KeyExtent(TableId.of("4"), null, new Text("g")).toMetaRange());
     check(tablets1, new IterFactory(tablets1, tablets2),
-        new KeyExtent(TableId.of("4"), null, new Text("f")).toMetadataRange());
+        new KeyExtent(TableId.of("4"), null, new Text("f")).toMetaRange());
   }
 
   @Test(expected = IllegalStateException.class)
@@ -161,6 +160,6 @@ public class LinkingIteratorTest {
     // tablets at end of table.
     List<TabletMetadata> tablets1 = Arrays.asList(create("4", null, "f"), create("4", "f", "m"));
     check(tablets1, new IterFactory(tablets1, tablets1),
-        new KeyExtent(TableId.of("4"), new Text("r"), new Text("e")).toMetadataRange());
+        new KeyExtent(TableId.of("4"), new Text("r"), new Text("e")).toMetaRange());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataSchemaTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataSchemaTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+
+public class MetadataSchemaTest {
+
+  @Test
+  public void testDecodeEncodePrevEndRow() {
+    assertNull(TabletColumnFamily.decodePrevEndRow(TabletColumnFamily.encodePrevEndRow(null)));
+
+    Text x = new Text();
+    assertEquals(x, TabletColumnFamily.decodePrevEndRow(TabletColumnFamily.encodePrevEndRow(x)));
+
+    Text ab = new Text("ab");
+    assertEquals(ab, TabletColumnFamily.decodePrevEndRow(TabletColumnFamily.encodePrevEndRow(ab)));
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -71,13 +71,13 @@ public class MergeTest {
           while (impl.hasNext()) {
             Size candidate = impl.next();
             if (start != null) {
-              if (candidate.extent.getEndRow() != null
-                  && candidate.extent.getEndRow().compareTo(start) < 0)
+              if (candidate.extent.endRow() != null
+                  && candidate.extent.endRow().compareTo(start) < 0)
                 continue;
             }
             if (end != null) {
-              if (candidate.extent.getPrevEndRow() != null
-                  && candidate.extent.getPrevEndRow().compareTo(end) >= 0)
+              if (candidate.extent.prevEndRow() != null
+                  && candidate.extent.prevEndRow().compareTo(end) >= 0)
                 continue;
             }
             return candidate;

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -852,7 +852,7 @@ public class InputConfigurator extends ConfiguratorBase {
         startRow = new Text();
 
       Range metadataRange =
-          new Range(new KeyExtent(tableId, startRow, null).getMetadataEntry(), true, null, false);
+          new Range(new KeyExtent(tableId, startRow, null).toMetaRow(), true, null, false);
       Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       scanner.fetchColumnFamily(LastLocationColumnFamily.NAME);
@@ -882,7 +882,7 @@ public class InputConfigurator extends ConfiguratorBase {
           }
 
           if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
-            extent = new KeyExtent(key.getRow(), entry.getValue());
+            extent = KeyExtent.fromMetaPrevRow(entry);
           }
 
         }
@@ -890,7 +890,7 @@ public class InputConfigurator extends ConfiguratorBase {
         if (location != null)
           return null;
 
-        if (!extent.getTableId().equals(tableId)) {
+        if (!extent.tableId().equals(tableId)) {
           throw new AccumuloException("Saw unexpected table Id " + tableId + " " + extent);
         }
 
@@ -901,8 +901,8 @@ public class InputConfigurator extends ConfiguratorBase {
         binnedRanges.computeIfAbsent(last, k -> new HashMap<>())
             .computeIfAbsent(extent, k -> new ArrayList<>()).add(range);
 
-        if (extent.getEndRow() == null
-            || range.afterEndKey(new Key(extent.getEndRow()).followingKey(PartialKey.ROW))) {
+        if (extent.endRow() == null
+            || range.afterEndKey(new Key(extent.endRow()).followingKey(PartialKey.ROW))) {
           break;
         }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -621,11 +621,11 @@ public class BulkImporter {
       TabletLocator locator, Path file, KeyExtent failed) throws Exception {
     locator.invalidateCache(failed);
     Text start = getStartRowForExtent(failed);
-    return findOverlappingTablets(context, fs, locator, file, start, failed.getEndRow());
+    return findOverlappingTablets(context, fs, locator, file, start, failed.endRow());
   }
 
   protected static Text getStartRowForExtent(KeyExtent extent) {
-    Text start = extent.getPrevEndRow();
+    Text start = extent.prevEndRow();
     if (start != null) {
       start = new Text(start);
       // ACCUMULO-3967 We want the first possible key in this tablet, not the following row from the
@@ -661,7 +661,7 @@ public class BulkImporter {
         TabletLocation tabletLocation = locator.locateTablet(context, row, false, true);
         // log.debug(filename + " found row " + row + " at location " + tabletLocation);
         result.add(tabletLocation);
-        row = tabletLocation.tablet_extent.getEndRow();
+        row = tabletLocation.tablet_extent.endRow();
         if (row != null && (endRow == null || row.compareTo(endRow) < 0)) {
           row = new Text(row);
           row.append(byte0, 0, byte0.length);

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -263,12 +263,12 @@ public class MetadataConstraints implements Constraint {
         } else if (new ColumnFQ(columnUpdate).equals(TabletColumnFamily.PREV_ROW_COLUMN)
             && columnUpdate.getValue().length > 0
             && (violations == null || !violations.contains((short) 4))) {
-          KeyExtent ke = new KeyExtent(new Text(mutation.getRow()), (Text) null);
+          KeyExtent ke = KeyExtent.fromMetaRow(new Text(mutation.getRow()));
 
-          Text per = KeyExtent.decodePrevEndRow(new Value(columnUpdate.getValue()));
+          Text per = TabletColumnFamily.decodePrevEndRow(new Value(columnUpdate.getValue()));
 
           boolean prevEndRowLessThanEndRow =
-              per == null || ke.getEndRow() == null || per.compareTo(ke.getEndRow()) < 0;
+              per == null || ke.endRow() == null || per.compareTo(ke.endRow()) < 0;
 
           if (!prevEndRowLessThanEndRow) {
             violations = addViolation(violations, 3);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.iterators.Combiner;
@@ -603,10 +602,10 @@ public class Initialize implements KeywordExecutable {
 
   private static void createEntriesForTablet(TreeMap<Key,Value> map, Tablet tablet) {
     Value EMPTY_SIZE = new DataFileValue(0, 0).encodeAsValue();
-    Text extent = new Text(TabletsSection.getRow(tablet.tableId, tablet.endRow));
+    Text extent = new Text(TabletsSection.encodeRow(tablet.tableId, tablet.endRow));
     addEntry(map, extent, DIRECTORY_COLUMN, new Value(tablet.dirName));
     addEntry(map, extent, TIME_COLUMN, new Value(new MetadataTime(0, TimeType.LOGICAL).encode()));
-    addEntry(map, extent, PREV_ROW_COLUMN, KeyExtent.encodePrevEndRow(tablet.prevEndRow));
+    addEntry(map, extent, PREV_ROW_COLUMN, TabletColumnFamily.encodePrevEndRow(tablet.prevEndRow));
     for (String file : tablet.files) {
       addEntry(map, extent, new ColumnFQ(DataFileColumnFamily.NAME, new Text(file)), EMPTY_SIZE);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancer.java
@@ -140,7 +140,7 @@ public class ChaoticLoadBalancer extends TabletBalancer {
           continue;
         try {
           for (TabletStats ts : getOnlineTabletsForTable(e.getKey(), id)) {
-            KeyExtent ke = new KeyExtent(ts.extent);
+            KeyExtent ke = KeyExtent.fromThrift(ts.extent);
             int index = r.nextInt(underCapacityTServer.size());
             TServerInstance dest = underCapacityTServer.get(index);
             if (dest.equals(e.getKey()))

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -251,7 +251,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
             return result;
           }
           for (TabletStats stat : stats)
-            onlineTabletsForTable.put(new KeyExtent(stat.extent), stat);
+            onlineTabletsForTable.put(KeyExtent.fromThrift(stat.extent), stat);
           donerTabletStats.put(table, onlineTabletsForTable);
         }
       } catch (Exception ex) {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -121,7 +121,7 @@ public abstract class GroupBalancer extends TabletBalancer {
     }
 
     for (KeyExtent keyExtent : migrations) {
-      if (keyExtent.getTableId().equals(tableId)) {
+      if (keyExtent.tableId().equals(tableId)) {
         return false;
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -351,7 +351,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
     // group the unassigned into tables
     Map<TableId,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
     unassigned.forEach((keyExtent, tServerInstance) -> {
-      groupedUnassigned.computeIfAbsent(keyExtent.getTableId(), p -> new HashMap<>()).put(keyExtent,
+      groupedUnassigned.computeIfAbsent(keyExtent.tableId(), p -> new HashMap<>()).put(keyExtent,
           tServerInstance);
     });
 
@@ -427,7 +427,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
               }
               Random random = new SecureRandom();
               for (TabletStats ts : outOfBoundsTablets) {
-                KeyExtent ke = new KeyExtent(ts.getExtent());
+                KeyExtent ke = KeyExtent.fromThrift(ts.getExtent());
                 if (migrations.contains(ke)) {
                   LOG.debug("Migration for out of bounds tablet {} has already been requested", ke);
                   continue;
@@ -489,12 +489,12 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
       Multimap<TServerInstance,String> serverTableIdCopied = HashMultimap.create();
       for (TabletMigration migration : migrationsFromLastPass.values()) {
         TableInfo fromInfo = getTableInfo(currentCopy, serverTableIdCopied,
-            migration.tablet.getTableId().toString(), migration.oldServer);
+            migration.tablet.tableId().toString(), migration.oldServer);
         if (fromInfo != null) {
           fromInfo.setOnlineTablets(fromInfo.getOnlineTablets() - 1);
         }
         TableInfo toInfo = getTableInfo(currentCopy, serverTableIdCopied,
-            migration.tablet.getTableId().toString(), migration.newServer);
+            migration.tablet.tableId().toString(), migration.newServer);
         if (toInfo != null) {
           toInfo.setOnlineTablets(toInfo.getOnlineTablets() + 1);
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
@@ -86,7 +86,7 @@ public class RegexGroupBalancer extends GroupBalancer {
 
       @Override
       public String apply(KeyExtent input) {
-        Text er = input.getEndRow();
+        Text er = input.endRow();
         if (er == null) {
           return defaultGroup;
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -117,7 +117,7 @@ public class TableLoadBalancer extends TabletBalancer {
     // separate the unassigned into tables
     Map<TableId,Map<KeyExtent,TServerInstance>> groupedUnassigned = new HashMap<>();
     unassigned.forEach((keyExtent, tServerInstance) -> {
-      groupedUnassigned.computeIfAbsent(keyExtent.getTableId(), p -> new HashMap<>()).put(keyExtent,
+      groupedUnassigned.computeIfAbsent(keyExtent.tableId(), p -> new HashMap<>()).put(keyExtent,
           tServerInstance);
     });
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MergeInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MergeInfo.java
@@ -44,15 +44,14 @@ public class MergeInfo implements Writable {
 
   @Override
   public void readFields(DataInput in) throws IOException {
-    extent = new KeyExtent();
-    extent.readFields(in);
+    extent = KeyExtent.readFrom(in);
     state = MergeState.values()[in.readInt()];
     operation = Operation.values()[in.readInt()];
   }
 
   @Override
   public void write(DataOutput out) throws IOException {
-    extent.write(out);
+    extent.writeTo(out);
     out.writeInt(state.ordinal());
     out.writeInt(operation.ordinal());
   }
@@ -85,11 +84,10 @@ public class MergeInfo implements Writable {
   public boolean needsToBeChopped(KeyExtent otherExtent) {
     // During a delete, the block after the merge will be stretched to cover the deleted area.
     // Therefore, it needs to be chopped
-    if (!otherExtent.getTableId().equals(extent.getTableId()))
+    if (!otherExtent.tableId().equals(extent.tableId()))
       return false;
     if (isDelete())
-      return otherExtent.getPrevEndRow() != null
-          && otherExtent.getPrevEndRow().equals(extent.getEndRow());
+      return otherExtent.prevEndRow() != null && otherExtent.prevEndRow().equals(extent.endRow());
     else
       return this.extent.overlaps(otherExtent);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -63,7 +63,7 @@ class MetaDataStateStore implements TabletStateStore {
     BatchWriter writer = createBatchWriter();
     try {
       for (Assignment assignment : assignments) {
-        Mutation m = new Mutation(assignment.tablet.getMetadataEntry());
+        Mutation m = new Mutation(assignment.tablet.toMetaRow());
         assignment.server.putLocation(m);
         assignment.server.putLastLocation(m);
         assignment.server.clearFutureLocation(m);
@@ -97,7 +97,7 @@ class MetaDataStateStore implements TabletStateStore {
     BatchWriter writer = createBatchWriter();
     try {
       for (Assignment assignment : assignments) {
-        Mutation m = new Mutation(assignment.tablet.getMetadataEntry());
+        Mutation m = new Mutation(assignment.tablet.toMetaRow());
         SuspendingTServer.clearSuspension(m);
         assignment.server.putFutureLocation(m);
         writer.addMutation(m);
@@ -132,7 +132,7 @@ class MetaDataStateStore implements TabletStateStore {
     BatchWriter writer = createBatchWriter();
     try {
       for (TabletLocationState tls : tablets) {
-        Mutation m = new Mutation(tls.extent.getMetadataEntry());
+        Mutation m = new Mutation(tls.extent.toMetaRow());
         if (tls.current != null) {
           tls.current.clearLocation(m);
           if (logsForDeadServers != null) {
@@ -178,7 +178,7 @@ class MetaDataStateStore implements TabletStateStore {
         if (tls.suspend != null) {
           continue;
         }
-        Mutation m = new Mutation(tls.extent.getMetadataEntry());
+        Mutation m = new Mutation(tls.extent.toMetaRow());
         SuspendingTServer.clearSuspension(m);
         writer.addMutation(m);
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataTableScanner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataTableScanner.java
@@ -160,15 +160,15 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       if (cf.compareTo(FutureLocationColumnFamily.NAME) == 0) {
         TServerInstance location = new TServerInstance(entry.getValue(), cq);
         if (future != null) {
-          throw new BadLocationStateException("found two assignments for the same extent "
-              + key.getRow() + ": " + future + " and " + location, entry.getKey().getRow());
+          throw new BadLocationStateException("found two assignments for the same extent " + row
+              + ": " + future + " and " + location, row);
         }
         future = location;
       } else if (cf.compareTo(CurrentLocationColumnFamily.NAME) == 0) {
         TServerInstance location = new TServerInstance(entry.getValue(), cq);
         if (current != null) {
-          throw new BadLocationStateException("found two locations for the same extent "
-              + key.getRow() + ": " + current + " and " + location, entry.getKey().getRow());
+          throw new BadLocationStateException("found two locations for the same extent " + row
+              + ": " + current + " and " + location, row);
         }
         current = location;
       } else if (cf.compareTo(LogColumnFamily.NAME) == 0) {
@@ -181,7 +181,7 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       } else if (cf.compareTo(ChoppedColumnFamily.NAME) == 0) {
         chopped = true;
       } else if (TabletColumnFamily.PREV_ROW_COLUMN.equals(cf, cq)) {
-        extent = new KeyExtent(row, entry.getValue());
+        extent = KeyExtent.fromMetaPrevRow(entry);
       } else if (SuspendLocationColumn.SUSPEND_COLUMN.equals(cf, cq)) {
         suspend = SuspendingTServer.fromValue(entry.getValue());
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletLocationState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletLocationState.java
@@ -63,7 +63,7 @@ public class TabletLocationState {
     if (current != null && future != null) {
       throw new BadLocationStateException(
           extent + " is both assigned and hosted, which should never happen: " + this,
-          extent.getMetadataEntry());
+          extent.toMetaRow());
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateChangeIterator.java
@@ -97,9 +97,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
       byte[] data = Base64.getDecoder().decode(migrations);
       buffer.reset(data, data.length);
       while (buffer.available() > 0) {
-        KeyExtent extent = new KeyExtent();
-        extent.readFields(buffer);
-        result.add(extent);
+        result.add(KeyExtent.readFrom(buffer));
       }
       return result;
     } catch (Exception ex) {
@@ -145,7 +143,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
       while (buffer.available() > 0) {
         MergeInfo mergeInfo = new MergeInfo();
         mergeInfo.readFields(buffer);
-        result.put(mergeInfo.extent.getTableId(), mergeInfo);
+        result.put(mergeInfo.extent.tableId(), mergeInfo);
       }
       return result;
     } catch (Exception ex) {
@@ -172,7 +170,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
         return;
       }
       // we always want data about merges
-      MergeInfo merge = merges.get(tls.extent.getTableId());
+      MergeInfo merge = merges.get(tls.extent.tableId());
       if (merge != null) {
         // could make this smarter by only returning if the tablet is involved in the merge
         return;
@@ -183,7 +181,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
       }
 
       // is the table supposed to be online or offline?
-      boolean shouldBeOnline = onlineTables.contains(tls.extent.getTableId());
+      boolean shouldBeOnline = onlineTables.contains(tls.extent.tableId());
 
       if (debug) {
         log.debug("{} is {} and should be {} line", tls.extent, tls.getState(current),
@@ -253,7 +251,7 @@ public class TabletStateChangeIterator extends SkippingIterator {
     DataOutputBuffer buffer = new DataOutputBuffer();
     try {
       for (KeyExtent extent : migrations) {
-        extent.write(buffer);
+        extent.writeTo(buffer);
       }
     } catch (Exception ex) {
       throw new RuntimeException(ex);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletStateStore.java
@@ -99,7 +99,7 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
   }
 
   static TabletStateStore getStoreForTablet(KeyExtent extent, ServerContext context) {
-    return getStoreForLevel(DataLevel.of(extent.getTableId()), context);
+    return getStoreForLevel(DataLevel.of(extent.tableId()), context);
   }
 
   public static TabletStateStore getStoreForLevel(DataLevel level, ClientContext context) {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -56,14 +56,14 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   protected TabletMutatorBase(ServerContext ctx, KeyExtent extent) {
     this.extent = extent;
     this.context = ctx;
-    mutation = new Mutation(extent.getMetadataEntry());
+    mutation = new Mutation(extent.toMetaRow());
   }
 
   @Override
   public Ample.TabletMutator putPrevEndRow(Text per) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     TabletColumnFamily.PREV_ROW_COLUMN.put(mutation,
-        KeyExtent.encodePrevEndRow(extent.getPrevEndRow()));
+        TabletColumnFamily.encodePrevEndRow(extent.prevEndRow()));
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
@@ -70,7 +70,7 @@ public class TabletsMutatorImpl implements TabletsMutator {
     if (extent.isRootTablet()) {
       return new RootTabletMutatorImpl(context);
     } else {
-      return new TabletMutatorImpl(context, extent, getWriter(extent.getTableId()));
+      return new TabletMutatorImpl(context, extent, getWriter(extent.tableId()));
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tabletserver/LargestFirstMemoryManager.java
@@ -135,7 +135,7 @@ public class LargestFirstMemoryManager {
   }
 
   protected long getMinCIdleThreshold(KeyExtent extent) {
-    TableId tableId = extent.getTableId();
+    TableId tableId = extent.tableId();
     if (!mincIdleThresholds.containsKey(tableId))
       mincIdleThresholds.put(tableId, context.getTableConfiguration(tableId)
           .getTimeInMillis(Property.TABLE_MINC_COMPACT_IDLETIME));
@@ -169,7 +169,7 @@ public class LargestFirstMemoryManager {
     // find the largest and most idle tablets
     for (TabletState ts : tablets) {
       // Make sure that the table still exists
-      if (!tableExists(ts.getExtent().getTableId())) {
+      if (!tableExists(ts.getExtent().tableId())) {
         log.trace("Ignoring extent for deleted table: {}", ts.getExtent());
         continue;
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -22,13 +22,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
@@ -44,61 +44,61 @@ import org.apache.htrace.TraceScope;
 public class CheckForMetadataProblems {
   private static boolean sawProblems = false;
 
-  public static void checkTable(String tablename, TreeSet<KeyExtent> tablets) {
+  private static void checkTable(TableId tableId, TreeSet<KeyExtent> tablets) {
     // sanity check of metadata table entries
     // make sure tablets has no holes, and that it starts and ends w/ null
 
     if (tablets.isEmpty()) {
-      System.out.println("No entries found in metadata table for table " + tablename);
+      System.out.println("No entries found in metadata table for table " + tableId);
       sawProblems = true;
       return;
     }
 
-    if (tablets.first().getPrevEndRow() != null) {
-      System.out.println("First entry for table " + tablename + "- " + tablets.first()
+    if (tablets.first().prevEndRow() != null) {
+      System.out.println("First entry for table " + tableId + "- " + tablets.first()
           + " - has non null prev end row");
       sawProblems = true;
       return;
     }
 
-    if (tablets.last().getEndRow() != null) {
+    if (tablets.last().endRow() != null) {
       System.out.println(
-          "Last entry for table " + tablename + "- " + tablets.last() + " - has non null end row");
+          "Last entry for table " + tableId + "- " + tablets.last() + " - has non null end row");
       sawProblems = true;
       return;
     }
 
     Iterator<KeyExtent> tabIter = tablets.iterator();
-    Text lastEndRow = tabIter.next().getEndRow();
+    Text lastEndRow = tabIter.next().endRow();
     boolean everythingLooksGood = true;
     while (tabIter.hasNext()) {
       KeyExtent tabke = tabIter.next();
       boolean broke = false;
-      if (tabke.getPrevEndRow() == null) {
+      if (tabke.prevEndRow() == null) {
         System.out
-            .println("Table " + tablename + " has null prev end row in middle of table " + tabke);
+            .println("Table " + tableId + " has null prev end row in middle of table " + tabke);
         broke = true;
-      } else if (!tabke.getPrevEndRow().equals(lastEndRow)) {
+      } else if (!tabke.prevEndRow().equals(lastEndRow)) {
         System.out.println(
-            "Table " + tablename + " has a hole " + tabke.getPrevEndRow() + " != " + lastEndRow);
+            "Table " + tableId + " has a hole " + tabke.prevEndRow() + " != " + lastEndRow);
         broke = true;
       }
       if (broke) {
         everythingLooksGood = false;
       }
 
-      lastEndRow = tabke.getEndRow();
+      lastEndRow = tabke.endRow();
     }
     if (everythingLooksGood)
-      System.out.println("All is well for table " + tablename);
+      System.out.println("All is well for table " + tableId);
     else
       sawProblems = true;
   }
 
-  public static void checkMetadataAndRootTableEntries(String tableNameToCheck, ServerUtilOpts opts)
+  private static void checkMetadataAndRootTableEntries(String tableNameToCheck, ServerUtilOpts opts)
       throws Exception {
     System.out.println("Checking table: " + tableNameToCheck);
-    Map<String,TreeSet<KeyExtent>> tables = new HashMap<>();
+    Map<TableId,TreeSet<KeyExtent>> tables = new HashMap<>();
 
     try (AccumuloClient client = Accumulo.newClient().from(opts.getClientProps()).build()) {
 
@@ -120,25 +120,21 @@ public class CheckForMetadataProblems {
 
         count++;
 
-        String tableName =
-            (new KeyExtent(entry.getKey().getRow(), (Text) null)).getTableId().canonical();
+        TableId tableId = KeyExtent.fromMetaRow(entry.getKey().getRow()).tableId();
 
-        TreeSet<KeyExtent> tablets = tables.get(tableName);
+        TreeSet<KeyExtent> tablets = tables.get(tableId);
         if (tablets == null) {
-          Set<Entry<String,TreeSet<KeyExtent>>> es = tables.entrySet();
 
-          for (Entry<String,TreeSet<KeyExtent>> entry2 : es) {
-            checkTable(entry2.getKey(), entry2.getValue());
-          }
+          tables.forEach(CheckForMetadataProblems::checkTable);
 
           tables.clear();
 
           tablets = new TreeSet<>();
-          tables.put(tableName, tablets);
+          tables.put(tableId, tablets);
         }
 
         if (TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
-          KeyExtent tabletKe = new KeyExtent(entry.getKey().getRow(), entry.getValue());
+          KeyExtent tabletKe = KeyExtent.fromMetaPrevRow(entry);
           tablets.add(tabletKe);
           justLoc = false;
         } else if (colf.equals(CurrentLocationColumnFamily.NAME)) {
@@ -156,11 +152,7 @@ public class CheckForMetadataProblems {
       }
     }
 
-    Set<Entry<String,TreeSet<KeyExtent>>> es = tables.entrySet();
-
-    for (Entry<String,TreeSet<KeyExtent>> entry : es) {
-      checkTable(entry.getKey(), entry.getValue());
-    }
+    tables.forEach(CheckForMetadataProblems::checkTable);
 
     if (!sawProblems) {
       System.out.println("No problems found");

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FindOfflineTablets.java
@@ -99,7 +99,7 @@ public class FindOfflineTablets {
     Range range = TabletsSection.getRange();
     if (tableName != null) {
       TableId tableId = Tables.getTableId(context, tableName);
-      range = new KeyExtent(tableId, null, null).toMetadataRange();
+      range = new KeyExtent(tableId, null, null).toMetaRange();
     }
 
     try (MetaDataTableScanner metaScanner =
@@ -116,7 +116,7 @@ public class FindOfflineTablets {
       TabletLocationState locationState = scanner.next();
       TabletState state = locationState.getState(tservers.getCurrentServers());
       if (state != null && state != TabletState.HOSTED
-          && context.getTableManager().getTableState(locationState.extent.getTableId())
+          && context.getTableManager().getTableState(locationState.extent.tableId())
               != TableState.OFFLINE) {
         System.out
             .println(locationState + " is " + state + "  #walogs:" + locationState.walogs.size());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -197,7 +197,7 @@ public class RemoveEntriesForMissingFiles {
       return checkTable(context, RootTable.NAME, TabletsSection.getRange(), fix);
     } else {
       TableId tableId = Tables.getTableId(context, tableName);
-      Range range = new KeyExtent(tableId, null, null).toMetadataRange();
+      Range range = new KeyExtent(tableId, null, null).toMetaRange();
       return checkTable(context, MetadataTable.NAME, range, fix);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ReplicationTableUtil.java
@@ -189,7 +189,7 @@ public class ReplicationTableUtil {
 
   private static Mutation createUpdateMutation(Text row, Value v, KeyExtent extent) {
     Mutation m = new Mutation(row);
-    m.put(ReplicationSection.COLF, new Text(extent.getTableId().canonical()), v);
+    m.put(ReplicationSection.COLF, new Text(extent.tableId().canonical()), v);
     return m;
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -176,7 +176,7 @@ public class TableDiskUsage {
         throw new RuntimeException(e);
       }
       mdScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      mdScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
+      mdScanner.setRange(new KeyExtent(tableId, null, null).toMetaRange());
 
       if (!mdScanner.iterator().hasNext()) {
         emptyTableIds.add(tableId);

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -59,9 +59,9 @@ public class BulkImporterTest {
     fakeMetaData.add(new KeyExtent(tableId, new Text("a"), null));
     for (String part : new String[] {"b", "bm", "c", "cm", "d", "dm", "e", "em", "f", "g", "h", "i",
         "j", "k", "l"}) {
-      fakeMetaData.add(new KeyExtent(tableId, new Text(part), fakeMetaData.last().getEndRow()));
+      fakeMetaData.add(new KeyExtent(tableId, new Text(part), fakeMetaData.last().endRow()));
     }
-    fakeMetaData.add(new KeyExtent(tableId, null, fakeMetaData.last().getEndRow()));
+    fakeMetaData.add(new KeyExtent(tableId, null, fakeMetaData.last().endRow()));
   }
 
   class MockTabletLocator extends TabletLocator {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -245,7 +245,7 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
   }
 
   protected boolean tabletInBounds(KeyExtent ke, TServerInstance tsi) {
-    String tid = ke.getTableId().canonical();
+    String tid = ke.tableId().canonical();
     String host = tsi.host();
     if (tid.equals("1")
         && (host.equals("192.168.0.1") || host.equals("192.168.0.2") || host.equals("192.168.0.3")

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/ChaoticLoadBalancerTest.java
@@ -50,7 +50,7 @@ public class ChaoticLoadBalancerTest {
       TabletServerStatus result = new TabletServerStatus();
       result.tableMap = new HashMap<>();
       for (KeyExtent extent : extents) {
-        TableId table = extent.getTableId();
+        TableId table = extent.tableId();
         TableInfo info = result.tableMap.get(table.canonical());
         if (info == null)
           result.tableMap.put(table.canonical(), info = new TableInfo());
@@ -71,7 +71,7 @@ public class ChaoticLoadBalancerTest {
     public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, TableId table) {
       List<TabletStats> result = new ArrayList<>();
       for (KeyExtent extent : servers.get(tserver).extents) {
-        if (extent.getTableId().equals(table)) {
+        if (extent.tableId().equals(table)) {
           result.add(new TabletStats(extent.toThrift(), null, null, null, 0L, 0., 0., 0));
         }
       }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -54,7 +54,7 @@ public class DefaultLoadBalancerTest {
       TabletServerStatus result = new TabletServerStatus();
       result.tableMap = new HashMap<>();
       for (KeyExtent extent : extents) {
-        TableId tableId = extent.getTableId();
+        TableId tableId = extent.tableId();
         TableInfo info = result.tableMap.get(tableId.canonical());
         if (info == null)
           result.tableMap.put(tableId.canonical(), info = new TableInfo());
@@ -76,7 +76,7 @@ public class DefaultLoadBalancerTest {
     public List<TabletStats> getOnlineTabletsForTable(TServerInstance tserver, TableId table) {
       List<TabletStats> result = new ArrayList<>();
       for (KeyExtent extent : servers.get(tserver).extents) {
-        if (extent.getTableId().equals(table)) {
+        if (extent.tableId().equals(table)) {
           result.add(new TabletStats(extent.toThrift(), null, null, null, 0L, 0., 0., 0));
         }
       }
@@ -272,7 +272,7 @@ public class DefaultLoadBalancerTest {
       for (FakeTServer server : servers.values()) {
         Map<String,Integer> counts = new HashMap<>();
         for (var extent : server.extents) {
-          String t = extent.getTableId().canonical();
+          String t = extent.tableId().canonical();
           counts.putIfAbsent(t, 0);
           counts.put(t, counts.get(t) + 1);
         }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -52,8 +52,8 @@ public class GroupBalancerTest {
 
     @Override
     public String apply(KeyExtent input) {
-      return (input == null || input.getEndRow() == null) ? null
-          : input.getEndRow().toString().substring(0, 2);
+      return (input == null || input.endRow() == null) ? null
+          : input.endRow().toString().substring(0, 2);
     }
   };
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -120,7 +120,7 @@ public class HostRegexTableLoadBalancerReconfigurationTest
     List<TabletStats> tablets = new ArrayList<>();
     // Report assignment information
     for (Entry<KeyExtent,TServerInstance> e : this.assignments.entrySet()) {
-      if (e.getValue().equals(tserver) && e.getKey().getTableId().equals(tableId)) {
+      if (e.getValue().equals(tserver) && e.getKey().tableId().equals(tableId)) {
         TabletStats ts = new TabletStats();
         ts.setExtent(e.getKey().toThrift());
         tablets.add(ts);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -177,7 +177,7 @@ public class TableLoadBalancerTest {
       if (migration.oldServer.equals(svr)) {
         count++;
       }
-      TableId key = migration.tablet.getTableId();
+      TableId key = migration.tablet.tableId();
       movedByTable.put(key, movedByTable.get(key) + 1);
     }
     assertEquals(15, count);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/MergeInfoTest.java
@@ -91,10 +91,10 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_DifferentTables() {
-    expect(keyExtent.getTableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent.tableId()).andReturn(TableId.of("table1"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(TableId.of("table2"));
+    expect(keyExtent2.tableId()).andReturn(TableId.of("table2"));
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.needsToBeChopped(keyExtent2));
@@ -102,9 +102,9 @@ public class MergeInfoTest {
 
   @Test
   public void testNeedsToBeChopped_NotDelete() {
-    expect(keyExtent.getTableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent.tableId()).andReturn(TableId.of("table1"));
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent2.tableId()).andReturn(TableId.of("table1"));
     replay(keyExtent2);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(true);
     replay(keyExtent);
@@ -128,12 +128,12 @@ public class MergeInfoTest {
   }
 
   private void testNeedsToBeChopped_Delete(String prevEndRow, boolean expected) {
-    expect(keyExtent.getTableId()).andReturn(TableId.of("table1"));
-    expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
+    expect(keyExtent.tableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent.endRow()).andReturn(new Text("prev"));
     replay(keyExtent);
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
-    expect(keyExtent2.getTableId()).andReturn(TableId.of("table1"));
-    expect(keyExtent2.getPrevEndRow()).andReturn(prevEndRow != null ? new Text(prevEndRow) : null);
+    expect(keyExtent2.tableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent2.prevEndRow()).andReturn(prevEndRow != null ? new Text(prevEndRow) : null);
     expectLastCall().anyTimes();
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.DELETE);
@@ -153,9 +153,9 @@ public class MergeInfoTest {
   public void testOverlaps_DoesNotNeedChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent.tableId()).andReturn(TableId.of("table1"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(TableId.of("table2"));
+    expect(keyExtent2.tableId()).andReturn(TableId.of("table2"));
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.MERGE);
     assertFalse(mi.overlaps(keyExtent2));
@@ -165,11 +165,11 @@ public class MergeInfoTest {
   public void testOverlaps_NeedsChopping() {
     KeyExtent keyExtent2 = createMock(KeyExtent.class);
     expect(keyExtent.overlaps(keyExtent2)).andReturn(false);
-    expect(keyExtent.getTableId()).andReturn(TableId.of("table1"));
-    expect(keyExtent.getEndRow()).andReturn(new Text("prev"));
+    expect(keyExtent.tableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent.endRow()).andReturn(new Text("prev"));
     replay(keyExtent);
-    expect(keyExtent2.getTableId()).andReturn(TableId.of("table1"));
-    expect(keyExtent2.getPrevEndRow()).andReturn(new Text("prev"));
+    expect(keyExtent2.tableId()).andReturn(TableId.of("table1"));
+    expect(keyExtent2.prevEndRow()).andReturn(new Text("prev"));
     expectLastCall().anyTimes();
     replay(keyExtent2);
     mi = new MergeInfo(keyExtent, MergeInfo.Operation.DELETE);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/TabletLocationStateTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/TabletLocationStateTest.java
@@ -84,7 +84,7 @@ public class TabletLocationStateTest {
 
   @Test(expected = TabletLocationState.BadLocationStateException.class)
   public void testConstruction_FutureAndCurrent() throws Exception {
-    expect(keyExtent.getMetadataEntry()).andReturn(new Text("entry"));
+    expect(keyExtent.toMetaRow()).andReturn(new Text("entry"));
     replay(keyExtent);
     try {
       new TabletLocationState(keyExtent, future, current, last, null, walogs, true);

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
@@ -128,7 +128,7 @@ public class ReplicationTableUtilTest {
     ColumnUpdate col = m.getUpdates().get(0);
 
     assertEquals(ReplicationSection.COLF, new Text(col.getColumnFamily()));
-    assertEquals(extent.getTableId().canonical(), new Text(col.getColumnQualifier()).toString());
+    assertEquals(extent.tableId().canonical(), new Text(col.getColumnQualifier()).toString());
     assertEquals(0, col.getColumnVisibility().length);
     assertArrayEquals(stat.toByteArray(), col.getValue());
   }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -60,7 +60,7 @@ public class GarbageCollectWriteAheadLogsTest {
   private final Map<TServerInstance,List<UUID>> markers2 =
       Collections.singletonMap(server2, Collections.singletonList(id));
   private final Path path = new Path("hdfs://localhost:9000/accumulo/wal/localhost+1234/" + id);
-  private final KeyExtent extent = new KeyExtent(new Text("1<"), new Text(new byte[] {0}));
+  private final KeyExtent extent = KeyExtent.fromMetaRow(new Text("1<"));
   private final Collection<Collection<String>> walogs = Collections.emptyList();
   private final TabletLocationState tabletAssignedToServer1;
   private final TabletLocationState tabletAssignedToServer2;

--- a/server/manager/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Master.java
@@ -459,7 +459,7 @@ public class Master extends AbstractServer
     ServerContext context = getContext();
     synchronized (mergeLock) {
       String path =
-          getZooKeeperRoot() + Constants.ZTABLES + "/" + info.getExtent().getTableId() + "/merge";
+          getZooKeeperRoot() + Constants.ZTABLES + "/" + info.getExtent().tableId() + "/merge";
       info.setState(state);
       if (state.equals(MergeState.NONE)) {
         context.getZooReaderWriter().recursiveDelete(path, NodeMissingPolicy.SKIP);
@@ -523,7 +523,7 @@ public class Master extends AbstractServer
 
   public void clearMigrations(TableId tableId) {
     synchronized (migrations) {
-      migrations.keySet().removeIf(extent -> extent.getTableId().equals(tableId));
+      migrations.keySet().removeIf(extent -> extent.tableId().equals(tableId));
     }
   }
 
@@ -571,7 +571,7 @@ public class Master extends AbstractServer
   }
 
   TabletGoalState getTableGoalState(KeyExtent extent) {
-    TableState tableState = getContext().getTableManager().getTableState(extent.getTableId());
+    TableState tableState = getContext().getTableManager().getTableState(extent.tableId());
     if (tableState == null) {
       return TabletGoalState.DELETED;
     }
@@ -677,7 +677,7 @@ public class Master extends AbstractServer
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
       Set<KeyExtent> found = new HashSet<>();
       for (Entry<Key,Value> entry : scanner) {
-        KeyExtent extent = new KeyExtent(entry.getKey().getRow(), entry.getValue());
+        KeyExtent extent = KeyExtent.fromMetaPrevRow(entry);
         if (migrations.containsKey(extent)) {
           found.add(extent);
         }

--- a/server/manager/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -153,7 +153,7 @@ abstract class TabletGroupWatcher extends Daemon {
         Map<TableId,MergeStats> currentMerges = new HashMap<>();
         for (MergeInfo merge : master.merges()) {
           if (merge.getExtent() != null) {
-            currentMerges.put(merge.getExtent().getTableId(), new MergeStats(merge));
+            currentMerges.put(merge.getExtent().tableId(), new MergeStats(merge));
           }
         }
 
@@ -195,7 +195,7 @@ abstract class TabletGroupWatcher extends Daemon {
           }
 
           // ignore entries for tables that do not exist in zookeeper
-          if (master.getTableManager().getTableState(tls.extent.getTableId()) == null)
+          if (master.getTableManager().getTableState(tls.extent.tableId()) == null)
             continue;
 
           // Don't overwhelm the tablet servers with work
@@ -211,7 +211,7 @@ abstract class TabletGroupWatcher extends Daemon {
             unloaded = 0;
             eventListener.waitForEvents(Master.TIME_TO_WAIT_BETWEEN_SCANS);
           }
-          TableId tableId = tls.extent.getTableId();
+          TableId tableId = tls.extent.tableId();
           TableConfiguration tableConf = this.master.getContext().getTableConfiguration(tableId);
 
           MergeStats mergeStats = mergeStatsCache.get(tableId);
@@ -402,7 +402,7 @@ abstract class TabletGroupWatcher extends Daemon {
 
   private void cancelOfflineTableMigrations(TabletLocationState tls) {
     TServerInstance dest = this.master.migrations.get(tls.extent);
-    TableState tableState = master.getTableManager().getTableState(tls.extent.getTableId());
+    TableState tableState = master.getTableManager().getTableState(tls.extent.tableId());
     if (dest != null && tableState == TableState.OFFLINE) {
       this.master.migrations.remove(tls.extent);
     }
@@ -416,7 +416,7 @@ abstract class TabletGroupWatcher extends Daemon {
     try {
       Map<Key,Value> future = new HashMap<>();
       Map<Key,Value> assigned = new HashMap<>();
-      KeyExtent extent = new KeyExtent(row, new Value(new byte[] {0}));
+      KeyExtent extent = KeyExtent.fromMetaRow(row);
       String table = MetadataTable.NAME;
       if (extent.isMeta())
         table = RootTable.NAME;
@@ -487,14 +487,14 @@ abstract class TabletGroupWatcher extends Daemon {
     // Does this extent cover the end points of the delete?
     KeyExtent range = info.getExtent();
     if (tls.extent.overlaps(range)) {
-      for (Text splitPoint : new Text[] {range.getPrevEndRow(), range.getEndRow()}) {
+      for (Text splitPoint : new Text[] {range.prevEndRow(), range.endRow()}) {
         if (splitPoint == null)
           continue;
         if (!tls.extent.contains(splitPoint))
           continue;
-        if (splitPoint.equals(tls.extent.getEndRow()))
+        if (splitPoint.equals(tls.extent.endRow()))
           continue;
-        if (splitPoint.equals(tls.extent.getPrevEndRow()))
+        if (splitPoint.equals(tls.extent.prevEndRow()))
           continue;
         try {
           TServerConnection conn;
@@ -581,21 +581,21 @@ abstract class TabletGroupWatcher extends Daemon {
     Master.log.debug("Deleting tablets for {}", extent);
     MetadataTime metadataTime = null;
     KeyExtent followingTablet = null;
-    if (extent.getEndRow() != null) {
-      Key nextExtent = new Key(extent.getEndRow()).followingKey(PartialKey.ROW);
-      followingTablet = getHighTablet(
-          new KeyExtent(extent.getTableId(), nextExtent.getRow(), extent.getEndRow()));
+    if (extent.endRow() != null) {
+      Key nextExtent = new Key(extent.endRow()).followingKey(PartialKey.ROW);
+      followingTablet =
+          getHighTablet(new KeyExtent(extent.tableId(), nextExtent.getRow(), extent.endRow()));
       Master.log.debug("Found following tablet {}", followingTablet);
     }
     try {
       AccumuloClient client = this.master.getContext();
-      Text start = extent.getPrevEndRow();
+      Text start = extent.prevEndRow();
       if (start == null) {
         start = new Text();
       }
       Master.log.debug("Making file deletion entries for {}", extent);
-      Range deleteRange = new Range(TabletsSection.getRow(extent.getTableId(), start), false,
-          TabletsSection.getRow(extent.getTableId(), extent.getEndRow()), true);
+      Range deleteRange = new Range(TabletsSection.encodeRow(extent.tableId(), start), false,
+          TabletsSection.encodeRow(extent.tableId(), extent.endRow()), true);
       Scanner scanner = client.createScanner(targetSystemTable, Authorizations.EMPTY);
       scanner.setRange(deleteRange);
       ServerColumnFamily.DIRECTORY_COLUMN.fetch(scanner);
@@ -617,7 +617,7 @@ abstract class TabletGroupWatcher extends Daemon {
           throw new IllegalStateException(
               "Tablet " + key.getRow() + " is assigned during a merge!");
         } else if (ServerColumnFamily.DIRECTORY_COLUMN.hasColumns(key)) {
-          String path = GcVolumeUtil.getDeleteTabletOnAllVolumesUri(extent.getTableId(),
+          String path = GcVolumeUtil.getDeleteTabletOnAllVolumesUri(extent.tableId(),
               entry.getValue().toString());
           datafiles.add(path);
           if (datafiles.size() > 1000) {
@@ -635,12 +635,12 @@ abstract class TabletGroupWatcher extends Daemon {
       }
 
       if (followingTablet != null) {
-        Master.log.debug("Updating prevRow of {} to {}", followingTablet, extent.getPrevEndRow());
+        Master.log.debug("Updating prevRow of {} to {}", followingTablet, extent.prevEndRow());
         bw = client.createBatchWriter(targetSystemTable, new BatchWriterConfig());
         try {
-          Mutation m = new Mutation(followingTablet.getMetadataEntry());
+          Mutation m = new Mutation(followingTablet.toMetaRow());
           TabletColumnFamily.PREV_ROW_COLUMN.put(m,
-              KeyExtent.encodePrevEndRow(extent.getPrevEndRow()));
+              TabletColumnFamily.encodePrevEndRow(extent.prevEndRow()));
           ChoppedColumnFamily.CHOPPED_COLUMN.putDelete(m);
           bw.addMutation(m);
           bw.flush();
@@ -649,8 +649,7 @@ abstract class TabletGroupWatcher extends Daemon {
         }
       } else {
         // Recreate the default tablet to hold the end of the table
-        MetadataTableUtil.addTablet(
-            new KeyExtent(extent.getTableId(), null, extent.getPrevEndRow()),
+        MetadataTableUtil.addTablet(new KeyExtent(extent.tableId(), null, extent.prevEndRow()),
             ServerColumnFamily.DEFAULT_TABLET_DIR_NAME, master.getContext(), metadataTime.getType(),
             this.master.masterLock);
       }
@@ -665,13 +664,13 @@ abstract class TabletGroupWatcher extends Daemon {
     KeyExtent stop = getHighTablet(range);
     Master.log.debug("Highest tablet is {}", stop);
     Value firstPrevRowValue = null;
-    Text stopRow = stop.getMetadataEntry();
-    Text start = range.getPrevEndRow();
+    Text stopRow = stop.toMetaRow();
+    Text start = range.prevEndRow();
     if (start == null) {
       start = new Text();
     }
     Range scanRange =
-        new Range(TabletsSection.getRow(range.getTableId(), start), false, stopRow, false);
+        new Range(TabletsSection.encodeRow(range.tableId(), start), false, stopRow, false);
     String targetSystemTable = MetadataTable.NAME;
     if (range.isMeta()) {
       targetSystemTable = RootTable.NAME;
@@ -705,7 +704,7 @@ abstract class TabletGroupWatcher extends Daemon {
               TabletTime.maxMetadataTime(maxLogicalTime, MetadataTime.parse(value.toString()));
         } else if (ServerColumnFamily.DIRECTORY_COLUMN.hasColumns(key)) {
           String uri =
-              GcVolumeUtil.getDeleteTabletOnAllVolumesUri(range.getTableId(), value.toString());
+              GcVolumeUtil.getDeleteTabletOnAllVolumesUri(range.tableId(), value.toString());
           bw.addMutation(ServerAmpleImpl.createDeleteMutation(uri));
         }
       }
@@ -738,8 +737,9 @@ abstract class TabletGroupWatcher extends Daemon {
         return;
       }
 
-      stop.setPrevEndRow(KeyExtent.decodePrevEndRow(firstPrevRowValue));
-      Mutation updatePrevRow = stop.getPrevRowUpdateMutation();
+      stop = new KeyExtent(stop.tableId(), stop.endRow(),
+          TabletColumnFamily.decodePrevEndRow(firstPrevRowValue));
+      Mutation updatePrevRow = TabletColumnFamily.createPrevRowMutation(stop);
       Master.log.debug("Setting the prevRow for last tablet: {}", stop);
       bw.addMutation(updatePrevRow);
       bw.flush();
@@ -795,16 +795,15 @@ abstract class TabletGroupWatcher extends Daemon {
       Scanner scanner = client.createScanner(range.isMeta() ? RootTable.NAME : MetadataTable.NAME,
           Authorizations.EMPTY);
       TabletColumnFamily.PREV_ROW_COLUMN.fetch(scanner);
-      KeyExtent start = new KeyExtent(range.getTableId(), range.getEndRow(), null);
-      scanner.setRange(new Range(start.getMetadataEntry(), null));
+      KeyExtent start = new KeyExtent(range.tableId(), range.endRow(), null);
+      scanner.setRange(new Range(start.toMetaRow(), null));
       Iterator<Entry<Key,Value>> iterator = scanner.iterator();
       if (!iterator.hasNext()) {
         throw new AccumuloException("No last tablet for a merge " + range);
       }
       Entry<Key,Value> entry = iterator.next();
-      KeyExtent highTablet =
-          new KeyExtent(entry.getKey().getRow(), KeyExtent.decodePrevEndRow(entry.getValue()));
-      if (!highTablet.getTableId().equals(range.getTableId())) {
+      KeyExtent highTablet = KeyExtent.fromMetaPrevRow(entry);
+      if (!highTablet.tableId().equals(range.tableId())) {
         throw new AccumuloException("No last tablet for merge " + range + " " + highTablet);
       }
       return highTablet;

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CopyFailed.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer1/CopyFailed.java
@@ -121,7 +121,7 @@ class CopyFailed extends MasterRepo {
     AccumuloClient client = master.getContext();
     try (Scanner mscanner =
         new IsolatedScanner(client.createScanner(MetadataTable.NAME, Authorizations.EMPTY))) {
-      mscanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
+      mscanner.setRange(new KeyExtent(tableId, null, null).toMetaRange());
       mscanner.fetchColumnFamily(BulkFileColumnFamily.NAME);
 
       for (Entry<Key,Value> entry : mscanner) {

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/LoadFiles.java
@@ -279,7 +279,7 @@ class LoadFiles extends MasterRepo {
           continue;
         }
 
-        Mutation mutation = new Mutation(tablet.getExtent().getMetadataEntry());
+        Mutation mutation = new Mutation(tablet.getExtent().toMetaRow());
 
         for (final Bulk.FileInfo fileInfo : files) {
           String fullPath = new Path(bulkDir, fileInfo.getFileName()).toString();
@@ -318,7 +318,7 @@ class LoadFiles extends MasterRepo {
     PeekingIterator<Map.Entry<KeyExtent,Bulk.Files>> lmi = new PeekingIterator<>(loadMapIter);
     Map.Entry<KeyExtent,Bulk.Files> loadMapEntry = lmi.peek();
 
-    Text startRow = loadMapEntry.getKey().getPrevEndRow();
+    Text startRow = loadMapEntry.getKey().prevEndRow();
 
     Iterator<TabletMetadata> tabletIter =
         TabletsMetadata.builder().forTable(tableId).overlapping(startRow, null).checkConsistency()
@@ -367,7 +367,7 @@ class LoadFiles extends MasterRepo {
       int cmp;
 
       // skip tablets until we find the prevEndRow of loadRange
-      while ((cmp = PREV_COMP.compare(currTablet.getPrevEndRow(), loadRange.getPrevEndRow())) < 0) {
+      while ((cmp = PREV_COMP.compare(currTablet.getPrevEndRow(), loadRange.prevEndRow())) < 0) {
         currTablet = tabletIter.next();
       }
 
@@ -380,7 +380,7 @@ class LoadFiles extends MasterRepo {
 
       // find the remaining tablets within the loadRange by
       // adding tablets to the list until the endRow matches the loadRange
-      while ((cmp = END_COMP.compare(currTablet.getEndRow(), loadRange.getEndRow())) < 0) {
+      while ((cmp = END_COMP.compare(currTablet.getEndRow(), loadRange.endRow())) < 0) {
         currTablet = tabletIter.next();
         tablets.add(currTablet);
       }

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImport.java
@@ -117,7 +117,7 @@ public class PrepBulkImport extends MasterRepo {
       TabletIterFactory tabletIterFactory, int maxNumTablets, long tid) throws Exception {
     var currRange = lmi.next();
 
-    Text startRow = currRange.getKey().getPrevEndRow();
+    Text startRow = currRange.getKey().prevEndRow();
 
     Iterator<KeyExtent> tabletIter = tabletIterFactory.newTabletIter(startRow);
 
@@ -126,8 +126,8 @@ public class PrepBulkImport extends MasterRepo {
     var fileCounts = new HashMap<String,Integer>();
     int count;
 
-    if (!tabletIter.hasNext() && equals(KeyExtent::getPrevEndRow, currTablet, currRange.getKey())
-        && equals(KeyExtent::getEndRow, currTablet, currRange.getKey()))
+    if (!tabletIter.hasNext() && equals(KeyExtent::prevEndRow, currTablet, currRange.getKey())
+        && equals(KeyExtent::endRow, currTablet, currRange.getKey()))
       currRange = null;
 
     while (tabletIter.hasNext()) {
@@ -139,21 +139,20 @@ public class PrepBulkImport extends MasterRepo {
         currRange = lmi.next();
       }
 
-      while (!equals(KeyExtent::getPrevEndRow, currTablet, currRange.getKey())
+      while (!equals(KeyExtent::prevEndRow, currTablet, currRange.getKey())
           && tabletIter.hasNext()) {
         currTablet = tabletIter.next();
       }
 
-      boolean matchedPrevRow = equals(KeyExtent::getPrevEndRow, currTablet, currRange.getKey());
+      boolean matchedPrevRow = equals(KeyExtent::prevEndRow, currTablet, currRange.getKey());
       count = matchedPrevRow ? 1 : 0;
 
-      while (!equals(KeyExtent::getEndRow, currTablet, currRange.getKey())
-          && tabletIter.hasNext()) {
+      while (!equals(KeyExtent::endRow, currTablet, currRange.getKey()) && tabletIter.hasNext()) {
         currTablet = tabletIter.next();
         count++;
       }
 
-      if (!matchedPrevRow || !equals(KeyExtent::getEndRow, currTablet, currRange.getKey())) {
+      if (!matchedPrevRow || !equals(KeyExtent::endRow, currTablet, currRange.getKey())) {
         break;
       }
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
@@ -87,7 +88,8 @@ class PopulateMetadata extends MasterRepo {
     Text prevSplit = null;
     Value dirValue;
     for (Text split : Iterables.concat(splits, Collections.singleton(null))) {
-      Mutation mut = new KeyExtent(tableId, split, prevSplit).getPrevRowUpdateMutation();
+      Mutation mut =
+          TabletColumnFamily.createPrevRowMutation(new KeyExtent(tableId, split, prevSplit));
       dirValue = (split == null) ? new Value(ServerColumnFamily.DEFAULT_TABLET_DIR_NAME)
           : new Value(data.get(split));
       ServerColumnFamily.DIRECTORY_COLUMN.put(mut, dirValue);

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/delete/CleanUp.java
@@ -92,7 +92,7 @@ class CleanUp extends MasterRepo {
     }
 
     boolean done = true;
-    Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();
+    Range tableRange = new KeyExtent(tableId, null, null).toMetaRange();
     Scanner scanner = master.getContext().createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     MetaDataTableScanner.configureScanner(scanner, master);
     scanner.setRange(tableRange);

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableExport/WriteExportFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableExport/WriteExportFiles.java
@@ -103,7 +103,7 @@ class WriteExportFiles extends MasterRepo {
     checkOffline(master.getContext());
 
     Scanner metaScanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    metaScanner.setRange(new KeyExtent(tableInfo.tableID, null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableInfo.tableID, null, null).toMetaRange());
 
     // scan for locations
     metaScanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
@@ -228,7 +228,7 @@ class WriteExportFiles extends MasterRepo {
     metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
     TabletColumnFamily.PREV_ROW_COLUMN.fetch(metaScanner);
     ServerColumnFamily.TIME_COLUMN.fetch(metaScanner);
-    metaScanner.setRange(new KeyExtent(tableID, null, null).toMetadataRange());
+    metaScanner.setRange(new KeyExtent(tableID, null, null).toMetaRange());
 
     for (Entry<Key,Value> entry : metaScanner) {
       entry.getKey().write(dataOut);

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableImport/PopulateMetadataTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/tableImport/PopulateMetadataTable.java
@@ -125,8 +125,8 @@ class PopulateMetadataTable extends MasterRepo {
             key.readFields(in);
             val.readFields(in);
 
-            Text endRow = new KeyExtent(key.getRow(), (Text) null).getEndRow();
-            Text metadataRow = new KeyExtent(tableInfo.tableId, endRow, null).getMetadataEntry();
+            Text endRow = KeyExtent.fromMetaRow(key.getRow()).endRow();
+            Text metadataRow = new KeyExtent(tableInfo.tableId, endRow, null).toMetaRow();
 
             Text cq;
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -162,7 +162,7 @@ public class Upgrader9to10 implements Upgrader {
 
       UpgradeMutator tabletMutator = new UpgradeMutator(ctx);
 
-      tabletMutator.putPrevEndRow(RootTable.EXTENT.getPrevEndRow());
+      tabletMutator.putPrevEndRow(RootTable.EXTENT.prevEndRow());
 
       tabletMutator.putDirName(upgradeDirColumn(dir));
 
@@ -649,7 +649,7 @@ public class Upgrader9to10 implements Upgrader {
       return new Path(prefix + metadataEntry.substring(3));
     } else {
       // resolve style "/t-0003/C0004.rf"
-      TableId tableId = KeyExtent.tableOfMetadataRow(key.getRow());
+      TableId tableId = KeyExtent.fromMetaRow(key.getRow()).tableId();
       return new Path(prefix + tableId.canonical() + metadataEntry);
     }
   }

--- a/server/manager/src/test/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/master/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -145,7 +145,7 @@ public class PrepBulkImportTest {
   }
 
   static String toRangeStrings(Collection<KeyExtent> extents) {
-    return extents.stream().map(ke -> "(" + ke.getPrevEndRow() + "," + ke.getEndRow() + "]")
+    return extents.stream().map(ke -> "(" + ke.prevEndRow() + "," + ke.endRow() + "]")
         .collect(Collectors.joining(","));
   }
 
@@ -201,11 +201,11 @@ public class PrepBulkImportTest {
 
       Set<String> rows = new HashSet<>();
       for (KeyExtent ke : loadRanges) {
-        if (ke.getPrevEndRow() != null) {
-          rows.add(ke.getPrevEndRow().toString());
+        if (ke.prevEndRow() != null) {
+          rows.add(ke.prevEndRow().toString());
         }
-        if (ke.getEndRow() != null) {
-          rows.add(ke.getEndRow().toString());
+        if (ke.endRow() != null) {
+          rows.add(ke.endRow().toString());
         }
       }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
@@ -150,8 +150,8 @@ public class TablesResource {
       String systemTableName =
           MetadataTable.ID.equals(tableId) ? RootTable.NAME : MetadataTable.NAME;
       MetaDataTableScanner scanner = new MetaDataTableScanner(monitor.getContext(),
-          new Range(TabletsSection.getRow(tableId, new Text()),
-              TabletsSection.getRow(tableId, null)),
+          new Range(TabletsSection.encodeRow(tableId, new Text()),
+              TabletsSection.encodeRow(tableId, null)),
           systemTableName);
 
       while (scanner.hasNext()) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -322,11 +322,11 @@ public class TabletServerResource {
       ActionStatsUpdator.update(total.minors, info.minors);
       ActionStatsUpdator.update(total.majors, info.majors);
 
-      KeyExtent extent = new KeyExtent(info.extent);
-      TableId tableId = extent.getTableId();
+      KeyExtent extent = KeyExtent.fromThrift(info.extent);
+      TableId tableId = extent.tableId();
       MessageDigest digester = MessageDigest.getInstance(Constants.PW_HASH_ALGORITHM);
-      if (extent.getEndRow() != null && extent.getEndRow().getLength() > 0) {
-        digester.update(extent.getEndRow().getBytes(), 0, extent.getEndRow().getLength());
+      if (extent.endRow() != null && extent.endRow().getLength() > 0) {
+        digester.update(extent.endRow().getBytes(), 0, extent.endRow().getLength());
       }
       String obscuredExtent = Base64.getEncoder().encodeToString(digester.digest());
       String displayExtent = String.format("[%s]", obscuredExtent);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -196,7 +196,7 @@ class AssignmentHandler implements Runnable {
         log.warn("{}", e.getMessage());
       }
 
-      TableId tableId = extent.getTableId();
+      TableId tableId = extent.tableId();
       ProblemReports.getInstance(server.getContext()).report(new ProblemReport(tableId, TABLET_LOAD,
           extent.getUUID().toString(), server.getClientAddressString(), e));
     } finally {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -312,13 +312,13 @@ public class FileManager {
         // log.debug("Opening "+file + " path " + path);
         FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
             .forFile(path.toString(), ns, ns.getConf(), context.getCryptoService())
-            .withTableConfiguration(context.getTableConfiguration(tablet.getTableId()))
+            .withTableConfiguration(context.getTableConfiguration(tablet.tableId()))
             .withCacheProvider(cacheProvider).withFileLenCache(fileLenCache).build();
         readersReserved.put(reader, file);
       } catch (Exception e) {
 
         ProblemReports.getInstance(context)
-            .report(new ProblemReport(tablet.getTableId(), ProblemType.FILE_READ, file, e));
+            .report(new ProblemReport(tablet.tableId(), ProblemType.FILE_READ, file, e));
 
         if (continueOnFailure) {
           // release the permit for the file that failed to open
@@ -474,7 +474,7 @@ public class FileManager {
       this.tablet = tablet;
       this.cacheProvider = cacheProvider;
 
-      continueOnFailure = context.getTableConfiguration(tablet.getTableId())
+      continueOnFailure = context.getTableConfiguration(tablet.tableId())
           .getBoolean(Property.TABLE_FAILURES_IGNORE);
 
       if (tablet.isMeta()) {
@@ -534,10 +534,10 @@ public class FileManager {
           FileDataSource fds = new FileDataSource(filename, source);
           dataSources.add(fds);
           SourceSwitchingIterator ssi = new SourceSwitchingIterator(fds);
-          iter = new ProblemReportingIterator(context, tablet.getTableId(), filename,
+          iter = new ProblemReportingIterator(context, tablet.tableId(), filename,
               continueOnFailure, ssi);
         } else {
-          iter = new ProblemReportingIterator(context, tablet.getTableId(), filename,
+          iter = new ProblemReportingIterator(context, tablet.tableId(), filename,
               continueOnFailure, source);
         }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1046,7 +1046,7 @@ public class TabletServer extends AbstractServer {
     final Map<String,TableInfo> tables = new HashMap<>();
 
     getOnlineTablets().forEach((ke, tablet) -> {
-      String tableId = ke.getTableId().canonical();
+      String tableId = ke.tableId().canonical();
       TableInfo table = tables.get(tableId);
       if (table == null) {
         table = new TableInfo();
@@ -1106,7 +1106,7 @@ public class TabletServer extends AbstractServer {
     }
 
     for (KeyExtent extent : offlineTabletsCopy) {
-      String tableId = extent.getTableId().canonical();
+      String tableId = extent.tableId().canonical();
       TableInfo table = tables.get(tableId);
       if (table == null) {
         table = new TableInfo();
@@ -1190,7 +1190,7 @@ public class TabletServer extends AbstractServer {
   }
 
   public TableConfiguration getTableConfiguration(KeyExtent extent) {
-    return getContext().getTableConfiguration(extent.getTableId());
+    return getContext().getTableConfiguration(extent.tableId());
   }
 
   public DfsLogger.ServerResources getServerConfig() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -885,11 +885,11 @@ public class TabletServerResourceManager {
       if (executor == null) {
         log.warn(
             "For table id {}, {} dispatched to non-existant executor {} Using default executor.",
-            tablet.getTableId(), dispatcher.getClass().getName(), prefs.getExecutorName());
+            tablet.tableId(), dispatcher.getClass().getName(), prefs.getExecutorName());
         executor = scanExecutors.get(SimpleScanDispatcher.DEFAULT_SCAN_EXECUTOR_NAME);
       } else if ("meta".equals(prefs.getExecutorName())) {
         log.warn("For table id {}, {} dispatched to meta executor. Using default executor.",
-            tablet.getTableId(), dispatcher.getClass().getName());
+            tablet.tableId(), dispatcher.getClass().getName());
         executor = scanExecutors.get(SimpleScanDispatcher.DEFAULT_SCAN_EXECUTOR_NAME);
       }
       executor.execute(task);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -69,8 +69,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
       case DEFINE_TABLET:
         seq = in.readLong();
         tabletId = in.readInt();
-        tablet = new KeyExtent();
-        tablet.readFields(in);
+        tablet = KeyExtent.readFrom(in);
         break;
       case MANY_MUTATIONS:
         seq = in.readLong();
@@ -109,7 +108,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
       case DEFINE_TABLET:
         out.writeLong(seq);
         out.writeInt(tabletId);
-        tablet.write(out);
+        tablet.writeTo(out);
         break;
       case MANY_MUTATIONS:
         out.writeLong(seq);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -606,7 +606,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
 
       switch (key.event) {
         case DEFINE_TABLET:
-          if (target.getSourceTableId().equals(key.tablet.getTableId())) {
+          if (target.getSourceTableId().equals(key.tablet.tableId())) {
             desiredTids.add(key.tabletId);
           }
           break;
@@ -657,7 +657,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
       switch (key.event) {
         case DEFINE_TABLET:
           // For new DEFINE_TABLETs, we also need to record the new tids we see
-          if (target.getSourceTableId().equals(key.tablet.getTableId())) {
+          if (target.getSourceTableId().equals(key.tablet.tableId())) {
             desiredTids.add(key.tabletId);
           }
           break;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/MultiScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/MultiScanSession.java
@@ -57,7 +57,7 @@ public class MultiScanSession extends ScanSession {
 
   @Override
   public TableId getTableId() {
-    return threadPoolExtent.getTableId();
+    return threadPoolExtent.tableId();
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -320,11 +320,11 @@ public class SessionManager {
       if (session instanceof SingleScanSession) {
         SingleScanSession ss = (SingleScanSession) session;
         nbt = ss.nextBatchTask;
-        tableID = ss.extent.getTableId();
+        tableID = ss.extent.tableId();
       } else if (session instanceof MultiScanSession) {
         MultiScanSession mss = (MultiScanSession) session;
         nbt = mss.lookupTask;
-        tableID = mss.threadPoolExtent.getTableId();
+        tableID = mss.threadPoolExtent.tableId();
       }
 
       if (nbt == null)
@@ -389,7 +389,7 @@ public class SessionManager {
 
         var params = ss.scanParams;
         ActiveScan activeScan =
-            new ActiveScan(ss.client, ss.getUser(), ss.extent.getTableId().canonical(),
+            new ActiveScan(ss.client, ss.getUser(), ss.extent.tableId().canonical(),
                 ct - ss.startTime, ct - ss.lastAccessTime, ScanType.SINGLE, state,
                 ss.extent.toThrift(), Translator.translate(params.getColumnSet(), Translators.CT),
                 params.getSsiList(), params.getSsio(),
@@ -425,8 +425,8 @@ public class SessionManager {
 
         var params = mss.scanParams;
         activeScans.add(new ActiveScan(mss.client, mss.getUser(),
-            mss.threadPoolExtent.getTableId().canonical(), ct - mss.startTime,
-            ct - mss.lastAccessTime, ScanType.BATCH, state, mss.threadPoolExtent.toThrift(),
+            mss.threadPoolExtent.tableId().canonical(), ct - mss.startTime, ct - mss.lastAccessTime,
+            ScanType.BATCH, state, mss.threadPoolExtent.toThrift(),
             Translator.translate(params.getColumnSet(), Translators.CT), params.getSsiList(),
             params.getSsio(), params.getAuthorizations().getAuthorizationsBB(),
             params.getClassLoaderContext()));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SingleScanSession.java
@@ -52,7 +52,7 @@ public class SingleScanSession extends ScanSession {
 
   @Override
   public TableId getTableId() {
-    return extent.getTableId();
+    return extent.tableId();
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -392,7 +392,7 @@ public class CompactableImpl implements Compactable {
 
   @Override
   public TableId getTableId() {
-    return getExtent().getTableId();
+    return getExtent().tableId();
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -237,7 +237,7 @@ public class CompactableUtils {
 
       @Override
       public TableId getTableId() {
-        return tablet.getExtent().getTableId();
+        return tablet.getExtent().tableId();
       }
     });
 
@@ -254,7 +254,7 @@ public class CompactableUtils {
 
       @Override
       public TableId getTableId() {
-        return tablet.getExtent().getTableId();
+        return tablet.getExtent().tableId();
       }
     });
 
@@ -296,7 +296,7 @@ public class CompactableUtils {
 
       @Override
       public TableId getTableId() {
-        return tablet.getExtent().getTableId();
+        return tablet.getExtent().tableId();
       }
     });
 
@@ -338,7 +338,7 @@ public class CompactableUtils {
 
       @Override
       public TableId getTableId() {
-        return tablet.getExtent().getTableId();
+        return tablet.getExtent().tableId();
       }
 
       @Override
@@ -491,11 +491,11 @@ public class CompactableUtils {
         var stratClassName = tconf.get(Property.TABLE_COMPACTION_STRATEGY);
 
         try {
-          strategyWarningsCache.get(tablet.getExtent().getTableId(), () -> {
+          strategyWarningsCache.get(tablet.getExtent().tableId(), () -> {
             log.warn(
                 "Table id {} set {} to {}.  Compaction strategies are deprecated.  See the Javadoc"
                     + " for class {} for more details.",
-                tablet.getExtent().getTableId(), Property.TABLE_COMPACTION_STRATEGY.getKey(),
+                tablet.getExtent().tableId(), Property.TABLE_COMPACTION_STRATEGY.getKey(),
                 stratClassName, CompactionStrategyConfig.class.getName());
             return true;
           });

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -301,7 +301,7 @@ public class Compactor implements Callable<CompactionStats> {
         readers.add(reader);
 
         SortedKeyValueIterator<Key,Value> iter = new ProblemReportingIterator(context,
-            extent.getTableId(), mapFile.getPathStr(), false, reader);
+            extent.tableId(), mapFile.getPathStr(), false, reader);
 
         if (filesToCompact.get(mapFile).isTimeSet()) {
           iter = new TimeSettingIterator(iter, filesToCompact.get(mapFile).getTime());
@@ -312,7 +312,7 @@ public class Compactor implements Callable<CompactionStats> {
       } catch (Throwable e) {
 
         ProblemReports.getInstance(context).report(
-            new ProblemReport(extent.getTableId(), ProblemType.FILE_READ, mapFile.getPathStr(), e));
+            new ProblemReport(extent.tableId(), ProblemType.FILE_READ, mapFile.getPathStr(), e));
 
         log.warn("Some problem opening map file {} {}", mapFile, e.getMessage(), e);
         // failed to open some map file... close the ones that were opened
@@ -358,10 +358,10 @@ public class Compactor implements Callable<CompactionStats> {
       TabletIteratorEnvironment iterEnv;
       if (env.getIteratorScope() == IteratorScope.majc)
         iterEnv = new TabletIteratorEnvironment(context, IteratorScope.majc, !propogateDeletes,
-            acuTableConf, getExtent().getTableId(), getMajorCompactionReason());
+            acuTableConf, getExtent().tableId(), getMajorCompactionReason());
       else if (env.getIteratorScope() == IteratorScope.minc)
         iterEnv = new TabletIteratorEnvironment(context, IteratorScope.minc, acuTableConf,
-            getExtent().getTableId());
+            getExtent().tableId());
       else
         throw new IllegalArgumentException();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -206,7 +206,7 @@ class DatafileManager {
       boolean inTheRightDirectory = false;
       Path parent = tpath.getPath().getParent().getParent();
       for (String tablesDir : ServerConstants.getTablesDirs(tablet.getContext())) {
-        if (parent.equals(new Path(tablesDir, tablet.getExtent().getTableId().canonical()))) {
+        if (parent.equals(new Path(tablesDir, tablet.getExtent().tableId().canonical()))) {
           inTheRightDirectory = true;
           break;
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -83,10 +83,10 @@ public class MinorCompactor extends Compactor {
 
   private boolean isTableDeleting() {
     try {
-      return Tables.getTableState(tabletServer.getContext(), extent.getTableId())
+      return Tables.getTableState(tabletServer.getContext(), extent.tableId())
           == TableState.DELETING;
     } catch (Exception e) {
-      log.warn("Failed to determine if table " + extent.getTableId() + " was deleting ", e);
+      log.warn("Failed to determine if table " + extent.tableId() + " was deleting ", e);
       return false; // can not get positive confirmation that its deleting.
     }
   }
@@ -94,7 +94,7 @@ public class MinorCompactor extends Compactor {
   @Override
   protected Map<String,Set<ByteSequence>> getLocalityGroups(AccumuloConfiguration acuTableConf)
       throws IOException {
-    return LocalityGroupUtil.getLocalityGroupsIgnoringErrors(acuTableConf, extent.getTableId());
+    return LocalityGroupUtil.getLocalityGroupsIgnoringErrors(acuTableConf, extent.tableId());
   }
 
   @Override
@@ -119,23 +119,23 @@ public class MinorCompactor extends Compactor {
           // (int)(map.size()/((t2 - t1)/1000.0)), (t2 - t1)/1000.0, estimatedSizeInBytes()));
 
           if (reportedProblem) {
-            ProblemReports.getInstance(tabletServer.getContext()).deleteProblemReport(
-                getExtent().getTableId(), ProblemType.FILE_WRITE, outputFileName);
+            ProblemReports.getInstance(tabletServer.getContext())
+                .deleteProblemReport(getExtent().tableId(), ProblemType.FILE_WRITE, outputFileName);
           }
 
           return ret;
         } catch (IOException | UnsatisfiedLinkError e) {
           log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), outputFileName);
-          ProblemReports.getInstance(tabletServer.getContext()).report(new ProblemReport(
-              getExtent().getTableId(), ProblemType.FILE_WRITE, outputFileName, e));
+          ProblemReports.getInstance(tabletServer.getContext()).report(
+              new ProblemReport(getExtent().tableId(), ProblemType.FILE_WRITE, outputFileName, e));
           reportedProblem = true;
         } catch (RuntimeException | NoClassDefFoundError e) {
           // if this is coming from a user iterator, it is possible that the user could change the
           // iterator config and that the
           // minor compaction would succeed
           log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), outputFileName, e);
-          ProblemReports.getInstance(tabletServer.getContext()).report(new ProblemReport(
-              getExtent().getTableId(), ProblemType.FILE_WRITE, outputFileName, e));
+          ProblemReports.getInstance(tabletServer.getContext()).report(
+              new ProblemReport(getExtent().tableId(), ProblemType.FILE_WRITE, outputFileName, e));
           reportedProblem = true;
         } catch (CompactionCanceledException e) {
           throw new IllegalStateException(e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -176,7 +176,7 @@ class ScanDataSource implements DataSource {
 
     TabletIteratorEnvironment iterEnv =
         new TabletIteratorEnvironment(tablet.getTabletServer().getContext(), IteratorScope.scan,
-            tablet.getTableConfiguration(), tablet.getExtent().getTableId(), fileManager, files,
+            tablet.getTableConfiguration(), tablet.getExtent().tableId(), fileManager, files,
             scanParams.getAuthorizations(), samplerConfig, new ArrayList<>());
 
     statsIterator =

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletMemory.java
@@ -45,7 +45,7 @@ class TabletMemory implements Closeable {
     this.tablet = tablet;
     this.context = tablet.getContext();
     memTable =
-        new InMemoryMap(tablet.getTableConfiguration(), context, tablet.getExtent().getTableId());
+        new InMemoryMap(tablet.getTableConfiguration(), context, tablet.getExtent().tableId());
     commitSession = new CommitSession(tablet, nextSeq, memTable);
     nextSeq += 2;
   }
@@ -72,7 +72,7 @@ class TabletMemory implements Closeable {
 
     otherMemTable = memTable;
     memTable =
-        new InMemoryMap(tablet.getTableConfiguration(), context, tablet.getExtent().getTableId());
+        new InMemoryMap(tablet.getTableConfiguration(), context, tablet.getExtent().tableId());
 
     CommitSession oldCommitSession = commitSession;
     commitSession = new CommitSession(tablet, nextSeq, memTable);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -92,7 +92,7 @@ public class CheckTabletMetadataTest {
     TreeMap<Key,Value> tabletMeta = new TreeMap<>();
 
     put(tabletMeta, "1<", TabletColumnFamily.PREV_ROW_COLUMN,
-        KeyExtent.encodePrevEndRow(null).get());
+        TabletColumnFamily.encodePrevEndRow(null).get());
     put(tabletMeta, "1<", ServerColumnFamily.DIRECTORY_COLUMN, "t1".getBytes());
     put(tabletMeta, "1<", ServerColumnFamily.TIME_COLUMN, "M0".getBytes());
     put(tabletMeta, "1<", FutureLocationColumnFamily.NAME, "4", "127.0.0.1:9997");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -79,9 +79,9 @@ public class GetSplitsCommand extends Command {
         scanner.setRange(new Range(start, end));
         for (final Entry<Key,Value> next : scanner) {
           if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(next.getKey())) {
-            KeyExtent extent = new KeyExtent(next.getKey().getRow(), next.getValue());
-            final String pr = encode(encode, extent.getPrevEndRow());
-            final String er = encode(encode, extent.getEndRow());
+            KeyExtent extent = KeyExtent.fromMetaPrevRow(next);
+            final String pr = encode(encode, extent.prevEndRow());
+            final String er = encode(encode, extent.endRow());
             final String line = String.format("%-26s (%s, %s%s", obscuredTabletName(extent),
                 pr == null ? "-inf" : pr, er == null ? "+inf" : er,
                 er == null ? ") Default Tablet " : "]");
@@ -117,8 +117,8 @@ public class GetSplitsCommand extends Command {
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }
-    if (extent.getEndRow() != null && extent.getEndRow().getLength() > 0) {
-      digester.update(extent.getEndRow().getBytes(), 0, extent.getEndRow().getLength());
+    if (extent.endRow() != null && extent.endRow().getLength() > 0) {
+      digester.update(extent.endRow().getBytes(), 0, extent.endRow().getLength());
     }
     return Base64.getEncoder().encodeToString(digester.digest());
   }

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -54,7 +54,7 @@ public class CloneIT extends AccumuloClusterHarness {
       client.tableOperations().create(tableName);
 
       KeyExtent ke = new KeyExtent(TableId.of("0"), null, null);
-      Mutation mut = ke.getPrevRowUpdateMutation();
+      Mutation mut = TabletColumnFamily.createPrevRowMutation(ke);
 
       ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
       ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value("/default_tablet"));
@@ -82,7 +82,7 @@ public class CloneIT extends AccumuloClusterHarness {
       client.tableOperations().create(tableName);
 
       KeyExtent ke = new KeyExtent(TableId.of("0"), null, null);
-      Mutation mut = ke.getPrevRowUpdateMutation();
+      Mutation mut = TabletColumnFamily.createPrevRowMutation(ke);
 
       ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
       ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value("/default_tablet"));
@@ -97,7 +97,7 @@ public class CloneIT extends AccumuloClusterHarness {
 
         MetadataTableUtil.initializeClone(tableName, TableId.of("0"), TableId.of("1"), client, bw2);
 
-        Mutation mut2 = new Mutation(ke.getMetadataEntry());
+        Mutation mut2 = new Mutation(ke.toMetaRow());
         mut2.putDelete(DataFileColumnFamily.NAME.toString(), filePrefix + "/default_tablet/0_0.rf");
         mut2.put(DataFileColumnFamily.NAME.toString(), filePrefix + "/default_tablet/1_0.rf",
             new DataFileValue(2, 300).encodeAsString());
@@ -118,7 +118,7 @@ public class CloneIT extends AccumuloClusterHarness {
       HashSet<String> files = new HashSet<>();
 
       try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetadataRange());
+        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetaRange());
         for (Entry<Key,Value> entry : scanner) {
           if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME))
             files.add(entry.getKey().getColumnQualifier().toString());
@@ -163,7 +163,7 @@ public class CloneIT extends AccumuloClusterHarness {
       int count = 0;
 
       try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetadataRange());
+        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetaRange());
         for (Entry<Key,Value> entry : scanner) {
           if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
             files.add(entry.getKey().getColumnQualifier().toString());
@@ -215,7 +215,7 @@ public class CloneIT extends AccumuloClusterHarness {
       int count = 0;
 
       try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetadataRange());
+        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetaRange());
         for (Entry<Key,Value> entry : scanner) {
           if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
             files.add(entry.getKey().getColumnQualifier().toString());
@@ -232,7 +232,7 @@ public class CloneIT extends AccumuloClusterHarness {
   private static Mutation deleteTablet(String tid, String endRow, String prevRow, String file) {
     KeyExtent ke = new KeyExtent(TableId.of(tid), endRow == null ? null : new Text(endRow),
         prevRow == null ? null : new Text(prevRow));
-    Mutation mut = new Mutation(ke.getMetadataEntry());
+    Mutation mut = new Mutation(ke.toMetaRow());
     TabletColumnFamily.PREV_ROW_COLUMN.putDelete(mut);
     ServerColumnFamily.TIME_COLUMN.putDelete(mut);
     ServerColumnFamily.DIRECTORY_COLUMN.putDelete(mut);
@@ -245,7 +245,7 @@ public class CloneIT extends AccumuloClusterHarness {
       String file) {
     KeyExtent ke = new KeyExtent(TableId.of(tid), endRow == null ? null : new Text(endRow),
         prevRow == null ? null : new Text(prevRow));
-    Mutation mut = ke.getPrevRowUpdateMutation();
+    Mutation mut = TabletColumnFamily.createPrevRowMutation(ke);
 
     ServerColumnFamily.TIME_COLUMN.put(mut, new Value("M0"));
     ServerColumnFamily.DIRECTORY_COLUMN.put(mut, new Value(dir));
@@ -289,7 +289,7 @@ public class CloneIT extends AccumuloClusterHarness {
       int count = 0;
 
       try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetadataRange());
+        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetaRange());
         for (Entry<Key,Value> entry : scanner) {
           if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
             files.add(entry.getKey().getColumnQualifier().toString());
@@ -354,7 +354,7 @@ public class CloneIT extends AccumuloClusterHarness {
       int count = 0;
 
       try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetadataRange());
+        scanner.setRange(new KeyExtent(TableId.of("1"), null, null).toMetaRange());
         for (Entry<Key,Value> entry : scanner) {
           if (entry.getKey().getColumnFamily().equals(DataFileColumnFamily.NAME)) {
             files.add(entry.getKey().getColumnQualifier().toString());

--- a/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
@@ -135,7 +135,7 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
       assertNotEquals(null, moved);
       // throw a mutation in as if we were the dying tablet
       BatchWriter bw = c.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
-      Mutation assignment = new Mutation(moved.extent.getMetadataEntry());
+      Mutation assignment = new Mutation(moved.extent.toMetaRow());
       moved.current.putLocation(assignment);
       bw.addMutation(assignment);
       bw.close();
@@ -143,7 +143,7 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
       waitForCleanStore(store);
       // now jam up the metadata table
       bw = c.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
-      assignment = new Mutation(new KeyExtent(MetadataTable.ID, null, null).getMetadataEntry());
+      assignment = new Mutation(new KeyExtent(MetadataTable.ID, null, null).toMetaRow());
       moved.current.putLocation(assignment);
       bw.addMutation(assignment);
       bw.close();

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -50,7 +50,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
       Writer w = new Writer(context, MetadataTable.ID);
       KeyExtent extent = new KeyExtent(TableId.of("5"), null, null);
 
-      Mutation m = new Mutation(extent.getMetadataEntry());
+      Mutation m = new Mutation(extent.toMetaRow());
       // unknown columns should cause constraint violation
       m.put("badcolfam", "badcolqual", "3");
 

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -146,7 +146,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       log.info("{} is offline", tableName);
 
-      Text row = TabletsSection.getRow(tableId, null);
+      Text row = TabletsSection.encodeRow(tableId, null);
       Mutation m = new Mutation(row);
       m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 
@@ -206,7 +206,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
 
       log.info("{} is offline", tableName);
 
-      Text row = TabletsSection.getRow(tableId, null);
+      Text row = TabletsSection.encodeRow(tableId, null);
       Mutation m = new Mutation(row);
       m.put(logEntry.getColumnFamily(), logEntry.getColumnQualifier(), logEntry.getValue());
 

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -95,10 +95,10 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
         TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
 
         KeyExtent extent = new KeyExtent(tableId, null, new Text("b"));
-        Mutation m = extent.getPrevRowUpdateMutation();
+        Mutation m = TabletColumnFamily.createPrevRowMutation(extent);
 
         TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m, new Value(Double.toString(0.5)));
-        TabletColumnFamily.OLD_PREV_ROW_COLUMN.put(m, KeyExtent.encodePrevEndRow(null));
+        TabletColumnFamily.OLD_PREV_ROW_COLUMN.put(m, TabletColumnFamily.encodePrevEndRow(null));
         try (BatchWriter bw = client.createBatchWriter(MetadataTable.NAME)) {
           bw.addMutation(m);
 
@@ -106,11 +106,11 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
             bw.flush();
 
             try (Scanner scanner = client.createScanner(MetadataTable.NAME)) {
-              scanner.setRange(extent.toMetadataRange());
+              scanner.setRange(extent.toMetaRange());
               scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
 
               KeyExtent extent2 = new KeyExtent(tableId, new Text("b"), null);
-              m = extent2.getPrevRowUpdateMutation();
+              m = TabletColumnFamily.createPrevRowMutation(extent2);
               ServerColumnFamily.DIRECTORY_COLUMN.put(m, new Value("t2"));
               ServerColumnFamily.TIME_COLUMN.put(m, new Value("M0"));
 

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -304,7 +304,7 @@ public class VolumeIT extends ConfigurableMacBase {
     TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
     try (Scanner metaScanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       metaScanner.fetchColumnFamily(DataFileColumnFamily.NAME);
-      metaScanner.setRange(new KeyExtent(tableId, null, null).toMetadataRange());
+      metaScanner.setRange(new KeyExtent(tableId, null, null).toMetaRange());
 
       int[] counts = new int[paths.length];
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
@@ -174,7 +174,7 @@ public class BulkFailureIT extends AccumuloClusterHarness {
           TablePermission.WRITE);
 
       BatchDeleter bd = c.createBatchDeleter(MetadataTable.NAME, Authorizations.EMPTY, 1);
-      bd.setRanges(Collections.singleton(extent.toMetadataRange()));
+      bd.setRanges(Collections.singleton(extent.toMetaRange()));
       bd.fetchColumnFamily(BulkFileColumnFamily.NAME);
       bd.delete();
 
@@ -240,7 +240,7 @@ public class BulkFailureIT extends AccumuloClusterHarness {
     HashSet<Path> files = new HashSet<>();
 
     Scanner scanner = connector.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-    scanner.setRange(extent.toMetadataRange());
+    scanner.setRange(extent.toMetaRange());
     scanner.fetchColumnFamily(fam);
 
     for (Entry<Key,Value> entry : scanner) {
@@ -299,7 +299,7 @@ public class BulkFailureIT extends AccumuloClusterHarness {
   protected static TabletClientService.Iface getClient(ClientContext context, KeyExtent extent)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
       TTransportException {
-    TabletLocator locator = TabletLocator.getLocator(context, extent.getTableId());
+    TabletLocator locator = TabletLocator.getLocator(context, extent.tableId());
 
     locator.invalidateCache(extent);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterAssignmentIT.java
@@ -90,7 +90,7 @@ public class MasterAssignmentIT extends AccumuloClusterHarness {
 
   private TabletLocationState getTabletLocationState(AccumuloClient c, String tableId) {
     try (MetaDataTableScanner s = new MetaDataTableScanner((ClientContext) c,
-        new Range(TabletsSection.getRow(TableId.of(tableId), null)), MetadataTable.NAME)) {
+        new Range(TabletsSection.encodeRow(TableId.of(tableId), null)), MetadataTable.NAME)) {
       return s.next();
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -142,13 +142,13 @@ public class SplitIT extends AccumuloClusterHarness {
       TableId id = TableId.of(c.tableOperations().tableIdMap().get(table));
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         KeyExtent extent = new KeyExtent(id, null, null);
-        s.setRange(extent.toMetadataRange());
+        s.setRange(extent.toMetaRange());
         TabletColumnFamily.PREV_ROW_COLUMN.fetch(s);
         int count = 0;
         int shortened = 0;
         for (Entry<Key,Value> entry : s) {
-          extent = new KeyExtent(entry.getKey().getRow(), entry.getValue());
-          if (extent.getEndRow() != null && extent.getEndRow().toString().length() < 14)
+          extent = KeyExtent.fromMetaPrevRow(entry);
+          if (extent.endRow() != null && extent.endRow().toString().length() < 14)
             shortened++;
           count++;
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -158,7 +158,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
 
       String dirName = "dir_" + i;
       String tdir = ServerConstants.getTablesDirs(context).iterator().next() + "/"
-          + extent.getTableId() + "/" + dirName;
+          + extent.tableId() + "/" + dirName;
       MetadataTableUtil.addTablet(extent, dirName, context, TimeType.LOGICAL, zl);
       SortedMap<TabletFile,DataFileValue> mapFiles = new TreeMap<>();
       mapFiles.put(new TabletFile(new Path(tdir + "/" + RFile.EXTENSION + "_000_000")),
@@ -176,8 +176,8 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
 
     KeyExtent extent = extents[extentToSplit];
 
-    KeyExtent high = new KeyExtent(extent.getTableId(), extent.getEndRow(), midRow);
-    KeyExtent low = new KeyExtent(extent.getTableId(), midRow, extent.getPrevEndRow());
+    KeyExtent high = new KeyExtent(extent.tableId(), extent.endRow(), midRow);
+    KeyExtent low = new KeyExtent(extent.tableId(), midRow, extent.prevEndRow());
 
     splitPartiallyAndRecover(context, extent, high, low, .4, splitMapFiles, midRow,
         "localhost:1234", failPoint, zl);
@@ -204,11 +204,11 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     MetadataTableUtil.splitDatafiles(midRow, splitRatio, new HashMap<>(), mapFiles,
         lowDatafileSizes, highDatafileSizes, highDatafilesToRemove);
 
-    MetadataTableUtil.splitTablet(high, extent.getPrevEndRow(), splitRatio, context, zl);
+    MetadataTableUtil.splitTablet(high, extent.prevEndRow(), splitRatio, context, zl);
     TServerInstance instance = new TServerInstance(location, zl.getSessionId());
     Writer writer = MetadataTableUtil.getMetadataTable(context);
     Assignment assignment = new Assignment(high, instance);
-    Mutation m = new Mutation(assignment.tablet.getMetadataEntry());
+    Mutation m = new Mutation(assignment.tablet.toMetaRow());
     assignment.server.putFutureLocation(m);
     writer.update(m);
 
@@ -252,7 +252,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   private void ensureTabletHasNoUnexpectedMetadataEntries(ServerContext context, KeyExtent extent,
       SortedMap<StoredTabletFile,DataFileValue> expectedMapFiles) throws Exception {
     try (Scanner scanner = new ScannerImpl(context, MetadataTable.ID, Authorizations.EMPTY)) {
-      scanner.setRange(extent.toMetadataRange());
+      scanner.setRange(extent.toMetaRange());
 
       HashSet<ColumnFQ> expectedColumns = new HashSet<>();
       expectedColumns.add(ServerColumnFamily.DIRECTORY_COLUMN);
@@ -275,14 +275,14 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
         Entry<Key,Value> entry = iter.next();
         Key key = entry.getKey();
 
-        if (!key.getRow().equals(extent.getMetadataEntry())) {
+        if (!key.getRow().equals(extent.toMetaRow())) {
           throw new Exception(
               "Tablet " + extent + " contained unexpected " + MetadataTable.NAME + " entry " + key);
         }
 
         if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key)) {
           sawPer = true;
-          if (!new KeyExtent(key.getRow(), entry.getValue()).equals(extent)) {
+          if (!KeyExtent.fromMetaPrevRow(entry).equals(extent)) {
             throw new Exception("Unexpected prev end row " + entry);
           }
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -75,7 +75,7 @@ public class TableIT extends AccumuloClusterHarness {
       VerifyIngest.verifyIngest(c, params);
       TableId id = TableId.of(to.tableIdMap().get(tableName));
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
-        s.setRange(new KeyExtent(id, null, null).toMetadataRange());
+        s.setRange(new KeyExtent(id, null, null).toMetaRange());
         s.fetchColumnFamily(DataFileColumnFamily.NAME);
         assertTrue(Iterators.size(s.iterator()) > 0);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -154,7 +154,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       throws TableNotFoundException, MutationsRejectedException {
     TableId tableIdToModify =
         TableId.of(client.tableOperations().tableIdMap().get(tableNameToModify));
-    Mutation m = new Mutation(new KeyExtent(tableIdToModify, null, null).getMetadataEntry());
+    Mutation m = new Mutation(new KeyExtent(tableIdToModify, null, null).toMetaRow());
     m.put(CurrentLocationColumnFamily.NAME, new Text("1234567"), new Value("fake:9005"));
     try (BatchWriter bw = client.createBatchWriter(table)) {
       bw.addMutation(m);
@@ -166,7 +166,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
     TableId tableIdToModify =
         TableId.of(client.tableOperations().tableIdMap().get(tableNameToModify));
     try (Scanner scanner = client.createScanner(table, Authorizations.EMPTY)) {
-      scanner.setRange(new KeyExtent(tableIdToModify, null, null).toMetadataRange());
+      scanner.setRange(new KeyExtent(tableIdToModify, null, null).toMetaRange());
       scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       Entry<Key,Value> entry = scanner.iterator().next();
       Mutation m = new Mutation(entry.getKey().getRow());
@@ -186,8 +186,8 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
         TableId.of(client.tableOperations().tableIdMap().get(tableNameToModify));
     BatchDeleter deleter =
         client.createBatchDeleter(table, Authorizations.EMPTY, 1, new BatchWriterConfig());
-    deleter.setRanges(
-        Collections.singleton(new KeyExtent(tableIdToModify, null, null).toMetadataRange()));
+    deleter
+        .setRanges(Collections.singleton(new KeyExtent(tableIdToModify, null, null).toMetaRange()));
     deleter.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
     deleter.delete();
     deleter.close();

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -147,7 +147,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       // log.debug("markers " + markers);
       assertEquals("one tablet should have markers", 1, markers.size());
       assertEquals("tableId of the keyExtent should be 1", "1",
-          markers.keySet().iterator().next().getTableId().canonical());
+          markers.keySet().iterator().next().tableId().canonical());
 
       // put some data in the WAL
       assertEquals(0, cluster.exec(SetGoalState.class, "NORMAL").getProcess().waitFor());
@@ -216,7 +216,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
           logs.add(key.getColumnQualifier().toString());
         }
         if (TabletColumnFamily.PREV_ROW_COLUMN.hasColumns(key) && !logs.isEmpty()) {
-          KeyExtent extent = new KeyExtent(key.getRow(), entry.getValue());
+          KeyExtent extent = KeyExtent.fromMetaPrevRow(entry);
           result.put(extent, logs);
           logs = new ArrayList<>();
         }

--- a/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/MergeStateIT.java
@@ -124,7 +124,8 @@ public class MergeStateIT extends ConfigurableMacBase {
       Text pr = null;
       for (String s : splits) {
         Text split = new Text(s);
-        Mutation prevRow = KeyExtent.getPrevRowUpdateMutation(new KeyExtent(tableId, split, pr));
+        Mutation prevRow =
+            TabletColumnFamily.createPrevRowMutation(new KeyExtent(tableId, split, pr));
         prevRow.put(CurrentLocationColumnFamily.NAME, new Text("123456"),
             new Value("127.0.0.1:1234"));
         ChoppedColumnFamily.CHOPPED_COLUMN.put(prevRow, new Value("junk"));
@@ -132,7 +133,8 @@ public class MergeStateIT extends ConfigurableMacBase {
         pr = split;
       }
       // Add the default tablet
-      Mutation defaultTablet = KeyExtent.getPrevRowUpdateMutation(new KeyExtent(tableId, null, pr));
+      Mutation defaultTablet =
+          TabletColumnFamily.createPrevRowMutation(new KeyExtent(tableId, null, pr));
       defaultTablet.put(CurrentLocationColumnFamily.NAME, new Text("123456"),
           new Value("127.0.0.1:1234"));
       bw.addMutation(defaultTablet);
@@ -155,9 +157,11 @@ public class MergeStateIT extends ConfigurableMacBase {
 
       // Create the hole
       // Split the tablet at one end of the range
-      Mutation m = new KeyExtent(tableId, new Text("t"), new Text("p")).getPrevRowUpdateMutation();
+      Mutation m = TabletColumnFamily
+          .createPrevRowMutation(new KeyExtent(tableId, new Text("t"), new Text("p")));
       TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m, new Value("0.5"));
-      TabletColumnFamily.OLD_PREV_ROW_COLUMN.put(m, KeyExtent.encodePrevEndRow(new Text("o")));
+      TabletColumnFamily.OLD_PREV_ROW_COLUMN.put(m,
+          TabletColumnFamily.encodePrevEndRow(new Text("o")));
       update(accumuloClient, m);
 
       // do the state check
@@ -178,7 +182,7 @@ public class MergeStateIT extends ConfigurableMacBase {
 
       // finish the split
       KeyExtent tablet = new KeyExtent(tableId, new Text("p"), new Text("o"));
-      m = tablet.getPrevRowUpdateMutation();
+      m = TabletColumnFamily.createPrevRowMutation(tablet);
       TabletColumnFamily.SPLIT_RATIO_COLUMN.put(m, new Value("0.5"));
       update(accumuloClient, m);
       metaDataStateStore
@@ -189,7 +193,7 @@ public class MergeStateIT extends ConfigurableMacBase {
       assertEquals(MergeState.WAITING_FOR_CHOPPED, stats.nextMergeState(accumuloClient, state));
 
       // chop it
-      m = tablet.getPrevRowUpdateMutation();
+      m = TabletColumnFamily.createPrevRowMutation(tablet);
       ChoppedColumnFamily.CHOPPED_COLUMN.put(m, new Value("junk"));
       update(accumuloClient, m);
 
@@ -197,7 +201,7 @@ public class MergeStateIT extends ConfigurableMacBase {
       assertEquals(MergeState.WAITING_FOR_OFFLINE, stats.nextMergeState(accumuloClient, state));
 
       // take it offline
-      m = tablet.getPrevRowUpdateMutation();
+      m = TabletColumnFamily.createPrevRowMutation(tablet);
       Collection<Collection<String>> walogs = Collections.emptyList();
       metaDataStateStore.unassign(
           Collections.singletonList(

--- a/test/src/main/java/org/apache/accumulo/test/master/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/master/SuspendedTabletsIT.java
@@ -315,7 +315,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
         while (scanner.hasNext()) {
           TabletLocationState tls = scanner.next();
 
-          if (!tls.extent.getTableId().canonical().equals(tableId)) {
+          if (!tls.extent.tableId().canonical().equals(tableId)) {
             continue;
           }
           locationStates.put(tls.extent, tls);

--- a/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
@@ -312,7 +312,7 @@ public class NullTserver {
     TableId tableId = Tables.getTableId(context, opts.tableName);
 
     // read the locations for the table
-    Range tableRange = new KeyExtent(tableId, null, null).toMetadataRange();
+    Range tableRange = new KeyExtent(tableId, null, null).toMetaRange();
     List<Assignment> assignments = new ArrayList<>();
     try (var s = new MetaDataTableScanner(context, tableRange, MetadataTable.NAME)) {
       long randomSessionID = opts.port;

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -223,8 +223,8 @@ public class CollectTabletStats {
           Test test = new Test(ke) {
             @Override
             public int runTest() throws Exception {
-              return scanTablet(client, opts.tableName, opts.auths, ke.getPrevEndRow(),
-                  ke.getEndRow(), columns);
+              return scanTablet(client, opts.tableName, opts.auths, ke.prevEndRow(), ke.endRow(),
+                  columns);
             }
           };
           tests.add(test);
@@ -464,7 +464,7 @@ public class CollectTabletStats {
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
           .forFile(file.getPathStr(), ns, ns.getConf(), CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(aconf).build();
-      Range range = new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true);
+      Range range = new Range(ke.prevEndRow(), false, ke.endRow(), true);
       reader.seek(range, columnSet, !columnSet.isEmpty());
       while (reader.hasTop() && !range.afterEndKey(reader.getTopKey())) {
         count++;
@@ -501,13 +501,13 @@ public class CollectTabletStats {
 
     List<IterInfo> emptyIterinfo = Collections.emptyList();
     Map<String,Map<String,String>> emptySsio = Collections.emptyMap();
-    TableConfiguration tconf = context.getTableConfiguration(ke.getTableId());
+    TableConfiguration tconf = context.getTableConfiguration(ke.tableId());
     reader = createScanIterator(ke, readers, auths, new byte[] {}, new HashSet<>(), emptyIterinfo,
         emptySsio, useTableIterators, tconf);
 
     HashSet<ByteSequence> columnSet = createColumnBSS(columns);
 
-    reader.seek(new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true), columnSet,
+    reader.seek(new Range(ke.prevEndRow(), false, ke.endRow(), true), columnSet,
         !columnSet.isEmpty());
 
     int count = 0;
@@ -547,7 +547,7 @@ public class CollectTabletStats {
     // long t1 = System.currentTimeMillis();
 
     try (Scanner scanner = client.createScanner(table, auths)) {
-      scanner.setRange(new Range(ke.getPrevEndRow(), false, ke.getEndRow(), true));
+      scanner.setRange(new Range(ke.prevEndRow(), false, ke.endRow(), true));
 
       for (String c : columns) {
         scanner.fetchColumnFamily(new Text(c));

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -160,7 +160,7 @@ public class ReplicationIT extends ConfigurableMacBase {
       scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
       for (Entry<Key,Value> entry : scanner) {
         var tServer = new TServerInstance(entry.getValue(), entry.getKey().getColumnQualifier());
-        TableId tableId = KeyExtent.tableOfMetadataRow(entry.getKey().getRow());
+        TableId tableId = KeyExtent.fromMetaRow(entry.getKey().getRow()).tableId();
         serverToTableID.put(tServer, tableId);
       }
       // Map of logs to tableId
@@ -551,20 +551,16 @@ public class ReplicationIT extends ConfigurableMacBase {
       final Multimap<String,TableId> logs = HashMultimap.create();
       final AtomicBoolean keepRunning = new AtomicBoolean(true);
 
-      Thread t = new Thread(new Runnable() {
-        @Override
-        public void run() {
-          // Should really be able to interrupt here, but the Scanner throws a fit to the logger
-          // when that happens
-          while (keepRunning.get()) {
-            try {
-              logs.putAll(getAllLogs(client, context));
-            } catch (Exception e) {
-              log.error("Error getting logs", e);
-            }
+      Thread t = new Thread(() -> {
+        // Should really be able to interrupt here, but the Scanner throws a fit to the logger
+        // when that happens
+        while (keepRunning.get()) {
+          try {
+            logs.putAll(getAllLogs(client, context));
+          } catch (Exception e) {
+            log.error("Error getting logs", e);
           }
         }
-
       });
 
       t.start();
@@ -1135,20 +1131,16 @@ public class ReplicationIT extends ConfigurableMacBase {
       final AtomicBoolean keepRunning = new AtomicBoolean(true);
       final Set<String> metadataWals = new HashSet<>();
 
-      Thread t = new Thread(new Runnable() {
-        @Override
-        public void run() {
-          // Should really be able to interrupt here, but the Scanner throws a fit to the logger
-          // when that happens
-          while (keepRunning.get()) {
-            try {
-              metadataWals.addAll(getLogs(client, context).keySet());
-            } catch (Exception e) {
-              log.error("Metadata table doesn't exist");
-            }
+      Thread t = new Thread(() -> {
+        // Should really be able to interrupt here, but the Scanner throws a fit to the logger
+        // when that happens
+        while (keepRunning.get()) {
+          try {
+            metadataWals.addAll(getLogs(client, context).keySet());
+          } catch (Exception e) {
+            log.error("Metadata table doesn't exist");
           }
         }
-
       });
 
       t.start();

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnusedWalDoesntCloseReplicationStatusIT.java
@@ -187,7 +187,7 @@ public class UnusedWalDoesntCloseReplicationStatusIT extends ConfigurableMacBase
       String walUri = tserverWal.toURI().toString();
       KeyExtent extent = new KeyExtent(tableId, null, null);
       try (BatchWriter bw = client.createBatchWriter(MetadataTable.NAME)) {
-        Mutation m = new Mutation(extent.getMetadataEntry());
+        Mutation m = new Mutation(extent.toMetaRow());
         m.put(LogColumnFamily.NAME, new Text("localhost:12345/" + walUri),
             new Value(walUri + "|1"));
         bw.addMutation(m);


### PR DESCRIPTION
* Replace confusing overloaded constructors with self-descriptive
  static factory methods
* Move metadata serialization into Metadata schema class
* Remove unnecessary WritableComparable interface
* Improve javadocs
* Replace private equals method with Objects.equals
* Remove methods only used in tests
* Use TableId instead of String and fix variable name (tableId
  instead of incorrect tablename)
* Shorten accessor method names
* Make KeyExtent closer to immutable (it's not truly immutable,
  because Text objects that represent endRow and prevEndRow are
  mutable)