### PR TITLE
Remove centralized crypto constants

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -100,7 +100,6 @@ public class Constants {
 
   // Security configuration
   public static final String NON_CRYPTO_USE_HASH_ALGORITHM = "SHA-256";
-  public static final String PW_HASH_ALGORITHM_OUTDATED = "SHA-256";
 
   public static final int MAX_DATA_TO_PRINT = 64;
   public static final String CORE_PACKAGE_NAME = "org.apache.accumulo.core";

--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -98,9 +98,6 @@ public class Constants {
   // fetching the next batch.
   public static final long SCANNER_DEFAULT_READAHEAD_THRESHOLD = 3L;
 
-  // Security configuration
-  public static final String NON_CRYPTO_USE_HASH_ALGORITHM = "SHA-256";
-
   public static final int MAX_DATA_TO_PRINT = 64;
   public static final String CORE_PACKAGE_NAME = "org.apache.accumulo.core";
   public static final String MAPFILE_EXTENSION = "map";

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -82,14 +82,6 @@ public enum Property {
   RPC_SASL_QOP("rpc.sasl.qop", "auth", PropertyType.STRING,
       "The quality of protection to be used with SASL. Valid values are 'auth', 'auth-int',"
           + " and 'auth-conf'"),
-  /**
-   * @since 2.1.0
-   */
-  INSTANCE_SYSTEM_TOKEN_HASH_TYPE("instance.system.token.hash.type",
-      Constants.PW_HASH_ALGORITHM_OUTDATED, PropertyType.STRING,
-      "Hash algorithm used for creating SystemTokens."
-          + " It is recommended to use SHA-512, but the default is SHA-256 to not break rolling"
-          + " restart on update."),
 
   // instance properties (must be the same for every node in an instance)
   INSTANCE_PREFIX("instance.", null, PropertyType.PREFIX,

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/VisMetricsGatherer.java
@@ -46,7 +46,7 @@ import com.google.common.util.concurrent.AtomicLongMap;
  */
 public class VisMetricsGatherer
     implements MetricsGatherer<Map<String,ArrayList<VisibilityMetric>>> {
-  static final String KEY_HASH_ALGORITHM = "SHA-256";
+  private static final String KEY_HASH_ALGORITHM = "SHA-256";
 
   protected Map<String,AtomicLongMap<String>> metric;
   protected Map<String,AtomicLongMap<String>> blocks;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -108,7 +108,7 @@ class ZKSecurityTool {
   }
 
   public static byte[] createPass(byte[] password) throws AccumuloException {
-    // we rely on default algorithm and hash length (SHA-512 and 8 byte)
+    // we rely on default algorithm and salt length (SHA-512 and 8 bytes)
     String cryptHash = Crypt.crypt(password);
     return cryptHash.getBytes(UTF_8);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -71,8 +71,10 @@ class ZKSecurityTool {
     }
   }
 
+  private static final String PW_HASH_ALGORITHM_OUTDATED = "SHA-256";
+
   private static byte[] hash(byte[] raw) throws NoSuchAlgorithmException {
-    MessageDigest md = MessageDigest.getInstance(Constants.PW_HASH_ALGORITHM_OUTDATED);
+    MessageDigest md = MessageDigest.getInstance(PW_HASH_ALGORITHM_OUTDATED);
     md.update(raw);
     return md.digest();
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -21,9 +21,7 @@ package org.apache.accumulo.monitor.rest.tservers;
 import static org.apache.accumulo.monitor.util.ParameterValidator.HOSTNAME_PORT_REGEX;
 
 import java.lang.management.ManagementFactory;
-import java.security.MessageDigest;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -38,7 +36,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.data.TableId;
@@ -323,12 +320,7 @@ public class TabletServerResource {
 
       KeyExtent extent = KeyExtent.fromThrift(info.extent);
       TableId tableId = extent.tableId();
-      MessageDigest digester = MessageDigest.getInstance(Constants.NON_CRYPTO_USE_HASH_ALGORITHM);
-      if (extent.endRow() != null && extent.endRow().getLength() > 0) {
-        digester.update(extent.endRow().getBytes(), 0, extent.endRow().getLength());
-      }
-      String obscuredExtent = Base64.getEncoder().encodeToString(digester.digest());
-      String displayExtent = String.format("[%s]", obscuredExtent);
+      String displayExtent = String.format("[%s]", extent.obscured());
 
       String tableName = Tables.getPrintableTableInfoFromId(monitor.getContext(), tableId);
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GetSplitsCommand.java
@@ -19,12 +19,9 @@
 package org.apache.accumulo.shell.commands;
 
 import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Scanner;
@@ -82,9 +79,9 @@ public class GetSplitsCommand extends Command {
             KeyExtent extent = KeyExtent.fromMetaPrevRow(next);
             final String pr = encode(encode, extent.prevEndRow());
             final String er = encode(encode, extent.endRow());
-            final String line = String.format("%-26s (%s, %s%s", obscuredTabletName(extent),
-                pr == null ? "-inf" : pr, er == null ? "+inf" : er,
-                er == null ? ") Default Tablet " : "]");
+            final String line =
+                String.format("%-26s (%s, %s%s", extent.obscured(), pr == null ? "-inf" : pr,
+                    er == null ? "+inf" : er, er == null ? ") Default Tablet " : "]");
             p.print(line);
           }
         }
@@ -108,19 +105,6 @@ public class GetSplitsCommand extends Command {
     final int length = text.getLength();
     return encode ? Base64.getEncoder().encodeToString(TextUtil.getBytes(text))
         : DefaultFormatter.appendText(new StringBuilder(), text, length).toString();
-  }
-
-  private static String obscuredTabletName(final KeyExtent extent) {
-    MessageDigest digester;
-    try {
-      digester = MessageDigest.getInstance(Constants.NON_CRYPTO_USE_HASH_ALGORITHM);
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException(e);
-    }
-    if (extent.endRow() != null && extent.endRow().getLength() > 0) {
-      digester.update(extent.endRow().getBytes(), 0, extent.endRow().getLength());
-    }
-    return Base64.getEncoder().encodeToString(digester.digest());
   }
 
   @Override


### PR DESCRIPTION
This PR contains two small commits:

---

Consolidate tablet obscuring code

This fixes #1805

Move implementation of tablet obscuring code into KeyExtent and remove
duplicate implementations.

Also fixup trivial constant in VisMetricsGatherer, so it is private and
fix typo in ZKSecurityTool to clarify that the salt length is 8 bytes by
default, not the hash length

---

Update SystemCredentials to use crypt(3) format

This fixes #1810

This updates the SystemToken generation to use SHA-512 while hashing the
system's `instance.*` configuration properties (including
`instance.secret`) by using commons-codec's crypt(3) implementation.

It also adds more javadocs and makes the code a bit more readable, while
removing a hard-coded global constant and an unneeded new instance
property introduced in #1798. That property is unneeded, since the
existence of the property itself creates wire-incompatibility. Instead,
this change explicitly bumps the wire version.

Also add sanity checks in SystemCredentialsTest for the wire version
values and to detect significant changes in the default algorithm used
by commons-codec to hash the credentials to prevent suprises when
upgrading the commons-codec library in future.
