### PR TITLE
Update zookeeper 3.5.x version to 3.5.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <thrift.version>0.12.0</thrift.version>
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
     <!-- ZooKeeper version -->
-    <zookeeper.version>3.5.8</zookeeper.version>
+    <zookeeper.version>3.5.9</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This change bumps the zookeeper version to the latest 3.5.x release. With 2.1 we are changing the zookeeper version to 3.5.x, this would keep the 2.1 release consistent with the current zookeeper release.