### PR TITLE
VolumeManager and Volume internals cleanup

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -192,13 +192,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
    * Check path of bulk directory and permissions
    */
   private Path checkPath(FileSystem fs, String dir) throws IOException, AccumuloException {
-    Path ret;
-
-    if (dir.contains(":")) {
-      ret = new Path(dir);
-    } else {
-      ret = fs.makeQualified(new Path(dir));
-    }
+    Path ret = dir.contains(":") ? new Path(dir) : fs.makeQualified(new Path(dir));
 
     try {
       if (!fs.getFileStatus(ret).isDirectory()) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -106,7 +106,9 @@ public enum Property {
           + " org.apache.accumulo.server.util.ChangeSecret"),
   INSTANCE_VOLUMES("instance.volumes", "", PropertyType.STRING,
       "A comma separated list of dfs uris to use. Files will be stored across"
-          + " these filesystems. If this is empty, then instance.dfs.uri will be used."
+          + " these filesystems. In some situations, the first volume in this list"
+          + " may be treated differently, such as being preferred for writing out"
+          + " temporary files (for example, when creating a pre-split table)."
           + " After adding uris to this list, run 'accumulo init --add-volume' and then"
           + " restart tservers. If entries are removed from this list then tservers"
           + " will need to be restarted. After a uri is removed from the list Accumulo"

--- a/core/src/main/java/org/apache/accumulo/core/volume/Volume.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/Volume.java
@@ -38,26 +38,25 @@ public interface Volume {
   String getBasePath();
 
   /**
-   * Convert the given Path into a Path that is relative to the base path for this Volume
+   * Convert the given child path into a Path that is relative to the base path for this Volume. The
+   * supplied path should not include any scheme (such as <code>file:</code> or <code>hdfs:</code>),
+   * and should not contain any relative path "breakout" patterns, such as <code>../</code>. If the
+   * path begins with a single slash, it will be preserved while prefixing this volume. If it does
+   * not begin with a single slash, one will be inserted.
    *
-   * @param p
+   * @param pathString
    *          The suffix to use
    * @return A Path for this Volume with the provided suffix
    */
-  Path prefixChild(Path p);
+  Path prefixChild(String pathString);
 
   /**
-   * Convert the given child path into a Path that is relative to the base path for this Volume
-   *
-   * @param p
-   *          The suffix to use
-   * @return A Path for this Volume with the provided suffix
+   * Determine if the Path is contained in Volume. A Path is considered contained if refers to a
+   * location within the base path for this Volume on the same FileSystem. It can be located at the
+   * base path, or within any sub-directory. Unqualified paths (those without a file system scheme)
+   * will resolve to using the configured Hadoop default file system before comparison. Paths are
+   * not considered "contained" within this Volume if they have any relative path "breakout"
+   * patterns, such as <code>../</code>.
    */
-  Path prefixChild(String p);
-
-  /**
-   * Determine if the Path is valid on this Volume. A Path is valid if it is contained in the
-   * Volume's FileSystem and is rooted beneath the basePath
-   */
-  boolean isValidPath(Path p);
+  boolean containsPath(Path path);
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerUtil.java
@@ -95,14 +95,14 @@ public class ServerUtil {
     return getAccumuloPersistentVersion(v.getFileSystem(), path);
   }
 
-  public static synchronized int getAccumuloPersistentVersion(VolumeManager fs) {
+  public static synchronized int getAccumuloPersistentVersion(VolumeManager vm) {
     // It doesn't matter which Volume is used as they should all have the data version stored
-    return getAccumuloPersistentVersion(fs.getVolumes().iterator().next());
+    return getAccumuloPersistentVersion(vm.getFirst());
   }
 
-  public static synchronized Path getAccumuloInstanceIdPath(VolumeManager fs) {
+  public static synchronized Path getAccumuloInstanceIdPath(VolumeManager vm) {
     // It doesn't matter which Volume is used as they should all have the instance ID stored
-    return ServerConstants.getInstanceIdLocation(fs.getVolumes().iterator().next());
+    return ServerConstants.getInstanceIdLocation(vm.getFirst());
   }
 
   public static void init(ServerContext context, String application) {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -179,12 +179,14 @@ public interface VolumeManager extends AutoCloseable {
   boolean canSyncAndFlush(Path path);
 
   /**
-   * Fetch the default Volume
+   * Fetch the first configured instance Volume
    */
-  Volume getDefaultVolume();
+  default Volume getFirst() {
+    return getVolumes().iterator().next();
+  }
 
   /**
-   * Fetch the configured Volumes, excluding the default Volume
+   * Fetch the configured instance Volumes
    */
   Collection<Volume> getVolumes();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -72,14 +72,12 @@ public class VolumeManagerImpl implements VolumeManager {
 
   private final Map<String,Volume> volumesByName;
   private final Multimap<URI,Volume> volumesByFileSystemUri;
-  private final Volume defaultVolume;
   private final VolumeChooser chooser;
   private final Configuration hadoopConf;
 
-  protected VolumeManagerImpl(Map<String,Volume> volumes, Volume defaultVolume,
-      AccumuloConfiguration conf, Configuration hadoopConf) {
+  protected VolumeManagerImpl(Map<String,Volume> volumes, AccumuloConfiguration conf,
+      Configuration hadoopConf) {
     this.volumesByName = volumes;
-    this.defaultVolume = defaultVolume;
     // We may have multiple directories used in a single FileSystem (e.g. testing)
     this.volumesByFileSystemUri = invertVolumesByFileSystem(volumesByName);
     ensureSyncIsEnabled();
@@ -110,9 +108,10 @@ public class VolumeManagerImpl implements VolumeManager {
   public static VolumeManager getLocalForTesting(String localBasePath) throws IOException {
     AccumuloConfiguration accConf = DefaultConfiguration.getInstance();
     Configuration hadoopConf = new Configuration();
-    Volume defaultLocalVolume = new VolumeImpl(FileSystem.getLocal(hadoopConf), localBasePath);
-    return new VolumeManagerImpl(Collections.singletonMap("", defaultLocalVolume),
-        defaultLocalVolume, accConf, hadoopConf);
+    FileSystem localFS = FileSystem.getLocal(hadoopConf);
+    Volume defaultLocalVolume = new VolumeImpl(localFS, localBasePath);
+    return new VolumeManagerImpl(Collections.singletonMap("", defaultLocalVolume), accConf,
+        hadoopConf);
   }
 
   @Override
@@ -244,19 +243,16 @@ public class VolumeManagerImpl implements VolumeManager {
 
   @Override
   public FileSystem getFileSystemByPath(Path path) {
-    if (!requireNonNull(path).toString().contains(":")) {
-      return defaultVolume.getFileSystem();
-    }
     FileSystem desiredFs;
     try {
-      desiredFs = path.getFileSystem(hadoopConf);
+      desiredFs = requireNonNull(path).getFileSystem(hadoopConf);
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }
     URI desiredFsUri = desiredFs.getUri();
     Collection<Volume> candidateVolumes = volumesByFileSystemUri.get(desiredFsUri);
     if (candidateVolumes != null) {
-      return candidateVolumes.stream().filter(volume -> volume.isValidPath(path))
+      return candidateVolumes.stream().filter(volume -> volume.containsPath(path))
           .map(Volume::getFileSystem).findFirst().orElse(desiredFs);
     } else {
       log.debug("Could not determine volume for Path: {}", path);
@@ -369,9 +365,7 @@ public class VolumeManagerImpl implements VolumeManager {
       }
     }
 
-    String uri = volumeStrings.iterator().next();
-    Volume defaultVolume = new VolumeImpl(new Path(uri), hadoopConf);
-    return new VolumeManagerImpl(volumes, defaultVolume, conf, hadoopConf);
+    return new VolumeManagerImpl(volumes, conf, hadoopConf);
   }
 
   @Override
@@ -449,11 +443,6 @@ public class VolumeManagerImpl implements VolumeManager {
       }
     }
     return true;
-  }
-
-  @Override
-  public Volume getDefaultVolume() {
-    return defaultVolume;
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -57,8 +57,9 @@ public class VolumeUtil {
   }
 
   public static Path removeTrailingSlash(Path path) {
-    if (path.toString().endsWith("/"))
-      return new Path(removeTrailingSlash(path.toString()));
+    String pathStr = path.toString();
+    if (pathStr.endsWith("/"))
+      return new Path(removeTrailingSlash(pathStr));
     return path;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/gc/GcVolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/gc/GcVolumeUtil.java
@@ -18,13 +18,12 @@
  */
 package org.apache.accumulo.server.gc;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
-import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerConstants;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.Path;
@@ -42,16 +41,8 @@ public class GcVolumeUtil {
   public static Collection<Path> expandAllVolumesUri(VolumeManager fs, Path path) {
     if (path.toString().startsWith(ALL_VOLUMES_PREFIX)) {
       String relPath = path.toString().substring(ALL_VOLUMES_PREFIX.length());
-
-      Collection<Volume> volumes = fs.getVolumes();
-
-      ArrayList<Path> ret = new ArrayList<>(volumes.size());
-      for (Volume vol : volumes) {
-        Path volPath = vol.prefixChild(relPath);
-        ret.add(volPath);
-      }
-
-      return ret;
+      return fs.getVolumes().stream().map(vol -> vol.prefixChild(relPath))
+          .collect(Collectors.toList());
     } else {
       return Collections.singleton(path);
     }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -26,7 +26,6 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -699,7 +698,6 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   static void minimizeDeletes(SortedMap<String,String> confirmedDeletes,
       List<String> processedDeletes, VolumeManager fs) {
     Set<Path> seenVolumes = new HashSet<>();
-    Collection<Volume> volumes = fs.getVolumes();
 
     // when deleting a dir and all files in that dir, only need to delete the dir
     // the dir will sort right before the files... so remove the files in this case
@@ -726,8 +724,8 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
             if (seenVolumes.contains(vol)) {
               sameVol = true;
             } else {
-              for (Volume cvol : volumes) {
-                if (cvol.isValidPath(vol)) {
+              for (Volume cvol : fs.getVolumes()) {
+                if (cvol.containsPath(vol)) {
                   seenVolumes.add(vol);
                   sameVol = true;
                 }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -145,12 +145,12 @@ public class SimpleGarbageCollectorTest {
   @Test
   public void testMinimizeDeletes() {
     Volume vol1 = createMock(Volume.class);
-    expect(vol1.isValidPath(anyObject()))
+    expect(vol1.containsPath(anyObject()))
         .andAnswer(() -> getCurrentArguments()[0].toString().startsWith("hdfs://nn1/accumulo"))
         .anyTimes();
 
     Volume vol2 = createMock(Volume.class);
-    expect(vol2.isValidPath(anyObject()))
+    expect(vol2.containsPath(anyObject()))
         .andAnswer(() -> getCurrentArguments()[0].toString().startsWith("hdfs://nn2/accumulo"))
         .anyTimes();
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/FateServiceHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.master;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.Constants.MAX_NAMESPACE_LEN;
 import static org.apache.accumulo.core.Constants.MAX_TABLE_NAME_LEN;
 import static org.apache.accumulo.master.util.TableValidators.CAN_CLONE;
@@ -789,7 +790,7 @@ class FateServiceHandler implements FateService.Iface {
       for (int i = splitOffset; i < splitCount + splitOffset; i++) {
         byte[] splitBytes = ByteBufferUtil.toBytes(arguments.get(i));
         String encodedSplit = Base64.getEncoder().encodeToString(splitBytes);
-        stream.writeBytes(encodedSplit + '\n');
+        stream.write((encodedSplit + '\n').getBytes(UTF_8));
       }
     } catch (IOException e) {
       log.error("Error in FateServiceHandler while writing splits to {}: {}", splitsPath,

--- a/server/manager/src/main/java/org/apache/accumulo/master/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/FateServiceHandler.java
@@ -169,12 +169,14 @@ class FateServiceHandler implements FateService.Iface {
             InitialTableState.valueOf(ByteBufferUtil.toString(arguments.get(2)));
         int splitCount = Integer.parseInt(ByteBufferUtil.toString(arguments.get(3)));
         validateArgumentCount(arguments, tableOp, SPLIT_OFFSET + splitCount);
-        String splitFile = null;
-        String splitDirsFile = null;
+        Path splitsPath = null;
+        Path splitsDirsPath = null;
         if (splitCount > 0) {
           try {
-            splitFile = writeSplitsToFile(opid, arguments, splitCount, SPLIT_OFFSET);
-            splitDirsFile = createSplitDirsFile(opid);
+            Path tmpDir = mkTempDir(opid);
+            splitsPath = new Path(tmpDir, "splits");
+            splitsDirsPath = new Path(tmpDir, "splitsDirs");
+            writeSplitsToFile(splitsPath, arguments, splitCount, SPLIT_OFFSET);
           } catch (IOException e) {
             throw new ThriftTableOperationException(null, tableName, tableOp,
                 TableOperationExceptionType.OTHER,
@@ -196,7 +198,7 @@ class FateServiceHandler implements FateService.Iface {
 
         master.fate.seedTransaction(opid,
             new TraceRepo<>(new CreateTable(c.getPrincipal(), tableName, timeType, options,
-                splitFile, splitCount, splitDirsFile, initialTableState, namespaceId)),
+                splitsPath, splitCount, splitsDirsPath, initialTableState, namespaceId)),
             autoCleanup);
 
         break;
@@ -779,65 +781,37 @@ class FateServiceHandler implements FateService.Iface {
   /**
    * Create a file on the file system to hold the splits to be created at table creation.
    */
-  private String writeSplitsToFile(final long opid, final List<ByteBuffer> arguments,
+  private void writeSplitsToFile(Path splitsPath, final List<ByteBuffer> arguments,
       final int splitCount, final int splitOffset) throws IOException {
-    String opidStr = String.format("%016x", opid);
-    String splitsPath = getSplitPath("/tmp/splits-" + opidStr);
-    removeAndCreateTempFile(splitsPath);
-    try (FSDataOutputStream stream = master.getOutputStream(splitsPath)) {
-      writeSplitsToFileSystem(stream, arguments, splitCount, splitOffset);
+    FileSystem fs = splitsPath.getFileSystem(master.getContext().getHadoopConf());
+    try (FSDataOutputStream stream = fs.create(splitsPath)) {
+      // base64 encode because splits can contain binary
+      for (int i = splitOffset; i < splitCount + splitOffset; i++) {
+        byte[] splitBytes = ByteBufferUtil.toBytes(arguments.get(i));
+        String encodedSplit = Base64.getEncoder().encodeToString(splitBytes);
+        stream.writeBytes(encodedSplit + '\n');
+      }
     } catch (IOException e) {
-      log.error("Error in FateServiceHandler while writing splits for opid: " + opidStr + ": "
-          + e.getMessage());
+      log.error("Error in FateServiceHandler while writing splits to {}: {}", splitsPath,
+          e.getMessage());
       throw e;
     }
-    return splitsPath;
   }
 
   /**
-   * Always check for and delete the splits file if it exists to prevent issues in case of server
-   * failure and/or FateServiceHandler retries.
+   * Creates a temporary directory for the given FaTE operation (deleting any existing, to avoid
+   * issues in case of server retry).
+   *
+   * @return the path of the created directory
    */
-  private void removeAndCreateTempFile(String path) throws IOException {
-    FileSystem fs = master.getVolumeManager().getDefaultVolume().getFileSystem();
-    if (fs.exists(new Path(path)))
-      fs.delete(new Path(path), true);
-    fs.create(new Path(path));
+  public Path mkTempDir(long opid) throws IOException {
+    Volume vol = master.getVolumeManager().getFirst();
+    Path p = vol.prefixChild("/tmp/fate-" + String.format("%016x", opid));
+    FileSystem fs = vol.getFileSystem();
+    if (fs.exists(p))
+      fs.delete(p, true);
+    fs.mkdirs(p);
+    return p;
   }
 
-  /**
-   * Check for and delete the temp file if it exists to prevent issues in case of server failure
-   * and/or FateServiceHandler retries. Then create/recreate the file.
-   */
-  private String createSplitDirsFile(final long opid) throws IOException {
-    String opidStr = String.format("%016x", opid);
-    String splitDirPath = getSplitPath("/tmp/splitDirs-" + opidStr);
-    removeAndCreateTempFile(splitDirPath);
-    return splitDirPath;
-  }
-
-  /**
-   * Write the split values to a tmp directory with unique name. Given that it is not known if the
-   * supplied splits will be textual or binary, all splits will be encoded to enable proper handling
-   * of binary data.
-   */
-  private void writeSplitsToFileSystem(final FSDataOutputStream stream,
-      final List<ByteBuffer> arguments, final int splitCount, final int splitOffset)
-      throws IOException {
-    for (int i = splitOffset; i < splitCount + splitOffset; i++) {
-      byte[] splitBytes = ByteBufferUtil.toBytes(arguments.get(i));
-      String encodedSplit = Base64.getEncoder().encodeToString(splitBytes);
-      stream.writeBytes(encodedSplit + '\n');
-    }
-  }
-
-  /**
-   * Get full path to location where initial splits are stored on file system.
-   */
-  private String getSplitPath(String relPath) {
-    Volume defaultVolume = master.getVolumeManager().getDefaultVolume();
-    String uri = defaultVolume.getFileSystem().getUri().toString();
-    String basePath = defaultVolume.getBasePath();
-    return uri + basePath + relPath;
-  }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Master.java
@@ -135,8 +135,6 @@ import org.apache.accumulo.server.util.TableInfoUtil;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
 import org.apache.accumulo.start.classloader.vfs.ContextManager;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -1708,14 +1706,6 @@ public class Master extends AbstractServer
   @Override
   public boolean isActiveService() {
     return masterInitialized.get();
-  }
-
-  public FSDataOutputStream getOutputStream(final String path) throws IOException {
-    return getVolumeManager().getDefaultVolume().getFileSystem().create(new Path(path));
-  }
-
-  public FSDataInputStream getInputStream(final String path) throws IOException {
-    return getVolumeManager().getDefaultVolume().getFileSystem().open(new Path(path));
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/TableInfo.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/TableInfo.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.client.admin.InitialTableState;
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.hadoop.fs.Path;
 
 public class TableInfo implements Serializable {
 
@@ -87,20 +88,22 @@ public class TableInfo implements Serializable {
     this.user = user;
   }
 
-  public String getSplitFile() {
-    return splitFile;
+  public Path getSplitPath() {
+    return new Path(splitFile);
   }
 
-  public void setSplitFile(String splitFile) {
-    this.splitFile = splitFile;
+  // stored as string for Java serialization
+  public void setSplitPath(Path splitPath) {
+    this.splitFile = splitPath == null ? null : splitPath.toString();
   }
 
-  public String getSplitDirsFile() {
-    return splitDirsFile;
+  public Path getSplitDirsPath() {
+    return new Path(splitDirsFile);
   }
 
-  public void setSplitDirsFile(String splitDirsFile) {
-    this.splitDirsFile = splitDirsFile;
+  // stored as string for Java serialization
+  public void setSplitDirsPath(Path splitDirsPath) {
+    this.splitDirsFile = splitDirsPath == null ? null : splitDirsPath.toString();
   }
 
   public InitialTableState getInitialTableState() {

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/Utils.java
@@ -20,9 +20,7 @@ package org.apache.accumulo.master.tableOps;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.util.Base64;
 import java.util.SortedSet;
@@ -47,7 +45,8 @@ import org.apache.accumulo.fate.zookeeper.ZooReservation;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -198,19 +197,21 @@ public class Utils {
    * Given an input stream and a flag indicating if the file info is base64 encoded or not, retrieve
    * the data from a file on the file system. It is assumed that the file is textual and not binary
    * data.
+   *
+   * @param path
+   *          the fully qualified path
    */
-  public static SortedSet<Text> getSortedSetFromFile(FSDataInputStream inputStream, boolean encoded)
+  public static SortedSet<Text> getSortedSetFromFile(Master master, Path path, boolean encoded)
       throws IOException {
-    SortedSet<Text> data = new TreeSet<>();
-    try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
-      String line;
-      while ((line = br.readLine()) != null) {
-        if (encoded)
-          data.add(new Text(Base64.getDecoder().decode(line)));
-        else
-          data.add(new Text(line));
+    FileSystem fs = path.getFileSystem(master.getContext().getHadoopConf());
+    var data = new TreeSet<Text>();
+    try (var file = new java.util.Scanner(fs.open(path), UTF_8)) {
+      while (file.hasNextLine()) {
+        String line = file.nextLine();
+        data.add(encoded ? new Text(Base64.getDecoder().decode(line)) : new Text(line));
       }
     }
     return data;
   }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/Utils.java
@@ -194,12 +194,12 @@ public class Utils {
   }
 
   /**
-   * Given an input stream and a flag indicating if the file info is base64 encoded or not, retrieve
-   * the data from a file on the file system. It is assumed that the file is textual and not binary
-   * data.
+   * Given a fully-qualified Path and a flag indicating if the file info is base64 encoded or not,
+   * retrieve the data from a file on the file system. It is assumed that the file is textual and
+   * not binary data.
    *
    * @param path
-   *          the fully qualified path
+   *          the fully-qualified path
    */
   public static SortedSet<Text> getSortedSetFromFile(Master master, Path path, boolean encoded)
       throws IOException {

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/ChooseDir.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/ChooseDir.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.master.tableOps.create;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -100,7 +102,7 @@ class ChooseDir extends MasterRepo {
       fs.delete(p, true);
     try (FSDataOutputStream stream = fs.create(p)) {
       for (Text dir : dirs)
-        stream.writeBytes(dir + "\n");
+        stream.write((dir + "\n").getBytes(UTF_8));
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
 import org.apache.accumulo.master.tableOps.TableInfo;
 import org.apache.accumulo.master.tableOps.Utils;
+import org.apache.hadoop.fs.Path;
 
 public class CreateTable extends MasterRepo {
   private static final long serialVersionUID = 1L;
@@ -37,7 +38,7 @@ public class CreateTable extends MasterRepo {
   private TableInfo tableInfo;
 
   public CreateTable(String user, String tableName, TimeType timeType, Map<String,String> props,
-      String splitFile, int splitCount, String splitDirsFile, InitialTableState initialTableState,
+      Path splitPath, int splitCount, Path splitDirsPath, InitialTableState initialTableState,
       NamespaceId namespaceId) {
     tableInfo = new TableInfo();
     tableInfo.setTableName(tableName);
@@ -45,10 +46,10 @@ public class CreateTable extends MasterRepo {
     tableInfo.setUser(user);
     tableInfo.props = props;
     tableInfo.setNamespaceId(namespaceId);
-    tableInfo.setSplitFile(splitFile);
+    tableInfo.setSplitPath(splitPath);
     tableInfo.setInitialSplitSize(splitCount);
     tableInfo.setInitialTableState(initialTableState);
-    tableInfo.setSplitDirsFile(splitDirsFile);
+    tableInfo.setSplitDirsPath(splitDirsPath);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/FinishCreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/FinishCreateTable.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 import org.apache.accumulo.core.client.admin.InitialTableState;
 import org.apache.accumulo.core.master.state.tables.TableState;
-import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
@@ -69,10 +68,11 @@ class FinishCreateTable extends MasterRepo {
   }
 
   private void cleanupSplitFiles(Master env) throws IOException {
-    Volume defaultVolume = env.getVolumeManager().getDefaultVolume();
-    FileSystem fs = defaultVolume.getFileSystem();
-    fs.delete(new Path(tableInfo.getSplitFile()), true);
-    fs.delete(new Path(tableInfo.getSplitDirsFile()), true);
+    // it is sufficient to delete from the parent, because both files are in the same directory, and
+    // we want to delete the directory also
+    Path p = tableInfo.getSplitPath().getParent();
+    FileSystem fs = p.getFileSystem(env.getContext().getHadoopConf());
+    fs.delete(p, true);
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/PopulateMetadata.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
@@ -63,20 +64,18 @@ class PopulateMetadata extends MasterRepo {
   }
 
   @Override
-  public Repo<Master> call(long tid, Master environment) throws Exception {
+  public Repo<Master> call(long tid, Master env) throws Exception {
     KeyExtent extent = new KeyExtent(tableInfo.getTableId(), null, null);
     MetadataTableUtil.addTablet(extent, ServerColumnFamily.DEFAULT_TABLET_DIR_NAME,
-        environment.getContext(), tableInfo.getTimeType(), environment.getMasterLock());
+        env.getContext(), tableInfo.getTimeType(), env.getMasterLock());
 
     if (tableInfo.getInitialSplitSize() > 0) {
-      SortedSet<Text> splits =
-          Utils.getSortedSetFromFile(environment.getInputStream(tableInfo.getSplitFile()), true);
-      SortedSet<Text> dirs = Utils
-          .getSortedSetFromFile(environment.getInputStream(tableInfo.getSplitDirsFile()), false);
+      SortedSet<Text> splits = Utils.getSortedSetFromFile(env, tableInfo.getSplitPath(), true);
+      SortedSet<Text> dirs = Utils.getSortedSetFromFile(env, tableInfo.getSplitDirsPath(), false);
       Map<Text,Text> splitDirMap = createSplitDirectoryMap(splits, dirs);
-      try (BatchWriter bw = environment.getContext().createBatchWriter("accumulo.metadata")) {
-        writeSplitsToMetadataTable(environment.getContext(), tableInfo.getTableId(), splits,
-            splitDirMap, tableInfo.getTimeType(), environment.getMasterLock(), bw);
+      try (BatchWriter bw = env.getContext().createBatchWriter(MetadataTable.NAME)) {
+        writeSplitsToMetadataTable(env.getContext(), tableInfo.getTableId(), splits, splitDirMap,
+            tableInfo.getTimeType(), env.getMasterLock(), bw);
       }
     }
     return new FinishCreateTable(tableInfo);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -862,8 +862,8 @@ public class TabletServer extends AbstractServer {
     TServerUtils.stopTServer(server);
 
     try {
-      log.debug("Closing filesystem");
-      getFileSystem().close();
+      log.debug("Closing filesystems");
+      getVolumeManager().close();
     } catch (IOException e) {
       log.warn("Failed to close filesystem : {}", e.getMessage(), e);
     }
@@ -1194,8 +1194,8 @@ public class TabletServer extends AbstractServer {
     return new DfsLogger.ServerResources() {
 
       @Override
-      public VolumeManager getFileSystem() {
-        return TabletServer.this.getFileSystem();
+      public VolumeManager getVolumeManager() {
+        return TabletServer.this.getVolumeManager();
       }
 
       @Override
@@ -1213,7 +1213,7 @@ public class TabletServer extends AbstractServer {
     return onlineTablets.snapshot().get(extent);
   }
 
-  public VolumeManager getFileSystem() {
+  public VolumeManager getVolumeManager() {
     return getContext().getVolumeManager();
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -406,7 +406,7 @@ public class TabletServerResourceManager {
     fileLenCache =
         CacheBuilder.newBuilder().maximumSize(Math.min(maxOpenFiles * 1000L, 100_000)).build();
 
-    fileManager = new FileManager(context, context.getVolumeManager(), maxOpenFiles, fileLenCache);
+    fileManager = new FileManager(context, maxOpenFiles, fileLenCache);
 
     memoryManager = new LargestFirstMemoryManager();
     memoryManager.init(context);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -143,7 +143,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
   public interface ServerResources {
     AccumuloConfiguration getConfiguration();
 
-    VolumeManager getFileSystem();
+    VolumeManager getVolumeManager();
   }
 
   private final LinkedBlockingQueue<DfsLogger.LogWork> workQueue = new LinkedBlockingQueue<>();
@@ -421,7 +421,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     String logger = Joiner.on("+").join(address.split(":"));
 
     log.debug("DfsLogger.open() begin");
-    VolumeManager fs = conf.getFileSystem();
+    VolumeManager fs = conf.getVolumeManager();
 
     var chooserEnv = new VolumeChooserEnvironmentImpl(ChooserScope.LOGGER, context);
     logPath = fs.choose(chooserEnv, ServerConstants.getBaseUris(context)) + Path.SEPARATOR

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -269,7 +269,7 @@ public class TabletServerLogger {
       @Override
       public void run() {
         final ServerResources conf = tserver.getServerConfig();
-        final VolumeManager fs = conf.getFileSystem();
+        final VolumeManager fs = conf.getVolumeManager();
         while (!nextLogMaker.isShutdown()) {
           log.debug("Creating next WAL");
           DfsLogger alog = null;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -108,7 +108,7 @@ public class CompactableUtils {
       Set<StoredTabletFile> allFiles) throws IOException {
     final Map<StoredTabletFile,Pair<Key,Key>> result = new HashMap<>();
     final FileOperations fileFactory = FileOperations.getInstance();
-    final VolumeManager fs = tablet.getTabletServer().getFileSystem();
+    final VolumeManager fs = tablet.getTabletServer().getVolumeManager();
     for (StoredTabletFile file : allFiles) {
       FileSystem ns = fs.getFileSystemByPath(file.getPath());
       try (FileSKVIterator openReader = fileFactory.newReaderBuilder()
@@ -150,7 +150,7 @@ public class CompactableUtils {
     BlockCache ic = trsm.getIndexCache();
     Cache<String,Long> fileLenCache = trsm.getFileLenCache();
     MajorCompactionRequest request = new MajorCompactionRequest(tablet.getExtent(),
-        CompactableUtils.from(kind), tablet.getTabletServer().getFileSystem(),
+        CompactableUtils.from(kind), tablet.getTabletServer().getVolumeManager(),
         tablet.getTableConfiguration(), sc, ic, fileLenCache, tablet.getContext());
 
     request.setFiles(datafiles);
@@ -347,7 +347,7 @@ public class CompactableUtils {
         try {
           FileOperations fileFactory = FileOperations.getInstance();
           Path path = new Path(file.getUri());
-          FileSystem ns = tablet.getTabletServer().getFileSystem().getFileSystemByPath(path);
+          FileSystem ns = tablet.getTabletServer().getVolumeManager().getFileSystemByPath(path);
           var fiter = fileFactory.newReaderBuilder()
               .forFile(path.toString(), ns, ns.getConf(), tablet.getContext().getCryptoService())
               .withTableConfiguration(tablet.getTableConfiguration()).seekToBeginning().build();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -152,7 +152,7 @@ public class Compactor implements Callable<CompactionStats> {
       List<IteratorSetting> iterators, int reason, AccumuloConfiguration tableConfiguation) {
     this.context = context;
     this.extent = tablet.getExtent();
-    this.fs = tablet.getTabletServer().getFileSystem();
+    this.fs = context.getVolumeManager();
     this.acuTableConf = tableConfiguation;
     this.filesToCompact = files;
     this.imm = imm;
@@ -165,7 +165,7 @@ public class Compactor implements Callable<CompactionStats> {
     startTime = System.currentTimeMillis();
   }
 
-  public VolumeManager getFileSystem() {
+  public VolumeManager getVolumeManager() {
     return fs;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -150,8 +150,8 @@ public class MinorCompactor extends Compactor {
 
         // clean up
         try {
-          if (getFileSystem().exists(new Path(outputFileName))) {
-            getFileSystem().deleteRecursively(new Path(outputFileName));
+          if (getVolumeManager().exists(new Path(outputFileName))) {
+            getVolumeManager().deleteRecursively(new Path(outputFileName));
           }
         } catch (IOException e) {
           log.warn("Failed to delete failed MinC file {} {}", outputFileName, e.getMessage());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -255,7 +255,7 @@ public class Tablet {
     VolumeChooserEnvironment chooserEnv =
         new VolumeChooserEnvironmentImpl(extent.tableId(), extent.endRow(), context);
     String dirUri =
-        tabletServer.getFileSystem().choose(chooserEnv, ServerConstants.getBaseUris(context))
+        tabletServer.getVolumeManager().choose(chooserEnv, ServerConstants.getBaseUris(context))
             + Constants.HDFS_TABLES_DIR + Path.SEPARATOR + extent.tableId() + Path.SEPARATOR
             + dirName;
     checkTabletDir(new Path(dirUri));
@@ -272,7 +272,7 @@ public class Tablet {
     if (!checkedTabletDirs.contains(path)) {
       FileStatus[] files = null;
       try {
-        files = getTabletServer().getFileSystem().listStatus(path);
+        files = getTabletServer().getVolumeManager().listStatus(path);
       } catch (FileNotFoundException ex) {
         // ignored
       }
@@ -280,7 +280,7 @@ public class Tablet {
       if (files == null) {
         log.debug("Tablet {} had no dir, creating {}", extent, path);
 
-        getTabletServer().getFileSystem().mkdirs(path);
+        getTabletServer().getVolumeManager().mkdirs(path);
       }
       checkedTabletDirs.add(path);
     }
@@ -352,8 +352,8 @@ public class Tablet {
           absPaths.add(ref.getPathStr());
         }
 
-        tabletServer.recover(this.getTabletServer().getFileSystem(), extent, logEntries, absPaths,
-            m -> {
+        tabletServer.recover(this.getTabletServer().getVolumeManager(), extent, logEntries,
+            absPaths, m -> {
               Collection<ColumnUpdate> muts = m.getUpdates();
               for (ColumnUpdate columnUpdate : muts) {
                 if (!columnUpdate.hasTimestamp()) {
@@ -440,16 +440,14 @@ public class Tablet {
   private void removeOldTemporaryFiles() {
     // remove any temporary files created by a previous tablet server
     try {
-      Collection<Volume> volumes = getTabletServer().getFileSystem().getVolumes();
-      for (Volume volume : volumes) {
+      for (Volume volume : getTabletServer().getVolumeManager().getVolumes()) {
         String dirUri = volume.getBasePath() + Constants.HDFS_TABLES_DIR + Path.SEPARATOR
             + extent.tableId() + Path.SEPARATOR + dirName;
 
-        for (FileStatus tmp : getTabletServer().getFileSystem()
-            .globStatus(new Path(dirUri, "*_tmp"))) {
+        for (FileStatus tmp : volume.getFileSystem().globStatus(new Path(dirUri, "*_tmp"))) {
           try {
             log.debug("Removing old temp file {}", tmp.getPath());
-            getTabletServer().getFileSystem().delete(tmp.getPath());
+            volume.getFileSystem().delete(tmp.getPath(), false);
           } catch (IOException ex) {
             log.error("Unable to remove old temp file " + tmp.getPath() + ": " + ex);
           }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -67,8 +67,7 @@ public class TabletServerSyncCheckTest {
   private class TestVolumeManagerImpl extends VolumeManagerImpl {
 
     public TestVolumeManagerImpl(Map<String,Volume> volumes) {
-      super(volumes, volumes.values().iterator().next(),
-          new ConfigurationCopy(Collections.emptyMap()), new Configuration());
+      super(volumes, new ConfigurationCopy(Collections.emptyMap()), new Configuration());
     }
 
     @Override

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/WalRemovalOrderTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/WalRemovalOrderTest.java
@@ -45,7 +45,7 @@ public class WalRemovalOrderTest {
       }
 
       @Override
-      public VolumeManager getFileSystem() {
+      public VolumeManager getVolumeManager() {
         throw new UnsupportedOperationException();
       }
     };

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.iterators.user.AgeOffFilter;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
 import org.apache.accumulo.core.iterators.user.ReqVisFilter;
 import org.apache.accumulo.core.iterators.user.VersioningIterator;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
 import org.apache.accumulo.shell.ShellCommandException;
@@ -91,7 +92,7 @@ public class SetIterCommand extends Command {
     String configuredName;
     try {
       if (profileOpt != null && (currentTableName == null || currentTableName.isBlank())) {
-        tmpTable = "accumulo.metadata";
+        tmpTable = MetadataTable.NAME;
         shellState.setTableName(tmpTable);
         tables = cl.hasOption(OptUtil.tableOpt().getOpt()) || !currentTableName.isEmpty();
       }


### PR DESCRIPTION
* VolumeManager
  * remove getDefaultVolume, which was only used to create a temporary
    directory for creating tables with split points, and to resolve
    relative paths
  * replace "default volume" concept with the first available volume
    (this is what it was effectively doing anyway... but now it's
    implemented more cleanly)
  * simplified much of the volume management code in the CreateTable
    FaTE operation classes, where creation of temporary files for
    storing splits on a pre-split table was being handled
  * rename getFileSystem methods throughout that return VolumeManager to
    getVolumeManager, and stop passing it as an extra parameter if it is
    already available via a ServerContext object
* Volume
  * Remove unneeded overloaded Volume.prefixChild(Path)
  * Rename Volume.isValidPath(Path) to Volume.containsPath(Path) to
    improve readability
  * Update javadoc for containsPath to describe what it means for a Path
    to be contained
  * Update VolumeImplTest to verify behavior of containsPath
* VolumeImpl
  * Make protected fields private
  * Rename conf to hadoopConf to clarify which config it is
  * normalize base path by stripping out trailing slashes
  * rename helper method equivalentPaths(Path) to isAncestorPathOf(Path)
    for readability in containsPath(Path) implementation
  * add more strict argument checking for prefixChild(String)
  * fix bug in isAncestorPathOf(Path) that incorrectly concluded /a/path
    is an ancestor of /a/pa (/a is an ancestor, but /a/pa is not)
* VolumeImplTest
  * check normalization by testing with trailing slashes
  * add more test cases for isAncestorPathOf, including checking for
    "breakout" path terms, like ".."
  * add test cases for prefixChild and containsPath
* Tablet
  * Fix bug in Tablet that wasn't using the Path's FileSystem when
    deleting a file, but instead was using an arbitrary FileSystem