### PR TITLE
Update run-verify.sh to not fail when optional arguments passed are empty

### DIFF
--- a/test/system/continuous/run-verify.sh
+++ b/test/system/continuous/run-verify.sh
@@ -33,10 +33,10 @@ CONTINUOUS_CONF_DIR=${CONTINUOUS_CONF_DIR:-${bin}}
 
 SERVER_LIBJAR="$ACCUMULO_HOME/lib/accumulo-test.jar"
 
-AUTH_OPT="";
-[[ -n $VERIFY_AUTHS ]] && AUTH_OPT="--auths $VERIFY_AUTHS"
+AUTH_OPT=()
+[[ -n $VERIFY_AUTHS ]] && AUTH_OPT=('--auths' "$VERIFY_AUTHS")
 
-SCAN_OPT=--offline
-[[ $SCAN_OFFLINE == false ]] && SCAN_OPT=
+SCAN_OPT=('--offline')
+[[ $SCAN_OFFLINE == 'false' ]] && SCAN_OPT=()
 
-"$ACCUMULO_HOME/bin/tool.sh" "$SERVER_LIBJAR" org.apache.accumulo.test.continuous.ContinuousVerify -Dmapreduce.job.reduce.slowstart.completedmaps=0.95 -libjars "$SERVER_LIBJAR" $AUTH_OPT -i "$INSTANCE_NAME" -z "$ZOO_KEEPERS" -u "$USER" -p "$PASS" --table "$TABLE" --output "$VERIFY_OUT" --maxMappers "$VERIFY_MAX_MAPS" --reducers "$VERIFY_REDUCERS" $SCAN_OPT
+"$ACCUMULO_HOME/bin/tool.sh" "$SERVER_LIBJAR" org.apache.accumulo.test.continuous.ContinuousVerify -Dmapreduce.job.reduce.slowstart.completedmaps=0.95 -libjars "$SERVER_LIBJAR" "${AUTH_OPT[@]}" -i "$INSTANCE_NAME" -z "$ZOO_KEEPERS" -u "$USER" -p "$PASS" --table "$TABLE" --output "$VERIFY_OUT" --maxMappers "$VERIFY_MAX_MAPS" --reducers "$VERIFY_REDUCERS" "${SCAN_OPT[@]}"

--- a/test/system/continuous/run-verify.sh
+++ b/test/system/continuous/run-verify.sh
@@ -39,4 +39,4 @@ AUTH_OPT="";
 SCAN_OPT=--offline
 [[ $SCAN_OFFLINE == false ]] && SCAN_OPT=
 
-"$ACCUMULO_HOME/bin/tool.sh" "$SERVER_LIBJAR" org.apache.accumulo.test.continuous.ContinuousVerify -Dmapreduce.job.reduce.slowstart.completedmaps=0.95 -libjars "$SERVER_LIBJAR" "$AUTH_OPT" -i "$INSTANCE_NAME" -z "$ZOO_KEEPERS" -u "$USER" -p "$PASS" --table "$TABLE" --output "$VERIFY_OUT" --maxMappers "$VERIFY_MAX_MAPS" --reducers "$VERIFY_REDUCERS" "$SCAN_OPT"
+"$ACCUMULO_HOME/bin/tool.sh" "$SERVER_LIBJAR" org.apache.accumulo.test.continuous.ContinuousVerify -Dmapreduce.job.reduce.slowstart.completedmaps=0.95 -libjars "$SERVER_LIBJAR" $AUTH_OPT -i "$INSTANCE_NAME" -z "$ZOO_KEEPERS" -u "$USER" -p "$PASS" --table "$TABLE" --output "$VERIFY_OUT" --maxMappers "$VERIFY_MAX_MAPS" --reducers "$VERIFY_REDUCERS" $SCAN_OPT


### PR DESCRIPTION
This PR resolves the issue reported in #1695. Noticed the ZK lib change has already been done via PR #1716.  