### PR TITLE
Improvements to BulkImportCacheCleaner

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
@@ -104,13 +104,15 @@ public class TransactionWatcher {
       final ZooReader reader = context.getZooReaderWriter();
       final Set<Long> result = new HashSet<>();
       final String parent = context.getZooKeeperRoot() + "/" + type;
-      reader.sync(parent);
-      List<String> children = reader.getChildren(parent);
-      for (String child : children) {
-        if (child.endsWith("-running")) {
-          continue;
+      if (reader.exists(parent)) {
+        reader.sync(parent);
+        List<String> children = reader.getChildren(parent);
+        for (String child : children) {
+          if (child.endsWith("-running")) {
+            continue;
+          }
+          result.add(Long.parseLong(child));
         }
-        result.add(Long.parseLong(child));
       }
       return result;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
@@ -104,8 +104,8 @@ public class TransactionWatcher {
       final ZooReader reader = context.getZooReaderWriter();
       final Set<Long> result = new HashSet<>();
       final String parent = context.getZooKeeperRoot() + "/" + type;
+      reader.sync(parent);
       if (reader.exists(parent)) {
-        reader.sync(parent);
         List<String> children = reader.getChildren(parent);
         for (String child : children) {
           if (child.endsWith("-running")) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
@@ -60,7 +60,7 @@ public class BulkImportCacheCleaner implements Runnable {
     } catch (InterruptedException e) {
       // propagate the interrupt status.
       Thread.currentThread().interrupt();
-      log.debug("Interrupted while reading bulk import live transactions {}", tids, e);
+      log.warn("Interrupted while reading bulk import live transactions {}", tids, e);
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/BulkImportCacheCleaner.java
@@ -54,9 +54,13 @@ public class BulkImportCacheCleaner implements Runnable {
       for (Tablet tablet : server.getOnlineTablets().values()) {
         tablet.cleanupBulkLoadedFiles(tids);
       }
-    } catch (KeeperException | InterruptedException e) {
+    } catch (KeeperException e) {
       // we'll just clean it up again later
-      log.debug("Error reading bulk import live transactions {}", e);
+      log.debug("Error reading bulk import live transactions {}", tids, e);
+    } catch (InterruptedException e) {
+      // propagate the interrupt status.
+      Thread.currentThread().interrupt();
+      log.debug("Interrupted while reading bulk import live transactions {}", tids, e);
     }
   }
 


### PR DESCRIPTION
* Check if the parent node exists before performing a sync and getting
the children in TransactionWatcher, preventing NoNodeExceptions.

Here is the exception that I have seen:

<pre>
2021-01-29T10:02:32,310 [tablet.BulkImportCacheCleaner] DEBUG: Error reading bulk import live transactions {}
org.apache.zookeeper.KeeperException$NoNodeException: KeeperErrorCode = NoNode for /accumulo/cc552965-f3c2-48b6-b200-9d1f2a7c48c5/bulkTx
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:118) ~[zookeeper-3.6.2.jar:3.6.2]
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:54) ~[zookeeper-3.6.2.jar:3.6.2]
        at org.apache.zookeeper.ZooKeeper.getChildren(ZooKeeper.java:2746) ~[zookeeper-3.6.2.jar:3.6.2]
        at org.apache.accumulo.fate.zookeeper.ZooReader.lambda$getChildren$5(ZooReader.java:87) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.fate.zookeeper.ZooReader.retryLoopMutator(ZooReader.java:165) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.fate.zookeeper.ZooReader.retryLoop(ZooReader.java:144) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.fate.zookeeper.ZooReader.retryLoop(ZooReader.java:131) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.fate.zookeeper.ZooReader.getChildren(ZooReader.java:87) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.server.zookeeper.TransactionWatcher$ZooArbitrator.allTransactionsAlive(TransactionWatcher.java:108) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.tserver.tablet.BulkImportCacheCleaner.run(BulkImportCacheCleaner.java:50) ~[accumulo-tserver-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
</pre>

I don't understand what the `reader.sync()` method call is doing, so I am not sure if that should be called before `exists()` or not.  The `reader.sync()` call is not throwing the exception so it may be OK to call that before checking.