### PR TITLE
Fixes #1841 - Broken or Flaky test: ConcurrentDeleteTableIT takes 30 minutes to run

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -52,7 +52,7 @@ import org.junit.Test;
 
 public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
 
-  @Test
+  @Test(timeout = 3 * 60 * 1000)
   public void testConcurrentDeleteTablesOps() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String[] tables = getUniqueNames(2);
@@ -150,7 +150,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
     protected abstract void doTableOp() throws Exception;
   }
 
-  @Test
+  @Test(timeout = 3 * 60 * 1000)
   public void testConcurrentFateOpsWithDelete() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String[] tables = getUniqueNames(2);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -52,7 +52,12 @@ import org.junit.Test;
 
 public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 7 * 60;
+  }
+
+  @Test
   public void testConcurrentDeleteTablesOps() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String[] tables = getUniqueNames(2);
@@ -150,7 +155,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
     protected abstract void doTableOp() throws Exception;
   }
 
-  @Test(timeout = 3 * 60 * 1000)
+  @Test
   public void testConcurrentFateOpsWithDelete() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String[] tables = getUniqueNames(2);


### PR DESCRIPTION
Added a timeout to both of the tests in this IT because they were observed taking far too long to complete as detailed in #1841. When I run these tests they both take about 40 seconds so I added a 3 minute timeout which should be plenty of time if they are running correctly. Not too sure why these tests took so long to complete, but these timeouts should ensure they are not running incorrectly for a long period of time.