### PR TITLE
Upgrade Thrift to 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <surefire.groups />
     <surefire.version>3.0.0-M3</surefire.version>
     <!-- Thrift version -->
-    <thrift.version>0.12.0</thrift.version>
+    <thrift.version>0.13.0</thrift.version>
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
     <!-- ZooKeeper version -->
     <zookeeper.version>3.5.8</zookeeper.version>

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
@@ -55,12 +55,12 @@ public class TimedProcessor implements TProcessor {
   }
 
   @Override
-  public boolean process(TProtocol in, TProtocol out) throws TException {
+  public void process(TProtocol in, TProtocol out) throws TException {
     long now = 0;
     now = System.currentTimeMillis();
     thriftMetrics.addIdle(now - idleStart);
     try {
-      return other.process(in, out);
+      other.process(in, out);
     } finally {
       idleStart = System.currentTimeMillis();
       thriftMetrics.addExecute(idleStart - now);

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/UGIAssumingProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/UGIAssumingProcessor.java
@@ -75,7 +75,7 @@ public class UGIAssumingProcessor implements TProcessor {
   }
 
   @Override
-  public boolean process(final TProtocol inProt, final TProtocol outProt) throws TException {
+  public void process(final TProtocol inProt, final TProtocol outProt) throws TException {
     TTransport trans = inProt.getTransport();
     if (!(trans instanceof TSaslServerTransport)) {
       throw new TException("Unexpected non-SASL transport " + trans.getClass() + ": " + trans);
@@ -100,25 +100,26 @@ public class UGIAssumingProcessor implements TProcessor {
         try {
           // Set the principal in the ThreadLocal for access to get authorizations
           rpcPrincipal.set(remoteUser);
-
-          return wrapped.process(inProt, outProt);
+          wrapped.process(inProt, outProt);
         } finally {
           // Unset the principal after we're done using it just to be sure that it's not incorrectly
           // used in the same thread down the line.
           rpcPrincipal.set(null);
         }
+        break;
       case DIGEST_MD5:
         // The CallbackHandler, after deserializing the TokenIdentifier in the name, has already
         // updated
         // the rpcPrincipal for us. We don't need to do it again here.
         try {
           rpcMechanism.set(mechanism);
-          return wrapped.process(inProt, outProt);
+          wrapped.process(inProt, outProt);
         } finally {
           // Unset the mechanism after we're done using it just to be sure that it's not incorrectly
           // used in the same thread down the line.
           rpcMechanism.set(null);
         }
+        break;
       default:
         throw new IllegalArgumentException("Cannot process SASL mechanism " + mechanism);
     }


### PR DESCRIPTION
In Apache Thrift all versions up to and including 0.12.0, a server or client may run into an endless loop when feed with specific input data.

Some of the classes Accumulo relied on (ie AutoExpandingBufferWriteTransport) are no longer public so the utility methods had to be rewritten. Unfortunately there is no TTransport implementation with the same functionality AutoExpandingBufferWriteTransport provided so I had to switch to TMemoryBuffer as a substitute. However this can not be reset and a new object have to be created for each serialization which is less then optimal. I considered adding a custom implementation, but the changes in the deserialize method should compensate for the the loss of performance.