### PR TITLE
Throw sercurity exceptions when permissions checks fail. Backport to 1.10

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/MasterClientServiceHandler.java
@@ -118,7 +118,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   public long initiateFlush(TInfo tinfo, TCredentials c, String tableId)
       throws ThriftSecurityException, ThriftTableOperationException {
     String namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
-    master.security.canFlush(c, tableId, namespaceId);
+    if (!master.security.canFlush(c, tableId, namespaceId))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     String zTablePath = Constants.ZROOT + "/" + master.getInstance().getInstanceID()
         + Constants.ZTABLES + "/" + tableId + Constants.ZTABLE_FLUSH_ID;
@@ -150,7 +151,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
       ByteBuffer endRow, long flushID, long maxLoops)
       throws ThriftSecurityException, ThriftTableOperationException {
     String namespaceId = getNamespaceIdFromTableId(TableOperation.FLUSH, tableId);
-    master.security.canFlush(c, tableId, namespaceId);
+    if (!master.security.canFlush(c, tableId, namespaceId))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     if (endRow != null && startRow != null
         && ByteBufferUtil.toText(startRow).compareTo(ByteBufferUtil.toText(endRow)) >= 0)
@@ -305,7 +307,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void shutdown(TInfo info, TCredentials c, boolean stopTabletServers)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
     if (stopTabletServers) {
       master.setMasterGoalState(MasterGoalState.CLEAN_STOP);
       EventCoordinator.Listener eventListener = master.nextEvent.getListener();
@@ -319,7 +322,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void shutdownTabletServer(TInfo info, TCredentials c, String tabletServer, boolean force)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     final TServerInstance doomed = master.tserverSet.find(tabletServer);
     if (!force) {
@@ -391,7 +395,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void setMasterGoalState(TInfo info, TCredentials c, MasterGoalState state)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     master.setMasterGoalState(state);
   }
@@ -399,7 +404,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void removeSystemProperty(TInfo info, TCredentials c, String property)
       throws ThriftSecurityException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     try {
       SystemPropUtil.removeSystemProperty(property);
@@ -413,7 +419,8 @@ public class MasterClientServiceHandler extends FateServiceHandler
   @Override
   public void setSystemProperty(TInfo info, TCredentials c, String property, String value)
       throws ThriftSecurityException, TException {
-    master.security.canPerformSystemActions(c);
+    if (!master.security.canPerformSystemActions(c))
+      throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
     try {
       SystemPropUtil.setSystemProperty(property, value);

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -465,7 +465,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
       auditConnector.tableOperations().rename(OLD_TEST_TABLE_NAME, NEW_TEST_TABLE_NAME);
     } catch (AccumuloSecurityException ex) {}
     try {
-      auditConnector.tableOperations().clone(OLD_TEST_TABLE_NAME, NEW_TEST_TABLE_NAME, true,
+      auditConnector.tableOperations().clone(OLD_TEST_TABLE_NAME, NEW_TEST_TABLE_NAME, false,
           Collections.<String,String>emptyMap(), Collections.<String>emptySet());
     } catch (AccumuloSecurityException ex) {}
     try {


### PR DESCRIPTION
Based on #1828 in main. This is to back to 1.10. Confirmed the bug did exist on that branch as well. 