### PR TITLE
Initialize hdfs connection with correct ugi for SetGoalState

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/SetGoalState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/SetGoalState.java
@@ -44,9 +44,10 @@ public class SetGoalState {
     }
 
     try {
-      var context = new ServerContext(SiteConfiguration.auto());
+      var siteConfig = SiteConfiguration.auto();
+      SecurityUtil.serverLogin(siteConfig);
+      var context = new ServerContext(siteConfig);
       RenameMasterDirInZK.renameMasterDirInZK(context);
-      SecurityUtil.serverLogin(context.getConfiguration());
       ServerUtil.waitForZookeeperAndHdfs(context);
       context.getZooReaderWriter().putPersistentData(
           context.getZooKeeperRoot() + Constants.ZMANAGER_GOAL_STATE, args[0].getBytes(UTF_8),


### PR DESCRIPTION
This is the same problem fixed for managers and tservers to use the keytab file for kerberos authentication previously (https://github.com/apache/accumulo/pull/1727/commits/b6a9ad000d261f201b6322031d34c60fcbbb9d5a).   **serverLogin** should be called before **ServerContext** is created in order to initialize hdfs connection with correct ugi for **SetGoalState**