### PR TITLE
Throw exceptions when permissions checks fail

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -118,7 +118,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
       throws ThriftSecurityException, ThriftTableOperationException {
     TableId tableId = TableId.of(tableIdStr);
     NamespaceId namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
-    master.security.canFlush(c, tableId, namespaceId);
+    if (!master.security.canFlush(c, tableId, namespaceId))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     String zTablePath = Constants.ZROOT + "/" + master.getInstanceID() + Constants.ZTABLES + "/"
         + tableId + Constants.ZTABLE_FLUSH_ID;
@@ -147,7 +148,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
       throws ThriftSecurityException, ThriftTableOperationException {
     TableId tableId = TableId.of(tableIdStr);
     NamespaceId namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
-    master.security.canFlush(c, tableId, namespaceId);
+    if (!master.security.canFlush(c, tableId, namespaceId))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     Text startRow = ByteBufferUtil.toText(startRowBB);
     Text endRow = ByteBufferUtil.toText(endRowBB);
@@ -249,7 +251,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void shutdown(TInfo info, TCredentials c, boolean stopTabletServers)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
     if (stopTabletServers) {
       master.setMasterGoalState(MasterGoalState.CLEAN_STOP);
       EventCoordinator.Listener eventListener = master.nextEvent.getListener();
@@ -263,7 +266,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void shutdownTabletServer(TInfo info, TCredentials c, String tabletServer, boolean force)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     final TServerInstance doomed = master.tserverSet.find(tabletServer);
     if (!force) {
@@ -336,7 +340,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void setMasterGoalState(TInfo info, TCredentials c, MasterGoalState state)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     master.setMasterGoalState(state);
   }
@@ -344,7 +349,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void removeSystemProperty(TInfo info, TCredentials c, String property)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     try {
       SystemPropUtil.removeSystemProperty(master.getContext(), property);
@@ -358,7 +364,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void setSystemProperty(TInfo info, TCredentials c, String property, String value)
       throws ThriftSecurityException, TException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     try {
       SystemPropUtil.setSystemProperty(master.getContext(), property, value);


### PR DESCRIPTION
Add and throw missing exceptions when permissions checks fail. This
prevents certain operations that the user does not have privileges to
perform from succeeding anyway.