### PR TITLE
Make ITs with compactions run in MINI only. Fixes #1713

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/IteratorEnvIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/IteratorEnvIT.java
@@ -54,6 +54,11 @@ import org.junit.Test;
 public class IteratorEnvIT extends AccumuloClusterHarness {
 
   @Override
+  public boolean canRunTest(ClusterType type) {
+    return type == ClusterType.MINI;
+  }
+
+  @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.setNumTservers(1);
   }
@@ -168,7 +173,8 @@ public class IteratorEnvIT extends AccumuloClusterHarness {
 
   @After
   public void finish() {
-    client.close();
+    if (client != null)
+      client.close();
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/RecoveryCompactionsAreFlushesIT.java
@@ -47,6 +47,11 @@ import com.google.common.collect.Iterators;
 public class RecoveryCompactionsAreFlushesIT extends AccumuloClusterHarness {
 
   @Override
+  public boolean canRunTest(ClusterType type) {
+    return type == ClusterType.MINI;
+  }
+
+  @Override
   public int defaultTimeoutSeconds() {
     return 180;
   }

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -60,7 +60,6 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.functional.BadIterator;
 import org.apache.accumulo.test.functional.FunctionalTestUtils;
@@ -74,8 +73,12 @@ import com.google.common.collect.Sets;
 
 public class TableOperationsIT extends AccumuloClusterHarness {
 
-  static TabletClientService.Client client;
   private AccumuloClient accumuloClient;
+
+  @Override
+  public boolean canRunTest(ClusterType type) {
+    return type == ClusterType.MINI;
+  }
 
   @Override
   public int defaultTimeoutSeconds() {
@@ -89,8 +92,10 @@ public class TableOperationsIT extends AccumuloClusterHarness {
 
   @After
   public void checkForDanglingFateLocks() {
-    FunctionalTestUtils.assertNoDanglingFateLocks((ClientContext) accumuloClient, getCluster());
-    accumuloClient.close();
+    if (getClusterType() == ClusterType.MINI) {
+      FunctionalTestUtils.assertNoDanglingFateLocks((ClientContext) accumuloClient, getCluster());
+      accumuloClient.close();
+    }
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UserCompactionStrategyIT.java
@@ -66,15 +66,22 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class UserCompactionStrategyIT extends AccumuloClusterHarness {
 
   @Override
+  public boolean canRunTest(ClusterType type) {
+    return type == ClusterType.MINI;
+  }
+
+  @Override
   public int defaultTimeoutSeconds() {
     return 3 * 60;
   }
 
   @After
   public void checkForDanglingFateLocks() {
-    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      assertNotNull(c);
-      FunctionalTestUtils.assertNoDanglingFateLocks((ClientContext) c, getCluster());
+    if (getClusterType() == ClusterType.MINI) {
+      try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+        assertNotNull(c);
+        FunctionalTestUtils.assertNoDanglingFateLocks((ClientContext) c, getCluster());
+      }
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MasterMetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MasterMetricsIT.java
@@ -52,6 +52,11 @@ import org.slf4j.LoggerFactory;
  */
 public class MasterMetricsIT extends AccumuloClusterHarness {
 
+  @Override
+  public boolean canRunTest(ClusterType type) {
+    return type == ClusterType.MINI;
+  }
+
   private static final Logger log = LoggerFactory.getLogger(MasterMetricsIT.class);
 
   private AccumuloClient accumuloClient;
@@ -87,7 +92,8 @@ public class MasterMetricsIT extends AccumuloClusterHarness {
 
   @After
   public void cleanup() {
-    metricsTail.close();
+    if (metricsTail != null)
+      metricsTail.close();
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -93,6 +93,11 @@ import com.google.common.collect.Lists;
 
 public class SummaryIT extends AccumuloClusterHarness {
 
+  @Override
+  public boolean canRunTest(ClusterType type) {
+    return type == ClusterType.MINI;
+  }
+
   private LongSummaryStatistics getTimestampStats(final String table, AccumuloClient c)
       throws TableNotFoundException {
     try (Scanner scanner = c.createScanner(table, Authorizations.EMPTY)) {


### PR DESCRIPTION
* Prevent several ITs that have compaction behavior from running in
standalone mode by overriding the canRunTest method.  These tests
currently don't work well in standalone mode and will fail.
* Remove standalone specific code in functional.CompactionIT