### PR TITLE
Update release candidate script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,6 @@
     <curator.version>2.11.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
-    <!-- extra release args for testing -->
-    <extraReleaseArguments />
     <failsafe.excludedGroups />
     <failsafe.groups />
     <!-- surefire/failsafe plugin option -->
@@ -685,10 +683,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
-            <arguments>-P !autoformat,thrift,sunny -Dtimeout.factor=2 ${extraReleaseArguments}</arguments>
+            <arguments>-P !autoformat,thrift -DskipTests</arguments>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <goals>clean deploy</goals>
-            <preparationGoals>clean verify</preparationGoals>
+            <preparationGoals>clean package</preparationGoals>
             <tagNameFormat>rel/@{project.version}</tagNameFormat>
             <releaseProfiles>apache-release,accumulo-release,skip-plugin-its-with-skipTests</releaseProfiles>
             <useReleaseProfile>false</useReleaseProfile>


### PR DESCRIPTION
Improving generated output:
* show link to staging repo website
* show full commits
* show reminders of which buttons to click on the staging site
* show reminder to replace `$origin` with actual remote name
* place `-s` in `git tag` command with the other options
* update draft release notes link to point to staged site

Optimizing performance:
* create the `-next` branch and switch to it in one command
* skip tests during release prep because the release can (and should) be
  tested outside of the actual release candidate creation process and
  this speeds things up significantly
* change release prep goal to only do `package`, because it's not
  necessary to run `verify` during `release:prepare`; all the QA checks
  done at `verify` can be done before/after release candidate staging

Being more interactive:
* prompt for gpg key to use
* prompt for the `remote` to push to (do not assume `origin`)

Removing junk:
* remove check for `gpg2` (modern Linux uses version 2 for the `gpg` binary)
* remove unnecessary `--test` option and related `runOrFail` function
* remove `extraReleaseArguments` to simplify things