### PR TITLE
Drop debug logs to trace in ZooLock

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
@@ -222,10 +222,7 @@ public class ZooLock implements Watcher {
         }
       });
     }
-    if (LOG.isTraceEnabled()) {
-      LOG.trace("Children nodes: {}", validChildren.size());
-      validChildren.forEach(c -> LOG.trace("- {}", c));
-    }
+    LOG.trace("Children nodes (size: {}): {}", validChildren.size(), validChildren);
     return validChildren;
   }
 

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
@@ -169,7 +169,7 @@ public class ZooLock implements Watcher {
    */
   public static List<String> validateAndSortChildrenByLockPrefix(String path,
       List<String> children) {
-    LOG.debug("validating and sorting children at path {}", path);
+    LOG.trace("validating and sorting children at path {}", path);
     List<String> validChildren = new ArrayList<>();
     if (null == children || children.size() == 0) {
       return validChildren;
@@ -222,9 +222,9 @@ public class ZooLock implements Watcher {
         }
       });
     }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Children nodes: {}", validChildren.size());
-      validChildren.forEach(c -> LOG.debug("- {}", c));
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Children nodes: {}", validChildren.size());
+      validChildren.forEach(c -> LOG.trace("- {}", c));
     }
     return validChildren;
   }


### PR DESCRIPTION
* Seeing ~300 logs per second per tserver with just these few debug statements