### PR TITLE
Re-throw exception from LoggingRunnable (re #1808)

### DIFF
--- a/fate/src/main/java/org/apache/accumulo/fate/util/LoggingRunnable.java
+++ b/fate/src/main/java/org/apache/accumulo/fate/util/LoggingRunnable.java
@@ -34,20 +34,36 @@ public class LoggingRunnable implements Runnable {
     try {
       runnable.run();
     } catch (Throwable t) {
+      boolean errorOnRun = (t instanceof Error);
       try {
         log.error("Thread \"{}\" died {}", Thread.currentThread().getName(), t.getMessage(), t);
       } catch (Throwable t2) {
-        // maybe the logging system is screwed up OR there is a bug in the exception, like
-        // t.getMessage() throws a NPE
-        System.err.println(
-            "ERROR " + new Date() + " Failed to log message about thread death " + t2.getMessage());
-        t2.printStackTrace();
+        boolean errorOnLog = (t2 instanceof Error);
+        try {
+          // maybe the logging system is screwed up OR there is a bug in the exception, like
+          // t.getMessage() throws a NPE
+          System.err.println("ERROR " + new Date() + " Failed to log message about thread death "
+              + t2.getMessage());
+          t2.printStackTrace();
 
-        // try to print original exception
-        System.err
-            .println("ERROR " + new Date() + " Exception that failed to log : " + t.getMessage());
-        t.printStackTrace();
+          // try to print original exception
+          System.err
+              .println("ERROR " + new Date() + " Exception that failed to log : " + t.getMessage());
+          t.printStackTrace();
+        } catch (Throwable t3) {
+          // If printing to System.err didn't work then don't try to log that exception but do
+          // re-throw it if it's the most serious failure we've seen so far.
+          boolean errorOnPrint = (t3 instanceof Error);
+          if (errorOnPrint && !errorOnLog && !errorOnRun)
+            throw t3;
+        }
+
+        // If we got a more serious failure when attempting to log the message,
+        // then throw that instead of the original exception.
+        if (errorOnLog && !errorOnRun)
+          throw t2;
       }
+      throw t;
     }
   }
 


### PR DESCRIPTION
There is a robust fix in #1818 that is probably too much to backport to 1.10. This fix simply re-throws the original exception (unless there is an exception when logging and that is more serious (i.e., it's an Error and the original Throwable was not an Error)).