### PR TITLE
Add tserver to badservers instead of dropping. Fixes #1775

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/manager/src/main/java/org/apache/accumulo/master/Master.java
@@ -847,7 +847,7 @@ public class Master extends AbstractServer
         } catch (TException e) {
           log.error("{}", e.getMessage(), e);
         }
-        tserverSet.remove(instance);
+        badServers.putIfAbsent(instance, new AtomicInteger(1));
       }
     }
 


### PR DESCRIPTION
* When the Master killed a tserver due to holdTime, it would just
disappear on the Monitor because it was being dropped from the active
tserver list. Instead of dropping it, this will add it to the list of
badservers, giving the Monitor a chance to see it dead.