### PR TITLE
Add created column to Fate Print command

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -86,6 +86,11 @@ public class FateLogger {
       }
 
       @Override
+      public String getTimestamp(long tid) {
+        return store.getTimestamp(tid);
+      }
+
+      @Override
       public long create() {
         long tid = store.create();
         if (storeLog.isTraceEnabled())

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -86,8 +86,8 @@ public class FateLogger {
       }
 
       @Override
-      public String getTimestamp(long tid) {
-        return store.getTimestamp(tid);
+      public String timeTopCreated(long tid) {
+        return store.timeTopCreated(tid);
       }
 
       @Override

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -86,7 +86,7 @@ public class FateLogger {
       }
 
       @Override
-      public String timeCreated(long tid) {
+      public long timeCreated(long tid) {
         return store.timeCreated(tid);
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/FateLogger.java
@@ -86,8 +86,8 @@ public class FateLogger {
       }
 
       @Override
-      public String timeTopCreated(long tid) {
-        return store.timeTopCreated(tid);
+      public String timeCreated(long tid) {
+        return store.timeCreated(tid);
       }
 
       @Override

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -80,10 +80,10 @@ public class AdminUtil<T> {
     private final List<String> hlocks;
     private final List<String> wlocks;
     private final String top;
-    private final String timeTopCreated;
+    private final String timeCreated;
 
     private TransactionStatus(Long tid, TStatus status, String debug, List<String> hlocks,
-        List<String> wlocks, String top, String timeTopCreated) {
+        List<String> wlocks, String top, String timeCreated) {
 
       this.txid = tid;
       this.status = status;
@@ -91,7 +91,7 @@ public class AdminUtil<T> {
       this.hlocks = Collections.unmodifiableList(hlocks);
       this.wlocks = Collections.unmodifiableList(wlocks);
       this.top = top;
-      this.timeTopCreated = timeTopCreated;
+      this.timeCreated = timeCreated;
 
     }
 
@@ -138,8 +138,8 @@ public class AdminUtil<T> {
     /**
      * @return The timestamp of when the operation was created.
      */
-    public String getTimeTopCreated() {
-      return timeTopCreated;
+    public String getTimeCreated() {
+      return timeCreated;
     }
   }
 
@@ -382,7 +382,7 @@ public class AdminUtil<T> {
 
       TStatus status = zs.getStatus(tid);
 
-      String timeTopCreated = zs.timeTopCreated(tid);
+      String timeCreated = zs.timeCreated(tid);
 
       zs.unreserve(tid, 0);
 
@@ -390,7 +390,7 @@ public class AdminUtil<T> {
           || (filterStatus != null && !filterStatus.contains(status)))
         continue;
 
-      statuses.add(new TransactionStatus(tid, status, debug, hlocks, wlocks, top, timeTopCreated));
+      statuses.add(new TransactionStatus(tid, status, debug, hlocks, wlocks, top, timeCreated));
     }
 
     return new FateStatus(statuses, heldLocks, waitingLocks);
@@ -412,7 +412,7 @@ public class AdminUtil<T> {
       fmt.format(
           "txid: %s  status: %-18s  op: %-15s  locked: %-15s locking: %-15s top: %-15s created: %s%n",
           txStatus.getTxid(), txStatus.getStatus(), txStatus.getDebug(), txStatus.getHeldLocks(),
-          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeTopCreated());
+          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeCreated());
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
 

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -20,8 +20,11 @@ package org.apache.accumulo.fate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.Formatter;
 import java.util.HashMap;
@@ -80,10 +83,10 @@ public class AdminUtil<T> {
     private final List<String> hlocks;
     private final List<String> wlocks;
     private final String top;
-    private final String timeCreated;
+    private final long timeCreated;
 
     private TransactionStatus(Long tid, TStatus status, String debug, List<String> hlocks,
-        List<String> wlocks, String top, String timeCreated) {
+        List<String> wlocks, String top, Long timeCreated) {
 
       this.txid = tid;
       this.status = status;
@@ -136,9 +139,17 @@ public class AdminUtil<T> {
     }
 
     /**
-     * @return The timestamp of when the operation was created.
+     * @return The timestamp of when the operation was created in ISO format wiht UTC timezone.
      */
-    public String getTimeCreated() {
+    public String getTimeCreatedFormatted() {
+      return timeCreated > 0 ? new Date(timeCreated).toInstant().atZone(ZoneOffset.UTC)
+          .format(DateTimeFormatter.ISO_DATE_TIME) : "ERROR";
+    }
+
+    /**
+     * @return The unformatted form of the timestamp.
+     */
+    public long getTimeCreated() {
       return timeCreated;
     }
   }
@@ -382,7 +393,7 @@ public class AdminUtil<T> {
 
       TStatus status = zs.getStatus(tid);
 
-      String timeCreated = zs.timeCreated(tid);
+      long timeCreated = zs.timeCreated(tid);
 
       zs.unreserve(tid, 0);
 
@@ -412,7 +423,7 @@ public class AdminUtil<T> {
       fmt.format(
           "txid: %s  status: %-18s  op: %-15s  locked: %-15s locking: %-15s top: %-15s created: %s%n",
           txStatus.getTxid(), txStatus.getStatus(), txStatus.getDebug(), txStatus.getHeldLocks(),
-          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeCreated());
+          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeCreatedFormatted());
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
 

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -80,9 +80,10 @@ public class AdminUtil<T> {
     private final List<String> hlocks;
     private final List<String> wlocks;
     private final String top;
+    private final String timestamp;
 
     private TransactionStatus(Long tid, TStatus status, String debug, List<String> hlocks,
-        List<String> wlocks, String top) {
+        List<String> wlocks, String top, String timestamp) {
 
       this.txid = tid;
       this.status = status;
@@ -90,6 +91,7 @@ public class AdminUtil<T> {
       this.hlocks = Collections.unmodifiableList(hlocks);
       this.wlocks = Collections.unmodifiableList(wlocks);
       this.top = top;
+      this.timestamp = timestamp;
 
     }
 
@@ -131,6 +133,13 @@ public class AdminUtil<T> {
      */
     public String getTop() {
       return top;
+    }
+
+    /**
+     * @return The timestamp of when the operation was created.
+     */
+    public String getTimestamp() {
+      return timestamp;
     }
   }
 
@@ -373,13 +382,15 @@ public class AdminUtil<T> {
 
       TStatus status = zs.getStatus(tid);
 
+      String timestamp = zs.getTimestamp(tid);
+
       zs.unreserve(tid, 0);
 
       if ((filterTxid != null && !filterTxid.contains(tid))
           || (filterStatus != null && !filterStatus.contains(status)))
         continue;
 
-      statuses.add(new TransactionStatus(tid, status, debug, hlocks, wlocks, top));
+      statuses.add(new TransactionStatus(tid, status, debug, hlocks, wlocks, top, timestamp));
     }
 
     return new FateStatus(statuses, heldLocks, waitingLocks);
@@ -398,9 +409,10 @@ public class AdminUtil<T> {
     FateStatus fateStatus = getStatus(zs, zk, lockPath, filterTxid, filterStatus);
 
     for (TransactionStatus txStatus : fateStatus.getTransactions()) {
-      fmt.format("txid: %s  status: %-18s  op: %-15s  locked: %-15s locking: %-15s top: %s%n",
+      fmt.format(
+          "txid: %s  status: %-18s  op: %-15s  locked: %-15s locking: %-15s top: %-15s created: %s%n",
           txStatus.getTxid(), txStatus.getStatus(), txStatus.getDebug(), txStatus.getHeldLocks(),
-          txStatus.getWaitingLocks(), txStatus.getTop());
+          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimestamp());
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
 

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -80,10 +80,10 @@ public class AdminUtil<T> {
     private final List<String> hlocks;
     private final List<String> wlocks;
     private final String top;
-    private final String timestamp;
+    private final String timeTopCreated;
 
     private TransactionStatus(Long tid, TStatus status, String debug, List<String> hlocks,
-        List<String> wlocks, String top, String timestamp) {
+        List<String> wlocks, String top, String timeTopCreated) {
 
       this.txid = tid;
       this.status = status;
@@ -91,7 +91,7 @@ public class AdminUtil<T> {
       this.hlocks = Collections.unmodifiableList(hlocks);
       this.wlocks = Collections.unmodifiableList(wlocks);
       this.top = top;
-      this.timestamp = timestamp;
+      this.timeTopCreated = timeTopCreated;
 
     }
 
@@ -138,8 +138,8 @@ public class AdminUtil<T> {
     /**
      * @return The timestamp of when the operation was created.
      */
-    public String getTimestamp() {
-      return timestamp;
+    public String getTimeTopCreated() {
+      return timeTopCreated;
     }
   }
 
@@ -382,7 +382,7 @@ public class AdminUtil<T> {
 
       TStatus status = zs.getStatus(tid);
 
-      String timestamp = zs.getTimestamp(tid);
+      String timeTopCreated = zs.timeTopCreated(tid);
 
       zs.unreserve(tid, 0);
 
@@ -390,7 +390,7 @@ public class AdminUtil<T> {
           || (filterStatus != null && !filterStatus.contains(status)))
         continue;
 
-      statuses.add(new TransactionStatus(tid, status, debug, hlocks, wlocks, top, timestamp));
+      statuses.add(new TransactionStatus(tid, status, debug, hlocks, wlocks, top, timeTopCreated));
     }
 
     return new FateStatus(statuses, heldLocks, waitingLocks);
@@ -412,7 +412,7 @@ public class AdminUtil<T> {
       fmt.format(
           "txid: %s  status: %-18s  op: %-15s  locked: %-15s locking: %-15s top: %-15s created: %s%n",
           txStatus.getTxid(), txStatus.getStatus(), txStatus.getDebug(), txStatus.getHeldLocks(),
-          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimestamp());
+          txStatus.getWaitingLocks(), txStatus.getTop(), txStatus.getTimeTopCreated());
     }
     fmt.format(" %s transactions", fateStatus.getTransactions().size());
 

--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -231,7 +231,7 @@ public class AgeOffStore<T> implements TStore<T> {
   }
 
   @Override
-  public String timeCreated(long tid) {
+  public long timeCreated(long tid) {
     return store.timeCreated(tid);
   }
 

--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -231,6 +231,11 @@ public class AgeOffStore<T> implements TStore<T> {
   }
 
   @Override
+  public String getTimestamp(long tid) {
+    return store.getTimestamp(tid);
+  }
+
+  @Override
   public List<ReadOnlyRepo<T>> getStack(long tid) {
     return store.getStack(tid);
   }

--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -231,8 +231,8 @@ public class AgeOffStore<T> implements TStore<T> {
   }
 
   @Override
-  public String getTimestamp(long tid) {
-    return store.getTimestamp(tid);
+  public String timeTopCreated(long tid) {
+    return store.timeTopCreated(tid);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -231,8 +231,8 @@ public class AgeOffStore<T> implements TStore<T> {
   }
 
   @Override
-  public String timeTopCreated(long tid) {
-    return store.timeTopCreated(tid);
+  public String timeCreated(long tid) {
+    return store.timeCreated(tid);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
@@ -116,4 +116,9 @@ public class ReadOnlyStore<T> implements ReadOnlyTStore<T> {
   public List<ReadOnlyRepo<T>> getStack(long tid) {
     return store.getStack(tid);
   }
+
+  @Override
+  public String getTimestamp(long tid) {
+    return store.getTimestamp(tid);
+  }
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
@@ -118,7 +118,7 @@ public class ReadOnlyStore<T> implements ReadOnlyTStore<T> {
   }
 
   @Override
-  public String getTimestamp(long tid) {
-    return store.getTimestamp(tid);
+  public String timeTopCreated(long tid) {
+    return store.timeTopCreated(tid);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
@@ -118,7 +118,7 @@ public class ReadOnlyStore<T> implements ReadOnlyTStore<T> {
   }
 
   @Override
-  public String timeTopCreated(long tid) {
-    return store.timeTopCreated(tid);
+  public String timeCreated(long tid) {
+    return store.timeCreated(tid);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
@@ -118,7 +118,7 @@ public class ReadOnlyStore<T> implements ReadOnlyTStore<T> {
   }
 
   @Override
-  public String timeCreated(long tid) {
+  public long timeCreated(long tid) {
     return store.timeCreated(tid);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
@@ -140,11 +140,11 @@ public interface ReadOnlyTStore<T> {
   List<Long> list();
 
   /**
-   * Retrieve timestamp of a transaction.
+   * Retrieve the creation time of a FaTE transaction.
    *
    * @param tid
    *          Transaction id, previously reserved.
-   * @return timestamp of transaction.
+   * @return creation time of transaction.
    */
-  String timeTopCreated(long tid);
+  String timeCreated(long tid);
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
@@ -139,4 +139,12 @@ public interface ReadOnlyTStore<T> {
    */
   List<Long> list();
 
+  /**
+   * Retrieve timestamp of a transaction.
+   *
+   * @param tid
+   *          Transaction id, previously reserved.
+   * @return timestamp of transaction.
+   */
+  String getTimestamp(long tid);
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
@@ -146,5 +146,5 @@ public interface ReadOnlyTStore<T> {
    *          Transaction id, previously reserved.
    * @return creation time of transaction.
    */
-  String timeCreated(long tid);
+  long timeCreated(long tid);
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
@@ -146,5 +146,5 @@ public interface ReadOnlyTStore<T> {
    *          Transaction id, previously reserved.
    * @return timestamp of transaction.
    */
-  String getTimestamp(long tid);
+  String timeTopCreated(long tid);
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -488,8 +488,8 @@ public class ZooStore<T> implements TStore<T> {
 
     try {
       Stat stat = zk.getZooKeeper().exists(getTXPath(tid), false);
-      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("E yyyy MMM dd z hh:mm:ss");
-      return new Date(stat.getCtime()).toInstant().atZone(ZoneOffset.UTC).format(dtf);
+      return new Date(stat.getCtime()).toInstant().atZone(ZoneOffset.UTC)
+          .format(DateTimeFormatter.ISO_DATE_TIME);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -28,6 +28,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.security.SecureRandom;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -486,7 +488,8 @@ public class ZooStore<T> implements TStore<T> {
 
     try {
       Stat stat = zk.getZooKeeper().exists(getTXPath(tid), false);
-      return new Date(stat.getCtime()).toString();
+      DateTimeFormatter dtf = DateTimeFormatter.ofPattern("E yyyy MMM dd z hh:mm:ss");
+      return new Date(stat.getCtime()).toInstant().atZone(ZoneOffset.UTC).format(dtf);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +45,7 @@ import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -473,6 +475,18 @@ public class ZooStore<T> implements TStore<T> {
         l.add(parseTid(txid));
       }
       return l;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String getTimestamp(long tid) {
+    verifyReserved(tid);
+
+    try {
+      Stat stat = zk.getZooKeeper().exists(getTXPath(tid), false);
+      return new Date(stat.getCtime()).toString();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -28,11 +28,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.security.SecureRandom;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -483,15 +480,14 @@ public class ZooStore<T> implements TStore<T> {
   }
 
   @Override
-  public String timeCreated(long tid) {
+  public long timeCreated(long tid) {
     verifyReserved(tid);
 
     try {
       Stat stat = zk.getZooKeeper().exists(getTXPath(tid), false);
-      return new Date(stat.getCtime()).toInstant().atZone(ZoneOffset.UTC)
-          .format(DateTimeFormatter.ISO_DATE_TIME);
+      return stat.getCtime();
     } catch (Exception e) {
-      return "ERROR";
+      return 0;
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -483,7 +483,7 @@ public class ZooStore<T> implements TStore<T> {
   }
 
   @Override
-  public String timeTopCreated(long tid) {
+  public String timeCreated(long tid) {
     verifyReserved(tid);
 
     try {

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -481,7 +481,7 @@ public class ZooStore<T> implements TStore<T> {
   }
 
   @Override
-  public String getTimestamp(long tid) {
+  public String timeTopCreated(long tid) {
     verifyReserved(tid);
 
     try {

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -491,7 +491,7 @@ public class ZooStore<T> implements TStore<T> {
       return new Date(stat.getCtime()).toInstant().atZone(ZoneOffset.UTC)
           .format(DateTimeFormatter.ISO_DATE_TIME);
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      return "ERROR";
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
+++ b/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
@@ -126,7 +126,7 @@ public class SimpleStore<T> implements TStore<T> {
   }
 
   @Override
-  public String timeTopCreated(long tid) {
+  public String timeCreated(long tid) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
+++ b/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
@@ -126,6 +126,11 @@ public class SimpleStore<T> implements TStore<T> {
   }
 
   @Override
+  public String getTimestamp(long tid) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public List<ReadOnlyRepo<T>> getStack(long tid) {
     throw new UnsupportedOperationException();
   }

--- a/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
+++ b/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
@@ -126,7 +126,7 @@ public class SimpleStore<T> implements TStore<T> {
   }
 
   @Override
-  public String timeCreated(long tid) {
+  public long timeCreated(long tid) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
+++ b/core/src/test/java/org/apache/accumulo/fate/SimpleStore.java
@@ -126,7 +126,7 @@ public class SimpleStore<T> implements TStore<T> {
   }
 
   @Override
-  public String getTimestamp(long tid) {
+  public String timeTopCreated(long tid) {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/ACCUMULO-4161. An age/created column was added to the `fate print ` command in the shell. 

Image below is what the timestamp looks like in its current state. 

![image](https://user-images.githubusercontent.com/29436247/112877128-617be080-9094-11eb-943c-4ca3f3ca853c.png)

