### PR TITLE
Add missing hadoop-mapreduce module API javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1640,6 +1640,7 @@
       </properties>
     </profile>
     <profile>
+      <!-- mvn clean package javadoc:aggregate -DskipTests -Paggregate-javadocs -->
       <id>aggregate-javadocs</id>
       <build>
         <pluginManagement>
@@ -1650,11 +1651,12 @@
               <configuration>
                 <sourceFileIncludes>
                   <sourceFileInclude>**/org/apache/accumulo/core/client/**/*.java</sourceFileInclude>
-                  <sourceFileInclude>**/org/apache/accumulo/core/iterators/**/*.java</sourceFileInclude>
                   <sourceFileInclude>**/org/apache/accumulo/core/data/**/*.java</sourceFileInclude>
+                  <sourceFileInclude>**/org/apache/accumulo/core/iterators/**/*.java</sourceFileInclude>
                   <sourceFileInclude>**/org/apache/accumulo/core/security/**/*.java</sourceFileInclude>
-                  <sourceFileInclude>**/org/apache/accumulo/minicluster/**/*.java</sourceFileInclude>
                   <sourceFileInclude>**/org/apache/accumulo/core/spi/**/*.java</sourceFileInclude>
+                  <sourceFileInclude>**/org/apache/accumulo/hadoop/**/*.java</sourceFileInclude>
+                  <sourceFileInclude>**/org/apache/accumulo/minicluster/**/*.java</sourceFileInclude>
                 </sourceFileIncludes>
               </configuration>
             </plugin>


### PR DESCRIPTION
* Include missing hadoop-mapreduce module's classes to the generated
  javadocs when building the aggregate javadocs for the public API to
  publish on the website
* Sort list of javadoc classes
* Add comment in the profile explaining how to run