### PR TITLE
WIP Design: Interface for handling tablet state migration

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/master/AbstractGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/AbstractGoal.java
@@ -1,0 +1,41 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.server.master.state.TServerInstance;
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+public abstract class AbstractGoal implements Goal {
+  Master master;
+  KeyExtent tablet;
+  TServerInstance location;
+
+  public AbstractGoal(Master m, TabletLocationState tls) {
+    this.master = m;
+    this.tablet = tls.extent;
+    this.location = tls.getServer();
+  }
+
+  @Override
+  public abstract State get();
+
+  @Override
+  public abstract TabletState getCurrentState();
+
+  @Override
+  public KeyExtent getTablet() {
+    return tablet;
+  }
+
+  @Override
+  public abstract void workTowardsGoal();
+
+  void cancelOfflineTableMigrations(KeyExtent tablet) {
+    TServerInstance dest = master.migrations.get(tablet);
+    TableState tableState = master.getTableManager().getTableState(tablet.tableId());
+    if (dest != null && tableState == TableState.OFFLINE) {
+      master.migrations.remove(tablet);
+    }
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/AbstractHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/AbstractHostedGoal.java
@@ -1,0 +1,25 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+
+/**
+ * A Goal of being hosted. Concrete types are defined based on current tablet state.
+ */
+public abstract class AbstractHostedGoal extends AbstractGoal {
+  final Goal.State goal;
+
+  public AbstractHostedGoal(Master m, TabletLocationState tls) {
+    super(m, tls);
+    this.goal = State.HOSTED;
+  }
+
+  @Override
+  public State get() {
+    return goal;
+  }
+
+  @Override
+  public String toString() {
+    return goal.toString();
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/AssignedTabletHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/AssignedTabletHostedGoal.java
@@ -1,0 +1,23 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * A Tablet with a current state of ASSIGNED with a goal of hosted.
+ */
+public class AssignedTabletHostedGoal extends AbstractHostedGoal {
+  public AssignedTabletHostedGoal(Master m, TabletLocationState tls) {
+    super(m, tls);
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.ASSIGNED;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/DeadTabletHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/DeadTabletHostedGoal.java
@@ -1,0 +1,21 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+public class DeadTabletHostedGoal extends AbstractHostedGoal{
+
+  public DeadTabletHostedGoal(Master m, TabletLocationState tls) {
+    super(m, tls);
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.ASSIGNED_TO_DEAD_SERVER;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/DeadTabletNotHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/DeadTabletNotHostedGoal.java
@@ -1,0 +1,32 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * Tablet ASSIGNED_TO_DEAD_SERVER with a goal of not hosted.  The work is the same no matter the
+ * Goal (UNASSIGNED, DELETED, or SUSPENDED)
+ */
+public class DeadTabletNotHostedGoal extends AbstractGoal {
+  final Goal.State goal;
+
+  public DeadTabletNotHostedGoal(Master m, TabletLocationState tls, Goal.State goal) {
+    super(m, tls);
+    this.goal = goal;
+  }
+
+  @Override
+  public State get() {
+    return goal;
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.ASSIGNED_TO_DEAD_SERVER;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/Goal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Goal.java
@@ -1,0 +1,36 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.server.master.state.TabletState;
+
+public interface Goal {
+  /**
+   * Pulled from the old TabletGoalState
+   */
+  enum State {
+    HOSTED,
+    UNASSIGNED, // aka NotHosted
+    DELETED, // aka NotHosted
+    SUSPENDED // aka NotHosted
+  }
+
+  /**
+   * Return this goal state.
+   */
+  State get();
+
+  /**
+   * Return the current state of the Tablet.
+   */
+  TabletState getCurrentState();
+
+  /**
+   * Return the tablet associated with this Goal.
+   */
+  KeyExtent getTablet();
+
+  /**
+   * Take the actions need to migrate the Tablet from current state to the Goal.
+   */
+  void workTowardsGoal(/* Pass object containing tablet lists and counts */);
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/HostedTabletHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/HostedTabletHostedGoal.java
@@ -1,0 +1,25 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * A Tablet with a current state of hosted with a goal of hosted.
+ */
+public class HostedTabletHostedGoal extends AbstractHostedGoal {
+
+  public HostedTabletHostedGoal(Master m, TabletLocationState tls) {
+    super(m, tls);
+  }
+
+  @Override
+  public void workTowardsGoal() {
+    if (location.equals(master.migrations.get(tablet)))
+      master.migrations.remove(tablet);
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.HOSTED;
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/HostedTabletNotHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/HostedTabletNotHostedGoal.java
@@ -1,0 +1,32 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * Tablet HOSTED with a goal of not hosted.  The work is the same no matter the
+ * Goal (UNASSIGNED, DELETED, or SUSPENDED)
+ */
+public class HostedTabletNotHostedGoal extends AbstractGoal {
+  final Goal.State goal;
+
+  public HostedTabletNotHostedGoal(Master m, TabletLocationState tls, Goal.State goal) {
+    super(m, tls);
+    this.goal = goal;
+  }
+
+  @Override
+  public Goal.State get() {
+    return goal;
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.HOSTED;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/SuspendedTabletHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/SuspendedTabletHostedGoal.java
@@ -1,0 +1,23 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * A Tablet with a current state of SUSPENDED with a goal of hosted.
+ */
+public class SuspendedTabletHostedGoal extends AbstractHostedGoal {
+  public SuspendedTabletHostedGoal(Master m, TabletLocationState tls) {
+    super(m, tls);
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.SUSPENDED;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/SuspendedTabletNotHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/SuspendedTabletNotHostedGoal.java
@@ -1,0 +1,34 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * Tablet SUSPENDED with a goal of not hosted.  The work is the same no matter the
+ * Goal (UNASSIGNED, DELETED, or SUSPENDED)
+ */
+public class SuspendedTabletNotHostedGoal extends AbstractGoal {
+  final Goal.State goal;
+
+  public SuspendedTabletNotHostedGoal(Master m, TabletLocationState tls, Goal.State goal) {
+    super(m, tls);
+    this.goal = goal;
+  }
+
+  @Override
+  public Goal.State get() {
+    return goal;
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.SUSPENDED;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+    // Request a move to UNASSIGNED, so as to allow balancing to continue.
+    //suspendedToGoneServers.add(tls);
+    cancelOfflineTableMigrations(tablet);
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -219,6 +219,8 @@ abstract class TabletGroupWatcher extends Daemon {
             return mStats != null ? mStats : new MergeStats(new MergeInfo());
           });
           TabletGoalState goal = master.getGoalState(tls, mergeStats.getMergeInfo());
+          // TODO replace TabletGoalState with Goal interface so this will look like
+          // Goal goal = master.getGoalState(tls, mergeStats.getMergeInfo());
           TServerInstance server = tls.getServer();
           TabletState state = tls.getState(currentTServers.keySet());
 
@@ -244,6 +246,7 @@ abstract class TabletGroupWatcher extends Daemon {
             }
           }
 
+          // TODO replace this with goal.workTowardsGoal()
           if (goal == TabletGoalState.HOSTED) {
             if (state != TabletState.HOSTED && !tls.walogs.isEmpty()) {
               if (master.recoveryManager.recoverLogs(tls.extent, tls.walogs))

--- a/server/manager/src/main/java/org/apache/accumulo/master/UnassignedTabletHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/UnassignedTabletHostedGoal.java
@@ -1,0 +1,23 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * A Tablet with a current state of UNASSIGNED with a goal of hosted.
+ */
+public class UnassignedTabletHostedGoal extends AbstractHostedGoal {
+  public UnassignedTabletHostedGoal(Master m, TabletLocationState tls) {
+    super(m, tls);
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.UNASSIGNED;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/master/UnassignedTabletNotHostedGoal.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/UnassignedTabletNotHostedGoal.java
@@ -1,0 +1,32 @@
+package org.apache.accumulo.master;
+
+import org.apache.accumulo.server.master.state.TabletLocationState;
+import org.apache.accumulo.server.master.state.TabletState;
+
+/**
+ * Tablet UNASSIGNED with a goal of not hosted.  The work is the same no matter the
+ * Goal (UNASSIGNED, DELETED, or SUSPENDED)
+ */
+public class UnassignedTabletNotHostedGoal extends AbstractGoal {
+  final Goal.State goal;
+
+  public UnassignedTabletNotHostedGoal(Master m, TabletLocationState tls, Goal.State goal) {
+    super(m, tls);
+    this.goal = goal;
+  }
+
+  @Override
+  public Goal.State get() {
+    return goal;
+  }
+
+  @Override
+  public TabletState getCurrentState() {
+    return TabletState.UNASSIGNED;
+  }
+
+  @Override
+  public void workTowardsGoal() {
+    cancelOfflineTableMigrations(tablet);
+  }
+}


### PR DESCRIPTION
Some objected oriented design ideas to clean up Master code in ```TabletGroupWatcher```.  The 
idea is to replace the ```TabletGoalState``` enum with concrete classes, to eliminate some of the complex if/else statements and switch cases.  It starts with a Goal interface, implemented by two Abstract types (AbstractGoal + AbstractHostedGoal).  The concrete types are classes which combine current state + goal state.  The classes are one of two goal categories of HOSTED or not (UNASSIGNED, DELETED, SUSPENDED), since the work is the same for the non hosted goals.  I haven't figured out how to integrate the ```MergeState``` that is also used to determine the Goal state [here](https://github.com/apache/accumulo/blob/62110a3c27b9a27d8a7c0bc272aa6778910acad7/server/manager/src/main/java/org/apache/accumulo/master/Master.java#L587).