### PR TITLE
Stabilize NamespaceIdTest and TableIdTest

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/NamespaceIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/NamespaceIdTest.java
@@ -79,12 +79,13 @@ public class NamespaceIdTest {
     assertEquals(namespaceString, nsId.canonical());
 
     // create a bunch more and throw them away
-    for (int i = 0; i < 999; i++) {
-      NamespaceId.of(new String("namespace" + i));
+    long preGCSize = 0;
+    int i = 0;
+    while ((preGCSize = NamespaceId.cache.asMap().entrySet().stream().count()) < 100) {
+      NamespaceId.of(new String("namespace" + i++));
     }
-    long preGCSize = NamespaceId.cache.asMap().entrySet().stream().count();
     LOG.info("Entries before System.gc(): {}", preGCSize);
-    assertTrue(preGCSize > 500); // verify amount increased significantly
+    assertEquals(100, preGCSize);
     long postGCSize = preGCSize;
     while (postGCSize >= preGCSize) {
       TableIdTest.tryToGc();

--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -88,12 +88,13 @@ public class TableIdTest {
     assertEquals(tableString, table1.canonical());
 
     // create a bunch more and throw them away
-    for (int i = 0; i < 999; i++) {
-      TableId.of(new String("table" + i));
+    long preGCSize = 0;
+    int i = 0;
+    while ((preGCSize = TableId.cache.asMap().entrySet().stream().count()) < 100) {
+      TableId.of(new String("table" + i++));
     }
-    long preGCSize = TableId.cache.asMap().entrySet().stream().count();
     LOG.info("Entries before System.gc(): {}", preGCSize);
-    assertTrue(preGCSize > 500); // verify amount increased significantly
+    assertEquals(100, preGCSize);
     long postGCSize = preGCSize;
     while (postGCSize >= preGCSize) {
       tryToGc();


### PR DESCRIPTION
TableId and NamespaceId have tests to ensure their caches work
correctly. Previously, the tests would only *attempt* to increase the
cache before checking that it decreased again. However, a garbage
collection could have reduced the size of the cache before we checked
its size. This change *guarantees* the cache will reach a specific size
before proceeding.