### PR TITLE
Implement IteratorEnvironment.getPluginEnv()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/IteratorEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/IteratorEnvironment.java
@@ -177,7 +177,7 @@ public interface IteratorEnvironment {
    * @since 2.1.0
    */
   default PluginEnvironment getPluginEnv() {
-    throw new UnsupportedOperationException();
+    return getServiceEnv();
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/IteratorEnvIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/IteratorEnvIT.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
@@ -41,6 +42,7 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.WrappingIterator;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
@@ -142,27 +144,40 @@ public class IteratorEnvIT extends AccumuloClusterHarness {
   /**
    * Test the environment methods return what is expected.
    */
-  @SuppressWarnings("deprecation")
   private static void testEnv(IteratorScope scope, Map<String,String> opts,
       IteratorEnvironment env) {
     TableId expectedTableId = TableId.of(opts.get("expected.table.id"));
-    if (!"value1".equals(env.getConfig().get("table.custom.iterator.env.test")))
-      throw new RuntimeException("Test failed - Expected table property not found.");
-    if (!"value1".equals(
-        env.getServiceEnv().getConfiguration(env.getTableId()).getTableCustom("iterator.env.test")))
-      throw new RuntimeException("Test failed - Expected table property not found.");
-    if (!"value1".equals(env.getConfig().get("table.custom.iterator.env.test")))
-      throw new RuntimeException("Test failed - Expected table property not found.");
-    if (!"value1".equals(
-        env.getPluginEnv().getConfiguration(env.getTableId()).getTableCustom("iterator.env.test")))
-      throw new RuntimeException("Test failed - Expected table property not found.");
+
+    // verify getServiceEnv() and getPluginEnv() are the same objects,
+    // so further checks only need to use getPluginEnv()
+    @SuppressWarnings("deprecation")
+    ServiceEnvironment serviceEnv = env.getServiceEnv();
+    PluginEnvironment pluginEnv = env.getPluginEnv();
+    if (serviceEnv != pluginEnv)
+      throw new RuntimeException("Test failed - assertSame(getServiceEnv(),getPluginEnv())");
+
+    // verify property exists on the table config (deprecated and new),
+    // with and without custom prefix, but not in the system config
+    @SuppressWarnings("deprecation")
+    String accTableConf = env.getConfig().get("table.custom.iterator.env.test");
+    if (!"value1".equals(accTableConf))
+      throw new RuntimeException("Test failed - Expected table property not found in getConfig().");
+    var tableConf = pluginEnv.getConfiguration(env.getTableId());
+    if (!"value1".equals(tableConf.get("table.custom.iterator.env.test")))
+      throw new RuntimeException("Test failed - Expected table property not found in table conf.");
+    if (!"value1".equals(tableConf.getTableCustom("iterator.env.test")))
+      throw new RuntimeException("Test failed - Expected table property not found in table conf.");
+    var systemConf = pluginEnv.getConfiguration();
+    if (systemConf.get("table.custom.iterator.env.test") != null)
+      throw new RuntimeException("Test failed - Unexpected table property found in system conf.");
+
+    // check other environment settings
     if (!scope.equals(env.getIteratorScope()))
       throw new RuntimeException("Test failed - Error getting iterator scope");
     if (env.isSamplingEnabled())
       throw new RuntimeException("Test failed - isSamplingEnabled returned true, expected false");
     if (!expectedTableId.equals(env.getTableId()))
       throw new RuntimeException("Test failed - Error getting Table ID");
-
   }
 
   @Before


### PR DESCRIPTION
* This fixes #1766
* Return an actual implementation for
  `IteratorEnvironment.getPluginEnv()`
* Clean up `IteratorEnvIT.testEnv()` method to:
  * Verify implementation of `getPluginEnv()` (same object as
    `getServiceEnv()`, but with the newer API that doesn't leak internal
    types
  * Remove duplicate check of the same table configuration via
    `getServiceEnv()` and `getPluginEnv()`
  * Remove duplicate (identical) check from the deprecated `getConfig()`
    method to get the table's configuration as `AccumuloConfiguration`
  * Ensure system configuration is covered in the test via
    `getPluginEnv().getConfiguration()`
  * Ensure getting the property by the full property name via `get()`
    works as well as by the `getTableCustom()` convenience method