### PR TITLE
Read/Write config files consistently

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
 import java.io.FileReader;
@@ -196,7 +197,7 @@ public class ClientConfiguration {
    */
   public static ClientConfiguration fromFile(File file) {
     var config = new PropertiesConfiguration();
-    try (var reader = new FileReader(file)) {
+    try (var reader = new FileReader(file, UTF_8)) {
       config.read(reader);
       return new ClientConfiguration(Collections.singletonList(config));
     } catch (ConfigurationException | IOException e) {
@@ -225,7 +226,7 @@ public class ClientConfiguration {
       File conf = new File(path);
       if (conf.isFile() && conf.canRead()) {
         var config = new PropertiesConfiguration();
-        try (var reader = new FileReader(conf)) {
+        try (var reader = new FileReader(conf, UTF_8)) {
           config.read(reader);
           configs.add(config);
           log.info("Loaded client configuration file {}", conf);
@@ -243,10 +244,10 @@ public class ClientConfiguration {
   }
 
   public static ClientConfiguration deserialize(String serializedConfig) {
-    PropertiesConfiguration propConfig = new PropertiesConfiguration();
+    var propConfig = new PropertiesConfiguration();
     try {
-      propConfig.getLayout().load(propConfig, new StringReader(serializedConfig));
-    } catch (ConfigurationException e) {
+      propConfig.read(new StringReader(serializedConfig));
+    } catch (ConfigurationException | IOException e) {
       throw new IllegalArgumentException(
           "Error deserializing client configuration: " + serializedConfig, e);
     }
@@ -300,12 +301,12 @@ public class ClientConfiguration {
   }
 
   public String serialize() {
-    PropertiesConfiguration propConfig = new PropertiesConfiguration();
+    var propConfig = new PropertiesConfiguration();
     propConfig.copy(compositeConfig);
     StringWriter writer = new StringWriter();
     try {
-      propConfig.getLayout().save(propConfig, writer);
-    } catch (ConfigurationException e) {
+      propConfig.write(writer);
+    } catch (ConfigurationException | IOException e) {
       // this should never happen
       throw new IllegalStateException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -199,10 +199,10 @@ public class ClientConfiguration {
     var config = new PropertiesConfiguration();
     try (var reader = new FileReader(file, UTF_8)) {
       config.read(reader);
-      return new ClientConfiguration(Collections.singletonList(config));
     } catch (ConfigurationException | IOException e) {
       throw new IllegalArgumentException("Bad configuration file: " + file, e);
     }
+    return new ClientConfiguration(Collections.singletonList(config));
   }
 
   /**
@@ -228,11 +228,11 @@ public class ClientConfiguration {
         var config = new PropertiesConfiguration();
         try (var reader = new FileReader(conf, UTF_8)) {
           config.read(reader);
-          configs.add(config);
-          log.info("Loaded client configuration file {}", conf);
         } catch (ConfigurationException | IOException e) {
           throw new IllegalStateException("Error loading client configuration file " + conf, e);
         }
+        configs.add(config);
+        log.info("Loaded client configuration file {}", conf);
       }
     }
     // We couldn't find the client configuration anywhere

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -141,8 +141,6 @@ public class SiteConfiguration extends AccumuloConfiguration {
       return this;
     }
 
-    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD",
-        justification = "location of props is specified by an admin")
     @Override
     public SiteConfiguration build() {
       // load properties from configuration file
@@ -204,6 +202,8 @@ public class SiteConfiguration extends AccumuloConfiguration {
   }
 
   // load properties from config file
+  @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD",
+      justification = "url is specified by an admin, not unchecked user input")
   private static AbstractConfiguration getPropsFileConfig(URL accumuloPropsLocation) {
     var config = new PropertiesConfiguration();
     if (accumuloPropsLocation != null) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -18,11 +18,12 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -140,7 +141,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
       return this;
     }
 
-    @SuppressFBWarnings(value = {"URLCONNECTION_SSRF_FD"},
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD",
         justification = "location of props is specified by an admin")
     @Override
     public SiteConfiguration build() {
@@ -203,18 +204,16 @@ public class SiteConfiguration extends AccumuloConfiguration {
   }
 
   // load properties from config file
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")
   private static AbstractConfiguration getPropsFileConfig(URL accumuloPropsLocation) {
+    var config = new PropertiesConfiguration();
     if (accumuloPropsLocation != null) {
-      try (var reader = new FileReader(accumuloPropsLocation.getFile())) {
-        var config = new PropertiesConfiguration();
+      try (var reader = new InputStreamReader(accumuloPropsLocation.openStream(), UTF_8)) {
         config.read(reader);
-        return config;
       } catch (ConfigurationException | IOException e) {
         throw new IllegalArgumentException(e);
       }
     }
-    return new PropertiesConfiguration();
+    return config;
   }
 
   // load sensitive properties from Hadoop credential provider

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloOutputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloOutputFormatTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.mapred;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -118,7 +119,7 @@ public class AccumuloOutputFormatTest {
       File file = File.createTempFile("accumulo-client", ".properties", null);
       file.deleteOnExit();
 
-      FileWriter writer = new FileWriter(file);
+      FileWriter writer = new FileWriter(file, UTF_8);
       writer.write("auth.type=password\n");
       writer.write("instance.zookeepers=zk\n");
       writer.write("instance.name=test\n");

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloOutputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloOutputFormatTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.hadoop.mapreduce;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -120,7 +121,7 @@ public class AccumuloOutputFormatTest {
       File file = File.createTempFile("accumulo-client", ".properties", null);
       file.deleteOnExit();
 
-      FileWriter writer = new FileWriter(file);
+      FileWriter writer = new FileWriter(file, UTF_8);
       writer.write("auth.type=password\n");
       writer.write("instance.zookeepers=zk\n");
       writer.write("instance.name=test\n");

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/RemoteShellOptions.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.cluster;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Map.Entry;
@@ -69,8 +70,8 @@ public class RemoteShellOptions {
       if (f.exists() && f.isFile() && f.canRead()) {
         FileReader reader = null;
         try {
-          reader = new FileReader(f);
-        } catch (FileNotFoundException e) {
+          reader = new FileReader(f, UTF_8);
+        } catch (IOException e) {
           log.warn("Could not read properties from specified file: {}", propertyFile, e);
         }
 

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControl.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.cluster.standalone;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
@@ -373,7 +374,7 @@ public class StandaloneClusterControl implements ClusterControl {
    * Read the provided file and return all lines which don't start with a '#' character
    */
   protected List<String> getHosts(File f) throws IOException {
-    try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
+    try (BufferedReader reader = new BufferedReader(new FileReader(f, UTF_8))) {
       List<String> hosts = new ArrayList<>();
       String line;
       while ((line = reader.readLine()) != null) {

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -389,7 +389,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
 
     if (!config.useExistingInstance() && !config.useExistingZooKeepers()) {
       zooCfgFile = new File(config.getConfDir(), "zoo.cfg");
-      FileWriter fileWriter = new FileWriter(zooCfgFile);
+      FileWriter fileWriter = new FileWriter(zooCfgFile, UTF_8);
 
       // zookeeper uses Properties to read its config, so use that to write in order to properly
       // escape things like Windows paths
@@ -418,7 +418,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
 
   private void writeConfig(File file, Iterable<Map.Entry<String,String>> settings)
       throws IOException {
-    FileWriter fileWriter = new FileWriter(file);
+    FileWriter fileWriter = new FileWriter(file, UTF_8);
     fileWriter.append("<configuration>\n");
 
     for (Entry<String,String> entry : settings) {
@@ -432,7 +432,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
   }
 
   private void writeConfigProperties(File file, Map<String,String> settings) throws IOException {
-    FileWriter fileWriter = new FileWriter(file);
+    FileWriter fileWriter = new FileWriter(file, UTF_8);
 
     for (Entry<String,String> entry : settings.entrySet()) {
       fileWriter.append(entry.getKey() + "=" + entry.getValue() + "\n");

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.minicluster;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -240,7 +241,7 @@ public class MiniAccumuloClusterTest {
     File confDir = new File(testDir, "conf");
     File accumuloProps = new File(confDir, "accumulo.properties");
     var config = new PropertiesConfiguration();
-    try (var reader = new FileReader(accumuloProps)) {
+    try (var reader = new FileReader(accumuloProps, UTF_8)) {
       config.read(reader);
     }
     for (Property randomPortProp : new Property[] {Property.TSERV_CLIENTPORT, Property.MONITOR_PORT,

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.server.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedWriter;
@@ -518,7 +519,7 @@ public class Admin implements KeywordExecutable {
       File outputDirectory)
       throws IOException, AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
     File namespaceScript = new File(outputDirectory, namespace + NS_FILE_SUFFIX);
-    try (BufferedWriter nsWriter = new BufferedWriter(new FileWriter(namespaceScript))) {
+    try (BufferedWriter nsWriter = new BufferedWriter(new FileWriter(namespaceScript, UTF_8))) {
       nsWriter.write(createNsFormat.format(new String[] {namespace}));
       TreeMap<String,String> props = new TreeMap<>();
       for (Entry<String,String> p : accumuloClient.namespaceOperations().getProperties(namespace)) {
@@ -542,7 +543,7 @@ public class Admin implements KeywordExecutable {
   private static void printUserConfiguration(AccumuloClient accumuloClient, String user,
       File outputDirectory) throws IOException, AccumuloException, AccumuloSecurityException {
     File userScript = new File(outputDirectory, user + USER_FILE_SUFFIX);
-    try (BufferedWriter userWriter = new BufferedWriter(new FileWriter(userScript))) {
+    try (BufferedWriter userWriter = new BufferedWriter(new FileWriter(userScript, UTF_8))) {
       userWriter.write(createUserFormat.format(new String[] {user}));
       Authorizations auths = accumuloClient.securityOperations().getUserAuthorizations(user);
       userWriter.write(userAuthsFormat.format(new String[] {user, auths.toString()}));
@@ -585,7 +586,7 @@ public class Admin implements KeywordExecutable {
       }
     }
     File siteBackup = new File(outputDirectory, ACCUMULO_SITE_BACKUP_FILE);
-    try (BufferedWriter fw = new BufferedWriter(new FileWriter(siteBackup))) {
+    try (BufferedWriter fw = new BufferedWriter(new FileWriter(siteBackup, UTF_8))) {
       for (Entry<String,String> prop : conf.entrySet()) {
         fw.write(prop.getKey() + "=" + prop.getValue() + "\n");
       }
@@ -597,7 +598,7 @@ public class Admin implements KeywordExecutable {
   private void printTableConfiguration(AccumuloClient accumuloClient, String tableName,
       File outputDirectory) throws AccumuloException, TableNotFoundException, IOException {
     File tableBackup = new File(outputDirectory, tableName + ".cfg");
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(tableBackup))) {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(tableBackup, UTF_8))) {
       writer.write(createTableFormat.format(new String[] {tableName}));
       TreeMap<String,String> props = new TreeMap<>();
       for (Entry<String,String> p : accumuloClient.tableOperations().getProperties(tableName)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileSystemMonitor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileSystemMonitor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.server.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -76,7 +78,7 @@ public class FileSystemMonitor {
       justification = "procFile path not from user input")
   static List<Mount> parse(String procFile) throws IOException {
 
-    FileReader fr = new FileReader(procFile);
+    FileReader fr = new FileReader(procFile, UTF_8);
 
     try (BufferedReader br = new BufferedReader(fr)) {
       return getMountsFromFile(br);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.shell.commands;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -121,7 +123,7 @@ public class ScriptCommand extends Command {
       Writer writer = null;
       if (cl.hasOption(out.getOpt())) {
         File f = new File(cl.getOptionValue(out.getOpt()));
-        writer = new FileWriter(f);
+        writer = new FileWriter(f, UTF_8);
         ctx.setWriter(writer);
       }
 
@@ -134,7 +136,7 @@ public class ScriptCommand extends Command {
           shellState.printException(new Exception(f.getAbsolutePath() + " not found"));
           return 1;
         }
-        Reader reader = new FileReader(f);
+        Reader reader = new FileReader(f, UTF_8);
         try {
           engine.eval(reader, ctx);
           if (invoke) {

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -18,9 +18,11 @@
  */
 package org.apache.accumulo.start.classloader;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -87,7 +89,7 @@ public class AccumuloClassLoader {
     }
     try {
       var config = new PropertiesConfiguration();
-      try (var reader = new FileReader(accumuloConfigUrl.getFile())) {
+      try (var reader = new InputStreamReader(accumuloConfigUrl.openStream(), UTF_8)) {
         config.read(reader);
       }
       String value = config.getString(propertyName);

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -79,7 +79,8 @@ public class AccumuloClassLoader {
    *          Value to default to if not found.
    * @return value of property or default
    */
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")
+  @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD",
+      justification = "url is specified by an admin, not unchecked user input")
   public static String getAccumuloProperty(String propertyName, String defaultValue) {
     if (accumuloConfigUrl == null) {
       log.warn(

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoaderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.start.classloader.vfs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -66,7 +67,7 @@ public class AccumuloVFSClassLoaderTest {
         (AccumuloReloadingVFSClassLoader) null);
 
     File conf = folder1.newFile("accumulo.properties");
-    FileWriter out = new FileWriter(conf);
+    FileWriter out = new FileWriter(conf, UTF_8);
     out.append("general.classpaths=\n");
     out.append("general.vfs.classpaths=\n");
     out.close();
@@ -91,7 +92,7 @@ public class AccumuloVFSClassLoaderTest {
         (AccumuloReloadingVFSClassLoader) null);
 
     File conf = folder1.newFile("accumulo.properties");
-    FileWriter out = new FileWriter(conf);
+    FileWriter out = new FileWriter(conf, UTF_8);
     out.append("general.classpaths=\n");
     out.append("general.vfs.classpaths=\n");
     out.append("general.dynamic.classpaths=" + System.getProperty("user.dir") + "\n");
@@ -118,7 +119,7 @@ public class AccumuloVFSClassLoaderTest {
         folder1.newFile("HelloWorld.jar"));
 
     File conf = folder1.newFile("accumulo.properties");
-    FileWriter out = new FileWriter(conf);
+    FileWriter out = new FileWriter(conf, UTF_8);
     out.append("general.classpaths=\n");
     out.append(
         "general.vfs.classpaths=" + new File(folder1.getRoot(), "HelloWorld.jar").toURI() + "\n");
@@ -148,7 +149,7 @@ public class AccumuloVFSClassLoaderTest {
         (AccumuloReloadingVFSClassLoader) null);
 
     File conf = folder1.newFile("accumulo.properties");
-    FileWriter out = new FileWriter(conf);
+    FileWriter out = new FileWriter(conf, UTF_8);
     out.append("general.classpaths=\n");
     out.append("general.vfs.classpaths=\n");
     out.close();
@@ -184,7 +185,7 @@ public class AccumuloVFSClassLoaderTest {
     String cacheDir = "/some/random/cache/dir";
 
     File conf = folder1.newFile("accumulo.properties");
-    FileWriter out = new FileWriter(conf);
+    FileWriter out = new FileWriter(conf, UTF_8);
     out.append("general.classpaths=\n");
     out.append(AccumuloVFSClassLoader.VFS_CACHE_DIR + "=" + cacheDir + "\n");
     out.close();

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloClusterPropertyConfiguration.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.harness.conf;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
@@ -60,7 +60,7 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
       // Check for properties provided in a file
       File f = new File(propertyFile);
       Properties fileProperties = new Properties();
-      try (FileReader reader = new FileReader(f)) {
+      try (FileReader reader = new FileReader(f, UTF_8)) {
         fileProperties.load(reader);
         clusterTypeValue = fileProperties.getProperty(ACCUMULO_CLUSTER_TYPE_KEY);
         clientConf = fileProperties.getProperty(ACCUMULO_CLUSTER_CLIENT_CONF_KEY);
@@ -137,8 +137,8 @@ public abstract class AccumuloClusterPropertyConfiguration implements AccumuloCl
         Properties fileProperties = new Properties();
         FileReader reader = null;
         try {
-          reader = new FileReader(f);
-        } catch (FileNotFoundException e) {
+          reader = new FileReader(f, UTF_8);
+        } catch (IOException e) {
           log.warn("Could not read properties from specified file: {}", propertyFile, e);
         }
 

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -392,7 +392,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
       // Implement a poor-man's DistCp
       try (BufferedReader reader =
-          new BufferedReader(new FileReader(new File(exportDir, "distcp.txt")))) {
+          new BufferedReader(new FileReader(new File(exportDir, "distcp.txt"), UTF_8))) {
         for (String line; (line = reader.readLine()) != null;) {
           Path exportedFile = new Path(line);
           // There isn't a cp on FileSystem??

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -189,7 +190,7 @@ public class VolumeIT extends ConfigurableMacBase {
       var config = new PropertiesConfiguration();
       config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v1 + "," + v2 + "," + v3);
       File f = new File(cluster.getAccumuloPropertiesPath());
-      try (FileWriter out = new FileWriter(f)) {
+      try (FileWriter out = new FileWriter(f, UTF_8)) {
         config.write(out);
       }
 
@@ -229,7 +230,7 @@ public class VolumeIT extends ConfigurableMacBase {
       var config = new PropertiesConfiguration();
       config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v2 + "," + v3);
       File f = new File(cluster.getAccumuloPropertiesPath());
-      try (FileWriter out = new FileWriter(f)) {
+      try (FileWriter out = new FileWriter(f, UTF_8)) {
         config.write(out);
       }
 
@@ -367,7 +368,7 @@ public class VolumeIT extends ConfigurableMacBase {
       var config = new PropertiesConfiguration();
       config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v2.toString());
       File f = new File(cluster.getAccumuloPropertiesPath());
-      try (FileWriter out = new FileWriter(f)) {
+      try (FileWriter out = new FileWriter(f, UTF_8)) {
         config.write(out);
       }
 
@@ -433,7 +434,7 @@ public class VolumeIT extends ConfigurableMacBase {
     config.setProperty(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey(),
         v1 + " " + v8 + "," + v2 + " " + v9);
     File f = new File(cluster.getAccumuloPropertiesPath());
-    try (FileWriter out = new FileWriter(f)) {
+    try (FileWriter out = new FileWriter(f, UTF_8)) {
       config.write(out);
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -187,12 +189,8 @@ public class VolumeIT extends ConfigurableMacBase {
 
       String uuid = verifyAndShutdownCluster(client, tableNames[0]);
 
-      var config = new PropertiesConfiguration();
-      config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v1 + "," + v2 + "," + v3);
-      File f = new File(cluster.getAccumuloPropertiesPath());
-      try (FileWriter out = new FileWriter(f, UTF_8)) {
-        config.write(out);
-      }
+      updateConfig(config -> config.setProperty(Property.INSTANCE_VOLUMES.getKey(),
+          v1 + "," + v2 + "," + v3));
 
       // initialize volume
       assertEquals(0, cluster.exec(Initialize.class, "--add-volumes").getProcess().waitFor());
@@ -227,12 +225,7 @@ public class VolumeIT extends ConfigurableMacBase {
 
       String uuid = verifyAndShutdownCluster(client, tableNames[0]);
 
-      var config = new PropertiesConfiguration();
-      config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v2 + "," + v3);
-      File f = new File(cluster.getAccumuloPropertiesPath());
-      try (FileWriter out = new FileWriter(f, UTF_8)) {
-        config.write(out);
-      }
+      updateConfig(config -> config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v2 + "," + v3));
 
       // initialize volume
       assertEquals(0, cluster.exec(Initialize.class, "--add-volumes").getProcess().waitFor());
@@ -365,12 +358,7 @@ public class VolumeIT extends ConfigurableMacBase {
       assertEquals(0, cluster.exec(Admin.class, "stopAll").getProcess().waitFor());
       cluster.stop();
 
-      var config = new PropertiesConfiguration();
-      config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v2.toString());
-      File f = new File(cluster.getAccumuloPropertiesPath());
-      try (FileWriter out = new FileWriter(f, UTF_8)) {
-        config.write(out);
-      }
+      updateConfig(config -> config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v2.toString()));
 
       // start cluster and verify that volume was decommissioned
       cluster.start();
@@ -402,7 +390,6 @@ public class VolumeIT extends ConfigurableMacBase {
     }
   }
 
-  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths provided by test")
   private void testReplaceVolume(AccumuloClient client, boolean cleanShutdown) throws Exception {
     String[] tableNames = getUniqueNames(3);
 
@@ -429,14 +416,11 @@ public class VolumeIT extends ConfigurableMacBase {
     assertTrue("Failed to rename " + v2f + " to " + v9f, v2f.renameTo(v9f));
     Path v9 = new Path(v9f.toURI());
 
-    var config = new PropertiesConfiguration();
-    config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v8 + "," + v9);
-    config.setProperty(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey(),
-        v1 + " " + v8 + "," + v2 + " " + v9);
-    File f = new File(cluster.getAccumuloPropertiesPath());
-    try (FileWriter out = new FileWriter(f, UTF_8)) {
-      config.write(out);
-    }
+    updateConfig(config -> {
+      config.setProperty(Property.INSTANCE_VOLUMES.getKey(), v8 + "," + v9);
+      config.setProperty(Property.INSTANCE_VOLUMES_REPLACEMENTS.getKey(),
+          v1 + " " + v8 + "," + v2 + " " + v9);
+    });
 
     // start cluster and verify that volumes were replaced
     cluster.start();
@@ -486,6 +470,19 @@ public class VolumeIT extends ConfigurableMacBase {
   public void testDirtyReplaceVolumes() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       testReplaceVolume(client, false);
+    }
+  }
+
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths provided by test")
+  private void updateConfig(Consumer<PropertiesConfiguration> updater) throws Exception {
+    var file = new File(cluster.getAccumuloPropertiesPath());
+    var config = new PropertiesConfiguration();
+    try (FileReader out = new FileReader(file, UTF_8)) {
+      config.read(out);
+    }
+    updater.accept(config);
+    try (FileWriter out = new FileWriter(file, UTF_8)) {
+      config.write(out);
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsFileTailer.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsFileTailer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test.metrics;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -132,7 +134,7 @@ public class MetricsFileTailer implements Runnable, AutoCloseable {
     File propertiesFile = new File(filename);
 
     var config = new PropertiesConfiguration();
-    try (var reader = new FileReader(propertiesFile)) {
+    try (var reader = new FileReader(propertiesFile, UTF_8)) {
       config.read(reader);
       final Configuration sub = config.subset(metricsPrefix);
 

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsFileTailer.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsFileTailer.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.test.metrics;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.net.URL;
 import java.util.Collections;
@@ -40,6 +40,8 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This class allows testing of the publishing to the hadoop metrics system by processing a file for
@@ -119,6 +121,8 @@ public class MetricsFileTailer implements Runnable, AutoCloseable {
    *
    * @return a configuration with http sink properties.
    */
+  @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD",
+      justification = "url specified by test code, not unchecked user input")
   private Configuration loadMetricsConfig() {
     final URL propUrl =
         getClass().getClassLoader().getResource(MetricsTestSinkProperties.METRICS_PROP_FILENAME);
@@ -128,31 +132,28 @@ public class MetricsFileTailer implements Runnable, AutoCloseable {
           "Could not find " + MetricsTestSinkProperties.METRICS_PROP_FILENAME + " on classpath");
     }
 
-    String filename = propUrl.getFile();
-
     // Read data from this file
-    File propertiesFile = new File(filename);
-
     var config = new PropertiesConfiguration();
-    try (var reader = new FileReader(propertiesFile, UTF_8)) {
+    try (var reader = new InputStreamReader(propUrl.openStream(), UTF_8)) {
       config.read(reader);
-      final Configuration sub = config.subset(metricsPrefix);
-
-      if (log.isTraceEnabled()) {
-        log.trace("Config {}", config);
-        Iterator<String> iterator = sub.getKeys();
-        while (iterator.hasNext()) {
-          String key = iterator.next();
-          log.trace("'{}'='{}'", key, sub.getProperty(key));
-        }
-      }
-
-      return sub;
     } catch (ConfigurationException | IOException e) {
       throw new IllegalStateException(
           String.format("Could not find configuration file \'%s\' on classpath",
               MetricsTestSinkProperties.METRICS_PROP_FILENAME));
     }
+
+    final Configuration sub = config.subset(metricsPrefix);
+
+    if (log.isTraceEnabled()) {
+      log.trace("Config {}", config);
+      Iterator<String> iterator = sub.getKeys();
+      while (iterator.hasNext()) {
+        String key = iterator.next();
+        log.trace("'{}'='{}'", key, sub.getProperty(key));
+      }
+    }
+
+    return sub;
   }
 
   /**


### PR DESCRIPTION
* Use UTF-8 for all FileReaders and FileWriters
* Use an InputStreamReader instead of a FileReader for reading class
  path resources identified with a URL rather than a file name
* This fixes a failure in some ITs, including VolumeIT, which reads a
  class path resource, rather than a file
* Ensure PropertiesConfigurations use read() and write() instead of
  less convenient getlayout() methods to load/save