### PR TITLE
Deprecate the shell script command

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -393,6 +393,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         {new ClasspathCommand(), new org.apache.accumulo.shell.commands.DebugCommand(),
             new ListScansCommand(), new ListCompactionsCommand(), new TraceCommand(),
             new PingCommand(), new ListBulkCommand(), new ListTabletsCommand()};
+    @SuppressWarnings("deprecation")
     Command[] execCommands =
         {new ExecfileCommand(), new HistoryCommand(), new ExtensionCommand(), new ScriptCommand()};
     Command[] exitCommands = {new ByeCommand(), new ExitCommand(), new QuitCommand()};

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -20,13 +20,27 @@ package org.apache.accumulo.shell.commands;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.script.*;
+import javax.script.Bindings;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.Invocable;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -55,8 +55,8 @@ import org.apache.commons.cli.Options;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * @deprecated since 2.0; this command shouldn't be used; umuch of the use case for having this
- *             script command is likely able to be replaced by Java 11's JShell feature
+ * @deprecated since 2.0; this command shouldn't be used; The script command is deprecated; use
+ *             jshell for scripting instead
  */
 
 @Deprecated(since = "2.1.0")
@@ -75,8 +75,7 @@ public class ScriptCommand extends Command {
 
     boolean invoke = false;
 
-    Shell.log.warn(
-        "Deprecated -- much of the use case for having this script command is likely able to be replaced by Java 11's JShell feature");
+    Shell.log.warn("The script command is deprecated; use jshell for scripting instead");
     ScriptEngineManager mgr = new ScriptEngineManager();
 
     if (cl.hasOption(list.getOpt())) {
@@ -206,7 +205,7 @@ public class ScriptCommand extends Command {
 
   @Override
   public String description() {
-    return "This is will be deprecated and will be replaced by Java 11's JShell Feature - execute JSR-223 scripts";
+    return "execute JSR-223 scripts";
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -45,7 +45,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *             script command is likely able to be replaced by Java 11's JShell feature
  */
 
-@Deprecated(since = "2.0.0")
+@Deprecated(since = "2.1.0")
 public class ScriptCommand extends Command {
 
   // Command to allow user to run scripts, see JSR-223
@@ -55,14 +55,14 @@ public class ScriptCommand extends Command {
   private static final String DEFAULT_ENGINE = "rhino";
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
-          justification = "app is run in same security context as user providing the filename")
+      justification = "app is run in same security context as user providing the filename")
   @Override
   public int execute(String fullCommand, CommandLine cl, Shell shellState) throws Exception {
 
     boolean invoke = false;
 
     Shell.log.warn(
-            "Deprecated -- much of the use case for having this script command is likely able to be replaced by Java 11's JShell feature");
+        "Deprecated -- much of the use case for having this script command is likely able to be replaced by Java 11's JShell feature");
     ScriptEngineManager mgr = new ScriptEngineManager();
 
     if (cl.hasOption(list.getOpt())) {
@@ -81,7 +81,7 @@ public class ScriptCommand extends Command {
       if (cl.hasOption(object.getOpt()) || cl.hasOption(function.getOpt())) {
         if (!(engine instanceof Invocable)) {
           shellState.printException(
-                  new Exception(engineName + " does not support invoking functions or methods"));
+              new Exception(engineName + " does not support invoking functions or methods"));
           return 1;
         }
         invoke = true;
@@ -285,7 +285,7 @@ public class ScriptCommand extends Command {
   }
 
   private void invokeFunctionOrMethod(Shell shellState, ScriptEngine engine, CommandLine cl,
-                                      Object[] args) {
+      Object[] args) {
     try {
       Invocable inv = (Invocable) engine;
       if (cl.hasOption(function.getOpt())) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -20,27 +20,13 @@ package org.apache.accumulo.shell.commands;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.script.Bindings;
-import javax.script.Compilable;
-import javax.script.CompiledScript;
-import javax.script.Invocable;
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineFactory;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-import javax.script.SimpleScriptContext;
+import javax.script.*;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -54,6 +40,12 @@ import org.apache.commons.cli.Options;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * @deprecated since 2.0; this command shouldn't be used; umuch of the use case for having this
+ *             script command is likely able to be replaced by Java 11's JShell feature
+ */
+
+@Deprecated(since = "2.0.0")
 public class ScriptCommand extends Command {
 
   // Command to allow user to run scripts, see JSR-223
@@ -63,11 +55,14 @@ public class ScriptCommand extends Command {
   private static final String DEFAULT_ENGINE = "rhino";
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
-      justification = "app is run in same security context as user providing the filename")
+          justification = "app is run in same security context as user providing the filename")
   @Override
   public int execute(String fullCommand, CommandLine cl, Shell shellState) throws Exception {
 
     boolean invoke = false;
+
+    Shell.log.warn(
+            "Deprecated -- much of the use case for having this script command is likely able to be replaced by Java 11's JShell feature");
     ScriptEngineManager mgr = new ScriptEngineManager();
 
     if (cl.hasOption(list.getOpt())) {
@@ -86,7 +81,7 @@ public class ScriptCommand extends Command {
       if (cl.hasOption(object.getOpt()) || cl.hasOption(function.getOpt())) {
         if (!(engine instanceof Invocable)) {
           shellState.printException(
-              new Exception(engineName + " does not support invoking functions or methods"));
+                  new Exception(engineName + " does not support invoking functions or methods"));
           return 1;
         }
         invoke = true;
@@ -197,7 +192,7 @@ public class ScriptCommand extends Command {
 
   @Override
   public String description() {
-    return "execute JSR-223 scripts";
+    return "This is will be deprecated and will be replaced by Java 11's JShell Feature - execute JSR-223 scripts";
   }
 
   @Override
@@ -290,7 +285,7 @@ public class ScriptCommand extends Command {
   }
 
   private void invokeFunctionOrMethod(Shell shellState, ScriptEngine engine, CommandLine cl,
-      Object[] args) {
+                                      Object[] args) {
     try {
       Invocable inv = (Invocable) engine;
       if (cl.hasOption(function.getOpt())) {


### PR DESCRIPTION
Mark the shell's ScriptCommand as deprecated and log a warning when used.

This fixes #1949