### PR TITLE
Update lastLocation on assignment in 1.10 branch

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -74,6 +74,7 @@ public class MetaDataStateStore extends TabletStateStore {
       for (Assignment assignment : assignments) {
         Mutation m = new Mutation(assignment.tablet.getMetadataEntry());
         assignment.server.putLocation(m);
+        assignment.server.putLastLocation(m);
         assignment.server.clearFutureLocation(m);
         SuspendingTServer.clearSuspension(m);
         writer.addMutation(m);


### PR DESCRIPTION
* Provides for faster initial accumulo by ensuring the last location is always up to date.

This is a backport of #1453 (re #1169)