### PR TITLE
Add tablename option to shell insert command.

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
@@ -171,7 +171,7 @@ public class InsertCommand extends Command {
         "durability to use for insert, should be one of \"none\" \"log\" \"flush\" or \"sync\"");
     o.addOption(durabilityOption);
 
-    o.addOption(OptUtil.tableOpt("table in which data is to be inserted"));
+    o.addOption(OptUtil.tableOpt("table into which data will be inserted"));
 
     return o;
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
@@ -65,95 +65,88 @@ public class InsertCommand extends Command {
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException,
       ConstraintViolationException {
 
-    String initialTable = null;
-    try {
-      if (cl.hasOption(tableNameOption.getOpt())) {
-        initialTable = shellState.getTableName();
-        shellState.setTableName(cl.getOptionValue(tableNameOption.getOpt()));
-      }
+    String tablename = null;
+    if (cl.hasOption(tableNameOption.getOpt())) {
+      // no need to checkTableState if tablename option is supplied
+      tablename = cl.getOptionValue(tableNameOption.getOpt());
+    } else {
+      tablename = shellState.getTableName();
+      // Verify currently in a context with tablename
       shellState.checkTableState();
+    }
 
-      final Mutation m = new Mutation(new Text(cl.getArgs()[0].getBytes(Shell.CHARSET)));
-      final Text colf = new Text(cl.getArgs()[1].getBytes(Shell.CHARSET));
-      final Text colq = new Text(cl.getArgs()[2].getBytes(Shell.CHARSET));
-      final Value val = new Value(cl.getArgs()[3].getBytes(Shell.CHARSET));
+    final Mutation m = new Mutation(new Text(cl.getArgs()[0].getBytes(Shell.CHARSET)));
+    final Text colf = new Text(cl.getArgs()[1].getBytes(Shell.CHARSET));
+    final Text colq = new Text(cl.getArgs()[2].getBytes(Shell.CHARSET));
+    final Value val = new Value(cl.getArgs()[3].getBytes(Shell.CHARSET));
 
-      if (cl.hasOption(insertOptAuths.getOpt())) {
-        final ColumnVisibility le =
-            new ColumnVisibility(cl.getOptionValue(insertOptAuths.getOpt()));
-        Shell.log.debug("Authorization label will be set to: {}", le);
+    if (cl.hasOption(insertOptAuths.getOpt())) {
+      final ColumnVisibility le = new ColumnVisibility(cl.getOptionValue(insertOptAuths.getOpt()));
+      Shell.log.debug("Authorization label will be set to: {}", le);
 
-        if (cl.hasOption(timestampOpt.getOpt()))
-          m.put(colf, colq, le, Long.parseLong(cl.getOptionValue(timestampOpt.getOpt())), val);
-        else
-          m.put(colf, colq, le, val);
-      } else if (cl.hasOption(timestampOpt.getOpt()))
-        m.put(colf, colq, Long.parseLong(cl.getOptionValue(timestampOpt.getOpt())), val);
+      if (cl.hasOption(timestampOpt.getOpt()))
+        m.put(colf, colq, le, Long.parseLong(cl.getOptionValue(timestampOpt.getOpt())), val);
       else
-        m.put(colf, colq, val);
+        m.put(colf, colq, le, val);
+    } else if (cl.hasOption(timestampOpt.getOpt()))
+      m.put(colf, colq, Long.parseLong(cl.getOptionValue(timestampOpt.getOpt())), val);
+    else
+      m.put(colf, colq, val);
 
-      final BatchWriterConfig cfg =
-          new BatchWriterConfig().setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024))
-              .setMaxWriteThreads(1).setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
-      if (cl.hasOption(durabilityOption.getOpt())) {
-        String userDurability = cl.getOptionValue(durabilityOption.getOpt());
-        switch (userDurability) {
-          case "sync":
-            cfg.setDurability(Durability.SYNC);
-            break;
-          case "flush":
-            cfg.setDurability(Durability.FLUSH);
-            break;
-          case "none":
-            cfg.setDurability(Durability.NONE);
-            break;
-          case "log":
-            cfg.setDurability(Durability.NONE);
-            break;
-          default:
-            throw new IllegalArgumentException("Unknown durability: " + userDurability);
-        }
-      }
-      final BatchWriter bw =
-          shellState.getAccumuloClient().createBatchWriter(shellState.getTableName(), cfg);
-      bw.addMutation(m);
-      try {
-        bw.close();
-      } catch (MutationsRejectedException e) {
-        final ArrayList<String> lines = new ArrayList<>();
-        if (!e.getSecurityErrorCodes().isEmpty()) {
-          lines.add("\tAuthorization Failures:");
-        }
-        for (Entry<TabletId,Set<SecurityErrorCode>> entry : e.getSecurityErrorCodes().entrySet()) {
-          lines.add("\t\t" + entry);
-        }
-        if (!e.getConstraintViolationSummaries().isEmpty()) {
-          lines.add("\tConstraint Failures:");
-        }
-        for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
-          lines.add("\t\t" + cvs);
-        }
-
-        if (lines.isEmpty() || e.getUnknownExceptions() > 0) {
-          // must always print something
-          lines.add(" " + e.getClass().getName() + " : " + e.getMessage());
-          if (e.getCause() != null)
-            lines.add("   Caused by : " + e.getCause().getClass().getName() + " : "
-                + e.getCause().getMessage());
-        }
-
-        shellState.printLines(lines.iterator(), false);
-
-        return 1;
-      }
-      return 0;
-
-    } finally {
-      // reset table context to initial table name
-      if (cl.hasOption(tableNameOption.getOpt())) {
-        shellState.setTableName(initialTable);
+    final BatchWriterConfig cfg =
+        new BatchWriterConfig().setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024))
+            .setMaxWriteThreads(1).setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
+    if (cl.hasOption(durabilityOption.getOpt())) {
+      String userDurability = cl.getOptionValue(durabilityOption.getOpt());
+      switch (userDurability) {
+        case "sync":
+          cfg.setDurability(Durability.SYNC);
+          break;
+        case "flush":
+          cfg.setDurability(Durability.FLUSH);
+          break;
+        case "none":
+          cfg.setDurability(Durability.NONE);
+          break;
+        case "log":
+          cfg.setDurability(Durability.NONE);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown durability: " + userDurability);
       }
     }
