### PR TITLE
Add comments for TableId/NamespaceId cache

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/NamespaceId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/NamespaceId.java
@@ -32,6 +32,9 @@ import com.google.common.cache.CacheBuilder;
  */
 public class NamespaceId extends AbstractId<NamespaceId> {
   private static final long serialVersionUID = 1L;
+  // cache is for canonicalization/deduplication of created objects,
+  // to limit the number of NamespaceId objects in the JVM at any given moment
+  // WeakReferences are used because we don't need them to stick around any longer than they need to
   static final Cache<String,NamespaceId> cache = CacheBuilder.newBuilder().weakValues().build();
 
   private NamespaceId(String canonical) {

--- a/core/src/main/java/org/apache/accumulo/core/data/TableId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/TableId.java
@@ -32,6 +32,9 @@ import com.google.common.cache.CacheBuilder;
  */
 public class TableId extends AbstractId<TableId> {
   private static final long serialVersionUID = 1L;
+  // cache is for canonicalization/deduplication of created objects,
+  // to limit the number of TableId objects in the JVM at any given moment
+  // WeakReferences are used because we don't need them to stick around any longer than they need to
   static final Cache<String,TableId> cache = CacheBuilder.newBuilder().weakValues().build();
 
   private TableId(final String canonical) {

--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -45,6 +45,12 @@ public class TableIdTest {
   @Rule
   public TestName name = new TestName();
 
+  private static long cacheCount() {
+    // guava cache size() is approximate, and can include garbage-collected entries
+    // so we iterate to get the actual cache size
+    return TableId.cache.asMap().entrySet().stream().count();
+  }
+
   @Test
   public void testCacheNoDuplicates() {
     // the next two lines just preloads the built-ins, since they now exist in a separate class from
@@ -53,9 +59,9 @@ public class TableIdTest {
     assertNotSame(RootTable.ID, ReplicationTable.ID);
 
     String tableString = "table-" + name.getMethodName();
-    long initialSize = TableId.cache.asMap().entrySet().stream().count();
+    long initialSize = cacheCount();
     TableId table1 = TableId.of(tableString);
-    assertEquals(initialSize + 1, TableId.cache.asMap().entrySet().stream().count());
+    assertEquals(initialSize + 1, cacheCount());
     assertEquals(tableString, table1.canonical());
 
     // ensure duplicates are not created
@@ -66,17 +72,17 @@ public class TableIdTest {
     builtInTableId = TableId.of("+rep");
     assertSame(ReplicationTable.ID, builtInTableId);
     table1 = TableId.of(tableString);
-    assertEquals(initialSize + 1, TableId.cache.asMap().entrySet().stream().count());
+    assertEquals(initialSize + 1, cacheCount());
     assertEquals(tableString, table1.canonical());
     TableId table2 = TableId.of(tableString);
-    assertEquals(initialSize + 1, TableId.cache.asMap().entrySet().stream().count());
+    assertEquals(initialSize + 1, cacheCount());
     assertEquals(tableString, table2.canonical());
     assertSame(table1, table2);
   }
 
   @Test(timeout = 30_000)
   public void testCacheIncreasesAndDecreasesAfterGC() {
-    long initialSize = TableId.cache.asMap().entrySet().stream().count();
+    long initialSize = cacheCount();
     assertTrue(initialSize < 20); // verify initial amount is reasonably low
     LOG.info("Initial cache size: {}", initialSize);
     LOG.info(TableId.cache.asMap().toString());
@@ -84,13 +90,13 @@ public class TableIdTest {
     // add one and check increase
     String tableString = "table-" + name.getMethodName();
     TableId table1 = TableId.of(tableString);
-    assertEquals(initialSize + 1, TableId.cache.asMap().entrySet().stream().count());
+    assertEquals(initialSize + 1, cacheCount());
     assertEquals(tableString, table1.canonical());
 
     // create a bunch more and throw them away
     long preGCSize = 0;
     int i = 0;
-    while ((preGCSize = TableId.cache.asMap().entrySet().stream().count()) < 100) {
+    while ((preGCSize = cacheCount()) < 100) {
       TableId.of(new String("table" + i++));
     }
     LOG.info("Entries before System.gc(): {}", preGCSize);
@@ -98,7 +104,7 @@ public class TableIdTest {
     long postGCSize = preGCSize;
     while (postGCSize >= preGCSize) {
       tryToGc();
-      postGCSize = TableId.cache.asMap().entrySet().stream().count();
+      postGCSize = cacheCount();
       LOG.info("Entries after System.gc(): {}", postGCSize);
     }
   }


### PR DESCRIPTION
* Add comments explaining the purpose of the Guava cache used in TableId
  and NamespaceId
* Create utility method for counting the cache entries in the tests and
  include a comment explaining why we need to count them the way we do