### PR TITLE
Convert Monitor table problems to datatables. Fixes #1719

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
@@ -67,9 +67,9 @@ $(document).ready(function() {
     "stateSave": true,
     "dom": 't<"align-left"l>p',
     "columnDefs": [
-      { "targets": "duration",
+      { "targets": "date",
         "render": function ( data, type, row ) {
-          if(type === 'display') data = timeDuration(data);
+          if(type === 'display') data = dateFormat(data);
           return data;
         }
       }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/problems.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/problems.ftl
@@ -39,14 +39,18 @@
             <thead>
               <tr>
                 <th class="firstcell">Table&nbsp;</th>
-                <th>FILE_READ&nbsp;</th>
-                <th>FILE_WRITE&nbsp;</th>
-                <th>TABLET_LOAD&nbsp;</th>
+                <th class="big-num">FILE_READ&nbsp;</th>
+                <th class="big-num">FILE_WRITE&nbsp;</th>
+                <th class="big-num">TABLET_LOAD&nbsp;</th>
                 <th>Operations&nbsp;</th>
               </tr>
             </thead>
             <tbody></tbody>
           </table>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
           <table id="problemDetails" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Details</span></caption>
             <thead>
@@ -54,7 +58,7 @@
                 <th class="firstcell" >Table&nbsp;</th>
                 <th>Problem&nbsp;Type&nbsp;</th>
                 <th>Server&nbsp;</th>
-                <th>Time&nbsp;</th>
+                <th class="duration">Time&nbsp;</th>
                 <th>Resource&nbsp;</th>
                 <th>Exception&nbsp;</th>
                 <th>Operations&nbsp;</th>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/problems.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/problems.ftl
@@ -58,7 +58,7 @@
                 <th class="firstcell" >Table&nbsp;</th>
                 <th>Problem&nbsp;Type&nbsp;</th>
                 <th>Server&nbsp;</th>
-                <th class="duration">Time&nbsp;</th>
+                <th class="date">Time&nbsp;</th>
                 <th>Resource&nbsp;</th>
                 <th>Exception&nbsp;</th>
                 <th>Operations&nbsp;</th>


### PR DESCRIPTION
This will fix the bug but we lose the ability to filter the details table.  I couldn't get the search box to look right with the two tables and don't think its intuitive to be used to filter anyway.  I think the making the table links filter the details table can be a follow on task.  This PR just makes the links go to the table page.

![pertable-problem-fix](https://user-images.githubusercontent.com/11872539/94830097-31030480-03d9-11eb-8658-732bb2108a27.png)
