### PR TITLE
Redirect other log frameworks to log4j

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -59,7 +59,8 @@ if [[ -n "$CLASSPATH" ]]; then
 else
   CLASSPATH="${conf}"
 fi
-CLASSPATH="${CLASSPATH}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${ZOOKEEPER_HOME}/lib/*:${HADOOP_HOME}/share/hadoop/client/*"
+ZK_JARS=$(find "$ZOOKEEPER_HOME/lib/" -maxdepth 1 -name '*.jar' -not -name '*slf4j*' -not -name '*log4j*' | paste -sd:)
+CLASSPATH="${CLASSPATH}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${ZK_JARS}:${HADOOP_HOME}/share/hadoop/client/*"
 export CLASSPATH
 
 ##################################################################

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -284,6 +284,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <optional>true</optional>
     </dependency>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -71,6 +71,8 @@
         <include>org.apache.logging.log4j:log4j-1.2-api</include>
         <include>org.apache.logging.log4j:log4j-api</include>
         <include>org.apache.logging.log4j:log4j-core</include>
+        <include>org.apache.logging.log4j:log4j-jcl</include>
+        <include>org.apache.logging.log4j:log4j-jul</include>
         <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
         <include>org.apache.logging.log4j:log4j-web</include>
         <include>org.apache.thrift:libthrift</include>

--- a/assemble/src/main/resources/NOTICE
+++ b/assemble/src/main/resources/NOTICE
@@ -21,3 +21,10 @@ From Apache Commons Math3:
 
 This product includes Jetty (http://eclipse.org/jetty)
 Copyright 1996-2009 Mort Bay Consulting Pty. Ltd.
+
+**********
+
+From log4j-core:
+
+  ResolverUtil.java
+  Copyright 2005-2006 Tim Fennell

--- a/pom.xml
+++ b/pom.xml
@@ -764,7 +764,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.1</version>
+        <version>2.14.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -1147,6 +1147,20 @@
                   <version>[11,)</version>
                 </requireJavaVersion>
                 <dependencyConvergence />
+                <bannedDependencies>
+                  <excludes>
+                    <!-- we redirect logging to log4j2, so we should have those bridges instead -->
+                    <!-- commons-logging is allowed because log4j-jcl uses it as a dependency -->
+                    <exclude>ch.qos.logback:*</exclude>
+                    <exclude>log4j:*</exclude>
+                    <exclude>org.apache.logging.log4j:log4j-to-slf4j</exclude>
+                    <exclude>org.slf4j:*</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- only allow API jar for slf4j, but no other slf4j implementations -->
+                    <include>org.slf4j:slf4j-api</include>
+                  </includes>
+                </bannedDependencies>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Include additional jars in the binary tarball assembly to redirect logs
sent to other logging frameworks to log4j by default:
* log4j-jcl to redirect commons-logging (commons-logging jar still
  needed as a transitive dependency)
* log4j-jul to redirect java.util.logging
(From https://logging.apache.org/log4j/2.x/faq.html#which_jars)

Propagate an additional NOTICE from log4j-core's jar in our binary
tarball assembly.

Include rules to ban other transitive dependencies from the project that
are likely to cause conflicts with our logging at runtime, as a sanity
check for our build quality.

Bump log4j to latest version 2.14.0