### PR TITLE
Ensure that the HostRegexTableLoadBalancer property changes are picked up

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -220,7 +220,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
    * @param conf
    *          server configuration
    */
-  protected void parseConfiguration(ServerConfiguration conf) {
+  protected void parseTableConfiguration(ServerConfiguration conf) {
     TableOperations t = getTableOperations();
     if (null == t) {
       throw new RuntimeException("Table Operations cannot be null");
@@ -251,6 +251,14 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
 
     tableIdToTableName = ImmutableMap.copyOf(tableIdToTableNameBuilder);
     poolNameToRegexPattern = ImmutableMap.copyOf(poolNameToRegexPatternBuilder);
+
+    LOG.info("{}", this);
+  }
+
+  public void parseSystemConfiguration(ServerConfiguration conf) {
+    // reparse the table configuration properties in case a table property is being
+    // changed at the system level.
+    parseTableConfiguration(conf);
 
     String oobProperty = conf.getConfiguration().get(HOST_BALANCER_OOB_CHECK_KEY);
     if (null != oobProperty) {
@@ -317,12 +325,14 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
   @Override
   public void init(ServerConfigurationFactory conf) {
     super.init(conf);
-    parseConfiguration(conf);
+    parseSystemConfiguration(conf);
   }
 
   @Override
   public void getAssignments(SortedMap<TServerInstance,TabletServerStatus> current,
       Map<KeyExtent,TServerInstance> unassigned, Map<KeyExtent,TServerInstance> assignments) {
+
+    parseSystemConfiguration(this.configuration);
 
     Map<String,SortedMap<TServerInstance,TabletServerStatus>> pools = splitCurrentByRegex(current);
     // group the unassigned into tables
@@ -367,6 +377,8 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
     TableOperations t = getTableOperations();
     if (t == null)
       return minBalanceTime;
+
+    parseSystemConfiguration(this.configuration);
 
     Map<String,String> tableIdMap = t.tableIdMap();
     long now = System.currentTimeMillis();
@@ -543,12 +555,12 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
 
   @Override
   public void propertyChanged(String key) {
-    parseConfiguration(this.configuration);
+    parseTableConfiguration(this.configuration);
   }
 
   @Override
   public void propertiesChanged() {
-    parseConfiguration(this.configuration);
+    parseTableConfiguration(this.configuration);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -255,7 +255,7 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer implements Con
     LOG.info("{}", this);
   }
 
-  public void parseSystemConfiguration(ServerConfiguration conf) {
+  protected void parseSystemConfiguration(ServerConfiguration conf) {
     // reparse the table configuration properties in case a table property is being
     // changed at the system level.
     parseTableConfiguration(conf);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -84,7 +84,6 @@ public class HostRegexTableLoadBalancerReconfigurationTest
     // Change property, simulate call by TableConfWatcher
     DEFAULT_TABLE_PROPERTIES
         .put(HostRegexTableLoadBalancer.HOST_BALANCER_PREFIX + BAR.getTableName(), "r01.*");
-    this.propertiesChanged();
     // Wait to trigger the out of bounds check and the repool check
     UtilWaitThread.sleep(10000);
     this.balance(Collections.unmodifiableSortedMap(allTabletServers), migrations, migrationsOut);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -96,6 +96,25 @@ public class HostRegexTableLoadBalancerReconfigurationTest
           || migration.newServer.host().startsWith("192.168.0.4")
           || migration.newServer.host().startsWith("192.168.0.5"));
     }
+
+    // checking that system properties are reread when balance is called
+    assertEquals(7000, this.getOobCheckMillis());
+    assertEquals(10, this.getMaxOutstandingMigrations());
+    assertEquals(4, this.getMaxMigrations());
+
+    DEFAULT_TABLE_PROPERTIES.put(HostRegexTableLoadBalancer.HOST_BALANCER_OOB_CHECK_KEY, "1m");
+    DEFAULT_TABLE_PROPERTIES
+        .put(HostRegexTableLoadBalancer.HOST_BALANCER_OUTSTANDING_MIGRATIONS_KEY, "50");
+    DEFAULT_TABLE_PROPERTIES.put(HostRegexTableLoadBalancer.HOST_BALANCER_REGEX_MAX_MIGRATIONS_KEY,
+        "1000");
+    migrations.clear();
+    migrationsOut.clear();
+    this.balance(Collections.unmodifiableSortedMap(allTabletServers), migrations, migrationsOut);
+
+    // now we should see the new values
+    assertEquals(60000, this.getOobCheckMillis());
+    assertEquals(50, this.getMaxOutstandingMigrations());
+    assertEquals(1000, this.getMaxMigrations());
   }
 
   @Override


### PR DESCRIPTION
Ensure that the HostRegexTableLoadBalancer property changes are picked up.
When properties are set at the system level for the HostRegexTableLoadBalancer, the changes are not picked up and require the master to be restarted.  This change ensures that the property changes are always picked up whenever balance or getAssignments is called.