### PR TITLE
Use stronger crypto settings for test certificates

### DIFF
--- a/test/src/main/java/org/apache/accumulo/harness/MiniClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/MiniClusterHarness.java
@@ -156,10 +156,9 @@ public class MiniClusterHarness {
         truststorePassword = "truststore_password";
     try {
       new CertUtils(Property.RPC_SSL_KEYSTORE_TYPE.getDefaultValue(),
-          "o=Apache Accumulo,cn=MiniAccumuloCluster", "RSA", 2048, "sha1WithRSAEncryption")
-              .createAll(rootKeystoreFile, localKeystoreFile, publicTruststoreFile,
-                  cfg.getInstanceName(), rootKeystorePassword, cfg.getRootPassword(),
-                  truststorePassword);
+          "o=Apache Accumulo,cn=MiniAccumuloCluster", "RSA", 4096, "SHA512WITHRSA").createAll(
+              rootKeystoreFile, localKeystoreFile, publicTruststoreFile, cfg.getInstanceName(),
+              rootKeystorePassword, cfg.getRootPassword(), truststorePassword);
     } catch (Exception e) {
       throw new RuntimeException("error creating MAC keystore", e);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableMacBase.java
@@ -100,7 +100,7 @@ public class ConfigurableMacBase extends AccumuloITBase {
     try {
       String hostname = InetAddress.getLocalHost().getHostName();
       new CertUtils(Property.RPC_SSL_KEYSTORE_TYPE.getDefaultValue(),
-          "o=Apache Accumulo,cn=" + hostname, "RSA", 2048, "sha1WithRSAEncryption").createAll(
+          "o=Apache Accumulo,cn=" + hostname, "RSA", 4096, "SHA512WITHRSA").createAll(
               rootKeystoreFile, localKeystoreFile, publicTruststoreFile, cfg.getInstanceName(),
               rootKeystorePassword, cfg.getRootPassword(), truststorePassword);
     } catch (Exception e) {

--- a/test/src/main/java/org/apache/accumulo/test/util/CertUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/CertUtils.java
@@ -117,14 +117,14 @@ public class CertUtils {
     public String accumuloPropsFile = null;
 
     @Parameter(names = "--signing-algorithm", description = "Algorithm used to sign certificates")
-    public String signingAlg = "SHA256WITHRSA";
+    public String signingAlg = "SHA512WITHRSA";
 
     @Parameter(names = "--encryption-algorithm",
         description = "Algorithm used to encrypt private keys")
     public String encryptionAlg = "RSA";
 
     @Parameter(names = "--keysize", description = "Key size used by encryption algorithm")
-    public int keysize = 2048;
+    public int keysize = 4096;
 
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")
     public SiteConfiguration getSiteConfiguration() {

--- a/test/src/test/java/org/apache/accumulo/test/util/CertUtilsTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/util/CertUtilsTest.java
@@ -45,7 +45,7 @@ public class CertUtilsTest {
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
   private CertUtils getUtils() {
-    return new CertUtils(KEYSTORE_TYPE, RDN_STRING, "RSA", 2048, "sha1WithRSAEncryption");
+    return new CertUtils(KEYSTORE_TYPE, RDN_STRING, "RSA", 4096, "SHA512WITHRSA");
   }
 
   @SuppressFBWarnings(value = "HARD_CODE_PASSWORD", justification = "test password is okay")


### PR DESCRIPTION
* Use 4096 bit RSA keys and SHA512withRSA instead of SHA1withRSA for the
  certificate signing algorithm for certificates generated for testing
  Accumulo's TLS support
* This avoids problems with test breakages in environments, such as
  Fedora 33, with strong default crypto policies for Java that restrict
  weak crypto, or if the user has restricted their Java security
  policies themselves