### PR TITLE
Fix log names in minicluster, some broken ITs.

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -31,14 +31,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.accumulo.cluster.ClusterControl;
-import org.apache.accumulo.gc.GCExecutable;
-import org.apache.accumulo.manager.ManagerExecutable;
+import org.apache.accumulo.gc.SimpleGarbageCollector;
+import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
-import org.apache.accumulo.monitor.MonitorExecutable;
+import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.server.util.Admin;
-import org.apache.accumulo.tracer.TracerExecutable;
-import org.apache.accumulo.tserver.TServerExecutable;
+import org.apache.accumulo.tracer.TraceServer;
+import org.apache.accumulo.tserver.TabletServer;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,15 +137,14 @@ public class MiniAccumuloClusterControl implements ClusterControl {
           for (int i = tabletServerProcesses.size();
               count < limit && i < cluster.getConfig().getNumTservers(); i++, ++count) {
             tabletServerProcesses
-                .add(cluster._exec(new TServerExecutable(), server, configOverrides).getProcess());
+                .add(cluster._exec(TabletServer.class, server, configOverrides).getProcess());
           }
         }
         break;
       case MASTER:
       case MANAGER:
         if (masterProcess == null) {
-          masterProcess =
-              cluster._exec(new ManagerExecutable(), server, configOverrides).getProcess();
+          masterProcess = cluster._exec(Manager.class, server, configOverrides).getProcess();
         }
         break;
       case ZOOKEEPER:
@@ -156,17 +155,18 @@ public class MiniAccumuloClusterControl implements ClusterControl {
         break;
       case GARBAGE_COLLECTOR:
         if (gcProcess == null) {
-          gcProcess = cluster._exec(new GCExecutable(), server, configOverrides).getProcess();
+          gcProcess =
+              cluster._exec(SimpleGarbageCollector.class, server, configOverrides).getProcess();
         }
         break;
       case MONITOR:
         if (monitor == null) {
-          monitor = cluster._exec(new MonitorExecutable(), server, configOverrides).getProcess();
+          monitor = cluster._exec(Monitor.class, server, configOverrides).getProcess();
         }
         break;
       case TRACER:
         if (tracer == null) {
-          tracer = cluster._exec(new TracerExecutable(), server, configOverrides).getProcess();
+          tracer = cluster._exec(TraceServer.class, server, configOverrides).getProcess();
         }
         break;
       default:

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -367,6 +367,12 @@ public class Manager extends AbstractServer
     return getContext().getTableManager();
   }
 
+  public static void main(String[] args) throws Exception {
+    try (Manager manager = new Manager(new ServerOpts(), args)) {
+      manager.runServer();
+    }
+  }
+
   Manager(ServerOpts opts, String[] args) throws IOException {
     super("master", opts, args);
     ServerContext context = super.getContext();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerExecutable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerExecutable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.manager;
 
-import org.apache.accumulo.server.ServerOpts;
 import org.apache.accumulo.start.spi.KeywordExecutable;
 
 import com.google.auto.service.AutoService;
@@ -43,9 +42,7 @@ public class ManagerExecutable implements KeywordExecutable {
 
   @Override
   public void execute(final String[] args) throws Exception {
-    try (Manager master = new Manager(new ServerOpts(), args)) {
-      master.runServer();
-    }
+    Manager.main(args);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/MasterExecutable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/MasterExecutable.java
@@ -43,7 +43,7 @@ public class MasterExecutable implements KeywordExecutable {
 
   @Override
   public void execute(final String[] args) throws Exception {
-    new ManagerExecutable().execute(args);
+    Manager.main(args);
   }
 
 }


### PR DESCRIPTION
Commit e6164901a3acdd464a7a9beff0126097b53fc06f removed the main method
from Manager. In order to work around this, minicluster was modified to
use KeywordExecutable classes to launch. However, this caused all
minicluster log files to be named "Main" since the main class is always
org.apache.accumulo.start.Main. This could be worked around with a
log4j2 properties file and variable name to cause the file logger to use
the right class name, but then that would require all minicluster users
to use the supplied logger configuration, or replicate the same
configuration. Instead, the main method was added back to Manager so
that minicluster logging will work as expected. This also fixes the
broken ITs BackupManagerIT and ThriftServerBindsBeforeZooKeeperLockIT
which were both broken since they were attempting to reference the main
method in the Manager class.