### PR TITLE
Stop passing watcher to ZooCache exists()

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -397,18 +397,10 @@ public class ZooCache {
           return val;
         }
 
-        /*
-         * The following call to exists() is important, since we are caching that a node does not
-         * exist. Once the node comes into existence, it will be added to the cache. But this
-         * notification of a node coming into existence will only be given if exists() was
-         * previously called. If the call to exists() is bypassed and only getData() is called with
-         * a special case that looks for Code.NONODE in the KeeperException, then non-existence can
-         * not be cached.
-         */
         cacheWriteLock.lock();
         try {
           final ZooKeeper zooKeeper = getZooKeeper();
-          Stat stat = zooKeeper.exists(zPath, watcher);
+          Stat stat = zooKeeper.exists(zPath, null);
           byte[] data = null;
           if (stat == null) {
             if (log.isTraceEnabled()) {


### PR DESCRIPTION
* Passing a watcher to calls to zk exist method in ZooCache.get() was
resulting in watchers hanging around forever after a table is deleted

This is a fix for #1809.  I am not 100% sure that we don't need a watcher here.  The calls to `zooKeeper.exists(zPath, watcher)` happen quite often as this is in the `ZooCache.get()` method but Accumulo doesn't seem to mind with my initial testing.  I also removed a very old comment about the importance of having a watcher on this method since I do not think it applies anymore.  The node is always added to the cache, whether it has data or not.  If the comment does still apply, then it seems like Accumulo is going to retry on a NONODE either way.  