### PR TITLE
Add table option to shell delete command.

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteCommand.java
@@ -53,11 +53,12 @@ public class DeleteCommand extends Command {
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException,
       ConstraintViolationException {
-    shellState.checkTableState();
 
     final Mutation m = new Mutation(new Text(cl.getArgs()[0].getBytes(Shell.CHARSET)));
     final Text colf = new Text(cl.getArgs()[1].getBytes(Shell.CHARSET));
     final Text colq = new Text(cl.getArgs()[2].getBytes(Shell.CHARSET));
+
+    final String tableName = OptUtil.getTableOpt(cl, shellState);
 
     if (cl.hasOption(deleteOptAuths.getOpt())) {
       final ColumnVisibility le = new ColumnVisibility(cl.getOptionValue(deleteOptAuths.getOpt()));
@@ -71,10 +72,9 @@ public class DeleteCommand extends Command {
     } else {
       m.putDelete(colf, colq);
     }
-    final BatchWriter bw =
-        shellState.getAccumuloClient().createBatchWriter(shellState.getTableName(),
-            new BatchWriterConfig().setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024))
-                .setMaxWriteThreads(1).setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS));
+    final BatchWriter bw = shellState.getAccumuloClient().createBatchWriter(tableName,
+        new BatchWriterConfig().setMaxMemory(Math.max(m.estimatedMemoryUsed(), 1024))
+            .setMaxWriteThreads(1).setTimeout(getTimeout(cl), TimeUnit.MILLISECONDS));
     bw.addMutation(m);
     bw.close();
     return 0;
@@ -107,6 +107,8 @@ public class DeleteCommand extends Command {
             + " given assumes seconds. Units d,h,m,s,and ms are supported. e.g. 30s" + " or 100ms");
     timeoutOption.setArgName("timeout");
     o.addOption(timeoutOption);
+
+    o.addOption(OptUtil.tableOpt("table from which data will be deleted"));
 
     return o;
   }

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -239,13 +239,21 @@ public class ShellIT extends SharedMiniClusterBase {
     // Add tests to verify use of --table parameter
     exec("createtable test2", true);
     exec("notable", true);
-    exec("insert r1 f1 q1 v1 -t  test2", true);
+    exec("insert r1 f1 q1 v1 -t test2", true);
     exec("insert r2 f2 q2 v2 --table test2", true);
     exec("insert r1 f1 q1 v1 -t", false,
         "org.apache.commons.cli.MissingArgumentException: Missing argument for option:");
     exec("insert r1 f1 q1 v1 -t  test3", false,
         "org.apache.accumulo.core.client.TableNotFoundException:");
     exec("scan -t test2", true, "r1 f1:q1 []    v1\nr2 f2:q2 []    v2");
+    exec("insert r3 f3 q3 v3 -t test2", true);
+    exec("delete r1 f1 q1 -t test2", true);
+    exec("delete r2 f2 q2 --table test2", true);
+    exec("scan -t test2", true, "r3 f3:q3 []    v3");
+    exec("delete r3 f3 q3 -t", false,
+        "org.apache.commons.cli.MissingArgumentException: Missing argument for option: t");
+    exec("delete r3 f3 q3 -t test4", false,
+        "org.apache.accumulo.core.client.TableNotFoundException:");
     exec("deletetable test2 -f", true, "Table: [test2] has been deleted");
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -236,6 +236,17 @@ public class ShellIT extends SharedMiniClusterBase {
     exec("delete \\x90 \\xa0 \\xb0", true);
     exec("scan", true, "\\x90 \\xA0:\\xB0 []\t\\xC0", false);
     exec("deletetable test -f", true, "Table: [test] has been deleted");
+    // Add tests to verify use of --table parameter
+    exec("createtable test2", true);
+    exec("notable", true);
+    exec("insert r1 f1 q1 v1 -t  test2", true);
+    exec("insert r2 f2 q2 v2 --table test2", true);
+    exec("insert r1 f1 q1 v1 -t", false,
+        "org.apache.commons.cli.MissingArgumentException: Missing argument for option:");
+    exec("insert r1 f1 q1 v1 -t  test3", false,
+        "org.apache.accumulo.core.client.TableNotFoundException:");
+    exec("scan -t test2", true, "r1 f1:q1 []    v1\nr2 f2:q2 []    v2");
+    exec("deletetable test2 -f", true, "Table: [test2] has been deleted");
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -239,21 +239,20 @@ public class ShellIT extends SharedMiniClusterBase {
     // Add tests to verify use of --table parameter
     exec("createtable test2", true);
     exec("notable", true);
+    exec("insert r f q v", false, "java.lang.IllegalStateException: Not in a table context");
     exec("insert r1 f1 q1 v1 -t test2", true);
     exec("insert r2 f2 q2 v2 --table test2", true);
-    exec("insert r1 f1 q1 v1 -t", false,
+    exec("delete r1 f1 q1 -t", false,
         "org.apache.commons.cli.MissingArgumentException: Missing argument for option:");
-    exec("insert r1 f1 q1 v1 -t  test3", false,
+    exec("delete r1 f1 q1 -t  test3", false,
         "org.apache.accumulo.core.client.TableNotFoundException:");
-    exec("scan -t test2", true, "r1 f1:q1 []    v1\nr2 f2:q2 []    v2");
-    exec("insert r3 f3 q3 v3 -t test2", true);
+    exec("scan -t test2", true, "r1 f1:q1 []\tv1\nr2 f2:q2 []\tv2");
     exec("delete r1 f1 q1 -t test2", true);
+    exec("scan -t test2", true, "r1 f1:q1 []\tv1", false);
+    exec("scan -t test2", true, "r2 f2:q2 []\tv2", true);
     exec("delete r2 f2 q2 --table test2", true);
-    exec("scan -t test2", true, "r3 f3:q3 []    v3");
-    exec("delete r3 f3 q3 -t", false,
-        "org.apache.commons.cli.MissingArgumentException: Missing argument for option: t");
-    exec("delete r3 f3 q3 -t test4", false,
-        "org.apache.accumulo.core.client.TableNotFoundException:");
+    exec("scan -t test2", true, "r1 f1:q1 []\tv1", false);
+    exec("scan -t test2", true, "r2 f2:q2 []\tv2", false);
     exec("deletetable test2 -f", true, "Table: [test2] has been deleted");
   }
 


### PR DESCRIPTION
This ticket examined the table-related shell commands to verify they provide a means to indicate the table name. After examination all but the 'delete' command did so. The PR added the ability for the 'delete' command to specify a target table. With this update all 39 shell commands that can take a table name parameter. This closes #1776.