### PR TITLE
Fix build_native_library.sh so that it runs on alpine-based (e.g. Alpine)-based distros

### DIFF
--- a/assemble/bin/build_native_library.sh
+++ b/assemble/bin/build_native_library.sh
@@ -40,7 +40,7 @@ fi
 mkdir -p "${final_native_target}" || exit 1
 
 # Make a directory for us to unpack the native source into
-TMP_DIR=$(mktemp -d /tmp/accumulo-native.XXXX) || exit 1
+TMP_DIR=$(mktemp -d /tmp/accumulo-native.XXXXXX) || exit 1
 
 # Unpack the tarball to our temp directory
 tar xf "${native_tarball}" -C "${TMP_DIR}"


### PR DESCRIPTION
Fixes https://github.com/apache/accumulo/issues/1731