### PR TITLE
Fixes #1760 - `listcompactions` command error is not helpful

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -105,7 +105,7 @@ public final class HostAndPort implements Serializable {
    *           occurring.
    */
   public int getPort() {
-    checkState(hasPort());
+    checkState(hasPort(), "The given address does not include a port");
     return port;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -105,7 +105,7 @@ public final class HostAndPort implements Serializable {
    *           occurring.
    */
   public int getPort() {
-    checkState(hasPort(), "The given address does not include a port");
+    checkState(hasPort(), "the address does not include a port");
     return port;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
@@ -90,7 +90,7 @@ class ActiveCompactionHelper {
         compactions.add(formatActiveCompactionLine(tserver, ac));
       }
     } catch (Exception e) {
-      log.debug("Exception thrown while attempting to list active compactions", e);
+      log.debug("Failed to list active compactions for server {}", tserver, e);
       compactions.add(tserver + " ERROR " + e.getMessage());
     }
     return compactions;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ActiveCompactionHelper.java
@@ -33,8 +33,12 @@ import org.apache.accumulo.core.client.admin.ActiveCompaction;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.util.Duration;
 import org.apache.accumulo.core.util.NamingThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ActiveCompactionHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(ActiveCompactionHelper.class);
 
   private static String maxDecimal(double count) {
     if (count < 9.995)
@@ -86,6 +90,7 @@ class ActiveCompactionHelper {
         compactions.add(formatActiveCompactionLine(tserver, ac));
       }
     } catch (Exception e) {
+      log.debug("Exception thrown while attempting to list active compactions", e);
       compactions.add(tserver + " ERROR " + e.getMessage());
     }
     return compactions;


### PR DESCRIPTION
Fixing issue #1760. Adding more helpful error messages for the listcompactions command when a tserver address is passed.