+    final BatchWriter bw = shellState.getAccumuloClient().createBatchWriter(tablename, cfg);
+    bw.addMutation(m);
+    try {
+      bw.close();
+    } catch (MutationsRejectedException e) {
+      final ArrayList<String> lines = new ArrayList<>();
+      if (!e.getSecurityErrorCodes().isEmpty()) {
+        lines.add("\tAuthorization Failures:");
+      }
+      for (Entry<TabletId,Set<SecurityErrorCode>> entry : e.getSecurityErrorCodes().entrySet()) {
+        lines.add("\t\t" + entry);
+      }
+      if (!e.getConstraintViolationSummaries().isEmpty()) {
+        lines.add("\tConstraint Failures:");
+      }
+      for (ConstraintViolationSummary cvs : e.getConstraintViolationSummaries()) {
+        lines.add("\t\t" + cvs);
+      }
+
+      if (lines.isEmpty() || e.getUnknownExceptions() > 0) {
+        // must always print something
+        lines.add(" " + e.getClass().getName() + " : " + e.getMessage());
+        if (e.getCause() != null)
+          lines.add("   Caused by : " + e.getCause().getClass().getName() + " : "
+              + e.getCause().getMessage());
+      }
+
+      shellState.printLines(lines.iterator(), false);
+
+      return 1;
+    }
+    return 0;
   }
 
   @Override
