### PR TITLE
Update jvm option for JDWP in Mini

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -590,8 +590,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
   }
 
   private List<String> buildRemoteDebugParams(int port) {
-    return Arrays.asList("-Xdebug",
-        String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=%d", port));
+    return Collections.singletonList(
+        String.format("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%d", port));
   }
 
   /**


### PR DESCRIPTION
* Since Java 5 the java debugger uses "-agentlib" for JDWP

https://docs.oracle.com/javase/7/docs/technotes/guides/jpda/conninv.html