### PR TITLE
Include stack trace in log for DfsLogger.fail()

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -224,7 +224,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     }
 
     private void fail(ArrayList<DfsLogger.LogWork> work, Exception ex, String why) {
-      log.warn("Exception " + why + " " + ex);
+      log.warn("Exception {} {}", why, ex, ex);
       for (DfsLogger.LogWork logWork : work) {
         logWork.exception = ex;
       }


### PR DESCRIPTION
Ensure the DfsLogger.fail() method includes the stack trace for the
exception that occurred, in case something happens and it doesn't get
wrapped and rethrown later. Also, use slf4j substitution syntax.