### PR TITLE
sendSpans NPE fix

### DIFF
--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
@@ -162,7 +162,7 @@ public class ZooTraceClient extends AsyncSpanReceiver<String,Client> implements 
 
   @Override
   protected void sendSpans() {
-    if (hosts.isEmpty()) {
+    if (hosts == null || hosts.isEmpty()) {
       if (!sendQueue.isEmpty()) {
         log.error("No hosts to send data to, dropping queued spans");
         synchronized (sendQueue) {


### PR DESCRIPTION
I kept seeing this NPE every time I started the shell in a test cluster:
```
2021-01-06 07:35:30,584 [tracer.AsyncSpanReceiver] WARN : Exception sending spans to destination
java.lang.NullPointerException
	at org.apache.accumulo.tracer.ZooTraceClient.sendSpans(ZooTraceClient.java:146)
	at org.apache.accumulo.tracer.AsyncSpanReceiver$1.run(AsyncSpanReceiver.java:116)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
```
It looks like ZooTraceClient varibles are not yet fully initialized when the timer created in AsyncSpanReceiver constructor calls sendSpans and hosts.isEmpty() throws an NPE. It's caught in the timer and the object is fully initialized by the next run so it causes no problems. This is just a small change to prevent the unnecessary warning.