### PR TITLE
Configure surefire/failsafe forkCount separately

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -60,8 +60,8 @@ jobs:
     strategy:
       matrix:
         profile:
-          - {name: 'Hadoop2', args: 'verify javadoc:jar -DskipITs -DforkCount=1C'}
-          - {name: 'Hadoop3', args: 'verify javadoc:jar -DskipITs -DforkCount=1C -Dhadoop.profile=3'}
+          - {name: 'Hadoop2', args: 'verify javadoc:jar -DskipITs'}
+          - {name: 'Hadoop3', args: 'verify javadoc:jar -DskipITs -Dhadoop.profile=3'}
       fail-fast: false
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -118,6 +118,19 @@
     </dependency>
   </dependencies>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <!-- mini tests shouldn't be forked, as they are a bit resource intensive -->
+            <forkCount>1</forkCount>
+            <reuseForks>false</reuseForks>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>net.revelc.code</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,8 @@
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <failsafe.excludedGroups />
+    <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
-    <!-- surefire/failsafe plugin option -->
-    <forkCount>1</forkCount>
     <!-- version that works when building with Hadoop 2 or 3.0; use 27.0-jre for 3.1 and later -->
     <guava.version>14.0.1</guava.version>
     <hadoop.version>2.6.5</hadoop.version>
@@ -148,6 +147,7 @@
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.excludedGroups />
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+    <surefire.forkCount>1C</surefire.forkCount>
     <surefire.groups />
     <surefire.version>3.0.0-M3</surefire.version>
     <!-- Thrift version -->
@@ -705,6 +705,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
+            <forkCount>${surefire.forkCount}</forkCount>
             <excludedGroups>${surefire.excludedGroups}</excludedGroups>
             <groups>${surefire.groups}</groups>
             <systemPropertyVariables>
@@ -717,6 +718,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
+            <forkCount>${failsafe.forkCount}</forkCount>
             <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
             <groups>${failsafe.groups}</groups>
             <systemPropertyVariables>
@@ -1389,6 +1391,18 @@
       </activation>
       <properties>
         <hadoop.version>3.0.3</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>forkCount</id>
+      <activation>
+        <property>
+          <name>forkCount</name>
+        </property>
+      </activation>
+      <properties>
+        <failsafe.forkCount>${forkCount}</failsafe.forkCount>
+        <surefire.forkCount>${forkCount}</surefire.forkCount>
       </properties>
     </profile>
   </profiles>

--- a/test/src/test/scripts/run-test.sh
+++ b/test/src/test/scripts/run-test.sh
@@ -38,5 +38,5 @@ cd "$bin/.."
 tests=$1
 shift
 
-# Let the user provide additional maven options (like -DforkCount=2)
+# Let the user provide additional maven options (like -Dsurefire.forkCount=2)
 mvn verify -Dit.test="$tests" -Dtest=testnamethatdoesntexist -DfailIfNoTests=false "$@"


### PR DESCRIPTION
* Create new configuration properties in the build configuration for
  surefire.forkCount and failsafe.forkCount to enable configuring them
  independently of one another
* Create a profile to set both surefire.forkCount and failsafe.forkCount
  together, if desired
* Remove forkCount settings from the build workflow, instead selecting
  sane defaults that are equivalent
* Force minicluter to use one surefire fork only (along with start
  module) to avoid potential conflicts