### PR TITLE
Set reuseForks to true for unit tests, false for ITs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,6 @@
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-12-17T22:06:50Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>
-    <!-- surefire/failsafe plugin option -->
-    <reuseForks>false</reuseForks>
     <slf4j.version>1.7.30</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.excludedGroups />
@@ -814,7 +812,17 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <forkCount>${surefire.forkCount}</forkCount>
+            <reuseForks>true</reuseForks>
             <excludedGroups>${surefire.excludedGroups}</excludedGroups>
+            <!-- Tests to exclude due to not working with reuseForks being True -->
+            <excludes>
+              <exclude>**/TableIdTest.java</exclude>
+              <exclude>**/HadoopCredentialProviderTest.java</exclude>
+              <exclude>**/IdleRatioScanPrioritizerTest.java</exclude>
+              <exclude>**/AssignmentWatcherTest.java</exclude>
+              <exclude>**/TestCfCqSlice.java</exclude>
+              <exclude>**/TestCfCqSliceSeekingFilter.java</exclude>
+            </excludes>
             <groups>${surefire.groups}</groups>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
@@ -827,8 +835,18 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
             <forkCount>${failsafe.forkCount}</forkCount>
+            <reuseForks>false</reuseForks>
             <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
             <groups>${failsafe.groups}</groups>
+            <!-- Tests that work excluded above to be included here -->
+            <includes>
+              <include>**/TableIdTest.java</include>
+              <include>**/HadoopCredentialProviderTest.java</include>
+              <include>**/IdleRatioScanPrioritizerTest.java</include>
+              <include>**/AssignmentWatcherTest.java</include>
+              <include>**/TestCfCqSlice.java</include>
+              <include>**/TestCfCqSliceSeekingFilter.java</include>
+            </includes>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
     <failsafe.excludedGroups />
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
+    <failsafe.reuseForks>false</failsafe.reuseForks>
     <hadoop.version>3.3.0</hadoop.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.2.0-incubating</htrace.version>
@@ -148,6 +149,7 @@
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <surefire.forkCount>1C</surefire.forkCount>
     <surefire.groups />
+    <surefire.reuseForks>true</surefire.reuseForks>
     <!-- 3.0.0-M5 causes RowHashIT.test and ShellServerIT.scansWithClassLoaderContext to fail -->
     <surefire.version>3.0.0-M4</surefire.version>
     <!-- Thrift version -->
@@ -812,7 +814,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <forkCount>${surefire.forkCount}</forkCount>
-            <reuseForks>true</reuseForks>
+            <reuseForks>${surefire.reuseForks}</reuseForks>
             <excludedGroups>${surefire.excludedGroups}</excludedGroups>
             <!-- Tests to exclude due to not working with reuseForks being True -->
             <excludes>
@@ -835,7 +837,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
             <forkCount>${failsafe.forkCount}</forkCount>
-            <reuseForks>false</reuseForks>
+            <reuseForks>${failsafe.reuseForks}</reuseForks>
             <excludedGroups>${failsafe.excludedGroups}</excludedGroups>
             <groups>${failsafe.groups}</groups>
             <!-- Tests that work excluded above to be included here -->
@@ -1570,6 +1572,18 @@
       <properties>
         <failsafe.forkCount>${forkCount}</failsafe.forkCount>
         <surefire.forkCount>${forkCount}</surefire.forkCount>
+      </properties>
+    </profile>
+    <profile>
+      <id>reuseForks</id>
+      <activation>
+        <property>
+          <name>reuseForks</name>
+        </property>
+      </activation>
+      <properties>
+        <failsafe.reuseForks>${reuseForks}</failsafe.reuseForks>
+        <surefire.reuseForks>${reuseForks}</surefire.reuseForks>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Fixes #2004. 

This sets the reuseForks flag in maven to 'true' for unit tests while keeping it 'false' for ITs. There are some unit tests that fail with this change so they have been excluded directly in the pom file. 

Though unit tests pass consistently now, there may be others that are affected by this change and may need to be investigated further. 