### PR TITLE
Add user test to ShellIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -352,11 +352,13 @@ public class ShellIT extends SharedMiniClusterBase {
   }
 
   @Test
-  public void userTest() throws IOException {
+  public void userExistsTest() throws IOException {
     Shell.log.debug("Starting user test --------------------------");
+    String user = testName.getMethodName();
     exec("createuser root", false, "user exists");
-    exec("createuser test", true);
-    exec("createuser test", false, "user exists");
+    exec("createuser " + user, true);
+    exec("createuser " + user, false, "user exists");
+    exec("deleteuser " + user + " -f", true);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -352,10 +352,11 @@ public class ShellIT extends SharedMiniClusterBase {
   }
 
   @Test
-  public void userTest() {
+  public void userTest() throws IOException {
     Shell.log.debug("Starting user test --------------------------");
-    // Test cannot be done via junit because createuser only prompts for password
-    // exec("createuser root", false, "user exists");
+    exec("createuser root", false, "user exists");
+    exec("createuser test", true);
+    exec("createuser test", false, "user exists");
   }
 
   @Test


### PR DESCRIPTION
This fixes [ACCUMULO-1119](https://issues.apache.org/jira/browse/ACCUMULO-1119?orderby=cf[12310200]+ASC%2C+priority+DESC%2C+updated+DESC). Since `ShellTest` became `ShellIT` (in 2.0), this test can be uncommented, assuming this is still something worthwhile to test. I confirmed it passes now, even without having to properly enter any passwords. 

`ShellServerIT` also has a user test but doesn't directly test for the "User Exists" exception. This could be added to that if it fits better or it can stay here. 