### PR TITLE
Related #1664. Allow Candidate batch size to be user configurable

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -568,6 +568,8 @@ public enum Property {
   // accumulo garbage collector properties
   GC_PREFIX("gc.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo garbage collector."),
+  GC_CANDIDATE_BATCH_SIZE("gc.candidate.batch.size", "4000000", PropertyType.COUNT,
+          "The batch size used for garbage collection. The default is effectively 8MB"),
   GC_CYCLE_START("gc.cycle.start", "30s", PropertyType.TIMEDURATION,
       "Time to wait before attempting to garbage collect any old RFiles or write-ahead logs."),
   GC_CYCLE_DELAY("gc.cycle.delay", "5m", PropertyType.TIMEDURATION,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -569,7 +569,7 @@ public enum Property {
   GC_PREFIX("gc.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo garbage collector."),
   GC_CANDIDATE_BATCH_SIZE("gc.candidate.batch.size", "8m", PropertyType.BYTES,
-          "The batch size used for garbage collection."),
+      "The batch size used for garbage collection."),
   GC_CYCLE_START("gc.cycle.start", "30s", PropertyType.TIMEDURATION,
       "Time to wait before attempting to garbage collect any old RFiles or write-ahead logs."),
   GC_CYCLE_DELAY("gc.cycle.delay", "5m", PropertyType.TIMEDURATION,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -568,7 +568,7 @@ public enum Property {
   // accumulo garbage collector properties
   GC_PREFIX("gc.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo garbage collector."),
-  GC_CANDIDATE_BATCH_SIZE("gc.candidate.batch.size", "8m", PropertyType.BYTES,
+  GC_CANDIDATE_BATCH_SIZE("gc.candidate.batch.size", "8M", PropertyType.BYTES,
       "The batch size used for garbage collection."),
   GC_CYCLE_START("gc.cycle.start", "30s", PropertyType.TIMEDURATION,
       "Time to wait before attempting to garbage collect any old RFiles or write-ahead logs."),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -568,8 +568,8 @@ public enum Property {
   // accumulo garbage collector properties
   GC_PREFIX("gc.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo garbage collector."),
-  GC_CANDIDATE_BATCH_SIZE("gc.candidate.batch.size", "4000000", PropertyType.COUNT,
-          "The batch size used for garbage collection. The default is effectively 8MB"),
+  GC_CANDIDATE_BATCH_SIZE("gc.candidate.batch.size", "8m", PropertyType.BYTES,
+          "The batch size used for garbage collection."),
   GC_CYCLE_START("gc.cycle.start", "30s", PropertyType.TIMEDURATION,
       "Time to wait before attempting to garbage collect any old RFiles or write-ahead logs."),
   GC_CYCLE_DELAY("gc.cycle.delay", "5m", PropertyType.TIMEDURATION,

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -188,7 +188,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
    * @return candidate batch size.
    */
   long getCandidateBatchSize() {
-    return getConfiguration().getCount(Property.GC_CANDIDATE_BATCH_SIZE);
+    return getConfiguration().getAsBytes(Property.GC_CANDIDATE_BATCH_SIZE);
   }
 
   /**
@@ -214,7 +214,8 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
       Iterator<String> candidates = getContext().getAmple().getGcCandidates(level, continuePoint);
       long candidateLength = 0;
-      long candidateBatchSize = getCandidateBatchSize();
+      // Converting the bytes to approximate number of characters for batch size.
+      long candidateBatchSize = getCandidateBatchSize() / 2;
 
       result.clear();
 


### PR DESCRIPTION
This is in relation to #1664. This allows the batch size for garbage collecting implemented in #1650 to be configurable. 

After a discussion with @ctubbsii, I determined that I couldn't fully test out the upper limits (batch sizes of 64MB for example). With that in mind, I went ahead and made it configurable but kept it at its current default batch size. 