### PR TITLE
Closes #1718. Fail if no Accumulo Instance on Standalone setup

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -221,9 +221,8 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
 
   public void checkConnection() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      // Use prefix so cleanupTables deletes it
-      String tablePrefix = this.getClass().getSimpleName() + "_";
-      client.tableOperations().create(tablePrefix);
+      // Run a client operation to test if accumulo is running
+      client.tableOperations().list();
 
     } catch (Exception e) {
       throw new RuntimeException("Could not connect to accumulo instance", e);

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -169,6 +169,8 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
     if (type.isDynamic()) {
       cluster.start();
     } else {
+      log.info("Check if we can connect to accumulo before starting test");
+      checkConnection();
       log.info("Removing tables which appear to be from a previous test run");
       cleanupTables();
       log.info("Removing users which appear to be from a previous test run");
@@ -214,6 +216,17 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
         break;
       default:
         // do nothing
+    }
+  }
+
+  public void checkConnection() {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      // Use prefix so cleanupTables deletes it
+      String tablePrefix = this.getClass().getSimpleName() + "_";
+      client.tableOperations().create(tablePrefix);
+
+    } catch (Exception e) {
+      throw new RuntimeException("Could not connect to accumulo instance", e);
     }
   }
 


### PR DESCRIPTION
A simple function that tries to establish a connection to the standalone cluster. If nothing is running then it will hang until zookeeper or the test times out, whichever happens first. That will depend if the user passes in a timeout factor or not.  I tested out a few other ways to check if the client was established, like some instance operations,  but ultimately with table creation. The created table gets deleted in the cleanupTables() function.  Closes #1718  