### PR TITLE
Update regex expression in tool.sh

### DIFF
--- a/assemble/bin/tool.sh
+++ b/assemble/bin/tool.sh
@@ -38,7 +38,7 @@ fi
 
 ZOOKEEPER_CMD='ls -1 $ZOOKEEPER_HOME/lib/zookeeper-[0-9]*[^csn].jar '
 ZOOKEEPER_VERSION=$(find -L "$ZOOKEEPER_HOME" -maxdepth 2 -name "zookeeper-[0-9]*.jar" | head -1)
-if [[ $ZOOKEEPER_VERSION =~ .*-3[.][01234].*$ ]]; then
+if [[ $ZOOKEEPER_VERSION =~ ^.*zookeeper-3[.][01234].*$ ]]; then
   ZOOKEEPER_CMD='ls -1 $ZOOKEEPER_HOME/zookeeper-[0-9]*[^csn].jar '
 fi
 if [[ $(eval $ZOOKEEPER_CMD | wc -l) -ne 1 ]] ; then

--- a/test/system/continuous/run-verify.sh
+++ b/test/system/continuous/run-verify.sh
@@ -33,10 +33,10 @@ CONTINUOUS_CONF_DIR=${CONTINUOUS_CONF_DIR:-${bin}}
 
 SERVER_LIBJAR="$ACCUMULO_HOME/lib/accumulo-test.jar"
 
-AUTH_OPT="";
-[[ -n $VERIFY_AUTHS ]] && AUTH_OPT="--auths $VERIFY_AUTHS"
+AUTH_OPT=()
+[[ -n $VERIFY_AUTHS ]] && AUTH_OPT=('--auths' "$VERIFY_AUTHS")
 
-SCAN_OPT=--offline
-[[ $SCAN_OFFLINE == false ]] && SCAN_OPT=
+SCAN_OPT=('--offline')
+[[ $SCAN_OFFLINE == 'false' ]] && SCAN_OPT=()
 
-"$ACCUMULO_HOME/bin/tool.sh" "$SERVER_LIBJAR" org.apache.accumulo.test.continuous.ContinuousVerify -Dmapreduce.job.reduce.slowstart.completedmaps=0.95 -libjars "$SERVER_LIBJAR" "$AUTH_OPT" -i "$INSTANCE_NAME" -z "$ZOO_KEEPERS" -u "$USER" -p "$PASS" --table "$TABLE" --output "$VERIFY_OUT" --maxMappers "$VERIFY_MAX_MAPS" --reducers "$VERIFY_REDUCERS" "$SCAN_OPT"
+"$ACCUMULO_HOME/bin/tool.sh" "$SERVER_LIBJAR" org.apache.accumulo.test.continuous.ContinuousVerify -Dmapreduce.job.reduce.slowstart.completedmaps=0.95 -libjars "$SERVER_LIBJAR" "${AUTH_OPT[@]}" -i "$INSTANCE_NAME" -z "$ZOO_KEEPERS" -u "$USER" -p "$PASS" --table "$TABLE" --output "$VERIFY_OUT" --maxMappers "$VERIFY_MAX_MAPS" --reducers "$VERIFY_REDUCERS" "${SCAN_OPT[@]}"


### PR DESCRIPTION
Modify the regex in tool.sh to successfully determine zookeeper version. Previous commit needed to be slightly modified to work correctly. Replacing ^3[.][01234].*$ with .*-3[.][01234].*$