### PR TITLE
Make UnloadTabletHandler log before waiting

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2220,6 +2220,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       synchronized (openingTablets) {
         while (openingTablets.contains(extent)) {
           try {
+            log.info("Waiting for tablet {} to finish opening before unloading.", extent);
             openingTablets.wait();
           } catch (InterruptedException e) {}
         }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -2247,7 +2247,7 @@ public class TabletServer extends AccumuloServerContext implements Runnable {
       } catch (Throwable e) {
 
         if ((t.isClosing() || t.isClosed()) && e instanceof IllegalStateException) {
-          log.debug("Failed to unload tablet {} ... it was alread closing or closed : {}", extent,
+          log.debug("Failed to unload tablet {} ... it was already closing or closed : {}", extent,
               e.getMessage());
         } else {
           log.error("Failed to close tablet {}... Aborting migration", extent, e);


### PR DESCRIPTION
* If a tablet is in the process of being opened, the UnloadTabletHandler
will wait for a tablet to be removed from the list before proceeding
with the unload.  This could take a long time so log info before waiting.