### PR TITLE
Remove error message on recovery success

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -41,7 +41,6 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.log.SortedLogState;
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue;
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue.Processor;
-import org.apache.accumulo.tserver.log.DfsLogger.DFSLoggerInputStreams;
 import org.apache.accumulo.tserver.log.DfsLogger.LogHeaderIncompleteException;
 import org.apache.accumulo.tserver.logger.LogFileKey;
 import org.apache.accumulo.tserver.logger.LogFileValue;
@@ -112,47 +111,42 @@ public class LogSorter {
         // the following call does not throw an exception if the file/dir does not exist
         fs.deleteRecursively(new Path(destPath));
 
-        try (final FSDataInputStream fsinput = fs.open(srcPath)) {
-          DFSLoggerInputStreams inputStreams;
-          try {
-            inputStreams = DfsLogger.readHeaderAndReturnStream(fsinput, conf);
-          } catch (LogHeaderIncompleteException e) {
-            log.warn("Could not read header from write-ahead log {}. Not sorting.", srcPath);
-            // Creating a 'finished' marker will cause recovery to proceed normally and the
-            // empty file will be correctly ignored downstream.
-            fs.mkdirs(new Path(destPath));
-            writeBuffer(destPath, Collections.emptyList(), part++);
-            fs.create(SortedLogState.getFinishedMarkerPath(destPath)).close();
-            return;
-          }
-
-          this.input = inputStreams.getOriginalInput();
-          this.decryptingInput = inputStreams.getDecryptingInputStream();
-
-          final long bufferSize = conf.getAsBytes(Property.TSERV_SORT_BUFFER_SIZE);
-          Thread.currentThread().setName("Sorting " + name + " for recovery");
-          while (true) {
-            final ArrayList<Pair<LogFileKey,LogFileValue>> buffer = new ArrayList<>();
-            try {
-              long start = input.getPos();
-              while (input.getPos() - start < bufferSize) {
-                LogFileKey key = new LogFileKey();
-                LogFileValue value = new LogFileValue();
-                key.readFields(decryptingInput);
-                value.readFields(decryptingInput);
-                buffer.add(new Pair<>(key, value));
-              }
-              writeBuffer(destPath, buffer, part++);
-              buffer.clear();
-            } catch (EOFException ex) {
-              writeBuffer(destPath, buffer, part++);
-              break;
-            }
-          }
-          fs.create(new Path(destPath, "finished")).close();
-          log.info("Finished log sort {} {} bytes {} parts in {}ms", name, getBytesCopied(), part,
-              getSortTime());
+        input = fs.open(srcPath);
+        try {
+          decryptingInput = DfsLogger.getDecryptingStream(input, conf);
+        } catch (LogHeaderIncompleteException e) {
+          log.warn("Could not read header from write-ahead log {}. Not sorting.", srcPath);
+          // Creating a 'finished' marker will cause recovery to proceed normally and the
+          // empty file will be correctly ignored downstream.
+          fs.mkdirs(new Path(destPath));
+          writeBuffer(destPath, Collections.emptyList(), part++);
+          fs.create(SortedLogState.getFinishedMarkerPath(destPath)).close();
+          return;
         }
+
+        final long bufferSize = conf.getAsBytes(Property.TSERV_SORT_BUFFER_SIZE);
+        Thread.currentThread().setName("Sorting " + name + " for recovery");
+        while (true) {
+          final ArrayList<Pair<LogFileKey,LogFileValue>> buffer = new ArrayList<>();
+          try {
+            long start = input.getPos();
+            while (input.getPos() - start < bufferSize) {
+              LogFileKey key = new LogFileKey();
+              LogFileValue value = new LogFileValue();
+              key.readFields(decryptingInput);
+              value.readFields(decryptingInput);
+              buffer.add(new Pair<>(key, value));
+            }
+            writeBuffer(destPath, buffer, part++);
+            buffer.clear();
+          } catch (EOFException ex) {
+            writeBuffer(destPath, buffer, part++);
+            break;
+          }
+        }
+        fs.create(new Path(destPath, "finished")).close();
+        log.info("Finished log sort {} {} bytes {} parts in {}ms", name, getBytesCopied(), part,
+            getSortTime());
       } catch (Throwable t) {
         try {
           // parent dir may not exist

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -68,7 +68,6 @@ import org.apache.accumulo.server.replication.ReplicaSystemHelper;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.tserver.log.DfsLogger;
-import org.apache.accumulo.tserver.log.DfsLogger.DFSLoggerInputStreams;
 import org.apache.accumulo.tserver.log.DfsLogger.LogHeaderIncompleteException;
 import org.apache.accumulo.tserver.logger.LogFileKey;
 import org.apache.accumulo.tserver.logger.LogFileValue;
@@ -618,13 +617,13 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
     return desiredTids;
   }
 
-  public DataInputStream getWalStream(Path p, FSDataInputStream input) throws IOException {
+  public DataInputStream getWalStream(Path p, FSDataInputStream input)
+      throws LogHeaderIncompleteException, IOException {
     try (TraceScope span = Trace.startSpan("Read WAL header")) {
       if (span.getSpan() != null) {
         span.getSpan().addKVAnnotation("file", p.toString());
       }
-      DFSLoggerInputStreams streams = DfsLogger.readHeaderAndReturnStream(input, conf);
-      return streams.getDecryptingInputStream();
+      return DfsLogger.getDecryptingStream(input, conf);
     }
   }
 


### PR DESCRIPTION
Fix an error message that the stream is closed after a successful
recovery in LogSorter.java. This occurred because a try-with-resources
block automatically closed the file input stream, and then it was
attempted to be closed again in the finally block in the
LogSorter.LogProcessor.sort() method. This resulted in an error message
always being shown in the finally block, even if the try-with-resources
block successfully finished without error and closed the input stream
already. This change removes the use of try-with-resources, and relies
on the finally block to close the resources once.

Related changes include:

* Remove unnecessary wrapping class to carry the original input stream
  alongside the decrypting wrapper input stream, since the original
  input stream is already available to all callers, and it was only used
  to get the decrypting wrapper input stream. The decrypting input
  stream can now be retrieved directly instead of placing it in a new
  holder object. The method to get the decrypting stream was renamed and
  a javadoc was added to make it easier to understand what it does.
* Change LogHeaderIncompleteException to not be a subclass of
  IOException, so that it can be explicitly caught, and not easily
  overlooked when handling other IOExceptions. Its cause parameter type
  was also narrowed to the EOFException, which is the only valid
  exception to cause the LogHeaderIncompleteException to be thrown.