### PR TITLE
Update hadoop version to 3.3.0 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <failsafe.excludedGroups />
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
-    <hadoop.version>3.2.2</hadoop.version>
+    <hadoop.version>3.3.0</hadoop.version>
     <hk2.version>2.6.1</hk2.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.2.0-incubating</htrace.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <failsafe.excludedGroups />
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
-    <hadoop.version>3.2.1</hadoop.version>
+    <hadoop.version>3.3.0</hadoop.version>
     <hk2.version>2.6.1</hk2.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.2.0-incubating</htrace.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <failsafe.excludedGroups />
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.2.2</hadoop.version>
     <hk2.version>2.6.1</hk2.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.2.0-incubating</htrace.version>


### PR DESCRIPTION
Update version of hadoop to 3.3.0 in order to remove warnings. With 3.3.0 version the "An illegal reflective access operaion has occurred" errors no longer appear as the issue has been corrected in that version of Hadoop (actually, corrected in 3.2.2 and above).