### PR TITLE
Remove TODO comments in InMemoryMap

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -703,8 +703,6 @@ public class InMemoryMap {
 
     int mc = kvCount.get();
     MemoryDataSource mds = new MemoryDataSource(iteratorSamplerConfig);
-    // TODO seems like a bug that two MemoryDataSources are created... may need to fix in older
-    // branches
     SourceSwitchingIterator ssi = new SourceSwitchingIterator(mds);
     MemoryIterator mi = new MemoryIterator(new PartialMutationSkippingIterator(ssi, mc));
     mi.setSSI(ssi);


### PR DESCRIPTION
In my investigation of [ACCUMULO-2407](https://issues.apache.org/jira/browse/ACCUMULO-2407), I found that the task has been completed already for both 2.0 and 1.10. Therefore, this TODO is no longer needed. 