### PR TITLE
Close #1739. Cleanup Splits file if CreateTable FaTE operation fails.

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.master.tableOps.create;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.admin.InitialTableState;
@@ -79,11 +80,13 @@ public class CreateTable extends MasterRepo {
   }
 
   @Override
-  public void undo(long tid, Master env) throws Exception {
+  public void undo(long tid, Master env) throws IOException {
     // Clean up split files if create table operation fails
-    Path p = tableInfo.getSplitPath().getParent();
-    FileSystem fs = p.getFileSystem(env.getContext().getHadoopConf());
-    fs.delete(p, true);
+    if(tableInfo.getInitialSplitSize() > 0) {
+      Path p = tableInfo.getSplitPath().getParent();
+      FileSystem fs = p.getFileSystem(env.getContext().getHadoopConf());
+      fs.delete(p, true);
+    }
     Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), tid, false);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/tableOps/create/CreateTable.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.tableOps.MasterRepo;
 import org.apache.accumulo.master.tableOps.TableInfo;
 import org.apache.accumulo.master.tableOps.Utils;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 public class CreateTable extends MasterRepo {
@@ -78,7 +79,11 @@ public class CreateTable extends MasterRepo {
   }
 
   @Override
-  public void undo(long tid, Master env) {
+  public void undo(long tid, Master env) throws Exception {
+    // Clean up split files if create table operation fails
+    Path p = tableInfo.getSplitPath().getParent();
+    FileSystem fs = p.getFileSystem(env.getContext().getHadoopConf());
+    fs.delete(p, true);
     Utils.unreserveNamespace(env, tableInfo.getNamespaceId(), tid, false);
   }
 


### PR DESCRIPTION
Uses the same cleanup logic that is used if the operation is successful. Closes #1739 