### PR TITLE
Refactor TabletGroupWatcher

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletLocationState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/TabletLocationState.java
@@ -87,7 +87,7 @@ public class TabletLocationState {
     return extent + "@(" + future + "," + current + "," + last + ")" + (chopped ? " chopped" : "");
   }
 
-  public TServerInstance getServer() {
+  public TServerInstance getLocation() {
     TServerInstance result = null;
     if (current != null) {
       result = current;

--- a/server/base/src/test/java/org/apache/accumulo/server/master/state/TabletLocationStateTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/state/TabletLocationStateTest.java
@@ -104,25 +104,25 @@ public class TabletLocationStateTest {
   @Test
   public void testGetServer_Current() throws Exception {
     tls = new TabletLocationState(keyExtent, null, current, last, null, walogs, true);
-    assertSame(current, tls.getServer());
+    assertSame(current, tls.getLocation());
   }
 
   @Test
   public void testGetServer_Future() throws Exception {
     tls = new TabletLocationState(keyExtent, future, null, last, null, walogs, true);
-    assertSame(future, tls.getServer());
+    assertSame(future, tls.getLocation());
   }
 
   @Test
   public void testGetServer_Last() throws Exception {
     tls = new TabletLocationState(keyExtent, null, null, last, null, walogs, true);
-    assertSame(last, tls.getServer());
+    assertSame(last, tls.getLocation());
   }
 
   @Test
   public void testGetServer_None() throws Exception {
     tls = new TabletLocationState(keyExtent, null, null, null, null, walogs, true);
-    assertNull(tls.getServer());
+    assertNull(tls.getLocation());
   }
 
   @Test

--- a/server/manager/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Master.java
@@ -1675,9 +1675,8 @@ public class Master extends AbstractServer
     }
   }
 
-  public void markDeadServerLogsAsClosed(Map<TServerInstance,List<Path>> logsForDeadServers)
-      throws WalMarkerException {
-    WalStateManager mgr = new WalStateManager(getContext());
+  public void markDeadServerLogsAsClosed(WalStateManager mgr,
+      Map<TServerInstance,List<Path>> logsForDeadServers) throws WalMarkerException {
     for (Entry<TServerInstance,List<Path>> server : logsForDeadServers.entrySet()) {
       for (Path path : server.getValue()) {
         mgr.closeWal(server.getKey(), path);

--- a/server/manager/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Master.java
@@ -100,8 +100,6 @@ import org.apache.accumulo.server.HighlyAvailableService;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
-import org.apache.accumulo.server.log.WalStateManager;
-import org.apache.accumulo.server.log.WalStateManager.WalMarkerException;
 import org.apache.accumulo.server.master.LiveTServerSet;
 import org.apache.accumulo.server.master.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.master.balancer.DefaultLoadBalancer;
@@ -135,7 +133,6 @@ import org.apache.accumulo.server.util.TableInfoUtil;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader;
 import org.apache.accumulo.start.classloader.vfs.ContextManager;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.thrift.TException;
@@ -1672,15 +1669,6 @@ public class Master extends AbstractServer
   public Set<TServerInstance> shutdownServers() {
     synchronized (serversToShutdown) {
       return new HashSet<>(serversToShutdown);
-    }
-  }
-
-  public void markDeadServerLogsAsClosed(WalStateManager mgr,
-      Map<TServerInstance,List<Path>> logsForDeadServers) throws WalMarkerException {
-    for (Entry<TServerInstance,List<Path>> server : logsForDeadServers.entrySet()) {
-      for (Path path : server.getValue()) {
-        mgr.closeWal(server.getKey(), path);
-      }
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/TabletGroupWatcher.java
@@ -862,7 +862,7 @@ abstract class TabletGroupWatcher extends Daemon {
       } else {
         store.unassign(deadTablets, deadLogs);
       }
-      master.markDeadServerLogsAsClosed(wals, deadLogs);
+      markDeadServerLogsAsClosed(wals, deadLogs);
       master.nextEvent.event(
           "Marked %d tablets as suspended because they don't have current servers",
           deadTablets.size());
@@ -925,6 +925,15 @@ abstract class TabletGroupWatcher extends Daemon {
         Master.log.warn("Could not connect to server {}", a.server);
       }
       master.assignedTablet(a.tablet);
+    }
+  }
+
+  private static void markDeadServerLogsAsClosed(WalStateManager mgr,
+      Map<TServerInstance,List<Path>> logsForDeadServers) throws WalMarkerException {
+    for (Entry<TServerInstance,List<Path>> server : logsForDeadServers.entrySet()) {
+      for (Path path : server.getValue()) {
+        mgr.closeWal(server.getKey(), path);
+      }
     }
   }
 }


### PR DESCRIPTION
* Create TabletLists to hold the many different data structures being
tracked in the run method of TabletGroupWatcher
* Create methods for some of the logic in the switch case
* Pass TabletLists to the flush method and break flush into methods
* Rename TabletLocationState.getServer() to getLocation() as location is
a more meaningful name instead of server