### PR TITLE
Drop duplicate constructor in ServiceLock

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ServiceLock.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.fate.zookeeper.ZooCache.ZcStat;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.LockID;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -109,22 +107,7 @@ public class ServiceLock implements Watcher {
   private String createdNodeName;
   private String watchingNodeName;
 
-  public ServiceLock(AccumuloConfiguration conf, ServiceLockPath path, UUID uuid) {
-    this.zooKeeper = ZooSession.getAuthenticatedSession(conf.get(Property.INSTANCE_ZK_HOST),
-        (int) conf.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT), "digest",
-        ("accumulo" + ":" + conf.get(Property.INSTANCE_SECRET)).getBytes(UTF_8));
-    this.path = requireNonNull(path);
-    try {
-      zooKeeper.exists(path.toString(), this);
-      watchingParent = true;
-      this.vmLockPrefix = new Prefix(ZLOCK_PREFIX + uuid.toString() + "#");
-    } catch (Exception ex) {
-      LOG.error("Error setting initial watch", ex);
-      throw new RuntimeException(ex);
-    }
-  }
-
-  protected ServiceLock(ZooKeeper zookeeper, ServiceLockPath path, UUID uuid) {
+  public ServiceLock(ZooKeeper zookeeper, ServiceLockPath path, UUID uuid) {
     this.zooKeeper = requireNonNull(zookeeper);
     this.path = requireNonNull(path);
     try {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -635,7 +635,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
     UUID zooLockUUID = UUID.randomUUID();
     while (true) {
-      lock = new ServiceLock(getContext().getSiteConfiguration(), path, zooLockUUID);
+      lock = new ServiceLock(getContext().getZooReaderWriter().getZooKeeper(), path, zooLockUUID);
       if (lock.tryLock(lockWatcher,
           new ServerServices(addr.toString(), Service.GC_CLIENT).toString().getBytes())) {
         log.debug("Got GC ZooKeeper lock");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1442,7 +1442,7 @@ public class Manager extends AbstractServer
 
   private void getManagerLock(final ServiceLockPath zManagerLoc)
       throws KeeperException, InterruptedException {
-    ServerContext context = getContext();
+    var zooKeeper = getContext().getZooReaderWriter().getZooKeeper();
     log.info("trying to get manager lock");
 
     final String managerClientAddress =
@@ -1452,7 +1452,7 @@ public class Manager extends AbstractServer
     while (true) {
 
       ManagerLockWatcher managerLockWatcher = new ManagerLockWatcher();
-      managerLock = new ServiceLock(context.getSiteConfiguration(), zManagerLoc, zooLockUUID);
+      managerLock = new ServiceLock(zooKeeper, zManagerLoc, zooLockUUID);
       managerLock.lock(managerLockWatcher, managerClientAddress.getBytes());
 
       managerLockWatcher.waitForChange();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -630,7 +630,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     UUID zooLockUUID = UUID.randomUUID();
     while (true) {
       MoniterLockWatcher monitorLockWatcher = new MoniterLockWatcher();
-      monitorLock = new ServiceLock(context.getSiteConfiguration(), monitorLockPath, zooLockUUID);
+      monitorLock = new ServiceLock(zoo.getZooKeeper(), monitorLockPath, zooLockUUID);
       monitorLock.lock(monitorLockWatcher, new byte[0]);
 
       monitorLockWatcher.waitForChange();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -640,8 +640,7 @@ public class TabletServer extends AbstractServer {
         throw e;
       }
 
-      tabletServerLock =
-          new ServiceLock(getContext().getSiteConfiguration(), zLockPath, UUID.randomUUID());
+      tabletServerLock = new ServiceLock(zoo.getZooKeeper(), zLockPath, UUID.randomUUID());
 
       LockWatcher lw = new LockWatcher() {
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -28,21 +28,18 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
-import org.apache.accumulo.core.conf.ConfigurationCopy;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ServiceLock.AccumuloLockWatcher;
 import org.apache.accumulo.fate.zookeeper.ServiceLock.LockLossReason;
 import org.apache.accumulo.fate.zookeeper.ServiceLock.ServiceLockPath;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.fate.zookeeper.ZooSession;
 import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.apache.zookeeper.CreateMode;
@@ -191,11 +188,9 @@ public class ServiceLockIT {
   private static final AtomicInteger pdCount = new AtomicInteger(0);
 
   private static ServiceLock getZooLock(ServiceLockPath parent, UUID uuid) {
-    Map<String,String> props = new HashMap<>();
-    props.put(Property.INSTANCE_ZK_HOST.toString(), szk.getConn());
-    props.put(Property.INSTANCE_ZK_TIMEOUT.toString(), "30000");
-    props.put(Property.INSTANCE_SECRET.toString(), "secret");
-    return new ServiceLock(new ConfigurationCopy(props), parent, uuid);
+    var zooKeeper = ZooSession.getAuthenticatedSession(szk.getConn(), 30000, "digest",
+        ("accumulo:secret").getBytes(UTF_8));
+    return new ServiceLock(zooKeeper, parent, uuid);
   }
 
   private static ServiceLock getZooLock(ZooKeeperWrapper zkw, ServiceLockPath parent, UUID uuid) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -95,7 +95,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     var zPath = ServiceLock.path(c.getZooKeeperRoot() + "/testLock");
     ZooReaderWriter zoo = c.getZooReaderWriter();
     zoo.putPersistentData(zPath.toString(), new byte[0], NodeExistsPolicy.OVERWRITE);
-    ServiceLock zl = new ServiceLock(c.getSiteConfiguration(), zPath, UUID.randomUUID());
+    ServiceLock zl = new ServiceLock(zoo.getZooKeeper(), zPath, UUID.randomUUID());
     boolean gotLock = zl.tryLock(new LockWatcher() {
 
       @SuppressFBWarnings(value = "DM_EXIT",

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -121,8 +121,7 @@ public class ZombieTServer {
     ZooReaderWriter zoo = context.getZooReaderWriter();
     zoo.putPersistentData(zLockPath.toString(), new byte[] {}, NodeExistsPolicy.SKIP);
 
-    ServiceLock zlock =
-        new ServiceLock(context.getSiteConfiguration(), zLockPath, UUID.randomUUID());
+    ServiceLock zlock = new ServiceLock(zoo.getZooKeeper(), zLockPath, UUID.randomUUID());
 
     LockWatcher lw = new LockWatcher() {
 


### PR DESCRIPTION
* Remove constructor in ServiceLock and make all services use the
constructor that takes a ZooKeeper object
* Get the authenticatedSession ZK from ServerContext instead of passing
in conf and parsing properties everytime.
* Simplify method in ServiceLockIT