### PR TITLE
Improve filename extension usage in RFile API

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFile.java
@@ -196,14 +196,14 @@ public class RFile {
 
   /**
    * This is an intermediate interface in a larger builder pattern. Supports setting the required
-   * output sink to write a RFile to.
+   * output sink to write a RFile to. The filename parameter requires the ".rf" extension.
    *
    * @since 1.8.0
    */
   public static interface OutputArguments {
     /**
      * @param filename
-     *          name of file to write RFile data
+     *          name of file to write RFile data, ending with the ".rf" extension
      * @return this
      */
     public WriterFSOptions to(String filename);

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriter.java
@@ -47,6 +47,7 @@ import com.google.common.base.Preconditions;
  * <li>Keys must be appended in sorted order within a locality group.</li>
  * <li>Locality groups must have a mutually exclusive set of column families.</li>
  * <li>The default locality group must be started last.</li>
+ * <li>If using RFile.newWriter().to("filename.rf"), the ".rf" extension is required.</li>
  * </ul>
  *
  * <p>
@@ -58,7 +59,7 @@ import com.google.common.base.Preconditions;
  *     Iterable&lt;Entry&lt;Key, Value&gt;&gt; localityGroup2Data = ...
  *     Iterable&lt;Entry&lt;Key, Value&gt;&gt; defaultGroupData = ...
  *
- *     try(RFileWriter writer = RFile.newWriter().to(file).build()) {
+ *     try(RFileWriter writer = RFile.newWriter().to("filename.rf").build()) {
  *
  *       // Start a locality group before appending data.
  *       writer.startNewLocalityGroup("groupA", "columnFam1", "columnFam2");

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
@@ -111,6 +111,10 @@ class RFileWriterBuilder implements RFile.OutputArguments, RFile.WriterFSOptions
   @Override
   public WriterFSOptions to(String filename) {
     Objects.requireNonNull(filename);
+    if (!filename.endsWith(".rf")) {
+      throw new IllegalArgumentException(
+          "Provided filename (" + filename + ") does not end with '.rf'");
+    }
     this.out = new OutputArgs(filename);
     return this;
   }


### PR DESCRIPTION
This was unclear to me and I had to look at the code to figure it out. The API will throw an error without the proper extension. I think we can improve it in 2.1 but for 1.10, we can improve the javadoc.