### PR TITLE
Add check for finished to LogSorter

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -93,7 +93,6 @@ public class LogSorter {
       }
 
       try {
-        log.info("Copying " + src + " to " + dest);
         sort(sortId, new Path(src), dest);
       } finally {
         currentWork.remove(sortId);
@@ -110,7 +109,13 @@ public class LogSorter {
       String formerThreadName = Thread.currentThread().getName();
       int part = 0;
       try {
+        // check for finished first since another thread may have already done the sort
+        if (fs.exists(SortedLogState.getFinishedMarkerPath(destPath))) {
+          log.debug("Sorting already finished at {}", destPath);
+          return;
+        }
 
+        log.info("Copying " + srcPath + " to " + destPath);
         // the following call does not throw an exception if the file/dir does not exist
         fs.deleteRecursively(new Path(destPath));
 


### PR DESCRIPTION
* Check for finished file in LogSorter before performing sort
* LogSorter was always removing the destination sort directory even if
it had previously been successfully sorted, creating lots of duplicate
and unnecessary work during recovery

I discovered this issue while looking into #1844 