### PR TITLE
Reduce log level of replication offline retries

### DIFF
--- a/server/master/src/main/java/org/apache/accumulo/master/replication/FinishedWorkUpdater.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/FinishedWorkUpdater.java
@@ -62,10 +62,10 @@ public class FinishedWorkUpdater implements Runnable {
 
   @Override
   public void run() {
-    log.debug("Looking for finished replication work");
+    log.trace("Looking for finished replication work");
 
     if (!ReplicationTable.isOnline(conn)) {
-      log.debug("Replication table is not yet online, will retry");
+      log.trace("Replication table is not yet online, will retry");
       return;
     }
 

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/RemoveCompleteReplicationRecords.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/RemoveCompleteReplicationRecords.java
@@ -74,7 +74,7 @@ public class RemoveCompleteReplicationRecords implements Runnable {
         throw new AssertionError("Inconceivable; an exception should have been"
             + " thrown, but 'bs' or 'bw' was null instead");
     } catch (ReplicationTableOfflineException e) {
-      log.debug("Not attempting to remove complete replication records as the"
+      log.trace("Not attempting to remove complete replication records as the"
           + " table ({}) isn't yet online", ReplicationTable.NAME);
       return;
     }

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/ReplicationDriver.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/ReplicationDriver.java
@@ -118,7 +118,7 @@ public class ReplicationDriver extends Daemon {
 
       // Sleep for a bit
       long sleepMillis = conf.getTimeInMillis(Property.MASTER_REPLICATION_SCAN_INTERVAL);
-      log.debug("Sleeping for {}ms before re-running", sleepMillis);
+      log.trace("Sleeping for {}ms before re-running", sleepMillis);
       try {
         Thread.sleep(sleepMillis);
       } catch (InterruptedException e) {

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkDriver.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkDriver.java
@@ -105,7 +105,7 @@ public class WorkDriver extends Daemon {
       }
 
       long sleepTime = conf.getTimeInMillis(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP);
-      log.debug("Sleeping {} ms before next work assignment", sleepTime);
+      log.trace("Sleeping {} ms before next work assignment", sleepTime);
       sleepUninterruptibly(sleepTime, TimeUnit.MILLISECONDS);
 
       // After each loop, make sure that the WorkAssigner implementation didn't change

--- a/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/replication/WorkMaker.java
@@ -67,7 +67,7 @@ public class WorkMaker {
 
   public void run() {
     if (!ReplicationTable.isOnline(conn)) {
-      log.debug("Replication table is not yet online");
+      log.trace("Replication table is not yet online");
       return;
     }
 


### PR DESCRIPTION
* Reduce logging level to trace of retries when replication is offline
* User can easily see if repl table is online through monitor, no need
to keep spamming logs when it is offline