### PR TITLE
Simplify and clean up LogEntry

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ReplicationOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ReplicationOperationsImpl.java
@@ -155,7 +155,7 @@ public class ReplicationOperationsImpl implements ReplicationOperations {
     Set<String> wals = new HashSet<>();
     try {
       for (Entry<Key,Value> entry : metaBs) {
-        LogEntry logEntry = LogEntry.fromKeyValue(entry.getKey(), entry.getValue());
+        LogEntry logEntry = LogEntry.fromMetaWalEntry(entry);
         wals.add(new Path(logEntry.filename).toString());
       }
     } finally {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -289,11 +289,11 @@ public class TabletMetadata {
     ByteSequence row = null;
 
     while (rowIter.hasNext()) {
-      Entry<Key,Value> kv = rowIter.next();
-      Key key = kv.getKey();
-      String val = kv.getValue().toString();
-      String fam = key.getColumnFamilyData().toString();
-      String qual = key.getColumnQualifierData().toString();
+      final Entry<Key,Value> kv = rowIter.next();
+      final Key key = kv.getKey();
+      final String val = kv.getValue().toString();
+      final String fam = key.getColumnFamilyData().toString();
+      final String qual = key.getColumnQualifierData().toString();
 
       if (buildKeyValueMap) {
         kvBuilder.put(key, kv.getValue());
@@ -366,7 +366,7 @@ public class TabletMetadata {
           te.cloned = val;
           break;
         case LogColumnFamily.STR_NAME:
-          logsBuilder.add(LogEntry.fromKeyValue(key, val));
+          logsBuilder.add(LogEntry.fromMetaWalEntry(kv));
           break;
         default:
           throw new IllegalStateException("Unexpected family " + fam);

--- a/core/src/main/java/org/apache/accumulo/core/tabletserver/log/LogEntry.java
+++ b/core/src/main/java/org/apache/accumulo/core/tabletserver/log/LogEntry.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.tabletserver.log;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map.Entry;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -30,23 +31,20 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
 
 public class LogEntry {
-  public final KeyExtent extent;
+  private final KeyExtent extent;
   public final long timestamp;
-  public final String server;
   public final String filename;
 
-  public LogEntry(LogEntry le) {
-    this.extent = le.extent;
-    this.timestamp = le.timestamp;
-    this.server = le.server;
-    this.filename = le.filename;
-  }
-
-  public LogEntry(KeyExtent extent, long timestamp, String server, String filename) {
+  public LogEntry(KeyExtent extent, long timestamp, String filename) {
+    // note the prevEndRow in the extent does not matter, and is not used by LogEntry
     this.extent = extent;
     this.timestamp = timestamp;
-    this.server = server;
     this.filename = filename;
+  }
+
+  // make copy, but with a different filename
+  public LogEntry switchFile(String filename) {
+    return new LogEntry(extent, timestamp, filename);
   }
 
   @Override
@@ -54,46 +52,46 @@ public class LogEntry {
     return extent.toMetaRow() + " " + filename;
   }
 
-  public String getName() {
-    return server + "/" + filename;
-  }
-
+  // unused; kept only for reference with corresponding fromBytes method
+  @Deprecated(since = "2.1.0", forRemoval = true)
   public byte[] toBytes() throws IOException {
     DataOutputBuffer out = new DataOutputBuffer();
     extent.writeTo(out);
     out.writeLong(timestamp);
-    out.writeUTF(server);
+    // this next string used to store server, but this is no longer used
+    out.writeUTF("-");
     out.writeUTF(filename);
     return Arrays.copyOf(out.getData(), out.getLength());
   }
 
+  // kept only for upgrade code to upgrade WAL entries for the root table
+  @Deprecated(since = "2.1.0", forRemoval = true)
   public static LogEntry fromBytes(byte[] bytes) throws IOException {
     DataInputBuffer inp = new DataInputBuffer();
     inp.reset(bytes, bytes.length);
     KeyExtent extent = KeyExtent.readFrom(inp);
     long timestamp = inp.readLong();
-    String server = inp.readUTF();
+    // this next string used to store the server, but this is no longer used
+    inp.readUTF();
     String filename = inp.readUTF();
-    return new LogEntry(extent, timestamp, server, filename);
+    return new LogEntry(extent, timestamp, filename);
   }
 
-  public static LogEntry fromKeyValue(Key key, String value) {
+  public static LogEntry fromMetaWalEntry(Entry<Key,Value> entry) {
+    final Key key = entry.getKey();
+    final Value value = entry.getValue();
     String qualifier = key.getColumnQualifierData().toString();
     if (qualifier.indexOf('/') < 1) {
       throw new IllegalArgumentException("Bad key for log entry: " + key);
     }
     KeyExtent extent = KeyExtent.fromMetaRow(key.getRow());
     String[] parts = qualifier.split("/", 2);
-    String server = parts[0];
+    // parts[0] used to store the server, but that is no longer used and can be ignored
     // handle old-style log entries that specify log sets
-    parts = value.split("\\|")[0].split(";");
+    parts = value.toString().split("\\|")[0].split(";");
     String filename = parts[parts.length - 1];
     long timestamp = key.getTimestamp();
-    return new LogEntry(extent, timestamp, server, filename);
-  }
-
-  public static LogEntry fromKeyValue(Key key, Value value) {
-    return fromKeyValue(key, value.toString());
+    return new LogEntry(extent, timestamp, filename);
   }
 
   public Text getRow() {
@@ -110,10 +108,11 @@ public class LogEntry {
   }
 
   public Text getColumnQualifier() {
-    return new Text(server + "/" + filename);
+    return new Text("-/" + filename);
   }
 
   public Value getValue() {
     return new Value(filename);
   }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/tabletserver/log/LogEntry.java
+++ b/core/src/main/java/org/apache/accumulo/core/tabletserver/log/LogEntry.java
@@ -80,15 +80,11 @@ public class LogEntry {
   public static LogEntry fromMetaWalEntry(Entry<Key,Value> entry) {
     final Key key = entry.getKey();
     final Value value = entry.getValue();
-    String qualifier = key.getColumnQualifierData().toString();
-    if (qualifier.indexOf('/') < 1) {
-      throw new IllegalArgumentException("Bad key for log entry: " + key);
-    }
     KeyExtent extent = KeyExtent.fromMetaRow(key.getRow());
-    String[] parts = qualifier.split("/", 2);
-    // parts[0] used to store the server, but that is no longer used and can be ignored
-    // handle old-style log entries that specify log sets
-    parts = value.toString().split("\\|")[0].split(";");
+    // qualifier.split("/")[0] used to store the server, but this is no longer used, and the
+    // qualifier can be ignored
+    // the following line handles old-style log entry values that specify log sets
+    String[] parts = value.toString().split("\\|")[0].split(";");
     String filename = parts[parts.length - 1];
     long timestamp = key.getTimestamp();
     return new LogEntry(extent, timestamp, filename);

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -88,10 +88,10 @@ public class TabletMetadataTest {
 
     mutation.at().family(LastLocationColumnFamily.NAME).qualifier("s000").put("server2:8555");
 
-    LogEntry le1 = new LogEntry(extent, 55, "server1", "lf1");
+    LogEntry le1 = new LogEntry(extent, 55, "lf1");
     mutation.at().family(le1.getColumnFamily()).qualifier(le1.getColumnQualifier())
         .timestamp(le1.timestamp).put(le1.getValue());
-    LogEntry le2 = new LogEntry(extent, 57, "server1", "lf2");
+    LogEntry le2 = new LogEntry(extent, 57, "lf2");
     mutation.at().family(le2.getColumnFamily()).qualifier(le2.getColumnQualifier())
         .timestamp(le2.timestamp).put(le2.getValue());
 
@@ -123,8 +123,8 @@ public class TabletMetadataTest {
     assertEquals(HostAndPort.fromParts("server2", 8555), tm.getLast().getHostAndPort());
     assertEquals("s000", tm.getLast().getSession());
     assertEquals(LocationType.LAST, tm.getLast().getType());
-    assertEquals(Set.of(le1.getName() + " " + le1.timestamp, le2.getName() + " " + le2.timestamp),
-        tm.getLogs().stream().map(le -> le.getName() + " " + le.timestamp).collect(toSet()));
+    assertEquals(Set.of(le1.getValue() + " " + le1.timestamp, le2.getValue() + " " + le2.timestamp),
+        tm.getLogs().stream().map(le -> le.getValue() + " " + le.timestamp).collect(toSet()));
     assertEquals(extent.prevEndRow(), tm.getPrevEndRow());
     assertEquals(extent.tableId(), tm.getTableId());
     assertTrue(tm.sawPrevEndRow());

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -104,7 +104,7 @@ public class VolumeUtil {
       return null;
     }
 
-    LogEntry newLogEntry = new LogEntry(le.extent, le.timestamp, le.server, switchedString);
+    LogEntry newLogEntry = le.switchFile(switchedString);
 
     log.trace("Switched {} to {}", le, newLogEntry);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -104,8 +104,7 @@ class MetaDataStateStore implements TabletStateStore {
             List<Path> logs = logsForDeadServers.get(tls.current);
             if (logs != null) {
               for (Path log : logs) {
-                LogEntry entry =
-                    new LogEntry(tls.extent, 0, tls.current.hostPort(), log.toString());
+                LogEntry entry = new LogEntry(tls.extent, 0, log.toString());
                 tabletMutator.putWal(entry);
               }
             }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/ZooTabletStateStore.java
@@ -148,8 +148,8 @@ class ZooTabletStateStore implements TabletStateStore {
       List<Path> logs = logsForDeadServers.get(tls.futureOrCurrent());
       if (logs != null) {
         for (Path entry : logs) {
-          LogEntry logEntry = new LogEntry(RootTable.EXTENT, System.currentTimeMillis(),
-              tls.futureOrCurrent().getLocation().toString(), entry.toString());
+          LogEntry logEntry =
+              new LogEntry(RootTable.EXTENT, System.currentTimeMillis(), entry.toString());
           tabletMutator.putWal(logEntry);
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/upgrade/Upgrader9to10.java
@@ -275,9 +275,10 @@ public class Upgrader9to10 implements Upgrader {
         result.clear();
         for (String child : zoo.getChildren(root)) {
           try {
+            @SuppressWarnings("removal")
             LogEntry e = LogEntry.fromBytes(zoo.getData(root + "/" + child, null));
             // upgrade from !0;!0<< -> +r<<
-            e = new LogEntry(RootTable.EXTENT, 0, e.server, e.filename);
+            e = new LogEntry(RootTable.EXTENT, 0, e.filename);
             result.add(e);
           } catch (KeeperException.NoNodeException ex) {
             // TODO I think this is a bug, probably meant to continue to while loop... was probably

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -671,7 +671,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     return logKeyData(key, durability);
   }
 
-  public String getLogger() {
+  private String getLogger() {
     String[] parts = logPath.split("/");
     return Joiner.on(":").join(parts[parts.length - 2].split("[+]"));
   }

--- a/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MissingWalHeaderCompletesRecoveryIT.java
@@ -138,8 +138,8 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
       TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
       assertNotNull("Table ID was null", tableId);
 
-      LogEntry logEntry = new LogEntry(new KeyExtent(tableId, null, null), 0, "127.0.0.1:12345",
-          emptyWalog.toURI().toString());
+      LogEntry logEntry =
+          new LogEntry(new KeyExtent(tableId, null, null), 0, emptyWalog.toURI().toString());
 
       log.info("Taking {} offline", tableName);
       client.tableOperations().offline(tableName, true);
@@ -198,8 +198,7 @@ public class MissingWalHeaderCompletesRecoveryIT extends ConfigurableMacBase {
       TableId tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
       assertNotNull("Table ID was null", tableId);
 
-      LogEntry logEntry =
-          new LogEntry(null, 0, "127.0.0.1:12345", partialHeaderWalog.toURI().toString());
+      LogEntry logEntry = new LogEntry(null, 0, partialHeaderWalog.toURI().toString());
 
       log.info("Taking {} offline", tableName);
       client.tableOperations().offline(tableName, true);

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -781,7 +781,7 @@ public class ReplicationIT extends ConfigurableMacBase {
         s.setRange(TabletsSection.getRange(tableId));
         Set<String> wals = new HashSet<>();
         for (Entry<Key,Value> entry : s) {
-          LogEntry logEntry = LogEntry.fromKeyValue(entry.getKey(), entry.getValue());
+          LogEntry logEntry = LogEntry.fromMetaWalEntry(entry);
           wals.add(new Path(logEntry.filename).toString());
         }
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationOperationsImplIT.java
@@ -308,8 +308,8 @@ public class ReplicationOperationsImplIT extends ConfigurableMacBase {
     bw.addMutation(m);
     bw.close();
 
-    LogEntry logEntry = new LogEntry(new KeyExtent(tableId1, null, null),
-        System.currentTimeMillis(), "tserver", file1);
+    LogEntry logEntry =
+        new LogEntry(new KeyExtent(tableId1, null, null), System.currentTimeMillis(), file1);
 
     bw = client.createBatchWriter(MetadataTable.NAME, new BatchWriterConfig());
     m = new Mutation(ReplicationSection.getRowPrefix() + file1);


### PR DESCRIPTION
* Remove unused server parameter from the WAL LogEntry
* Remove overloaded fromKeyValue method and rename to fromMetaWalEntry
* Remove unused LogEntry copy constructor
* Prevent extent inside LogEntry from leaving LogEntry by making it
  private, to ensure prevEndRow won't matter in any code outside the
  class, because log entries don't contain the prevEndRow information in
  the metadata tables
* Deprecate LogEntry methods used only for upgrading the root table's
  WAL entries from previous versions (Upgrader9to10)