### PR TITLE
Better error message when instance.volumes does not specify the accumulo directory

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
@@ -126,8 +126,8 @@ public class VolumeImpl implements Volume {
     String reason;
     if (basePath.isBlank()) {
       log.error("Basepath is empty. Make sure instance.volumes is set to a correct path");
-      throw new RuntimeException(
-          "Accumulo cannot be initialized because basepath is empty. This probably means instace.volumes is an incorrect value");
+      throw new RuntimeException("Accumulo cannot be initialized because basepath is empty. "
+          + "This probably means instace.volumes is an incorrect value");
     }
 
     if (p.isBlank()) {

--- a/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
@@ -126,8 +126,9 @@ public class VolumeImpl implements Volume {
     String reason;
     if (basePath.isBlank()) {
       log.error("Basepath is empty. Make sure instance.volumes is set to a correct path");
-      throw new IllegalArgumentException("Accumulo cannot be initialized because basepath is empty. "
-          + "This probably means instace.volumes is an incorrect value");
+      throw new IllegalArgumentException(
+          "Accumulo cannot be initialized because basepath is empty. "
+              + "This probably means instace.volumes is an incorrect value");
     }
 
     if (p.isBlank()) {

--- a/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
@@ -124,6 +124,12 @@ public class VolumeImpl implements Volume {
     String p = requireNonNull(pathString).strip();
     p = p.startsWith("/") ? p.substring(1) : p;
     String reason;
+    if (basePath.isBlank()) {
+      log.error("Basepath is empty. Make sure instance.volumes is set to a correct path");
+      throw new RuntimeException(
+          "Accumulo cannot be initialized because basepath is empty. This probably means instace.volumes is an incorrect value");
+    }
+
     if (p.isBlank()) {
       return fs.makeQualified(new Path(basePath));
     } else if (p.startsWith("/")) {

--- a/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
@@ -126,7 +126,7 @@ public class VolumeImpl implements Volume {
     String reason;
     if (basePath.isBlank()) {
       log.error("Basepath is empty. Make sure instance.volumes is set to a correct path");
-      throw new RuntimeException("Accumulo cannot be initialized because basepath is empty. "
+      throw new IllegalArgumentException("Accumulo cannot be initialized because basepath is empty. "
           + "This probably means instace.volumes is an incorrect value");
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -205,7 +205,7 @@ public interface VolumeManager extends AutoCloseable {
       }
       log.debug("Trying to read instance id from {}", instanceDirectory);
       if (files == null || files.length == 0) {
-        log.error("unable obtain instance id at {}", instanceDirectory);
+        log.error("unable to obtain instance id at {}", instanceDirectory);
         throw new RuntimeException(
             "Accumulo not initialized, there is no instance id at " + instanceDirectory);
       } else if (files.length != 1) {


### PR DESCRIPTION
Closes https://issues.apache.org/jira/browse/ACCUMULO-2809 

This no longer throws an NPE  but instead throws :

<details>
<pre>
java.lang.IllegalArgumentException: Can not create a Path from an empty string
	at org.apache.hadoop.fs.Path.checkPathArg(Path.java:172) ~[hadoop-client-api-3.3.0.jar:?]
	at org.apache.hadoop.fs.Path.<init>(Path.java:184) ~[hadoop-client-api-3.3.0.jar:?]
	at org.apache.hadoop.fs.Path.<init>(Path.java:119) ~[hadoop-client-api-3.3.0.jar:?]
	at org.apache.accumulo.core.volume.VolumeImpl.prefixChild(VolumeImpl.java:137) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerConstants.getInstanceIdLocation(ServerConstants.java:175) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerUtil.getAccumuloInstanceIdPath(ServerUtil.java:105) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerInfo.<init>(ServerInfo.java:96) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerContext.<init>(ServerContext.java:71) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.manager.state.SetGoalState.main(SetGoalState.java:47) ~[accumulo-manager-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.apache.accumulo.start.Main.lambda$execMainClass$1(Main.java:163) ~[accumulo-start-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:834) [?:?]
</pre>
</details>

With the change the message is now
<details>
<pre>
java.lang.RuntimeException: Accumulo cannot be initialized because basepath is empty. 
This probably means instace.volumes is an incorrect value
	at org.apache.accumulo.core.volume.VolumeImpl.prefixChild(VolumeImpl.java:129) ~[accumulo-core-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerConstants.getInstanceIdLocation(ServerConstants.java:175) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerUtil.getAccumuloInstanceIdPath(ServerUtil.java:105) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerInfo.<init>(ServerInfo.java:96) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.server.ServerContext.<init>(ServerContext.java:71) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.accumulo.manager.state.SetGoalState.main(SetGoalState.java:47) ~[accumulo-manager-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.apache.accumulo.start.Main.lambda$execMainClass$1(Main.java:163) ~[accumulo-start-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:834) [?:?]

</pre>
</details>

I think this message could be improved and possibly moved if we decide to detect for this specific case earlier in the initialization phase. 