### PR TITLE
Prevent deleted tablets from being flushed

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -559,7 +559,7 @@ public class TabletServerResourceManager {
               Tablet tablet = tabletReport.getTablet();
               var state = context.getTableManager().getTableState(tablet.getExtent().tableId());
               if (!tablet.initiateMinorCompaction(MinorCompactionReason.SYSTEM, state)) {
-                if (tablet.isClosed() || state.equals(TableState.DELETING)) {
+                if (tablet.isClosed() || state == TableState.DELETING) {
                   // attempt to remove it from the current reports if still there
                   synchronized (tabletReports) {
                     TabletMemoryReport latestReport = tabletReports.remove(keyExtent);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -52,7 +52,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheConfiguration;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheManagerFactory;
 import org.apache.accumulo.core.file.blockfile.impl.ScanCacheProvider;
-import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.spi.cache.BlockCache;
 import org.apache.accumulo.core.spi.cache.BlockCacheManager;
 import org.apache.accumulo.core.spi.cache.CacheType;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -52,7 +52,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheConfiguration;
 import org.apache.accumulo.core.file.blockfile.cache.impl.BlockCacheManagerFactory;
 import org.apache.accumulo.core.file.blockfile.impl.ScanCacheProvider;
-import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.spi.cache.BlockCache;
 import org.apache.accumulo.core.spi.cache.BlockCacheManager;
 import org.apache.accumulo.core.spi.cache.CacheType;
@@ -557,9 +556,8 @@ public class TabletServerResourceManager {
                 continue;
               }
               Tablet tablet = tabletReport.getTablet();
-              var state = context.getTableManager().getTableState(tablet.getExtent().tableId());
-              if (!tablet.initiateMinorCompaction(MinorCompactionReason.SYSTEM, state)) {
-                if (tablet.isClosed() || state == TableState.DELETING) {
+              if (!tablet.initiateMinorCompaction(MinorCompactionReason.SYSTEM)) {
+                if (tablet.isClosed() || tablet.isBeingDeleted()) {
                   // attempt to remove it from the current reports if still there
                   synchronized (tabletReports) {
                     TabletMemoryReport latestReport = tabletReports.remove(keyExtent);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
@@ -148,7 +148,7 @@ public class LargestFirstMemoryManager {
     return context.getTableConfiguration(tableId) != null;
   }
 
-  private boolean tableBeingDeleted(TableId tableId) {
+  protected boolean tableBeingDeleted(TableId tableId) {
     return context.getTableManager().getTableState(tableId) == TableState.DELETING;
   }
 
@@ -175,7 +175,7 @@ public class LargestFirstMemoryManager {
       KeyExtent tablet = ts.getExtent();
       // Make sure that the table still exists
       if (!tableExists(tablet.tableId()) || tableBeingDeleted(tablet.tableId())) {
-        log.debug("Ignoring extent for deleted table: {}", tablet);
+        log.trace("Ignoring extent for deleted table: {}", tablet);
         continue;
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.server.ServerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
@@ -149,8 +149,7 @@ public class LargestFirstMemoryManager {
   }
 
   private boolean tableBeingDeleted(TableId tableId) {
-    var state = context.getTableManager().getTableState(tableId);
-    return state.equals(TableState.DELETING);
+    return context.getTableManager().getTableState(tableId) == TableState.DELETING;
   }
 
   public List<KeyExtent> tabletsToMinorCompact(List<TabletMemoryReport> tablets) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -876,11 +876,11 @@ public class Tablet {
 
   }
 
-  public boolean initiateMinorCompaction(MinorCompactionReason mincReason, TableState tableState) {
+  public boolean initiateMinorCompaction(MinorCompactionReason mincReason) {
     if (isClosed()) {
       return false;
     }
-    if (isBeingDeleted(tableState)) {
+    if (isBeingDeleted()) {
       log.debug("Table {} is being deleted so don't flush {}", extent.tableId(), extent);
       return false;
     }
@@ -1583,8 +1583,8 @@ public class Tablet {
     return localCS == CloseState.CLOSED || localCS == CloseState.COMPLETE;
   }
 
-  public boolean isBeingDeleted(TableState state) {
-    return state == TableState.DELETING;
+  public boolean isBeingDeleted() {
+    return context.getTableManager().getTableState(extent.tableId()) == TableState.DELETING;
   }
 
   public boolean isCloseComplete() {
@@ -1911,8 +1911,7 @@ public class Tablet {
     if (reason != null) {
       // initiate and log outside of tablet lock
       log.debug("Initiating minor compaction for {} because {}", getExtent(), reason);
-      TableState tableState = context.getTableManager().getTableState(extent.tableId());
-      initiateMinorCompaction(MinorCompactionReason.SYSTEM, tableState);
+      initiateMinorCompaction(MinorCompactionReason.SYSTEM);
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -68,7 +68,7 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.YieldCallback;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator;
 import org.apache.accumulo.core.logging.TabletLogger;
-import org.apache.accumulo.core.master.state.tables.TableState;
+import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1906,9 +1906,9 @@ public class Tablet {
 
     if (reason != null) {
       // initiate and log outside of tablet lock
+      log.debug("Initiating minor compaction for {} because {}", getExtent(), reason);
       TableState tableState = context.getTableManager().getTableState(extent.tableId());
       initiateMinorCompaction(MinorCompactionReason.SYSTEM, tableState);
-      log.debug("Initiating minor compaction for {} because {}", getExtent(), reason);
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -880,7 +880,7 @@ public class Tablet {
     if (isClosed()) {
       return false;
     }
-    if (tableState.equals(TableState.DELETING)) {
+    if (isBeingDeleted(tableState)) {
       log.debug("Table {} is being deleted so don't flush {}", extent.tableId(), extent);
       return false;
     }
@@ -1581,6 +1581,10 @@ public class Tablet {
     // comparisons are done.
     CloseState localCS = closeState;
     return localCS == CloseState.CLOSED || localCS == CloseState.COMPLETE;
+  }
+
+  public boolean isBeingDeleted(TableState state) {
+    return state == TableState.DELETING;
   }
 
   public boolean isCloseComplete() {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -176,10 +176,9 @@ public class LargestFirstMemoryManagerTest {
   public void testDeletedTable() {
     final String deletedTableId = "1";
     final String beingDeleted = "2";
-    Function<TableId,Boolean> existenceCheck =
+    Predicate<TableId> existenceCheck =
         tableId -> !deletedTableId.contentEquals(tableId.canonical());
-    Function<TableId,Boolean> deletingCheck =
-        tableId -> beingDeleted.contentEquals(tableId.canonical());
+    Predicate<TableId> deletingCheck = tableId -> beingDeleted.contentEquals(tableId.canonical());
     LargestFirstMemoryManagerWithExistenceCheck mgr =
         new LargestFirstMemoryManagerWithExistenceCheck(existenceCheck, deletingCheck);
 
@@ -222,11 +221,11 @@ public class LargestFirstMemoryManagerTest {
   private static class LargestFirstMemoryManagerWithExistenceCheck
       extends LargestFirstMemoryManagerUnderTest {
 
-    Function<TableId,Boolean> existenceCheck;
-    Function<TableId,Boolean> deletingCheck;
+    Predicate<TableId> existenceCheck;
+    Predicate<TableId> deletingCheck;
 
-    public LargestFirstMemoryManagerWithExistenceCheck(Function<TableId,Boolean> existenceCheck,
-        Function<TableId,Boolean> deletingCheck) {
+    public LargestFirstMemoryManagerWithExistenceCheck(Predicate<TableId> existenceCheck,
+        Predicate<TableId> deletingCheck) {
       super();
       this.existenceCheck = existenceCheck;
       this.deletingCheck = deletingCheck;
@@ -234,12 +233,12 @@ public class LargestFirstMemoryManagerTest {
 
     @Override
     protected boolean tableExists(TableId tableId) {
-      return existenceCheck.apply(tableId);
+      return existenceCheck.test(tableId);
     }
 
     @Override
     protected boolean tableBeingDeleted(TableId tableId) {
-      return deletingCheck.apply(tableId);
+      return deletingCheck.test(tableId);
     }
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
@@ -34,9 +34,13 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class LargestFirstMemoryManagerTest {
+  @Rule
+  public Timeout timeout = Timeout.seconds(60);
 
   private static final long ZERO = System.currentTimeMillis();
   private static final long LATER = ZERO + 20 * 60 * 1000;
@@ -171,17 +175,21 @@ public class LargestFirstMemoryManagerTest {
   @Test
   public void testDeletedTable() {
     final String deletedTableId = "1";
+    final String beingDeleted = "2";
     Function<TableId,Boolean> existenceCheck =
         tableId -> !deletedTableId.contentEquals(tableId.canonical());
+    Function<TableId,Boolean> deletingCheck =
+        tableId -> beingDeleted.contentEquals(tableId.canonical());
     LargestFirstMemoryManagerWithExistenceCheck mgr =
-        new LargestFirstMemoryManagerWithExistenceCheck(existenceCheck);
+        new LargestFirstMemoryManagerWithExistenceCheck(existenceCheck, deletingCheck);
 
     mgr.init(context);
     List<KeyExtent> tabletsToMinorCompact;
     // one tablet is really big and the other is for a nonexistent table
-    KeyExtent extent = new KeyExtent(TableId.of("2"), new Text("j"), null);
-    tabletsToMinorCompact = mgr
-        .tabletsToMinorCompact(tablets(t(extent, ZERO, ONE_GIG, 0), t(k("j"), ZERO, ONE_GIG, 0)));
+    KeyExtent extent = new KeyExtent(TableId.of("3"), new Text("j"), null);
+    KeyExtent extent2 = new KeyExtent(TableId.of("2"), new Text("j"), null);
+    tabletsToMinorCompact = mgr.tabletsToMinorCompact(tablets(t(extent, ZERO, ONE_GIG, 0),
+        t(extent2, ZERO, ONE_GIG, 0), t(k("j"), ZERO, ONE_GIG, 0)));
     assertEquals(1, tabletsToMinorCompact.size());
     assertEquals(extent, tabletsToMinorCompact.get(0));
   }
@@ -204,21 +212,34 @@ public class LargestFirstMemoryManagerTest {
     protected boolean tableExists(TableId tableId) {
       return true;
     }
+
+    @Override
+    protected boolean tableBeingDeleted(TableId tableId) {
+      return false;
+    }
   }
 
   private static class LargestFirstMemoryManagerWithExistenceCheck
       extends LargestFirstMemoryManagerUnderTest {
 
     Function<TableId,Boolean> existenceCheck;
+    Function<TableId,Boolean> deletingCheck;
 
-    public LargestFirstMemoryManagerWithExistenceCheck(Function<TableId,Boolean> existenceCheck) {
+    public LargestFirstMemoryManagerWithExistenceCheck(Function<TableId,Boolean> existenceCheck,
+        Function<TableId,Boolean> deletingCheck) {
       super();
       this.existenceCheck = existenceCheck;
+      this.deletingCheck = deletingCheck;
     }
 
     @Override
     protected boolean tableExists(TableId tableId) {
       return existenceCheck.apply(tableId);
+    }
+
+    @Override
+    protected boolean tableBeingDeleted(TableId tableId) {
+      return deletingCheck.apply(tableId);
     }
   }
 


### PR DESCRIPTION
* The CleanUp step of deletes will wait until all tablets of a tablet
are unassigned. This will stop the memory mgr from flushing if the table
is being deleted, allowing it to be unassigned faster.
* Remove deleted tablet from memory reports in TabletServerResourceManager
so it won't keep trying to flush delete tablets when they are large
* Add TableState param to Tablet.initiateMinorCompaction() so calling code
in TabletServerResourceManager only has to get the state once
* Add debug to Tablet.completeClose() for better insight when waiting