### PR TITLE
Add specific types for Fate locks and Zoo locks

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -73,7 +73,7 @@ import org.apache.accumulo.core.singletons.SingletonReservation;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -367,8 +367,7 @@ public class ClientContext implements AccumuloClient {
 
   // available only for sharing code with old ZooKeeperInstance
   public static List<String> getManagerLocations(ZooCache zooCache, String instanceId) {
-    ZooLockPath zLockManagerPath =
-        new ZooLockPath(ZooUtil.getRoot(instanceId) + Constants.ZMANAGER_LOCK);
+    var zLockManagerPath = ZooLock.path(ZooUtil.getRoot(instanceId) + Constants.ZMANAGER_LOCK);
 
     OpTimer timer = null;
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -71,9 +71,9 @@ import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonReservation;
 import org.apache.accumulo.core.util.OpTimer;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -367,7 +367,7 @@ public class ClientContext implements AccumuloClient {
 
   // available only for sharing code with old ZooKeeperInstance
   public static List<String> getManagerLocations(ZooCache zooCache, String instanceId) {
-    var zLockManagerPath = ZooLock.path(ZooUtil.getRoot(instanceId) + Constants.ZMANAGER_LOCK);
+    var zLockManagerPath = ServiceLock.path(ZooUtil.getRoot(instanceId) + Constants.ZMANAGER_LOCK);
 
     OpTimer timer = null;
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -78,7 +78,7 @@ import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.LockID;
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang3.mutable.MutableLong;
@@ -659,7 +659,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
     LockID lid = new LockID(context.getZooKeeperRoot() + Constants.ZTSERVERS, sessionId.lockId);
 
     while (true) {
-      if (!ZooLock.isLockHeld(context.getZooCache(), lid)) {
+      if (!ServiceLock.isLockHeld(context.getZooCache(), lid)) {
         // ACCUMULO-1152 added a tserver lock check to the tablet location cache, so this
         // invalidation prevents future attempts to contact the
         // tserver even its gone zombie and is still running w/o a lock

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
@@ -35,8 +35,8 @@ import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.TServiceClientFactory;
@@ -144,7 +144,8 @@ public class ServerClient {
     // add tservers
     ZooCache zc = context.getZooCache();
     for (String tserver : zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS)) {
-      var zLocPath = ZooLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
+      var zLocPath =
+          ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
       byte[] data = zc.getLockData(zLocPath);
       if (data != null) {
         String strData = new String(data, UTF_8);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.TServiceClientFactory;
@@ -144,8 +144,7 @@ public class ServerClient {
     // add tservers
     ZooCache zc = context.getZooCache();
     for (String tserver : zc.getChildren(context.getZooKeeperRoot() + Constants.ZTSERVERS)) {
-      ZooLockPath zLocPath =
-          new ZooLockPath(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
+      var zLocPath = ZooLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
       byte[] data = zc.getLockData(zLocPath);
       if (data != null) {
         String strData = new String(data, UTF_8);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
@@ -22,7 +22,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.TabletLocatorImpl.TabletServerLockChecker;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 
 public class ZookeeperLockChecker implements TabletServerLockChecker {
 
@@ -36,7 +35,7 @@ public class ZookeeperLockChecker implements TabletServerLockChecker {
 
   @Override
   public boolean isLockHeld(String tserver, String session) {
-    ZooLockPath zLockPath = new ZooLockPath(root + "/" + tserver);
+    var zLockPath = ZooLock.path(root + "/" + tserver);
     return ZooLock.getSessionId(zc, zLockPath) == Long.parseLong(session, 16);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ZookeeperLockChecker.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.clientImpl;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.TabletLocatorImpl.TabletServerLockChecker;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 
 public class ZookeeperLockChecker implements TabletServerLockChecker {
 
@@ -35,8 +35,8 @@ public class ZookeeperLockChecker implements TabletServerLockChecker {
 
   @Override
   public boolean isLockHeld(String tserver, String session) {
-    var zLockPath = ZooLock.path(root + "/" + tserver);
-    return ZooLock.getSessionId(zc, zLockPath) == Long.parseLong(session, 16);
+    var zLockPath = ServiceLock.path(root + "/" + tserver);
+    return ServiceLock.getSessionId(zc, zLockPath) == Long.parseLong(session, 16);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -248,7 +248,7 @@ public interface Ample {
 
     TabletMutator deleteLocation(TServerInstance tserver, LocationType type);
 
-    TabletMutator putZooLock(ZooLock zooLock);
+    TabletMutator putZooLock(ServiceLock zooLock);
 
     TabletMutator putDirName(String dirName);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -71,8 +71,8 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Ta
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.ServerServices;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -471,9 +471,9 @@ public class TabletMetadata {
   private static Optional<TServerInstance> checkServer(ClientContext context, String path,
       String zPath) {
     Optional<TServerInstance> server = Optional.empty();
-    final var lockPath = ZooLock.path(path + "/" + zPath);
+    final var lockPath = ServiceLock.path(path + "/" + zPath);
     ZooCache.ZcStat stat = new ZooCache.ZcStat();
-    byte[] lockData = ZooLock.getLockData(context.getZooCache(), lockPath, stat);
+    byte[] lockData = ServiceLock.getLockData(context.getZooCache(), lockPath, stat);
 
     log.trace("Checking server at ZK path = " + lockPath);
     if (lockData != null) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.COMPACT_QUAL;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_QUAL;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.FLUSH_QUAL;
@@ -67,13 +66,13 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.La
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -472,7 +471,7 @@ public class TabletMetadata {
   private static Optional<TServerInstance> checkServer(ClientContext context, String path,
       String zPath) {
     Optional<TServerInstance> server = Optional.empty();
-    final ZooLockPath lockPath = new ZooLockPath(path + "/" + zPath);
+    final var lockPath = ZooLock.path(path + "/" + zPath);
     ZooCache.ZcStat stat = new ZooCache.ZcStat();
     byte[] lockData = ZooLock.getLockData(context.getZooCache(), lockPath, stat);
 

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -31,10 +31,10 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
+import org.apache.accumulo.fate.zookeeper.FateLock;
+import org.apache.accumulo.fate.zookeeper.FateLock.FateLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
-import org.apache.accumulo.fate.zookeeper.ZooQueueLock;
-import org.apache.accumulo.fate.zookeeper.ZooQueueLock.FateLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -276,9 +276,9 @@ public class AdminUtil<T> {
 
       try {
 
-        FateLockPath fLockPath = new FateLockPath(lockPath + "/" + id);
-        List<String> lockNodes = ZooQueueLock.validateAndSortChildrenByLockPrefix(fLockPath,
-            zk.getChildren(fLockPath.toString()));
+        FateLockPath fLockPath = FateLock.path(lockPath + "/" + id);
+        List<String> lockNodes =
+            FateLock.validateAndSort(fLockPath, zk.getChildren(fLockPath.toString()));
 
         int pos = 0;
         boolean sawWriteLock = false;

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -33,8 +33,8 @@ import java.util.Set;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.zookeeper.FateLock;
 import org.apache.accumulo.fate.zookeeper.FateLock.FateLockPath;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.ServiceLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -415,7 +415,8 @@ public class AdminUtil<T> {
     }
   }
 
-  public boolean prepDelete(TStore<T> zs, ZooReaderWriter zk, ZooLockPath path, String txidStr) {
+  public boolean prepDelete(TStore<T> zs, ZooReaderWriter zk, ServiceLockPath path,
+      String txidStr) {
     if (!checkGlobalLock(zk, path)) {
       return false;
     }
@@ -450,7 +451,7 @@ public class AdminUtil<T> {
     return state;
   }
 
-  public boolean prepFail(TStore<T> zs, ZooReaderWriter zk, ZooLockPath path, String txidStr) {
+  public boolean prepFail(TStore<T> zs, ZooReaderWriter zk, ServiceLockPath path, String txidStr) {
     if (!checkGlobalLock(zk, path)) {
       return false;
     }
@@ -512,9 +513,9 @@ public class AdminUtil<T> {
   @SuppressFBWarnings(value = "DM_EXIT",
       justification = "TODO - should probably avoid System.exit here; "
           + "this code is used by the fate admin shell command")
-  public boolean checkGlobalLock(ZooReaderWriter zk, ZooLockPath path) {
+  public boolean checkGlobalLock(ZooReaderWriter zk, ServiceLockPath path) {
     try {
-      if (ZooLock.getLockData(zk.getZooKeeper(), path) != null) {
+      if (ServiceLock.getLockData(zk.getZooKeeper(), path) != null) {
         System.err.println("ERROR: Manager lock is held, not running");
         if (this.exitOnError)
           System.exit(1);

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ZooQueueLock;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -275,7 +276,7 @@ public class AdminUtil<T> {
 
         String path = lockPath + "/" + id;
         List<String> lockNodes =
-            ZooLock.validateAndSortChildrenByLockPrefix(path, zk.getChildren(path));
+            ZooQueueLock.validateAndSortChildrenByLockPrefix(path, zk.getChildren(path));
 
         int pos = 0;
         boolean sawWriteLock = false;

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -31,7 +31,7 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.ServiceLockPath;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.WatchedEvent;
@@ -566,8 +566,8 @@ public class ZooCache {
     }
   }
 
-  public byte[] getLockData(ZooLockPath path) {
-    List<String> children = ZooLock.validateAndSort(path, getChildren(path.toString()));
+  public byte[] getLockData(ServiceLockPath path) {
+    List<String> children = ServiceLock.validateAndSort(path, getChildren(path.toString()));
     if (children == null || children.isEmpty()) {
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -567,7 +567,6 @@ public class ZooCache {
   }
 
   public byte[] getLockData(ZooLockPath path) {
-    // ZooLock style lock.
     List<String> children =
         ZooLock.validateAndSortChildrenByLockPrefix(path, getChildren(path.toString()));
     if (children == null || children.isEmpty()) {

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -567,8 +567,7 @@ public class ZooCache {
   }
 
   public byte[] getLockData(ZooLockPath path) {
-    List<String> children =
-        ZooLock.validateAndSortChildrenByLockPrefix(path, getChildren(path.toString()));
+    List<String> children = ZooLock.validateAndSort(path, getChildren(path.toString()));
     if (children == null || children.isEmpty()) {
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooLock.java
@@ -348,7 +348,6 @@ public class ZooLock implements Watcher {
             renew = false;
           }
           if (renew) {
-            LOG.debug("[{}] Renewing watch on prior node  {}", vmLockPrefix, nodeToWatch);
             try {
               Stat restat = zooKeeper.exists(nodeToWatch, this);
               if (restat == null) {
@@ -357,6 +356,8 @@ public class ZooLock implements Watcher {
                 // created.
                 zooKeeper.removeWatches(nodeToWatch, this, WatcherType.Any, true);
                 determineLockOwnership(createdEphemeralNode, lw);
+              } else {
+                LOG.debug("[{}] Renewed watch on prior node  {}", vmLockPrefix, nodeToWatch);
               }
             } catch (KeeperException | InterruptedException e) {
               lw.failedToAcquireLock(new Exception("Failed to renew watch on other manager node"));

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooQueueLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooQueueLock.java
@@ -39,7 +39,7 @@ public class ZooQueueLock implements QueueLock {
   private static final String PREFIX = "flock#";
 
   private ZooReaderWriter zoo;
-  private String path;
+  private FateLockPath path;
   private boolean ephemeral;
 
   public static class FateLockPath {
@@ -55,7 +55,7 @@ public class ZooQueueLock implements QueueLock {
     }
   }
 
-  public ZooQueueLock(ZooReaderWriter zrw, String path, boolean ephemeral) {
+  public ZooQueueLock(ZooReaderWriter zrw, FateLockPath path, boolean ephemeral) {
     this.zoo = zrw;
     this.path = path;
     this.ephemeral = ephemeral;
@@ -77,7 +77,7 @@ public class ZooQueueLock implements QueueLock {
           return Long.parseLong(last.substring(PREFIX.length()));
         } catch (NoNodeException nne) {
           // the parent does not exist so try to create it
-          zoo.putPersistentData(path, new byte[] {}, NodeExistsPolicy.SKIP);
+          zoo.putPersistentData(path.toString(), new byte[] {}, NodeExistsPolicy.SKIP);
         }
       }
     } catch (Exception ex) {
@@ -91,7 +91,7 @@ public class ZooQueueLock implements QueueLock {
     try {
       List<String> children = Collections.emptyList();
       try {
-        children = zoo.getChildren(path);
+        children = zoo.getChildren(path.toString());
       } catch (KeeperException.NoNodeException ex) {
         // the path does not exist (it was deleted or not created yet), that is ok there are no
         // earlier entries then
@@ -120,7 +120,7 @@ public class ZooQueueLock implements QueueLock {
       zoo.recursiveDelete(path + String.format("/%s%010d", PREFIX, entry), NodeMissingPolicy.SKIP);
       try {
         // try to delete the parent if it has no children
-        zoo.delete(path);
+        zoo.delete(path.toString());
       } catch (NotEmptyException nee) {
         // the path had other lock nodes, no big deal
       }

--- a/core/src/test/java/org/apache/accumulo/fate/zookeeper/ServiceLockTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/zookeeper/ServiceLockTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-public class ZooLockTest {
+public class ServiceLockTest {
 
   @Test
   public void testSortAndFindLowestPrevPrefix() throws Exception {
@@ -42,7 +42,7 @@ public class ZooLockTest {
     children.add("zlock#987654321");
     children.add("zlock#00000000-0000-0000-0000-aaaaaaaaaaaa#0000000001");
 
-    final List<String> validChildren = ZooLock.validateAndSort(ZooLock.path(""), children);
+    final List<String> validChildren = ServiceLock.validateAndSort(ServiceLock.path(""), children);
 
     assertEquals(8, validChildren.size());
     assertEquals("zlock#00000000-0000-0000-0000-aaaaaaaaaaaa#0000000001", validChildren.get(0));
@@ -55,24 +55,24 @@ public class ZooLockTest {
     assertEquals("zlock#00000000-0000-0000-0000-eeeeeeeeeeee#0000000010", validChildren.get(7));
 
     assertEquals("zlock#00000000-0000-0000-0000-bbbbbbbbbbbb#0000000004",
-        ZooLock.findLowestPrevPrefix(validChildren,
+        ServiceLock.findLowestPrevPrefix(validChildren,
             "zlock#00000000-0000-0000-0000-ffffffffffff#0000000007"));
 
     assertEquals("zlock#00000000-0000-0000-0000-aaaaaaaaaaaa#0000000001",
-        ZooLock.findLowestPrevPrefix(validChildren,
+        ServiceLock.findLowestPrevPrefix(validChildren,
             "zlock#00000000-0000-0000-0000-cccccccccccc#0000000003"));
 
     assertEquals("zlock#00000000-0000-0000-0000-dddddddddddd#0000000008",
-        ZooLock.findLowestPrevPrefix(validChildren,
+        ServiceLock.findLowestPrevPrefix(validChildren,
             "zlock#00000000-0000-0000-0000-eeeeeeeeeeee#0000000010"));
 
     assertThrows(IndexOutOfBoundsException.class, () -> {
-      ZooLock.findLowestPrevPrefix(validChildren,
+      ServiceLock.findLowestPrevPrefix(validChildren,
           "zlock#00000000-0000-0000-0000-aaaaaaaaaaaa#0000000001");
     });
 
     assertThrows(IndexOutOfBoundsException.class, () -> {
-      ZooLock.findLowestPrevPrefix(validChildren,
+      ServiceLock.findLowestPrevPrefix(validChildren,
           "zlock#00000000-0000-0000-0000-XXXXXXXXXXXX#0000000099");
     });
   }

--- a/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooLockTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooLockTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertThrows;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.junit.Test;
 
 public class ZooLockTest {
@@ -43,8 +42,7 @@ public class ZooLockTest {
     children.add("zlock#987654321");
     children.add("zlock#00000000-0000-0000-0000-aaaaaaaaaaaa#0000000001");
 
-    final List<String> validChildren =
-        ZooLock.validateAndSortChildrenByLockPrefix(new ZooLockPath(""), children);
+    final List<String> validChildren = ZooLock.validateAndSort(ZooLock.path(""), children);
 
     assertEquals(8, validChildren.size());
     assertEquals("zlock#00000000-0000-0000-0000-aaaaaaaaaaaa#0000000001", validChildren.get(0));

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -49,8 +49,8 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Su
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.core.util.cleaner.CleanerUtil;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
@@ -287,7 +287,7 @@ public class MetadataConstraints implements Constraint {
           String lockId = new String(columnUpdate.getValue(), UTF_8);
 
           try {
-            lockHeld = ZooLock.isLockHeld(zooCache, new ZooUtil.LockID(zooRoot, lockId));
+            lockHeld = ServiceLock.isLockHeld(zooCache, new ZooUtil.LockID(zooRoot, lockId));
           } catch (Exception e) {
             log.debug("Failed to verify lock was held {} {}", lockId, e.getMessage());
           }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.Pair;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.server.ServerConstants;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
@@ -135,7 +135,7 @@ public class VolumeUtil {
    * configured in instance.volumes.replacements. Second, if a tablet dir is no longer configured
    * for use it chooses a new tablet directory.
    */
-  public static TabletFiles updateTabletVolumes(ServerContext context, ZooLock zooLock,
+  public static TabletFiles updateTabletVolumes(ServerContext context, ServiceLock zooLock,
       KeyExtent extent, TabletFiles tabletFiles, boolean replicate) {
     List<Pair<Path,Path>> replacements =
         ServerConstants.getVolumeReplacements(context.getConfiguration(), context.getHadoopConf());

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCache.ZcStat;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
@@ -294,7 +293,7 @@ public class LiveTServerSet implements Watcher {
 
     TServerInfo info = current.get(zPath);
 
-    final ZooLockPath zLockPath = new ZooLockPath(path + "/" + zPath);
+    final var zLockPath = ZooLock.path(path + "/" + zPath);
     ZcStat stat = new ZcStat();
     byte[] lockData = ZooLock.getLockData(getZooCache(), zLockPath, stat);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.fate.FateTxId;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 
@@ -155,7 +155,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putZooLock(ZooLock zooLock) {
+  public Ample.TabletMutator putZooLock(ServiceLock zooLock) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     ServerColumnFamily.LOCK_COLUMN.put(mutation,
         new Value(zooLock.getLockID().serialize(context.getZooKeeperRoot() + "/")));

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -60,7 +60,6 @@ import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.security.SecurityUtil;
@@ -415,7 +414,7 @@ public class Admin implements KeywordExecutable {
    */
   static String qualifyWithZooKeeperSessionId(String zTServerRoot, ZooCache zooCache,
       String hostAndPort) {
-    ZooLockPath zLockPath = new ZooLockPath(zTServerRoot + "/" + hostAndPort);
+    var zLockPath = ZooLock.path(zTServerRoot + "/" + hostAndPort);
     long sessionId = ZooLock.getSessionId(zooCache, zLockPath);
     if (sessionId == 0) {
       return hostAndPort;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -58,8 +58,8 @@ import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.security.SecurityUtil;
@@ -414,8 +414,8 @@ public class Admin implements KeywordExecutable {
    */
   static String qualifyWithZooKeeperSessionId(String zTServerRoot, ZooCache zooCache,
       String hostAndPort) {
-    var zLockPath = ZooLock.path(zTServerRoot + "/" + hostAndPort);
-    long sessionId = ZooLock.getSessionId(zooCache, zLockPath);
+    var zLockPath = ServiceLock.path(zTServerRoot + "/" + hostAndPort);
+    long sessionId = ServiceLock.getSessionId(zooCache, zLockPath);
     if (sessionId == 0) {
       return hostAndPort;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
@@ -34,7 +34,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,8 +167,7 @@ public class ListInstances {
     }
 
     try {
-      ZooLockPath zLockManagerPath =
-          new ZooLockPath(Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK);
+      var zLockManagerPath = ZooLock.path(Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK);
       byte[] manager = ZooLock.getLockData(cache, zLockManagerPath, null);
       if (manager == null) {
         return null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
@@ -32,8 +32,8 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,8 +167,9 @@ public class ListInstances {
     }
 
     try {
-      var zLockManagerPath = ZooLock.path(Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK);
-      byte[] manager = ZooLock.getLockData(cache, zLockManagerPath, null);
+      var zLockManagerPath =
+          ServiceLock.path(Constants.ZROOT + "/" + iid + Constants.ZMANAGER_LOCK);
+      byte[] manager = ServiceLock.getLockData(cache, zLockManagerPath, null);
       if (manager == null) {
         return null;
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -52,7 +52,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
@@ -66,7 +66,7 @@ public class ManagerMetadataUtil {
   public static void addNewTablet(ServerContext context, KeyExtent extent, String dirName,
       TServerInstance location, Map<StoredTabletFile,DataFileValue> datafileSizes,
       Map<Long,? extends Collection<TabletFile>> bulkLoadedFiles, MetadataTime time,
-      long lastFlushID, long lastCompactID, ZooLock zooLock) {
+      long lastFlushID, long lastCompactID, ServiceLock zooLock) {
 
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
     tablet.putPrevEndRow(extent.prevEndRow());
@@ -96,7 +96,7 @@ public class ManagerMetadataUtil {
     tablet.mutate();
   }
 
-  public static KeyExtent fixSplit(ServerContext context, TabletMetadata meta, ZooLock lock)
+  public static KeyExtent fixSplit(ServerContext context, TabletMetadata meta, ServiceLock lock)
       throws AccumuloException {
     log.info("Incomplete split {} attempting to fix", meta.getExtent());
 
@@ -115,7 +115,7 @@ public class ManagerMetadataUtil {
   }
 
   private static KeyExtent fixSplit(ServerContext context, TableId tableId, Text metadataEntry,
-      Text metadataPrevEndRow, Text oper, double splitRatio, ZooLock lock)
+      Text metadataPrevEndRow, Text oper, double splitRatio, ServiceLock lock)
       throws AccumuloException {
     if (metadataPrevEndRow == null)
       // something is wrong, this should not happen... if a tablet is split, it will always have a
@@ -168,7 +168,7 @@ public class ManagerMetadataUtil {
     }
   }
 
-  private static TServerInstance getTServerInstance(String address, ZooLock zooLock) {
+  private static TServerInstance getTServerInstance(String address, ServiceLock zooLock) {
     while (true) {
       try {
         return new TServerInstance(address, zooLock.getSessionId());
@@ -182,7 +182,7 @@ public class ManagerMetadataUtil {
   public static void replaceDatafiles(ServerContext context, KeyExtent extent,
       Set<StoredTabletFile> datafilesToDelete, Set<StoredTabletFile> scanFiles, TabletFile path,
       Long compactionId, DataFileValue size, String address, TServerInstance lastLocation,
-      ZooLock zooLock) {
+      ServiceLock zooLock) {
 
     context.getAmple().putGcCandidates(extent.tableId(), datafilesToDelete);
 
@@ -217,7 +217,7 @@ public class ManagerMetadataUtil {
    *
    */
   public static StoredTabletFile updateTabletDataFile(ServerContext context, KeyExtent extent,
-      TabletFile path, DataFileValue dfv, MetadataTime time, String address, ZooLock zooLock,
+      TabletFile path, DataFileValue dfv, MetadataTime time, String address, ServiceLock zooLock,
       Set<String> unusedWalLogs, TServerInstance lastLocation, long flushId) {
 
     TabletMutator tablet = context.getAmple().mutateTablet(extent);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TabletServerLocks.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TabletServerLocks.java
@@ -27,7 +27,6 @@ import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.ServerContext;
 
@@ -57,7 +56,7 @@ public class TabletServerLocks {
         List<String> tabletServers = zoo.getChildren(tserverPath);
 
         for (String tabletServer : tabletServers) {
-          ZooLockPath zLockPath = new ZooLockPath(tserverPath + "/" + tabletServer);
+          var zLockPath = ZooLock.path(tserverPath + "/" + tabletServer);
           byte[] lockData = ZooLock.getLockData(cache, zLockPath, null);
           String holder = null;
           if (lockData != null) {
@@ -67,7 +66,7 @@ public class TabletServerLocks {
           System.out.printf("%32s %16s%n", tabletServer, holder);
         }
       } else if (opts.delete != null) {
-        ZooLock.deleteLock(zoo, new ZooLockPath(tserverPath + "/" + args[1]));
+        ZooLock.deleteLock(zoo, ZooLock.path(tserverPath + "/" + args[1]));
       } else {
         System.out.println(
             "Usage : " + TabletServerLocks.class.getName() + " -list|-delete <tserver lock>");

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TabletServerLocks.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TabletServerLocks.java
@@ -25,8 +25,8 @@ import java.util.List;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.ServerContext;
 
@@ -56,8 +56,8 @@ public class TabletServerLocks {
         List<String> tabletServers = zoo.getChildren(tserverPath);
 
         for (String tabletServer : tabletServers) {
-          var zLockPath = ZooLock.path(tserverPath + "/" + tabletServer);
-          byte[] lockData = ZooLock.getLockData(cache, zLockPath, null);
+          var zLockPath = ServiceLock.path(tserverPath + "/" + tabletServer);
+          byte[] lockData = ServiceLock.getLockData(cache, zLockPath, null);
           String holder = null;
           if (lockData != null) {
             holder = new String(lockData, UTF_8);
@@ -66,7 +66,7 @@ public class TabletServerLocks {
           System.out.printf("%32s %16s%n", tabletServer, holder);
         }
       } else if (opts.delete != null) {
-        ZooLock.deleteLock(zoo, ZooLock.path(tserverPath + "/" + args[1]));
+        ServiceLock.deleteLock(zoo, ServiceLock.path(tserverPath + "/" + args[1]));
       } else {
         System.out.println(
             "Usage : " + TabletServerLocks.class.getName() + " -list|-delete <tserver lock>");

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -110,7 +109,7 @@ public class ZooZap {
             if (opts.zapManager || opts.zapMaster) {
               zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
             } else {
-              ZooLockPath zLockPath = new ZooLockPath(tserversPath + "/" + child);
+              var zLockPath = ZooLock.path(tserversPath + "/" + child);
               if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
                 if (!ZooLock.deleteLock(zoo, zLockPath, "tserver")) {
                   message("Did not delete " + tserversPath + "/" + child, opts);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -27,7 +27,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -109,9 +109,9 @@ public class ZooZap {
             if (opts.zapManager || opts.zapMaster) {
               zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
             } else {
-              var zLockPath = ZooLock.path(tserversPath + "/" + child);
+              var zLockPath = ServiceLock.path(tserversPath + "/" + child);
               if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
-                if (!ZooLock.deleteLock(zoo, zLockPath, "tserver")) {
+                if (!ServiceLock.deleteLock(zoo, zLockPath, "tserver")) {
                   message("Did not delete " + tserversPath + "/" + child, opts);
                 }
               }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -76,9 +76,9 @@ import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.Volume;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockWatcher;
 import org.apache.accumulo.gc.metrics.GcCycleMetrics;
 import org.apache.accumulo.gc.metrics.GcMetricsFactory;
 import org.apache.accumulo.gc.replication.CloseWriteAheadLogReferences;
@@ -118,7 +118,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
   private static final Logger log = LoggerFactory.getLogger(SimpleGarbageCollector.class);
 
-  private ZooLock lock;
+  private ServiceLock lock;
 
   private GCStatus status =
       new GCStatus(new GcCycleStats(), new GcCycleStats(), new GcCycleStats(), new GcCycleStats());
@@ -617,7 +617,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   private void getZooLock(HostAndPort addr) throws KeeperException, InterruptedException {
-    var path = ZooLock.path(getContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
+    var path = ServiceLock.path(getContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
 
     LockWatcher lockWatcher = new LockWatcher() {
       @Override
@@ -635,7 +635,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
     UUID zooLockUUID = UUID.randomUUID();
     while (true) {
-      lock = new ZooLock(getContext().getSiteConfiguration(), path, zooLockUUID);
+      lock = new ServiceLock(getContext().getSiteConfiguration(), path, zooLockUUID);
       if (lock.tryLock(lockWatcher,
           new ServerServices(addr.toString(), Service.GC_CLIENT).toString().getBytes())) {
         log.debug("Got GC ZooKeeper lock");

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -79,7 +79,6 @@ import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.gc.metrics.GcCycleMetrics;
 import org.apache.accumulo.gc.metrics.GcMetricsFactory;
 import org.apache.accumulo.gc.replication.CloseWriteAheadLogReferences;
@@ -618,7 +617,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   private void getZooLock(HostAndPort addr) throws KeeperException, InterruptedException {
-    ZooLockPath path = new ZooLockPath(getContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
+    var path = ZooLock.path(getContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
 
     LockWatcher lockWatcher = new LockWatcher() {
       @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1043,7 +1043,7 @@ public class Manager extends AbstractServer
 
     // block until we can obtain the ZK lock for the manager
     try {
-      getManagerLock(new ZooLockPath(zroot + Constants.ZMANAGER_LOCK));
+      getManagerLock(ZooLock.path(zroot + Constants.ZMANAGER_LOCK));
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception getting manager lock", e);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -97,9 +97,9 @@ import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.fate.AgeOffStore;
 import org.apache.accumulo.fate.Fate;
 import org.apache.accumulo.fate.util.Retry;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.ServiceLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
@@ -202,7 +202,7 @@ public class Manager extends AbstractServer
   private ZooAuthenticationKeyDistributor keyDistributor;
   private AuthenticationTokenKeyManager authenticationTokenKeyManager;
 
-  ZooLock managerLock = null;
+  ServiceLock managerLock = null;
   private TServer clientService = null;
   private volatile TabletBalancer tabletBalancer;
   private final BalancerEnvironment balancerEnvironment;
@@ -1043,7 +1043,7 @@ public class Manager extends AbstractServer
 
     // block until we can obtain the ZK lock for the manager
     try {
-      getManagerLock(ZooLock.path(zroot + Constants.ZMANAGER_LOCK));
+      getManagerLock(ServiceLock.path(zroot + Constants.ZMANAGER_LOCK));
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception getting manager lock", e);
     }
@@ -1379,11 +1379,11 @@ public class Manager extends AbstractServer
     return Math.max(1, deadline - System.currentTimeMillis());
   }
 
-  public ZooLock getManagerLock() {
+  public ServiceLock getManagerLock() {
     return managerLock;
   }
 
-  private static class ManagerLockWatcher implements ZooLock.AccumuloLockWatcher {
+  private static class ManagerLockWatcher implements ServiceLock.AccumuloLockWatcher {
 
     boolean acquiredLock = false;
     boolean failedToAcquireLock = false;
@@ -1440,7 +1440,7 @@ public class Manager extends AbstractServer
     }
   }
 
-  private void getManagerLock(final ZooLockPath zManagerLoc)
+  private void getManagerLock(final ServiceLockPath zManagerLoc)
       throws KeeperException, InterruptedException {
     ServerContext context = getContext();
     log.info("trying to get manager lock");
@@ -1452,7 +1452,7 @@ public class Manager extends AbstractServer
     while (true) {
 
       ManagerLockWatcher managerLockWatcher = new ManagerLockWatcher();
-      managerLock = new ZooLock(context.getSiteConfiguration(), zManagerLoc, zooLockUUID);
+      managerLock = new ServiceLock(context.getSiteConfiguration(), zManagerLoc, zooLockUUID);
       managerLock.lock(managerLockWatcher, managerClientAddress.getBytes());
 
       managerLockWatcher.waitForChange();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.zookeeper.DistributedReadWriteLock;
 import org.apache.accumulo.fate.zookeeper.ZooQueueLock;
+import org.apache.accumulo.fate.zookeeper.ZooQueueLock.FateLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooReservation;
 import org.apache.accumulo.manager.Manager;
@@ -156,8 +157,9 @@ public class Utils {
   private static Lock getLock(ServerContext context, AbstractId<?> id, long tid,
       boolean writeLock) {
     byte[] lockData = String.format("%016x", tid).getBytes(UTF_8);
-    ZooQueueLock qlock = new ZooQueueLock(context.getZooReaderWriter(),
-        context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical(), false);
+    FateLockPath fLockPath = new FateLockPath(
+        context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical());
+    ZooQueueLock qlock = new ZooQueueLock(context.getZooReaderWriter(), fLockPath, false);
     Lock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
     if (lock == null) {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, lockData);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -39,8 +39,7 @@ import org.apache.accumulo.core.data.AbstractId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.zookeeper.DistributedReadWriteLock;
-import org.apache.accumulo.fate.zookeeper.ZooQueueLock;
-import org.apache.accumulo.fate.zookeeper.ZooQueueLock.FateLockPath;
+import org.apache.accumulo.fate.zookeeper.FateLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooReservation;
 import org.apache.accumulo.manager.Manager;
@@ -157,9 +156,9 @@ public class Utils {
   private static Lock getLock(ServerContext context, AbstractId<?> id, long tid,
       boolean writeLock) {
     byte[] lockData = String.format("%016x", tid).getBytes(UTF_8);
-    FateLockPath fLockPath = new FateLockPath(
-        context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical());
-    ZooQueueLock qlock = new ZooQueueLock(context.getZooReaderWriter(), fLockPath, false);
+    var fLockPath =
+        FateLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical());
+    FateLock qlock = new FateLock(context.getZooReaderWriter(), fLockPath);
     Lock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
     if (lock == null) {
       DistributedReadWriteLock locker = new DistributedReadWriteLock(qlock, lockData);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateMetadata.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateMetadata.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.fate.Repo;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TableInfo;
@@ -82,8 +82,8 @@ class PopulateMetadata extends ManagerRepo {
   }
 
   private void writeSplitsToMetadataTable(ServerContext ctx, TableId tableId,
-      SortedSet<Text> splits, Map<Text,Text> data, TimeType timeType, ZooLock lock, BatchWriter bw)
-      throws MutationsRejectedException {
+      SortedSet<Text> splits, Map<Text,Text> data, TimeType timeType, ServiceLock lock,
+      BatchWriter bw) throws MutationsRejectedException {
     Text prevSplit = null;
     Value dirValue;
     for (Text split : Iterables.concat(splits, Collections.singleton(null))) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.fate.Repo;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
@@ -92,9 +92,11 @@ public class ShutdownTServer extends ManagerRepo {
     // suppress assignment of tablets to the server
     if (force) {
       ZooReaderWriter zoo = manager.getContext().getZooReaderWriter();
-      var path = ZooLock.path(manager.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + hostAndPort);
-      ZooLock.deleteLock(zoo, path);
-      path = ZooLock.path(manager.getZooKeeperRoot() + Constants.ZDEADTSERVERS + "/" + hostAndPort);
+      var path =
+          ServiceLock.path(manager.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + hostAndPort);
+      ServiceLock.deleteLock(zoo, path);
+      path = ServiceLock
+          .path(manager.getZooKeeperRoot() + Constants.ZDEADTSERVERS + "/" + hostAndPort);
       zoo.putPersistentData(path.toString(), "forced down".getBytes(UTF_8),
           NodeExistsPolicy.OVERWRITE);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tserverOps/ShutdownTServer.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.manager.Manager;
@@ -93,11 +92,9 @@ public class ShutdownTServer extends ManagerRepo {
     // suppress assignment of tablets to the server
     if (force) {
       ZooReaderWriter zoo = manager.getContext().getZooReaderWriter();
-      ZooLockPath path =
-          new ZooLockPath(manager.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + hostAndPort);
+      var path = ZooLock.path(manager.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + hostAndPort);
       ZooLock.deleteLock(zoo, path);
-      path =
-          new ZooLockPath(manager.getZooKeeperRoot() + Constants.ZDEADTSERVERS + "/" + hostAndPort);
+      path = ZooLock.path(manager.getZooKeeperRoot() + Constants.ZDEADTSERVERS + "/" + hostAndPort);
       zoo.putPersistentData(path.toString(), "forced down".getBytes(UTF_8),
           NodeExistsPolicy.OVERWRITE);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/util/FateAdmin.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/util/FateAdmin.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.AdminUtil;
 import org.apache.accumulo.fate.ReadOnlyStore;
 import org.apache.accumulo.fate.ZooStore;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.ServerContext;
@@ -83,7 +83,7 @@ public class FateAdmin {
     try (var context = new ServerContext(SiteConfiguration.auto())) {
       final String zkRoot = context.getZooKeeperRoot();
       String path = zkRoot + Constants.ZFATE;
-      ZooLockPath zLockManagerPath = new ZooLockPath(zkRoot + Constants.ZMANAGER_LOCK);
+      var zLockManagerPath = ZooLock.path(zkRoot + Constants.ZMANAGER_LOCK);
       ZooReaderWriter zk = context.getZooReaderWriter();
       ZooStore<Manager> zs = new ZooStore<>(path, zk);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/util/FateAdmin.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/util/FateAdmin.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.AdminUtil;
 import org.apache.accumulo.fate.ReadOnlyStore;
 import org.apache.accumulo.fate.ZooStore;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.ServerContext;
@@ -83,7 +83,7 @@ public class FateAdmin {
     try (var context = new ServerContext(SiteConfiguration.auto())) {
       final String zkRoot = context.getZooKeeperRoot();
       String path = zkRoot + Constants.ZFATE;
-      var zLockManagerPath = ZooLock.path(zkRoot + Constants.ZMANAGER_LOCK);
+      var zLockManagerPath = ServiceLock.path(zkRoot + Constants.ZMANAGER_LOCK);
       ZooReaderWriter zk = context.getZooReaderWriter();
       ZooStore<Manager> zs = new ZooStore<>(path, zk);
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -393,7 +393,6 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
       // Read the gc location from its lock
       ZooReaderWriter zk = context.getZooReaderWriter();
       ZooLockPath path = new ZooLockPath(context.getZooKeeperRoot() + Constants.ZGC_LOCK);
-      // ZooLock style lock.
       List<String> locks =
           ZooLock.validateAndSortChildrenByLockPrefix(path, zk.getChildren(path.toString()));
       if (locks != null && !locks.isEmpty()) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -64,7 +64,6 @@ import org.apache.accumulo.core.util.ServerServices.Service;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -392,9 +391,8 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     try {
       // Read the gc location from its lock
       ZooReaderWriter zk = context.getZooReaderWriter();
-      ZooLockPath path = new ZooLockPath(context.getZooKeeperRoot() + Constants.ZGC_LOCK);
-      List<String> locks =
-          ZooLock.validateAndSortChildrenByLockPrefix(path, zk.getChildren(path.toString()));
+      var path = ZooLock.path(context.getZooKeeperRoot() + Constants.ZGC_LOCK);
+      List<String> locks = ZooLock.validateAndSort(path, zk.getChildren(path.toString()));
       if (locks != null && !locks.isEmpty()) {
         address = new ServerServices(new String(zk.getData(path + "/" + locks.get(0)), UTF_8))
             .getAddress(Service.GC_CLIENT);
@@ -600,7 +598,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     ServerContext context = getContext();
     final String zRoot = context.getZooKeeperRoot();
     final String monitorPath = zRoot + Constants.ZMONITOR;
-    final ZooLockPath monitorLockPath = new ZooLockPath(zRoot + Constants.ZMONITOR_LOCK);
+    final var monitorLockPath = ZooLock.path(zRoot + Constants.ZMONITOR_LOCK);
 
     // Ensure that everything is kosher with ZK as this has changed.
     ZooReaderWriter zoo = context.getZooReaderWriter();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -93,10 +93,10 @@ import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.accumulo.fate.util.Retry.RetryFactory;
 import org.apache.accumulo.fate.util.UtilWaitThread;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockWatcher;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.AbstractServer;
@@ -213,7 +213,7 @@ public class TabletServer extends AbstractServer {
   private volatile boolean serverStopRequested = false;
   private volatile boolean shutdownComplete = false;
 
-  private ZooLock tabletServerLock;
+  private ServiceLock tabletServerLock;
 
   private TServer server;
   private volatile TServer replServer;
@@ -620,14 +620,14 @@ public class TabletServer extends AbstractServer {
     }
   }
 
-  public ZooLock getLock() {
+  public ServiceLock getLock() {
     return tabletServerLock;
   }
 
   private void announceExistence() {
     ZooReaderWriter zoo = getContext().getZooReaderWriter();
     try {
-      var zLockPath = ZooLock.path(
+      var zLockPath = ServiceLock.path(
           getContext().getZooKeeperRoot() + Constants.ZTSERVERS + "/" + getClientAddressString());
 
       try {
@@ -641,7 +641,7 @@ public class TabletServer extends AbstractServer {
       }
 
       tabletServerLock =
-          new ZooLock(getContext().getSiteConfiguration(), zLockPath, UUID.randomUUID());
+          new ServiceLock(getContext().getSiteConfiguration(), zLockPath, UUID.randomUUID());
 
       LockWatcher lw = new LockWatcher() {
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -97,7 +97,6 @@ import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.AbstractServer;
@@ -628,7 +627,7 @@ public class TabletServer extends AbstractServer {
   private void announceExistence() {
     ZooReaderWriter zoo = getContext().getZooReaderWriter();
     try {
-      ZooLockPath zLockPath = new ZooLockPath(
+      var zLockPath = ZooLock.path(
           getContext().getZooKeeperRoot() + Constants.ZTSERVERS + "/" + getClientAddressString());
 
       try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
@@ -115,7 +115,7 @@ import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.Halt;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.threads.Threads;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.client.ClientServiceHandler;
 import org.apache.accumulo.server.conf.TableConfiguration;
@@ -1365,11 +1365,11 @@ class ThriftClientHandler extends ClientServiceHandler implements TabletClientSe
           new ZooUtil.LockID(context.getZooKeeperRoot() + Constants.ZMANAGER_LOCK, lock);
 
       try {
-        if (!ZooLock.isLockHeld(server.managerLockCache, lid)) {
+        if (!ServiceLock.isLockHeld(server.managerLockCache, lid)) {
           // maybe the cache is out of date and a new manager holds the
           // lock?
           server.managerLockCache.clear();
-          if (!ZooLock.isLockHeld(server.managerLockCache, lid)) {
+          if (!ServiceLock.isLockHeld(server.managerLockCache, lid)) {
             log.warn("Got {} message from a manager that does not hold the current lock {}",
                 request, lock);
             throw new RuntimeException("bad manager lock");

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
@@ -41,7 +41,7 @@ import org.apache.accumulo.fate.ReadOnlyRepo;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.ZooStore;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -131,8 +131,7 @@ public class FateCommand extends Command {
     AdminUtil<FateCommand> admin = new AdminUtil<>(false);
 
     String path = context.getZooKeeperRoot() + Constants.ZFATE;
-    ZooLockPath managerLockPath =
-        new ZooLockPath(context.getZooKeeperRoot() + Constants.ZMANAGER_LOCK);
+    var managerLockPath = ZooLock.path(context.getZooKeeperRoot() + Constants.ZMANAGER_LOCK);
     ZooReaderWriter zk =
         getZooReaderWriter(context, siteConfig, cl.getOptionValue(secretOption.getOpt()));
     ZooStore<FateCommand> zs = new ZooStore<>(path, zk);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
@@ -41,7 +41,7 @@ import org.apache.accumulo.fate.ReadOnlyRepo;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.ZooStore;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -131,7 +131,7 @@ public class FateCommand extends Command {
     AdminUtil<FateCommand> admin = new AdminUtil<>(false);
 
     String path = context.getZooKeeperRoot() + Constants.ZFATE;
-    var managerLockPath = ZooLock.path(context.getZooKeeperRoot() + Constants.ZMANAGER_LOCK);
+    var managerLockPath = ServiceLock.path(context.getZooKeeperRoot() + Constants.ZMANAGER_LOCK);
     ZooReaderWriter zk =
         getZooReaderWriter(context, siteConfig, cl.getOptionValue(secretOption.getOpt()));
     ZooStore<FateCommand> zs = new ZooStore<>(path, zk);

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -43,7 +43,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -104,8 +103,8 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(client.properties());
       ZooCache zcache = new ZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       zcache.clear();
-      ZooLockPath path = new ZooLockPath(
-          ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
+      var path = ZooLock
+          .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
       byte[] gcLockData;
       do {
         gcLockData = ZooLock.getLockData(zcache, path, null);

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -41,8 +41,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.minicluster.ServerType;
@@ -103,11 +103,11 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(client.properties());
       ZooCache zcache = new ZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       zcache.clear();
-      var path = ZooLock
+      var path = ServiceLock
           .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
       byte[] gcLockData;
       do {
-        gcLockData = ZooLock.getLockData(zcache, path, null);
+        gcLockData = ServiceLock.getLockData(zcache, path, null);
         if (gcLockData != null) {
           log.info("Waiting for GC ZooKeeper lock to expire");
           Thread.sleep(2000);
@@ -121,7 +121,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
 
       gcLockData = null;
       do {
-        gcLockData = ZooLock.getLockData(zcache, path, null);
+        gcLockData = ServiceLock.getLockData(zcache, path, null);
         if (gcLockData == null) {
           log.info("Waiting for GC ZooKeeper lock to be acquired");
           Thread.sleep(2000);

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -38,10 +38,10 @@ import java.util.concurrent.locks.LockSupport;
 
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.AccumuloLockWatcher;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.AccumuloLockWatcher;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.ServiceLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
@@ -61,7 +61,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Category({ZooKeeperTestingServerTests.class})
-public class ZooLockIT {
+public class ServiceLockIT {
 
   private static ZooKeeperTestingServer szk = null;
 
@@ -99,9 +99,9 @@ public class ZooLockIT {
 
   }
 
-  private static class ZooLockWrapper extends ZooLock {
+  private static class ServiceLockWrapper extends ServiceLock {
 
-    protected ZooLockWrapper(ZooKeeper zookeeper, ZooLockPath path, UUID uuid) {
+    protected ServiceLockWrapper(ZooKeeper zookeeper, ServiceLockPath path, UUID uuid) {
       super(zookeeper, path, uuid);
     }
 
@@ -190,24 +190,24 @@ public class ZooLockIT {
 
   private static final AtomicInteger pdCount = new AtomicInteger(0);
 
-  private static ZooLock getZooLock(ZooLockPath parent, UUID uuid) {
+  private static ServiceLock getZooLock(ServiceLockPath parent, UUID uuid) {
     Map<String,String> props = new HashMap<>();
     props.put(Property.INSTANCE_ZK_HOST.toString(), szk.getConn());
     props.put(Property.INSTANCE_ZK_TIMEOUT.toString(), "30000");
     props.put(Property.INSTANCE_SECRET.toString(), "secret");
-    return new ZooLock(new ConfigurationCopy(props), parent, uuid);
+    return new ServiceLock(new ConfigurationCopy(props), parent, uuid);
   }
 
-  private static ZooLock getZooLock(ZooKeeperWrapper zkw, ZooLockPath parent, UUID uuid) {
-    return new ZooLockWrapper(zkw, parent, uuid);
+  private static ServiceLock getZooLock(ZooKeeperWrapper zkw, ServiceLockPath parent, UUID uuid) {
+    return new ServiceLockWrapper(zkw, parent, uuid);
   }
 
   @Test(timeout = 10000)
   public void testDeleteParent() throws Exception {
-    var parent =
-        ZooLock.path("/zltestDeleteParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent = ServiceLock
+        .path("/zltestDeleteParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
-    ZooLock zl = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
     assertFalse(zl.isLocked());
 
@@ -237,9 +237,9 @@ public class ZooLockIT {
   @Test(timeout = 10000)
   public void testNoParent() throws Exception {
     var parent =
-        ZooLock.path("/zltestNoParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+        ServiceLock.path("/zltestNoParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
-    ZooLock zl = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
     assertFalse(zl.isLocked());
 
@@ -258,12 +258,12 @@ public class ZooLockIT {
   @Test(timeout = 10000)
   public void testDeleteLock() throws Exception {
     var parent =
-        ZooLock.path("/zltestDeleteLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+        ServiceLock.path("/zltestDeleteLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 30000, "secret");
     zk.mkdirs(parent.toString());
 
-    ZooLock zl = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
     assertFalse(zl.isLocked());
 
@@ -289,13 +289,13 @@ public class ZooLockIT {
 
   @Test(timeout = 15000)
   public void testDeleteWaiting() throws Exception {
-    var parent =
-        ZooLock.path("/zltestDeleteWaiting-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent = ServiceLock
+        .path("/zltestDeleteWaiting-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 30000, "secret");
     zk.mkdirs(parent.toString());
 
-    ZooLock zl = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
     assertFalse(zl.isLocked());
 
@@ -310,7 +310,7 @@ public class ZooLockIT {
     assertNull(lw.exception);
     assertNull(lw.reason);
 
-    ZooLock zl2 = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl2 = getZooLock(parent, UUID.randomUUID());
 
     TestALW lw2 = new TestALW();
 
@@ -319,13 +319,13 @@ public class ZooLockIT {
     assertFalse(lw2.locked);
     assertFalse(zl2.isLocked());
 
-    ZooLock zl3 = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl3 = getZooLock(parent, UUID.randomUUID());
 
     TestALW lw3 = new TestALW();
 
     zl3.lock(lw3, "test3".getBytes(UTF_8));
 
-    List<String> children = ZooLock.validateAndSort(parent, zk.getChildren(parent.toString()));
+    List<String> children = ServiceLock.validateAndSort(parent, zk.getChildren(parent.toString()));
 
     zk.delete(parent + "/" + children.get(1));
 
@@ -355,7 +355,7 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testUnexpectedEvent() throws Exception {
-    var parent = ZooLock
+    var parent = ServiceLock
         .path("/zltestUnexpectedEvent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ConnectedWatcher watcher = new ConnectedWatcher();
@@ -368,7 +368,7 @@ public class ZooLockIT {
 
       zk.create(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
-      ZooLock zl = getZooLock(parent, UUID.randomUUID());
+      ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
       assertFalse(zl.isLocked());
 
@@ -401,7 +401,7 @@ public class ZooLockIT {
 
   @Test(timeout = 60000)
   public void testLockSerial() throws Exception {
-    var parent = ZooLock.path("/zlretryLockSerial");
+    var parent = ServiceLock.path("/zlretryLockSerial");
 
     ConnectedWatcher watcher1 = new ConnectedWatcher();
     ConnectedWatcher watcher2 = new ConnectedWatcher();
@@ -424,7 +424,7 @@ public class ZooLockIT {
           CreateMode.PERSISTENT);
 
       final RetryLockWatcher zlw1 = new RetryLockWatcher();
-      ZooLock zl1 =
+      ServiceLock zl1 =
           getZooLock(zk1, parent, UUID.fromString("00000000-0000-0000-0000-aaaaaaaaaaaa"));
       zl1.lock(zlw1, "test1".getBytes(UTF_8));
       // The call above creates two nodes in ZK because of the overridden create method in
@@ -439,7 +439,7 @@ public class ZooLockIT {
       // zl1 assumes that it has the lock.
 
       final RetryLockWatcher zlw2 = new RetryLockWatcher();
-      ZooLock zl2 =
+      ServiceLock zl2 =
           getZooLock(zk2, parent, UUID.fromString("00000000-0000-0000-0000-bbbbbbbbbbbb"));
       zl2.lock(zlw2, "test1".getBytes(UTF_8));
       // The call above creates two nodes in ZK because of the overridden create method in
@@ -491,7 +491,7 @@ public class ZooLockIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(LockWorker.class);
 
-    private final ZooLockPath parent;
+    private final ServiceLockPath parent;
     private final UUID uuid;
     private final CountDownLatch getLockLatch;
     private final CountDownLatch lockCompletedLatch;
@@ -499,7 +499,7 @@ public class ZooLockIT {
     private final RetryLockWatcher lockWatcher = new RetryLockWatcher();
     private volatile Exception ex = null;
 
-    public LockWorker(final ZooLockPath parent, final UUID uuid, final CountDownLatch lockLatch,
+    public LockWorker(final ServiceLockPath parent, final UUID uuid, final CountDownLatch lockLatch,
         final CountDownLatch lockCompletedLatch) {
       this.parent = parent;
       this.uuid = uuid;
@@ -524,7 +524,7 @@ public class ZooLockIT {
           while (!watcher.isConnected()) {
             Thread.sleep(50);
           }
-          ZooLock zl = getZooLock(zk, parent, uuid);
+          ServiceLock zl = getZooLock(zk, parent, uuid);
           getLockLatch.countDown(); // signal we are done
           getLockLatch.await(); // wait for others to finish
           zl.lock(lockWatcher, "test1".getBytes(UTF_8)); // race to the lock
@@ -565,7 +565,7 @@ public class ZooLockIT {
 
   @Test(timeout = 60000)
   public void testLockParallel() throws Exception {
-    var parent = ZooLock.path("/zlParallel");
+    var parent = ServiceLock.path("/zlParallel");
 
     ConnectedWatcher watcher = new ConnectedWatcher();
     try (ZooKeeperWrapper zk = new ZooKeeperWrapper(szk.getConn(), 30000, watcher)) {
@@ -601,7 +601,7 @@ public class ZooLockIT {
 
       for (int i = 4; i > 0; i--) {
         List<String> children =
-            ZooLock.validateAndSort(parent, zk.getChildren(parent.toString(), null));
+            ServiceLock.validateAndSort(parent, zk.getChildren(parent.toString(), null));
         while (children.size() != i) {
           Thread.sleep(100);
           children = zk.getChildren(parent.toString(), false);
@@ -638,9 +638,9 @@ public class ZooLockIT {
   @Test(timeout = 10000)
   public void testTryLock() throws Exception {
     var parent =
-        ZooLock.path("/zltestTryLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+        ServiceLock.path("/zltestTryLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
-    ZooLock zl = getZooLock(parent, UUID.randomUUID());
+    ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
     ConnectedWatcher watcher = new ConnectedWatcher();
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
@@ -678,7 +678,7 @@ public class ZooLockIT {
   @Test(timeout = 10000)
   public void testChangeData() throws Exception {
     var parent =
-        ZooLock.path("/zltestChangeData-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+        ServiceLock.path("/zltestChangeData-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
     ConnectedWatcher watcher = new ConnectedWatcher();
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
       zk.addAuthInfo("digest", "accumulo:secret".getBytes(UTF_8));
@@ -689,7 +689,7 @@ public class ZooLockIT {
 
       zk.create(parent.toString(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
-      ZooLock zl = getZooLock(parent, UUID.randomUUID());
+      ServiceLock zl = getZooLock(parent, UUID.randomUUID());
 
       TestALW lw = new TestALW();
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooLockIT.java
@@ -204,8 +204,8 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testDeleteParent() throws Exception {
-    ZooLockPath parent = new ZooLockPath(
-        "/zltestDeleteParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent =
+        ZooLock.path("/zltestDeleteParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooLock zl = getZooLock(parent, UUID.randomUUID());
 
@@ -236,8 +236,8 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testNoParent() throws Exception {
-    ZooLockPath parent =
-        new ZooLockPath("/zltestNoParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent =
+        ZooLock.path("/zltestNoParent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooLock zl = getZooLock(parent, UUID.randomUUID());
 
@@ -257,8 +257,8 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testDeleteLock() throws Exception {
-    ZooLockPath parent =
-        new ZooLockPath("/zltestDeleteLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent =
+        ZooLock.path("/zltestDeleteLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 30000, "secret");
     zk.mkdirs(parent.toString());
@@ -289,8 +289,8 @@ public class ZooLockIT {
 
   @Test(timeout = 15000)
   public void testDeleteWaiting() throws Exception {
-    ZooLockPath parent = new ZooLockPath(
-        "/zltestDeleteWaiting-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent =
+        ZooLock.path("/zltestDeleteWaiting-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 30000, "secret");
     zk.mkdirs(parent.toString());
@@ -325,8 +325,7 @@ public class ZooLockIT {
 
     zl3.lock(lw3, "test3".getBytes(UTF_8));
 
-    List<String> children =
-        ZooLock.validateAndSortChildrenByLockPrefix(parent, zk.getChildren(parent.toString()));
+    List<String> children = ZooLock.validateAndSort(parent, zk.getChildren(parent.toString()));
 
     zk.delete(parent + "/" + children.get(1));
 
@@ -356,8 +355,8 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testUnexpectedEvent() throws Exception {
-    ZooLockPath parent = new ZooLockPath(
-        "/zltestUnexpectedEvent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent = ZooLock
+        .path("/zltestUnexpectedEvent-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ConnectedWatcher watcher = new ConnectedWatcher();
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
@@ -402,7 +401,7 @@ public class ZooLockIT {
 
   @Test(timeout = 60000)
   public void testLockSerial() throws Exception {
-    ZooLockPath parent = new ZooLockPath("/zlretryLockSerial");
+    var parent = ZooLock.path("/zlretryLockSerial");
 
     ConnectedWatcher watcher1 = new ConnectedWatcher();
     ConnectedWatcher watcher2 = new ConnectedWatcher();
@@ -566,7 +565,7 @@ public class ZooLockIT {
 
   @Test(timeout = 60000)
   public void testLockParallel() throws Exception {
-    ZooLockPath parent = new ZooLockPath("/zlParallel");
+    var parent = ZooLock.path("/zlParallel");
 
     ConnectedWatcher watcher = new ConnectedWatcher();
     try (ZooKeeperWrapper zk = new ZooKeeperWrapper(szk.getConn(), 30000, watcher)) {
@@ -601,8 +600,8 @@ public class ZooLockIT {
       workers.forEach(w -> assertNull(w.getException()));
 
       for (int i = 4; i > 0; i--) {
-        List<String> children = ZooLock.validateAndSortChildrenByLockPrefix(parent,
-            zk.getChildren(parent.toString(), false));
+        List<String> children =
+            ZooLock.validateAndSort(parent, zk.getChildren(parent.toString(), null));
         while (children.size() != i) {
           Thread.sleep(100);
           children = zk.getChildren(parent.toString(), false);
@@ -638,8 +637,8 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testTryLock() throws Exception {
-    ZooLockPath parent =
-        new ZooLockPath("/zltestTryLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent =
+        ZooLock.path("/zltestTryLock-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
 
     ZooLock zl = getZooLock(parent, UUID.randomUUID());
 
@@ -678,8 +677,8 @@ public class ZooLockIT {
 
   @Test(timeout = 10000)
   public void testChangeData() throws Exception {
-    ZooLockPath parent =
-        new ZooLockPath("/zltestChangeData-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
+    var parent =
+        ZooLock.path("/zltestChangeData-" + this.hashCode() + "-l" + pdCount.incrementAndGet());
     ConnectedWatcher watcher = new ConnectedWatcher();
     try (ZooKeeper zk = new ZooKeeper(szk.getConn(), 30000, watcher)) {
       zk.addAuthInfo("digest", "accumulo:secret".getBytes(UTF_8));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.manager.Manager;
@@ -53,9 +52,8 @@ public class BackupManagerIT extends ConfigurableMacBase {
       // wait for 2 lock entries
       do {
         UtilWaitThread.sleep(100);
-        ZooLockPath path = new ZooLockPath(root + Constants.ZMANAGER_LOCK);
-        children =
-            ZooLock.validateAndSortChildrenByLockPrefix(path, writer.getChildren(path.toString()));
+        var path = ZooLock.path(root + Constants.ZMANAGER_LOCK);
+        children = ZooLock.validateAndSort(path, writer.getChildren(path.toString()));
       } while (children.size() != 2);
       // wait for the backup manager to learn to be the backup
       UtilWaitThread.sleep(1000);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.fate.util.UtilWaitThread;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.manager.Manager;
@@ -52,8 +52,8 @@ public class BackupManagerIT extends ConfigurableMacBase {
       // wait for 2 lock entries
       do {
         UtilWaitThread.sleep(100);
-        var path = ZooLock.path(root + Constants.ZMANAGER_LOCK);
-        children = ZooLock.validateAndSort(path, writer.getChildren(path.toString()));
+        var path = ServiceLock.path(root + Constants.ZMANAGER_LOCK);
+        children = ServiceLock.validateAndSort(path, writer.getChildren(path.toString()));
       } while (children.size() != 2);
       // wait for the backup manager to learn to be the backup
       UtilWaitThread.sleep(1000);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -73,8 +73,8 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.MonitorUtil;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -171,11 +171,11 @@ public class ReadWriteIT extends AccumuloClusterHarness {
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
       var zLockPath =
-          ZooLock.path(ZooUtil.getRoot(accumuloClient.instanceOperations().getInstanceID())
+          ServiceLock.path(ZooUtil.getRoot(accumuloClient.instanceOperations().getInstanceID())
               + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
-        managerLockData = ZooLock.getLockData(zcache, zLockPath, null);
+        managerLockData = ServiceLock.getLockData(zcache, zLockPath, null);
         if (managerLockData != null) {
           log.info("Manager lock is still held");
           Thread.sleep(1000);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -75,7 +75,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.MonitorUtil;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -171,8 +170,8 @@ public class ReadWriteIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(accumuloClient.properties());
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
-      ZooLockPath zLockPath =
-          new ZooLockPath(ZooUtil.getRoot(accumuloClient.instanceOperations().getInstanceID())
+      var zLockPath =
+          ZooLock.path(ZooUtil.getRoot(accumuloClient.instanceOperations().getInstanceID())
               + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -39,7 +39,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -142,8 +141,8 @@ public class RestartIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(c.properties());
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
-      ZooLockPath zLockPath = new ZooLockPath(
-          ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
+      var zLockPath = ZooLock
+          .path(ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
         managerLockData = ZooLock.getLockData(zcache, zLockPath, null);
@@ -195,8 +194,8 @@ public class RestartIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(c.properties());
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
-      ZooLockPath zLockPath = new ZooLockPath(
-          ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
+      var zLockPath = ZooLock
+          .path(ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
         managerLockData = ZooLock.getLockData(zcache, zLockPath, null);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -37,8 +37,8 @@ import org.apache.accumulo.core.clientImpl.ClientInfo;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -141,11 +141,11 @@ public class RestartIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(c.properties());
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
-      var zLockPath = ZooLock
+      var zLockPath = ServiceLock
           .path(ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
-        managerLockData = ZooLock.getLockData(zcache, zLockPath, null);
+        managerLockData = ServiceLock.getLockData(zcache, zLockPath, null);
         if (managerLockData != null) {
           log.info("Manager lock is still held");
           Thread.sleep(1000);
@@ -158,7 +158,7 @@ public class RestartIT extends AccumuloClusterHarness {
 
       managerLockData = new byte[0];
       do {
-        managerLockData = ZooLock.getLockData(zcache, zLockPath, null);
+        managerLockData = ServiceLock.getLockData(zcache, zLockPath, null);
         if (managerLockData != null) {
           log.info("Manager lock is still held");
           Thread.sleep(1000);
@@ -194,11 +194,11 @@ public class RestartIT extends AccumuloClusterHarness {
       ClientInfo info = ClientInfo.from(c.properties());
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
-      var zLockPath = ZooLock
+      var zLockPath = ServiceLock
           .path(ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
-        managerLockData = ZooLock.getLockData(zcache, zLockPath, null);
+        managerLockData = ServiceLock.getLockData(zcache, zLockPath, null);
         if (managerLockData != null) {
           log.info("Manager lock is still held");
           Thread.sleep(1000);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -62,9 +62,9 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockWatcher;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerConstants;
@@ -92,10 +92,10 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   private void run(ServerContext c) throws Exception {
-    var zPath = ZooLock.path(c.getZooKeeperRoot() + "/testLock");
+    var zPath = ServiceLock.path(c.getZooKeeperRoot() + "/testLock");
     ZooReaderWriter zoo = c.getZooReaderWriter();
     zoo.putPersistentData(zPath.toString(), new byte[0], NodeExistsPolicy.OVERWRITE);
-    ZooLock zl = new ZooLock(c.getSiteConfiguration(), zPath, UUID.randomUUID());
+    ServiceLock zl = new ServiceLock(c.getSiteConfiguration(), zPath, UUID.randomUUID());
     boolean gotLock = zl.tryLock(new LockWatcher() {
 
       @SuppressFBWarnings(value = "DM_EXIT",
@@ -148,7 +148,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   private void runSplitRecoveryTest(ServerContext context, int failPoint, String mr,
-      int extentToSplit, ZooLock zl, KeyExtent... extents) throws Exception {
+      int extentToSplit, ServiceLock zl, KeyExtent... extents) throws Exception {
 
     Text midRow = new Text(mr);
 
@@ -196,7 +196,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
 
   private void splitPartiallyAndRecover(ServerContext context, KeyExtent extent, KeyExtent high,
       KeyExtent low, double splitRatio, SortedMap<StoredTabletFile,DataFileValue> mapFiles,
-      Text midRow, String location, int steps, ZooLock zl) throws Exception {
+      Text midRow, String location, int steps, ServiceLock zl) throws Exception {
 
     SortedMap<StoredTabletFile,DataFileValue> lowDatafileSizes = new TreeMap<>();
     SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes = new TreeMap<>();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -65,7 +65,6 @@ import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerConstants;
@@ -93,7 +92,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
   }
 
   private void run(ServerContext c) throws Exception {
-    ZooLockPath zPath = new ZooLockPath(c.getZooKeeperRoot() + "/testLock");
+    var zPath = ZooLock.path(c.getZooKeeperRoot() + "/testLock");
     ZooReaderWriter zoo = c.getZooReaderWriter();
     zoo.putPersistentData(zPath.toString(), new byte[0], NodeExistsPolicy.OVERWRITE);
     ZooLock zl = new ZooLock(c.getSiteConfiguration(), zPath, UUID.randomUUID());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -63,7 +63,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.manager.state.CurrentState;
@@ -309,9 +308,8 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       HashSet<TServerInstance> tservers = new HashSet<>();
       for (String tserver : client.instanceOperations().getTabletServers()) {
         try {
-          ZooLockPath zPath =
-              new ZooLockPath(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
-                  + Constants.ZTSERVERS + "/" + tserver);
+          var zPath = ZooLock.path(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+              + Constants.ZTSERVERS + "/" + tserver);
           ClientInfo info = getClientInfo();
           long sessionId = ZooLock.getSessionId(
               new ZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut()), zPath);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -61,8 +61,8 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.fate.util.UtilWaitThread;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.manager.state.CurrentState;
@@ -308,10 +308,10 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       HashSet<TServerInstance> tservers = new HashSet<>();
       for (String tserver : client.instanceOperations().getTabletServers()) {
         try {
-          var zPath = ZooLock.path(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+          var zPath = ServiceLock.path(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
               + Constants.ZTSERVERS + "/" + tserver);
           ClientInfo info = getClientInfo();
-          long sessionId = ZooLock.getSessionId(
+          long sessionId = ServiceLock.getSessionId(
               new ZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut()), zPath);
           tservers.add(new TServerInstance(tserver, sessionId));
         } catch (Exception e) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -39,9 +39,9 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.ServerServices;
 import org.apache.accumulo.core.util.ServerServices.Service;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
-import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
+import org.apache.accumulo.fate.zookeeper.ServiceLock.LockWatcher;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerContext;
@@ -117,11 +117,12 @@ public class ZombieTServer {
 
     String addressString = serverPort.address.toString();
     var zLockPath =
-        ZooLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + addressString);
+        ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + addressString);
     ZooReaderWriter zoo = context.getZooReaderWriter();
     zoo.putPersistentData(zLockPath.toString(), new byte[] {}, NodeExistsPolicy.SKIP);
 
-    ZooLock zlock = new ZooLock(context.getSiteConfiguration(), zLockPath, UUID.randomUUID());
+    ServiceLock zlock =
+        new ServiceLock(context.getSiteConfiguration(), zLockPath, UUID.randomUUID());
 
     LockWatcher lw = new LockWatcher() {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockLossReason;
 import org.apache.accumulo.fate.zookeeper.ZooLock.LockWatcher;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerContext;
@@ -117,8 +116,8 @@ public class ZombieTServer {
             null, -1, HostAndPort.fromParts("0.0.0.0", port));
 
     String addressString = serverPort.address.toString();
-    ZooLockPath zLockPath =
-        new ZooLockPath(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + addressString);
+    var zLockPath =
+        ZooLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + addressString);
     ZooReaderWriter zoo = context.getZooReaderWriter();
     zoo.putPersistentData(zLockPath.toString(), new byte[] {}, NodeExistsPolicy.SKIP);
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -83,9 +83,9 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
 import org.apache.accumulo.minicluster.ServerType;
@@ -207,14 +207,14 @@ public class ReplicationIT extends ConfigurableMacBase {
     ZooCacheFactory zcf = new ZooCacheFactory();
     ClientInfo info = ClientInfo.from(client.properties());
     ZooCache zcache = zcf.getZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
-    var zkPath = ZooLock
+    var zkPath = ServiceLock
         .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
     log.info("Looking for GC lock at {}", zkPath);
-    byte[] data = ZooLock.getLockData(zcache, zkPath, null);
+    byte[] data = ServiceLock.getLockData(zcache, zkPath, null);
     while (data == null) {
       log.info("Waiting for GC ZooKeeper lock to be acquired");
       Thread.sleep(1000);
-      data = ZooLock.getLockData(zcache, zkPath, null);
+      data = ServiceLock.getLockData(zcache, zkPath, null);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -86,7 +86,6 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
 import org.apache.accumulo.minicluster.ServerType;
@@ -208,8 +207,8 @@ public class ReplicationIT extends ConfigurableMacBase {
     ZooCacheFactory zcf = new ZooCacheFactory();
     ClientInfo info = ClientInfo.from(client.properties());
     ZooCache zcache = zcf.getZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
-    ZooLockPath zkPath = new ZooLockPath(
-        ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
+    var zkPath = ZooLock
+        .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
     log.info("Looking for GC lock at {}", zkPath);
     byte[] data = ZooLock.getLockData(zcache, zkPath, null);
     while (data == null) {

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgrade9to10TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgrade9to10TestIT.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.fate.zookeeper.ZooLock;
-import org.apache.accumulo.fate.zookeeper.ZooLock.ZooLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.upgrade.Upgrader9to10;
 import org.apache.accumulo.minicluster.ServerType;
@@ -84,7 +83,7 @@ public class GCUpgrade9to10TestIT extends ConfigurableMacBase {
     getCluster().killProcess(ServerType.GARBAGE_COLLECTOR,
         getCluster().getProcesses().get(ServerType.GARBAGE_COLLECTOR).iterator().next());
     // delete lock in zookeeper if there, this will allow next GC to start quickly
-    ZooLockPath path = new ZooLockPath(getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
+    var path = ZooLock.path(getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
     ZooReaderWriter zk = new ZooReaderWriter(cluster.getZooKeepers(), 30000, OUR_SECRET);
     try {
       ZooLock.deleteLock(zk, path);

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgrade9to10TestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/GCUpgrade9to10TestIT.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
-import org.apache.accumulo.fate.zookeeper.ZooLock;
+import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.upgrade.Upgrader9to10;
 import org.apache.accumulo.minicluster.ServerType;
@@ -83,10 +83,10 @@ public class GCUpgrade9to10TestIT extends ConfigurableMacBase {
     getCluster().killProcess(ServerType.GARBAGE_COLLECTOR,
         getCluster().getProcesses().get(ServerType.GARBAGE_COLLECTOR).iterator().next());
     // delete lock in zookeeper if there, this will allow next GC to start quickly
-    var path = ZooLock.path(getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
+    var path = ServiceLock.path(getServerContext().getZooKeeperRoot() + Constants.ZGC_LOCK);
     ZooReaderWriter zk = new ZooReaderWriter(cluster.getZooKeepers(), 30000, OUR_SECRET);
     try {
-      ZooLock.deleteLock(zk, path);
+      ServiceLock.deleteLock(zk, path);
     } catch (IllegalStateException e) {
       log.error("Unable to delete ZooLock for mini accumulo-gc", e);
     }


### PR DESCRIPTION
A possible solution for #1966.  

Giving lock paths a more specific type over just `String` will reduce confusion on which type of lock is being used and which appropriate function calls to make.

This is just one possible implementation of this. I wavered on including a specific path function or not. Any ideas on improvements are welcomed.