### PR TITLE
Increase difference between test values. Fixes #1789

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class LargestFirstMemoryManager {
 
   private static final Logger log = LoggerFactory.getLogger(LargestFirstMemoryManager.class);
-  private static final long ZERO_TIME = System.currentTimeMillis();
+  static final long ZERO_TIME = System.currentTimeMillis();
   private static final int TSERV_MINC_MAXCONCURRENT_NUMWAITING_MULTIPLIER = 2;
   private static final double MAX_FLUSH_AT_ONCE_PERCENT = 0.20;
 


### PR DESCRIPTION
* Increases the difference between the large memory values used in the
test so the likelihood of tablets getting keyed at the same
timeMemoryLoad is much less
* Also set the ZERO_TIME of LargestFirstMemoryManagerTest equal to
LargestFirstMemoryManager to prevent different times between classes
loading