### PR TITLE
Minor cleanup in BulkImport

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -31,9 +31,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Stream;
 
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.bulk.BulkImport.KeyExtentCache;
 import org.apache.accumulo.core.data.TableId;
@@ -85,15 +82,13 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
   }
 
   @VisibleForTesting
-  protected Stream<KeyExtent> lookupExtents(Text row)
-      throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
+  protected Stream<KeyExtent> lookupExtents(Text row) {
     return TabletsMetadata.builder().forTable(tableId).overlapping(row, null).checkConsistency()
         .fetch(PREV_ROW).build(ctx).stream().limit(100).map(TabletMetadata::getExtent);
   }
 
   @Override
-  public KeyExtent lookup(Text row)
-      throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+  public KeyExtent lookup(Text row) {
     while (true) {
       KeyExtent ke = getFromCache(row);
       if (ke != null)

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -31,9 +31,6 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.Text;
@@ -92,13 +89,9 @@ public class ConcurrentKeyExtentCacheTest {
   }
 
   private void testLookup(TestCache tc, Text lookupRow) {
-    try {
-      KeyExtent extent = tc.lookup(lookupRow);
-      assertTrue(extent.contains(lookupRow));
-      assertTrue(extentsSet.contains(extent));
-    } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    KeyExtent extent = tc.lookup(lookupRow);
+    assertTrue(extent.contains(lookupRow));
+    assertTrue(extentsSet.contains(extent));
   }
 
   @Test


### PR DESCRIPTION
* Remove exceptions from BulkImport and ConcurrentKeyExtentCache
internal classes that were declared but never thrown
* Remove some unused code in findOverlappingTablets
* Shorten a few lines that use lambdas