### PR TITLE
Fix Accumulo-init hanging when TLS enabled on Zookeeper

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -77,6 +77,8 @@ import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.core.replication.ReplicationSchema.WorkSection;
 import org.apache.accumulo.core.replication.ReplicationTable;
+import org.apache.accumulo.core.singletons.SingletonManager;
+import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.ColumnFQ;
@@ -988,6 +990,8 @@ public class Initialize implements KeywordExecutable {
     } catch (Exception e) {
       log.error("Fatal exception", e);
       throw new RuntimeException(e);
+    } finally {
+      SingletonManager.setMode(Mode.CLOSED);
     }
   }
 


### PR DESCRIPTION
This PR address 'accumulo init' command being hanging when TLS enabled on Zookeeper. The related PR (https://github.com/apache/accumulo/pull/1586) addressed the 'accumulo master' being hanging with TLS-enabled zookeeper. 