### PR TITLE
Updates shell scripts and logs to use manager

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -341,7 +341,7 @@ function main() {
   SSH='ssh -qnf -o ConnectTimeout=2'
 
   manager_file="managers"
-  if [[ ! -f "$conf/$manager_file" -a -f "$conf/masters" ]]; then
+  if [[ ! -f "$conf/$manager_file" && -f "$conf/masters" ]]; then
     echo "WARN : Use of 'masters' file is deprecated; use 'managers' file instead."
     manager_file="masters"
   fi 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -341,7 +341,7 @@ function main() {
   SSH='ssh -qnf -o ConnectTimeout=2'
 
   manager_file="managers"
-  if [ ! -f "$conf/$manager_file" -a -f "$conf/masters" ]; then
+  if [[ ! -f "$conf/$manager_file" -a -f "$conf/masters" ]]; then
     echo "WARN : Use of masters files is deprecated.  Use managers files instead"
     manager_file="masters"
   fi 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -342,7 +342,7 @@ function main() {
 
   manager_file="managers"
   if [[ ! -f "$conf/$manager_file" -a -f "$conf/masters" ]]; then
-    echo "WARN : Use of masters files is deprecated.  Use managers files instead"
+    echo "WARN : Use of 'masters' file is deprecated; use 'managers' file instead."
     manager_file="masters"
   fi 
 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -57,37 +57,37 @@ function verify_config {
     exit 1
   fi
 
-  unset master1
-  if [[ -f "${conf}/masters" ]]; then
-    master1=$(egrep -v '(^#|^\s*$)' "${conf}/masters" | head -1)
+  unset manager1
+  if [[ -f "${conf}/$manager_file" ]]; then
+    manager1=$(egrep -v '(^#|^\s*$)' "${conf}/$manager_file" | head -1)
   fi
 
   if [[ -z "${monitor}" ]] ; then
-    monitor=$master1
+    monitor=$manager1
     if [[ -f "${conf}/monitor" ]]; then
       monitor=$(egrep -v '(^#|^\s*$)' "${conf}/monitor" | head -1)
     fi
     if [[ -z "${monitor}" ]] ; then
       echo "Could not infer a Monitor role. You need to either define \"${conf}/monitor\"," 
-      echo "or make sure \"${conf}/masters\" is non-empty."
+      echo "or make sure \"${conf}/$manager_file\" is non-empty."
       exit 1
     fi
   fi
   if [[ ! -f "${conf}/tracers" ]]; then
-    if [[ -z "${master1}" ]] ; then
+    if [[ -z "${manager1}" ]] ; then
       echo "Could not find a master node to use as a default for the tracer role."
-      echo "Either set up \"${conf}/tracers\" or make sure \"${conf}/masters\" is non-empty."
+      echo "Either set up \"${conf}/tracers\" or make sure \"${conf}/$manager_file\" is non-empty."
       exit 1
     else
-      echo "$master1" > "${conf}/tracers"
+      echo "$manager1" > "${conf}/tracers"
     fi
   fi
   if [[ ! -f "${conf}/gc" ]]; then
-    if [[ -z "${master1}" ]] ; then
-      echo "Could not infer a GC role. You need to either set up \"${conf}/gc\" or make sure \"${conf}/masters\" is non-empty."
+    if [[ -z "${manager1}" ]] ; then
+      echo "Could not infer a GC role. You need to either set up \"${conf}/gc\" or make sure \"${conf}/$manager_file\" is non-empty."
       exit 1
     else
-      echo "$master1" > "${conf}/gc"
+      echo "$manager1" > "${conf}/gc"
     fi
   fi
 }
@@ -147,8 +147,8 @@ function start_all() {
     start_tservers
   fi
 
-  for host in $(egrep -v '(^#|^\s*$)' "${conf}/masters"); do
-    start_service "$host" master
+  for host in $(egrep -v '(^#|^\s*$)' "${conf}/$manager_file"); do
+    start_service "$host" manager
   done
 
   for host in $(egrep -v '(^#|^\s*$)' "${conf}/gc"); do
@@ -173,8 +173,8 @@ function start_here() {
   done
 
   for host in $local_hosts; do
-    if grep -q "^${host}\$" "${conf}/masters"; then
-      start_service "$host" master
+    if grep -q "^${host}\$" "${conf}/$manager_file"; then
+      start_service "$host" manager
       break
     fi
   done
@@ -235,7 +235,7 @@ function stop_tservers() {
 function kill_all() {
   echo "Killing Accumulo cluster..."
 
-  for master in $(grep -v '^#' "${conf}/masters"); do
+  for master in $(grep -v '^#' "${conf}/$manager_file"); do
     kill_service "$master" master
   done
 
@@ -275,8 +275,8 @@ function stop_all() {
 
   # Look for processes not killed by 'admin stopAll'
   for end_cmd in "stop" "kill" ; do
-    for master in $(grep -v '^#' "${conf}/masters"); do
-      end_service "$master" master $end_cmd
+    for manager in $(grep -v '^#' "${conf}/$manager_file"); do
+      end_service "$manager" manager $end_cmd
     done
 
     for gc in $(grep -v '^#' "${conf}/gc"); do
@@ -340,10 +340,16 @@ function main() {
   accumulo_cmd="${bin}/accumulo"
   SSH='ssh -qnf -o ConnectTimeout=2'
 
+  manager_file="managers"
+  if [ ! -f "$conf/$manager_file" -a -f "$conf/masters" ]; then
+    echo "WARN : Use of masters files is deprecated.  Use managers files instead"
+    manager_file="masters"
+  fi 
+
   case "$1" in
     create-config)
       echo "localhost" > "$conf/gc"
-      echo "localhost" > "$conf/masters"
+      echo "localhost" > "$conf/managers"
       echo "localhost" > "$conf/monitor"
       echo "localhost" > "$conf/tracers"
       echo "localhost" > "$conf/tservers"

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -25,7 +25,8 @@ Usage: accumulo-service <service> <command>
 Services:
   gc          Accumulo garbage collector
   monitor     Accumulo monitor
-  master      Accumulo master
+  manager     Accumulo manager
+  master      Accumulo master (Deprecated)
   tserver     Accumulo tserver
   tracer      Accumulo tracter
 
@@ -67,7 +68,7 @@ function start_service() {
   fi
   echo "Starting $service on $host"
 
-  if [[ $service == "master" ]]; then
+  if [[ $service == "manager" ]]; then
     "${bin}/accumulo" org.apache.accumulo.master.state.SetGoalState NORMAL
   fi
 
@@ -137,9 +138,15 @@ function main() {
     host=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
   fi 
   service="$1"
+
+  if [[ $service == "master" ]]; then
+    echo "WARN : Use of master service name is deprecated, use manager instead."
+    service="manager"
+  fi
+
   pid_file="${ACCUMULO_PID_DIR}/accumulo-${service}${ACCUMULO_SERVICE_INSTANCE}.pid"
   case "$service" in
-    gc|master|monitor|tserver|tracer)
+    gc|manager|monitor|tserver|tracer)
       if [[ -z $2 ]]; then
         invalid_args "<command> cannot be empty"
       fi

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -140,7 +140,7 @@ function main() {
   service="$1"
 
   if [[ $service == "master" ]]; then
-    echo "WARN : Use of master service name is deprecated, use manager instead."
+    echo "WARN : Use of 'master' service name is deprecated; use 'manager' instead."
     service="manager"
   fi
 

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -20,7 +20,7 @@
 
 ## Before accumulo-env.sh is loaded, these environment variables are set and can be used in this file:
 
-# cmd - Command that is being called such as tserver, master, etc.
+# cmd - Command that is being called such as tserver, manager, etc.
 # basedir - Root of Accumulo installation
 # bin - Directory containing Accumulo scripts
 # conf - Directory containing Accumulo configuration
@@ -79,7 +79,7 @@ JAVA_OPTS=("${ACCUMULO_JAVA_OPTS[@]}"
 
 ## JVM options set for individual applications
 case "$cmd" in
-  master)  JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx512m' '-Xms512m') ;;
+  manager|master)  JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx512m' '-Xms512m') ;;
   monitor) JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx256m' '-Xms256m') ;;
   gc)      JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx256m' '-Xms256m') ;;
   tserver) JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx768m' '-Xms768m') ;;
@@ -95,7 +95,7 @@ JAVA_OPTS=("${JAVA_OPTS[@]}"
 )
 
 case "$cmd" in
-  monitor|gc|master|tserver|tracer)
+  monitor|gc|manager|master|tserver|tracer)
     JAVA_OPTS=("${JAVA_OPTS[@]}" "-Dlog4j.configurationFile=log4j2-service.properties")
     ;;
   *)

--- a/server/manager/src/main/java/org/apache/accumulo/master/ManagerExecutable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/ManagerExecutable.java
@@ -23,11 +23,11 @@ import org.apache.accumulo.start.spi.KeywordExecutable;
 import com.google.auto.service.AutoService;
 
 @AutoService(KeywordExecutable.class)
-public class MasterExecutable implements KeywordExecutable {
+public class ManagerExecutable implements KeywordExecutable {
 
   @Override
   public String keyword() {
-    return "master";
+    return "manager";
   }
 
   @Override
@@ -37,7 +37,7 @@ public class MasterExecutable implements KeywordExecutable {
 
   @Override
   public String description() {
-    return "Starts Accumulo master (Deprecated)";
+    return "Starts Accumulo Manager";
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/start/KeywordStartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/start/KeywordStartIT.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.util.Help;
 import org.apache.accumulo.core.util.Version;
 import org.apache.accumulo.gc.GCExecutable;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
+import org.apache.accumulo.master.ManagerExecutable;
 import org.apache.accumulo.master.Master;
 import org.apache.accumulo.master.MasterExecutable;
 import org.apache.accumulo.minicluster.MiniAccumuloRunner;
@@ -110,6 +111,7 @@ public class KeywordStartIT {
     expectSet.put("info", Info.class);
     expectSet.put("init", Initialize.class);
     expectSet.put("login-info", LoginProperties.class);
+    expectSet.put("manager", ManagerExecutable.class);
     expectSet.put("master", MasterExecutable.class);
     expectSet.put("minicluster", MiniClusterExecutable.class);
     expectSet.put("monitor", MonitorExecutable.class);


### PR DESCRIPTION
While running test against 2.1.0-SNAP I noticed a master.log file was being created. I tried to fix that and ended up with this PR which modifies the scripts to support manager and also fixes the log file name.