### PR TITLE
Create readTablets method in Ample. Closes #1473

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -269,8 +269,8 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
   }
 
   private TabletMetadata getTabletFiles(Range nextRange) {
-    try (TabletsMetadata tablets = TabletsMetadata.builder().scanMetadataTable()
-        .overRange(nextRange).fetch(FILES, LOCATION, PREV_ROW).build(context)) {
+    try (TabletsMetadata tablets = TabletsMetadata.builder(context).scanMetadataTable()
+        .overRange(nextRange).fetch(FILES, LOCATION, PREV_ROW).build()) {
       return tablets.iterator().next();
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1274,8 +1274,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
       else
         range = new Range(startRow, lastRow);
 
-      TabletsMetadata tablets = TabletsMetadata.builder().scanMetadataTable().overRange(range)
-          .fetch(LOCATION, PREV_ROW).build(context);
+      TabletsMetadata tablets = TabletsMetadata.builder(context).scanMetadataTable()
+          .overRange(range).fetch(LOCATION, PREV_ROW).build();
 
       KeyExtent lastExtent = null;
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -83,8 +83,8 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
 
   @VisibleForTesting
   protected Stream<KeyExtent> lookupExtents(Text row) {
-    return TabletsMetadata.builder().forTable(tableId).overlapping(row, null).checkConsistency()
-        .fetch(PREV_ROW).build(ctx).stream().limit(100).map(TabletMetadata::getExtent);
+    return TabletsMetadata.builder(ctx).forTable(tableId).overlapping(row, null).checkConsistency()
+        .fetch(PREV_ROW).build().stream().limit(100).map(TabletMetadata::getExtent);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -159,7 +159,6 @@ public interface Ample {
    * from a ClientContext. Associated methods of the TabletsMetadata Builder class are used to
    * generate the metadata.
    */
-
   TabletsMetadata.TableOptions readTablets();
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -154,6 +154,15 @@ public interface Ample {
       ColumnType... colsToFetch);
 
   /**
+   * Entry point for reading multiple tablets' metadata. Generates a TabletsMetadata builder object
+   * and assigns the AmpleImpl client to that builder object. This allows readTablets() to be called
+   * from a ClientContext. Associated methods of the TabletsMetadata Builder class are used to
+   * generate the metadata.
+   */
+
+  TabletsMetadata.TableOptions readTablets();
+
+  /**
    * Initiates mutating a single tablets persistent metadata. No data is persisted until the
    * {@code mutate()} method is called on the returned object. If updating multiple tablets,
    * consider using {@link #mutateTablets()}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
@@ -48,8 +48,7 @@ public class AmpleImpl implements Ample {
 
   @Override
   public TabletsMetadata.TableOptions readTablets() {
-    TabletsMetadata.TableOptions builder = TabletsMetadata.builder(this.client);
-    return builder;
+    return TabletsMetadata.builder(this.client);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
@@ -35,14 +35,21 @@ public class AmpleImpl implements Ample {
   @Override
   public TabletMetadata readTablet(KeyExtent extent, ReadConsistency readConsistency,
       ColumnType... colsToFetch) {
-    Options builder = TabletsMetadata.builder().forTablet(extent);
+    Options builder = TabletsMetadata.builder(client).forTablet(extent);
     if (colsToFetch.length > 0)
       builder.fetch(colsToFetch);
 
     builder.readConsistency(readConsistency);
 
-    try (TabletsMetadata tablets = builder.build(client)) {
+    try (TabletsMetadata tablets = builder.build()) {
       return Iterables.getOnlyElement(tablets);
     }
   }
+
+  @Override
+  public TabletsMetadata.TableOptions readTablets() {
+    TabletsMetadata.TableOptions builder = TabletsMetadata.builder(this.client);
+    return builder;
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -93,7 +93,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
     @Override
     public TabletsMetadata build() {
-      Preconditions.checkState((level == null) != (table == null));
+      Preconditions.checkState((level == null) != (table == null),
+          "scanTable() cannot be used in conjunction with forLevel(), forTable() or forTablet()");
       if (level == DataLevel.ROOT) {
         ClientContext ctx = ((ClientContext) _client);
         return new TabletsMetadata(getRootMetadata(ctx, readConsistency));

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -72,7 +72,7 @@ import com.google.common.base.Preconditions;
  */
 public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable {
 
-  private static class Builder implements TableRangeOptions, TableOptions, RangeOptions, Options {
+  public static class Builder implements TableRangeOptions, TableOptions, RangeOptions, Options {
 
     private List<Text> families = new ArrayList<>();
     private List<ColumnFQ> qualifiers = new ArrayList<>();
@@ -85,15 +85,20 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     private boolean saveKeyValues;
     private TableId tableId;
     private ReadConsistency readConsistency = ReadConsistency.IMMEDIATE;
+    private AccumuloClient _client;
+
+    Builder(AccumuloClient client) {
+      this._client = client;
+    }
 
     @Override
-    public TabletsMetadata build(AccumuloClient client) {
-      Preconditions.checkState(level == null ^ table == null);
+    public TabletsMetadata build() {
+      Preconditions.checkState((level == null) != (table == null));
       if (level == DataLevel.ROOT) {
-        ClientContext ctx = ((ClientContext) client);
+        ClientContext ctx = ((ClientContext) _client);
         return new TabletsMetadata(getRootMetadata(ctx, readConsistency));
       } else {
-        return buildNonRoot(client);
+        return buildNonRoot(_client);
       }
     }
 
@@ -257,7 +262,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
   }
 
   public interface Options {
-    TabletsMetadata build(AccumuloClient client);
+
+    TabletsMetadata build();
 
     /**
      * Checks that the metadata table forms a linked list and automatically backs up until it does.
@@ -367,8 +373,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     }
   }
 
-  public static TableOptions builder() {
-    return new Builder();
+  public static TableOptions builder(AccumuloClient client) {
+    return new Builder(client);
   }
 
   private static TabletMetadata getRootMetadata(ClientContext ctx,

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -169,8 +169,8 @@ public class Gatherer {
   private Map<String,Map<TabletFile,List<TRowRange>>>
       getFilesGroupedByLocation(Predicate<TabletFile> fileSelector) {
 
-    Iterable<TabletMetadata> tmi = TabletsMetadata.builder().forTable(tableId)
-        .overlapping(startRow, endRow).fetch(FILES, LOCATION, LAST, PREV_ROW).build(ctx);
+    Iterable<TabletMetadata> tmi = TabletsMetadata.builder(ctx).forTable(tableId)
+        .overlapping(startRow, endRow).fetch(FILES, LOCATION, LAST, PREV_ROW).build();
 
     // get a subset of files
     Map<TabletFile,List<TabletMetadata>> files = new HashMap<>();
@@ -534,8 +534,8 @@ public class Gatherer {
 
   private int countFiles() {
     // TODO use a batch scanner + iterator to parallelize counting files
-    return TabletsMetadata.builder().forTable(tableId).overlapping(startRow, endRow)
-        .fetch(FILES, PREV_ROW).build(ctx).stream().mapToInt(tm -> tm.getFiles().size()).sum();
+    return TabletsMetadata.builder(ctx).forTable(tableId).overlapping(startRow, endRow)
+        .fetch(FILES, PREV_ROW).build().stream().mapToInt(tm -> tm.getFiles().size()).sum();
   }
 
   private class GatherRequest implements Supplier<SummaryCollection> {

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -235,9 +235,9 @@ public class Merge {
     try {
       ClientContext context = (ClientContext) client;
       tableId = Tables.getTableId(context, tablename);
-      tablets = TabletsMetadata.builder().scanMetadataTable()
+      tablets = TabletsMetadata.builder(context).scanMetadataTable()
           .overRange(new KeyExtent(tableId, end, start).toMetaRange()).fetch(FILES, PREV_ROW)
-          .build(context);
+          .build();
     } catch (Exception e) {
       throw new MergeException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
@@ -72,8 +72,8 @@ public class BalancerEnvironmentImpl extends ServiceEnvironmentImpl implements B
   @Override
   public Map<TabletId,TabletServerId> listTabletLocations(TableId tableId) {
     Map<TabletId,TabletServerId> tablets = new LinkedHashMap<>();
-    for (var tm : TabletsMetadata.builder().forTable(tableId).fetch(LOCATION, PREV_ROW)
-        .build(getContext())) {
+    for (var tm : TabletsMetadata.builder(getContext()).forTable(tableId).fetch(LOCATION, PREV_ROW)
+        .build()) {
       tablets.put(new TabletIdImpl(tm.getExtent()),
           TabletServerIdImpl.fromThrift(tm.getLocation()));
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -92,8 +92,8 @@ public abstract class GroupBalancer extends TabletBalancer {
 
   protected Map<KeyExtent,TServerInstance> getLocationProvider() {
     Map<KeyExtent,TServerInstance> tablets = new LinkedHashMap<>();
-    for (var tm : TabletsMetadata.builder().forTable(tableId).fetch(LOCATION, PREV_ROW)
-        .build(context)) {
+    for (var tm : TabletsMetadata.builder(context).forTable(tableId).fetch(LOCATION, PREV_ROW)
+        .build()) {
       tablets.put(tm.getExtent(), tm.getLocation());
     }
     return tablets;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -62,8 +62,8 @@ public class ListVolumesUsed {
     System.out.println("Listing volumes referenced in " + level + " tablets section");
 
     TreeSet<String> volumes = new TreeSet<>();
-    try (TabletsMetadata tablets = TabletsMetadata.builder().forLevel(level)
-        .fetch(TabletMetadata.ColumnType.FILES, TabletMetadata.ColumnType.LOGS).build(context)) {
+    try (TabletsMetadata tablets = TabletsMetadata.builder(context).forLevel(level)
+        .fetch(TabletMetadata.ColumnType.FILES, TabletMetadata.ColumnType.LOGS).build()) {
       for (TabletMetadata tabletMetadata : tablets) {
         tabletMetadata.getFiles().forEach(file -> volumes.add(getTableURI(file.getPathStr())));
         tabletMetadata.getLogs().forEach(le -> getLogURIs(volumes, le));

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -465,8 +465,8 @@ public class MetadataTableUtil {
       range = TabletsSection.getRange(tableId);
     }
 
-    return TabletsMetadata.builder().scanTable(tableName).overRange(range).checkConsistency()
-        .saveKeyValues().fetch(FILES, LOCATION, LAST, CLONED, PREV_ROW, TIME).build(client);
+    return TabletsMetadata.builder(client).scanTable(tableName).overRange(range).checkConsistency()
+        .saveKeyValues().fetch(FILES, LOCATION, LAST, CLONED, PREV_ROW, TIME).build();
   }
 
   @VisibleForTesting

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.metadata.TabletMutatorBase;
 import org.junit.Test;
@@ -55,6 +56,11 @@ public class RootTabletStateStoreTest {
         ColumnType... colsToFetch) {
       Preconditions.checkArgument(extent.equals(RootTable.EXTENT));
       return RootTabletMetadata.fromJson(json).convertToTabletMetadata();
+    }
+
+    @Override
+    public TabletsMetadata.TableOptions readTablets() {
+      throw new UnsupportedOperationException("This method should be implemented in subclasses");
     }
 
     @Override

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -259,8 +259,8 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
         tabletStream =
             Stream.of(getContext().getAmple().readTablet(RootTable.EXTENT, DIR, FILES, SCANS));
       } else {
-        tabletStream = TabletsMetadata.builder().scanTable(level.metaTable()).checkConsistency()
-            .fetch(DIR, FILES, SCANS).build(getContext()).stream();
+        tabletStream = TabletsMetadata.builder(getContext()).scanTable(level.metaTable())
+            .checkConsistency().fetch(DIR, FILES, SCANS).build().stream();
       }
 
       Stream<Reference> refStream = tabletStream.flatMap(tm -> {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -181,9 +181,8 @@ public class ManagerClientServiceHandler extends FateServiceHandler
 
       serversToFlush.clear();
 
-      try (TabletsMetadata tablets =
-          TabletsMetadata.builder().forTable(tableId).overlapping(startRow, endRow)
-              .fetch(FLUSH_ID, LOCATION, LOGS, PREV_ROW).build(manager.getContext())) {
+      try (TabletsMetadata tablets = TabletsMetadata.builder(manager.getContext()).forTable(tableId)
+          .overlapping(startRow, endRow).fetch(FLUSH_ID, LOCATION, LOGS, PREV_ROW).build()) {
         int tabletsToWaitFor = 0;
         int tabletCount = 0;
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -323,8 +323,8 @@ class LoadFiles extends ManagerRepo {
     Text startRow = loadMapEntry.getKey().prevEndRow();
 
     Iterator<TabletMetadata> tabletIter =
-        TabletsMetadata.builder().forTable(tableId).overlapping(startRow, null).checkConsistency()
-            .fetch(PREV_ROW, LOCATION, LOADED).build(manager.getContext()).iterator();
+        TabletsMetadata.builder(manager.getContext()).forTable(tableId).overlapping(startRow, null)
+            .checkConsistency().fetch(PREV_ROW, LOCATION, LOADED).build().iterator();
 
     Loader loader;
     if (bulkInfo.tableState == TableState.ONLINE) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImport.java
@@ -191,9 +191,10 @@ public class PrepBulkImport extends ManagerRepo {
     try (LoadMappingIterator lmi =
         BulkSerialize.readLoadMapping(bulkDir.toString(), bulkInfo.tableId, fs::open)) {
 
-      TabletIterFactory tabletIterFactory = startRow -> TabletsMetadata.builder()
-          .forTable(bulkInfo.tableId).overlapping(startRow, null).checkConsistency().fetch(PREV_ROW)
-          .build(manager.getContext()).stream().map(TabletMetadata::getExtent).iterator();
+      TabletIterFactory tabletIterFactory =
+          startRow -> TabletsMetadata.builder(manager.getContext()).forTable(bulkInfo.tableId)
+              .overlapping(startRow, null).checkConsistency().fetch(PREV_ROW).build().stream()
+              .map(TabletMetadata::getExtent).iterator();
 
       sanityCheckLoadMapping(bulkInfo.tableId.canonical(), lmi, tabletIterFactory, maxTablets, tid);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -88,9 +88,8 @@ class CompactionDriver extends ManagerRepo {
     int tabletsToWaitFor = 0;
     int tabletCount = 0;
 
-    TabletsMetadata tablets =
-        TabletsMetadata.builder().forTable(tableId).overlapping(startRow, endRow)
-            .fetch(LOCATION, PREV_ROW, COMPACT_ID).build(manager.getContext());
+    TabletsMetadata tablets = TabletsMetadata.builder(manager.getContext()).forTable(tableId)
+        .overlapping(startRow, endRow).fetch(LOCATION, PREV_ROW, COMPACT_ID).build();
 
     for (TabletMetadata tablet : tablets) {
       if (tablet.getCompactId().orElse(-1) < compactId) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -234,7 +234,7 @@ public class ListTabletsCommand extends Command {
     final ClientContext context = shellState.getContext();
     Set<TServerInstance> liveTserverSet = TabletMetadata.getLiveTServers(context);
 
-    try (var tabletsMetadata = TabletsMetadata.builder().forTable(tableInfo.id).build(context)) {
+    try (var tabletsMetadata = TabletsMetadata.builder(context).forTable(tableInfo.id).build()) {
       for (var md : tabletsMetadata) {
         TabletRowInfo.Factory factory = new TabletRowInfo.Factory(tableInfo.name, md.getExtent());
         var fileMap = md.getFilesMap();

--- a/test/src/main/java/org/apache/accumulo/test/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CompactionExecutorIT.java
@@ -546,7 +546,7 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     var tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
 
     try (var tabletsMeta =
-        TabletsMetadata.builder().forTable(tableId).fetch(ColumnType.FILES).build(client)) {
+        TabletsMetadata.builder(client).forTable(tableId).fetch(ColumnType.FILES).build()) {
       return tabletsMeta.stream().flatMap(tm -> tm.getFiles().stream()).mapToLong(stf -> {
         try {
           return FileSystem.getLocal(new Configuration()).getFileStatus(stf.getPath()).getLen();
@@ -614,7 +614,7 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
     var tableId = TableId.of(client.tableOperations().tableIdMap().get(name));
 
     try (var tabletsMeta =
-        TabletsMetadata.builder().forTable(tableId).fetch(ColumnType.FILES).build(client)) {
+        TabletsMetadata.builder(client).forTable(tableId).fetch(ColumnType.FILES).build()) {
       return tabletsMeta.stream().flatMap(tm -> tm.getFiles().stream())
           .map(StoredTabletFile::getFileName).collect(Collectors.toSet());
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -46,14 +46,10 @@ import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.After;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 
 public class AccumuloClientIT extends AccumuloClusterHarness {
-
-  Logger log = LoggerFactory.getLogger(AccumuloClientIT.class);
 
   @After
   public void deleteUsers() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -46,10 +46,14 @@ import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.After;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 
 public class AccumuloClientIT extends AccumuloClusterHarness {
+
+  Logger log = LoggerFactory.getLogger(AccumuloClientIT.class);
 
   @After
   public void deleteUsers() throws Exception {
@@ -242,6 +246,5 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
     expectClosed(() -> tops.create("expectFail"));
     expectClosed(() -> tops.cancelCompaction(tableName));
     expectClosed(() -> tops.listSplits(tableName));
-
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -513,8 +513,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
     Set<String> endRowsSeen = new HashSet<>();
 
     String id = client.tableOperations().tableIdMap().get(tableName);
-    try (TabletsMetadata tablets = TabletsMetadata.builder().forTable(TableId.of(id))
-        .fetch(FILES, LOADED, PREV_ROW).build(client)) {
+    try (TabletsMetadata tablets = TabletsMetadata.builder(client).forTable(TableId.of(id))
+        .fetch(FILES, LOADED, PREV_ROW).build()) {
       for (TabletMetadata tablet : tablets) {
         assertTrue(tablet.getLoaded().isEmpty());
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -18,6 +18,10 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LAST;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
+import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -35,21 +39,27 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 
 public class MetadataIT extends AccumuloClusterHarness {
@@ -154,6 +164,69 @@ public class MetadataIT extends AccumuloClusterHarness {
         }
         assertTrue(count > 0);
       }
+    }
+  }
+
+  @Test
+  public void testAmpleReadTablets() throws Exception {
+
+    try (AccumuloClient accumuloClient = Accumulo.newClient().from(getClientProps()).build()) {
+      accumuloClient.securityOperations().grantTablePermission(accumuloClient.whoami(),
+          MetadataTable.NAME, TablePermission.WRITE);
+
+      ClientContext cc = (ClientContext) accumuloClient;
+
+      SortedSet<Text> partitionKeys = new TreeSet<Text>();
+      partitionKeys.add(new Text("a"));
+      partitionKeys.add(new Text("e"));
+      partitionKeys.add(new Text("j"));
+
+      cc.tableOperations().create("t");
+      cc.tableOperations().addSplits("t", partitionKeys);
+
+      Text startRow = new Text("a");
+      Text endRow = new Text("z");
+
+      // Call up Ample from the client context using table "t" and build
+      TabletsMetadata tablets = cc.getAmple().readTablets().forTable(TableId.of("1"))
+          .overlapping(startRow, endRow).fetch(FILES, LOCATION, LAST, PREV_ROW).build();
+
+      TabletMetadata tabletMetadata0 = Iterables.get(tablets, 0);
+      TabletMetadata tabletMetadata1 = Iterables.get(tablets, 1);
+
+      String infoTabletId0 = tabletMetadata0.getTableId().toString();
+      String infoExtent0 = tabletMetadata0.getExtent().toString();
+      String infoPrevEndRow0 = tabletMetadata0.getPrevEndRow().toString();
+      String infoEndRow0 = tabletMetadata0.getEndRow().toString();
+
+      String infoTabletId1 = tabletMetadata1.getTableId().toString();
+      String infoExtent1 = tabletMetadata1.getExtent().toString();
+      String infoPrevEndRow1 = tabletMetadata1.getPrevEndRow().toString();
+      String infoEndRow1 = tabletMetadata1.getEndRow().toString();
+
+      String testInfoTableId = "1";
+
+      String testInfoKeyExtent0 = "1;e;a";
+      String testInfoKeyExtent1 = "1;j;e";
+
+      String testInfoPrevEndRow0 = "a";
+      String testInfoPrevEndRow1 = "e";
+
+      String testInfoEndRow0 = "e";
+      String testInfoEndRow1 = "j";
+
+      assertEquals(infoTabletId0, testInfoTableId);
+      assertEquals(infoTabletId1, testInfoTableId);
+
+      assertEquals(infoExtent0, testInfoKeyExtent0);
+      assertEquals(infoExtent1, testInfoKeyExtent1);
+
+      assertEquals(infoPrevEndRow0, testInfoPrevEndRow0);
+      assertEquals(infoPrevEndRow1, testInfoPrevEndRow1);
+
+      assertEquals(infoEndRow0, testInfoEndRow0);
+      assertEquals(infoEndRow1, testInfoEndRow1);
+
     }
   }
 }


### PR DESCRIPTION
* Modify TabletsMetadata to impl readTablets in Ample
* Modify classes calling TabletsMetadata to pass the client object as
part of the builder init, instead of the final build method
* Add testAmpleReadTablets to MetadataIT

Co-authored-by: cradal <20303105+cradal@users.noreply.github.com>

Updated version of #1651 