### PR TITLE
Make zk watch offenders call getWithoutWatch(). Fixes #1809

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -160,6 +160,10 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
    */
   public abstract String get(Property property);
 
+  public String getWithoutWatch(Property property) {
+    return get(property);
+  }
+
   /**
    * Returns property key/value pairs in this configuration. The pairs include those defined in this
    * configuration which pass the given filter, and those supplied from the parent configuration

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1299,8 +1299,8 @@ public enum Property {
    */
   public static <T> T createTableInstanceFromPropertyName(AccumuloConfiguration conf,
       Property property, Class<T> base, T defaultInstance) {
-    String clazzName = conf.get(property);
-    String context = conf.get(TABLE_CLASSPATH);
+    String clazzName = conf.getWithoutWatch(property);
+    String context = conf.getWithoutWatch(TABLE_CLASSPATH);
 
     return createInstance(context, clazzName, base, defaultInstance);
   }

--- a/core/src/main/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/replication/ReplicationConfigurationUtil.java
@@ -39,7 +39,7 @@ public class ReplicationConfigurationUtil {
       return false;
     }
 
-    return conf.getBoolean(Property.TABLE_REPLICATION);
+    return Boolean.parseBoolean(conf.getWithoutWatch(Property.TABLE_REPLICATION));
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -112,7 +112,7 @@ public class LocalityGroupUtil {
   public static Map<String,Set<ByteSequence>> getLocalityGroups(AccumuloConfiguration acuconf)
       throws LocalityGroupConfigurationError {
     Map<String,Set<ByteSequence>> result = new HashMap<>();
-    String[] groups = acuconf.get(Property.TABLE_LOCALITY_GROUPS).split(",");
+    String[] groups = acuconf.getWithoutWatch(Property.TABLE_LOCALITY_GROUPS).split(",");
     for (String group : groups) {
       if (group.length() > 0)
         result.put(group, new HashSet<ByteSequence>());

--- a/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
@@ -426,7 +426,8 @@ public class ZooLock implements Watcher {
       return false;
 
     ZcStat stat = new ZcStat();
-    return zc.get(lid.path + "/" + lid.node, stat) != null && stat.getEphemeralOwner() == lid.eid;
+    return zc.get(lid.path + "/" + lid.node, stat, false) != null
+        && stat.getEphemeralOwner() == lid.eid;
   }
 
   public static byte[] getLockData(ZooKeeper zk, String path)
@@ -462,7 +463,7 @@ public class ZooLock implements Watcher {
       throw new RuntimeException("Node " + lockNode + " at " + path + " is not a lock node");
     }
 
-    return zc.get(path + "/" + lockNode, stat);
+    return zc.get(path + "/" + lockNode, stat, false);
   }
 
   public static long getSessionId(ZooCache zc, String path)
@@ -479,7 +480,7 @@ public class ZooLock implements Watcher {
     String lockNode = children.get(0);
 
     ZcStat stat = new ZcStat();
-    if (zc.get(path + "/" + lockNode, stat) != null)
+    if (zc.get(path + "/" + lockNode, stat, false) != null)
       return stat.getEphemeralOwner();
     return 0;
   }

--- a/fate/src/test/java/org/apache/accumulo/fate/zookeeper/ZooCacheTest.java
+++ b/fate/src/test/java/org/apache/accumulo/fate/zookeeper/ZooCacheTest.java
@@ -89,7 +89,7 @@ public class ZooCacheTest {
     replay(zk);
 
     assertFalse(zc.dataCached(ZPATH));
-    assertArrayEquals(DATA, (fillStat ? zc.get(ZPATH, myStat) : zc.get(ZPATH)));
+    assertArrayEquals(DATA, (fillStat ? zc.get(ZPATH, myStat, false) : zc.get(ZPATH)));
     verify(zk);
     if (fillStat) {
       assertEquals(ephemeralOwner, myStat.getEphemeralOwner());

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -122,6 +122,11 @@ public class TableConfiguration extends ObservableConfiguration {
   }
 
   @Override
+  public String getWithoutWatch(Property property) {
+    return getPropCacheAccessor().getWithoutWatch(property, getPath(), parent);
+  }
+
+  @Override
   @SuppressModernizer
   public void getProperties(Map<String,String> props, Predicate<String> filter) {
     getPropCacheAccessor().getProperties(props, getPath(), filter, parent, null);

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
@@ -103,6 +103,20 @@ public class ZooCachePropertyAccessor {
     String key = property.getKey();
     String value = get(path + "/" + key);
 
+    return checkValue(property, parent, key, value);
+  }
+
+  private String get(String path) {
+    byte[] v = propCache.get(path);
+    if (v != null) {
+      return new String(v, UTF_8);
+    } else {
+      return null;
+    }
+  }
+
+  private String checkValue(Property property, AccumuloConfiguration parent, String key,
+      String value) {
     if (value == null || !property.getType().isValidFormat(value)) {
       if (value != null) {
         log.error("Using default value for " + key + " due to improperly formatted "
@@ -115,8 +129,15 @@ public class ZooCachePropertyAccessor {
     return value;
   }
 
-  private String get(String path) {
-    byte[] v = propCache.get(path);
+  public String getWithoutWatch(Property property, String path, AccumuloConfiguration parent) {
+    String key = property.getKey();
+    String value = getWithoutWatch(path + "/" + key);
+
+    return checkValue(property, parent, key, value);
+  }
+
+  private String getWithoutWatch(String path) {
+    byte[] v = propCache.getWithoutWatch(path);
     if (v != null) {
       return new String(v, UTF_8);
     } else {

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -49,7 +49,8 @@ public class TableLoadBalancer extends TabletBalancer {
       throws Exception {
     String context = null;
     if (null != configuration)
-      context = configuration.getTableConfiguration(table).get(Property.TABLE_CLASSPATH);
+      context =
+          configuration.getTableConfiguration(table).getWithoutWatch(Property.TABLE_CLASSPATH);
     Class<? extends TabletBalancer> clazz;
     if (context != null && !context.equals(""))
       clazz = AccumuloVFSClassLoader.getContextManager().loadClass(context, clazzName,
@@ -65,7 +66,8 @@ public class TableLoadBalancer extends TabletBalancer {
     if (tableState == null)
       return null;
     if (tableState.equals(TableState.ONLINE))
-      return configuration.getTableConfiguration(table).get(Property.TABLE_LOAD_BALANCER);
+      return configuration.getTableConfiguration(table)
+          .getWithoutWatch(Property.TABLE_LOAD_BALANCER);
     return null;
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/util/AdminTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/AdminTest.java
@@ -56,7 +56,8 @@ public class AdminTest {
 
     String serverPath = root + "/" + server;
     EasyMock.expect(zc.getChildren(serverPath)).andReturn(Collections.singletonList("child"));
-    EasyMock.expect(zc.get(EasyMock.eq(serverPath + "/child"), EasyMock.anyObject(ZcStat.class)))
+    EasyMock
+        .expect(zc.get(EasyMock.eq(serverPath + "/child"), EasyMock.anyObject(ZcStat.class), false))
         .andAnswer(new IAnswer<byte[]>() {
 
           @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -130,9 +130,10 @@ public class InMemoryMap {
 
   public InMemoryMap(AccumuloConfiguration config, String tableId) {
 
-    boolean useNativeMap = config.getBoolean(Property.TSERV_NATIVEMAP_ENABLED);
+    boolean useNativeMap =
+        Boolean.parseBoolean(config.getWithoutWatch(Property.TSERV_NATIVEMAP_ENABLED));
 
-    this.memDumpDir = config.get(Property.TSERV_MEMDUMP_DIR);
+    this.memDumpDir = config.getWithoutWatch(Property.TSERV_MEMDUMP_DIR);
     this.lggroups = LocalityGroupUtil.getLocalityGroupsIgnoringErrors(config, tableId);
 
     this.config = config;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -687,7 +687,9 @@ public class TabletServerResourceManager {
           idleTime = System.currentTimeMillis() - lastReportedCommitTime;
         }
 
-        if (idleTime < tableConf.getTimeInMillis(Property.TABLE_MAJC_COMPACTALL_IDLETIME)) {
+        ;
+        if (idleTime < AccumuloConfiguration
+            .getTimeInMillis(tableConf.getWithoutWatch(Property.TABLE_MAJC_COMPACTALL_IDLETIME))) {
           return false;
         }
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/constraints/ConstraintChecker.java
@@ -52,7 +52,7 @@ public class ConstraintChecker {
     this.conf = conf;
 
     try {
-      String context = conf.get(Property.TABLE_CLASSPATH);
+      String context = conf.getWithoutWatch(Property.TABLE_CLASSPATH);
 
       if (context != null && !context.equals("")) {
         loader = AccumuloVFSClassLoader.getContextManager().getClassLoader(context);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -560,7 +560,7 @@ public class Tablet implements TabletCommitter {
     } else {
       try {
         ColumnVisibility cv = new ColumnVisibility(
-            tableConfiguration.get(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY));
+            tableConfiguration.getWithoutWatch(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY));
         this.defaultSecurityLabel = cv.getExpression();
       } catch (Exception e) {
         log.error(e, e);
@@ -1620,8 +1620,10 @@ public class Tablet implements TabletCommitter {
     // check if we already decided that we can never split
     // check to see if we're big enough to split
 
-    long splitThreshold = tableConfiguration.getMemoryInBytes(Property.TABLE_SPLIT_THRESHOLD);
-    long maxEndRow = tableConfiguration.getMemoryInBytes(Property.TABLE_MAX_END_ROW_SIZE);
+    long splitThreshold = TableConfiguration
+        .getMemoryInBytes(tableConfiguration.getWithoutWatch(Property.TABLE_SPLIT_THRESHOLD));
+    long maxEndRow = TableConfiguration
+        .getMemoryInBytes(tableConfiguration.getWithoutWatch(Property.TABLE_MAX_END_ROW_SIZE));
 
     if (extent.isRootTablet() || estimateTabletSize() <= splitThreshold) {
       return null;
@@ -2555,7 +2557,8 @@ public class Tablet implements TabletCommitter {
   public void checkIfMinorCompactionNeededForLogs(List<DfsLogger> closedLogs) {
 
     // grab this outside of tablet lock.
-    int maxLogs = tableConfiguration.getCount(Property.TABLE_MINC_LOGS_MAX);
+    int maxLogs =
+        Integer.parseInt(tableConfiguration.getWithoutWatch(Property.TABLE_MINC_LOGS_MAX));
 
     String reason = null;
     synchronized (this) {


### PR DESCRIPTION
* This patch replaces calls to get properties where a Zookeeper watch is
definitely not needed. The new method getWithoutWatch() will function
the same but not set a watch on the call to zookeeper exists(). This fix
will stop ZK watches from hanging around after a table is deleted.
* This patch will only work in 1.10 and cannot be merged forward to 2.x