### PR TITLE
Fixes #1867. Move authentication before attempting to create new Client object

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -1183,7 +1183,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   public void updateUser(String principal, AuthenticationToken token)
       throws AccumuloException, AccumuloSecurityException {
     var newClient = Accumulo.newClient().from(clientProperties).as(principal, token).build();
-    if (!newClient.securityOperations().authenticateUser(principal, token)) {
+    try {
+      newClient.securityOperations().authenticateUser(principal, token);
+    } catch (AccumuloSecurityException e) {
       newClient.close();
       throw new AccumuloSecurityException(principal, SecurityErrorCode.BAD_CREDENTIALS);
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -62,7 +62,6 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.clientImpl.Tables;
-import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -62,6 +62,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
@@ -1181,11 +1182,14 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
   public void updateUser(String principal, AuthenticationToken token)
       throws AccumuloException, AccumuloSecurityException {
+
     if (accumuloClient != null) {
+      if (!accumuloClient.securityOperations().authenticateUser(principal, token)) {
+        throw new AccumuloSecurityException(principal, SecurityErrorCode.BAD_CREDENTIALS);
+      }
       accumuloClient.close();
     }
     accumuloClient = Accumulo.newClient().from(clientProperties).as(principal, token).build();
-    accumuloClient.securityOperations().authenticateUser(principal, token);
     context = (ClientContext) accumuloClient;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -1186,8 +1186,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     try {
       newClient.securityOperations().authenticateUser(principal, token);
     } catch (AccumuloSecurityException e) {
+      // new client can't authenticate; close and discard
       newClient.close();
-      throw new AccumuloSecurityException(principal, SecurityErrorCode.BAD_CREDENTIALS);
+      throw e;
     }
     var oldClient = accumuloClient;
     accumuloClient = newClient; // swap out old client if the new client has authenticated


### PR DESCRIPTION
There are a few possible options on where we could authenticate so if anyone has feedback on a better way, let me know. 

Results after the change: 
![image](https://user-images.githubusercontent.com/29436247/104745175-c96c8d00-571b-11eb-9a74-2bfb6413f9e4.png)
The user stays as root since the wrong credentials were entered for the user 'jeff'. 


Closes #1867 