@@ -188,7 +181,7 @@ public class InsertCommand extends Command {
     o.addOption(durabilityOption);
 
     tableNameOption =
-        new Option("null", "tablename", true, "name of table in which data is being inserted");
+        new Option("", "tablename", true, "name of table in which data is being inserted");
     tableNameOption.setArgName("tablename");
     o.addOption(tableNameOption);
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/InsertCommand.java
@@ -79,7 +79,8 @@ public class InsertCommand extends Command {
       final Value val = new Value(cl.getArgs()[3].getBytes(Shell.CHARSET));
 
       if (cl.hasOption(insertOptAuths.getOpt())) {
-        final ColumnVisibility le = new ColumnVisibility(cl.getOptionValue(insertOptAuths.getOpt()));
+        final ColumnVisibility le =
+            new ColumnVisibility(cl.getOptionValue(insertOptAuths.getOpt()));
         Shell.log.debug("Authorization label will be set to: {}", le);
 
         if (cl.hasOption(timestampOpt.getOpt()))
@@ -91,9 +92,9 @@ public class InsertCommand extends Command {
       else
         m.put(colf, colq, val);
 
-      final BatchWriterConfig cfg = new BatchWriterConfig()
-          .setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024)).setMaxWriteThreads(1)
-          .setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
+      final BatchWriterConfig cfg =
+          new BatchWriterConfig().setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024))
+              .setMaxWriteThreads(1).setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS);
       if (cl.hasOption(durabilityOption.getOpt())) {
         String userDurability = cl.getOptionValue(durabilityOption.getOpt());
         switch (userDurability) {
@@ -113,8 +114,8 @@ public class InsertCommand extends Command {
             throw new IllegalArgumentException("Unknown durability: " + userDurability);
         }
       }
-      final BatchWriter bw = shellState.getAccumuloClient()
-          .createBatchWriter(shellState.getTableName(), cfg);
+      final BatchWriter bw =
+          shellState.getAccumuloClient().createBatchWriter(shellState.getTableName(), cfg);
       bw.addMutation(m);
       try {
         bw.close();
@@ -137,7 +138,8 @@ public class InsertCommand extends Command {
           // must always print something
           lines.add(" " + e.getClass().getName() + " : " + e.getMessage());
           if (e.getCause() != null)
-            lines.add("   Caused by : " + e.getCause().getClass().getName() + " : " + e.getCause().getMessage());
+            lines.add("   Caused by : " + e.getCause().getClass().getName() + " : "
+                + e.getCause().getMessage());
         }
 
         shellState.printLines(lines.iterator(), false);
@@ -147,11 +149,11 @@ public class InsertCommand extends Command {
       return 0;
 
     } finally {
-        // reset table context to initial table name
-        if (cl.hasOption(tableNameOption.getOpt())) {
-          shellState.setTableName(initialTable);
-        }
+      // reset table context to initial table name
+      if (cl.hasOption(tableNameOption.getOpt())) {
+        shellState.setTableName(initialTable);
       }
+    }
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -246,35 +246,38 @@ public class ShellIT extends SharedMiniClusterBase {
     exec("createtable tab2", true);
     // insert data into tab2 while in tab2 context
     exec("insert row1 f q tab2", true);
-    // insert another with the tablename argument to verify also works
-    exec("insert row2 f q tab2 --tablename tab2", true);
+    // insert another with the table and t argument to verify also works
+    exec("insert row2 f q tab2 --table tab2", true);
+    exec("insert row3 f q tab2 -t tab2", true);
     // leave all table contexts
     exec("notable", true);
     // without option cannot insert when not in a table context, also cannot add to a table
     // using 'accumulo shell -e "insert ...." fron command line due to no table context being set.
     exec("insert row1 f q tab1", false, "java.lang.IllegalStateException: Not in a table context");
     // but using option can insert to a table with tablename option without being in a table context
-    exec("insert row1 f q tab1 --tablename tab1", true);
-    exec("insert row3 f q tab2 --tablename tab2", true);
+    exec("insert row1 f q tab1 --table tab1", true);
+    exec("insert row4 f q tab2 -t tab2", true);
     exec("table tab2", true);
     // can also insert into another table even if a different table context
-    exec("insert row2 f q tab1 --tablename tab1", true);
+    exec("insert row2 f q tab1 -t tab1", true);
     exec("notable", true);
     // must supply a tablename if option is used
-    exec("insert row5 f q tab5 --tablename", false,
+    exec("insert row5 f q tab5 --table", false,
         "org.apache.commons.cli.MissingArgumentException: Missing argument for option:");
-    // verify that -t option does not work for insertion, only tablename
-    exec("insert row3 f q tab1 -t tab1", false,
-        "org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: -t");
+    exec("insert row5 f q tab5 --t", false,
+        "org.apache.commons.cli.AmbiguousOptionException: Ambiguous option: '--t'");
     // verify expected data is in both tables
     exec("scan -t tab1", true, "row1 f:q []    tab1\nrow2 f:q []    tab1");
-    exec("scan -t tab2", true, "row1 f:q []    tab2\nrow2 f:q []    tab2\nrow3 f:q []    tab2");
+    exec("scan -t tab2", true,
+        "row1 f:q []    tab2\nrow2 f:q []    tab2\nrow3 f:q []    tab2\nrow4 f:q []    tab2");
     // check that if in table context, inserting into a non-existent table does not change context
     exec("createtable tab3", true);
     exec("table tab3", true);
     exec("insert row1 f1 q1 tab3", true);
-    exec("insert row2 f2 q2 tab3 --tablename idontexist", false,
-        "org.apache.accumulo.core.client.TableNotFoundException: Table idontexist does not exist");
+    exec("insert row2 f2 q2 tab3 --table idontexist", false,
+        "org.apache.accumulo.core.client.TableNotFoundException:");
+    exec("insert row2 f2 q2 tab3 -t idontexist", false,
+        "org.apache.accumulo.core.client.TableNotFoundException:");
     exec("insert row3 f3 q3 tab3", true); // should be able to insert w/o changing tables
     // verify expected data is in tab3
     exec("scan", true, "row1 f1:q1 []    tab3\nrow3 f3:q3 []    tab3");

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -239,6 +239,51 @@ public class ShellIT extends SharedMiniClusterBase {
   }
 
   @Test
+  public void insertIntoSpecifiedTableTest() throws IOException {
+    Shell.log.debug("Starting insertIntoSpecifiedTableTest -----------------");
+    // create two tables for insertion tests
+    exec("createtable tab1", true);
+    exec("createtable tab2", true);
+    // insert data into tab2 while in tab2 context
+    exec("insert row1 f q tab2", true);
+    // insert another with the tablename argument to verify also works
+    exec("insert row2 f q tab2 --tablename tab2", true);
+    // leave all table contexts
+    exec("notable", true);
+    // without option cannot insert when not in a table context, also cannot add to a table
+    // using 'accumulo shell -e "insert ...."  fron command line due to no table context being set.
+    exec("insert row1 f q tab1", false,
+        "java.lang.IllegalStateException: Not in a table context");
+    // but using optino can insert to a table with tablename option without being in a table context
+    exec("insert row1 f q tab1 --tablename tab1",  true);
+    exec("insert row3 f q tab2 --tablename tab2", true);
+    exec("table tab2", true);
+    // can also insert into another table even if a different table context
+    exec("insert row2 f q tab1 --tablename tab1", true);
+    exec("notable", true);
+    // verify that -t option does not work for insertion, only tablename
+    exec("insert row3 f q tab1 -t tab1", false,
+        "org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: -t");
+    // verify expected data is in both tables
+    exec("scan -t tab1", true, "row1 f:q []    tab1\nrow2 f:q []    tab1");
+    exec("scan -t tab2", true, "row1 f:q []    tab2\nrow2 f:q []    tab2\nrow3 f:q []    tab2");
+    // check that if in table context, inserting into a non-existent table does not change context
+    exec("createtable tab3", true);
+    exec("table tab3", true);
+    exec("insert row1 f1 q1 tab3", true);
+    exec("insert row2 f2 q2 tab3 --tablename idontexist", false,
+        "org.apache.accumulo.core.client.TableNotFoundException: Table idontexist does not exist");
+    exec("insert row3 f3 q3 tab3", true); // should be able to insert w/o changing tables
+    // verify expected data is in tab3
+    exec("scan", true,
+        "row1 f1:q1 []    tab3\nrow3 f3:q3 []    tab3");
+    // cleanup
+    exec("deletetable tab1 -f", true, "Table: [tab1] has been deleted");
+    exec("deletetable tab2 -f", true, "Table: [tab2] has been deleted");
+    exec("deletetable tab3 -f", true, "Table: [tab3] has been deleted");
+  }
+
+  @Test
   public void deleteManyTest() throws IOException {
     exec("deletemany", false, "java.lang.IllegalStateException: Not in a table context");
     exec("createtable test", true);

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -251,11 +251,10 @@ public class ShellIT extends SharedMiniClusterBase {
     // leave all table contexts
     exec("notable", true);
     // without option cannot insert when not in a table context, also cannot add to a table
-    // using 'accumulo shell -e "insert ...."  fron command line due to no table context being set.
-    exec("insert row1 f q tab1", false,
-        "java.lang.IllegalStateException: Not in a table context");
+    // using 'accumulo shell -e "insert ...." fron command line due to no table context being set.
+    exec("insert row1 f q tab1", false, "java.lang.IllegalStateException: Not in a table context");
     // but using optino can insert to a table with tablename option without being in a table context
-    exec("insert row1 f q tab1 --tablename tab1",  true);
+    exec("insert row1 f q tab1 --tablename tab1", true);
     exec("insert row3 f q tab2 --tablename tab2", true);
     exec("table tab2", true);
     // can also insert into another table even if a different table context
@@ -275,8 +274,7 @@ public class ShellIT extends SharedMiniClusterBase {
         "org.apache.accumulo.core.client.TableNotFoundException: Table idontexist does not exist");
     exec("insert row3 f3 q3 tab3", true); // should be able to insert w/o changing tables
     // verify expected data is in tab3
-    exec("scan", true,
-        "row1 f1:q1 []    tab3\nrow3 f3:q3 []    tab3");
+    exec("scan", true, "row1 f1:q1 []    tab3\nrow3 f3:q3 []    tab3");
     // cleanup
     exec("deletetable tab1 -f", true, "Table: [tab1] has been deleted");
     exec("deletetable tab2 -f", true, "Table: [tab2] has been deleted");

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -253,13 +253,16 @@ public class ShellIT extends SharedMiniClusterBase {
     // without option cannot insert when not in a table context, also cannot add to a table
     // using 'accumulo shell -e "insert ...." fron command line due to no table context being set.
     exec("insert row1 f q tab1", false, "java.lang.IllegalStateException: Not in a table context");
-    // but using optino can insert to a table with tablename option without being in a table context
+    // but using option can insert to a table with tablename option without being in a table context
     exec("insert row1 f q tab1 --tablename tab1", true);
     exec("insert row3 f q tab2 --tablename tab2", true);
     exec("table tab2", true);
     // can also insert into another table even if a different table context
     exec("insert row2 f q tab1 --tablename tab1", true);
     exec("notable", true);
+    // must supply a tablename if option is used
+    exec("insert row5 f q tab5 --tablename", false,
+        "org.apache.commons.cli.MissingArgumentException: Missing argument for option:");
     // verify that -t option does not work for insertion, only tablename
     exec("insert row3 f q tab1 -t tab1", false,
         "org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: -t");


### PR DESCRIPTION
This change adds the <code>--tablename</code> option to the insert command when inside the shell or when using the accumulo command with <code>accumulo shell -e \<task\></code>. The option is not required, but if used it allows data to be inserted into a table in situations where the shell is not within a table context or when in a table context to insert data into another table.

Although I would not expect this option to be utilized very often, I found myself in need of it when working with the various accumulo examples in the accumulo-examples repo. I had many situations where I wished to insert some test data from a bash shell using the form:

<code>accumulo shell -u user -p pwd -e "insert r f q v"</code>

but this would fail due to there being no table name context for the insertion. This update allows data inserts from a command line using the form: 

<code>accumulo shell -u user -p pwd -e "insert r f q v --tablename destination_table" </code>

Note, there is no shortened form of the option to minimize confusion with the -ts option.