### PR TITLE
Return a Dispatch object from Dispatchers

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/ScanCacheProvider.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/ScanCacheProvider.java
@@ -21,16 +21,16 @@ package org.apache.accumulo.core.file.blockfile.impl;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.spi.cache.BlockCache;
-import org.apache.accumulo.core.spi.scan.ScanDirectives;
+import org.apache.accumulo.core.spi.scan.ScanDispatch;
 
 public class ScanCacheProvider implements CacheProvider {
 
   private final BlockCache indexCache;
   private final BlockCache dataCache;
 
-  public ScanCacheProvider(AccumuloConfiguration tableConfig, ScanDirectives directives,
+  public ScanCacheProvider(AccumuloConfiguration tableConfig, ScanDispatch dispatch,
       BlockCache indexCache, BlockCache dataCache) {
-    switch (directives.getIndexCacheUsage()) {
+    switch (dispatch.getIndexCacheUsage()) {
       case ENABLED:
         this.indexCache = indexCache;
         break;
@@ -48,7 +48,7 @@ public class ScanCacheProvider implements CacheProvider {
         throw new IllegalStateException();
     }
 
-    switch (directives.getDataCacheUsage()) {
+    switch (dispatch.getDataCacheUsage()) {
       case ENABLED:
         this.dataCache = dataCache;
         break;

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatch.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatch.java
@@ -18,31 +18,38 @@
  */
 package org.apache.accumulo.core.spi.compaction;
 
-import java.util.Objects;
-
 /**
- * This class intentionally package private.
+ * The dispatch of a {@link CompactionDispatcher}
+ *
+ * @since 2.1.0
+ * @see org.apache.accumulo.core.spi.compaction
  */
-class CompactionDirectivesBuilder
-    implements CompactionDirectives.Builder, CompactionDirectives.ServiceBuilder {
+public interface CompactionDispatch {
 
-  private CompactionServiceId service;
+  /**
+   * @return The service where a compaction should run.
+   */
+  CompactionServiceId getService();
 
-  @Override
-  public CompactionDirectives.Builder toService(CompactionServiceId service) {
-    this.service = Objects.requireNonNull(service, "CompactionServiceId cannot be null");
-    return this;
+  /**
+   * Required service parameter for {@link CompactionDispatch}
+   *
+   * @since 2.1.0
+   */
+  interface ServiceBuilder {
+    Builder toService(CompactionServiceId service);
+
+    Builder toService(String compactionServiceId);
   }
 
-  @Override
-  public CompactionDirectives.Builder toService(String compactionServiceId) {
-    this.service = CompactionServiceId.of(compactionServiceId);
-    return this;
+  /**
+   * @since 2.1.0
+   */
+  interface Builder {
+    CompactionDispatch build();
   }
 
-  @Override
-  public CompactionDirectives build() {
-    return new CompactionDirectivesImpl(service);
+  static ServiceBuilder builder() {
+    return new CompactionDispatchBuilder();
   }
-
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatchBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatchBuilder.java
@@ -18,25 +18,31 @@
  */
 package org.apache.accumulo.core.spi.compaction;
 
+import java.util.Objects;
+
 /**
- * This class intentionally package private. It is immutable and provides default allocation for
- * {@code CompactionDirectives}.
+ * This class intentionally package private.
  */
-class CompactionDirectivesImpl implements CompactionDirectives {
+class CompactionDispatchBuilder
+    implements CompactionDispatch.Builder, CompactionDispatch.ServiceBuilder {
 
-  private final CompactionServiceId service;
+  private CompactionServiceId service;
 
-  public CompactionDirectivesImpl(CompactionServiceId service) {
-    this.service = service;
+  @Override
+  public CompactionDispatch.Builder toService(CompactionServiceId service) {
+    this.service = Objects.requireNonNull(service, "CompactionServiceId cannot be null");
+    return this;
   }
 
   @Override
-  public CompactionServiceId getService() {
-    return service;
+  public CompactionDispatch.Builder toService(String compactionServiceId) {
+    this.service = CompactionServiceId.of(compactionServiceId);
+    return this;
   }
 
   @Override
-  public String toString() {
-    return "service=" + service;
+  public CompactionDispatch build() {
+    return new CompactionDispatchImpl(service);
   }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatchImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatchImpl.java
@@ -19,37 +19,24 @@
 package org.apache.accumulo.core.spi.compaction;
 
 /**
- * The directions of a {@link CompactionDispatcher}
- *
- * @since 2.1.0
- * @see org.apache.accumulo.core.spi.compaction
+ * This class intentionally package private. It is immutable and provides default allocation for
+ * {@link CompactionDispatch}.
  */
-public interface CompactionDirectives {
+class CompactionDispatchImpl implements CompactionDispatch {
 
-  /**
-   * @return The service where a compaction should run.
-   */
-  CompactionServiceId getService();
+  private final CompactionServiceId service;
 
-  /**
-   * Required for CompactionDirectives
-   *
-   * @since 2.1.0
-   */
-  interface ServiceBuilder {
-    Builder toService(CompactionServiceId service);
-
-    Builder toService(String compactionServiceId);
+  public CompactionDispatchImpl(CompactionServiceId service) {
+    this.service = service;
   }
 
-  /**
-   * @since 2.1.0
-   */
-  interface Builder {
-    CompactionDirectives build();
+  @Override
+  public CompactionServiceId getService() {
+    return service;
   }
 
-  static ServiceBuilder builder() {
-    return new CompactionDirectivesBuilder();
+  @Override
+  public String toString() {
+    return "service=" + service;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionDispatcher.java
@@ -87,5 +87,5 @@ public interface CompactionDispatcher {
   /**
    * Accumulo calls this method for compactions to determine what service to use.
    */
-  CompactionDirectives dispatch(DispatchParameters params);
+  CompactionDispatch dispatch(DispatchParameters params);
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/SimpleCompactionDispatcher.java
@@ -65,18 +65,18 @@ import org.apache.accumulo.core.client.admin.CompactionConfig;
 
 public class SimpleCompactionDispatcher implements CompactionDispatcher {
 
-  private Map<CompactionKind,CompactionDirectives> services;
-  private Map<String,CompactionDirectives> userServices;
+  private Map<CompactionKind,CompactionDispatch> services;
+  private Map<String,CompactionDispatch> userServices;
 
   @Override
   public void init(InitParameters params) {
     services = new EnumMap<>(CompactionKind.class);
 
-    var defaultService = CompactionDirectives.builder().toService("default").build();
+    var defaultService = CompactionDispatch.builder().toService("default").build();
 
     if (params.getOptions().containsKey("service")) {
       defaultService =
-          CompactionDirectives.builder().toService(params.getOptions().get("service")).build();
+          CompactionDispatch.builder().toService(params.getOptions().get("service")).build();
     }
 
     for (CompactionKind ctype : CompactionKind.values()) {
@@ -84,17 +84,17 @@ public class SimpleCompactionDispatcher implements CompactionDispatcher {
       if (service == null)
         services.put(ctype, defaultService);
       else
-        services.put(ctype, CompactionDirectives.builder().toService(service).build());
+        services.put(ctype, CompactionDispatch.builder().toService(service).build());
     }
 
     if (params.getOptions().isEmpty()) {
       userServices = Map.of();
     } else {
-      Map<String,CompactionDirectives> tmpUS = new HashMap<>();
+      Map<String,CompactionDispatch> tmpUS = new HashMap<>();
       params.getOptions().forEach((k, v) -> {
         if (k.startsWith("service.user.")) {
           String type = k.substring("service.user.".length());
-          tmpUS.put(type, CompactionDirectives.builder().toService(v).build());
+          tmpUS.put(type, CompactionDispatch.builder().toService(v).build());
         }
       });
 
@@ -103,14 +103,14 @@ public class SimpleCompactionDispatcher implements CompactionDispatcher {
   }
 
   @Override
-  public CompactionDirectives dispatch(DispatchParameters params) {
+  public CompactionDispatch dispatch(DispatchParameters params) {
 
     if (params.getCompactionKind() == CompactionKind.USER) {
       String hintType = params.getExecutionHints().get("compaction_type");
       if (hintType != null) {
-        var userDirectives = userServices.get(hintType);
-        if (userDirectives != null) {
-          return userDirectives;
+        var userDispatch = userServices.get(hintType);
+        if (userDispatch != null) {
+          return userDispatch;
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/DefaultScanDispatch.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/DefaultScanDispatch.java
@@ -23,34 +23,33 @@ package org.apache.accumulo.core.spi.scan;
  *
  * <p>
  * The purpose of this class is to avoid any object creation in the case where
- * {@code ScanDirectives.builder().build()} is called.
+ * {@code ScanDispatch.builder().build()} is called.
  */
-class DefaultScanDirectives extends ScanDirectivesImpl {
+class DefaultScanDispatch extends ScanDispatchImpl {
 
-  static DefaultScanDirectives DEFAULT_SCAN_DIRECTIVES = new DefaultScanDirectives();
+  static DefaultScanDispatch DEFAULT_SCAN_DISPATCH = new DefaultScanDispatch();
 
-  private DefaultScanDirectives() {
-    super();
+  private DefaultScanDispatch() {
     super.build();
   }
 
   @Override
   public Builder setExecutorName(String name) {
-    return new ScanDirectivesImpl().setExecutorName(name);
+    return new ScanDispatchImpl().setExecutorName(name);
   }
 
   @Override
   public Builder setIndexCacheUsage(CacheUsage usage) {
-    return new ScanDirectivesImpl().setIndexCacheUsage(usage);
+    return new ScanDispatchImpl().setIndexCacheUsage(usage);
   }
 
   @Override
   public Builder setDataCacheUsage(CacheUsage usage) {
-    return new ScanDirectivesImpl().setDataCacheUsage(usage);
+    return new ScanDispatchImpl().setDataCacheUsage(usage);
   }
 
   @Override
-  public ScanDirectives build() {
+  public ScanDispatch build() {
     return this;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatch.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatch.java
@@ -23,11 +23,11 @@ import org.apache.accumulo.core.spi.scan.ScanDispatcher.DispatchParameters;
 /**
  * Encapsulates information about how a scan should be executed. This is the return type for
  * {@link ScanDispatcher#dispatch(DispatchParameters)}. To create an instance of this use
- * {@link ScanDirectives#builder()}
+ * {@link ScanDispatch#builder()}
  *
  * @since 2.1.0
  */
-public interface ScanDirectives {
+public interface ScanDispatch {
 
   /**
    * Communicates how a scan should use cache.
@@ -95,15 +95,15 @@ public interface ScanDirectives {
     public Builder setDataCacheUsage(CacheUsage usage);
 
     /**
-     * @return an immutable {@link ScanDirectives} object.
+     * @return an immutable {@link ScanDispatch} object.
      */
-    public ScanDirectives build();
+    public ScanDispatch build();
   }
 
   /**
-   * @return a {@link ScanDirectives} builder
+   * @return a {@link ScanDispatch} builder
    */
   public static Builder builder() {
-    return DefaultScanDirectives.DEFAULT_SCAN_DIRECTIVES;
+    return DefaultScanDispatch.DEFAULT_SCAN_DISPATCH;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatchImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatchImpl.java
@@ -20,17 +20,17 @@ package org.apache.accumulo.core.spi.scan;
 
 import java.util.Objects;
 
-import org.apache.accumulo.core.spi.scan.ScanDirectives.Builder;
+import org.apache.accumulo.core.spi.scan.ScanDispatch.Builder;
 
 import com.google.common.base.Preconditions;
 
 /**
  * This class is intentionally package private. Do not make public!
  */
-class ScanDirectivesImpl implements ScanDirectives, Builder {
+class ScanDispatchImpl implements ScanDispatch, Builder {
 
-  // The purpose of this is to allow building an immutable ScanDirectives object without creating
-  // separate Builder and ScanDirectives objects. This is done to reduce object creation and
+  // The purpose of this is to allow building an immutable ScanDispatch object without creating
+  // separate Builder and ScanDispatch objects. This is done to reduce object creation and
   // copying. This could easily be changed to two objects without changing the interfaces.
   private boolean built = false;
 
@@ -38,7 +38,7 @@ class ScanDirectivesImpl implements ScanDirectives, Builder {
   private CacheUsage indexCacheUsage;
   private CacheUsage dataCacheUsage;
 
-  ScanDirectivesImpl() {
+  ScanDispatchImpl() {
     executorName = SimpleScanDispatcher.DEFAULT_SCAN_EXECUTOR_NAME;
     indexCacheUsage = CacheUsage.TABLE;
     dataCacheUsage = CacheUsage.TABLE;
@@ -58,7 +58,7 @@ class ScanDirectivesImpl implements ScanDirectives, Builder {
   }
 
   @Override
-  public ScanDirectives build() {
+  public ScanDispatch build() {
     Preconditions.checkState(!built);
     built = true;
     return this;

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatcher.java
@@ -116,11 +116,11 @@ public interface ScanDispatcher {
    * @since 2.1.0
    */
 
-  default ScanDirectives dispatch(DispatchParameters params) {
+  default ScanDispatch dispatch(DispatchParameters params) {
     String executor = dispatch((DispatchParmaters) params);
-    if (executor.equals(DefaultScanDirectives.DEFAULT_SCAN_DIRECTIVES.getExecutorName()))
-      return DefaultScanDirectives.DEFAULT_SCAN_DIRECTIVES;
+    if (executor.equals(DefaultScanDispatch.DEFAULT_SCAN_DISPATCH.getExecutorName()))
+      return DefaultScanDispatch.DEFAULT_SCAN_DISPATCH;
 
-    return ScanDirectives.builder().setExecutorName(executor).build();
+    return ScanDispatch.builder().setExecutorName(executor).build();
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcher.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.accumulo.core.client.ScannerBase;
-import org.apache.accumulo.core.spi.scan.ScanDirectives.CacheUsage;
+import org.apache.accumulo.core.spi.scan.ScanDispatch.CacheUsage;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -61,9 +61,9 @@ public class SimpleScanDispatcher implements ScanDispatcher {
 
   private final Set<String> VALID_OPTS = Set.of("executor", "multi_executor", "single_executor");
 
-  private ScanDirectives singleDirectives;
-  private ScanDirectives multiDirectives;
-  private Map<String,Map<ScanInfo.Type,ScanDirectives>> hintDirectives;
+  private ScanDispatch singleDispatch;
+  private ScanDispatch multiDispatch;
+  private Map<String,Map<ScanInfo.Type,ScanDispatch>> hintDispatch;
 
   private static Pattern CACHE_PATTERN = Pattern.compile("cacheUsage[.](\\w+)([.](index|data))?");
 
@@ -106,60 +106,60 @@ public class SimpleScanDispatcher implements ScanDispatcher {
       }
     });
 
-    // This method pre-computes all possible scan directives objects that could ever be needed.
+    // This method pre-computes all possible scan dispatch objects that could ever be needed.
     // This is done to make the dispatch method more efficient. If the number of config permutations
     // grows, this approach may have to be abandoned. For now its tractable.
 
-    ScanDirectives baseDirectives = Optional.ofNullable(options.get("executor"))
-        .map(name -> ScanDirectives.builder().setExecutorName(name).build())
-        .orElse(DefaultScanDirectives.DEFAULT_SCAN_DIRECTIVES);
-    singleDirectives = Optional.ofNullable(options.get("single_executor"))
-        .map(name -> ScanDirectives.builder().setExecutorName(name).build()).orElse(baseDirectives);
-    multiDirectives = Optional.ofNullable(options.get("multi_executor"))
-        .map(name -> ScanDirectives.builder().setExecutorName(name).build()).orElse(baseDirectives);
+    ScanDispatch baseDispatch = Optional.ofNullable(options.get("executor"))
+        .map(name -> ScanDispatch.builder().setExecutorName(name).build())
+        .orElse(DefaultScanDispatch.DEFAULT_SCAN_DISPATCH);
+    singleDispatch = Optional.ofNullable(options.get("single_executor"))
+        .map(name -> ScanDispatch.builder().setExecutorName(name).build()).orElse(baseDispatch);
+    multiDispatch = Optional.ofNullable(options.get("multi_executor"))
+        .map(name -> ScanDispatch.builder().setExecutorName(name).build()).orElse(baseDispatch);
 
-    var stpb = ImmutableMap.<String,Map<ScanInfo.Type,ScanDirectives>>builder();
+    var stpb = ImmutableMap.<String,Map<ScanInfo.Type,ScanDispatch>>builder();
 
     for (String hintScanType : hintScanTypes) {
-      EnumMap<ScanInfo.Type,ScanDirectives> precomupted = new EnumMap<>(ScanInfo.Type.class);
+      EnumMap<ScanInfo.Type,ScanDispatch> precomupted = new EnumMap<>(ScanInfo.Type.class);
 
-      precomupted.put(ScanInfo.Type.SINGLE, ScanDirectives.builder()
+      precomupted.put(ScanInfo.Type.SINGLE, ScanDispatch.builder()
           .setExecutorName(
-              scanExecutors.getOrDefault(hintScanType, singleDirectives.getExecutorName()))
+              scanExecutors.getOrDefault(hintScanType, singleDispatch.getExecutorName()))
           .setIndexCacheUsage(indexCacheUsage.getOrDefault(hintScanType, CacheUsage.TABLE))
           .setDataCacheUsage(dataCacheUsage.getOrDefault(hintScanType, CacheUsage.TABLE)).build());
 
-      precomupted.put(ScanInfo.Type.MULTI, ScanDirectives.builder()
+      precomupted.put(ScanInfo.Type.MULTI, ScanDispatch.builder()
           .setExecutorName(
-              scanExecutors.getOrDefault(hintScanType, multiDirectives.getExecutorName()))
+              scanExecutors.getOrDefault(hintScanType, multiDispatch.getExecutorName()))
           .setIndexCacheUsage(indexCacheUsage.getOrDefault(hintScanType, CacheUsage.TABLE))
           .setDataCacheUsage(dataCacheUsage.getOrDefault(hintScanType, CacheUsage.TABLE)).build());
 
       stpb.put(hintScanType, precomupted);
     }
 
-    hintDirectives = stpb.build();
+    hintDispatch = stpb.build();
   }
 
   @Override
-  public ScanDirectives dispatch(DispatchParameters params) {
+  public ScanDispatch dispatch(DispatchParameters params) {
     ScanInfo scanInfo = params.getScanInfo();
 
-    if (!hintDirectives.isEmpty()) {
+    if (!hintDispatch.isEmpty()) {
       String hintScanType = scanInfo.getExecutionHints().get("scan_type");
       if (hintScanType != null) {
-        var precomputedDirectives = hintDirectives.get(hintScanType);
-        if (precomputedDirectives != null) {
-          return precomputedDirectives.get(scanInfo.getScanType());
+        var precomputedDispatch = hintDispatch.get(hintScanType);
+        if (precomputedDispatch != null) {
+          return precomputedDispatch.get(scanInfo.getScanType());
         }
       }
     }
 
     switch (scanInfo.getScanType()) {
       case MULTI:
-        return multiDirectives;
+        return multiDispatch;
       case SINGLE:
-        return singleDirectives;
+        return singleDispatch;
       default:
         throw new IllegalArgumentException("Unexpected scan type " + scanInfo.getScanType());
     }

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcherTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/SimpleScanDispatcherTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.core.spi.scan;
 
-import static org.apache.accumulo.core.spi.scan.ScanDirectives.CacheUsage.DISABLED;
-import static org.apache.accumulo.core.spi.scan.ScanDirectives.CacheUsage.ENABLED;
-import static org.apache.accumulo.core.spi.scan.ScanDirectives.CacheUsage.OPPORTUNISTIC;
-import static org.apache.accumulo.core.spi.scan.ScanDirectives.CacheUsage.TABLE;
+import static org.apache.accumulo.core.spi.scan.ScanDispatch.CacheUsage.DISABLED;
+import static org.apache.accumulo.core.spi.scan.ScanDispatch.CacheUsage.ENABLED;
+import static org.apache.accumulo.core.spi.scan.ScanDispatch.CacheUsage.OPPORTUNISTIC;
+import static org.apache.accumulo.core.spi.scan.ScanDispatch.CacheUsage.TABLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -32,7 +32,7 @@ import java.util.Map;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
-import org.apache.accumulo.core.spi.scan.ScanDirectives.CacheUsage;
+import org.apache.accumulo.core.spi.scan.ScanDispatch.CacheUsage;
 import org.apache.accumulo.core.spi.scan.ScanDispatcher.DispatchParameters;
 import org.apache.accumulo.core.spi.scan.ScanInfo.Type;
 import org.junit.Test;
@@ -105,12 +105,12 @@ public class SimpleScanDispatcherTest {
     executors.put("E2", null);
     executors.put("E3", null);
 
-    ScanDirectives multiPrefs = ssd1.dispatch(new DispatchParametersImps(msi, executors));
+    ScanDispatch multiPrefs = ssd1.dispatch(new DispatchParametersImps(msi, executors));
     assertEquals(expectedMulti, multiPrefs.getExecutorName());
     assertEquals(expectedIndexCU, multiPrefs.getIndexCacheUsage());
     assertEquals(expectedDataCU, multiPrefs.getDataCacheUsage());
 
-    ScanDirectives singlePrefs = ssd1.dispatch(new DispatchParametersImps(ssi, executors));
+    ScanDispatch singlePrefs = ssd1.dispatch(new DispatchParametersImps(ssi, executors));
     assertEquals(expectedSingle, singlePrefs.getExecutorName());
     assertEquals(expectedIndexCU, singlePrefs.getIndexCacheUsage());
     assertEquals(expectedDataCU, singlePrefs.getDataCacheUsage());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -56,7 +56,7 @@ import org.apache.accumulo.core.spi.cache.BlockCache;
 import org.apache.accumulo.core.spi.cache.BlockCacheManager;
 import org.apache.accumulo.core.spi.cache.CacheType;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
-import org.apache.accumulo.core.spi.scan.ScanDirectives;
+import org.apache.accumulo.core.spi.scan.ScanDispatch;
 import org.apache.accumulo.core.spi.scan.ScanDispatcher;
 import org.apache.accumulo.core.spi.scan.ScanDispatcher.DispatchParameters;
 import org.apache.accumulo.core.spi.scan.ScanExecutor;
@@ -686,13 +686,13 @@ public class TabletServerResourceManager {
       lastReportedCommitTime = System.currentTimeMillis();
     }
 
-    public synchronized ScanFileManager newScanFileManager(ScanDirectives scanDirectives) {
+    public synchronized ScanFileManager newScanFileManager(ScanDispatch scanDispatch) {
       if (closed) {
         throw new IllegalStateException("closed");
       }
 
       return fileManager.newScanFileManager(extent,
-          new ScanCacheProvider(tableConf, scanDirectives, _iCache, _dCache));
+          new ScanCacheProvider(tableConf, scanDispatch, _iCache, _dCache));
     }
 
     // END methods that Tablets call to manage their set of open map files
@@ -795,11 +795,11 @@ public class TabletServerResourceManager {
 
     if (tablet.isRootTablet()) {
       // TODO make meta dispatch??
-      scanInfo.scanParams.setScanDirectives(ScanDirectives.builder().build());
+      scanInfo.scanParams.setScanDispatch(ScanDispatch.builder().build());
       task.run();
     } else if (tablet.isMeta()) {
       // TODO make meta dispatch??
-      scanInfo.scanParams.setScanDirectives(ScanDirectives.builder().build());
+      scanInfo.scanParams.setScanDispatch(ScanDispatch.builder().build());
       scanExecutors.get("meta").execute(task);
     } else {
       DispatchParameters params = new DispatchParamsImpl() {
@@ -819,8 +819,8 @@ public class TabletServerResourceManager {
         }
       };
 
-      ScanDirectives prefs = dispatcher.dispatch(params);
-      scanInfo.scanParams.setScanDirectives(prefs);
+      ScanDispatch prefs = dispatcher.dispatch(params);
+      scanInfo.scanParams.setScanDispatch(prefs);
 
       ExecutorService executor = scanExecutors.get(prefs.getExecutorName());
       if (executor == null) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/ScanParameters.java
@@ -27,7 +27,7 @@ import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.dataImpl.thrift.IterInfo;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.spi.scan.ScanDirectives;
+import org.apache.accumulo.core.spi.scan.ScanDispatch;
 
 /**
  * Information needed to execute a scan inside a tablet
@@ -43,7 +43,7 @@ public final class ScanParameters {
   private final SamplerConfiguration samplerConfig;
   private final long batchTimeOut;
   private final String classLoaderContext;
-  private volatile ScanDirectives directives;
+  private volatile ScanDispatch dispatch;
 
   public ScanParameters(int maxEntries, Authorizations authorizations, Set<Column> columnSet,
       List<IterInfo> ssiList, Map<String,Map<String,String>> ssio, boolean isolated,
@@ -97,12 +97,12 @@ public final class ScanParameters {
     return classLoaderContext;
   }
 
-  public void setScanDirectives(ScanDirectives directives) {
-    this.directives = directives;
+  public void setScanDispatch(ScanDispatch dispatch) {
+    this.dispatch = dispatch;
   }
 
-  public ScanDirectives getScanDirectives() {
-    return directives;
+  public ScanDispatch getScanDispatch() {
+    return dispatch;
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -712,7 +712,7 @@ public class CompactableImpl implements Compactable {
       var hints = tmpHints;
       debugHints = hints;
 
-      var directives = dispatcher.dispatch(new DispatchParameters() {
+      var dispatch = dispatcher.dispatch(new DispatchParameters() {
 
         @Override
         public ServiceEnvironment getServiceEnv() {
@@ -735,7 +735,7 @@ public class CompactableImpl implements Compactable {
         }
       });
 
-      return directives.getService();
+      return dispatch.getService();
     } catch (RuntimeException e) {
       log.error("Failed to dispatch compaction {} kind:{} hints:{}, falling back to {} service.",
           getExtent(), kind, debugHints, CompactionManager.DEFAULT_SERVICE, e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -141,8 +141,7 @@ class ScanDataSource implements DataSource {
 
       // only acquire the file manager when we know the tablet is open
       if (fileManager == null) {
-        fileManager =
-            tablet.getTabletResources().newScanFileManager(scanParams.getScanDirectives());
+        fileManager = tablet.getTabletResources().newScanFileManager(scanParams.getScanDispatch());
         tablet.addActiveScans(this);
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -82,7 +82,7 @@ import org.apache.accumulo.core.replication.ReplicationConfigurationUtil;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment;
-import org.apache.accumulo.core.spi.scan.ScanDirectives;
+import org.apache.accumulo.core.spi.scan.ScanDispatch;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
@@ -603,7 +603,7 @@ public class Tablet {
 
     ScanParameters scanParams = new ScanParameters(-1, authorizations, Collections.emptySet(), null,
         null, false, null, -1, null);
-    scanParams.setScanDirectives(ScanDirectives.builder().build());
+    scanParams.setScanDispatch(ScanDispatch.builder().build());
 
     ScanDataSource dataSource = new ScanDataSource(this, scanParams, false, iFlag);
 


### PR DESCRIPTION
Make Scan/Compaction Dispatchers return a Dispatch object when they
dispatch() by renaming Directives objects to use Dispatch in the name
instead.