### PR TITLE
Converting table creation to pre-split

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
@@ -79,8 +79,7 @@ public class BulkImportMonitoringIT extends ConfigurableMacBase {
       HashMap<String,String> props = new HashMap<>();
       props.put(Property.TABLE_MAJC_RATIO.getKey(), "1");
       // creating table with configuration
-      NewTableConfiguration ntc =
-          new NewTableConfiguration().setProperties(props).withSplits(splits);
+      var ntc = new NewTableConfiguration().setProperties(props).withSplits(splits);
       c.tableOperations().create(tableName, ntc);
 
       MasterMonitorInfo stats = getCluster().getMasterMonitorInfo();

--- a/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BulkImportMonitoringIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
@@ -65,15 +67,21 @@ public class BulkImportMonitoringIT extends ConfigurableMacBase {
   public void test() throws Exception {
     getCluster().getClusterControl().start(ServerType.MONITOR);
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
+
+      // creating table name
       final String tableName = getUniqueNames(1)[0];
-      c.tableOperations().create(tableName);
-      c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1");
-      // splits to slow down bulk import
+      // creating splits
       SortedSet<Text> splits = new TreeSet<>();
       for (int i = 1; i < 0xf; i++) {
         splits.add(new Text(Integer.toHexString(i)));
       }
-      c.tableOperations().addSplits(tableName, splits);
+      // creating properties
+      HashMap<String,String> props = new HashMap<>();
+      props.put(Property.TABLE_MAJC_RATIO.getKey(), "1");
+      // creating table with configuration
+      NewTableConfiguration ntc =
+          new NewTableConfiguration().setProperties(props).withSplits(splits);
+      c.tableOperations().create(tableName, ntc);
 
       MasterMonitorInfo stats = getCluster().getMasterMonitorInfo();
       assertEquals(1, stats.tServerInfo.size());

--- a/test/src/main/java/org/apache/accumulo/test/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CompactionExecutorIT.java
@@ -403,13 +403,13 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     String tableName = "tiwr";
 
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().create(tableName);
+
       SortedSet<Text> splits = new TreeSet<>();
-      splits.add(new Text("f"));
-      splits.add(new Text("m"));
-      splits.add(new Text("r"));
-      splits.add(new Text("t"));
-      client.tableOperations().addSplits(tableName, splits);
+      for (String s : List.of("f", "m", "r", "t"))
+        splits.add(new Text(s));
+
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      client.tableOperations().create(tableName, ntc);
 
       Map<String,String> expected = new TreeMap<>();
 

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -874,8 +874,8 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
 
-      client.tableOperations().create(tableName);
-      client.tableOperations().addSplits(tableName, nss("2", "4", "6"));
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(nss("2", "4", "6"));
+      client.tableOperations().create(tableName, ntc);
 
       sleepUninterruptibly(2, TimeUnit.SECONDS);
 
@@ -1223,18 +1223,20 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
     String tableName = getUniqueNames(1)[0];
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
-      client.tableOperations().create(tableName);
+      NewTableConfiguration ntc = new NewTableConfiguration();
 
       Random rand = new SecureRandom();
 
       switch (rand.nextInt(3)) {
         case 1:
-          client.tableOperations().addSplits(tableName, nss("4"));
+          ntc = ntc.withSplits(nss("4"));
           break;
         case 2:
-          client.tableOperations().addSplits(tableName, nss("3", "5"));
+          ntc = ntc.withSplits(nss("3", "5"));
           break;
       }
+
+      client.tableOperations().create(tableName, ntc);
 
       try (ConditionalWriter cw =
           client.createConditionalWriter(tableName, new ConditionalWriterConfig())) {

--- a/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MasterRepairsDualAssignmentIT.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -79,12 +80,12 @@ public class MasterRepairsDualAssignmentIT extends ConfigurableMacBase {
       c.securityOperations().grantTablePermission("root", MetadataTable.NAME,
           TablePermission.WRITE);
       c.securityOperations().grantTablePermission("root", RootTable.NAME, TablePermission.WRITE);
-      c.tableOperations().create(table);
       SortedSet<Text> partitions = new TreeSet<>();
       for (String part : "a b c d e f g h i j k l m n o p q r s t u v w x y z".split(" ")) {
         partitions.add(new Text(part));
       }
-      c.tableOperations().addSplits(table, partitions);
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(partitions);
+      c.tableOperations().create(table, ntc);
       // scan the metadata table and get the two table location states
       Set<TServerInstance> states = new HashSet<>();
       Set<TabletLocationState> oldLocations = new HashSet<>();

--- a/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -208,8 +209,8 @@ public class TestBinaryRows {
         System.out.printf("added split point 0x%016x  %,12d%n", splitPoint, splitPoint);
       }
 
-      accumuloClient.tableOperations().create(opts.tableName);
-      accumuloClient.tableOperations().addSplits(opts.tableName, splits);
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      accumuloClient.tableOperations().create(opts.tableName, ntc);
 
     } else {
       throw new Exception("ERROR : " + opts.mode + " is not a valid operation.");

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.security.SecurityErrorCode;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.conf.ClientProperty;
@@ -169,15 +170,17 @@ public class TestIngest {
     if (params.createTable) {
       TreeSet<Text> splits =
           getSplitPoints(params.startRow, params.startRow + params.rows, params.numsplits);
-
+      // if the table does not exit, create it (with splits)
       if (!client.tableOperations().exists(params.tableName)) {
-        client.tableOperations().create(params.tableName);
-      }
-      try {
-        client.tableOperations().addSplits(params.tableName, splits);
-      } catch (TableNotFoundException ex) {
-        // unlikely
-        throw new RuntimeException(ex);
+        NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+        client.tableOperations().create(params.tableName, ntc);
+      } else { // if the table already exists, add splits to it
+        try {
+          client.tableOperations().addSplits(params.tableName, splits);
+        } catch (TableNotFoundException ex) {
+          // unlikely
+          throw new RuntimeException(ex);
+        }
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -170,7 +170,7 @@ public class TestIngest {
     if (params.createTable) {
       TreeSet<Text> splits =
           getSplitPoints(params.startRow, params.startRow + params.rows, params.numsplits);
-      // if the table does not exit, create it (with splits)
+      // if the table does not exist, create it (with splits)
       if (!client.tableOperations().exists(params.tableName)) {
         NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
         client.tableOperations().create(params.tableName, ntc);

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -30,6 +30,7 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.security.Authorizations;
@@ -83,12 +84,17 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
     // make a table with many splits
     String tableName = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
-      c.tableOperations().create(tableName);
+
+      // create splits
       SortedSet<Text> splits = new TreeSet<>();
       for (int i = 0; i < 200; i++) {
         splits.add(new Text(randomHex(8)));
       }
-      c.tableOperations().addSplits(tableName, splits);
+
+      // create table with config
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      c.tableOperations().create(tableName, ntc);
+
       // load data to give the recovery something to do
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 50000; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BinaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BinaryIT.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.TestBinaryRows;
 import org.apache.hadoop.io.Text;
@@ -48,11 +49,11 @@ public class BinaryIT extends AccumuloClusterHarness {
   public void testPreSplit() throws Exception {
     String tableName = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      c.tableOperations().create(tableName);
       SortedSet<Text> splits = new TreeSet<>();
       splits.add(new Text("8"));
       splits.add(new Text("256"));
-      c.tableOperations().addSplits(tableName, splits);
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      c.tableOperations().create(tableName, ntc);
       runTest(c, tableName);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkOldIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkOldIT.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.data.Key;
@@ -66,11 +67,11 @@ public class BulkOldIT extends AccumuloClusterHarness {
   public void testBulkFile() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
-      c.tableOperations().create(tableName);
       SortedSet<Text> splits = new TreeSet<>();
       for (String split : "0333 0666 0999 1333 1666".split(" "))
         splits.add(new Text(split));
-      c.tableOperations().addSplits(tableName, splits);
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      c.tableOperations().create(tableName, ntc);
       Configuration conf = new Configuration();
       AccumuloConfiguration aconf = getCluster().getServerContext().getConfiguration();
       FileSystem fs = getCluster().getFileSystem();

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.CloneConfiguration;
 import org.apache.accumulo.core.client.admin.DiskUsage;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.conf.Property;
@@ -310,9 +311,8 @@ public class CloneTestIT extends AccumuloClusterHarness {
 
       String[] tables = getUniqueNames(2);
 
-      client.tableOperations().create(tables[0]);
-
-      client.tableOperations().addSplits(tables[0], splits);
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      client.tableOperations().create(tables[0], ntc);
 
       try (BatchWriter bw = client.createBatchWriter(tables[0])) {
         bw.addMutations(mutations);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -16,24 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -16,6 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
@@ -43,6 +61,7 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.security.Authorizations;
@@ -60,16 +79,17 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
   @Test
   public void testConcurrentDeleteTablesOps() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+
       String[] tables = getUniqueNames(2);
 
       TreeSet<Text> splits = createSplits();
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
 
       ExecutorService es = Executors.newFixedThreadPool(20);
 
       int count = 0;
       for (final String table : tables) {
-        c.tableOperations().create(table);
-        c.tableOperations().addSplits(table, splits);
+        c.tableOperations().create(table, ntc);
         writeData(c, table);
         if (count == 1) {
           c.tableOperations().flush(table, null, null, true);
@@ -161,6 +181,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
       String[] tables = getUniqueNames(2);
 
       TreeSet<Text> splits = createSplits();
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
 
       int numOperations = 8;
 
@@ -168,8 +189,7 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
 
       int count = 0;
       for (final String table : tables) {
-        c.tableOperations().create(table);
-        c.tableOperations().addSplits(table, splits);
+        c.tableOperations().create(table, ntc);
         writeData(c, table);
         if (count == 1) {
           c.tableOperations().flush(table, null, null, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.TestIngest;
@@ -46,9 +47,8 @@ public class FateStarvationIT extends AccumuloClusterHarness {
   public void run() throws Exception {
     String tableName = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      c.tableOperations().create(tableName);
-
-      c.tableOperations().addSplits(tableName, TestIngest.getSplitPoints(0, 100000, 50));
+      var ntc = new NewTableConfiguration().withSplits(TestIngest.getSplitPoints(0, 100000, 50));
+      c.tableOperations().create(tableName, ntc);
 
       IngestParams params = new IngestParams(getClientProps(), tableName, 100_000);
       params.random = 89;

--- a/test/src/main/java/org/apache/accumulo/test/functional/LogicalTimeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LogicalTimeIT.java
@@ -94,14 +94,12 @@ public class LogicalTimeIT extends AccumuloClusterHarness {
   private void runMergeTest(AccumuloClient client, String table, String[] splits, String[] inserts,
       String start, String end, String last, long expected) throws Exception {
     log.info("table {}", table);
-    client.tableOperations().create(table,
-        new NewTableConfiguration().setTimeType(TimeType.LOGICAL));
     TreeSet<Text> splitSet = new TreeSet<>();
     for (String split : splits) {
       splitSet.add(new Text(split));
     }
-    client.tableOperations().addSplits(table, splitSet);
-
+    client.tableOperations().create(table,
+        new NewTableConfiguration().setTimeType(TimeType.LOGICAL).withSplits(splitSet));
     BatchWriter bw = client.createBatchWriter(table);
     for (String row : inserts) {
       Mutation m = new Mutation(row);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -129,8 +130,9 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
 
       String manyWALsTable = tableNames[0];
       String rollWALsTable = tableNames[1];
-      c.tableOperations().create(manyWALsTable);
-      c.tableOperations().addSplits(manyWALsTable, splits);
+
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+      c.tableOperations().create(manyWALsTable, ntc);
 
       c.tableOperations().create(rollWALsTable);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -28,6 +29,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -101,10 +103,11 @@ public class MaxOpenIT extends AccumuloClusterHarness {
   public void run() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       final String tableName = getUniqueNames(1)[0];
-      c.tableOperations().create(tableName);
-      c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "10");
-      c.tableOperations().addSplits(tableName,
-          TestIngest.getSplitPoints(0, NUM_TO_INGEST, NUM_TABLETS));
+      HashMap<String,String> props = new HashMap<>();
+      props.put(Property.TABLE_MAJC_RATIO.getKey(), "10");
+      NewTableConfiguration ntc = new NewTableConfiguration().setProperties(props)
+          .withSplits(TestIngest.getSplitPoints(0, NUM_TO_INGEST, NUM_TABLETS));
+      c.tableOperations().create(tableName, ntc);
 
       // the following loop should create three tablets in each map file
       for (int i = 0; i < 3; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.MasterClient;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftNotActiveServiceException;
@@ -72,10 +73,9 @@ public class MetadataMaxFilesIT extends ConfigurableMacBase {
       sleepUninterruptibly(5, TimeUnit.SECONDS);
       for (int i = 0; i < 2; i++) {
         String tableName = "table" + i;
-        log.info("Creating {}", tableName);
-        c.tableOperations().create(tableName);
-        log.info("adding splits");
-        c.tableOperations().addSplits(tableName, splits);
+        log.info("Creating {} with splits", tableName);
+        NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+        c.tableOperations().create(tableName, ntc);
         log.info("flushing");
         c.tableOperations().flush(MetadataTable.NAME, null, null, true);
         c.tableOperations().flush(RootTable.NAME, null, null, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanRangeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanRangeIT.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -53,12 +54,12 @@ public class ScanRangeIT extends AccumuloClusterHarness {
       String table1 = tableNames[0];
       c.tableOperations().create(table1);
       String table2 = tableNames[1];
-      c.tableOperations().create(table2);
       TreeSet<Text> splitRows = new TreeSet<>();
       int splits = 3;
       for (int i = (ROW_LIMIT / splits); i < ROW_LIMIT; i += (ROW_LIMIT / splits))
         splitRows.add(createRow(i));
-      c.tableOperations().addSplits(table2, splitRows);
+      NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splitRows);
+      c.tableOperations().create(table2, ntc);
 
       insertData(c, table1);
       scanTable(c, table1);


### PR DESCRIPTION
In many cases, tables are created and then splits are added. This is not as efficient as creating the tables with the splits.  Significant decreases in time taken in tests with pre-split tables is observed, especially in cases with many splits. This PR aims to convert to pre-split tables in cases where improvement is obvious, and discuss to what extent and in what scenarios this conversion should take place.