### PR TITLE
Add new public API to get manager locations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/Instance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/Instance.java
@@ -44,21 +44,8 @@ public interface Instance {
    * Returns the location(s) of the accumulo master and any redundant servers.
    *
    * @return a list of locations in "hostname:port" form
-   *
-   * @deprecated Use {@link #getManagerLocations()} instead
    */
-  @Deprecated(since = "2.1.0", forRemoval = true)
-  default List<String> getMasterLocations() {
-    return getManagerLocations();
-  }
-
-  /**
-   * Returns the location(s) of the accumulo manager and any redundant servers.
-   *
-   * @return a list of locations in "hostname:port" form
-   *
-   */
-  List<String> getManagerLocations();
+  List<String> getMasterLocations();
 
   /**
    * Returns a unique string that identifies this instance of accumulo.

--- a/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
@@ -134,7 +134,7 @@ public class ZooKeeperInstance implements Instance {
   }
 
   @Override
-  public List<String> getManagerLocations() {
+  public List<String> getMasterLocations() {
     return ClientContext.getMasterLocations(zooCache, getInstanceID());
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -60,28 +60,35 @@ public interface InstanceOperations {
   void removeProperty(final String property) throws AccumuloException, AccumuloSecurityException;
 
   /**
+   * Retrieve the system-wide configuration.
    *
    * @return A map of system properties set in zookeeper. If a property is not set in zookeeper,
    *         then it will return the value set in accumulo.properties on some server. If nothing is
    *         set in an accumulo.properties file it will return the default value for each property.
    */
-
   Map<String,String> getSystemConfiguration() throws AccumuloException, AccumuloSecurityException;
 
   /**
+   * Retrieve the site configuration (that set in the server configuration file).
    *
    * @return A map of system properties set in accumulo.properties on some server. If nothing is set
    *         in an accumulo.properties file it will return the default value for each property.
    */
-
   Map<String,String> getSiteConfiguration() throws AccumuloException, AccumuloSecurityException;
+
+  /**
+   * Returns the location(s) of the accumulo manager and any redundant servers.
+   *
+   * @return a list of locations in <code>hostname:port</code> form.
+   * @since 2.1.0
+   */
+  List<String> getManagerLocations();
 
   /**
    * List the currently active tablet servers participating in the accumulo instance
    *
    * @return A list of currently active tablet servers.
    */
-
   List<String> getTabletServers();
 
   /**
@@ -91,7 +98,6 @@ public interface InstanceOperations {
    *          The tablet server address should be of the form {@code <ip address>:<port>}
    * @return A list of active scans on tablet server.
    */
-
   List<ActiveScan> getActiveScans(String tserver)
       throws AccumuloException, AccumuloSecurityException;
 
@@ -103,7 +109,6 @@ public interface InstanceOperations {
    * @return the list of active compactions
    * @since 1.5.0
    */
-
   List<ActiveCompaction> getActiveCompactions(String tserver)
       throws AccumuloException, AccumuloSecurityException;
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -166,7 +166,7 @@ public class ClientContext implements AccumuloClient {
       }
 
       @Override
-      public List<String> getManagerLocations() {
+      public List<String> getMasterLocations() {
         return context.getMasterLocations();
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -110,6 +110,11 @@ public class InstanceOperationsImpl implements InstanceOperations {
   }
 
   @Override
+  public List<String> getManagerLocations() {
+    return context.getMasterLocations();
+  }
+
+  @Override
   public List<String> getTabletServers() {
     ZooCache cache = context.getZooCache();
     String path = context.getZooKeeperRoot() + Constants.ZTSERVERS;


### PR DESCRIPTION
* Partially revert bc6fa04283d1dda3bfcde5ef193027d171adb37b to prevent
  addition of new API methods in already-deprecated API classes (#1703)
* Add a new getManagerLocations() API to InstanceOperations