### PR TITLE
Improve some IT framework and build-related code

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -76,7 +76,7 @@ public class MiniAccumuloConfigImpl {
   private long zooKeeperStartupTime = 20 * 1000;
   private String existingZooKeepers;
 
-  private long defaultMemorySize = 128 * 1024 * 1024;
+  private long defaultMemorySize = 256 * 1024 * 1024;
 
   private boolean initialized = false;
 
@@ -363,8 +363,8 @@ public class MiniAccumuloConfigImpl {
   }
 
   /**
-   * Sets the amount of memory to use in the master process. Calling this method is optional.
-   * Default memory is 128M
+   * Sets the amount of memory to use in the specified process. Calling this method is optional.
+   * Default memory is 256M
    *
    * @param serverType
    *          the type of server to apply the memory settings
@@ -384,7 +384,7 @@ public class MiniAccumuloConfigImpl {
 
   /**
    * Sets the default memory size to use. This value is also used when a ServerType has not been
-   * configured explicitly. Calling this method is optional. Default memory is 128M
+   * configured explicitly. Calling this method is optional. Default memory is 256M
    *
    * @param memory
    *          amount of memory to set

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,8 @@
     <curator.version>4.3.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
+    <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
+    <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <failsafe.excludedGroups />
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -124,7 +124,7 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
         MiniClusterHarness miniClusterHarness = new MiniClusterHarness();
         // Intrinsically performs the callback to let tests alter MiniAccumuloConfig and
         // core-site.xml
-        cluster = miniClusterHarness.create(this, getAdminToken(), krb);
+        cluster = miniClusterHarness.create(this, getAdminToken(), krb, this);
         // Login as the "root" user
         if (krb != null) {
           ClusterUser rootUser = krb.getRootUser();

--- a/test/src/main/java/org/apache/accumulo/harness/MiniClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/MiniClusterHarness.java
@@ -21,6 +21,8 @@ package org.apache.accumulo.harness;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.minikdc.MiniKdc.JAVA_SECURITY_KRB5_CONF;
+import static org.apache.hadoop.minikdc.MiniKdc.SUN_SECURITY_KRB5_DEBUG;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedOutputStream;
@@ -29,7 +31,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -57,76 +58,16 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class MiniClusterHarness {
   private static final Logger log = LoggerFactory.getLogger(MiniClusterHarness.class);
 
-  private static final AtomicLong COUNTER = new AtomicLong(0);
-
   private static final String PROP_PREFIX = "org.apache.accumulo.test.functional.";
   public static final String USE_SSL_FOR_IT_OPTION = PROP_PREFIX + "useSslForIT";
   public static final String USE_CRED_PROVIDER_FOR_IT_OPTION = PROP_PREFIX + "useCredProviderForIT";
   public static final String USE_KERBEROS_FOR_IT_OPTION = PROP_PREFIX + "useKrbForIT";
   public static final String TRUE = Boolean.toString(true);
 
-  // TODO These are defined in MiniKdc >= 2.6.0. Can be removed when minimum Hadoop dependency is
-  // increased to that.
-  public static final String JAVA_SECURITY_KRB5_CONF = "java.security.krb5.conf",
-      SUN_SECURITY_KRB5_DEBUG = "sun.security.krb5.debug";
-
-  /**
-   * Create a MiniAccumuloCluster using the given Token as the credentials for the root user.
-   */
-  public MiniAccumuloClusterImpl create(AuthenticationToken token) throws Exception {
-    return create(MiniClusterHarness.class.getName(), Long.toString(COUNTER.incrementAndGet()),
-        token);
-  }
-
-  public MiniAccumuloClusterImpl create(AuthenticationToken token, TestingKdc kdc)
-      throws Exception {
-    return create(MiniClusterHarness.class.getName(), Long.toString(COUNTER.incrementAndGet()),
-        token, kdc);
-  }
-
-  public MiniAccumuloClusterImpl create(AccumuloITBase testBase, AuthenticationToken token)
-      throws Exception {
-    return create(testBase.getClass().getName(), testBase.testName.getMethodName(), token);
-  }
-
-  public MiniAccumuloClusterImpl create(AccumuloITBase testBase, AuthenticationToken token,
-      TestingKdc kdc) throws Exception {
-    return create(testBase, token, kdc, MiniClusterConfigurationCallback.NO_CALLBACK);
-  }
-
   public MiniAccumuloClusterImpl create(AccumuloITBase testBase, AuthenticationToken token,
       TestingKdc kdc, MiniClusterConfigurationCallback configCallback) throws Exception {
     return create(testBase.getClass().getName(), testBase.testName.getMethodName(), token,
         configCallback, kdc);
-  }
-
-  public MiniAccumuloClusterImpl create(AccumuloClusterHarness testBase, AuthenticationToken token,
-      TestingKdc kdc) throws Exception {
-    return create(testBase.getClass().getName(), testBase.testName.getMethodName(), token, testBase,
-        kdc);
-  }
-
-  public MiniAccumuloClusterImpl create(AccumuloClusterHarness testBase, AuthenticationToken token,
-      MiniClusterConfigurationCallback callback) throws Exception {
-    return create(testBase.getClass().getName(), testBase.testName.getMethodName(), token,
-        callback);
-  }
-
-  public MiniAccumuloClusterImpl create(String testClassName, String testMethodName,
-      AuthenticationToken token) throws Exception {
-    return create(testClassName, testMethodName, token,
-        MiniClusterConfigurationCallback.NO_CALLBACK);
-  }
-
-  public MiniAccumuloClusterImpl create(String testClassName, String testMethodName,
-      AuthenticationToken token, TestingKdc kdc) throws Exception {
-    return create(testClassName, testMethodName, token,
-        MiniClusterConfigurationCallback.NO_CALLBACK, kdc);
-  }
-
-  public MiniAccumuloClusterImpl create(String testClassName, String testMethodName,
-      AuthenticationToken token, MiniClusterConfigurationCallback configCallback) throws Exception {
-    return create(testClassName, testMethodName, token, configCallback, null);
   }
 
   public MiniAccumuloClusterImpl create(String testClassName, String testMethodName,

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService;
 import org.apache.accumulo.core.util.HostAndPort;
-import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
@@ -48,7 +47,6 @@ public class TotalQueuedIT extends ConfigurableMacBase {
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.setNumTservers(1);
-    cfg.setDefaultMemory(cfg.getDefaultMemory() * 2, MemoryUnit.BYTE);
     cfg.useMiniDFS();
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -104,7 +104,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
   private static class Callback implements MiniClusterConfigurationCallback {
     @Override
     public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration conf) {
-      cfg.setMemory(ServerType.TABLET_SERVER, 128 * 4, MemoryUnit.MEGABYTE);
+      cfg.setMemory(ServerType.TABLET_SERVER, 512, MemoryUnit.MEGABYTE);
 
       // use raw local file system
       conf.set("fs.file.impl", RawLocalFileSystem.class.getName());

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkOldIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkOldIT.java
@@ -52,7 +52,7 @@ public class BulkOldIT extends AccumuloClusterHarness {
 
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration conf) {
-    cfg.setMemory(ServerType.TABLET_SERVER, 128 * 4, MemoryUnit.MEGABYTE);
+    cfg.setMemory(ServerType.TABLET_SERVER, 512, MemoryUnit.MEGABYTE);
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
@@ -57,7 +57,7 @@ public class CreateInitialSplitsIT extends AccumuloClusterHarness {
 
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration conf) {
-    cfg.setMemory(ServerType.TABLET_SERVER, 128 * 4, MemoryUnit.MEGABYTE);
+    cfg.setMemory(ServerType.TABLET_SERVER, 512, MemoryUnit.MEGABYTE);
 
     // use raw local file system
     conf.set("fs.file.impl", RawLocalFileSystem.class.getName());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
-import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -50,7 +49,6 @@ public class TabletIT extends AccumuloClusterHarness {
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     Map<String,String> siteConfig = cfg.getSiteConfig();
     siteConfig.put(Property.TSERV_MAXMEM.getKey(), "128M");
-    cfg.setDefaultMemory(256, MemoryUnit.MEGABYTE);
     cfg.setSiteConfig(siteConfig);
   }
 


### PR DESCRIPTION
* Increase the default memory for mini-based ITs (from 128MB to 256MB)
  The justification for this is that using the G1GC in newer JVMs seems
  to use a little bit more base memory than the old CMS, which was
  removed. Some of our tests seem to push the memory limits a bit.
  Increasing the default memory for mini processes in our ITs makes many
  ITs a bit more reliable, and less prone to OutOfMemoryErrors killing
  background threads (which I've noticed a lot more during development
  since running my development environment with newer versions (11+) of
  Java).
* Use more meaningful directory name for SharedMiniClusterBase ITs to
  make it easier to debug specific failed tests.
* Remove a bunch of unused overloaded static create methods from
  MiniClusterHarness and remove constants kerberos constants that are
  available from MiniKdc (since we now build with Hadoop 3.0 or later,
  and these have been available since 2.6)
* Remove warning from exec-maven-plugin about Java built-in
  ForkJoinPool.commonPool() daemon threads not being able to be stopped