### PR TITLE
Fixes #1763 - Flaky test: SimpleTimerTest

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/util/time/SimpleTimerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/time/SimpleTimerTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
-
 public class SimpleTimerTest {
   private static final long DELAY = 1000L;
   private static final long PERIOD = 2000L;
@@ -98,11 +97,15 @@ public class SimpleTimerTest {
     assertTrue(r.wasRun);
   }
 
-  @Test
-  public void testSingleton() {
-    assertEquals(1, SimpleTimer.getInstanceThreadPoolSize());
-    SimpleTimer t2 = SimpleTimer.getInstance(2);
-    assertSame(t, t2);
+  @Test(timeout = 5000)
+  public void testSingleton() throws InterruptedException {
+    while (true) {
+      SimpleTimer t2 = SimpleTimer.getInstance(2);
+      if((SimpleTimer.getInstanceThreadPoolSize() == 1) && (t == t2)) {
+        break;
+      }
+      Thread.sleep(PAD);
+    }
     assertEquals(1, SimpleTimer.getInstanceThreadPoolSize()); // unchanged
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/time/SimpleTimerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/time/SimpleTimerTest.java
@@ -75,10 +75,7 @@ public class SimpleTimerTest {
     Incrementer r = new Incrementer(i);
     t.schedule(r, DELAY);
     Thread.sleep(DELAY + PAD);
-    while (true) {
-      if (i.get() == 1) {
-        break;
-      }
+    while (i.get() != 1) {
       Thread.sleep(PAD);
     }
     r.cancel();
@@ -90,10 +87,7 @@ public class SimpleTimerTest {
     Incrementer r = new Incrementer(i);
     t.schedule(r, DELAY, PERIOD);
     Thread.sleep(DELAY + (2 * PERIOD) + PAD);
-    while (true) {
-      if (i.get() == 3) {
-        break;
-      }
+    while (i.get() != 3) {
       Thread.sleep(PAD);
     }
     r.cancel();
@@ -104,10 +98,7 @@ public class SimpleTimerTest {
     Thrower r = new Thrower();
     t.schedule(r, DELAY);
     Thread.sleep(DELAY + PAD);
-    while (true) {
-      if (r.wasRun) {
-        break;
-      }
+    while (!r.wasRun) {
       Thread.sleep(PAD);
     }
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/time/SimpleTimerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/time/SimpleTimerTest.java
@@ -19,13 +19,13 @@
 package org.apache.accumulo.server.util.time;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
+
 public class SimpleTimerTest {
   private static final long DELAY = 1000L;
   private static final long PERIOD = 2000L;


### PR DESCRIPTION
Did my best to resolve #1763. Replaced the assert statements with an if statement so that they could be repeated if they don't pass immediately. The test will repeat until passed or until the added timeout occurs. As suggested, I left the assert statement after the loop which verifies the thread pool size remains unchanged after the previous operations. Not sure if I should have kept the other asserts as well but I don't see the point if the same conditions were verified already. Please suggest any changes or improvements.