### PR TITLE
Fix broken ITs caused by #1892

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -172,7 +172,10 @@ public class TestIngest {
           getSplitPoints(params.startRow, params.startRow + params.rows, params.numsplits);
       // if the table does not exist, create it (with splits)
       if (!client.tableOperations().exists(params.tableName)) {
-        NewTableConfiguration ntc = new NewTableConfiguration().withSplits(splits);
+        NewTableConfiguration ntc = new NewTableConfiguration();
+        if (!splits.isEmpty()) {
+          ntc = ntc.withSplits(splits);
+        }
         client.tableOperations().create(params.tableName, ntc);
       } else { // if the table already exists, add splits to it
         try {


### PR DESCRIPTION
On my last PR, #1892, which converted to pre-split tables, it was pointed out [in a comment](https://github.com/apache/accumulo/pull/1892#issuecomment-774045325) that the changes broke some ITs. This change fixes those broken ITs.