### PR TITLE
Explicit error message for grant/revoke System perm Closes:  #1903

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrantCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrantCommand.java
@@ -50,13 +50,19 @@ public class GrantCommand extends TableOperation {
         : shellState.getAccumuloClient().whoami();
 
     permission = cl.getArgs()[0].split("\\.", 2);
-    if (cl.hasOption(systemOpt.getOpt()) && permission[0].equalsIgnoreCase("System")) {
-      try {
-        shellState.getAccumuloClient().securityOperations().grantSystemPermission(user,
-            SystemPermission.valueOf(permission[1]));
-        Shell.log.debug("Granted {} the {} permission", user, permission[1]);
-      } catch (IllegalArgumentException e) {
-        throw new BadArgumentException("No such system permission", fullCommand,
+    if (permission[0].equalsIgnoreCase("System")) {
+      if (cl.hasOption(systemOpt.getOpt())) {
+        try {
+          shellState.getAccumuloClient().securityOperations().grantSystemPermission(user,
+              SystemPermission.valueOf(permission[1]));
+          Shell.log.debug("Granted {} the {} permission", user, permission[1]);
+        } catch (IllegalArgumentException e) {
+          throw new BadArgumentException("No such system permission", fullCommand,
+              fullCommand.indexOf(cl.getArgs()[0]));
+        }
+      } else {
+        throw new BadArgumentException(
+            "Missing required option for granting System Permission: -s ", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
       }
     } else if (permission[0].equalsIgnoreCase("Table")) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/RevokeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/RevokeCommand.java
@@ -50,13 +50,19 @@ public class RevokeCommand extends TableOperation {
         : shellState.getAccumuloClient().whoami();
 
     permission = cl.getArgs()[0].split("\\.", 2);
-    if (cl.hasOption(systemOpt.getOpt()) && permission[0].equalsIgnoreCase("System")) {
-      try {
-        shellState.getAccumuloClient().securityOperations().revokeSystemPermission(user,
-            SystemPermission.valueOf(permission[1]));
-        Shell.log.debug("Revoked from {} the {} permission", user, permission[1]);
-      } catch (IllegalArgumentException e) {
-        throw new BadArgumentException("No such system permission", fullCommand,
+    if (permission[0].equalsIgnoreCase("System")) {
+      if (cl.hasOption(systemOpt.getOpt())) {
+        try {
+          shellState.getAccumuloClient().securityOperations().revokeSystemPermission(user,
+              SystemPermission.valueOf(permission[1]));
+          Shell.log.debug("Revoked from {} the {} permission", user, permission[1]);
+        } catch (IllegalArgumentException e) {
+          throw new BadArgumentException("No such system permission", fullCommand,
+              fullCommand.indexOf(cl.getArgs()[0]));
+        }
+      } else {
+        throw new BadArgumentException(
+            "Missing required option for granting System Permission: -s ", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
       }
     } else if (permission[0].equalsIgnoreCase("Table")) {


### PR DESCRIPTION
In conjunction with the conversation from #1903, I added a more explicit error message or granting and revoking System permissions in case the user forgets to add the '-s' option. Before, It would throw an error with "Unrecognized permission" and not really tell you why it was unrecognized.  

This is how it looked before: 
<pre>
org.apache.accumulo.core.util.BadArgumentException: Unrecognized permission near index 7
revoke System.ALTER_USER -u jeff
</pre>

This is how it looks now: 
<pre>
org.apache.accumulo.core.util.BadArgumentException: Missing required option for granting System Permission: s  near index 7
revoke System.ALTER_USER -u jeff
       ^
</pre>

This is similar formatting to the error message if the user forgets to add  `-u <user>` to a command. I can alter it if there is a preferred formatting/style choice.