### PR TITLE
Initilaize hdfs connection with correct ugi

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -44,8 +44,8 @@ public abstract class AbstractServer implements AutoCloseable, Runnable {
     this.hostname = Objects.requireNonNull(opts.getAddress());
     opts.parseArgs(appName, args);
     var siteConfig = opts.getSiteConfiguration();
-    context = new ServerContext(siteConfig);
     SecurityUtil.serverLogin(siteConfig);
+    context = new ServerContext(siteConfig);
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + context.getInstanceID());
     ServerUtil.init(context, appName);


### PR DESCRIPTION
ServerContext creates a ServerInfo which initializes the hdfs connection
and among others a LeaseRenewer is started with the current
UserGroupInformation. To make sure the correct UserGroupInformation is
used I moved the serverLogin call before ServerContext creation.