### PR TITLE
Improvements to TabletStateChangeIteratorIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -199,9 +199,10 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
     log.debug("Current state = {}", state);
     scanner.updateScanIteratorOption("tabletChange", "debug", "1");
     for (Entry<Key,Value> e : scanner) {
-      if (e != null)
+      if (e != null) {
         results++;
-      resultList.add(e.getKey());
+        resultList.add(e.getKey());
+      }
     }
     log.debug("Tablets in flux: {}", resultList);
     return results;


### PR DESCRIPTION
* Modified copyTable method to gather info about the metadata first
before creating the copy, preventing information about the copy itself
from being seen.
* Added debugging information