### PR TITLE
Make ThriftTransportPool logs a little less spammy

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -424,8 +424,8 @@ public class ThriftTransportPool {
 
   static class CachedTTransport extends TTransport {
 
-    private ThriftTransportKey cacheKey;
-    private TTransport wrappedTransport;
+    private final ThriftTransportKey cacheKey;
+    private final TTransport wrappedTransport;
     private boolean sawError = false;
 
     private volatile String ioThreadName = null;
@@ -582,7 +582,9 @@ public class ThriftTransportPool {
     public void close() {
       try {
         ioCount++;
-        wrappedTransport.close();
+        if (wrappedTransport.isOpen()) {
+          wrappedTransport.close();
+        }
       } finally {
         ioCount++;
       }

--- a/test/src/main/resources/log4j2-test.properties
+++ b/test/src/main/resources/log4j2-test.properties
@@ -136,6 +136,13 @@ logger.34.level = trace
 logger.35.name = org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl
 logger.35.level = info
 
+# This is pointless, as it only ever logs errors closing connections that are
+# already closed, such as when we release a cached thrift transport after the
+# network socket has already disconnected; These can't really be avoided,
+# because TIOStreamTransport does not implement a good isOpen()
+logger.36.name = org.apache.thrift.transport.TIOStreamTransport
+logger.36.level = error
+
 rootLogger.level = debug
 rootLogger.appenderRef.console.ref = STDOUT
 


### PR DESCRIPTION
* Avoid closing already closed transports
* For TIOStreamTransport, which does not implement a reasonable isOpen()
  method, suppress its log messages during integration testing, so logs
  don't contain spammy errors about closed network connections that are
  expected during testing