### PR TITLE
Minor java improvements

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/bloomfilter/BloomFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/bloomfilter/BloomFilter.java
@@ -76,9 +76,7 @@ public class BloomFilter extends Filter {
   BitSet bits;
 
   /** Default constructor - use with readFields */
-  public BloomFilter() {
-    super();
-  }
+  public BloomFilter() {}
 
   /**
    * Constructor

--- a/core/src/main/java/org/apache/accumulo/core/bloomfilter/Filter.java
+++ b/core/src/main/java/org/apache/accumulo/core/bloomfilter/Filter.java
@@ -168,7 +168,7 @@ public abstract class Filter implements Writable {
       this.nbHash = ver;
       this.hashType = Hash.JENKINS_HASH;
 
-    } else if (ver == VERSION | ver == VERSION + 1) { // Support for directly serializing the bitset
+    } else if (ver == VERSION || ver == VERSION + 1) { // Support for directly serializing bitset
       this.nbHash = in.readInt();
       this.hashType = in.readByte();
     } else {

--- a/core/src/main/java/org/apache/accumulo/core/classloader/ClassLoaderUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/ClassLoaderUtil.java
@@ -75,9 +75,8 @@ public class ClassLoaderUtil {
   public static ClassLoader getClassLoader(String context) {
     if (context != null && !context.isEmpty()) {
       return FACTORY.getClassLoader(context);
-    } else {
-      return org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader.getClassLoader();
     }
+    return org.apache.accumulo.start.classloader.vfs.AccumuloVFSClassLoader.getClassLoader();
   }
 
   public static <U> Class<? extends U> loadClass(String context, String className,

--- a/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ClientOpts.java
@@ -107,7 +107,7 @@ public class ClientOpts extends Help {
 
       String prefix;
 
-      private KeyType(String prefix) {
+      KeyType(String prefix) {
         this.prefix = prefix;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/BatchWriterConfig.java
@@ -29,6 +29,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.clientImpl.DurabilityImpl;
@@ -67,8 +68,7 @@ public class BatchWriterConfig implements Writable {
         ConfigurationTypeHelper.getTimeInMillis(BATCH_WRITER_TIMEOUT_MAX.getDefaultValue());
     if (defVal == 0L)
       return Long.MAX_VALUE;
-    else
-      return defVal;
+    return defVal;
   }
 
   /**
@@ -291,44 +291,20 @@ public class BatchWriterConfig implements Writable {
     if (o instanceof BatchWriterConfig) {
       BatchWriterConfig other = (BatchWriterConfig) o;
 
-      if (maxMemory != null) {
-        if (!maxMemory.equals(other.maxMemory)) {
-          return false;
-        }
-      } else {
-        if (other.maxMemory != null) {
-          return false;
-        }
+      if (!Objects.equals(maxMemory, other.maxMemory)) {
+        return false;
       }
 
-      if (maxLatency != null) {
-        if (!maxLatency.equals(other.maxLatency)) {
-          return false;
-        }
-      } else {
-        if (other.maxLatency != null) {
-          return false;
-        }
+      if (!Objects.equals(maxLatency, other.maxLatency)) {
+        return false;
       }
 
-      if (maxWriteThreads != null) {
-        if (!maxWriteThreads.equals(other.maxWriteThreads)) {
-          return false;
-        }
-      } else {
-        if (other.maxWriteThreads != null) {
-          return false;
-        }
+      if (!Objects.equals(maxWriteThreads, other.maxWriteThreads)) {
+        return false;
       }
 
-      if (timeout != null) {
-        if (!timeout.equals(other.timeout)) {
-          return false;
-        }
-      } else {
-        if (other.timeout != null) {
-          return false;
-        }
+      if (!Objects.equals(timeout, other.timeout)) {
+        return false;
       }
       return durability == other.durability;
     }

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -113,11 +113,11 @@ public class ClientConfiguration {
     private PropertyType type;
     private String description;
 
-    private ClientProperty(Property prop) {
+    ClientProperty(Property prop) {
       this(prop.getKey(), prop.getDefaultValue(), prop.getType(), prop.getDescription());
     }
 
-    private ClientProperty(String key, String defaultValue, PropertyType type, String description) {
+    ClientProperty(String key, String defaultValue, PropertyType type, String description) {
       this.key = key;
       this.defaultValue = defaultValue;
       this.type = type;
@@ -320,8 +320,7 @@ public class ClientConfiguration {
   public String get(ClientProperty prop) {
     if (compositeConfig.containsKey(prop.getKey()))
       return compositeConfig.getString(prop.getKey());
-    else
-      return prop.getDefaultValue();
+    return prop.getDefaultValue();
   }
 
   private void checkType(ClientProperty property, PropertyType type) {

--- a/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriter.java
@@ -66,8 +66,8 @@ public interface ConditionalWriter extends AutoCloseable {
           throw new AccumuloSecurityException(ase.getUser(),
               SecurityErrorCode.valueOf(ase.getSecurityErrorCode().name()), ase.getTableInfo(),
               ase);
-        } else
-          throw new AccumuloException(exception);
+        }
+        throw new AccumuloException(exception);
       }
 
       return status;

--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -78,12 +78,11 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
           while (source.hasNext()) {
             Entry<Key,Value> entry = source.next();
 
-            if (entry.getKey().getRowData().equals(row)) {
-              buffer.add(entry);
-            } else {
+            if (!entry.getKey().getRowData().equals(row)) {
               nextRowStart = entry;
               break;
             }
+            buffer.add(entry);
           }
 
           lastRow = row;

--- a/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IteratorSetting.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
@@ -297,13 +298,7 @@ public class IteratorSetting implements Writable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((iteratorClass == null) ? 0 : iteratorClass.hashCode());
-    result = prime * result + ((name == null) ? 0 : name.hashCode());
-    result = prime * result + priority;
-    result = prime * result + ((properties == null) ? 0 : properties.hashCode());
-    return result;
+    return Objects.hash(iteratorClass, name, priority, properties);
   }
 
   @Override
@@ -315,23 +310,18 @@ public class IteratorSetting implements Writable {
     if (!(obj instanceof IteratorSetting))
       return false;
     IteratorSetting other = (IteratorSetting) obj;
-    if (iteratorClass == null) {
-      if (other.iteratorClass != null)
-        return false;
-    } else if (!iteratorClass.equals(other.iteratorClass))
+    if (!Objects.equals(iteratorClass, other.iteratorClass)) {
       return false;
-    if (name == null) {
-      if (other.name != null)
-        return false;
-    } else if (!name.equals(other.name))
+    }
+    if (!Objects.equals(name, other.name)) {
       return false;
+    }
     if (priority != other.priority)
       return false;
     if (properties == null) {
       return other.properties == null;
-    } else {
-      return properties.equals(other.properties);
     }
+    return properties.equals(other.properties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/SampleNotPresentException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/SampleNotPresentException.java
@@ -34,9 +34,7 @@ public class SampleNotPresentException extends RuntimeException {
     super(message);
   }
 
-  public SampleNotPresentException() {
-    super();
-  }
+  public SampleNotPresentException() {}
 
   private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/ActiveCompaction.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/ActiveCompaction.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.data.TabletId;
  */
 public abstract class ActiveCompaction {
 
-  public static enum CompactionType {
+  public enum CompactionType {
     /**
      * compaction to flush a tablets memory
      */
@@ -49,7 +49,7 @@ public abstract class ActiveCompaction {
     FULL
   }
 
-  public static enum CompactionReason {
+  public enum CompactionReason {
     /**
      * compaction initiated by user
      */

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/CloneConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/CloneConfiguration.java
@@ -35,14 +35,14 @@ public interface CloneConfiguration {
    *
    * @return true if memory is flushed in the source table before cloning.
    */
-  public boolean isFlush();
+  boolean isFlush();
 
   /**
    * The source table properties are copied. This allows overriding of some of those properties.
    *
    * @return The source table properties to override.
    */
-  public Map<String,String> getPropertiesToSet();
+  Map<String,String> getPropertiesToSet();
 
   /**
    * The source table properties are copied, this allows reverting to system defaults for some of
@@ -50,7 +50,7 @@ public interface CloneConfiguration {
    *
    * @return The properties that are to be reverted to system defaults.
    */
-  public Set<String> getPropertiesToExclude();
+  Set<String> getPropertiesToExclude();
 
   /**
    * The new table is normally brought online after the cloning process. This allows leaving the new
@@ -58,21 +58,21 @@ public interface CloneConfiguration {
    *
    * @return true if the new table is to be kept offline after cloning.
    */
-  public boolean isKeepOffline();
+  boolean isKeepOffline();
 
   /**
    * A CloneConfiguration builder
    *
    * @since 1.10 and 2.1
    */
-  public static interface Builder {
+  public interface Builder {
     /**
      * Determines if memory is flushed in the source table before cloning.
      *
      * @param flush
      *          true if memory is flushed in the source table before cloning.
      */
-    public Builder setFlush(boolean flush);
+    Builder setFlush(boolean flush);
 
     /**
      * The source table properties are copied. This allows overriding of some of those properties.
@@ -80,7 +80,7 @@ public interface CloneConfiguration {
      * @param propertiesToSet
      *          The source table properties to override.
      */
-    public Builder setPropertiesToSet(Map<String,String> propertiesToSet);
+    Builder setPropertiesToSet(Map<String,String> propertiesToSet);
 
     /**
      * The source table properties are copied, this allows reverting to system defaults for some of
@@ -89,7 +89,7 @@ public interface CloneConfiguration {
      * @param propertiesToExclude
      *          The properties that are to be reverted to system defaults.
      */
-    public Builder setPropertiesToExclude(Set<String> propertiesToExclude);
+    Builder setPropertiesToExclude(Set<String> propertiesToExclude);
 
     /**
      * The new table is normally brought online after the cloning process. This allows leaving the
@@ -98,20 +98,20 @@ public interface CloneConfiguration {
      * @param keepOffline
      *          true if the new table is to be kept offline after cloning.
      */
-    public Builder setKeepOffline(boolean keepOffline);
+    Builder setKeepOffline(boolean keepOffline);
 
     /**
      * Build the clone configuration
      *
      * @return the built immutable clone configuration
      */
-    public CloneConfiguration build();
+    CloneConfiguration build();
   }
 
   /**
    * @return a {@link CloneConfiguration} builder
    */
-  public static CloneConfiguration.Builder builder() {
+  static CloneConfiguration.Builder builder() {
     return new CloneConfigurationImpl();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/FindMax.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/FindMax.java
@@ -118,27 +118,26 @@ public class FindMax {
 
     Iterator<Entry<Key,Value>> iter = scanner.iterator();
 
-    if (iter.hasNext()) {
-      Key next = iter.next().getKey();
-
-      int count = 0;
-      while (count < 10 && iter.hasNext()) {
-        next = iter.next().getKey();
-        count++;
-      }
-
-      if (!iter.hasNext())
-        return next.getRow();
-
-      Text ret = _findMax(scanner, next.followingKey(PartialKey.ROW).getRow(), true, end, inclEnd);
-      if (ret == null)
-        return next.getRow();
-      else
-        return ret;
-    } else {
+    if (!iter.hasNext()) {
 
       return _findMax(scanner, start, inclStart, mid, mid.equals(start) ? inclStart : false);
     }
+    Key next = iter.next().getKey();
+
+    int count = 0;
+    while (count < 10 && iter.hasNext()) {
+      next = iter.next().getKey();
+      count++;
+    }
+
+    if (!iter.hasNext())
+      return next.getRow();
+
+    Text ret = _findMax(scanner, next.followingKey(PartialKey.ROW).getRow(), true, end, inclEnd);
+    if (ret == null)
+      return next.getRow();
+    else
+      return ret;
   }
 
   private static Text findInitialEnd(Scanner scanner) {

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/NewTableConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/NewTableConfiguration.java
@@ -319,7 +319,7 @@ public class NewTableConfiguration {
    * Verify the provided properties are valid table properties.
    */
   private void checkTableProperties(Map<String,String> props) {
-    props.keySet().forEach((key) -> {
+    props.keySet().forEach(key -> {
       if (!key.startsWith(Property.TABLE_PREFIX.toString())) {
         throw new IllegalArgumentException("'" + key + "' is not a valid table property");
       }

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactableFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactableFile.java
@@ -27,13 +27,13 @@ import org.apache.accumulo.core.metadata.CompactableFileImpl;
  */
 public interface CompactableFile {
 
-  public String getFileName();
+  String getFileName();
 
-  public URI getUri();
+  URI getUri();
 
-  public long getEstimatedSize();
+  long getEstimatedSize();
 
-  public long getEstimatedEntries();
+  long getEstimatedEntries();
 
   static CompactableFile create(URI uri, long estimatedSize, long estimatedEntries) {
     return new CompactableFileImpl(uri, estimatedSize, estimatedEntries);

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
@@ -50,7 +50,7 @@ public interface CompactionConfigurer {
   public interface InputParameters {
     TableId getTableId();
 
-    public Collection<CompactableFile> getInputFiles();
+    Collection<CompactableFile> getInputFiles();
 
     PluginEnvironment getEnvironment();
   }
@@ -60,7 +60,7 @@ public interface CompactionConfigurer {
    *
    * @since 2.1.0
    */
-  public class Overrides {
+  public static class Overrides {
     private final Map<String,String> tablePropertyOverrides;
 
     public Overrides(Map<String,String> tablePropertyOverrides) {

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/TooManyDeletesSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/TooManyDeletesSelector.java
@@ -106,7 +106,7 @@ public class TooManyDeletesSelector implements CompactionSelector {
         SummarizerConfiguration.fromTableProperties(tableConf);
 
     // check if delete summarizer is configured for table
-    if (configuredSummarizers.stream().map(sc -> sc.getClassName())
+    if (configuredSummarizers.stream().map(SummarizerConfiguration::getClassName)
         .noneMatch(cn -> cn.equals(DeletesSummarizer.class.getName()))) {
       return new Selection(List.of());
     }
@@ -129,10 +129,9 @@ public class TooManyDeletesSelector implements CompactionSelector {
         long numEntries = file.getEstimatedEntries();
         if (numEntries == 0 && !proceed_bns) {
           return new Selection(List.of());
-        } else {
-          // no summary data so use Accumulo's estimate of total entries in file
-          total += numEntries;
         }
+        // no summary data so use Accumulo's estimate of total entries in file
+        total += numEntries;
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
@@ -661,8 +661,8 @@ public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
       }
 
       boolean batchScan = InputConfigurator.isBatchScan(CLASS, job);
-      boolean supportBatchScan = !(tableConfig.isOfflineScan()
-          || tableConfig.shouldUseIsolatedScanners() || tableConfig.shouldUseLocalIterators());
+      boolean supportBatchScan = (!tableConfig.isOfflineScan()
+          && !tableConfig.shouldUseIsolatedScanners() && !tableConfig.shouldUseLocalIterators());
       if (batchScan && !supportBatchScan)
         throw new IllegalArgumentException("BatchScanner optimization not available for offline"
             + " scan, isolated, or local iterators");

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloInputFormat.java
@@ -62,15 +62,14 @@ public class AccumuloInputFormat extends InputFormatBase<Key,Value> {
 
     // Override the log level from the configuration as if the RangeInputSplit has one it's the more
     // correct one to use.
-    if (split instanceof org.apache.accumulo.core.client.mapreduce.RangeInputSplit) {
-      org.apache.accumulo.core.client.mapreduce.RangeInputSplit accSplit =
-          (org.apache.accumulo.core.client.mapreduce.RangeInputSplit) split;
-      Level level = accSplit.getLogLevel();
-      if (level != null) {
-        log.setLevel(level);
-      }
-    } else {
+    if (!(split instanceof org.apache.accumulo.core.client.mapreduce.RangeInputSplit)) {
       throw new IllegalArgumentException("No RecordReader for " + split.getClass());
+    }
+    org.apache.accumulo.core.client.mapreduce.RangeInputSplit accSplit =
+        (org.apache.accumulo.core.client.mapreduce.RangeInputSplit) split;
+    Level level = accSplit.getLogLevel();
+    if (level != null) {
+      log.setLevel(level);
     }
 
     RecordReaderBase<Key,Value> recordReader = new RecordReaderBase<>() {

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/RangeInputSplit.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/RangeInputSplit.java
@@ -37,9 +37,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class RangeInputSplit extends org.apache.accumulo.core.client.mapreduce.RangeInputSplit
     implements InputSplit {
 
-  public RangeInputSplit() {
-    super();
-  }
+  public RangeInputSplit() {}
 
   public RangeInputSplit(RangeInputSplit split) throws IOException {
     super(split);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
@@ -692,8 +692,8 @@ public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
       }
 
       boolean batchScan = InputConfigurator.isBatchScan(CLASS, job.getConfiguration());
-      boolean supportBatchScan = !(tableConfig.isOfflineScan()
-          || tableConfig.shouldUseIsolatedScanners() || tableConfig.shouldUseLocalIterators());
+      boolean supportBatchScan = (!tableConfig.isOfflineScan()
+          && !tableConfig.shouldUseIsolatedScanners() && !tableConfig.shouldUseLocalIterators());
       if (batchScan && !supportBatchScan)
         throw new IllegalArgumentException("BatchScanner optimization not available for offline"
             + " scan, isolated, or local iterators");

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloInputFormat.java
@@ -61,15 +61,14 @@ public class AccumuloInputFormat extends InputFormatBase<Key,Value> {
 
     // Override the log level from the configuration as if the InputSplit has one it's the more
     // correct one to use.
-    if (split instanceof org.apache.accumulo.core.client.mapreduce.RangeInputSplit) {
-      org.apache.accumulo.core.client.mapreduce.RangeInputSplit accSplit =
-          (org.apache.accumulo.core.client.mapreduce.RangeInputSplit) split;
-      Level level = accSplit.getLogLevel();
-      if (level != null) {
-        log.setLevel(level);
-      }
-    } else {
+    if (!(split instanceof org.apache.accumulo.core.client.mapreduce.RangeInputSplit)) {
       throw new IllegalArgumentException("No RecordReader for " + split.getClass());
+    }
+    org.apache.accumulo.core.client.mapreduce.RangeInputSplit accSplit =
+        (org.apache.accumulo.core.client.mapreduce.RangeInputSplit) split;
+    Level level = accSplit.getLogLevel();
+    if (level != null) {
+      log.setLevel(level);
     }
 
     return new RecordReaderBase<>() {

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/RangeInputSplit.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/RangeInputSplit.java
@@ -101,22 +101,21 @@ public class RangeInputSplit extends InputSplit implements Writable {
   public float getProgress(Key currentKey) {
     if (currentKey == null)
       return 0f;
-    if (range.contains(currentKey)) {
-      if (range.getStartKey() != null && range.getEndKey() != null) {
-        if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW) != 0) {
-          // just look at the row progress
-          return getProgress(range.getStartKey().getRowData(), range.getEndKey().getRowData(),
-              currentKey.getRowData());
-        } else if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM) != 0) {
-          // just look at the column family progress
-          return getProgress(range.getStartKey().getColumnFamilyData(),
-              range.getEndKey().getColumnFamilyData(), currentKey.getColumnFamilyData());
-        } else if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM_COLQUAL)
-            != 0) {
-          // just look at the column qualifier progress
-          return getProgress(range.getStartKey().getColumnQualifierData(),
-              range.getEndKey().getColumnQualifierData(), currentKey.getColumnQualifierData());
-        }
+    if (range.contains(currentKey) && (range.getStartKey() != null && range.getEndKey() != null)) {
+      if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW) != 0) {
+        // just look at the row progress
+        return getProgress(range.getStartKey().getRowData(), range.getEndKey().getRowData(),
+            currentKey.getRowData());
+      }
+      if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM) != 0) {
+        // just look at the column family progress
+        return getProgress(range.getStartKey().getColumnFamilyData(),
+            range.getEndKey().getColumnFamilyData(), currentKey.getColumnFamilyData());
+      } else if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM_COLQUAL)
+          != 0) {
+        // just look at the column qualifier progress
+        return getProgress(range.getStartKey().getColumnQualifierData(),
+            range.getEndKey().getColumnQualifierData(), currentKey.getColumnQualifierData());
       }
     }
     // if we can't figure it out, then claim no progress
@@ -279,7 +278,8 @@ public class RangeInputSplit extends InputSplit implements Writable {
       if (token != null && tokenFile != null) {
         throw new IOException(
             "Cannot use both inline AuthenticationToken and file-based AuthenticationToken");
-      } else if (token != null) {
+      }
+      if (token != null) {
         out.writeUTF(token.getClass().getName());
         out.writeUTF(
             Base64.getEncoder().encodeToString(AuthenticationTokenSerializer.serialize(token)));
@@ -462,9 +462,7 @@ public class RangeInputSplit extends InputSplit implements Writable {
 
   public void setFetchedColumns(Collection<Pair<Text,Text>> fetchedColumns) {
     this.fetchedColumns = new HashSet<>();
-    for (Pair<Text,Text> columns : fetchedColumns) {
-      this.fetchedColumns.add(columns);
-    }
+    this.fetchedColumns.addAll(fetchedColumns);
   }
 
   public void setFetchedColumns(Set<Pair<Text,Text>> fetchedColumns) {

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
@@ -53,7 +53,7 @@ import org.apache.accumulo.core.data.Key;
  * <pre>
  * <code>
  * new SamplerConfiguration(RowColumnSampler.class.getName()).setOptions(
- *   ImmutableMap.of("hasher","murmur3_32","modulus","1009","qualifier","true"));
+ *   Map.of("hasher","murmur3_32","modulus","1009","qualifier","true"));
  * </code>
  * </pre>
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/RowSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/RowSampler.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.data.Key;
  * <pre>
  * <code>
  * new SamplerConfiguration(RowSampler.class.getName()).setOptions(
- *   ImmutableMap.of("hasher","murmur3_32","modulus","1009"));
+ *   Map.of("hasher","murmur3_32","modulus","1009"));
  * </code>
  * </pre>
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/CredentialProviderToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/CredentialProviderToken.java
@@ -38,9 +38,7 @@ public class CredentialProviderToken extends PasswordToken {
   private String name;
   private String credentialProviders;
 
-  public CredentialProviderToken() {
-    super();
-  }
+  public CredentialProviderToken() {}
 
   public CredentialProviderToken(String name, String credentialProviders) throws IOException {
     requireNonNull(name);

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/PasswordToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/PasswordToken.java
@@ -148,10 +148,9 @@ public class PasswordToken implements AuthenticationToken {
 
   @Override
   public void init(Properties properties) {
-    if (properties.containsKey("password")) {
-      setPassword(CharBuffer.wrap(properties.get("password")));
-    } else
+    if (!properties.containsKey("password"))
       throw new IllegalArgumentException("Missing 'password' property");
+    setPassword(CharBuffer.wrap(properties.get("password")));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/CountingSummarizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/CountingSummarizer.java
@@ -238,13 +238,11 @@ public abstract class CountingSummarizer<K> implements Summarizer {
           if (counters.size() >= maxCounters) {
             // no need to store this counter in the map and get() it... just use instance variable
             tooMany++;
-          } else {
+          } else if (encoder.apply(counter).length() >= maxCounterKeyLen) {
             // we have never seen this key before, check if its too long
-            if (encoder.apply(counter).length() >= maxCounterKeyLen) {
-              tooLong++;
-            } else {
-              counters.put(copier.apply(counter), new MutableLong(1));
-            }
+            tooLong++;
+          } else {
+            counters.put(copier.apply(counter), new MutableLong(1));
           }
         } else {
           // using mutable long allows calling put() to be avoided

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -182,13 +182,12 @@ public class SummarizerConfiguration {
    * @since 2.0.0
    */
   public static class Builder {
-    private String className;
-    private ImmutableMap.Builder<String,String> imBuilder;
+    private final String className;
+    private final ImmutableMap.Builder<String,String> imBuilder = ImmutableMap.builder();
     private String configId = null;
 
     private Builder(String className) {
       this.className = className;
-      this.imBuilder = ImmutableMap.builder();
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
@@ -171,30 +171,26 @@ public class ClientConfConverter {
             if (value != null) {
               log.trace("Loaded sensitive value for {} from CredentialProvider", key);
               return new String(value);
-            } else {
-              log.trace("Tried to load sensitive value for {} from CredentialProvider, "
-                  + "but none was found", key);
             }
+            log.trace("Tried to load sensitive value for {} from CredentialProvider, "
+                + "but none was found", key);
           }
         }
 
         if (config.containsKey(key)) {
           return config.getString(key);
-        } else {
-          // Reconstitute the server kerberos property from the client config
-          if (property == Property.GENERAL_KERBEROS_PRINCIPAL) {
-            if (config.containsKey(
-                org.apache.accumulo.core.client.ClientConfiguration.ClientProperty.KERBEROS_SERVER_PRIMARY
-                    .getKey())) {
-              // Avoid providing a realm since we don't know what it is...
-              return config.getString(
-                  org.apache.accumulo.core.client.ClientConfiguration.ClientProperty.KERBEROS_SERVER_PRIMARY
-                      .getKey())
-                  + "/_HOST@" + SaslConnectionParams.getDefaultRealm();
-            }
-          }
-          return defaults.get(property);
         }
+        // Reconstitute the server kerberos property from the client config
+        if ((property == Property.GENERAL_KERBEROS_PRINCIPAL) && config.containsKey(
+            org.apache.accumulo.core.client.ClientConfiguration.ClientProperty.KERBEROS_SERVER_PRIMARY
+                .getKey())) {
+          // Avoid providing a realm since we don't know what it is...
+          return config.getString(
+              org.apache.accumulo.core.client.ClientConfiguration.ClientProperty.KERBEROS_SERVER_PRIMARY
+                  .getKey())
+              + "/_HOST@" + SaslConnectionParams.getDefaultRealm();
+        }
+        return defaults.get(property);
       }
 
       @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfoImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientInfoImpl.java
@@ -90,7 +90,7 @@ public class ClientInfoImpl implements ClientInfo {
 
   @Override
   public boolean saslEnabled() {
-    return Boolean.valueOf(getString(ClientProperty.SASL_ENABLED));
+    return Boolean.parseBoolean(getString(ClientProperty.SASL_ENABLED));
   }
 
   private String getString(ClientProperty property) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/CloneConfigurationImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/CloneConfigurationImpl.java
@@ -53,23 +53,27 @@ public class CloneConfigurationImpl implements CloneConfiguration, CloneConfigur
 
   public CloneConfigurationImpl() {}
 
+  @Override
   public boolean isFlush() {
     Preconditions.checkState(built);
     return flush;
   }
 
+  @Override
   public Map<String,String> getPropertiesToSet() {
     Preconditions.checkState(built);
     return (propertiesToSet == null ? Collections.<String,String>emptyMap()
         : Collections.unmodifiableMap(propertiesToSet));
   }
 
+  @Override
   public Set<String> getPropertiesToExclude() {
     Preconditions.checkState(built);
     return (propertiesToExclude == null ? Collections.<String>emptySet()
         : Collections.unmodifiableSet(propertiesToExclude));
   }
 
+  @Override
   public boolean isKeepOffline() {
     Preconditions.checkState(built);
     return keepOffline;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/DelegationTokenImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/DelegationTokenImpl.java
@@ -43,9 +43,7 @@ public class DelegationTokenImpl extends PasswordToken implements DelegationToke
 
   private AuthenticationTokenIdentifier identifier;
 
-  public DelegationTokenImpl() {
-    super();
-  }
+  public DelegationTokenImpl() {}
 
   public DelegationTokenImpl(byte[] delegationTokenPassword,
       AuthenticationTokenIdentifier identifier) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/IsolationException.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/IsolationException.java
@@ -29,7 +29,5 @@ public class IsolationException extends RuntimeException {
     super(cause);
   }
 
-  public IsolationException() {
-    super();
-  }
+  public IsolationException() {}
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ManagerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ManagerClient.java
@@ -73,7 +73,7 @@ public class ManagerClient {
           context);
     } catch (TTransportException tte) {
       Throwable cause = tte.getCause();
-      if (cause != null && cause instanceof UnknownHostException) {
+      if (cause instanceof UnknownHostException) {
         // do not expect to recover from this
         throw new RuntimeException(tte);
       }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/MultiTableBatchWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/MultiTableBatchWriterImpl.java
@@ -120,7 +120,8 @@ public class MultiTableBatchWriterImpl implements MultiTableBatchWriter {
 
       if (cause == null) {
         throw new RuntimeException(e);
-      } else if (cause instanceof TableNotFoundException) {
+      }
+      if (cause instanceof TableNotFoundException) {
         throw (TableNotFoundException) cause;
       } else if (cause instanceof TableOfflineException) {
         throw (TableOfflineException) cause;
@@ -142,9 +143,8 @@ public class MultiTableBatchWriterImpl implements MultiTableBatchWriter {
       BatchWriter current = tableWriters.putIfAbsent(tableId, tbw);
       // return the current one if another thread created one first
       return current != null ? current : tbw;
-    } else {
-      return tbw;
     }
+    return tbw;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsHelper.java
@@ -124,13 +124,11 @@ public abstract class NamespaceOperationsHelper implements NamespaceOperations {
     for (Entry<String,String> property : this.getProperties(namespace)) {
       String name = property.getKey();
       String[] parts = name.split("\\.");
-      if (parts.length == 4) {
-        if (parts[0].equals("table") && parts[1].equals("iterator")) {
-          IteratorScope scope = IteratorScope.valueOf(parts[2]);
-          if (!result.containsKey(parts[3]))
-            result.put(parts[3], EnumSet.noneOf(IteratorScope.class));
-          result.get(parts[3]).add(scope);
-        }
+      if ((parts.length == 4) && (parts[0].equals("table") && parts[1].equals("iterator"))) {
+        IteratorScope scope = IteratorScope.valueOf(parts[2]);
+        if (!result.containsKey(parts[3]))
+          result.put(parts[3], EnumSet.noneOf(IteratorScope.class));
+        result.get(parts[3]).add(scope);
       }
     }
     return result;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Namespaces.java
@@ -187,11 +187,10 @@ public class Namespaces {
     ZooCache zc = context.getZooCache();
     byte[] path = zc.get(context.getZooKeeperRoot() + Constants.ZNAMESPACES + "/"
         + namespaceId.canonical() + Constants.ZNAMESPACE_NAME);
-    if (path != null)
-      name = new String(path, UTF_8);
-    else
+    if (path == null)
       throw new NamespaceNotFoundException(namespaceId.canonical(), null,
           "getNamespaceName() failed to find namespace");
+    name = new String(path, UTF_8);
     return name;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/RootTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/RootTabletLocator.java
@@ -124,8 +124,7 @@ public class RootTabletLocator extends TabletLocator {
 
     if (lockChecker.isLockHeld(server, loc.getSession()))
       return new TabletLocation(RootTable.EXTENT, server, loc.getSession());
-    else
-      return null;
+    return null;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -135,10 +135,9 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   @Override
   public synchronized void setBatchSize(int size) {
     ensureOpen();
-    if (size > 0)
-      this.size = size;
-    else
+    if (size <= 0)
       throw new IllegalArgumentException("size must be greater than zero");
+    this.size = size;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/SecurityOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/SecurityOperationsImpl.java
@@ -58,7 +58,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       // recast missing table
       if (ttoe.getType() == TableOperationExceptionType.NOTFOUND)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST);
-      else if (ttoe.getType() == TableOperationExceptionType.NAMESPACE_NOTFOUND)
+      if (ttoe.getType() == TableOperationExceptionType.NAMESPACE_NOTFOUND)
         throw new AccumuloSecurityException(null, SecurityErrorCode.NAMESPACE_DOESNT_EXIST);
       else
         throw new AccumuloException(ttoe);
@@ -79,7 +79,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
       // recast missing table
       if (ttoe.getType() == TableOperationExceptionType.NOTFOUND)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST);
-      else if (ttoe.getType() == TableOperationExceptionType.NAMESPACE_NOTFOUND)
+      if (ttoe.getType() == TableOperationExceptionType.NAMESPACE_NOTFOUND)
         throw new AccumuloSecurityException(null, SecurityErrorCode.NAMESPACE_DOESNT_EXIST);
       else
         throw new AccumuloException(ttoe);
@@ -184,8 +184,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
     } catch (AccumuloSecurityException e) {
       if (e.getSecurityErrorCode() == NAMESPACE_DOESNT_EXIST)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST, e);
-      else
-        throw e;
+      throw e;
     }
   }
 
@@ -220,8 +219,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
     } catch (AccumuloSecurityException e) {
       if (e.getSecurityErrorCode() == NAMESPACE_DOESNT_EXIST)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST, e);
-      else
-        throw e;
+      throw e;
     }
   }
 
@@ -256,8 +254,7 @@ public class SecurityOperationsImpl implements SecurityOperations {
     } catch (AccumuloSecurityException e) {
       if (e.getSecurityErrorCode() == NAMESPACE_DOESNT_EXIST)
         throw new AccumuloSecurityException(null, SecurityErrorCode.TABLE_DOESNT_EXIST, e);
-      else
-        throw e;
+      throw e;
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ServerClient.java
@@ -164,15 +164,13 @@ public class ServerClient {
       warnedAboutTServersBeingDown = false;
       return new Pair<>(pair.getFirst(), client);
     } finally {
-      if (!opened) {
-        if (!warnedAboutTServersBeingDown) {
-          if (servers.isEmpty()) {
-            log.warn("There are no tablet servers: check that zookeeper and accumulo are running.");
-          } else {
-            log.warn("Failed to find an available server in the list of servers: {}", servers);
-          }
-          warnedAboutTServersBeingDown = true;
+      if (!opened && !warnedAboutTServersBeingDown) {
+        if (servers.isEmpty()) {
+          log.warn("There are no tablet servers: check that zookeeper and accumulo are running.");
+        } else {
+          log.warn("Failed to find an available server in the list of servers: {}", servers);
         }
+        warnedAboutTServersBeingDown = true;
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableMap.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableMap.java
@@ -55,8 +55,8 @@ public class TableMap {
 
     List<String> tableIds = zooCache.getChildren(context.getZooKeeperRoot() + Constants.ZTABLES);
     Map<NamespaceId,String> namespaceIdToNameMap = new HashMap<>();
-    var tableNameToIdBuilder = ImmutableMap.<String,TableId>builder();
-    var tableIdToNameBuilder = ImmutableMap.<TableId,String>builder();
+    final var tableNameToIdBuilder = ImmutableMap.<String,TableId>builder();
+    final var tableIdToNameBuilder = ImmutableMap.<TableId,String>builder();
 
     // use StringBuilder to construct zPath string efficiently across many tables
     StringBuilder zPathBuilder = new StringBuilder();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsHelper.java
@@ -116,13 +116,11 @@ public abstract class TableOperationsHelper implements TableOperations {
     for (Entry<String,String> property : this.getProperties(tableName)) {
       String name = property.getKey();
       String[] parts = name.split("\\.");
-      if (parts.length == 4) {
-        if (parts[0].equals("table") && parts[1].equals("iterator")) {
-          IteratorScope scope = IteratorScope.valueOf(parts[2]);
-          if (!result.containsKey(parts[3]))
-            result.put(parts[3], EnumSet.noneOf(IteratorScope.class));
-          result.get(parts[3]).add(scope);
-        }
+      if ((parts.length == 4) && (parts[0].equals("table") && parts[1].equals("iterator"))) {
+        IteratorScope scope = IteratorScope.valueOf(parts[2]);
+        if (!result.containsKey(parts[3]))
+          result.put(parts[3], EnumSet.noneOf(IteratorScope.class));
+        result.get(parts[3]).add(scope);
       }
     }
     return result;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
@@ -123,8 +123,7 @@ public class Tables {
         String namespace = qualify(tableName).getFirst();
         if (Namespaces.getNameToIdMap(context).containsKey(namespace))
           throw new TableNotFoundException(null, tableName, null);
-        else
-          throw new NamespaceNotFoundException(null, namespace, null);
+        throw new NamespaceNotFoundException(null, namespace, null);
       }
     }
     return tableId;
@@ -275,8 +274,7 @@ public class Tables {
     Pair<String,String> qualifiedTableName = qualify(tableName, defaultNamespace);
     if (Namespace.DEFAULT.name().equals(qualifiedTableName.getFirst()))
       return qualifiedTableName.getSecond();
-    else
-      return qualifiedTableName.toString("", ".", "");
+    return qualifiedTableName.toString("", ".", "");
   }
 
   public static Pair<String,String> qualify(String tableName) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -679,12 +679,13 @@ public class TabletServerBatchWriter implements AutoCloseable {
             if (!tableFailures.isEmpty()) {
               failedMutations.add(tableId, tableFailures);
 
-              if (tableFailures.size() == tableMutations.size())
+              if (tableFailures.size() == tableMutations.size()) {
                 if (!Tables.exists(context, entry.getKey()))
                   throw new TableDeletedException(entry.getKey().canonical());
-                else if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
+                if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
                   throw new TableOfflineException(
                       Tables.getTableOfflineMsg(context, entry.getKey()));
+              }
             }
           }
 
@@ -764,7 +765,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
       if (count > 0 && log.isTraceEnabled())
         log.trace(String.format("Started sending %,d mutations to %,d tablet servers", count,
-            binnedMutations.keySet().size()));
+            binnedMutations.size()));
 
       // randomize order of servers
       ArrayList<String> servers = new ArrayList<>(binnedMutations.keySet());
@@ -802,8 +803,6 @@ public class TabletServerBatchWriter implements AutoCloseable {
             send(tsmuts);
             tsmuts = getMutationsToSend(location);
           }
-
-          return;
         } catch (Exception t) {
           updateUnknownErrors(
               "Failed to send tablet server " + location + " its batch : " + t.getMessage(), t);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportKey.java
@@ -44,11 +44,9 @@ public class ThriftTransportKey {
     this.timeout = timeout;
     this.sslParams = context.getClientSslParams();
     this.saslParams = context.getSaslParams();
-    if (saslParams != null) {
-      // TSasl and TSSL transport factories don't play nicely together
-      if (sslParams != null) {
-        throw new RuntimeException("Cannot use both SSL and SASL thrift transports");
-      }
+    // TSasl and TSSL transport factories don't play nicely together
+    if ((saslParams != null) && (sslParams != null)) {
+      throw new RuntimeException("Cannot use both SSL and SASL thrift transports");
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -113,7 +113,7 @@ public class ThriftTransportPool {
     }
 
     void closeTransports(final Iterable<CachedConnection> stream) {
-      stream.forEach((connection) -> {
+      stream.forEach(connection -> {
         try {
           connection.transport.close();
         } catch (Exception e) {
@@ -348,7 +348,7 @@ public class ThriftTransportPool {
       ArrayList<CachedConnection> expired = new ArrayList<>();
       for (Entry<ThriftTransportKey,CachedConnections> entry : connections.entrySet()) {
         CachedConnections connections = entry.getValue();
-        executeWithinLock(entry.getKey(), (key) -> {
+        executeWithinLock(entry.getKey(), key -> {
           connections.removeExpiredConnections(expired, killTime);
           connections.checkReservedForStuckIO();
         });
@@ -492,14 +492,12 @@ public class ThriftTransportPool {
             stuckThreadName = null;
           }
         }
-      } else {
-        // I/O is not currently happening
-        if (stuckThreadName != null) {
-          // no longer stuck, and was stuck in the past
-          log.info("Thread \"{}\" no longer stuck on IO to {} sawError = {}", stuckThreadName,
-              cacheKey, sawError);
-          stuckThreadName = null;
-        }
+      } else // I/O is not currently happening
+      if (stuckThreadName != null) {
+        // no longer stuck, and was stuck in the past
+        log.info("Thread \"{}\" no longer stuck on IO to {} sawError = {}", stuckThreadName,
+            cacheKey, sawError);
+        stuckThreadName = null;
       }
     }
 
@@ -674,9 +672,8 @@ public class ThriftTransportPool {
     if (connection != null) {
       log.trace("Using existing connection to {}", cacheKey.getServer());
       return connection.transport;
-    } else {
-      return createNewTransport(cacheKey);
     }
+    return createNewTransport(cacheKey);
   }
 
   @VisibleForTesting
@@ -768,7 +765,7 @@ public class ThriftTransportPool {
     boolean existInCache = pool.returnTransport(cachedTransport, closeList);
 
     // close outside of sync block
-    closeList.forEach((connection) -> {
+    closeList.forEach(connection -> {
       try {
         connection.transport.close();
       } catch (Exception e) {
@@ -892,7 +889,7 @@ public class ThriftTransportPool {
     }
 
     // Close connections outside of sync block
-    expiredConnections.forEach((c) -> c.transport.close());
+    expiredConnections.forEach(c -> c.transport.close());
   }
 
   private void shutdown() {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/UserCompactionUtils.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/UserCompactionUtils.java
@@ -75,8 +75,8 @@ public class UserCompactionUtils {
     }
   }
 
-  public static interface Encoder<T> {
-    public void encode(DataOutput dout, T p);
+  public interface Encoder<T> {
+    void encode(DataOutput dout, T p);
   }
 
   public static <T> byte[] encode(T csc, Encoder<T> encoder) {
@@ -146,7 +146,7 @@ public class UserCompactionUtils {
     }
   }
 
-  public static interface Decoder<T> {
+  public interface Decoder<T> {
     T decode(DataInput di);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Writer.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Writer.java
@@ -72,7 +72,6 @@ public class Writer {
       client = ThriftUtil.getTServerClient(server, context);
       client.update(TraceUtil.traceInfo(), context.rpcCreds(), extent.toThrift(), m.toThrift(),
           TDurability.DEFAULT);
-      return;
     } catch (ThriftSecurityException e) {
       throw new AccumuloSecurityException(e.user, e.code);
     } finally {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -199,10 +199,9 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         throw new AccumuloException("Bulk import directory " + dir + " is not a directory!");
       }
       Path tmpFile = new Path(ret, "isWritable");
-      if (fs.createNewFile(tmpFile))
-        fs.delete(tmpFile, true);
-      else
+      if (!fs.createNewFile(tmpFile))
         throw new AccumuloException("Bulk import directory " + dir + " is not writable.");
+      fs.delete(tmpFile, true);
     } catch (FileNotFoundException fnf) {
       throw new AccumuloException(
           "Bulk import directory " + dir + " does not exist or has bad permissions", fnf);
@@ -320,10 +319,9 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
       KeyExtent extent = extentCache.lookup(row);
       result.add(extent);
       row = extent.endRow();
-      if (row != null) {
-        row = nextRow(row);
-      } else
+      if (row == null)
         break;
+      row = nextRow(row);
     }
 
     return result;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -49,9 +49,8 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
 
   List<Text> lookupRows = new ArrayList<>();
 
-  private ConcurrentSkipListMap<Text,KeyExtent> extents = new ConcurrentSkipListMap<>((t1, t2) -> {
-    return (t1 == t2) ? 0 : (t1 == MAX ? 1 : (t2 == MAX ? -1 : t1.compareTo(t2)));
-  });
+  private ConcurrentSkipListMap<Text,KeyExtent> extents = new ConcurrentSkipListMap<>(
+      (t1, t2) -> ((t1 == t2) ? 0 : (t1 == MAX ? 1 : (t2 == MAX ? -1 : t1.compareTo(t2)))));
   private TableId tableId;
   private ClientContext ctx;
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/LoadMappingIterator.java
@@ -76,9 +76,8 @@ public class LoadMappingIterator
     if (renameMap != null) {
       return new AbstractMap.SimpleEntry<>(bm.getKeyExtent(tableId),
           bm.getFiles().mapNames(renameMap));
-    } else {
-      return new AbstractMap.SimpleEntry<>(bm.getKeyExtent(tableId), bm.getFiles());
     }
+    return new AbstractMap.SimpleEntry<>(bm.getKeyExtent(tableId), bm.getFiles());
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapred/BatchInputSplit.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapred/BatchInputSplit.java
@@ -39,9 +39,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class BatchInputSplit extends org.apache.accumulo.core.clientImpl.mapreduce.BatchInputSplit
     implements InputSplit {
 
-  public BatchInputSplit() {
-    super();
-  }
+  public BatchInputSplit() {}
 
   public BatchInputSplit(BatchInputSplit split) throws IOException {
     super(split);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/ConfiguratorBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/ConfiguratorBase.java
@@ -67,7 +67,7 @@ public class ConfiguratorBase {
 
     private String prefix;
 
-    private TokenSource() {
+    TokenSource() {
       prefix = name().toLowerCase() + ":";
     }
 
@@ -348,7 +348,8 @@ public class ConfiguratorBase {
     if ("ZooKeeperInstance".equals(instanceType)) {
       return new org.apache.accumulo.core.client.ZooKeeperInstance(
           getClientConfiguration(implementingClass, conf));
-    } else if (instanceType.isEmpty()) {
+    }
+    if (instanceType.isEmpty()) {
       throw new IllegalStateException(
           "Instance has not been configured for " + implementingClass.getSimpleName());
     } else {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/DistributedCacheHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/DistributedCacheHelper.java
@@ -63,14 +63,12 @@ public class DistributedCacheHelper {
       } catch (FileNotFoundException e) {
         throw new AssertionError("FileNotFoundException after verifying file exists", e);
       }
-    } else {
-
-      // try to get token directly from HDFS path, without using the distributed cache
-      try {
-        return FileSystem.get(conf).open(new Path(path));
-      } catch (IOException e) {
-        throw new IllegalArgumentException("Unable to read file at DFS Path " + path, e);
-      }
+    }
+    // try to get token directly from HDFS path, without using the distributed cache
+    try {
+      return FileSystem.get(conf).open(new Path(path));
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to read file at DFS Path " + path, e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -42,7 +42,7 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum Opts {
+  public enum Opts {
     ACCUMULO_PROPERTIES
   }
 
@@ -85,17 +85,15 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    */
   private static <T> void setAccumuloProperty(Class<?> implementingClass, Configuration conf,
       Property property, T value) {
-    if (isSupportedAccumuloProperty(property)) {
-      String val = String.valueOf(value);
-      if (property.getType().isValidFormat(val))
-        conf.set(
-            enumToConfKey(implementingClass, Opts.ACCUMULO_PROPERTIES) + "." + property.getKey(),
-            val);
-      else
-        throw new IllegalArgumentException(
-            "Value is not appropriate for property type '" + property.getType() + "'");
-    } else
+    if (!isSupportedAccumuloProperty(property))
       throw new IllegalArgumentException("Unsupported configuration property " + property.getKey());
+    String val = String.valueOf(value);
+    if (property.getType().isValidFormat(val))
+      conf.set(enumToConfKey(implementingClass, Opts.ACCUMULO_PROPERTIES) + "." + property.getKey(),
+          val);
+    else
+      throw new IllegalArgumentException(
+          "Value is not appropriate for property type '" + property.getType() + "'");
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/OutputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/OutputConfigurator.java
@@ -37,7 +37,7 @@ public class OutputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum WriteOpts {
+  public enum WriteOpts {
     DEFAULT_TABLE_NAME, BATCH_WRITER_CONFIG
   }
 
@@ -46,7 +46,7 @@ public class OutputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum Features {
+  public enum Features {
     CAN_CREATE_TABLES, SIMULATION_MODE
   }
 
@@ -128,16 +128,15 @@ public class OutputConfigurator extends ConfiguratorBase {
     BatchWriterConfig bwConfig = new BatchWriterConfig();
     if (serialized == null || serialized.isEmpty()) {
       return bwConfig;
-    } else {
-      try {
-        ByteArrayInputStream bais = new ByteArrayInputStream(serialized.getBytes(UTF_8));
-        bwConfig.readFields(new DataInputStream(bais));
-        bais.close();
-        return bwConfig;
-      } catch (IOException e) {
-        throw new IllegalArgumentException(
-            "unable to serialize " + BatchWriterConfig.class.getName());
-      }
+    }
+    try {
+      ByteArrayInputStream bais = new ByteArrayInputStream(serialized.getBytes(UTF_8));
+      bwConfig.readFields(new DataInputStream(bais));
+      bais.close();
+      return bwConfig;
+    } catch (IOException e) {
+      throw new IllegalArgumentException(
+          "unable to serialize " + BatchWriterConfig.class.getName());
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/compaction/CompactionSettings.java
+++ b/core/src/main/java/org/apache/accumulo/core/compaction/CompactionSettings.java
@@ -39,7 +39,7 @@ public enum CompactionSettings {
   private Type type;
   private boolean selectorOpt;
 
-  private CompactionSettings(Type type, boolean selectorOpt) {
+  CompactionSettings(Type type, boolean selectorOpt) {
     this.type = type;
     this.selectorOpt = selectorOpt;
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -97,9 +97,8 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
   public Property resolve(Property property, Property deprecatedProperty) {
     if (isPropertySet(property, true) || !isPropertySet(deprecatedProperty, true)) {
       return property;
-    } else {
-      return deprecatedProperty;
     }
+    return deprecatedProperty;
   }
 
   /**
@@ -221,7 +220,8 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
     String memString = get(property);
     if (property.getType() == PropertyType.MEMORY) {
       return ConfigurationTypeHelper.getMemoryAsBytes(memString);
-    } else if (property.getType() == PropertyType.BYTES) {
+    }
+    if (property.getType() == PropertyType.BYTES) {
       return ConfigurationTypeHelper.getFixedMemoryAsBytes(memString);
     } else {
       throw new IllegalArgumentException(property.getKey() + " is not of BYTES or MEMORY type");
@@ -302,10 +302,9 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
         int port = Integer.parseInt(portString);
         if (port == 0 || PortRange.VALID_RANGE.contains(port)) {
           return IntStream.of(port);
-        } else {
-          log.error("Invalid port number {}; Using default {}", port, property.getDefaultValue());
-          return IntStream.of(Integer.parseInt(property.getDefaultValue()));
         }
+        log.error("Invalid port number {}; Using default {}", port, property.getDefaultValue());
+        return IntStream.of(Integer.parseInt(property.getDefaultValue()));
       } catch (NumberFormatException e1) {
         throw new IllegalArgumentException("Invalid port syntax. Must be a single positive "
             + "integers or a range (M-N) of positive integers");
@@ -433,7 +432,8 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
             prop.getKey());
       }
       return Integer.valueOf(get(deprecatedProp));
-    } else if (isPropertySet(prop, true) && isPropertySet(deprecatedProp, true) && !depPropWarned) {
+    }
+    if (isPropertySet(prop, true) && isPropertySet(deprecatedProp, true) && !depPropWarned) {
       depPropWarned = true;
       log.warn("Deprecated property {} ignored because {} is set", deprecatedProp.getKey(),
           prop.getKey());

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -198,7 +198,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
   }
 
   public Map<String,String> getAllPropertiesWithPrefixStripped(Property prefix) {
-    var builder = ImmutableMap.<String,String>builder();
+    final var builder = ImmutableMap.<String,String>builder();
     getAllPropertiesWithPrefix(prefix).forEach((k, v) -> {
       String optKey = k.substring(prefix.getKey().length());
       builder.put(optKey, v);

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientConfigGenerate.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientConfigGenerate.java
@@ -195,7 +195,8 @@ public class ClientConfigGenerate {
         if (args[0].equals("--generate-markdown")) {
           clientConfigGenerate.generateMarkdown();
           return;
-        } else if (args[0].equals("--generate-config")) {
+        }
+        if (args[0].equals("--generate-config")) {
           clientConfigGenerate.generateConfigFile();
           return;
         }

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -218,7 +218,7 @@ public enum ClientProperty {
     if (value.isEmpty()) {
       return false;
     }
-    return Boolean.valueOf(value);
+    return Boolean.parseBoolean(value);
   }
 
   public void setBytes(Properties properties, Long bytes) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigSanityCheck.java
@@ -55,7 +55,7 @@ public class ConfigSanityCheck {
       Property prop = Property.getPropertyByKey(entry.getKey());
       if (prop == null && Property.isValidPropertyKey(key))
         continue; // unknown valid property (i.e. has proper prefix)
-      else if (prop == null)
+      if (prop == null)
         log.warn(PREFIX + "unrecognized property key (" + key + ")");
       else if (prop.getType() == PropertyType.PREFIX)
         fatal(PREFIX + "incomplete property key (" + key + ")");

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationDocGen.java
@@ -98,13 +98,11 @@ public class ConfigurationDocGen {
     } else if (defaultValue.contains("\n")) {
       // deal with multi-line values, skip strikethrough of value
       defaultValue = strike("**default value:** ", depr) + "\n```\n" + defaultValue + "\n```\n";
+    } else if (prop.getType() == PropertyType.CLASSNAME
+        && defaultValue.startsWith("org.apache.accumulo")) {
+      defaultValue = strike("**default value:** " + "{% jlink -f " + defaultValue + " %}", depr);
     } else {
-      if (prop.getType() == PropertyType.CLASSNAME
-          && defaultValue.startsWith("org.apache.accumulo")) {
-        defaultValue = strike("**default value:** " + "{% jlink -f " + defaultValue + " %}", depr);
-      } else {
-        defaultValue = strike("**default value:** " + "`" + defaultValue + "`", depr);
-      }
+      defaultValue = strike("**default value:** " + "`" + defaultValue + "`", depr);
     }
     doc.println(defaultValue + " |");
   }
@@ -154,13 +152,12 @@ public class ConfigurationDocGen {
    *           if args is invalid
    */
   public static void main(String[] args) throws IOException {
-    if (args.length == 2 && args[0].equals("--generate-markdown")) {
-      try (var printStream = new PrintStream(args[1], UTF_8)) {
-        new ConfigurationDocGen(printStream).generate();
-      }
-    } else {
+    if ((args.length != 2) || !args[0].equals("--generate-markdown")) {
       throw new IllegalArgumentException(
           "Usage: " + ConfigurationDocGen.class.getName() + " --generate-markdown <filename>");
+    }
+    try (var printStream = new PrintStream(args[1], UTF_8)) {
+      new ConfigurationDocGen(printStream).generate();
     }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -443,7 +443,7 @@ public enum Property {
   TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS(
       "tserver.compaction.major.service.root.planner.opts.executors",
       "[{'name':'small','maxSize':'32M','numThreads':1},"
-          + "{'name':'huge','numThreads':1}]".replaceAll("'", "\""),
+          + "{'name':'huge','numThreads':1}]".replace("'", "\""),
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %} "),
   TSERV_COMPACTION_SERVICE_META_PLANNER("tserver.compaction.major.service.meta.planner",
@@ -459,7 +459,7 @@ public enum Property {
   TSERV_COMPACTION_SERVICE_META_EXECUTORS(
       "tserver.compaction.major.service.meta.planner.opts.executors",
       "[{'name':'small','maxSize':'32M','numThreads':2},"
-          + "{'name':'huge','numThreads':2}]".replaceAll("'", "\""),
+          + "{'name':'huge','numThreads':2}]".replace("'", "\""),
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %} "),
   TSERV_COMPACTION_SERVICE_DEFAULT_PLANNER("tserver.compaction.major.service.default.planner",
@@ -476,7 +476,7 @@ public enum Property {
       "tserver.compaction.major.service.default.planner.opts.executors",
       "[{'name':'small','maxSize':'32M','numThreads':2},"
           + "{'name':'medium','maxSize':'128M','numThreads':2},"
-          + "{'name':'large','numThreads':2}]".replaceAll("'", "\""),
+          + "{'name':'large','numThreads':2}]".replace("'", "\""),
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %} "),
   @Deprecated(since = "2.1.0", forRemoval = true)
@@ -1196,13 +1196,10 @@ public enum Property {
     Property prop = propertiesByKey.get(key);
     if (prop != null) {
       return prop.isSensitive();
-    } else {
-      for (String prefix : validPrefixes) {
-        if (key.startsWith(prefix)) {
-          if (propertiesByKey.get(prefix).isSensitive()) {
-            return true;
-          }
-        }
+    }
+    for (String prefix : validPrefixes) {
+      if (key.startsWith(prefix) && propertiesByKey.get(prefix).isSensitive()) {
+        return true;
       }
     }
     return false;
@@ -1241,10 +1238,8 @@ public enum Property {
   private static <T extends Annotation> boolean hasPrefixWithAnnotation(String key,
       Class<T> annotationType) {
     for (String prefix : validPrefixes) {
-      if (key.startsWith(prefix)) {
-        if (propertiesByKey.get(prefix).hasAnnotation(annotationType)) {
-          return true;
-        }
+      if (key.startsWith(prefix) && propertiesByKey.get(prefix).hasAnnotation(annotationType)) {
+        return true;
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -144,7 +144,7 @@ public enum PropertyType {
   // see https://github.com/spotbugs/spotbugs/issues/740
   private transient Predicate<String> predicate;
 
-  private PropertyType(String shortname, Predicate<String> predicate, String formatDescription) {
+  PropertyType(String shortname, Predicate<String> predicate, String formatDescription) {
     this.shortname = shortname;
     this.predicate = Objects.requireNonNull(predicate);
     this.format = formatDescription;
@@ -182,11 +182,10 @@ public enum PropertyType {
     if (caseSensitive) {
       return x -> Arrays.stream(allowedSet)
           .anyMatch(y -> (x == null && y == null) || (x != null && x.equals(y)));
-    } else {
-      Function<String,String> toLower = x -> x == null ? null : x.toLowerCase();
-      return x -> Arrays.stream(allowedSet).map(toLower)
-          .anyMatch(y -> (x == null && y == null) || (x != null && toLower.apply(x).equals(y)));
     }
+    Function<String,String> toLower = x -> x == null ? null : x.toLowerCase();
+    return x -> Arrays.stream(allowedSet).map(toLower)
+        .anyMatch(y -> (x == null && y == null) || (x != null && toLower.apply(x).equals(y)));
   }
 
   private static Predicate<String> boundedUnits(final long lowerBound, final long upperBound,
@@ -212,14 +211,13 @@ public enum PropertyType {
     public boolean test(final String input) {
       requireNonNull(input);
       Matcher m = SUFFIX_REGEX.matcher(input);
-      if (m.find()) {
-        if (m.groupCount() != 0) {
-          throw new AssertionError(m.groupCount());
-        }
-        return p.test(m.group());
-      } else {
+      if (!m.find()) {
         return true;
       }
+      if (m.groupCount() != 0) {
+        throw new AssertionError(m.groupCount());
+      }
+      return p.test(m.group());
     }
   }
 
@@ -318,14 +316,13 @@ public enum PropertyType {
 
     @Override
     public boolean test(final String input) {
-      if (super.test(input)) {
-        try {
-          PortRange.parse(input);
-          return true;
-        } catch (IllegalArgumentException e) {
-          return false;
-        }
-      } else {
+      if (!super.test(input)) {
+        return false;
+      }
+      try {
+        PortRange.parse(input);
+        return true;
+      } catch (IllegalArgumentException e) {
         return false;
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -113,16 +113,15 @@ public class SiteConfiguration extends AccumuloConfiguration {
           throw new IllegalArgumentException(
               "Failed to load Accumulo configuration at " + configFile);
         }
+      }
+      URL accumuloConfigUrl = SiteConfiguration.class.getClassLoader().getResource(configFile);
+      if (accumuloConfigUrl == null) {
+        throw new IllegalArgumentException(
+            "Failed to load Accumulo configuration '" + configFile + "' from classpath");
       } else {
-        URL accumuloConfigUrl = SiteConfiguration.class.getClassLoader().getResource(configFile);
-        if (accumuloConfigUrl == null) {
-          throw new IllegalArgumentException(
-              "Failed to load Accumulo configuration '" + configFile + "' from classpath");
-        } else {
-          log.info("Found Accumulo configuration on classpath at {}", accumuloConfigUrl.getFile());
-          url = accumuloConfigUrl;
-          return this;
-        }
+        log.info("Found Accumulo configuration on classpath at {}", accumuloConfigUrl.getFile());
+        url = accumuloConfigUrl;
+        return this;
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedInputStream.java
@@ -112,7 +112,8 @@ public class BlockedInputStream extends InputStream {
     if (size < 0 || size > array.length) {
       finished = true;
       return false;
-    } else if (size == 0)
+    }
+    if (size == 0)
       throw new RuntimeException(
           "Empty block written, this shouldn't happen with this BlockedOutputStream.");
 

--- a/core/src/main/java/org/apache/accumulo/core/data/ArrayByteSequence.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ArrayByteSequence.java
@@ -112,9 +112,8 @@ public class ArrayByteSequence extends ByteSequence implements Serializable {
   private static byte[] copy(ByteSequence bs) {
     if (bs.isBackedByArray()) {
       return Arrays.copyOfRange(bs.getBackingArray(), bs.offset(), bs.offset() + bs.length());
-    } else {
-      return bs.toArray();
     }
+    return bs.toArray();
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/Key.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Key.java
@@ -1226,13 +1226,12 @@ public class Key implements WritableComparable<Key>, Cloneable {
 
     last--;
 
-    if (a1[last] == a2[last]) {
-      for (int i = 0; i < last; i++)
-        if (a1[i] != a2[i])
-          return false;
-    } else {
+    if (a1[last] != a2[last]) {
       return false;
     }
+    for (int i = 0; i < last; i++)
+      if (a1[i] != a2[i])
+        return false;
 
     return true;
 

--- a/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
@@ -197,7 +197,7 @@ public class LoadPlan {
 
   public static Builder builder() {
     return new Builder() {
-      ImmutableList.Builder<Destination> fmb = ImmutableList.builder();
+      final ImmutableList.Builder<Destination> fmb = ImmutableList.builder();
 
       @Override
       public Builder loadFileTo(String fileName, RangeType rangeType, Text startRow, Text endRow) {

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -90,7 +90,7 @@ public class Mutation implements Writable {
    * Formats available for serializing Mutations. The formats are described in a
    * <a href="doc-files/mutation-serialization.html">separate document</a>.
    */
-  public static enum SERIALIZED_FORMAT {
+  public enum SERIALIZED_FORMAT {
     VERSION1, VERSION2
   }
 
@@ -129,9 +129,8 @@ public class Mutation implements Writable {
   private ByteBuffer serializedSnapshot() {
     if (buffer != null) {
       return this.buffer.toByteBuffer();
-    } else {
-      return ByteBuffer.wrap(this.data);
     }
+    return ByteBuffer.wrap(this.data);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/PartialKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/PartialKey.java
@@ -32,7 +32,7 @@ public enum PartialKey {
 
   int depth;
 
-  private PartialKey(int depth) {
+  PartialKey(int depth) {
     this.depth = depth;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/Range.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Range.java
@@ -560,7 +560,7 @@ public class Range implements WritableComparable<Range> {
       }
     } else if (afterEndKey(range.getStartKey())
         || (getEndKey() != null && range.getStartKey().equals(getEndKey())
-            && !(range.isStartKeyInclusive() && isEndKeyInclusive()))) {
+            && (!range.isStartKeyInclusive() || !isEndKeyInclusive()))) {
       if (returnNullIfDisjoint)
         return null;
       throw new IllegalArgumentException("Range " + range + " does not overlap " + this);
@@ -576,7 +576,7 @@ public class Range implements WritableComparable<Range> {
       }
     } else if (beforeStartKey(range.getEndKey())
         || (getStartKey() != null && range.getEndKey().equals(getStartKey())
-            && !(range.isEndKeyInclusive() && isStartKeyInclusive()))) {
+            && (!range.isEndKeyInclusive() || !isStartKeyInclusive()))) {
       if (returnNullIfDisjoint)
         return null;
       throw new IllegalArgumentException("Range " + range + " does not overlap " + this);

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -187,9 +187,8 @@ public class KeyExtent implements Comparable<KeyExtent> {
   public static KeyExtent fromTabletId(TabletId tabletId) {
     if (tabletId instanceof TabletIdImpl) {
       return ((TabletIdImpl) tabletId).toKeyExtent();
-    } else {
-      return new KeyExtent(tabletId.getTable(), tabletId.getEndRow(), tabletId.getPrevEndRow());
     }
+    return new KeyExtent(tabletId.getTable(), tabletId.getEndRow(), tabletId.getPrevEndRow());
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -85,7 +85,6 @@ public class BloomFilterLayer {
 
   public static class Writer implements FileSKVWriter {
     private DynamicBloomFilter bloomFilter;
-    private int numKeys;
     private int vectorSize;
 
     private FileSKVWriter writer;
@@ -101,7 +100,7 @@ public class BloomFilterLayer {
     private synchronized void initBloomFilter(AccumuloConfiguration acuconf,
         boolean useAccumuloStart) {
 
-      numKeys = acuconf.getCount(Property.TABLE_BLOOM_SIZE);
+      int numKeys = acuconf.getCount(Property.TABLE_BLOOM_SIZE);
       // vector size should be <code>-kn / (ln(1 - c^(1/k)))</code> bits for
       // single key, where <code> is the number of hash functions,
       // <code>n</code> is the number of keys and <code>c</code> is the desired
@@ -257,10 +256,9 @@ public class BloomFilterLayer {
           LOG.error("Could not instantiate KeyFunctor: " + sanitize(ClassName), e);
           bloomFilter = null;
         } catch (RuntimeException rte) {
-          if (closed)
-            LOG.debug("Can't open BloomFilter, RTE after closed ", rte);
-          else
+          if (!closed)
             throw rte;
+          LOG.debug("Can't open BloomFilter, RTE after closed ", rte);
         } finally {
           if (in != null) {
             try {

--- a/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
@@ -50,7 +50,8 @@ class DispatchingFileFactory extends FileOperations {
     if (extension.equals(Constants.MAPFILE_EXTENSION)
         || extension.equals(Constants.MAPFILE_EXTENSION + "_tmp")) {
       return new MapFileOperations();
-    } else if (extension.equals(RFile.EXTENSION) || extension.equals(RFile.EXTENSION + "_tmp")) {
+    }
+    if (extension.equals(RFile.EXTENSION) || extension.equals(RFile.EXTENSION + "_tmp")) {
       return new RFileOperations();
     } else {
       throw new IllegalArgumentException("File type " + extension + " not supported");
@@ -85,9 +86,8 @@ class DispatchingFileFactory extends FileOperations {
     FileSKVIterator iter = findFileFactory(options).openReader(options);
     if (options.getTableConfiguration().getBoolean(Property.TABLE_BLOOM_ENABLED)) {
       return new BloomFilterLayer.Reader(iter, options.getTableConfiguration());
-    } else {
-      return iter;
     }
+    return iter;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -165,7 +165,7 @@ public abstract class FileOperations {
     return new ReaderBuilder();
   }
 
-  public class FileOptions {
+  public static class FileOptions {
     // objects used by all
     public final AccumuloConfiguration tableConfiguration;
     public final String filename;
@@ -272,7 +272,7 @@ public abstract class FileOperations {
   /**
    * Helper class extended by both writers and readers.
    */
-  public class FileHelper {
+  public static class FileHelper {
     private AccumuloConfiguration tableConfiguration;
     private String filename;
     private FileSystem fs;
@@ -387,7 +387,7 @@ public abstract class FileOperations {
   }
 
   public interface WriterTableConfiguration {
-    public WriterBuilder withTableConfiguration(AccumuloConfiguration tableConfiguration);
+    WriterBuilder withTableConfiguration(AccumuloConfiguration tableConfiguration);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/CachedBlock.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/CachedBlock.java
@@ -40,7 +40,7 @@ public class CachedBlock implements HeapSize, Comparable<CachedBlock> {
       ClassSize.align(ClassSize.OBJECT + (3 * ClassSize.REFERENCE) + (2 * SizeConstants.SIZEOF_LONG)
           + ClassSize.STRING + ClassSize.BYTE_BUFFER + ClassSize.REFERENCE);
 
-  public static enum BlockPriority {
+  public enum BlockPriority {
     /**
      * Accessed a single time (used for scan-resistance)
      */
@@ -98,8 +98,7 @@ public class CachedBlock implements HeapSize, Comparable<CachedBlock> {
 
   @Override
   public boolean equals(Object obj) {
-    return this == obj
-        || (obj != null && obj instanceof CachedBlock && compareTo((CachedBlock) obj) == 0);
+    return this == obj || (obj instanceof CachedBlock && compareTo((CachedBlock) obj) == 0);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
@@ -133,7 +133,6 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
   @SuppressFBWarnings(value = "SC_START_IN_CTOR",
       justification = "bad practice to start threads in constructor; probably needs rewrite")
   public LruBlockCache(final LruBlockCacheConfiguration conf) {
-    super();
     this.conf = conf;
 
     int mapInitialSize = (int) Math.ceil(1.2 * conf.getMaxSize() / conf.getBlockSize());

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
@@ -89,9 +89,7 @@ public final class TinyLfuBlockCache implements BlockCache {
 
   @Override
   public CacheEntry cacheBlock(String blockName, byte[] buffer) {
-    return wrap(blockName, cache.asMap().compute(blockName, (key, block) -> {
-      return new Block(buffer);
-    }));
+    return wrap(blockName, cache.asMap().compute(blockName, (key, block) -> new Block(buffer)));
   }
 
   @Override
@@ -216,17 +214,16 @@ public final class TinyLfuBlockCache implements BlockCache {
         return null;
       }
       return Collections.singletonMap(entry.getKey(), ce.getBuffer());
-    } else {
-      HashMap<String,byte[]> resolvedDeps = new HashMap<>();
-      for (Entry<String,Loader> entry : deps.entrySet()) {
-        CacheEntry ce = getBlock(entry.getKey(), entry.getValue());
-        if (ce == null) {
-          return null;
-        }
-        resolvedDeps.put(entry.getKey(), ce.getBuffer());
-      }
-      return resolvedDeps;
     }
+    HashMap<String,byte[]> resolvedDeps = new HashMap<>();
+    for (Entry<String,Loader> entry : deps.entrySet()) {
+      CacheEntry ce = getBlock(entry.getKey(), entry.getValue());
+      if (ce == null) {
+        return null;
+      }
+      resolvedDeps.put(entry.getKey(), ce.getBuffer());
+    }
+    return resolvedDeps;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -59,7 +59,7 @@ public class CachableBlockFile {
 
   private static final Logger log = LoggerFactory.getLogger(CachableBlockFile.class);
 
-  private static interface IoeSupplier<T> {
+  private interface IoeSupplier<T> {
     T get() throws IOException;
   }
 
@@ -190,11 +190,10 @@ public class CachableBlockFile {
         if (bcfr.compareAndSet(null, tmpReader)) {
           fin = fsIn;
           return tmpReader;
-        } else {
-          fsIn.close();
-          tmpReader.close();
-          return bcfr.get();
         }
+        fsIn.close();
+        tmpReader.close();
+        return bcfr.get();
       }
 
       return reader;
@@ -308,7 +307,6 @@ public class CachableBlockFile {
       private boolean loadingMetaBlock;
 
       public BaseBlockLoader(boolean loadingMetaBlock) {
-        super();
         this.loadingMetaBlock = loadingMetaBlock;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CacheProvider.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CacheProvider.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.core.file.blockfile.impl;
 import org.apache.accumulo.core.spi.cache.BlockCache;
 
 public interface CacheProvider {
-  static final CacheProvider NULL_PROVIDER = new BasicCacheProvider(null, null);
+  CacheProvider NULL_PROVIDER = new BasicCacheProvider(null, null);
 
   BlockCache getDataCache();
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -49,9 +49,8 @@ public class SeekableByteArrayInputStream extends InputStream {
   public int read() {
     if (cur < max) {
       return buffer[cur++] & 0xff;
-    } else {
-      return -1;
     }
+    return -1;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/BlockIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/BlockIndex.java
@@ -133,20 +133,18 @@ public class BlockIndex implements Weighable {
       // found exact key in index
       index = pos;
       while (index > 0) {
-        if (blockIndex[index].getPrevKey().equals(startKey))
-          index--;
-        else
+        if (!blockIndex[index].getPrevKey().equals(startKey))
           break;
+        index--;
       }
     }
 
     // handle case where multiple keys in block are exactly the same, want to find the earliest key
     // in the index
     while (index - 1 > 0) {
-      if (blockIndex[index].getPrevKey().equals(blockIndex[index - 1].getPrevKey()))
-        index--;
-      else
+      if (!blockIndex[index].getPrevKey().equals(blockIndex[index - 1].getPrevKey()))
         break;
+      index--;
 
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/KeyShortener.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/KeyShortener.java
@@ -74,7 +74,8 @@ public class KeyShortener {
           successor = Bytes.concat(prev.subSequence(0, newLen).toArray(), B00);
         }
         return new ArrayByteSequence(successor);
-      } else if (diff > 1) {
+      }
+      if (diff > 1) {
         byte[] copy = new byte[i + 1];
         System.arraycopy(prev.subSequence(0, i + 1).toArray(), 0, copy, 0, i + 1);
         copy[i] = (byte) ((0xff & copy[i]) + 1);
@@ -123,7 +124,8 @@ public class KeyShortener {
         return prev;
       }
       return sanityCheck(prev, current, new Key(shortenedRow.toArray(), EMPTY, EMPTY, EMPTY, 0));
-    } else if (prev.getColumnFamilyData().compareTo(current.getColumnFamilyData()) < 0) {
+    }
+    if (prev.getColumnFamilyData().compareTo(current.getColumnFamilyData()) < 0) {
       ByteSequence shortenedFam =
           shorten(prev.getColumnFamilyData(), current.getColumnFamilyData());
       if (shortenedFam == null) {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -197,9 +197,8 @@ public class MultiLevelIndex {
     public int size() {
       if (offsets == null) {
         return numOffsets;
-      } else {
-        return offsets.length;
       }
+      return offsets.length;
     }
 
   }
@@ -223,9 +222,8 @@ public class MultiLevelIndex {
     public long sizeInBytes() {
       if (offsets == null) {
         return indexSize + 4L * numOffsets;
-      } else {
-        return data.length + 4L * offsets.length;
       }
+      return data.length + 4L * offsets.length;
     }
 
     @Override
@@ -408,9 +406,8 @@ public class MultiLevelIndex {
       // problems with deep copies.
       if (offsetsArray == null) {
         return new SerializedIndex(data, offsetsOffset, numOffsets, indexOffset, indexSize);
-      } else {
-        return new SerializedIndex(offsetsArray, data, newFormat);
       }
+      return new SerializedIndex(offsetsArray, data, newFormat);
     }
 
     public List<Key> getKeyIndex() {
@@ -419,9 +416,8 @@ public class MultiLevelIndex {
       // deep copies.
       if (offsetsArray == null) {
         return new KeyIndex(data, offsetsOffset, numOffsets, indexOffset, indexSize);
-      } else {
-        return new KeyIndex(offsetsArray, data);
       }
+      return new KeyIndex(offsetsArray, data);
     }
 
     int getLevel() {
@@ -721,9 +717,8 @@ public class MultiLevelIndex {
 
         if (liter.hasNext()) {
           return true;
-        } else {
-          return node.indexBlock.hasNext();
         }
+        return node.indexBlock.hasNext();
 
       }
 
@@ -756,9 +751,8 @@ public class MultiLevelIndex {
 
         if (liter.hasPrevious()) {
           return true;
-        } else {
-          return node.indexBlock.getOffset() > 0;
         }
+        return node.indexBlock.getOffset() > 0;
       }
 
       @Override

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/BCFile.java
@@ -806,11 +806,10 @@ public final class BCFile {
 
     public MetaIndexEntry(DataInput in) throws IOException {
       String fullMetaName = Utils.readString(in);
-      if (fullMetaName.startsWith(defaultPrefix)) {
-        metaName = fullMetaName.substring(defaultPrefix.length(), fullMetaName.length());
-      } else {
+      if (!fullMetaName.startsWith(defaultPrefix)) {
         throw new IOException("Corrupted Meta region Index");
       }
+      metaName = fullMetaName.substring(defaultPrefix.length());
 
       compressionAlgorithm = Compression.getCompressionAlgorithmByName(Utils.readString(in));
       region = new BlockRegion(in);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/FirstEntryInRowIterator.java
@@ -54,12 +54,9 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
   }
 
   // this must be public for OptionsDescriber
-  public FirstEntryInRowIterator() {
-    super();
-  }
+  public FirstEntryInRowIterator() {}
 
   public FirstEntryInRowIterator(FirstEntryInRowIterator other, IteratorEnvironment env) {
-    super();
     setSource(other.getSource().deepCopy(env));
   }
 
@@ -98,10 +95,10 @@ public class FirstEntryInRowIterator extends SkippingIterator implements OptionD
         if (latestRange.afterEndKey(nextKey)) {
           finished = true;
           break;
-        } else
-          source.seek(
-              new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()),
-              latestColumnFamilies, latestInclusive);
+        }
+        source.seek(
+            new Range(nextKey, true, latestRange.getEndKey(), latestRange.isEndKeyInclusive()),
+            latestColumnFamilies, latestInclusive);
       }
     }
     lastRowFound = source.hasTop() ? source.getTopKey().getRow(lastRowFound) : null;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/IterationInterruptedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/IterationInterruptedException.java
@@ -22,9 +22,7 @@ public class IterationInterruptedException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
-  public IterationInterruptedException() {
-    super();
-  }
+  public IterationInterruptedException() {}
 
   public IterationInterruptedException(String msg) {
     super(msg);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/LongCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/LongCombiner.java
@@ -250,10 +250,8 @@ public abstract class LongCombiner extends TypedValueCombiner<Long> {
       if (aSign > 0) {
         if (Long.MAX_VALUE - a < b)
           return Long.MAX_VALUE;
-      } else {
-        if (Long.MIN_VALUE - a > b)
-          return Long.MIN_VALUE;
-      }
+      } else if (Long.MIN_VALUE - a > b)
+        return Long.MIN_VALUE;
     }
     return a + b;
   }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/CfCqSliceOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/CfCqSliceOpts.java
@@ -94,12 +94,12 @@ public class CfCqSliceOpts {
     maxCq = optStr == null ? new Text() : new Text(optStr.getBytes(UTF_8));
 
     optStr = options.get(OPT_MIN_INCLUSIVE);
-    minInclusive =
-        optStr == null || optStr.isEmpty() ? true : Boolean.valueOf(options.get(OPT_MIN_INCLUSIVE));
+    minInclusive = optStr == null || optStr.isEmpty() ? true
+        : Boolean.parseBoolean(options.get(OPT_MIN_INCLUSIVE));
 
     optStr = options.get(OPT_MAX_INCLUSIVE);
-    maxInclusive =
-        optStr == null || optStr.isEmpty() ? true : Boolean.valueOf(options.get(OPT_MAX_INCLUSIVE));
+    maxInclusive = optStr == null || optStr.isEmpty() ? true
+        : Boolean.parseBoolean(options.get(OPT_MAX_INCLUSIVE));
   }
 
   static class Describer implements OptionDescriber {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/ColumnAgeOffFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/ColumnAgeOffFilter.java
@@ -41,8 +41,6 @@ import org.apache.hadoop.io.Text;
 public class ColumnAgeOffFilter extends Filter {
   public static class TTLSet extends ColumnToClassMapping<Long> {
     public TTLSet(Map<String,String> objectStrings) {
-      super();
-
       for (Entry<String,String> entry : objectStrings.entrySet()) {
         String column = entry.getKey();
         String ttl = entry.getValue().trim();

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/GrepIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/GrepIterator.java
@@ -85,9 +85,7 @@ public class GrepIterator extends Filter {
       IteratorEnvironment env) throws IOException {
     super.init(source, options, env);
     term = options.get("term").getBytes(UTF_8);
-    for (int i = 0; i < right.length; i++) {
-      right[i] = -1;
-    }
+    Arrays.fill(right, -1);
     for (int i = 0; i < term.length; i++) {
       right[term[i] & 0xff] = i;
     }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/IntersectingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/IntersectingIterator.java
@@ -245,7 +245,8 @@ public class IntersectingIterator implements SortedKeyValueIterator<Key,Value> {
         // If we are past the target, this is a valid result
         if (docIDCompare < 0) {
           break;
-        } else if (docIDCompare > 0) {
+        }
+        if (docIDCompare > 0) {
           // if this source is not yet at the currentCQ then advance in this source
 
           // seek forwards

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RegExFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RegExFilter.java
@@ -73,8 +73,7 @@ public class RegExFilter extends Filter {
   private Matcher copyMatcher(Matcher m) {
     if (m == null)
       return m;
-    else
-      return m.pattern().matcher("");
+    return m.pattern().matcher("");
   }
 
   private boolean matches(Matcher matcher, ByteSequence bs) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowDeletingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowDeletingIterator.java
@@ -133,17 +133,16 @@ public class RowDeletingIterator implements SortedKeyValueIterator<Key,Value> {
         }
       }
 
-      if (!currentRowDeleted && source.hasTop()
-          && isDeleteMarker(source.getTopKey(), source.getTopValue())) {
-        currentRow = source.getTopKey().getRowData();
-        currentRowDeleted = true;
-        deleteTS = source.getTopKey().getTimestamp();
-
-        if (propogateDeletes)
-          break;
-      } else {
+      if (currentRowDeleted || !source.hasTop()
+          || !isDeleteMarker(source.getTopKey(), source.getTopValue())) {
         break;
       }
+      currentRow = source.getTopKey().getRowData();
+      currentRowDeleted = true;
+      deleteTS = source.getTopKey().getTimestamp();
+
+      if (propogateDeletes)
+        break;
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowFilter.java
@@ -107,22 +107,21 @@ public abstract class RowFilter extends WrappingIterator {
       if (acceptRow(decisionIterator)) {
         currentRow = row;
         break;
-      } else {
-        currentRow = null;
-        int count = 0;
-        while (source.hasTop() && count < 10 && source.getTopKey().getRow().equals(row)) {
-          count++;
-          source.next();
-        }
+      }
+      currentRow = null;
+      int count = 0;
+      while (source.hasTop() && count < 10 && source.getTopKey().getRow().equals(row)) {
+        count++;
+        source.next();
+      }
 
-        if (source.hasTop() && source.getTopKey().getRow().equals(row)) {
-          Range nextRow = new Range(row, false, null, false);
-          nextRow = range.clip(nextRow, true);
-          if (nextRow == null)
-            hasTop = false;
-          else
-            source.seek(nextRow, columnFamilies, inclusive);
-        }
+      if (source.hasTop() && source.getTopKey().getRow().equals(row)) {
+        Range nextRow = new Range(row, false, null, false);
+        nextRow = range.clip(nextRow, true);
+        if (nextRow == null)
+          hasTop = false;
+        else
+          source.seek(nextRow, columnFamilies, inclusive);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
@@ -180,13 +180,12 @@ public abstract class SeekingFilter extends WrappingIterator {
             f.advance == AdvanceResult.USE_HINT ? getNextKeyHint(src.getTopKey(), src.getTopValue())
                 : " (none)");
       }
-      if (f.accept == negate) {
-        advanceSource(src, f.advance);
-      } else {
+      if (f.accept != negate) {
         // advance will be processed when next is called
         advance = f.advance;
         break;
       }
+      advanceSource(src, f.advance);
     }
   }
 
@@ -210,12 +209,11 @@ public abstract class SeekingFilter extends WrappingIterator {
       case USE_HINT:
         Value topVal = src.getTopValue();
         Key hintKey = getNextKeyHint(topKey, topVal);
-        if (hintKey != null && hintKey.compareTo(topKey) > 0) {
-          advRange = new Range(hintKey, null);
-        } else {
+        if ((hintKey == null) || (hintKey.compareTo(topKey) <= 0)) {
           String msg = "Filter returned USE_HINT for " + topKey + " but invalid hint: " + hintKey;
           throw new IOException(msg);
         }
+        advRange = new Range(hintKey, null);
         break;
     }
     if (advRange == null) {

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
@@ -88,12 +88,11 @@ public class SummingArrayCombiner extends TypedValueCombiner<List<Long>> {
         la.set(i, LongCombiner.safeAdd(la.get(i), lb.get(i)));
       }
       return la;
-    } else {
-      for (int i = 0; i < la.size(); i++) {
-        lb.set(i, LongCombiner.safeAdd(lb.get(i), la.get(i)));
-      }
-      return lb;
     }
+    for (int i = 0; i < la.size(); i++) {
+      lb.set(i, LongCombiner.safeAdd(lb.get(i), la.get(i)));
+    }
+    return lb;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -417,15 +417,13 @@ public abstract class TransformingIterator extends WrappingIterator implements O
         parsedVisibilitiesCache.put(visibility, Boolean.FALSE);
         if (scanning) {
           return false;
-        } else {
-          throw e;
         }
+        throw e;
       }
     } else if (!parsed) {
       if (scanning)
         return false;
-      else
-        throw new IllegalStateException();
+      throw new IllegalStateException();
     }
 
     Boolean visible = canSeeColumnFamily(key);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/VisibilityFilter.java
@@ -86,23 +86,22 @@ public class VisibilityFilter extends Filter implements OptionDescriber {
         cache.put(testVis, false);
         return false;
       }
-    } else {
-      if (testVis.length() == 0) {
-        return true;
-      }
+    }
+    if (testVis.length() == 0) {
+      return true;
+    }
 
-      Boolean b = cache.get(testVis);
-      if (b != null)
-        return b;
+    Boolean b = cache.get(testVis);
+    if (b != null)
+      return b;
 
-      try {
-        boolean bb = ve.evaluate(new ColumnVisibility(testVis.toArray()));
-        cache.put(testVis, bb);
-        return bb;
-      } catch (VisibilityParseException | BadArgumentException e) {
-        log.error("Parse Error", e);
-        return false;
-      }
+    try {
+      boolean bb = ve.evaluate(new ColumnVisibility(testVis.toArray()));
+      cache.put(testVis, bb);
+      return bb;
+    } catch (VisibilityParseException | BadArgumentException e) {
+      log.error("Parse Error", e);
+      return false;
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/conf/ColumnSet.java
@@ -131,7 +131,8 @@ public class ColumnSet {
 
     if (cols.length == 1) {
       return new Pair<>(decode(cols[0]), null);
-    } else if (cols.length == 2) {
+    }
+    if (cols.length == 2) {
       return new Pair<>(decode(cols[0]), decode(cols[1]));
     } else {
       throw new IllegalArgumentException(columns);
@@ -148,15 +149,14 @@ public class ColumnSet {
       if (sb[i] == '%') {
         int x = ++i;
         int y = ++i;
-        if (y < sb.length) {
-          byte[] hex = {sb[x], sb[y]};
-          String hs = new String(hex, UTF_8);
-          int b = Integer.parseInt(hs, 16);
-          t.append(new byte[] {(byte) b}, 0, 1);
-        } else {
+        if (y >= sb.length) {
           throw new IllegalArgumentException("Invalid characters in encoded string (" + s + ")."
               + " Expected two characters after '%'");
         }
+        byte[] hex = {sb[x], sb[y]};
+        String hs = new String(hex, UTF_8);
+        int b = Integer.parseInt(hs, 16);
+        t.append(new byte[] {(byte) b}, 0, 1);
       } else {
         t.append(new byte[] {sb[i]}, 0, 1);
       }

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/ColumnQualifierFilter.java
@@ -89,8 +89,7 @@ public class ColumnQualifierFilter extends ServerFilter {
 
     if (sawNonNullQual) {
       return new ColumnQualifierFilter(source, cols);
-    } else {
-      return source;
     }
+    return source;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/LocalityGroupIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/LocalityGroupIterator.java
@@ -166,13 +166,10 @@ public class LocalityGroupIterator extends HeapIterator implements Interruptible
     Set<ByteSequence> cfSet;
     if (columnFamilies.isEmpty()) {
       cfSet = Collections.emptySet();
+    } else if (columnFamilies instanceof Set<?>) {
+      cfSet = (Set<ByteSequence>) columnFamilies;
     } else {
-      if (columnFamilies instanceof Set<?>) {
-        cfSet = (Set<ByteSequence>) columnFamilies;
-      } else {
-        cfSet = new HashSet<>();
-        cfSet.addAll(columnFamilies);
-      }
+      cfSet = new HashSet<>(columnFamilies);
     }
 
     // determine the set of groups to use

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SourceSwitchingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/SourceSwitchingIterator.java
@@ -128,10 +128,8 @@ public class SourceSwitchingIterator implements InterruptibleIterator {
     this.yield = Optional.of(yield);
 
     // if we require row isolation, then we cannot support yielding in the middle.
-    if (!onlySwitchAfterRow) {
-      if (iter != null) {
-        iter.enableYielding(yield);
-      }
+    if (!onlySwitchAfterRow && (iter != null)) {
+      iter.enableYielding(yield);
     }
   }
 
@@ -239,11 +237,9 @@ public class SourceSwitchingIterator implements InterruptibleIterator {
     if (onlySwitchAfterRow)
       throw new IllegalStateException("Can only switch on row boundries");
 
-    if (switchSource()) {
-      if (key != null) {
-        iter.seek(new Range(key, true, range.getEndKey(), range.isEndKeyInclusive()),
-            columnFamilies, inclusive);
-      }
+    if (switchSource() && (key != null)) {
+      iter.seek(new Range(key, true, range.getEndKey(), range.isEndKeyInclusive()), columnFamilies,
+          inclusive);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/VisibilityFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/VisibilityFilter.java
@@ -70,7 +70,7 @@ public class VisibilityFilter extends SynchronizedServerFilter {
 
     if (testVis.length() == 0 && defaultVisibility.length() == 0)
       return true;
-    else if (testVis.length() == 0)
+    if (testVis.length() == 0)
       testVis = defaultVisibility;
 
     Boolean b = cache.get(testVis);
@@ -111,8 +111,7 @@ public class VisibilityFilter extends SynchronizedServerFilter {
       Authorizations authorizations, byte[] defaultVisibility) {
     if (authorizations.isEmpty() && defaultVisibility.length == 0) {
       return new EmptyAuthsVisibilityFilter(source);
-    } else {
-      return new VisibilityFilter(source, authorizations, defaultVisibility);
     }
+    return new VisibilityFilter(source, authorizations, defaultVisibility);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/manager/balancer/TabletServerIdImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/manager/balancer/TabletServerIdImpl.java
@@ -90,10 +90,9 @@ public class TabletServerIdImpl implements TabletServerId {
   public static TServerInstance toThrift(TabletServerId tabletServerId) {
     if (tabletServerId instanceof TabletServerIdImpl) {
       return ((TabletServerIdImpl) tabletServerId).toThrift();
-    } else {
-      return new TServerInstance(
-          HostAndPort.fromParts(tabletServerId.getHost(), tabletServerId.getPort()),
-          tabletServerId.getSession());
     }
+    return new TServerInstance(
+        HostAndPort.fromParts(tabletServerId.getHost(), tabletServerId.getPort()),
+        tabletServerId.getSession());
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
@@ -82,9 +82,8 @@ public class CompactableFileImpl implements CompactableFile {
   public static StoredTabletFile toStoredTabletFile(CompactableFile cf) {
     if (cf instanceof CompactableFileImpl) {
       return ((CompactableFileImpl) cf).storedTabletFile;
-    } else {
-      throw new IllegalArgumentException("Can not convert " + cf.getClass());
     }
+    throw new IllegalArgumentException("Can not convert " + cf.getClass());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataServicer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataServicer.java
@@ -44,7 +44,7 @@ public abstract class MetadataServicer {
     checkArgument(tableId != null, "tableId is null");
     if (RootTable.ID.equals(tableId))
       return new ServicerForRootTable(context);
-    else if (MetadataTable.ID.equals(tableId))
+    if (MetadataTable.ID.equals(tableId))
       return new ServicerForMetadataTable(context);
     else
       return new ServicerForUserTables(context, tableId);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -132,9 +132,8 @@ public class TabletFile implements Comparable<TabletFile> {
   public int compareTo(TabletFile o) {
     if (equals(o)) {
       return 0;
-    } else {
-      return normalizedPath.compareTo(o.normalizedPath);
     }
+    return normalizedPath.compareTo(o.normalizedPath);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
@@ -115,7 +115,7 @@ public class TabletLocationState {
     if (hasFuture())
       return liveServers.contains(future) ? TabletState.ASSIGNED
           : TabletState.ASSIGNED_TO_DEAD_SERVER;
-    else if (hasCurrent())
+    if (hasCurrent())
       return liveServers.contains(current) ? TabletState.HOSTED
           : TabletState.ASSIGNED_TO_DEAD_SERVER;
     else if (hasSuspend())

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -75,7 +75,7 @@ public interface Ample {
     private final String table;
     private final TableId id;
 
-    private DataLevel(String table, TableId id) {
+    DataLevel(String table, TableId id) {
       this.table = table;
       this.id = id;
     }
@@ -101,7 +101,8 @@ public interface Ample {
     public static DataLevel of(TableId tableId) {
       if (tableId.equals(RootTable.ID)) {
         return DataLevel.ROOT;
-      } else if (tableId.equals(MetadataTable.ID)) {
+      }
+      if (tableId.equals(MetadataTable.ID)) {
         return DataLevel.METADATA;
       } else {
         return DataLevel.USER;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -97,20 +97,19 @@ public class MetadataSchema {
         throw new IllegalArgumentException("Metadata row does not contain ; or <  " + metadataRow);
       }
 
-      if (semiPos < 0) {
-        // default tablet ending in '<'
-        if (ltPos != metadataRow.getLength() - 1) {
-          throw new IllegalArgumentException("< must come at end of Metadata row  " + metadataRow);
-        }
-        TableId tableId = TableId.of(new String(metadataRow.getBytes(), 0, ltPos, UTF_8));
-        return new Pair<>(tableId, null);
-      } else {
+      if (semiPos >= 0) {
         // other tablets containing ';'
         TableId tableId = TableId.of(new String(metadataRow.getBytes(), 0, semiPos, UTF_8));
         Text endRow = new Text();
         endRow.set(metadataRow.getBytes(), semiPos + 1, metadataRow.getLength() - (semiPos + 1));
         return new Pair<>(tableId, endRow);
       }
+      // default tablet ending in '<'
+      if (ltPos != metadataRow.getLength() - 1) {
+        throw new IllegalArgumentException("< must come at end of Metadata row  " + metadataRow);
+      }
+      TableId tableId = TableId.of(new String(metadataRow.getBytes(), 0, ltPos, UTF_8));
+      return new Pair<>(tableId, null);
     }
 
     /**
@@ -278,11 +277,10 @@ public class MetadataSchema {
       public static long getBulkLoadTid(String vs) {
         if (FateTxId.isFormatedTid(vs)) {
           return FateTxId.fromString(vs);
-        } else {
-          // a new serialization format was introduce in 2.0. This code support deserializing the
-          // old format.
-          return Long.parseLong(vs);
         }
+        // a new serialization format was introduce in 2.0. This code support deserializing the
+        // old format.
+        return Long.parseLong(vs);
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -46,8 +46,8 @@ public final class MetadataTime implements Comparable<MetadataTime> {
 
     if (timestr != null && timestr.length() > 1) {
       return new MetadataTime(Long.parseLong(timestr.substring(1)), getType(timestr.charAt(0)));
-    } else
-      throw new IllegalArgumentException("Unknown metadata time value " + timestr);
+    }
+    throw new IllegalArgumentException("Unknown metadata time value " + timestr);
   }
 
   /**
@@ -116,9 +116,8 @@ public final class MetadataTime implements Comparable<MetadataTime> {
   public int compareTo(MetadataTime mtime) {
     if (this.type.equals(mtime.getType()))
       return Long.compare(this.time, mtime.getTime());
-    else
-      throw new IllegalArgumentException(
-          "Cannot compare different time types: " + this + " and " + mtime);
+    throw new IllegalArgumentException(
+        "Cannot compare different time types: " + this + " and " + mtime);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -298,14 +298,12 @@ public class TabletMetadata {
     Objects.requireNonNull(rowIter);
 
     TabletMetadata te = new TabletMetadata();
-    ImmutableSortedMap.Builder<Key,Value> kvBuilder = null;
-    if (buildKeyValueMap) {
-      kvBuilder = ImmutableSortedMap.naturalOrder();
-    }
+    final ImmutableSortedMap.Builder<Key,Value> kvBuilder =
+        buildKeyValueMap ? ImmutableSortedMap.naturalOrder() : null;
 
-    var filesBuilder = ImmutableMap.<StoredTabletFile,DataFileValue>builder();
-    var scansBuilder = ImmutableList.<StoredTabletFile>builder();
-    var logsBuilder = ImmutableList.<LogEntry>builder();
+    final var filesBuilder = ImmutableMap.<StoredTabletFile,DataFileValue>builder();
+    final var scansBuilder = ImmutableList.<StoredTabletFile>builder();
+    final var logsBuilder = ImmutableList.<LogEntry>builder();
     final var loadedFilesBuilder = ImmutableMap.<TabletFile,Long>builder();
     ByteSequence row = null;
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -429,9 +429,8 @@ public class TabletMetadata {
 
     if (checkConsistency) {
       return () -> new LinkingIterator(iterFactory, range);
-    } else {
-      return () -> iterFactory.apply(range);
     }
+    return () -> iterFactory.apply(range);
   }
 
   @VisibleForTesting

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -98,9 +98,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
       if (level == DataLevel.ROOT) {
         ClientContext ctx = ((ClientContext) _client);
         return new TabletsMetadata(getRootMetadata(ctx, readConsistency));
-      } else {
-        return buildNonRoot(_client);
       }
+      return buildNonRoot(_client);
     }
 
     private TabletsMetadata buildNonRoot(AccumuloClient client) {
@@ -135,9 +134,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
           // create an iterable that will stop at the tablet which contains the endRow
           return new TabletsMetadata(scanner,
               () -> new TabletMetadataIterator(tmi.iterator(), endRow));
-        } else {
-          return new TabletsMetadata(scanner, tmi);
         }
+        return new TabletsMetadata(scanner, tmi);
       } catch (TableNotFoundException e) {
         throw new RuntimeException(e);
       }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SaslClientDigestCallbackHandler.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SaslClientDigestCallbackHandler.java
@@ -67,7 +67,8 @@ public class SaslClientDigestCallbackHandler extends SaslDigestCallbackHandler {
     for (Callback callback : callbacks) {
       if (callback instanceof RealmChoiceCallback) {
         continue;
-      } else if (callback instanceof NameCallback) {
+      }
+      if (callback instanceof NameCallback) {
         nc = (NameCallback) callback;
       } else if (callback instanceof PasswordCallback) {
         pc = (PasswordCallback) callback;

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -56,7 +57,7 @@ public class SaslConnectionParams {
 
     private final String quality;
 
-    private QualityOfProtection(String quality) {
+    QualityOfProtection(String quality) {
       this.quality = quality;
     }
 
@@ -67,7 +68,8 @@ public class SaslConnectionParams {
     public static QualityOfProtection get(String name) {
       if (AUTH.quality.equals(name)) {
         return AUTH;
-      } else if (AUTH_INT.quality.equals(name)) {
+      }
+      if (AUTH_INT.quality.equals(name)) {
         return AUTH_INT;
       } else if (AUTH_CONF.quality.equals(name)) {
         return AUTH_CONF;
@@ -91,7 +93,7 @@ public class SaslConnectionParams {
 
     private final String mechanismName;
 
-    private SaslMechanism(String mechanismName) {
+    SaslMechanism(String mechanismName) {
       this.mechanismName = mechanismName;
     }
 
@@ -102,7 +104,8 @@ public class SaslConnectionParams {
     public static SaslMechanism get(String mechanismName) {
       if (GSSAPI.mechanismName.equals(mechanismName)) {
         return GSSAPI;
-      } else if (DIGEST_MD5.mechanismName.equals(mechanismName)) {
+      }
+      if (DIGEST_MD5.mechanismName.equals(mechanismName)) {
         return DIGEST_MD5;
       }
 
@@ -260,11 +263,7 @@ public class SaslConnectionParams {
       if (!mechanism.equals(other.mechanism)) {
         return false;
       }
-      if (callbackHandler == null) {
-        if (other.callbackHandler != null) {
-          return false;
-        }
-      } else if (!callbackHandler.equals(other.callbackHandler)) {
+      if (!Objects.equals(callbackHandler, other.callbackHandler)) {
         return false;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
@@ -97,11 +97,9 @@ public class SslConnectionParams {
     String keystorePassword = conf.get(passwordOverrideProperty);
     if (keystorePassword.isEmpty()) {
       keystorePassword = defaultPassword;
-    } else {
-      if (log.isTraceEnabled())
-        log.trace("Using explicit SSL private key password from {}",
-            passwordOverrideProperty.getKey());
-    }
+    } else if (log.isTraceEnabled())
+      log.trace("Using explicit SSL private key password from {}",
+          passwordOverrideProperty.getKey());
     return keystorePassword;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -164,11 +164,9 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
         }
         checkAuths();
       }
-    } else {
-      // it's the old format
-      if (authorizations.length > 0)
-        setAuthorizations(authsString.split(","));
-    }
+    } else // it's the old format
+    if (authorizations.length > 0)
+      setAuthorizations(authsString.split(","));
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
@@ -91,7 +91,7 @@ public class ColumnVisibility {
   /**
    * The node types in a parse tree for a visibility expression.
    */
-  public static enum NodeType {
+  public enum NodeType {
     EMPTY, TERM, OR, AND,
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/NamespacePermission.java
@@ -45,7 +45,7 @@ public enum NamespacePermission {
       mapping[perm.permID] = perm;
   }
 
-  private NamespacePermission(byte id) {
+  NamespacePermission(byte id) {
     this.permID = id;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/SystemPermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/SystemPermission.java
@@ -52,7 +52,7 @@ public enum SystemPermission {
       mapping.put(perm.permID, perm);
   }
 
-  private SystemPermission(byte id) {
+  SystemPermission(byte id) {
     this.permID = id;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/TablePermission.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/TablePermission.java
@@ -47,7 +47,7 @@ public enum TablePermission {
       mapping[perm.permID] = perm;
   }
 
-  private TablePermission(byte id) {
+  TablePermission(byte id) {
     this.permID = id;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/security/VisibilityEvaluator.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/VisibilityEvaluator.java
@@ -58,33 +58,33 @@ public class VisibilityEvaluator {
       }
     }
 
-    if (escapeCharCount > 0) {
-      if (escapeCharCount % 2 == 1) {
+    if (escapeCharCount <= 0) {
+      return auth;
+    }
+
+    if (escapeCharCount % 2 != 0) {
+      throw new IllegalArgumentException("Illegal escape sequence in auth : " + auth);
+    }
+
+    byte[] unescapedCopy = new byte[auth.length() - escapeCharCount / 2];
+    int pos = 0;
+    for (int i = 0; i < auth.length(); i++) {
+      byte b = auth.byteAt(i);
+      if (b == '\\') {
+        i++;
+        b = auth.byteAt(i);
+        if (b != '"' && b != '\\') {
+          throw new IllegalArgumentException("Illegal escape sequence in auth : " + auth);
+        }
+      } else if (b == '"') {
+        // should only see quote after a slash
         throw new IllegalArgumentException("Illegal escape sequence in auth : " + auth);
       }
 
-      byte[] unescapedCopy = new byte[auth.length() - escapeCharCount / 2];
-      int pos = 0;
-      for (int i = 0; i < auth.length(); i++) {
-        byte b = auth.byteAt(i);
-        if (b == '\\') {
-          i++;
-          b = auth.byteAt(i);
-          if (b != '"' && b != '\\') {
-            throw new IllegalArgumentException("Illegal escape sequence in auth : " + auth);
-          }
-        } else if (b == '"') {
-          // should only see quote after a slash
-          throw new IllegalArgumentException("Illegal escape sequence in auth : " + auth);
-        }
-
-        unescapedCopy[pos++] = b;
-      }
-
-      return new ArrayByteSequence(unescapedCopy);
-    } else {
-      return auth;
+      unescapedCopy[pos++] = b;
     }
+
+    return new ArrayByteSequence(unescapedCopy);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/singletons/SingletonManager.java
+++ b/core/src/main/java/org/apache/accumulo/core/singletons/SingletonManager.java
@@ -194,15 +194,13 @@ public class SingletonManager {
         services.forEach(SingletonManager::disable);
         enabled = false;
       }
-    } else {
-      // if we're in a disabled state AND
-      // the mode is CONNECTOR or SERVER or if there are active clients,
-      // then enable everything
-      if (mode == Mode.CONNECTOR || mode == Mode.SERVER
-          || (mode == Mode.CLIENT && reservations > 0)) {
-        services.forEach(SingletonManager::enable);
-        enabled = true;
-      }
+    } else // if we're in a disabled state AND
+    // the mode is CONNECTOR or SERVER or if there are active clients,
+    // then enable everything
+    if (mode == Mode.CONNECTOR || mode == Mode.SERVER
+        || (mode == Mode.CLIENT && reservations > 0)) {
+      services.forEach(SingletonManager::enable);
+      enabled = true;
     }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/singletons/SingletonReservation.java
+++ b/core/src/main/java/org/apache/accumulo/core/singletons/SingletonReservation.java
@@ -53,7 +53,6 @@ public class SingletonReservation implements AutoCloseable {
 
   private static class NoopSingletonReservation extends SingletonReservation {
     NoopSingletonReservation() {
-      super();
       super.closed.set(true);
       // deregister the cleaner
       super.cleanable.clean();

--- a/core/src/main/java/org/apache/accumulo/core/singletons/SingletonService.java
+++ b/core/src/main/java/org/apache/accumulo/core/singletons/SingletonService.java
@@ -25,9 +25,9 @@ package org.apache.accumulo.core.singletons;
  */
 public interface SingletonService {
 
-  public boolean isEnabled();
+  boolean isEnabled();
 
-  public void enable();
+  void enable();
 
-  public void disable();
+  void disable();
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/GroupBalancer.java
@@ -549,9 +549,8 @@ public abstract class GroupBalancer implements TabletBalancer {
       // smooth things out
       balanceExtraMultiple(tservers, maxExtraGroups, moves, extraMultiple, true);
       return false;
-    } else {
-      return true;
     }
+    return true;
   }
 
   private void balanceExtraMultiple(Map<TabletServerId,TserverGroupInfo> tservers,
@@ -626,11 +625,10 @@ public abstract class GroupBalancer implements TabletBalancer {
             TserverGroupInfo srcTgi = iter.next();
 
             while (srcTgi.getExtras().size() <= expectedExtra) {
-              if (iter.hasNext()) {
-                srcTgi = iter.next();
-              } else {
+              if (!iter.hasNext()) {
                 continue nextGroup;
               }
+              srcTgi = iter.next();
             }
 
             moves.move(group, 1, srcTgi, destTgi);

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/SimpleLoadBalancer.java
@@ -369,16 +369,14 @@ public class SimpleLoadBalancer implements TabletBalancer {
     // do we have any servers?
     if (params.currentStatus().isEmpty()) {
       problemReporter.reportProblem(noTserversProblem);
+    } else // Don't migrate if we have migrations in progress
+    if (params.currentMigrations().isEmpty()) {
+      problemReporter.clearProblemReportTimes();
+      if (getMigrations(params.currentStatus(), params.migrationsOut()))
+        return TimeUnit.SECONDS.toMillis(1);
     } else {
-      // Don't migrate if we have migrations in progress
-      if (params.currentMigrations().isEmpty()) {
-        problemReporter.clearProblemReportTimes();
-        if (getMigrations(params.currentStatus(), params.migrationsOut()))
-          return TimeUnit.SECONDS.toMillis(1);
-      } else {
-        outstandingMigrationsProblem.setMigrations(params.currentMigrations());
-        problemReporter.reportProblem(outstandingMigrationsProblem);
-      }
+      outstandingMigrationsProblem.setMigrations(params.currentMigrations());
+      problemReporter.reportProblem(outstandingMigrationsProblem);
     }
     return 5 * 1000;
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancer.java
@@ -72,18 +72,16 @@ public class TableLoadBalancer implements TabletBalancer {
 
     if (clazzName == null)
       clazzName = SimpleLoadBalancer.class.getName();
-    if (balancer != null) {
-      if (!clazzName.equals(balancer.getClass().getName())) {
-        // the balancer class for this table does not match the class specified in the configuration
-        try {
-          balancer = constructNewBalancerForTable(clazzName, tableId);
-          perTableBalancers.put(tableId, balancer);
-          balancer.init(environment);
+    if ((balancer != null) && !clazzName.equals(balancer.getClass().getName())) {
+      // the balancer class for this table does not match the class specified in the configuration
+      try {
+        balancer = constructNewBalancerForTable(clazzName, tableId);
+        perTableBalancers.put(tableId, balancer);
+        balancer.init(environment);
 
-          log.info("Loaded new class {} for table {}", clazzName, tableId);
-        } catch (Exception e) {
-          log.warn("Failed to load table balancer class {} for table {}", clazzName, tableId, e);
-        }
+        log.info("Loaded new class {} for table {}", clazzName, tableId);
+      } catch (Exception e) {
+        log.warn("Failed to load table balancer class {} for table {}", clazzName, tableId, e);
       }
     }
     if (balancer == null) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -69,7 +69,7 @@ public interface CompactionPlanner {
     ExecutorManager getExecutorManager();
   }
 
-  public void init(InitParameters params);
+  void init(InitParameters params);
 
   /**
    * This interface exists so the API can evolve and additional parameters can be passed to the

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -221,12 +221,11 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
       if (group.isEmpty()) {
         return params.createPlanBuilder().build();
-      } else {
-        // determine which executor to use based on the size of the files
-        var ceid = getExecutor(group);
-
-        return params.createPlanBuilder().addJob(createPriority(params), ceid, group).build();
       }
+      // determine which executor to use based on the size of the files
+      var ceid = getExecutor(group);
+
+      return params.createPlanBuilder().addJob(createPriority(params), ceid, group).build();
     } catch (RuntimeException e) {
       throw e;
     }
@@ -381,12 +380,11 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
         // previous files are candidates. However we must ensure that any candidate set produces a
         // file smaller than the next largest file in the next candidate set to ensure future
         // compactions are not prevented.
-        if (larsmaIndex == -1 || larsmaSum > sortedFiles.get(goodIndex).getEstimatedSize()) {
-          larsmaIndex = goodIndex;
-          larsmaSum = sum - currSize;
-        } else {
+        if ((larsmaIndex != -1) && (larsmaSum <= sortedFiles.get(goodIndex).getEstimatedSize())) {
           break;
         }
+        larsmaIndex = goodIndex;
+        larsmaSum = sum - currSize;
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/ExecutorManager.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/ExecutorManager.java
@@ -30,5 +30,5 @@ public interface ExecutorManager {
   /**
    * Create a thread pool executor within a compaction service.
    */
-  public CompactionExecutorId createExecutor(String name, int threads);
+  CompactionExecutorId createExecutor(String name, int threads);
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -359,9 +359,7 @@ public class AESCryptoService implements CryptoService {
         if (iv[i] == 0) {
           if (i == 0)
             return;
-          else {
-            incrementIV(iv, i - 1);
-          }
+          incrementIV(iv, i - 1);
         }
 
       }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/CryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/CryptoService.java
@@ -50,13 +50,11 @@ public interface CryptoService {
   /**
    * Runtime Crypto exception
    */
-  class CryptoException extends RuntimeException {
+  static class CryptoException extends RuntimeException {
 
     private static final long serialVersionUID = -7588781060677839664L;
 
-    public CryptoException() {
-      super();
-    }
+    public CryptoException() {}
 
     public CryptoException(String message) {
       super(message);

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/PerTableVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/PerTableVolumeChooser.java
@@ -145,7 +145,8 @@ public class PerTableVolumeChooser implements VolumeChooser {
       if (previousChooser != null && previousChooser.getClass().getName().equals(className)) {
         // no change; return the old one
         return previousChooser;
-      } else if (previousChooser == null) {
+      }
+      if (previousChooser == null) {
         // TODO stricter definition of when the updated property is used, ref ACCUMULO-3412
         // don't log change if this is the first use
         log.trace("Change detected for {} for {}", property, key);
@@ -154,9 +155,8 @@ public class PerTableVolumeChooser implements VolumeChooser {
         if (key instanceof TableId) {
           TableId tableId = (TableId) key;
           return env.getServiceEnv().instantiate(tableId, className, VolumeChooser.class);
-        } else {
-          return env.getServiceEnv().instantiate(className, VolumeChooser.class);
         }
+        return env.getServiceEnv().instantiate(className, VolumeChooser.class);
       } catch (Exception e) {
         String msg = "Failed to create instance for " + key + " configured to use " + className
             + " via " + property;

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/VolumeChooserEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/VolumeChooserEnvironment.java
@@ -33,15 +33,15 @@ public interface VolumeChooserEnvironment {
    *
    * @since 2.1.0
    */
-  public static enum Scope {
+  public enum Scope {
     DEFAULT, TABLE, INIT, LOGGER
   }
 
-  public Text getEndRow();
+  Text getEndRow();
 
-  public Optional<TableId> getTable();
+  Optional<TableId> getTable();
 
-  public Scope getChooserScope();
+  Scope getChooserScope();
 
-  public ServiceEnvironment getServiceEnv();
+  ServiceEnvironment getServiceEnv();
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizer.java
@@ -18,14 +18,14 @@
  */
 package org.apache.accumulo.core.spi.scan;
 
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
 import java.util.Comparator;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.ScannerBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * When configured for a scan executor, this prioritizer allows scanners to set priorities as
@@ -115,16 +115,10 @@ public class HintScanPrioritizer implements ScanPrioritizer {
     int defaultPriority = Integer
         .parseInt(params.getOptions().getOrDefault("default_priority", Integer.MAX_VALUE + ""));
 
-    var tpb = ImmutableMap.<String,Integer>builder();
-
-    params.getOptions().forEach((k, v) -> {
-      if (k.startsWith(PRIO_PREFIX)) {
-        String type = k.substring(PRIO_PREFIX.length());
-        tpb.put(type, Integer.parseInt(v));
-      }
-    });
-
-    Map<String,Integer> typePriorities = tpb.build();
+    Map<String,Integer> typePriorities =
+        params.getOptions().entrySet().stream().filter(e -> e.getKey().startsWith(PRIO_PREFIX))
+            .collect(toUnmodifiableMap(e -> e.getKey().substring(PRIO_PREFIX.length()),
+                e -> Integer.parseInt(e.getValue())));
 
     HintProblemAction hpa = HintProblemAction.valueOf(params.getOptions()
         .getOrDefault("bad_hint_action", HintProblemAction.LOG.name()).toUpperCase());

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatch.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanDispatch.java
@@ -53,16 +53,16 @@ public interface ScanDispatch {
     TABLE
   }
 
-  public String getExecutorName();
+  String getExecutorName();
 
-  public CacheUsage getDataCacheUsage();
+  CacheUsage getDataCacheUsage();
 
-  public CacheUsage getIndexCacheUsage();
+  CacheUsage getIndexCacheUsage();
 
   /**
    * @since 2.1.0
    */
-  public static interface Builder {
+  public interface Builder {
 
     /**
      * If this is not called, then {@value SimpleScanDispatcher#DEFAULT_SCAN_EXECUTOR_NAME} should
@@ -73,7 +73,7 @@ public interface ScanDispatch {
      *          of {@link ScanDispatcher.DispatchParameters#getScanExecutors()}
      * @return may return self or a new object
      */
-    public Builder setExecutorName(String name);
+    Builder setExecutorName(String name);
 
     /**
      * If this is not called, then {@link CacheUsage#TABLE} should be used.
@@ -83,7 +83,7 @@ public interface ScanDispatch {
      *          the index tree within a file)
      * @return may return self or a new object
      */
-    public Builder setIndexCacheUsage(CacheUsage usage);
+    Builder setIndexCacheUsage(CacheUsage usage);
 
     /**
      * If this is not called, then {@link CacheUsage#TABLE} should be used.
@@ -92,18 +92,18 @@ public interface ScanDispatch {
      *          a non null usage indicating how the scan should use cache for file data
      * @return may return self or a new object
      */
-    public Builder setDataCacheUsage(CacheUsage usage);
+    Builder setDataCacheUsage(CacheUsage usage);
 
     /**
      * @return an immutable {@link ScanDispatch} object.
      */
-    public ScanDispatch build();
+    ScanDispatch build();
   }
 
   /**
    * @return a {@link ScanDispatch} builder
    */
-  public static Builder builder() {
+  static Builder builder() {
     return DefaultScanDispatch.DEFAULT_SCAN_DISPATCH;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanPrioritizer.java
@@ -39,7 +39,7 @@ public interface ScanPrioritizer {
    *
    * @since 2.0.0
    */
-  public static interface CreateParameters {
+  public interface CreateParameters {
     /**
      * @return The options configured for the scan prioritizer with properties of the form
      *         {@code tserver.scan.executors.<name>.prioritizer.opts.<key>=<value>}. Only the

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -415,12 +415,10 @@ public class Gatherer {
     }
 
     private synchronized CompletableFuture<ProcessedFiles> updateFuture() {
-      if (future.isDone()) {
-        if (!future.isCancelled() && !future.isCompletedExceptionally()) {
-          ProcessedFiles pf = _get();
-          if (!pf.failedFiles.isEmpty()) {
-            initiateProcessing(pf);
-          }
+      if (future.isDone() && (!future.isCancelled() && !future.isCompletedExceptionally())) {
+        ProcessedFiles pf = _get();
+        if (!pf.failedFiles.isEmpty()) {
+          initiateProcessing(pf);
         }
       }
 
@@ -457,9 +455,8 @@ public class Gatherer {
         ProcessedFiles pf = _get();
         if (pf.failedFiles.isEmpty()) {
           return true;
-        } else {
-          updateFuture();
         }
+        updateFuture();
       }
 
       return false;
@@ -612,9 +609,8 @@ public class Gatherer {
       Preconditions.checkArgument(row.length() >= 1 && row.byteAt(row.length() - 1) == 0);
       t.set(row.getBackingArray(), row.offset(), row.length() - 1);
       return t;
-    } else {
-      return null;
     }
+    return null;
   }
 
   private RowRange toClippedExtent(Range r) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
@@ -46,10 +46,9 @@ public class SummarizerFactory {
     if (classloader != null) {
       return classloader.loadClass(classname).asSubclass(Summarizer.class).getDeclaredConstructor()
           .newInstance();
-    } else {
-      return ClassLoaderUtil.loadClass(context, classname, Summarizer.class)
-          .getDeclaredConstructor().newInstance();
     }
+    return ClassLoaderUtil.loadClass(context, classname, Summarizer.class).getDeclaredConstructor()
+        .newInstance();
   }
 
   public Summarizer getSummarizer(SummarizerConfiguration conf) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
@@ -90,18 +90,16 @@ public class SummaryReader {
           idxCacheEntry = indexCache.getBlock(blockName);
           if (idxCacheEntry == null) {
             return loader.getDependencies();
-          } else {
-            return Collections.emptyMap();
           }
+          return Collections.emptyMap();
         }
 
         @Override
         public byte[] load(int maxSize, Map<String,byte[]> dependencies) {
           if (idxCacheEntry == null) {
             return loader.load(maxSize, dependencies);
-          } else {
-            return idxCacheEntry.getBuffer();
           }
+          return idxCacheEntry.getBuffer();
         }
       };
       return summaryCache.getBlock(blockName, idxLoader);

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -537,7 +537,7 @@ class SummarySerializer {
 
   private static Map<String,Long> readSummary(DataInputStream in, String[] symbols)
       throws IOException {
-    var imb = ImmutableMap.<String,Long>builder();
+    final var imb = ImmutableMap.<String,Long>builder();
     int numEntries = WritableUtils.readVInt(in);
 
     for (int i = 0; i < numEntries; i++) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -309,11 +309,10 @@ class SummarySerializer {
           collapsedSome |= lgBuilder.collapse();
         }
 
-        if (collapsedSome) {
-          data = _save();
-        } else {
+        if (!collapsedSome) {
           break;
         }
+        data = _save();
       }
 
       if (data.length > maxSize) {
@@ -400,23 +399,22 @@ class SummarySerializer {
     boolean exceededMaxSize = in.readBoolean();
     if (exceededMaxSize) {
       return new SummarySerializer(sconf);
-    } else {
-      WritableUtils.readVInt(in);
-      // load symbol table
-      int numSymbols = WritableUtils.readVInt(in);
-      String[] symbols = new String[numSymbols];
-      for (int i = 0; i < numSymbols; i++) {
-        symbols[i] = in.readUTF();
-      }
-
-      int numLGroups = WritableUtils.readVInt(in);
-      LgSummaries[] allSummaries = new LgSummaries[numLGroups];
-      for (int i = 0; i < numLGroups; i++) {
-        allSummaries[i] = readLGroup(in, symbols);
-      }
-
-      return new SummarySerializer(sconf, allSummaries);
     }
+    WritableUtils.readVInt(in);
+    // load symbol table
+    int numSymbols = WritableUtils.readVInt(in);
+    String[] symbols = new String[numSymbols];
+    for (int i = 0; i < numSymbols; i++) {
+      symbols[i] = in.readUTF();
+    }
+
+    int numLGroups = WritableUtils.readVInt(in);
+    LgSummaries[] allSummaries = new LgSummaries[numLGroups];
+    for (int i = 0; i < numLGroups; i++) {
+      allSummaries[i] = readLGroup(in, symbols);
+    }
+
+    return new SummarySerializer(sconf, allSummaries);
   }
 
   private static class LgSummaries {

--- a/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/AddressUtil.java
@@ -75,7 +75,8 @@ public class AddressUtil {
               + "'networkaddress.cache.negative.ttl', see java.net.InetAddress.",
           originalException);
       throw new IllegalArgumentException(originalException);
-    } else if (negativeTtl < 0) {
+    }
+    if (negativeTtl < 0) {
       log.warn("JVM specified negative DNS response cache TTL was negative (and not 'forever'). "
           + "Falling back to default based on Oracle JVM 1.4+ (10s)");
       negativeTtl = 10;

--- a/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ByteBufferUtil.java
@@ -43,12 +43,11 @@ public class ByteBufferUtil {
       // did not use buffer.get() because it changes the position
       return Arrays.copyOfRange(buffer.array(), buffer.position() + buffer.arrayOffset(),
           buffer.limit() + buffer.arrayOffset());
-    } else {
-      byte[] data = new byte[buffer.remaining()];
-      // duplicate inorder to avoid changing position
-      buffer.duplicate().get(data);
-      return data;
     }
+    byte[] data = new byte[buffer.remaining()];
+    // duplicate inorder to avoid changing position
+    buffer.duplicate().get(data);
+    return data;
   }
 
   public static List<ByteBuffer> toByteBuffers(Collection<byte[]> bytesList) {
@@ -90,18 +89,16 @@ public class ByteBufferUtil {
       result.set(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(),
           byteBuffer.remaining());
       return result;
-    } else {
-      return new Text(toBytes(byteBuffer));
     }
+    return new Text(toBytes(byteBuffer));
   }
 
   public static String toString(ByteBuffer bytes) {
     if (bytes.hasArray()) {
       return new String(bytes.array(), bytes.arrayOffset() + bytes.position(), bytes.remaining(),
           UTF_8);
-    } else {
-      return new String(toBytes(bytes), UTF_8);
     }
+    return new String(toBytes(bytes), UTF_8);
   }
 
   public static TableId toTableId(ByteBuffer bytes) {
@@ -114,9 +111,8 @@ public class ByteBufferUtil {
 
     if (bs.isBackedByArray()) {
       return ByteBuffer.wrap(bs.getBackingArray(), bs.offset(), bs.length());
-    } else {
-      return ByteBuffer.wrap(bs.toArray());
     }
+    return ByteBuffer.wrap(bs.toArray());
   }
 
   public static void write(DataOutput out, ByteBuffer buffer) throws IOException {
@@ -131,8 +127,7 @@ public class ByteBufferUtil {
     if (buffer.hasArray()) {
       return new ByteArrayInputStream(buffer.array(), buffer.arrayOffset() + buffer.position(),
           buffer.remaining());
-    } else {
-      return new ByteArrayInputStream(toBytes(buffer));
     }
+    return new ByteArrayInputStream(toBytes(buffer));
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/ConfigurationImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ConfigurationImpl.java
@@ -32,8 +32,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.PropertyType;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
 
-import com.google.common.collect.ImmutableMap;
-
 public class ConfigurationImpl implements Configuration {
 
   private final AccumuloConfiguration acfg;
@@ -110,13 +108,9 @@ public class ConfigurationImpl implements Configuration {
 
   private Map<String,String> buildCustom(Property customPrefix) {
     // This could be optimized as described in #947
-    Map<String,String> props = acfg.getAllPropertiesWithPrefix(customPrefix);
-    var builder = ImmutableMap.<String,String>builder();
-    props.forEach((k, v) -> {
-      builder.put(k.substring(customPrefix.getKey().length()), v);
-    });
-
-    return builder.build();
+    return acfg.getAllPropertiesWithPrefix(customPrefix).entrySet().stream().collect(
+        Collectors.toUnmodifiableMap(e -> e.getKey().substring(customPrefix.getKey().length()),
+            Entry::getValue));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/ConfigurationImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ConfigurationImpl.java
@@ -47,23 +47,21 @@ public class ConfigurationImpl implements Configuration {
     Property prop = Property.getPropertyByKey(key);
     if (prop != null) {
       return acfg.isPropertySet(prop, false);
-    } else {
-      return acfg.get(key) != null;
     }
+    return acfg.get(key) != null;
   }
 
   @Override
   public String get(String key) {
     // Get prop to check if sensitive, also looking up by prop may be more efficient.
     Property prop = Property.getPropertyByKey(key);
-    if (prop != null) {
-      if (prop.isSensitive()) {
-        return null;
-      }
-      return acfg.get(prop);
-    } else {
+    if (prop == null) {
       return acfg.get(key);
     }
+    if (prop.isSensitive()) {
+      return null;
+    }
+    return acfg.get(prop);
   }
 
   @Override
@@ -71,11 +69,10 @@ public class ConfigurationImpl implements Configuration {
     Property propertyPrefix = Property.getPropertyByKey(prefix);
     if (propertyPrefix != null && propertyPrefix.getType() == PropertyType.PREFIX) {
       return acfg.getAllPropertiesWithPrefix(propertyPrefix);
-    } else {
-      return StreamSupport.stream(acfg.spliterator(), false)
-          .filter(prop -> prop.getKey().startsWith(prefix))
-          .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
+    return StreamSupport.stream(acfg.spliterator(), false)
+        .filter(prop -> prop.getKey().startsWith(prefix))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
@@ -100,12 +100,10 @@ public class CreateToken implements KeywordExecutable {
         String input;
         if (pass != null && tp.getKey().equals("password")) {
           input = pass;
+        } else if (tp.getMask()) {
+          input = getConsoleReader().readLine(tp.getDescription() + ": ", '*');
         } else {
-          if (tp.getMask()) {
-            input = getConsoleReader().readLine(tp.getDescription() + ": ", '*');
-          } else {
-            input = getConsoleReader().readLine(tp.getDescription() + ": ");
-          }
+          input = getConsoleReader().readLine(tp.getDescription() + ": ");
         }
         props.put(tp.getKey(), input);
         token.init(props);

--- a/core/src/main/java/org/apache/accumulo/core/util/Halt.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Halt.java
@@ -31,21 +31,11 @@ public class Halt {
 
   public static void halt(final String msg) {
     // ACCUMULO-3651 Changed level to error and added FATAL to message for slf4j compatibility
-    halt(0, new Runnable() {
-      @Override
-      public void run() {
-        log.error("FATAL {}", msg);
-      }
-    });
+    halt(0, () -> log.error("FATAL {}", msg));
   }
 
   public static void halt(final String msg, int status) {
-    halt(status, new Runnable() {
-      @Override
-      public void run() {
-        log.error("FATAL {}", msg);
-      }
-    });
+    halt(status, () -> log.error("FATAL {}", msg));
   }
 
   public static void halt(final int status, Runnable runnable) {

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -191,8 +191,8 @@ public final class HostAndPort implements Serializable {
    *           if parsing the bracketed host-port string fails.
    */
   private static String[] getHostAndPortFromBracketedHost(String hostPortString) {
-    int colonIndex = 0;
-    int closeBracketIndex = 0;
+    int colonIndex;
+    int closeBracketIndex;
     checkArgument(hostPortString.charAt(0) == '[',
         "Bracketed host-port string must start with a bracket: %s", hostPortString);
     colonIndex = hostPortString.indexOf(':');
@@ -203,15 +203,14 @@ public final class HostAndPort implements Serializable {
     String host = hostPortString.substring(1, closeBracketIndex);
     if (closeBracketIndex + 1 == hostPortString.length()) {
       return new String[] {host, ""};
-    } else {
-      checkArgument(hostPortString.charAt(closeBracketIndex + 1) == ':',
-          "Only a colon may follow a close bracket: %s", hostPortString);
-      for (int i = closeBracketIndex + 2; i < hostPortString.length(); ++i) {
-        checkArgument(Character.isDigit(hostPortString.charAt(i)), "Port must be numeric: %s",
-            hostPortString);
-      }
-      return new String[] {host, hostPortString.substring(closeBracketIndex + 2)};
     }
+    checkArgument(hostPortString.charAt(closeBracketIndex + 1) == ':',
+        "Only a colon may follow a close bracket: %s", hostPortString);
+    for (int i = closeBracketIndex + 2; i < hostPortString.length(); ++i) {
+      checkArgument(Character.isDigit(hostPortString.charAt(i)), "Port must be numeric: %s",
+          hostPortString);
+    }
+    return new String[] {host, hostPortString.substring(closeBracketIndex + 2)};
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.util;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,18 +53,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 
 public class LocalityGroupUtil {
 
   private static final Logger log = LoggerFactory.getLogger(LocalityGroupUtil.class);
 
-  // using an ImmutableSet here for more efficient comparisons in LocalityGroupIterator
-  public static final Set<ByteSequence> EMPTY_CF_SET = Set.of();
-
   /**
    * Create a set of families to be passed into the SortedKeyValueIterator seek call from a supplied
-   * set of columns. We are using the ImmutableSet to enable faster comparisons down in the
+   * set of columns. We are using the immutable set to enable faster comparisons down in the
    * LocalityGroupIterator.
    *
    * @param columns
@@ -71,11 +69,10 @@ public class LocalityGroupUtil {
    */
   public static Set<ByteSequence> families(Collection<Column> columns) {
     if (columns.isEmpty()) {
-      return EMPTY_CF_SET;
+      return Set.of();
     }
-    var builder = ImmutableSet.<ByteSequence>builder();
-    columns.forEach(c -> builder.add(new ArrayByteSequence(c.getColumnFamily())));
-    return builder.build();
+    return columns.stream().map(c -> new ArrayByteSequence(c.getColumnFamily()))
+        .collect(toUnmodifiableSet());
   }
 
   @SuppressWarnings("serial")
@@ -129,18 +126,16 @@ public class LocalityGroupUtil {
         String group = property.substring(prefix.length());
         String[] parts = group.split("\\.");
         group = parts[0];
-        if (result.containsKey(group)) {
-          if (parts.length == 1) {
-            Set<ByteSequence> colFamsSet = decodeColumnFamilies(value);
-            if (!Collections.disjoint(all, colFamsSet)) {
-              colFamsSet.retainAll(all);
-              throw new LocalityGroupConfigurationError("Column families " + colFamsSet
-                  + " in group " + group + " is already used by another locality group");
-            }
-
-            all.addAll(colFamsSet);
-            result.put(group, colFamsSet);
+        if (result.containsKey(group) && (parts.length == 1)) {
+          Set<ByteSequence> colFamsSet = decodeColumnFamilies(value);
+          if (!Collections.disjoint(all, colFamsSet)) {
+            colFamsSet.retainAll(all);
+            throw new LocalityGroupConfigurationError("Column families " + colFamsSet + " in group "
+                + group + " is already used by another locality group");
           }
+
+          all.addAll(colFamsSet);
+          result.put(group, colFamsSet);
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -183,15 +183,13 @@ public class Merge {
 
     if (numToMerge > 1) {
       mergeSome(client, table, sizes, numToMerge);
-    } else {
-      if (numToMerge == 1 && sizes.size() > 1) {
-        // here we have the case of a merge candidate that is surrounded by candidates that would
-        // split
-        if (force) {
-          mergeSome(client, table, sizes, 2);
-        } else {
-          sizes.remove(0);
-        }
+    } else if (numToMerge == 1 && sizes.size() > 1) {
+      // here we have the case of a merge candidate that is surrounded by candidates that would
+      // split
+      if (force) {
+        mergeSome(client, table, sizes, 2);
+      } else {
+        sizes.remove(0);
       }
     }
     if (numToMerge == 0 && sizes.size() > 1 && last) {

--- a/core/src/main/java/org/apache/accumulo/core/util/ServerServices.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ServerServices.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.core.util;
 import java.util.EnumMap;
 
 public class ServerServices implements Comparable<ServerServices> {
-  public static enum Service {
+  public enum Service {
     TSERV_CLIENT, GC_CLIENT
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/format/HexFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/HexFormatter.java
@@ -49,7 +49,8 @@ public class HexFormatter implements Formatter, ScanInterpreter {
   private int fromChar(char b) {
     if (b >= '0' && b <= '9') {
       return (b - '0');
-    } else if (b >= 'a' && b <= 'f') {
+    }
+    if (b >= 'a' && b <= 'f') {
       return (b - 'a' + 10);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/NamedRunnable.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/NamedRunnable.java
@@ -48,6 +48,7 @@ class NamedRunnable implements Runnable {
     return priority;
   }
 
+  @Override
   public void run() {
     r.run();
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -154,9 +154,8 @@ public class ThreadPools {
     if (enableTracing) {
       return new TracingScheduledThreadPoolExecutor(numThreads,
           new NamedThreadFactory(name, priority));
-    } else {
-      return new ScheduledThreadPoolExecutor(numThreads, new NamedThreadFactory(name, priority));
     }
+    return new ScheduledThreadPoolExecutor(numThreads, new NamedThreadFactory(name, priority));
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/TracingScheduledThreadPoolExecutor.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/TracingScheduledThreadPoolExecutor.java
@@ -48,7 +48,7 @@ class TracingScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return super.submit(new TraceCallable<T>(task));
+    return super.submit(new TraceCallable<>(task));
   }
 
   @Override
@@ -63,8 +63,8 @@ class TracingScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 
   private <T> Collection<? extends Callable<T>>
       wrapCollection(Collection<? extends Callable<T>> tasks) {
-    List<Callable<T>> result = new ArrayList<Callable<T>>(tasks.size());
-    tasks.forEach(t -> result.add(new TraceCallable<T>(t)));
+    List<Callable<T>> result = new ArrayList<>(tasks.size());
+    tasks.forEach(t -> result.add(new TraceCallable<>(t)));
     return result;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/TracingThreadPoolExecutor.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/TracingThreadPoolExecutor.java
@@ -50,7 +50,7 @@ class TracingThreadPoolExecutor extends ThreadPoolExecutor {
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return super.submit(new TraceCallable<T>(task));
+    return super.submit(new TraceCallable<>(task));
   }
 
   @Override
@@ -65,8 +65,8 @@ class TracingThreadPoolExecutor extends ThreadPoolExecutor {
 
   private <T> Collection<? extends Callable<T>>
       wrapCollection(Collection<? extends Callable<T>> tasks) {
-    List<Callable<T>> result = new ArrayList<Callable<T>>(tasks.size());
-    tasks.forEach(t -> result.add(new TraceCallable<T>(t)));
+    List<Callable<T>> result = new ArrayList<>(tasks.size());
+    tasks.forEach(t -> result.add(new TraceCallable<>(t)));
     return result;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/volume/VolumeImpl.java
@@ -133,7 +133,8 @@ public class VolumeImpl implements Volume {
 
     if (p.isBlank()) {
       return fs.makeQualified(new Path(basePath));
-    } else if (p.startsWith("/")) {
+    }
+    if (p.startsWith("/")) {
       // check for starting with '//'
       reason = "absolute path";
     } else if (pathString.contains(":")) {

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -540,23 +540,20 @@ public class AdminUtil<T> {
     try {
       if (ServiceLock.getLockData(zk.getZooKeeper(), path) != null) {
         System.err.println("ERROR: Manager lock is held, not running");
-        if (this.exitOnError)
-          System.exit(1);
-        else
+        if (!this.exitOnError)
           return false;
+        System.exit(1);
       }
     } catch (KeeperException e) {
       System.err.println("ERROR: Could not read manager lock, not running " + e.getMessage());
-      if (this.exitOnError)
-        System.exit(1);
-      else
+      if (!this.exitOnError)
         return false;
+      System.exit(1);
     } catch (InterruptedException e) {
       System.err.println("ERROR: Could not read manager lock, not running" + e.getMessage());
-      if (this.exitOnError)
-        System.exit(1);
-      else
+      if (!this.exitOnError)
         return false;
+      System.exit(1);
     }
     return true;
   }

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -75,11 +75,10 @@ public class Fate<T> {
             try {
               deferTime = op.isReady(tid, environment);
 
-              if (deferTime == 0) {
-                prevOp = op;
-                op = op.call(tid, environment);
-              } else
+              if (deferTime != 0)
                 continue;
+              prevOp = op;
+              op = op.call(tid, environment);
 
             } catch (Exception e) {
               blockIfHadoopShutdown(tid, e);

--- a/core/src/main/java/org/apache/accumulo/fate/util/Retry.java
+++ b/core/src/main/java/org/apache/accumulo/fate/util/Retry.java
@@ -211,10 +211,8 @@ public class Retry {
     } else if ((now - lastRetryLog) > logIntervalNanoSec) {
       log.warn(getMessage(message), t);
       lastRetryLog = now;
-    } else {
-      if (log.isTraceEnabled()) {
-        log.trace(getMessage(message, t));
-      }
+    } else if (log.isTraceEnabled()) {
+      log.trace(getMessage(message, t));
     }
   }
 
@@ -230,10 +228,8 @@ public class Retry {
     } else if ((now - lastRetryLog) > logIntervalNanoSec) {
       log.warn(getMessage(message));
       lastRetryLog = now;
-    } else {
-      if (log.isTraceEnabled()) {
-        log.trace(getMessage(message));
-      }
+    } else if (log.isTraceEnabled()) {
+      log.trace(getMessage(message));
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/DistributedReadWriteLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/DistributedReadWriteLock.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DistributedReadWriteLock implements java.util.concurrent.locks.ReadWriteLock {
 
-  static enum LockType {
+  enum LockType {
     READ, WRITE,
   }
 

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ServiceLock.java
@@ -259,11 +259,10 @@ public class ServiceLock implements Watcher {
     while ((idx - i) >= 0) {
       prev = children.get(idx - i);
       i++;
-      if (prev.startsWith(prevPrefix)) {
-        lowestPrevNode = prev;
-      } else {
+      if (!prev.startsWith(prevPrefix)) {
         break;
       }
+      lowestPrevNode = prev;
     }
     return lowestPrevNode;
   }
@@ -702,9 +701,8 @@ public class ServiceLock implements Watcher {
     Stat stat = zooKeeper.exists(path + "/" + lockNode, null);
     if (null != stat) {
       return stat.getEphemeralOwner();
-    } else {
-      return 0;
     }
+    return 0;
   }
 
   public static void deleteLock(ZooReaderWriter zk, ServiceLockPath path)

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/BulkSerializeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/BulkSerializeTest.java
@@ -103,7 +103,8 @@ public class BulkSerializeTest {
     Input input = p -> {
       if (p.getName().equals(Constants.BULK_LOAD_MAPPING)) {
         return new ByteArrayInputStream(mappingBaos.toByteArray());
-      } else if (p.getName().equals(Constants.BULK_RENAME_FILE)) {
+      }
+      if (p.getName().equals(Constants.BULK_RENAME_FILE)) {
         return new ByteArrayInputStream(nameBaos.toByteArray());
       } else {
         throw new IllegalArgumentException("bad path " + p);

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -163,7 +163,7 @@ public class AccumuloConfigurationTest {
     @Override
     public String get(Property property) {
       String v = props.get(property.getKey());
-      if (v == null & parent != null) {
+      if (v == null && parent != null) {
         v = parent.get(property);
       }
       return v;

--- a/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
@@ -62,20 +62,20 @@ public class ClientPropertyTest {
   public void testTypes() {
     Properties props = new Properties();
     props.setProperty(ClientProperty.BATCH_WRITER_LATENCY_MAX.getKey(), "10s");
-    Long value = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
-    assertEquals(10000L, value.longValue());
+    long value = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
+    assertEquals(10000L, value);
 
     props.setProperty(ClientProperty.BATCH_WRITER_MEMORY_MAX.getKey(), "555M");
     value = ClientProperty.BATCH_WRITER_MEMORY_MAX.getBytes(props);
-    assertEquals(581959680L, value.longValue());
+    assertEquals(581959680L, value);
 
     ClientProperty.BATCH_WRITER_MEMORY_MAX.setBytes(props, 5819L);
     value = ClientProperty.BATCH_WRITER_MEMORY_MAX.getBytes(props);
-    assertEquals(5819L, value.longValue());
+    assertEquals(5819L, value);
 
     ClientProperty.BATCH_WRITER_LATENCY_MAX.setTimeInMillis(props, 1234L);
     value = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
-    assertEquals(1234L, value.longValue());
+    assertEquals(1234L, value);
 
     assertThrows(IllegalStateException.class,
         () -> ClientProperty.BATCH_WRITER_LATENCY_MAX.getBytes(props));

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigurationTypeHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigurationTypeHelperTest.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.core.conf;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
-import java.util.function.Function;
+import java.util.function.ToLongFunction;
 
 import org.junit.Test;
 
@@ -29,17 +29,17 @@ public class ConfigurationTypeHelperTest {
 
   @Test
   public void testGetMemoryInBytes() {
-    Arrays.<Function<String,Long>>asList(ConfigurationTypeHelper::getFixedMemoryAsBytes,
+    Arrays.<ToLongFunction<String>>asList(ConfigurationTypeHelper::getFixedMemoryAsBytes,
         ConfigurationTypeHelper::getMemoryAsBytes).stream().forEach(memFunc -> {
-          assertEquals(42L, memFunc.apply("42").longValue());
-          assertEquals(42L, memFunc.apply("42b").longValue());
-          assertEquals(42L, memFunc.apply("42B").longValue());
-          assertEquals(42L * 1024L, memFunc.apply("42K").longValue());
-          assertEquals(42L * 1024L, memFunc.apply("42k").longValue());
-          assertEquals(42L * 1024L * 1024L, memFunc.apply("42M").longValue());
-          assertEquals(42L * 1024L * 1024L, memFunc.apply("42m").longValue());
-          assertEquals(42L * 1024L * 1024L * 1024L, memFunc.apply("42G").longValue());
-          assertEquals(42L * 1024L * 1024L * 1024L, memFunc.apply("42g").longValue());
+          assertEquals(42L, memFunc.applyAsLong("42"));
+          assertEquals(42L, memFunc.applyAsLong("42b"));
+          assertEquals(42L, memFunc.applyAsLong("42B"));
+          assertEquals(42L * 1024L, memFunc.applyAsLong("42K"));
+          assertEquals(42L * 1024L, memFunc.applyAsLong("42k"));
+          assertEquals(42L * 1024L * 1024L, memFunc.applyAsLong("42M"));
+          assertEquals(42L * 1024L * 1024L, memFunc.applyAsLong("42m"));
+          assertEquals(42L * 1024L * 1024L * 1024L, memFunc.applyAsLong("42G"));
+          assertEquals(42L * 1024L * 1024L * 1024L, memFunc.applyAsLong("42g"));
         });
     assertEquals(Runtime.getRuntime().maxMemory() / 10,
         ConfigurationTypeHelper.getMemoryAsBytes("10%"));

--- a/core/src/test/java/org/apache/accumulo/core/conf/HadoopCredentialProviderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/HadoopCredentialProviderTest.java
@@ -149,10 +149,8 @@ public class HadoopCredentialProviderTest {
   public void createKeystoreProvider() throws Exception {
     File targetDir = new File(System.getProperty("user.dir") + "/target");
     File keystoreFile = new File(targetDir, "create.jks");
-    if (keystoreFile.exists()) {
-      if (!keystoreFile.delete()) {
-        log.error("Unable to delete {}", keystoreFile);
-      }
+    if (keystoreFile.exists() && !keystoreFile.delete()) {
+      log.error("Unable to delete {}", keystoreFile);
     }
 
     String providerUrl = "jceks://file" + keystoreFile.getAbsolutePath();

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/KeyShortenerTest.java
@@ -59,7 +59,8 @@ public class KeyShortenerTest {
   private byte[] toBytes(Object o) {
     if (o instanceof String) {
       return ((String) o).getBytes();
-    } else if (o instanceof byte[]) {
+    }
+    if (o instanceof byte[]) {
       return (byte[]) o;
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
@@ -139,7 +139,7 @@ public class RFileMetricsTest {
 
     assertEquals(1, blocks.get("L1"));
 
-    assertEquals(1, vmg.numEntries.get(vmg.localityGroups.indexOf(null)).longValue());
+    assertEquals(Long.valueOf(1), vmg.numEntries.get(vmg.localityGroups.indexOf(null)));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf(null)).longValue());
 
     trf.closeReader();
@@ -166,7 +166,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(2, vmg.numEntries.get(vmg.localityGroups.indexOf(null)).longValue());
+    assertEquals(Long.valueOf(2), vmg.numEntries.get(vmg.localityGroups.indexOf(null)));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf(null)).longValue());
 
     trf.closeReader();
@@ -195,7 +195,7 @@ public class RFileMetricsTest {
 
     assertEquals(1, blocks.get("L1"));
 
-    assertEquals(1, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(1), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     trf.closeReader();
@@ -227,7 +227,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(2, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(2), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     trf.closeReader();
@@ -267,7 +267,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(2, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(2), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     metrics = vmg.metric.get("lg2");
@@ -278,7 +278,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(2, vmg.numEntries.get(vmg.localityGroups.indexOf("lg2")).longValue());
+    assertEquals(Long.valueOf(2), vmg.numEntries.get(vmg.localityGroups.indexOf("lg2")));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg2")).longValue());
 
     trf.closeReader();
@@ -316,7 +316,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(3, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(3), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     metrics = vmg.metric.get(null);
@@ -327,7 +327,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("A"));
     assertEquals(1, blocks.get("B"));
 
-    assertEquals(2, vmg.numEntries.get(vmg.localityGroups.indexOf(null)).longValue());
+    assertEquals(Long.valueOf(2), vmg.numEntries.get(vmg.localityGroups.indexOf(null)));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf(null)).longValue());
 
     trf.closeReader();
@@ -370,7 +370,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(4, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(4), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     metrics = vmg.metric.get(null);
@@ -381,7 +381,7 @@ public class RFileMetricsTest {
     assertEquals(1, blocks.get("A"));
     assertEquals(1, blocks.get("B"));
 
-    assertEquals(4, vmg.numEntries.get(vmg.localityGroups.indexOf(null)).longValue());
+    assertEquals(Long.valueOf(4), vmg.numEntries.get(vmg.localityGroups.indexOf(null)));
     assertEquals(1, vmg.numBlocks.get(vmg.localityGroups.indexOf(null)).longValue());
 
     trf.closeReader();
@@ -411,7 +411,7 @@ public class RFileMetricsTest {
     assertEquals(3, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(4, vmg.numEntries.get(vmg.localityGroups.indexOf(null)).longValue());
+    assertEquals(Long.valueOf(4), vmg.numEntries.get(vmg.localityGroups.indexOf(null)));
     assertEquals(4, vmg.numBlocks.get(vmg.localityGroups.indexOf(null)).longValue());
 
     trf.closeReader();
@@ -446,7 +446,7 @@ public class RFileMetricsTest {
     assertEquals(3, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(4, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(4), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(4, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     trf.closeReader();
@@ -489,7 +489,7 @@ public class RFileMetricsTest {
     assertEquals(3, blocks.get("L1"));
     assertEquals(1, blocks.get("L2"));
 
-    assertEquals(4, vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")).longValue());
+    assertEquals(Long.valueOf(4), vmg.numEntries.get(vmg.localityGroups.indexOf("lg1")));
     assertEquals(4, vmg.numBlocks.get(vmg.localityGroups.indexOf("lg1")).longValue());
 
     metrics = vmg.metric.get(null);
@@ -500,7 +500,7 @@ public class RFileMetricsTest {
     assertEquals(2, blocks.get("A"));
     assertEquals(2, blocks.get("B"));
 
-    assertEquals(4, vmg.numEntries.get(vmg.localityGroups.indexOf(null)).longValue());
+    assertEquals(Long.valueOf(4), vmg.numEntries.get(vmg.localityGroups.indexOf(null)));
     assertEquals(4, vmg.numBlocks.get(vmg.localityGroups.indexOf(null)).longValue());
 
     trf.closeReader();
@@ -562,7 +562,7 @@ public class RFileMetricsTest {
     assertEquals(expected, vmg.metric.get("lg1").asMap());
     assertEquals(expectedBlocks, vmg.blocks.get("lg1").asMap());
 
-    assertEquals(2, vmg.metric.keySet().size());
-    assertEquals(2, vmg.blocks.keySet().size());
+    assertEquals(2, vmg.metric.size());
+    assertEquals(2, vmg.blocks.size());
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -286,8 +286,8 @@ public class RFileTest {
     }
 
     public void openReader(boolean cfsi) throws IOException {
-      int fileLength = 0;
-      byte[] data = null;
+      int fileLength;
+      byte[] data;
       data = baos.toByteArray();
 
       bais = new SeekableByteArrayInputStream(data);
@@ -2219,8 +2219,7 @@ public class RFileTest {
         checkSample(sample, sampleDataLG2, newColFamByteSequence("metaA", "metaB"), false);
         checkSample(sample, sampleDataLG2, newColFamByteSequence("dataA"), true);
 
-        ArrayList<Entry<Key,Value>> allSampleData = new ArrayList<>();
-        allSampleData.addAll(sampleDataLG1);
+        ArrayList<Entry<Key,Value>> allSampleData = new ArrayList<>(sampleDataLG1);
         allSampleData.addAll(sampleDataLG2);
 
         allSampleData.sort(Comparator.comparing(Entry::getKey));

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RelativeKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RelativeKeyTest.java
@@ -50,8 +50,7 @@ public class RelativeKeyTest {
     assertEquals(-1, commonPrefixHelper("aa", "aa"));
     assertEquals(-1, commonPrefixHelper("aaa", "aaa"));
     assertEquals(-1, commonPrefixHelper("abab", "abab"));
-    assertEquals(-1,
-        commonPrefixHelper(new String("aaa"), new ArrayByteSequence("aaa").toString()));
+    assertEquals(-1, commonPrefixHelper("aaa", new ArrayByteSequence("aaa").toString()));
     assertEquals(-1,
         commonPrefixHelper("abababababab".substring(3, 6), "ccababababcc".substring(3, 6)));
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/FirstEntryInRowIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/FirstEntryInRowIteratorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -30,7 +31,6 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iteratorsImpl.system.CountingIterator;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.junit.Test;
 
 public class FirstEntryInRowIteratorTest {
@@ -44,7 +44,7 @@ public class FirstEntryInRowIteratorTest {
 
     feiri.init(counter, iteratorSetting.getOptions(), env);
 
-    feiri.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
+    feiri.seek(range, Set.of(), false);
     while (feiri.hasTop()) {
       resultMap.put(feiri.getTopKey(), feiri.getTopValue());
       feiri.next();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.ByteSequence;
@@ -37,7 +38,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
@@ -79,11 +79,11 @@ public class MultiIteratorTest {
       Range range = new Range(prevEndRow, false, endRow, true);
       if (init)
         for (SortedKeyValueIterator<Key,Value> iter : iters)
-          iter.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
+          iter.seek(range, Set.of(), false);
       mi = new MultiIterator(iters, range);
 
       if (init)
-        mi.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
+        mi.seek(range, Set.of(), false);
     }
 
     if (seekKey != null)

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
@@ -356,7 +356,7 @@ public class SourceSwitchingIteratorTest {
 
     @Override
     public boolean hasTop() {
-      return (!(yield.isPresent() && yield.get().hasYielded()) && super.hasTop());
+      return ((!yield.isPresent() || !yield.get().hasYielded()) && super.hasTop());
     }
 
     @Override

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -107,10 +107,8 @@ public class IndexedDocIteratorTest {
             if (negateMask[j]) {
               docHits = false;
             }
-          } else {
-            if (!negateMask[j]) {
-              docHits = false;
-            }
+          } else if (!negateMask[j]) {
+            docHits = false;
           }
         }
         if (docHits) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
@@ -83,10 +83,8 @@ public class IntersectingIteratorTest {
             map.put(k, v);
             if (negateMask[j])
               docHits = false;
-          } else {
-            if (!negateMask[j])
-              docHits = false;
-          }
+          } else if (!negateMask[j])
+            docHits = false;
         }
         if (docHits) {
           docs.add(doc);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/LargeRowFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/LargeRowFilterTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -35,7 +36,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.junit.Test;
 
 public class LargeRowFilterTest {
@@ -82,7 +82,7 @@ public class LargeRowFilterTest {
       genTestData(expectedData, i);
 
       LargeRowFilter lrfi = setupIterator(testData, i, IteratorScope.scan);
-      lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+      lrfi.seek(new Range(), Set.of(), false);
 
       TreeMap<Key,Value> filteredData = new TreeMap<>();
 
@@ -111,7 +111,7 @@ public class LargeRowFilterTest {
 
       // seek to each row... rows that exceed max columns should be filtered
       for (int j = 1; j <= i; j++) {
-        lrfi.seek(new Range(genRow(j), genRow(j)), LocalityGroupUtil.EMPTY_CF_SET, false);
+        lrfi.seek(new Range(genRow(j), genRow(j)), Set.of(), false);
 
         while (lrfi.hasTop()) {
           assertEquals(genRow(j), lrfi.getTopKey().getRow().toString());
@@ -133,16 +133,12 @@ public class LargeRowFilterTest {
     LargeRowFilter lrfi = setupIterator(testData, 13, IteratorScope.scan);
 
     // test seeking to the middle of a row
-    lrfi.seek(
-        new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
-            new Key(genRow(15)).followingKey(PartialKey.ROW), false),
-        LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
+        new Key(genRow(15)).followingKey(PartialKey.ROW), false), Set.of(), false);
     assertFalse(lrfi.hasTop());
 
-    lrfi.seek(
-        new Range(new Key(genRow(10), "cf001", genCQ(4), 5), true,
-            new Key(genRow(10)).followingKey(PartialKey.ROW), false),
-        LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(new Key(genRow(10), "cf001", genCQ(4), 5), true,
+        new Key(genRow(10)).followingKey(PartialKey.ROW), false), Set.of(), false);
     TreeMap<Key,Value> expectedData = new TreeMap<>();
     genRow(expectedData, 10, 4, 10);
 
@@ -162,7 +158,7 @@ public class LargeRowFilterTest {
     genTestData(testData, 20);
 
     LargeRowFilter lrfi = setupIterator(testData, 13, IteratorScope.majc);
-    lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(), Set.of(), false);
 
     TreeMap<Key,Value> compactedData = new TreeMap<>();
     while (lrfi.hasTop()) {
@@ -178,7 +174,7 @@ public class LargeRowFilterTest {
     // because there are suppression markers.. if there was a bug and data
     // was not suppressed, increasing the threshold would expose the bug
     lrfi = setupIterator(compactedData, 20, IteratorScope.scan);
-    lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(), Set.of(), false);
 
     // only expect to see 13 rows
     TreeMap<Key,Value> expectedData = new TreeMap<>();
@@ -195,10 +191,8 @@ public class LargeRowFilterTest {
 
     // try seeking to the middle of row 15... row has data and suppression marker... this seeks past
     // the marker but before the column
-    lrfi.seek(
-        new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
-            new Key(genRow(15)).followingKey(PartialKey.ROW), false),
-        LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
+        new Key(genRow(15)).followingKey(PartialKey.ROW), false), Set.of(), false);
     assertFalse(lrfi.hasTop());
 
     // test seeking w/ column families
@@ -224,7 +218,7 @@ public class LargeRowFilterTest {
     genRow(expectedData, 4, 0, 5);
 
     LargeRowFilter lrfi = setupIterator(testData, 13, IteratorScope.scan);
-    lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(), Set.of(), false);
 
     TreeMap<Key,Value> filteredData = new TreeMap<>();
     while (lrfi.hasTop()) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RegExFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RegExFilterTest.java
@@ -223,8 +223,8 @@ public class RegExFilterTest {
     rei.deepCopy(new DefaultIteratorEnvironment());
 
     // -----------------------------------------------------
-    String multiByteText = new String("\u6d67" + "\u6F68" + "\u7067");
-    String multiByteRegex = new String(".*" + "\u6F68" + ".*");
+    String multiByteText = ("\u6d67" + "\u6F68" + "\u7067");
+    String multiByteRegex = (".*" + "\u6F68" + ".*");
 
     Key k4 = new Key("boo4".getBytes(), "hoo".getBytes(), "20080203".getBytes(), "".getBytes(), 1L);
     Value inVal = new Value(multiByteText);

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RowEncodingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RowEncodingIteratorTest.java
@@ -129,8 +129,7 @@ public class RowEncodingIteratorTest {
     pkv(map3, "row3", "cf1", "cq1", "cv1", 5, kbVal);
     pkv(map3, "row3", "cf1", "cq2", "cv1", 6, kbVal);
 
-    SortedMap<Key,Value> map = new TreeMap<>();
-    map.putAll(map1);
+    SortedMap<Key,Value> map = new TreeMap<>(map1);
     map.putAll(map2);
     map.putAll(map3);
     SortedMapIterator src = new SortedMapIterator(map);
@@ -165,8 +164,7 @@ public class RowEncodingIteratorTest {
     pkv(map1, "row1", "cf1", "cq1", "cv1", 5, kbVal);
     pkv(map1, "row1", "cf1", "cq2", "cv1", 6, kbVal);
 
-    SortedMap<Key,Value> map = new TreeMap<>();
-    map.putAll(map1);
+    SortedMap<Key,Value> map = new TreeMap<>(map1);
     SortedMapIterator src = new SortedMapIterator(map);
     Range range = new Range(new Text("row1"), true, new Text("row2"), true);
     RowEncodingIteratorImpl iter = new RowEncodingIteratorImpl();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeColumnFamilyIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeColumnFamilyIteratorTest.java
@@ -157,8 +157,7 @@ public class WholeColumnFamilyIteratorTest {
     pkv(map3, "row3", "cf1", "cq1", "cv1", 5, "foo");
     pkv(map3, "row3", "cf1", "cq2", "cv1", 6, "bar");
 
-    SortedMap<Key,Value> map = new TreeMap<>();
-    map.putAll(map1);
+    SortedMap<Key,Value> map = new TreeMap<>(map1);
     map.putAll(map2);
     map.putAll(map3);
 
@@ -196,8 +195,7 @@ public class WholeColumnFamilyIteratorTest {
     SortedMap<Key,Value> map2 = new TreeMap<>();
     pkv(map2, "row2", "cf1", "cq1", "cv1", 5, "foo");
 
-    SortedMap<Key,Value> map = new TreeMap<>();
-    map.putAll(map1);
+    SortedMap<Key,Value> map = new TreeMap<>(map1);
     map.putAll(map2);
 
     MultiIterator source = new MultiIterator(Collections.singletonList(new SortedMapIterator(map)),

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeRowIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeRowIteratorTest.java
@@ -148,8 +148,7 @@ public class WholeRowIteratorTest {
     pkv(map3, "row3", "cf1", "cq1", "cv1", 5, "foo");
     pkv(map3, "row3", "cf1", "cq2", "cv1", 6, "bar");
 
-    SortedMap<Key,Value> map = new TreeMap<>();
-    map.putAll(map1);
+    SortedMap<Key,Value> map = new TreeMap<>(map1);
     map.putAll(map2);
     map.putAll(map3);
 
@@ -185,8 +184,7 @@ public class WholeRowIteratorTest {
     SortedMap<Key,Value> map2 = new TreeMap<>();
     pkv(map2, "row2", "cf1", "cq1", "cv1", 5, "foo");
 
-    SortedMap<Key,Value> map = new TreeMap<>();
-    map.putAll(map1);
+    SortedMap<Key,Value> map = new TreeMap<>(map1);
     map.putAll(map2);
 
     MultiIterator source = new MultiIterator(Collections.singletonList(new SortedMapIterator(map)),

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/SortSkewTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/SortSkewTest.java
@@ -27,7 +27,7 @@ public class SortSkewTest {
   private static final String shortpath = "1";
   private static final String longpath =
       "/verylongpath/12345679xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii/zzzzzzzzzzzzzzzzzzzzz"
-          + "aaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbccccccccccccccccccccccccccxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzz";;
+          + "aaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbccccccccccccccccccccccccccxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzz";
   // these are values previously generated from SortSkew.getCode() for the above
   private static final String shortcode = "9416ac93";
   private static final String longcode = "b9ddf266";

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import static java.util.stream.Collectors.toSet;
-import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.COMPACT_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN;
 import static org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily.FLUSH_COLUMN;
@@ -55,6 +54,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Da
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.FutureLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LastLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ScanFileColumnFamily;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -206,7 +206,8 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
         && (host.equals("192.168.0.1") || host.equals("192.168.0.2") || host.equals("192.168.0.3")
             || host.equals("192.168.0.4") || host.equals("192.168.0.5"))) {
       return true;
-    } else if (tid.equals("2")
+    }
+    if (tid.equals("2")
         && (host.equals("192.168.0.6") || host.equals("192.168.0.7") || host.equals("192.168.0.8")
             || host.equals("192.168.0.9") || host.equals("192.168.0.10"))) {
       return true;
@@ -220,7 +221,8 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
   protected String idToTableName(TableId id) {
     if (id.equals(FOO.getId())) {
       return FOO.getTableName();
-    } else if (id.equals(BAR.getId())) {
+    }
+    if (id.equals(BAR.getId())) {
       return BAR.getTableName();
     } else if (id.equals(BAZ.getId())) {
       return BAZ.getTableName();
@@ -238,9 +240,8 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
   protected String getNameFromIp(String hostIp) throws UnknownHostException {
     if (servers.containsKey(hostIp)) {
       return servers.get(hostIp);
-    } else {
-      throw new UnknownHostException();
     }
+    throw new UnknownHostException();
   }
 
   protected SortedMap<TabletServerId,TServerStatus> createCurrent(int numTservers) {

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -143,8 +143,7 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     init(DEFAULT_TABLE_PROPERTIES);
     // lets say we already have migrations ongoing for the FOO and BAR table extends (should be 5 of
     // each of them) for a total of 10
-    Set<TabletId> migrations = new HashSet<>();
-    migrations.addAll(tableTablets.get(FOO.getTableName()));
+    Set<TabletId> migrations = new HashSet<>(tableTablets.get(FOO.getTableName()));
     migrations.addAll(tableTablets.get(BAR.getTableName()));
     long wait =
         this.balance(new BalanceParamsImpl(Collections.unmodifiableSortedMap(createCurrent(15)),

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -353,7 +353,7 @@ public class DefaultCompactionPlannerTest {
       execBldr.append("]");
     }
 
-    String executors = execBldr.toString().replaceAll("'", "\"");
+    String executors = execBldr.toString().replace("'", "\"");
 
     planner.init(new CompactionPlanner.InitParameters() {
 
@@ -375,28 +375,25 @@ public class DefaultCompactionPlannerTest {
 
       @Override
       public ExecutorManager getExecutorManager() {
-        return new ExecutorManager() {
-          @Override
-          public CompactionExecutorId createExecutor(String name, int threads) {
-            switch (name) {
-              case "small":
-                assertEquals(1, threads);
-                break;
-              case "medium":
-                assertEquals(2, threads);
-                break;
-              case "large":
-                assertEquals(3, threads);
-                break;
-              case "huge":
-                assertEquals(4, threads);
-                break;
-              default:
-                fail("Unexpected name " + name);
-                break;
-            }
-            return CompactionExecutorId.of(name);
+        return (name, threads) -> {
+          switch (name) {
+            case "small":
+              assertEquals(1, threads);
+              break;
+            case "medium":
+              assertEquals(2, threads);
+              break;
+            case "large":
+              assertEquals(3, threads);
+              break;
+            case "huge":
+              assertEquals(4, threads);
+              break;
+            default:
+              fail("Unexpected name " + name);
+              break;
           }
+          return CompactionExecutorId.of(name);
         };
       }
     });

--- a/core/src/test/java/org/apache/accumulo/core/util/InternerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/InternerTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 public class InternerTest {
 
-  private class TestObj {
+  private static class TestObj {
     private final int id;
 
     TestObj(int id) {

--- a/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/MergeTest.java
@@ -70,16 +70,12 @@ public class MergeTest {
         private Size skip() {
           while (impl.hasNext()) {
             Size candidate = impl.next();
-            if (start != null) {
-              if (candidate.extent.endRow() != null
-                  && candidate.extent.endRow().compareTo(start) < 0)
-                continue;
-            }
-            if (end != null) {
-              if (candidate.extent.prevEndRow() != null
-                  && candidate.extent.prevEndRow().compareTo(end) >= 0)
-                continue;
-            }
+            if ((start != null) && (candidate.extent.endRow() != null
+                && candidate.extent.endRow().compareTo(start) < 0))
+              continue;
+            if ((end != null) && (candidate.extent.prevEndRow() != null
+                && candidate.extent.prevEndRow().compareTo(end) >= 0))
+              continue;
             return candidate;
           }
           return null;

--- a/core/src/test/java/org/apache/accumulo/fate/zookeeper/DistributedReadWriteLockTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/zookeeper/DistributedReadWriteLockTest.java
@@ -40,8 +40,7 @@ public class DistributedReadWriteLockTest {
 
     @Override
     public synchronized SortedMap<Long,byte[]> getEarlierEntries(long entry) {
-      SortedMap<Long,byte[]> result = new TreeMap<>();
-      result.putAll(locks.headMap(entry + 1));
+      SortedMap<Long,byte[]> result = new TreeMap<>(locks.headMap(entry + 1));
       return result;
     }
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -307,8 +307,8 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
         }
 
         boolean batchScan = InputConfigurator.isBatchScan(callingClass, job);
-        boolean supportBatchScan = !(tableConfig.isOfflineScan()
-            || tableConfig.shouldUseIsolatedScanners() || tableConfig.shouldUseLocalIterators());
+        boolean supportBatchScan = (!tableConfig.isOfflineScan()
+            && !tableConfig.shouldUseIsolatedScanners() && !tableConfig.shouldUseLocalIterators());
         if (batchScan && !supportBatchScan)
           throw new IllegalArgumentException("BatchScanner optimization not available for offline"
               + " scan, isolated, or local iterators");

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/BatchInputSplit.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/BatchInputSplit.java
@@ -36,9 +36,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class BatchInputSplit extends org.apache.accumulo.hadoopImpl.mapreduce.BatchInputSplit
     implements InputSplit {
 
-  public BatchInputSplit() {
-    super();
-  }
+  public BatchInputSplit() {}
 
   public BatchInputSplit(BatchInputSplit split) throws IOException {
     super(split);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/RangeInputSplit.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/RangeInputSplit.java
@@ -33,9 +33,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class RangeInputSplit extends org.apache.accumulo.hadoopImpl.mapreduce.RangeInputSplit
     implements InputSplit {
 
-  public RangeInputSplit() {
-    super();
-  }
+  public RangeInputSplit() {}
 
   public RangeInputSplit(RangeInputSplit split) throws IOException {
     super(split);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
@@ -340,8 +340,8 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
         }
 
         boolean batchScan = InputConfigurator.isBatchScan(callingClass, context.getConfiguration());
-        boolean supportBatchScan = !(tableConfig.isOfflineScan()
-            || tableConfig.shouldUseIsolatedScanners() || tableConfig.shouldUseLocalIterators());
+        boolean supportBatchScan = (!tableConfig.isOfflineScan()
+            && !tableConfig.shouldUseIsolatedScanners() && !tableConfig.shouldUseLocalIterators());
         if (batchScan && !supportBatchScan)
           throw new IllegalArgumentException("BatchScanner optimization not available for offline"
               + " scan, isolated, or local iterators");

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/RangeInputSplit.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/RangeInputSplit.java
@@ -87,22 +87,21 @@ public class RangeInputSplit extends InputSplit implements Writable {
   public float getProgress(Key currentKey) {
     if (currentKey == null)
       return 0f;
-    if (range.contains(currentKey)) {
-      if (range.getStartKey() != null && range.getEndKey() != null) {
-        if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW) != 0) {
-          // just look at the row progress
-          return getProgress(range.getStartKey().getRowData(), range.getEndKey().getRowData(),
-              currentKey.getRowData());
-        } else if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM) != 0) {
-          // just look at the column family progress
-          return getProgress(range.getStartKey().getColumnFamilyData(),
-              range.getEndKey().getColumnFamilyData(), currentKey.getColumnFamilyData());
-        } else if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM_COLQUAL)
-            != 0) {
-          // just look at the column qualifier progress
-          return getProgress(range.getStartKey().getColumnQualifierData(),
-              range.getEndKey().getColumnQualifierData(), currentKey.getColumnQualifierData());
-        }
+    if (range.contains(currentKey) && (range.getStartKey() != null && range.getEndKey() != null)) {
+      if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW) != 0) {
+        // just look at the row progress
+        return getProgress(range.getStartKey().getRowData(), range.getEndKey().getRowData(),
+            currentKey.getRowData());
+      }
+      if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM) != 0) {
+        // just look at the column family progress
+        return getProgress(range.getStartKey().getColumnFamilyData(),
+            range.getEndKey().getColumnFamilyData(), currentKey.getColumnFamilyData());
+      } else if (range.getStartKey().compareTo(range.getEndKey(), PartialKey.ROW_COLFAM_COLQUAL)
+          != 0) {
+        // just look at the column qualifier progress
+        return getProgress(range.getStartKey().getColumnQualifierData(),
+            range.getEndKey().getColumnQualifierData(), currentKey.getColumnQualifierData());
       }
     }
     // if we can't figure it out, then claim no progress
@@ -287,9 +286,7 @@ public class RangeInputSplit extends InputSplit implements Writable {
 
   public void setFetchedColumns(Collection<IteratorSetting.Column> fetchedColumns) {
     this.fetchedColumns = new HashSet<>();
-    for (IteratorSetting.Column columns : fetchedColumns) {
-      this.fetchedColumns.add(columns);
-    }
+    this.fetchedColumns.addAll(fetchedColumns);
   }
 
   public void setFetchedColumns(Set<IteratorSetting.Column> fetchedColumns) {

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -46,7 +46,7 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum Opts {
+  public enum Opts {
     ACCUMULO_PROPERTIES
   }
 
@@ -89,18 +89,17 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    */
   private static <T> void setAccumuloProperty(Class<?> implementingClass, Configuration conf,
       Property property, T value) {
-    if (isSupportedAccumuloProperty(property)) {
-      String val = String.valueOf(value);
-      if (property.getType().isValidFormat(val)) {
-        String key =
-            enumToConfKey(implementingClass, Opts.ACCUMULO_PROPERTIES) + "." + property.getKey();
-        log.debug("Setting accumulo property {} = {} ", key, val);
-        conf.set(key, val);
-      } else
-        throw new IllegalArgumentException(
-            "Value is not appropriate for property type '" + property.getType() + "'");
-    } else
+    if (!isSupportedAccumuloProperty(property))
       throw new IllegalArgumentException("Unsupported configuration property " + property.getKey());
+    String val = String.valueOf(value);
+    if (property.getType().isValidFormat(val)) {
+      String key =
+          enumToConfKey(implementingClass, Opts.ACCUMULO_PROPERTIES) + "." + property.getKey();
+      log.debug("Setting accumulo property {} = {} ", key, val);
+      conf.set(key, val);
+    } else
+      throw new IllegalArgumentException(
+          "Value is not appropriate for property type '" + property.getType() + "'");
   }
 
   /**

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/InputConfigurator.java
@@ -326,10 +326,12 @@ public class InputConfigurator extends ConfiguratorBase {
       if (column.getFirst() == null)
         throw new IllegalArgumentException("Column family can not be null");
 
-      String col = Base64.getEncoder().encodeToString(TextUtil.getBytes(column.getFirst()));
+      StringBuilder col = new StringBuilder(
+          Base64.getEncoder().encodeToString(TextUtil.getBytes(column.getFirst())));
       if (column.getSecond() != null)
-        col += ":" + Base64.getEncoder().encodeToString(TextUtil.getBytes(column.getSecond()));
-      columnStrings.add(col);
+        col.append(":")
+            .append(Base64.getEncoder().encodeToString(TextUtil.getBytes(column.getSecond())));
+      columnStrings.add(col.toString());
     }
 
     return columnStrings.toArray(new String[0]);
@@ -725,9 +727,8 @@ public class InputConfigurator extends ConfiguratorBase {
     final int delimiterPos = tableName.indexOf('.');
     if (delimiterPos < 1) {
       return ""; // default namespace
-    } else {
-      return tableName.substring(0, delimiterPos);
     }
+    return tableName.substring(0, delimiterPos);
   }
 
   /**
@@ -768,14 +769,12 @@ public class InputConfigurator extends ConfiguratorBase {
 
       for (Map.Entry<String,InputTableConfig> tableConfigEntry : inputTableConfigs.entrySet()) {
         InputTableConfig tableConfig = tableConfigEntry.getValue();
-        if (!tableConfig.shouldUseLocalIterators()) {
-          if (tableConfig.getIterators() != null) {
-            for (IteratorSetting iter : tableConfig.getIterators()) {
-              if (!client.tableOperations().testClassLoad(tableConfigEntry.getKey(),
-                  iter.getIteratorClass(), SortedKeyValueIterator.class.getName()))
-                throw new AccumuloException("Servers are unable to load " + iter.getIteratorClass()
-                    + " as a " + SortedKeyValueIterator.class.getName());
-            }
+        if (!tableConfig.shouldUseLocalIterators() && (tableConfig.getIterators() != null)) {
+          for (IteratorSetting iter : tableConfig.getIterators()) {
+            if (!client.tableOperations().testClassLoad(tableConfigEntry.getKey(),
+                iter.getIteratorClass(), SortedKeyValueIterator.class.getName()))
+              throw new AccumuloException("Servers are unable to load " + iter.getIteratorClass()
+                  + " as a " + SortedKeyValueIterator.class.getName());
           }
         }
       }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/MapReduceClientOpts.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/MapReduceClientOpts.java
@@ -42,6 +42,7 @@ public class MapReduceClientOpts extends ClientOpts {
 
   private static final Logger log = LoggerFactory.getLogger(MapReduceClientOpts.class);
 
+  @Override
   public Properties getClientProps() {
     Properties props = super.getClientProps();
     // For MapReduce, Kerberos credentials don't make it to the Mappers and Reducers,

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/OutputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/OutputConfigurator.java
@@ -42,7 +42,7 @@ public class OutputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum WriteOpts {
+  public enum WriteOpts {
     DEFAULT_TABLE_NAME, BATCH_WRITER_CONFIG
   }
 
@@ -51,7 +51,7 @@ public class OutputConfigurator extends ConfiguratorBase {
    *
    * @since 1.6.0
    */
-  public static enum Features {
+  public enum Features {
     CAN_CREATE_TABLES, SIMULATION_MODE
   }
 

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestOutput.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestOutput.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.iteratortest;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.SortedMap;
 
 import org.apache.accumulo.core.data.Key;
@@ -128,12 +129,7 @@ public class IteratorTestOutput {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((exception == null) ? 0 : exception.hashCode());
-    result = prime * result + ((outcome == null) ? 0 : outcome.hashCode());
-    result = prime * result + ((output == null) ? 0 : output.hashCode());
-    return result;
+    return Objects.hash(exception, outcome, output);
   }
 
   @Override

--- a/minicluster/src/main/java/org/apache/accumulo/cluster/ClusterUser.java
+++ b/minicluster/src/main/java/org/apache/accumulo/cluster/ClusterUser.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
@@ -84,7 +85,8 @@ public class ClusterUser {
   public AuthenticationToken getToken() throws IOException {
     if (password != null) {
       return new PasswordToken(password);
-    } else if (keytab != null) {
+    }
+    if (keytab != null) {
       UserGroupInformation.loginUserFromKeytab(principal, keytab.getAbsolutePath());
       return new KerberosToken();
     }
@@ -120,19 +122,11 @@ public class ClusterUser {
 
     if (obj instanceof ClusterUser) {
       ClusterUser other = (ClusterUser) obj;
-      if (keytab == null) {
-        if (other.keytab != null) {
-          return false;
-        }
-      } else if (!keytab.equals(other.keytab)) {
+      if (!Objects.equals(keytab, other.keytab)) {
         return false;
       }
 
-      if (password == null) {
-        if (other.password != null) {
-          return false;
-        }
-      } else if (!password.equals(other.password)) {
+      if (!Objects.equals(password, other.password)) {
         return false;
       }
 

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MemoryUnit.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MemoryUnit.java
@@ -31,7 +31,7 @@ public enum MemoryUnit {
   private final long multiplier;
   private final String suffix;
 
-  private MemoryUnit(long multiplier, String suffix) {
+  MemoryUnit(long multiplier, String suffix) {
     this.multiplier = multiplier;
     this.suffix = suffix;
   }

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloRunner.java
@@ -256,15 +256,15 @@ public class MiniAccumuloRunner {
   }
 
   private static boolean validateMemoryString(String memoryString) {
-    String unitsRegex = "[";
+    StringBuilder unitsRegex = new StringBuilder("[");
     MemoryUnit[] units = MemoryUnit.values();
     for (int i = 0; i < units.length; i++) {
-      unitsRegex += units[i].suffix();
+      unitsRegex.append(units[i].suffix());
       if (i < units.length - 1)
-        unitsRegex += "|";
+        unitsRegex.append("|");
     }
-    unitsRegex += "]";
-    Pattern p = Pattern.compile("\\d+" + unitsRegex);
+    unitsRegex.append("]");
+    Pattern p = Pattern.compile("\\d+" + unitsRegex.toString());
     return p.matcher(memoryString).matches();
   }
 

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -210,8 +210,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
 
     String className = clazz.getName();
 
-    ArrayList<String> argList = new ArrayList<>();
-    argList.addAll(Arrays.asList(javaBin, "-Dproc=" + clazz.getSimpleName(), "-cp", classpath));
+    ArrayList<String> argList = new ArrayList<>(
+        Arrays.asList(javaBin, "-Dproc=" + clazz.getSimpleName(), "-cp", classpath));
     argList.addAll(extraJvmOpts);
     for (Entry<String,String> sysProp : config.getSystemProperties().entrySet()) {
       argList.add(String.format("-D%s=%s", sysProp.getKey(), sysProp.getValue()));
@@ -290,8 +290,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
     if (configOverrides != null && !configOverrides.isEmpty()) {
       File siteFile =
           Files.createTempFile(config.getConfDir().toPath(), "accumulo", ".properties").toFile();
-      Map<String,String> confMap = new HashMap<>();
-      confMap.putAll(config.getSiteConfig());
+      Map<String,String> confMap = new HashMap<>(config.getSiteConfig());
       confMap.putAll(configOverrides);
       writeConfigProperties(siteFile, confMap);
       jvmOpts.add("-Daccumulo.properties=" + siteFile.getName());

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerConstants.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerConstants.java
@@ -123,9 +123,8 @@ public class ServerConstants {
       } catch (Exception e) {
         if (ignore) {
           continue;
-        } else {
-          throw new IllegalArgumentException("Accumulo volume " + path + " not initialized", e);
         }
+        throw new IllegalArgumentException("Accumulo volume " + path + " not initialized", e);
       }
 
       if (firstIid == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -209,7 +209,8 @@ public class ServerContext extends ClientContext {
       }
 
       return ThriftServerType.SSL;
-    } else if (conf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
+    }
+    if (conf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
       if (conf.getBoolean(Property.INSTANCE_RPC_SSL_ENABLED)) {
         throw new IllegalStateException(
             "Cannot create a Thrift server capable of both SASL and SSL");

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
@@ -45,8 +46,6 @@ import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.conf.ZooCachePropertyAccessor.PropCacheKey;
-
-import com.google.common.collect.ImmutableMap;
 
 public class TableConfiguration extends AccumuloConfiguration {
 
@@ -183,11 +182,8 @@ public class TableConfiguration extends AccumuloConfiguration {
     private ParsedIteratorConfig(List<IterInfo> ii, Map<String,Map<String,String>> opts,
         String context) {
       this.tableIters = List.copyOf(ii);
-      var imb = ImmutableMap.<String,Map<String,String>>builder();
-      for (Entry<String,Map<String,String>> entry : opts.entrySet()) {
-        imb.put(entry.getKey(), Map.copyOf(entry.getValue()));
-      }
-      tableOpts = imb.build();
+      tableOpts = opts.entrySet().stream()
+          .collect(Collectors.toUnmodifiableMap(Entry::getKey, e -> Map.copyOf(e.getValue())));
       this.context = context;
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
@@ -123,9 +123,8 @@ public class ZooCachePropertyAccessor {
     byte[] v = propCache.get(path);
     if (v != null) {
       return new String(v, UTF_8);
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfiguration.java
@@ -78,20 +78,19 @@ public class ZooConfiguration extends AccumuloConfiguration {
 
   @Override
   public String get(Property property) {
-    if (Property.isFixedZooPropertyKey(property)) {
-      String val = fixedProps.get(property.getKey());
-      if (val != null) {
-        return val;
-      } else {
-        synchronized (fixedProps) {
-          val = _get(property);
-          fixedProps.put(property.getKey(), val);
-          return val;
-        }
-
-      }
-    } else {
+    if (!Property.isFixedZooPropertyKey(property)) {
       return _get(property);
+    }
+    String val = fixedProps.get(property.getKey());
+    if (val != null) {
+      return val;
+    } else {
+      synchronized (fixedProps) {
+        val = _get(property);
+        fixedProps.put(property.getKey(), val);
+        return val;
+      }
+
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfigurationFactory.java
@@ -25,7 +25,6 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 
 /**
@@ -57,10 +56,7 @@ class ZooConfigurationFactory {
         // The purpose of this watcher is a hack. It forces the creation on a new zoocache instead
         // of using a shared one. This was done so that the zoocache
         // would update less, causing the configuration update count to changes less.
-        Watcher watcher = new Watcher() {
-          @Override
-          public void process(WatchedEvent arg0) {}
-        };
+        Watcher watcher = arg0 -> {};
         propCache = zcf.getZooCache(context.getZooKeepers(), context.getZooKeepersSessionTimeOut(),
             watcher);
         config = new ZooConfiguration(context, propCache, parent);

--- a/server/base/src/main/java/org/apache/accumulo/server/data/ServerMutation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/data/ServerMutation.java
@@ -86,7 +86,7 @@ public class ServerMutation extends Mutation {
 
   @Override
   public boolean equals(Object o) {
-    return o == this || (o != null && o instanceof ServerMutation
+    return o == this || (o instanceof ServerMutation
         && systemTime == ((ServerMutation) o).systemTime && super.equals(o));
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class PerTableVolumeChooser extends org.apache.accumulo.core.spi.fs.PerTableVolumeChooser
     implements VolumeChooser {
   public PerTableVolumeChooser() {
-    super();
     LoggerFactory.getLogger(PerTableVolumeChooser.class).warn(
         "The class {} is deprecated.  Please configure {} instead.",
         PerTableVolumeChooser.class.getName(),

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PreferredVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PreferredVolumeChooser.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class PreferredVolumeChooser extends org.apache.accumulo.core.spi.fs.PreferredVolumeChooser
     implements VolumeChooser {
   public PreferredVolumeChooser() {
-    super();
     LoggerFactory.getLogger(PreferredVolumeChooser.class).warn(
         "The class {} is deprecated.  Please configure {} instead.",
         PreferredVolumeChooser.class.getName(),

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/RandomVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/RandomVolumeChooser.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class RandomVolumeChooser extends org.apache.accumulo.core.spi.fs.RandomVolumeChooser
     implements VolumeChooser {
   public RandomVolumeChooser() {
-    super();
     LoggerFactory.getLogger(RandomVolumeChooser.class).warn(
         "The class {} is deprecated.  Please configure {} instead.",
         RandomVolumeChooser.class.getName(),

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/SpaceAwareVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/SpaceAwareVolumeChooser.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class SpaceAwareVolumeChooser extends org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooser
     implements VolumeChooser {
   public SpaceAwareVolumeChooser() {
-    super();
     LoggerFactory.getLogger(SpaceAwareVolumeChooser.class).warn(
         "The class {} is deprecated.  Please configure {} instead.",
         SpaceAwareVolumeChooser.class.getName(),

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironment.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironment.java
@@ -36,7 +36,7 @@ public interface VolumeChooserEnvironment
    *
    * @since 2.0.0
    */
-  public static enum ChooserScope {
+  public enum ChooserScope {
     DEFAULT, TABLE, INIT, LOGGER
   }
 
@@ -47,16 +47,16 @@ public interface VolumeChooserEnvironment
    * @since 2.0.0
    */
   @Override
-  public Text getEndRow();
+  Text getEndRow();
 
-  public boolean hasTableId();
+  boolean hasTableId();
 
-  public TableId getTableId();
+  TableId getTableId();
 
   /**
    * @since 2.0.0
    */
-  public default ChooserScope getScope() {
+  default ChooserScope getScope() {
 
     var scope = getChooserScope();
     switch (scope) {
@@ -77,10 +77,10 @@ public interface VolumeChooserEnvironment
    * @since 2.0.0
    */
   @Override
-  public ServiceEnvironment getServiceEnv();
+  ServiceEnvironment getServiceEnv();
 
   /**
    * @since 2.0.0
    */
-  public FileSystem getFileSystem(String option);
+  FileSystem getFileSystem(String option);
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -208,7 +208,8 @@ public interface VolumeManager extends AutoCloseable {
         log.error("unable to obtain instance id at {}", instanceDirectory);
         throw new RuntimeException(
             "Accumulo not initialized, there is no instance id at " + instanceDirectory);
-      } else if (files.length != 1) {
+      }
+      if (files.length != 1) {
         log.error("multiple potential instances in {}", instanceDirectory);
         throw new RuntimeException(
             "Accumulo found multiple possible instance ids in " + instanceDirectory);

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -255,10 +255,9 @@ public class VolumeManagerImpl implements VolumeManager {
     if (candidateVolumes != null) {
       return candidateVolumes.stream().filter(volume -> volume.containsPath(path))
           .map(Volume::getFileSystem).findFirst().orElse(desiredFs);
-    } else {
-      log.debug("Could not determine volume for Path: {}", path);
-      return desiredFs;
     }
+    log.debug("Could not determine volume for Path: {}", path);
+    return desiredFs;
   }
 
   @Override
@@ -315,7 +314,8 @@ public class VolumeManagerImpl implements VolumeManager {
       if (!success && (!exists(newPath) || exists(oldPath))) {
         throw new IOException("Rename operation " + transactionId + " returned false. orig: "
             + oldPath + " new: " + newPath);
-      } else if (log.isTraceEnabled()) {
+      }
+      if (log.isTraceEnabled()) {
         log.trace("{} moved {} to {}", transactionId, oldPath, newPath);
       }
       return null;
@@ -358,12 +358,11 @@ public class VolumeManagerImpl implements VolumeManager {
         throw new IllegalArgumentException("Cannot use viewfs as a volume");
 
       // We require a URI here, fail if it doesn't look like one
-      if (volumeUriOrDir.contains(":")) {
-        volumes.put(volumeUriOrDir, new VolumeImpl(new Path(volumeUriOrDir), hadoopConf));
-      } else {
+      if (!volumeUriOrDir.contains(":")) {
         throw new IllegalArgumentException("Expected fully qualified URI for "
             + Property.INSTANCE_VOLUMES.getKey() + " got " + volumeUriOrDir);
       }
+      volumes.put(volumeUriOrDir, new VolumeImpl(new Path(volumeUriOrDir), hadoopConf));
     }
 
     return new VolumeManagerImpl(volumes, conf, hadoopConf);

--- a/server/base/src/main/java/org/apache/accumulo/server/gc/GcVolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/gc/GcVolumeUtil.java
@@ -43,9 +43,8 @@ public class GcVolumeUtil {
       String relPath = path.toString().substring(ALL_VOLUMES_PREFIX.length());
       return fs.getVolumes().stream().map(vol -> vol.prefixChild(relPath))
           .collect(Collectors.toList());
-    } else {
-      return Collections.singleton(path);
     }
+    return Collections.singleton(path);
   }
 
   public static boolean isAllVolumesUri(Path path) {

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -870,8 +870,7 @@ public class Initialize implements KeywordExecutable {
     Set<String> initializedDirs =
         ServerConstants.checkBaseUris(siteConfig, hadoopConf, volumeURIs, true);
 
-    HashSet<String> uinitializedDirs = new HashSet<>();
-    uinitializedDirs.addAll(volumeURIs);
+    HashSet<String> uinitializedDirs = new HashSet<>(volumeURIs);
     uinitializedDirs.removeAll(initializedDirs);
 
     Path aBasePath = new Path(initializedDirs.iterator().next());
@@ -984,10 +983,9 @@ public class Initialize implements KeywordExecutable {
           addVolumes(fs, siteConfig, hadoopConfig);
         }
 
-        if (!opts.resetSecurity && !opts.addVolumes) {
-          if (!doInit(siteConfig, opts, hadoopConfig, fs)) {
-            System.exit(-1);
-          }
+        if ((!opts.resetSecurity && !opts.addVolumes)
+            && !doInit(siteConfig, opts, hadoopConfig, fs)) {
+          System.exit(-1);
         }
       }
     } catch (Exception e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/log/SortedLogState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/log/SortedLogState.java
@@ -30,7 +30,7 @@ public enum SortedLogState {
 
   private String marker;
 
-  private SortedLogState(String marker) {
+  SortedLogState(String marker) {
     this.marker = marker;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  */
 public class WalStateManager {
 
-  public class WalMarkerException extends Exception {
+  public static class WalMarkerException extends Exception {
     private static final long serialVersionUID = 1L;
 
     public WalMarkerException(Exception ex) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -403,11 +403,10 @@ public class LiveTServerSet implements Watcher {
       addr = AddressUtil.parseAddress(tabletServer, false);
     }
     for (Entry<String,TServerInfo> entry : servers.entrySet()) {
-      if (entry.getValue().instance.getHostAndPort().equals(addr)) {
-        // Return the instance if we have no desired session ID, or we match the desired session ID
-        if (sessionId == null || sessionId.equals(entry.getValue().instance.getSession()))
-          return entry.getValue().instance;
-      }
+      // Return the instance if we have no desired session ID, or we match the desired session ID
+      if (entry.getValue().instance.getHostAndPort().equals(addr)
+          && (sessionId == null || sessionId.equals(entry.getValue().instance.getSession())))
+        return entry.getValue().instance;
     }
     return null;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MergeInfo.java
@@ -88,8 +88,7 @@ public class MergeInfo implements Writable {
       return false;
     if (isDelete())
       return otherExtent.prevEndRow() != null && otherExtent.prevEndRow().equals(extent.endRow());
-    else
-      return this.extent.overlaps(otherExtent);
+    return this.extent.overlaps(otherExtent);
   }
 
   public boolean overlaps(KeyExtent otherExtent) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
@@ -56,6 +56,7 @@ class MetaDataStateStore implements TabletStateStore {
     return new MetaDataTableScanner(context, TabletsSection.getRange(), state, targetTableName);
   }
 
+  @Override
   public void setLocations(Collection<Assignment> assignments) throws DistributedStoreException {
     try (var tabletsMutator = ample.mutateTablets()) {
       for (Assignment assignment : assignments) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletServerState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletServerState.java
@@ -56,7 +56,7 @@ public enum TabletServerState {
     }
   }
 
-  private TabletServerState(byte id) {
+  TabletServerState(byte id) {
     this.id = id;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateStore.java
@@ -81,20 +81,20 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
    */
   void unsuspend(Collection<TabletLocationState> tablets) throws DistributedStoreException;
 
-  public static void unassign(ServerContext context, TabletLocationState tls,
+  static void unassign(ServerContext context, TabletLocationState tls,
       Map<TServerInstance,List<Path>> logsForDeadServers) throws DistributedStoreException {
     getStoreForTablet(tls.extent, context).unassign(Collections.singletonList(tls),
         logsForDeadServers);
   }
 
-  public static void suspend(ServerContext context, TabletLocationState tls,
+  static void suspend(ServerContext context, TabletLocationState tls,
       Map<TServerInstance,List<Path>> logsForDeadServers, long suspensionTimestamp)
       throws DistributedStoreException {
     getStoreForTablet(tls.extent, context).suspend(Collections.singletonList(tls),
         logsForDeadServers, suspensionTimestamp);
   }
 
-  public static void setLocation(ServerContext context, Assignment assignment)
+  static void setLocation(ServerContext context, Assignment assignment)
       throws DistributedStoreException {
     getStoreForTablet(assignment.tablet, context)
         .setLocations(Collections.singletonList(assignment));
@@ -104,11 +104,11 @@ public interface TabletStateStore extends Iterable<TabletLocationState> {
     return getStoreForLevel(DataLevel.of(extent.tableId()), context);
   }
 
-  public static TabletStateStore getStoreForLevel(DataLevel level, ClientContext context) {
+  static TabletStateStore getStoreForLevel(DataLevel level, ClientContext context) {
     return getStoreForLevel(level, context, null);
   }
 
-  public static TabletStateStore getStoreForLevel(DataLevel level, ClientContext context,
+  static TabletStateStore getStoreForLevel(DataLevel level, ClientContext context,
       CurrentState state) {
 
     TabletStateStore tss;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancer.java
@@ -119,8 +119,7 @@ public class DefaultLoadBalancer extends TabletBalancer {
 
     @Override
     public boolean equals(Object obj) {
-      return obj == this
-          || (obj != null && obj instanceof ServerCounts && compareTo((ServerCounts) obj) == 0);
+      return obj == this || (obj instanceof ServerCounts && compareTo((ServerCounts) obj) == 0);
     }
 
     @Override
@@ -347,16 +346,14 @@ public class DefaultLoadBalancer extends TabletBalancer {
     // do we have any servers?
     if (current.isEmpty()) {
       constraintNotMet(NO_SERVERS);
+    } else // Don't migrate if we have migrations in progress
+    if (migrations.isEmpty()) {
+      resetBalancerErrors();
+      if (getMigrations(current, migrationsOut))
+        return 1 * 1000;
     } else {
-      // Don't migrate if we have migrations in progress
-      if (migrations.isEmpty()) {
-        resetBalancerErrors();
-        if (getMigrations(current, migrationsOut))
-          return 1 * 1000;
-      } else {
-        outstandingMigrations.migrations = migrations;
-        constraintNotMet(outstandingMigrations);
-      }
+      outstandingMigrations.migrations = migrations;
+      constraintNotMet(outstandingMigrations);
     }
     return 5 * 1000;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -567,9 +567,8 @@ public abstract class GroupBalancer extends TabletBalancer {
       // smooth things out
       balanceExtraMultiple(tservers, maxExtraGroups, moves, extraMultiple, true);
       return false;
-    } else {
-      return true;
     }
+    return true;
   }
 
   private void balanceExtraMultiple(Map<TServerInstance,TserverGroupInfo> tservers,
@@ -644,11 +643,10 @@ public abstract class GroupBalancer extends TabletBalancer {
             TserverGroupInfo srcTgi = iter.next();
 
             while (srcTgi.getExtras().size() <= expectedExtra) {
-              if (iter.hasNext()) {
-                srcTgi = iter.next();
-              } else {
+              if (!iter.hasNext()) {
                 continue nextGroup;
               }
+              srcTgi = iter.next();
             }
 
             moves.move(group, 1, srcTgi, destTgi);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/RegexGroupBalancer.java
@@ -86,22 +86,18 @@ public class RegexGroupBalancer extends GroupBalancer {
 
     final Pattern pattern = Pattern.compile(regex);
 
-    return new Function<>() {
-
-      @Override
-      public String apply(KeyExtent input) {
-        Text er = input.endRow();
-        if (er == null) {
-          return defaultGroup;
-        }
-
-        Matcher matcher = pattern.matcher(er.toString());
-        if (matcher.matches() && matcher.groupCount() == 1) {
-          return matcher.group(1);
-        }
-
+    return input -> {
+      Text er = input.endRow();
+      if (er == null) {
         return defaultGroup;
       }
+
+      Matcher matcher = pattern.matcher(er.toString());
+      if (matcher.matches() && matcher.groupCount() == 1) {
+        return matcher.group(1);
+      }
+
+      return defaultGroup;
     };
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -60,7 +60,7 @@ public class TableLoadBalancer extends TabletBalancer {
 
   private TabletBalancer constructNewBalancerForTable(String clazzName, TableId tableId)
       throws Exception {
-    String context = null;
+    String context;
     context = ClassLoaderUtil.tableContext(this.context.getTableConfiguration(tableId));
     Class<? extends TabletBalancer> clazz =
         ClassLoaderUtil.loadClass(context, clazzName, TabletBalancer.class);
@@ -84,22 +84,20 @@ public class TableLoadBalancer extends TabletBalancer {
 
     if (clazzName == null)
       clazzName = DefaultLoadBalancer.class.getName();
-    if (balancer != null) {
-      if (!clazzName.equals(balancer.getClass().getName())) {
-        // the balancer class for this table does not match the class specified in the configuration
-        try {
-          // attempt to construct a balancer with the specified class
-          TabletBalancer newBalancer = constructNewBalancerForTable(clazzName, tableId);
-          if (newBalancer != null) {
-            balancer = newBalancer;
-            perTableBalancers.put(tableId, balancer);
-            balancer.init(this.context);
-          }
-
-          log.info("Loaded new class {} for table {}", clazzName, tableId);
-        } catch (Exception e) {
-          log.warn("Failed to load table balancer class {} for table {}", clazzName, tableId, e);
+    if ((balancer != null) && !clazzName.equals(balancer.getClass().getName())) {
+      // the balancer class for this table does not match the class specified in the configuration
+      try {
+        // attempt to construct a balancer with the specified class
+        TabletBalancer newBalancer = constructNewBalancerForTable(clazzName, tableId);
+        if (newBalancer != null) {
+          balancer = newBalancer;
+          perTableBalancers.put(tableId, balancer);
+          balancer.init(this.context);
         }
+
+        log.info("Loaded new class {} for table {}", clazzName, tableId);
+      } catch (Exception e) {
+        log.warn("Failed to load table balancer class {} for table {}", clazzName, tableId, e);
       }
     }
     if (balancer == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -176,7 +176,8 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       }
 
       return candidates.iterator();
-    } else if (level == DataLevel.METADATA || level == DataLevel.USER) {
+    }
+    if (level == DataLevel.METADATA || level == DataLevel.USER) {
       Range range = DeletesSection.getRange();
       if (continuePoint != null && !continuePoint.isEmpty()) {
         String continueRow = DeletesSection.encodeRow(continuePoint);
@@ -206,9 +207,8 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     try {
       if (MetadataTable.ID.equals(tableId)) {
         return context.createBatchWriter(RootTable.NAME);
-      } else {
-        return context.createBatchWriter(MetadataTable.NAME);
       }
+      return context.createBatchWriter(MetadataTable.NAME);
     } catch (TableNotFoundException e) {
       throw new RuntimeException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
@@ -53,13 +53,12 @@ public class TabletsMutatorImpl implements TabletsMutator {
         }
 
         return rootWriter;
-      } else {
-        if (metaWriter == null) {
-          metaWriter = context.createBatchWriter(MetadataTable.NAME);
-        }
-
-        return metaWriter;
       }
+      if (metaWriter == null) {
+        metaWriter = context.createBatchWriter(MetadataTable.NAME);
+      }
+
+      return metaWriter;
     } catch (TableNotFoundException e) {
       throw new RuntimeException(e);
     }
@@ -69,9 +68,8 @@ public class TabletsMutatorImpl implements TabletsMutator {
   public Ample.TabletMutator mutateTablet(KeyExtent extent) {
     if (extent.isRootTablet()) {
       return new RootTabletMutatorImpl(context);
-    } else {
-      return new TabletMutatorImpl(context, extent, getWriter(extent.tableId()));
     }
+    return new TabletMutatorImpl(context, extent, getWriter(extent.tableId()));
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/StatusCombiner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/StatusCombiner.java
@@ -113,15 +113,14 @@ public class StatusCombiner extends TypedValueCombiner<Status> {
       // Avoid creation of a new builder and message when we only have one
       // message to reduce
       if (combined == null) {
-        if (iter.hasNext()) {
-          combined = Status.newBuilder();
-        } else {
+        if (!iter.hasNext()) {
           if (log.isTraceEnabled()) {
             log.trace("Returned single value: {} {}", key.toStringNoTruncate(),
                 ProtobufUtil.toString(status));
           }
           return status;
         }
+        combined = Status.newBuilder();
       }
 
       // Add the new message in with the previous message(s)

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/StatusFormatter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/StatusFormatter.java
@@ -78,21 +78,20 @@ public class StatusFormatter implements Formatter {
 
     // If we expected this to be a protobuf, try to parse it, adding a message when it fails to
     // parse
-    if (REPLICATION_COLFAMS.contains(entry.getKey().getColumnFamily())) {
-      Status status;
-      try {
-        status = Status.parseFrom(entry.getValue().get());
-      } catch (InvalidProtocolBufferException e) {
-        log.trace("Could not deserialize protocol buffer for {}", entry.getKey(), e);
-        status = null;
-      }
-
-      return formatEntry(entry.getKey(), status, timestampFormat);
-    } else {
+    if (!REPLICATION_COLFAMS.contains(entry.getKey().getColumnFamily())) {
       // Otherwise, we're set on a table that contains other data too (e.g. accumulo.metadata)
       // Just do the normal thing
       return DefaultFormatter.formatEntry(entry, timestampFormat);
     }
+    Status status;
+    try {
+      status = Status.parseFrom(entry.getValue().get());
+    } catch (InvalidProtocolBufferException e) {
+      log.trace("Could not deserialize protocol buffer for {}", entry.getKey(), e);
+      status = null;
+    }
+
+    return formatEntry(entry.getKey(), status, timestampFormat);
   }
 
   public String formatEntry(Key key, Status status, DateFormat timestampFormat) {

--- a/server/base/src/main/java/org/apache/accumulo/server/replication/StatusUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/replication/StatusUtil.java
@@ -214,9 +214,8 @@ public class StatusUtil {
   public static boolean isFullyReplicated(Status status) {
     if (status.getInfiniteEnd()) {
       return status.getBegin() == Long.MAX_VALUE;
-    } else {
-      return status.getBegin() >= status.getEnd();
     }
+    return status.getBegin() >= status.getEnd();
   }
 
   /**
@@ -229,8 +228,7 @@ public class StatusUtil {
   public static boolean isWorkRequired(Status status) {
     if (status.getInfiniteEnd()) {
       return status.getBegin() != Long.MAX_VALUE;
-    } else {
-      return status.getBegin() < status.getEnd();
     }
+    return status.getBegin() < status.getEnd();
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/SaslServerConnectionParams.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/SaslServerConnectionParams.java
@@ -53,12 +53,11 @@ public class SaslServerConnectionParams extends SaslConnectionParams {
   @Override
   protected void updateFromToken(AuthenticationToken token) {
     // Servers should never have a delegation token -- only a strong kerberos identity
-    if (token instanceof KerberosToken || token instanceof SystemToken) {
-      mechanism = SaslMechanism.GSSAPI;
-    } else {
+    if (!(token instanceof KerberosToken) && !(token instanceof SystemToken)) {
       throw new IllegalArgumentException(
           "Cannot determine SASL mechanism for token class: " + token.getClass());
     }
+    mechanism = SaslMechanism.GSSAPI;
   }
 
   public AuthenticationTokenSecretManager getSecretManager() {

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/SaslServerDigestCallbackHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/SaslServerDigestCallbackHandler.java
@@ -86,7 +86,7 @@ public class SaslServerDigestCallbackHandler extends SaslDigestCallbackHandler {
       AuthenticationTokenIdentifier tokenIdentifier =
           getIdentifier(nc.getDefaultName(), secretManager);
       char[] password = getPassword(secretManager, tokenIdentifier);
-      UserGroupInformation user = null;
+      UserGroupInformation user;
       user = tokenIdentifier.getUser();
 
       // Set the principal since we already deserialized the token identifier

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandler.java
@@ -77,9 +77,9 @@ public class TCredentialsUpdatingInvocationHandler<I> implements InvocationHandl
     }
 
     TCredentials tcreds = null;
-    if (args[0] != null && args[0] instanceof TCredentials) {
+    if (args[0] instanceof TCredentials) {
       tcreds = (TCredentials) args[0];
-    } else if (args[1] != null && args[1] instanceof TCredentials) {
+    } else if (args[1] instanceof TCredentials) {
       tcreds = (TCredentials) args[1];
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/ThriftServerType.java
@@ -38,7 +38,7 @@ public enum ThriftServerType {
 
   private final String name;
 
-  private ThriftServerType(String name) {
+  ThriftServerType(String name) {
     this.name = name;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
@@ -56,7 +56,7 @@ public class TimedProcessor implements TProcessor {
 
   @Override
   public boolean process(TProtocol in, TProtocol out) throws TException {
-    long now = 0;
+    long now;
     now = System.currentTimeMillis();
     thriftMetrics.addIdle(now - idleStart);
     try {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/UserImpersonation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/UserImpersonation.java
@@ -214,8 +214,7 @@ public class UserImpersonation {
         usersWithHosts.setAcceptAllUsers(true);
       } else {
         String[] allowedUsers = allowedImpersonationsForRemoteUser.split(",");
-        Set<String> usersSet = new HashSet<>();
-        usersSet.addAll(Arrays.asList(allowedUsers));
+        Set<String> usersSet = new HashSet<>(Arrays.asList(allowedUsers));
         usersWithHosts.setUsers(usersSet);
       }
 
@@ -223,8 +222,7 @@ public class UserImpersonation {
         usersWithHosts.setAcceptAllHosts(true);
       } else {
         String[] allowedHosts = hostConfig.split(",");
-        Set<String> hostsSet = new HashSet<>();
-        hostsSet.addAll(Arrays.asList(allowedHosts));
+        Set<String> hostsSet = new HashSet<>(Arrays.asList(allowedHosts));
         usersWithHosts.setHosts(hostsSet);
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationKey.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationKey.java
@@ -88,7 +88,7 @@ public class AuthenticationKey implements Writable {
 
   @Override
   public boolean equals(Object obj) {
-    return obj != null && obj instanceof AuthenticationKey
+    return obj instanceof AuthenticationKey
         && Objects.equals(authKey, ((AuthenticationKey) obj).authKey);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributor.java
@@ -85,9 +85,8 @@ public class ZooAuthenticationKeyDistributor {
       log.error("Expected {} to have ACLs {} but was {}", baseNode, ZooUtil.PRIVATE, acls);
       throw new IllegalStateException(
           "Delegation token secret key node in ZooKeeper is not protected.");
-    } else {
-      zk.putPrivatePersistentData(baseNode, new byte[0], NodeExistsPolicy.FAIL);
     }
+    zk.putPrivatePersistentData(baseNode, new byte[0], NodeExistsPolicy.FAIL);
 
     initialized.set(true);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
@@ -171,26 +171,25 @@ public final class ZKAuthenticator implements Authenticator {
     if (!(token instanceof PasswordToken))
       throw new AccumuloSecurityException(principal, SecurityErrorCode.INVALID_TOKEN);
     PasswordToken pt = (PasswordToken) token;
-    if (userExists(principal)) {
-      try {
-        synchronized (zooCache) {
-          zooCache.clear(ZKUserPath + "/" + principal);
-          context.getZooReaderWriter().putPrivatePersistentData(ZKUserPath + "/" + principal,
-              ZKSecurityTool.createPass(pt.getPassword()), NodeExistsPolicy.OVERWRITE);
-        }
-      } catch (KeeperException e) {
-        log.error("{}", e.getMessage(), e);
-        throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
-      } catch (InterruptedException e) {
-        log.error("{}", e.getMessage(), e);
-        throw new RuntimeException(e);
-      } catch (AccumuloException e) {
-        log.error("{}", e.getMessage(), e);
-        throw new AccumuloSecurityException(principal, SecurityErrorCode.DEFAULT_SECURITY_ERROR, e);
-      }
-    } else
+    if (!userExists(principal))
       // user doesn't exist
       throw new AccumuloSecurityException(principal, SecurityErrorCode.USER_DOESNT_EXIST);
+    try {
+      synchronized (zooCache) {
+        zooCache.clear(ZKUserPath + "/" + principal);
+        context.getZooReaderWriter().putPrivatePersistentData(ZKUserPath + "/" + principal,
+            ZKSecurityTool.createPass(pt.getPassword()), NodeExistsPolicy.OVERWRITE);
+      }
+    } catch (KeeperException e) {
+      log.error("{}", e.getMessage(), e);
+      throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
+    } catch (InterruptedException e) {
+      log.error("{}", e.getMessage(), e);
+      throw new RuntimeException(e);
+    } catch (AccumuloException e) {
+      log.error("{}", e.getMessage(), e);
+      throw new AccumuloSecurityException(principal, SecurityErrorCode.DEFAULT_SECURITY_ERROR, e);
+    }
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/TabletTime.java
@@ -50,7 +50,8 @@ public abstract class TabletTime {
 
     if (metadataTime.getType().equals(TimeType.LOGICAL)) {
       return new LogicalTime(metadataTime.getTime());
-    } else if (metadataTime.getType().equals(TimeType.MILLIS)) {
+    }
+    if (metadataTime.getType().equals(TimeType.MILLIS)) {
       return new MillisTime(metadataTime.getTime());
     } else // this should really never happen here
       throw new IllegalArgumentException("Time type unknown : " + metadataTime);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -250,11 +250,9 @@ public class Admin implements KeywordExecutable {
           if (RemoveEntriesForMissingFiles.checkAllTables(context, checkTabletsCommand.fixFiles)
               != 0)
             rc = 6;
-        } else {
-          if (RemoveEntriesForMissingFiles.checkTable(context, checkTabletsCommand.tableName,
-              checkTabletsCommand.fixFiles) != 0)
-            rc = 6;
-        }
+        } else if (RemoveEntriesForMissingFiles.checkTable(context, checkTabletsCommand.tableName,
+            checkTabletsCommand.fixFiles) != 0)
+          rc = 6;
 
       } else if (cl.getParsedCommand().equals("stop")) {
         stopTabletServer(context, stopOpts.args, opts.force);
@@ -534,12 +532,11 @@ public class Admin implements KeywordExecutable {
       }
       for (Entry<String,String> entry : props.entrySet()) {
         String defaultValue = getDefaultConfigValue(entry.getKey());
-        if (defaultValue == null || !defaultValue.equals(entry.getValue())) {
-          if (!entry.getValue().equals(siteConfig.get(entry.getKey()))
-              && !entry.getValue().equals(systemConfig.get(entry.getKey()))) {
-            nsWriter.write(nsConfigFormat
-                .format(new String[] {namespace, entry.getKey() + "=" + entry.getValue()}));
-          }
+        if ((defaultValue == null || !defaultValue.equals(entry.getValue()))
+            && (!entry.getValue().equals(siteConfig.get(entry.getKey()))
+                && !entry.getValue().equals(systemConfig.get(entry.getKey())))) {
+          nsWriter.write(nsConfigFormat
+              .format(new String[] {namespace, entry.getKey() + "=" + entry.getValue()}));
         }
       }
     }
@@ -614,12 +611,11 @@ public class Admin implements KeywordExecutable {
       for (Entry<String,String> prop : props.entrySet()) {
         if (prop.getKey().startsWith(Property.TABLE_PREFIX.getKey())) {
           String defaultValue = getDefaultConfigValue(prop.getKey());
-          if (defaultValue == null || !defaultValue.equals(prop.getValue())) {
-            if (!prop.getValue().equals(siteConfig.get(prop.getKey()))
-                && !prop.getValue().equals(systemConfig.get(prop.getKey()))) {
-              writer.write(configFormat
-                  .format(new String[] {tableName, prop.getKey() + "=" + prop.getValue()}));
-            }
+          if ((defaultValue == null || !defaultValue.equals(prop.getValue()))
+              && (!prop.getValue().equals(siteConfig.get(prop.getKey()))
+                  && !prop.getValue().equals(systemConfig.get(prop.getKey())))) {
+            writer.write(configFormat
+                .format(new String[] {tableName, prop.getKey() + "=" + prop.getValue()}));
           }
         }
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileSystemMonitor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileSystemMonitor.java
@@ -126,12 +126,8 @@ public class FileSystemMonitor {
             try {
               checkMount(mount);
             } catch (final Exception e) {
-              Halt.halt(-42, new Runnable() {
-                @Override
-                public void run() {
-                  log.error("Exception while checking mount points, halting process", e);
-                }
-              });
+              Halt.halt(-42,
+                  () -> log.error("Exception while checking mount points, halting process", e));
             }
           }), period, period, TimeUnit.MILLISECONDS);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,6 @@ import org.apache.accumulo.core.file.rfile.RFileOperations;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.metadata.TabletFile;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.conf.Configuration;
@@ -56,8 +56,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableSortedMap;
 
 public class FileUtil {
 
@@ -237,7 +235,7 @@ public class FileUtil {
       if (prevEndRow == null)
         prevEndRow = new Text();
 
-      long numKeys = 0;
+      long numKeys;
 
       numKeys = countIndexEntries(context, prevEndRow, endRow, mapFiles, true, readers);
 
@@ -322,7 +320,7 @@ public class FileUtil {
 
       long t1 = System.currentTimeMillis();
 
-      long numKeys = 0;
+      long numKeys;
 
       numKeys = countIndexEntries(context, prevEndRow, endRow, mapFiles,
           tmpDir == null ? useIndex : false, readers);
@@ -337,7 +335,7 @@ public class FileUtil {
           return findMidPoint(context, tabletDirectory, prevEndRow, endRow, origMapFiles, minSplit,
               false);
         }
-        return ImmutableSortedMap.of();
+        return Collections.emptySortedMap();
       }
 
       List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<>(readers);
@@ -443,9 +441,8 @@ public class FileUtil {
         else
           reader = FileOperations.getInstance().newScanReaderBuilder()
               .forFile(file.getPathStr(), ns, ns.getConf(), context.getCryptoService())
-              .withTableConfiguration(acuConf).overRange(new Range(prevEndRow, false, null, true),
-                  LocalityGroupUtil.EMPTY_CF_SET, false)
-              .build();
+              .withTableConfiguration(acuConf)
+              .overRange(new Range(prevEndRow, false, null, true), Set.of(), false).build();
 
         while (reader.hasTop()) {
           Key key = reader.getTopKey();
@@ -472,9 +469,8 @@ public class FileUtil {
       else
         readers.add(FileOperations.getInstance().newScanReaderBuilder()
             .forFile(file.getPathStr(), ns, ns.getConf(), context.getCryptoService())
-            .withTableConfiguration(acuConf).overRange(new Range(prevEndRow, false, null, true),
-                LocalityGroupUtil.EMPTY_CF_SET, false)
-            .build());
+            .withTableConfiguration(acuConf)
+            .overRange(new Range(prevEndRow, false, null, true), Set.of(), false).build());
 
     }
     return numKeys;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -448,7 +448,7 @@ public class FileUtil {
           Key key = reader.getTopKey();
           if (endRow != null && key.compareRow(endRow) > 0)
             break;
-          else if (prevEndRow == null || key.compareRow(prevEndRow) > 0)
+          if (prevEndRow == null || key.compareRow(prevEndRow) > 0)
             numKeys++;
 
           reader.next();

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -186,14 +186,14 @@ public class RemoveEntriesForMissingFiles {
 
     if (missing == 0)
       return checkTable(context, MetadataTable.NAME, TabletsSection.getRange(), fix);
-    else
-      return missing;
+    return missing;
   }
 
   static int checkTable(ServerContext context, String tableName, boolean fix) throws Exception {
     if (tableName.equals(RootTable.NAME)) {
       throw new IllegalArgumentException("Can not check root table");
-    } else if (tableName.equals(MetadataTable.NAME)) {
+    }
+    if (tableName.equals(MetadataTable.NAME)) {
       return checkTable(context, RootTable.NAME, TabletsSection.getRange(), fix);
     } else {
       TableId tableId = Tables.getTableId(context, tableName);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -87,8 +87,7 @@ public class TableDiskUsage {
     Integer[] tables = tableFiles.get(file);
     if (tables == null) {
       tables = new Integer[internalIds.size()];
-      for (int i = 0; i < tables.length; i++)
-        tables[i] = 0;
+      Arrays.fill(tables, 0);
       tableFiles.put(file, tables);
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -110,10 +110,9 @@ public class ZooZap {
               zoo.recursiveDelete(tserversPath + "/" + child, NodeMissingPolicy.SKIP);
             } else {
               var zLockPath = ServiceLock.path(tserversPath + "/" + child);
-              if (!zoo.getChildren(zLockPath.toString()).isEmpty()) {
-                if (!ServiceLock.deleteLock(zoo, zLockPath, "tserver")) {
-                  message("Did not delete " + tserversPath + "/" + child, opts);
-                }
+              if (!zoo.getChildren(zLockPath.toString()).isEmpty()
+                  && !ServiceLock.deleteLock(zoo, zLockPath, "tserver")) {
+                message("Did not delete " + tserversPath + "/" + child, opts);
               }
             }
           }

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/TransactionWatcher.java
@@ -183,10 +183,8 @@ public class TransactionWatcher {
       AtomicInteger count = counts.get(tid);
       if (count == null) {
         log.error("unexpected missing count for transaction {}", tid);
-      } else {
-        if (count.decrementAndGet() == 0)
-          counts.remove(tid);
-      }
+      } else if (count.decrementAndGet() == 0)
+        counts.remove(tid);
     }
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -252,7 +252,8 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
         && (host.equals("192.168.0.1") || host.equals("192.168.0.2") || host.equals("192.168.0.3")
             || host.equals("192.168.0.4") || host.equals("192.168.0.5"))) {
       return true;
-    } else if (tid.equals("2")
+    }
+    if (tid.equals("2")
         && (host.equals("192.168.0.6") || host.equals("192.168.0.7") || host.equals("192.168.0.8")
             || host.equals("192.168.0.9") || host.equals("192.168.0.10"))) {
       return true;
@@ -266,7 +267,8 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
   protected String idToTableName(TableId id) {
     if (id.equals(FOO.getId())) {
       return FOO.getTableName();
-    } else if (id.equals(BAR.getId())) {
+    }
+    if (id.equals(BAR.getId())) {
       return BAR.getTableName();
     } else if (id.equals(BAZ.getId())) {
       return BAZ.getTableName();
@@ -307,9 +309,8 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
   protected String getNameFromIp(String hostIp) throws UnknownHostException {
     if (servers.containsKey(hostIp)) {
       return servers.get(hostIp);
-    } else {
-      throw new UnknownHostException();
     }
+    throw new UnknownHostException();
   }
 
   protected SortedMap<TServerInstance,TabletServerStatus> createCurrent(int numTservers) {

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -46,14 +46,9 @@ import org.junit.Test;
 @Deprecated(since = "2.1.0")
 public class GroupBalancerTest {
 
-  private static Function<KeyExtent,String> partitioner = new Function<>() {
-
-    @Override
-    public String apply(KeyExtent input) {
-      return (input == null || input.endRow() == null) ? null
+  private static Function<KeyExtent,String> partitioner =
+      input -> (input == null || input.endRow() == null) ? null
           : input.endRow().toString().substring(0, 2);
-    }
-  };
 
   public static class TabletServers {
     private final Set<TServerInstance> tservers = new HashSet<>();

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
@@ -140,8 +140,7 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     init();
     // lets say we already have migrations ongoing for the FOO and BAR table extends (should be 5 of
     // each of them) for a total of 10
-    Set<KeyExtent> migrations = new HashSet<>();
-    migrations.addAll(tableExtents.get(FOO.getTableName()));
+    Set<KeyExtent> migrations = new HashSet<>(tableExtents.get(FOO.getTableName()));
     migrations.addAll(tableExtents.get(BAR.getTableName()));
     long wait = this.balance(Collections.unmodifiableSortedMap(createCurrent(15)), migrations,
         migrationsOut);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -152,12 +152,11 @@ public class GarbageCollectionAlgorithm {
           int count = 0;
 
           while (tailIter.hasNext()) {
-            if (tailIter.next().startsWith(blipPath)) {
-              count++;
-              tailIter.remove();
-            } else {
+            if (!tailIter.next().startsWith(blipPath)) {
               break;
             }
+            count++;
+            tailIter.remove();
           }
 
           if (count > 0)
@@ -302,8 +301,7 @@ public class GarbageCollectionAlgorithm {
 
       if (candidates.isEmpty())
         break;
-      else
-        lastCandidate = candidates.get(candidates.size() - 1);
+      lastCandidate = candidates.get(candidates.size() - 1);
 
       long origSize = candidates.size();
       gce.incrementCandidatesStat(origSize);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -361,11 +361,10 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
                   String tabletDir = parts[2];
                   getContext().getTableManager().updateTableStateCache(tableId);
                   TableState tableState = getContext().getTableManager().getTableState(tableId);
-                  if (tableState != null && tableState != TableState.DELETING) {
-                    // clone directories don't always exist
-                    if (!tabletDir.startsWith(Constants.CLONE_PREFIX)) {
-                      log.debug("File doesn't exist: {}", pathToDel);
-                    }
+                  // clone directories don't always exist
+                  if ((tableState != null && tableState != TableState.DELETING)
+                      && !tabletDir.startsWith(Constants.CLONE_PREFIX)) {
+                    log.debug("File doesn't exist: {}", pathToDel);
                   }
                 } else {
                   log.warn("Very strange path name: {}", delete);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -659,7 +659,7 @@ class FateServiceHandler implements FateService.Iface {
       Exception e = manager.fate.getException(opid);
       if (e instanceof ThriftTableOperationException)
         throw (ThriftTableOperationException) e;
-      else if (e instanceof ThriftSecurityException)
+      if (e instanceof ThriftSecurityException)
         throw (ThriftSecurityException) e;
       else if (e instanceof RuntimeException)
         throw (RuntimeException) e;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptySortedMap;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
@@ -211,10 +212,8 @@ public class Manager extends AbstractServer
 
   Fate<Manager> fate;
 
-  volatile SortedMap<TServerInstance,TabletServerStatus> tserverStatus =
-      Collections.unmodifiableSortedMap(new TreeMap<>());
-  volatile SortedMap<TabletServerId,TServerStatus> tserverStatusForBalancer =
-      Collections.unmodifiableSortedMap(new TreeMap<>());
+  volatile SortedMap<TServerInstance,TabletServerStatus> tserverStatus = emptySortedMap();
+  volatile SortedMap<TabletServerId,TServerStatus> tserverStatusForBalancer = emptySortedMap();
   final ServerBulkImportStatus bulkImportStatus = new ServerBulkImportStatus();
 
   private final AtomicBoolean managerInitialized = new AtomicBoolean(false);
@@ -615,10 +614,8 @@ public class Manager extends AbstractServer
                 if (tls.chopped) {
                   return TabletGoalState.UNASSIGNED;
                 }
-              } else {
-                if (tls.chopped && tls.walogs.isEmpty()) {
-                  return TabletGoalState.UNASSIGNED;
-                }
+              } else if (tls.chopped && tls.walogs.isEmpty()) {
+                return TabletGoalState.UNASSIGNED;
               }
 
               return TabletGoalState.HOSTED;
@@ -1189,11 +1186,10 @@ public class Manager extends AbstractServer
     ThreadPools.createGeneralScheduledExecutorService(getConfiguration())
         .scheduleWithFixedDelay(() -> {
           try {
-            if (replServer.get() == null) {
-              if (!getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
-                log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
-                replServer.set(setupReplication());
-              }
+            if ((replServer.get() == null)
+                && !getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
+              log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
+              replServer.set(setupReplication());
             }
           } catch (UnknownHostException | KeeperException | InterruptedException e) {
             log.error("Error occurred starting replication services. ", e);
@@ -1497,10 +1493,9 @@ public class Manager extends AbstractServer
 
       Set<TServerInstance> unexpected = new HashSet<>(deleted);
       unexpected.removeAll(this.serversToShutdown);
-      if (!unexpected.isEmpty()) {
-        if (stillManager() && !getManagerGoalState().equals(ManagerGoalState.CLEAN_STOP)) {
-          log.warn("Lost servers {}", unexpected);
-        }
+      if (!unexpected.isEmpty()
+          && (stillManager() && !getManagerGoalState().equals(ManagerGoalState.CLEAN_STOP))) {
+        log.warn("Lost servers {}", unexpected);
       }
       serversToShutdown.removeAll(deleted);
       badServers.keySet().removeAll(deleted);
@@ -1582,10 +1577,8 @@ public class Manager extends AbstractServer
 
     for (TableId tableId : Tables.getIdToNameMap(context).keySet()) {
       TableState state = manager.getTableState(tableId);
-      if (state != null) {
-        if (state == TableState.ONLINE) {
-          result.add(tableId);
-        }
+      if ((state != null) && (state == TableState.ONLINE)) {
+        result.add(tableId);
       }
     }
     return result;
@@ -1620,16 +1613,12 @@ public class Manager extends AbstractServer
   }
 
   public void assignedTablet(KeyExtent extent) {
-    if (extent.isMeta()) {
-      if (getManagerState().equals(ManagerState.UNLOAD_ROOT_TABLET)) {
-        setManagerState(ManagerState.UNLOAD_METADATA_TABLETS);
-      }
+    if (extent.isMeta() && getManagerState().equals(ManagerState.UNLOAD_ROOT_TABLET)) {
+      setManagerState(ManagerState.UNLOAD_METADATA_TABLETS);
     }
-    if (extent.isRootTablet()) {
-      // probably too late, but try anyhow
-      if (getManagerState().equals(ManagerState.STOP)) {
-        setManagerState(ManagerState.UNLOAD_ROOT_TABLET);
-      }
+    // probably too late, but try anyhow
+    if (extent.isRootTablet() && getManagerState().equals(ManagerState.STOP)) {
+      setManagerState(ManagerState.UNLOAD_ROOT_TABLET);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -572,12 +572,11 @@ public class ManagerClientServiceHandler extends FateServiceHandler
         }
 
         // Skip files that we didn't observe when we started (new files/data)
-        if (relevantLogs.contains(file)) {
-          drainLog.trace("Found file that we *do* care about {}", file);
-        } else {
+        if (!relevantLogs.contains(file)) {
           drainLog.trace("Found file that we didn't care about {}", file);
           continue;
         }
+        drainLog.trace("Found file that we *do* care about {}", file);
 
         try {
           Status stat = Status.parseFrom(entry.getValue().get());

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
@@ -65,7 +65,7 @@ public class ManagerTime {
     }
 
     ThreadPools.createGeneralScheduledExecutorService(conf).scheduleWithFixedDelay(
-        Threads.createNamedRunnable("Manager time keeper", () -> run()), 0,
+        Threads.createNamedRunnable("Manager time keeper", this::run), 0,
         MILLISECONDS.convert(10, SECONDS), MILLISECONDS);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -106,7 +106,7 @@ abstract class TabletGroupWatcher extends Thread {
   private final TabletStateStore store;
   private final TabletGroupWatcher dependentWatcher;
   final TableStats stats = new TableStats();
-  private SortedSet<TServerInstance> lastScanServers = ImmutableSortedSet.of();
+  private SortedSet<TServerInstance> lastScanServers = Collections.emptySortedSet();
 
   TabletGroupWatcher(Manager manager, TabletStateStore store, TabletGroupWatcher dependentWatcher) {
     this.manager = manager;
@@ -198,7 +198,7 @@ abstract class TabletGroupWatcher extends Thread {
         if (currentTServers.isEmpty()) {
           eventListener.waitForEvents(Manager.TIME_TO_WAIT_BETWEEN_SCANS);
           synchronized (this) {
-            lastScanServers = ImmutableSortedSet.of();
+            lastScanServers = Collections.emptySortedSet();
           }
           continue;
         }
@@ -254,19 +254,17 @@ abstract class TabletGroupWatcher extends Thread {
           }
 
           // if we are shutting down all the tabletservers, we have to do it in order
-          if (goal == TabletGoalState.SUSPENDED && state == TabletState.HOSTED) {
-            if (manager.serversToShutdown.equals(currentTServers.keySet())) {
-              if (dependentWatcher != null && dependentWatcher.assignedOrHosted() > 0) {
-                goal = TabletGoalState.HOSTED;
-              }
+          if ((goal == TabletGoalState.SUSPENDED && state == TabletState.HOSTED)
+              && manager.serversToShutdown.equals(currentTServers.keySet())) {
+            if (dependentWatcher != null && dependentWatcher.assignedOrHosted() > 0) {
+              goal = TabletGoalState.HOSTED;
             }
           }
 
           if (goal == TabletGoalState.HOSTED) {
-            if (state != TabletState.HOSTED && !tls.walogs.isEmpty()) {
-              if (manager.recoveryManager.recoverLogs(tls.extent, tls.walogs))
-                continue;
-            }
+            if ((state != TabletState.HOSTED && !tls.walogs.isEmpty())
+                && manager.recoveryManager.recoverLogs(tls.extent, tls.walogs))
+              continue;
             switch (state) {
               case HOSTED:
                 if (location.equals(manager.migrations.get(tls.extent)))

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/SequentialWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/SequentialWorkAssigner.java
@@ -181,7 +181,8 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
       }
 
       return true;
-    } else if (queuedWork.startsWith(path.getName())) {
+    }
+    if (queuedWork.startsWith(path.getName())) {
       log.debug("Not re-queueing work for {} as it has already been queued for replication to {}",
           path, target);
       return false;
@@ -202,9 +203,8 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
     String queuedWork = queuedWorkForPeer.get(target.getSourceTableId());
     if (queuedWork == null) {
       return Collections.emptySet();
-    } else {
-      return Collections.singleton(queuedWork);
     }
+    return Collections.singleton(queuedWork);
   }
 
   @Override
@@ -216,12 +216,11 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
     }
 
     String queuedWork = queuedWorkForPeer.get(target.getSourceTableId());
-    if (queuedWork.equals(queueKey)) {
-      queuedWorkForPeer.remove(target.getSourceTableId());
-    } else {
+    if (!queuedWork.equals(queueKey)) {
       log.warn("removeQueuedWork called on {} with differing queueKeys, expected {} but was {}",
           target, queueKey, queuedWork);
       return;
     }
+    queuedWorkForPeer.remove(target.getSourceTableId());
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/WorkDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/WorkDriver.java
@@ -44,7 +44,6 @@ public class WorkDriver implements Runnable {
   private String assignerImplName;
 
   public WorkDriver(Manager manager) {
-    super();
     this.manager = manager;
     this.client = manager.getContext();
     this.conf = manager.getConfiguration();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -92,10 +92,8 @@ public class MergeStats {
       return;
     if (info.needsToBeChopped(ke)) {
       this.needsToBeChopped++;
-      if (chopped) {
-        if (state.equals(TabletState.HOSTED) || !hasWALs) {
-          this.chopped++;
-        }
+      if (chopped && (state.equals(TabletState.HOSTED) || !hasWALs)) {
+        this.chopped++;
       }
     }
     this.total++;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
@@ -99,16 +99,15 @@ public class BulkImport extends ManagerRepo {
       return 100;
 
     Tables.clearCache(manager.getContext());
-    if (Tables.getTableState(manager.getContext(), tableId) == TableState.ONLINE) {
-      long reserve1, reserve2;
-      reserve1 = reserve2 = Utils.reserveHdfsDirectory(manager, sourceDir, tid);
-      if (reserve1 == 0)
-        reserve2 = Utils.reserveHdfsDirectory(manager, errorDir, tid);
-      return reserve2;
-    } else {
+    if (Tables.getTableState(manager.getContext(), tableId) != TableState.ONLINE) {
       throw new AcceptableThriftTableOperationException(tableId.canonical(), null,
           TableOperation.BULK_IMPORT, TableOperationExceptionType.OFFLINE, null);
     }
+    long reserve1, reserve2;
+    reserve1 = reserve2 = Utils.reserveHdfsDirectory(manager, sourceDir, tid);
+    if (reserve1 == 0)
+      reserve2 = Utils.reserveHdfsDirectory(manager, errorDir, tid);
+    return reserve2;
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
@@ -217,9 +217,8 @@ class LoadFiles extends ManagerRepo {
       if (i >= max) {
         result.append("...");
         break;
-      } else {
-        result.append(", ");
       }
+      result.append(", ");
       i++;
     }
     if (i < max)

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -108,9 +108,8 @@ class LoadFiles extends ManagerRepo {
   public Repo<Manager> call(final long tid, final Manager manager) {
     if (bulkInfo.tableState == TableState.ONLINE) {
       return new CompleteBulkImport(bulkInfo);
-    } else {
-      return new CleanUpBulkImport(bulkInfo);
     }
+    return new CleanUpBulkImport(bulkInfo);
   }
 
   private abstract static class Loader {
@@ -208,13 +207,12 @@ class LoadFiles extends ManagerRepo {
         // ideally there should only be one tablet location to send all the files
 
         TabletMetadata.Location location = tablet.getLocation();
-        HostAndPort server = null;
+        HostAndPort server;
         if (location == null) {
           locationLess++;
           continue;
-        } else {
-          server = location.getHostAndPort();
         }
+        server = location.getHostAndPort();
 
         Set<TabletFile> loadedFiles = tablet.getLoaded().keySet();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -74,11 +74,10 @@ public class CancelCompactions extends ManagerRepo {
         log.debug("{} setting cancel compaction id to {} for {}", FateTxId.formatTid(tid), flushID,
             tableId);
         return Long.toString(flushID).getBytes(UTF_8);
-      } else {
-        log.debug("{} leaving cancel compaction id as {} for {}", FateTxId.formatTid(tid), cid,
-            tableId);
-        return Long.toString(cid).getBytes(UTF_8);
       }
+      log.debug("{} leaving cancel compaction id as {} for {}", FateTxId.formatTid(tid), cid,
+          tableId);
+      return Long.toString(cid).getBytes(UTF_8);
     });
 
     return new FinishCancelCompaction(namespaceId, tableId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/CleanUp.java
@@ -182,12 +182,11 @@ class CleanUp extends ManagerRepo {
       } catch (IOException e) {
         log.error("Unable to remove deleted table directory", e);
       } catch (IllegalArgumentException exception) {
-        if (exception.getCause() instanceof UnknownHostException) {
-          /* Thrown if HDFS encounters a DNS problem in some edge cases */
-          log.error("Unable to remove deleted table directory", exception);
-        } else {
+        if (!(exception.getCause() instanceof UnknownHostException)) {
           throw exception;
         }
+        /* Thrown if HDFS encounters a DNS problem in some edge cases */
+        log.error("Unable to remove deleted table directory", exception);
       }
     }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableExport/WriteExportFiles.java
@@ -275,11 +275,10 @@ class WriteExportFiles extends ManagerRepo {
       if (prop.getKey().startsWith(Property.TABLE_PREFIX.getKey())) {
         Property key = Property.getPropertyByKey(prop.getKey());
 
-        if (key == null || !defaultConfig.get(key).equals(prop.getValue())) {
-          if (!prop.getValue().equals(siteConfig.get(prop.getKey()))
-              && !prop.getValue().equals(systemConfig.get(prop.getKey()))) {
-            osw.append(prop.getKey() + "=" + prop.getValue() + "\n");
-          }
+        if ((key == null || !defaultConfig.get(key).equals(prop.getValue()))
+            && (!prop.getValue().equals(siteConfig.get(prop.getKey()))
+                && !prop.getValue().equals(systemConfig.get(prop.getKey())))) {
+          osw.append(prop.getKey() + "=" + prop.getValue() + "\n");
         }
       }
     }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -80,7 +80,7 @@ public class PrepBulkImportTest {
   }
 
   Iterable<List<KeyExtent>> powerSet(KeyExtent... extents) {
-    Set<Set<KeyExtent>> powerSet = Sets.powerSet(Set.copyOf(Arrays.asList(extents)));
+    Set<Set<KeyExtent>> powerSet = Sets.powerSet(Set.of(extents));
 
     return Iterables.transform(powerSet, set -> {
       List<KeyExtent> list = new ArrayList<>(set);

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/RootFilesUpgradeTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/RootFilesUpgradeTest.java
@@ -148,9 +148,7 @@ public class RootFilesUpgradeTest {
         }
       }
 
-      HashSet<String> expected = new HashSet<>();
-      expected.addAll(Arrays.asList(files));
-
+      HashSet<String> expected = new HashSet<>(Arrays.asList(files));
       assertEquals(expected, actual);
     }
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -63,45 +63,44 @@ public class EmbeddedWebServer {
   private static AbstractConnectionFactory[] getConnectionFactories(AccumuloConfiguration conf,
       boolean secure) {
     HttpConnectionFactory httpFactory = new HttpConnectionFactory();
-    if (secure) {
-      LOG.debug("Configuring Jetty to use TLS");
-      final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-      // If the key password is the same as the keystore password, we don't
-      // have to explicitly set it. Thus, if the user doesn't provide a key
-      // password, don't set anything.
-      final String keyPass = conf.get(Property.MONITOR_SSL_KEYPASS);
-      if (!Property.MONITOR_SSL_KEYPASS.getDefaultValue().equals(keyPass)) {
-        sslContextFactory.setKeyManagerPassword(keyPass);
-      }
-      sslContextFactory.setKeyStorePath(conf.get(Property.MONITOR_SSL_KEYSTORE));
-      sslContextFactory.setKeyStorePassword(conf.get(Property.MONITOR_SSL_KEYSTOREPASS));
-      sslContextFactory.setKeyStoreType(conf.get(Property.MONITOR_SSL_KEYSTORETYPE));
-      sslContextFactory.setTrustStorePath(conf.get(Property.MONITOR_SSL_TRUSTSTORE));
-      sslContextFactory.setTrustStorePassword(conf.get(Property.MONITOR_SSL_TRUSTSTOREPASS));
-      sslContextFactory.setTrustStoreType(conf.get(Property.MONITOR_SSL_TRUSTSTORETYPE));
-
-      final String includedCiphers = conf.get(Property.MONITOR_SSL_INCLUDE_CIPHERS);
-      if (!Property.MONITOR_SSL_INCLUDE_CIPHERS.getDefaultValue().equals(includedCiphers)) {
-        sslContextFactory.setIncludeCipherSuites(includedCiphers.split(","));
-      }
-
-      final String excludedCiphers = conf.get(Property.MONITOR_SSL_EXCLUDE_CIPHERS);
-      if (!Property.MONITOR_SSL_EXCLUDE_CIPHERS.getDefaultValue().equals(excludedCiphers)) {
-        sslContextFactory.setExcludeCipherSuites(excludedCiphers.split(","));
-      }
-
-      final String includeProtocols = conf.get(Property.MONITOR_SSL_INCLUDE_PROTOCOLS);
-      if (includeProtocols != null && !includeProtocols.isEmpty()) {
-        sslContextFactory.setIncludeProtocols(includeProtocols.split(","));
-      }
-
-      SslConnectionFactory sslFactory =
-          new SslConnectionFactory(sslContextFactory, httpFactory.getProtocol());
-      return new AbstractConnectionFactory[] {sslFactory, httpFactory};
-    } else {
+    if (!secure) {
       LOG.debug("Not configuring Jetty to use TLS");
       return new AbstractConnectionFactory[] {httpFactory};
     }
+    LOG.debug("Configuring Jetty to use TLS");
+    final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+    // If the key password is the same as the keystore password, we don't
+    // have to explicitly set it. Thus, if the user doesn't provide a key
+    // password, don't set anything.
+    final String keyPass = conf.get(Property.MONITOR_SSL_KEYPASS);
+    if (!Property.MONITOR_SSL_KEYPASS.getDefaultValue().equals(keyPass)) {
+      sslContextFactory.setKeyManagerPassword(keyPass);
+    }
+    sslContextFactory.setKeyStorePath(conf.get(Property.MONITOR_SSL_KEYSTORE));
+    sslContextFactory.setKeyStorePassword(conf.get(Property.MONITOR_SSL_KEYSTOREPASS));
+    sslContextFactory.setKeyStoreType(conf.get(Property.MONITOR_SSL_KEYSTORETYPE));
+    sslContextFactory.setTrustStorePath(conf.get(Property.MONITOR_SSL_TRUSTSTORE));
+    sslContextFactory.setTrustStorePassword(conf.get(Property.MONITOR_SSL_TRUSTSTOREPASS));
+    sslContextFactory.setTrustStoreType(conf.get(Property.MONITOR_SSL_TRUSTSTORETYPE));
+
+    final String includedCiphers = conf.get(Property.MONITOR_SSL_INCLUDE_CIPHERS);
+    if (!Property.MONITOR_SSL_INCLUDE_CIPHERS.getDefaultValue().equals(includedCiphers)) {
+      sslContextFactory.setIncludeCipherSuites(includedCiphers.split(","));
+    }
+
+    final String excludedCiphers = conf.get(Property.MONITOR_SSL_EXCLUDE_CIPHERS);
+    if (!Property.MONITOR_SSL_EXCLUDE_CIPHERS.getDefaultValue().equals(excludedCiphers)) {
+      sslContextFactory.setExcludeCipherSuites(excludedCiphers.split(","));
+    }
+
+    final String includeProtocols = conf.get(Property.MONITOR_SSL_INCLUDE_PROTOCOLS);
+    if (includeProtocols != null && !includeProtocols.isEmpty()) {
+      sslContextFactory.setIncludeProtocols(includeProtocols.split(","));
+    }
+
+    SslConnectionFactory sslFactory =
+        new SslConnectionFactory(sslContextFactory, httpFactory.getProtocol());
+    return new AbstractConnectionFactory[] {sslFactory, httpFactory};
   }
 
   public void addServlet(ServletHolder restServlet, String where) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/ZooKeeperStatus.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/ZooKeeperStatus.java
@@ -65,26 +65,24 @@ public class ZooKeeperStatus implements Runnable {
 
     @Override
     public boolean equals(Object obj) {
-      return obj == this
-          || (obj != null && obj instanceof ZooKeeperState && compareTo((ZooKeeperState) obj) == 0);
+      return obj == this || (obj instanceof ZooKeeperState && compareTo((ZooKeeperState) obj) == 0);
     }
 
     @Override
     public int compareTo(ZooKeeperState other) {
       if (this == other) {
         return 0;
-      } else if (other == null) {
+      }
+      if (other == null) {
+        return 1;
+      } else if (this.keeper == other.keeper) {
+        return 0;
+      } else if (this.keeper == null) {
+        return -1;
+      } else if (other.keeper == null) {
         return 1;
       } else {
-        if (this.keeper == other.keeper) {
-          return 0;
-        } else if (this.keeper == null) {
-          return -1;
-        } else if (other.keeper == null) {
-          return 1;
-        } else {
-          return this.keeper.compareTo(other.keeper);
-        }
+        return this.keeper.compareTo(other.keeper);
       }
     }
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/logs/SanitizedLogEvent.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/logs/SanitizedLogEvent.java
@@ -58,7 +58,7 @@ public class SanitizedLogEvent {
           || type == Character.NON_SPACING_MARK || type == Character.PRIVATE_USE;
       text.append(notPrintable ? '?' : c);
     }
-    return text.toString().trim().replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">",
+    return text.toString().trim().replaceAll("&", "&amp;").replaceAll("<", "&lt;").replace(">",
         "&gt;");
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/trace/TracesResource.java
@@ -322,22 +322,20 @@ public class TracesResource {
 
     if (saslEnabled) {
       at = null;
+    } else if (loginMap.isEmpty()) {
+      Property p = Property.TRACE_PASSWORD;
+      at = new PasswordToken(conf.get(p).getBytes(UTF_8));
     } else {
-      if (loginMap.isEmpty()) {
-        Property p = Property.TRACE_PASSWORD;
-        at = new PasswordToken(conf.get(p).getBytes(UTF_8));
-      } else {
-        Properties props = new Properties();
-        int prefixLength = Property.TRACE_TOKEN_PROPERTY_PREFIX.getKey().length();
-        for (Entry<String,String> entry : loginMap.entrySet()) {
-          props.put(entry.getKey().substring(prefixLength), entry.getValue());
-        }
-
-        AuthenticationToken token = Property.createInstanceFromPropertyName(conf,
-            Property.TRACE_TOKEN_TYPE, AuthenticationToken.class, new PasswordToken());
-        token.init(props);
-        at = token;
+      Properties props = new Properties();
+      int prefixLength = Property.TRACE_TOKEN_PROPERTY_PREFIX.getKey().length();
+      for (Entry<String,String> entry : loginMap.entrySet()) {
+        props.put(entry.getKey().substring(prefixLength), entry.getValue());
       }
+
+      AuthenticationToken token = Property.createInstanceFromPropertyName(conf,
+          Property.TRACE_TOKEN_TYPE, AuthenticationToken.class, new PasswordToken());
+      token.init(props);
+      at = token;
     }
 
     java.util.Properties props = monitor.getContext().getProperties();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -166,11 +166,11 @@ public class TabletServerResource {
       return null;
     }
 
-    double splitStdDev = 0;
-    double minorStdDev = 0;
-    double minorQueueStdDev = 0;
-    double majorStdDev = 0;
-    double majorQueueStdDev = 0;
+    double splitStdDev;
+    double minorStdDev;
+    double minorQueueStdDev;
+    double majorStdDev;
+    double majorQueueStdDev;
     double currentMinorAvg = 0;
     double currentMajorAvg = 0;
     double currentMinorStdDev = 0;

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceDump.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceDump.java
@@ -132,13 +132,10 @@ public class TraceDump {
     out.print("Time  Start  Service@Location       Name");
 
     final long finalStart = start;
-    Set<Long> visited = tree.visit(new SpanTreeVisitor() {
-      @Override
-      public void visit(int level, RemoteSpan node) {
-        String fmt = "%5d+%-5d %" + (level * 2 + 1) + "s%s@%s %s";
-        out.print(String.format(fmt, node.stop - node.start, node.start - finalStart, "", node.svc,
-            node.sender, node.description));
-      }
+    Set<Long> visited = tree.visit((level, node) -> {
+      String fmt = "%5d+%-5d %" + (level * 2 + 1) + "s%s@%s %s";
+      out.print(String.format(fmt, node.stop - node.start, node.start - finalStart, "", node.svc,
+          node.sender, node.description));
     });
     tree.nodes.keySet().removeAll(visited);
     if (!tree.nodes.isEmpty()) {

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -313,11 +313,9 @@ public class TraceServer implements Watcher, AutoCloseable {
       final BatchWriter writer = this.writer.get();
       if (writer != null) {
         writer.flush();
-      } else {
-        // We don't have a writer. If the table exists, try to make a new writer.
-        if (accumuloClient.tableOperations().exists(tableName)) {
-          resetWriter();
-        }
+      } else // We don't have a writer. If the table exists, try to make a new writer.
+      if (accumuloClient.tableOperations().exists(tableName)) {
+        resetWriter();
       }
     } catch (MutationsRejectedException | RuntimeException exception) {
       log.warn("Problem flushing traces, resetting writer. Set log level to"

--- a/server/tracer/src/test/java/org/apache/accumulo/tracer/TracerTest.java
+++ b/server/tracer/src/test/java/org/apache/accumulo/tracer/TracerTest.java
@@ -59,7 +59,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class TracerTest {
   static class SpanStruct {
     public SpanStruct(long start, long stop, String description) {
-      super();
       this.start = start;
       this.stop = stop;
       this.description = description;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -313,13 +313,7 @@ public class FileManager {
         ProblemReports.getInstance(context)
             .report(new ProblemReport(tablet.tableId(), ProblemType.FILE_READ, file, e));
 
-        if (continueOnFailure) {
-          // release the permit for the file that failed to open
-          if (!tablet.isMeta()) {
-            filePermits.release(1);
-          }
-          log.warn("Failed to open file {} {} continuing...", file, e.getMessage(), e);
-        } else {
+        if (!continueOnFailure) {
           // close whatever files were opened
           closeReaders(readersReserved.keySet());
 
@@ -330,6 +324,11 @@ public class FileManager {
           log.error("Failed to open file {} {}", file, e.getMessage());
           throw new IOException("Failed to open " + file, e);
         }
+        // release the permit for the file that failed to open
+        if (!tablet.isMeta()) {
+          filePermits.release(1);
+        }
+        log.warn("Failed to open file {} {} continuing...", file, e.getMessage(), e);
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -213,16 +213,14 @@ public class InMemoryMap {
     public InterruptibleIterator skvIterator(SamplerConfigurationImpl samplerConfig) {
       if (samplerConfig == null)
         return map.skvIterator(null);
-      else {
-        Pair<SamplerConfigurationImpl,Sampler> samplerAndConf = samplerRef.get();
-        if (samplerAndConf == null) {
-          return EmptyIterator.EMPTY_ITERATOR;
-        } else if (samplerAndConf.getFirst() != null
-            && samplerAndConf.getFirst().equals(samplerConfig)) {
-          return sample.skvIterator(null);
-        } else {
-          throw new SampleNotPresentException();
-        }
+      Pair<SamplerConfigurationImpl,Sampler> samplerAndConf = samplerRef.get();
+      if (samplerAndConf == null) {
+        return EmptyIterator.EMPTY_ITERATOR;
+      } else if (samplerAndConf.getFirst() != null
+          && samplerAndConf.getFirst().equals(samplerConfig)) {
+        return sample.skvIterator(null);
+      } else {
+        throw new SampleNotPresentException();
       }
     }
 
@@ -528,14 +526,13 @@ public class InMemoryMap {
     private SamplerConfigurationImpl iteratorSamplerConfig;
 
     private SamplerConfigurationImpl getSamplerConfig() {
-      if (env != null) {
-        if (env.isSamplingEnabled()) {
-          return new SamplerConfigurationImpl(env.getSamplerConfiguration());
-        } else {
-          return null;
-        }
-      } else {
+      if (env == null) {
         return iteratorSamplerConfig;
+      }
+      if (env.isSamplingEnabled()) {
+        return new SamplerConfigurationImpl(env.getSamplerConfiguration());
+      } else {
+        return null;
       }
     }
 
@@ -556,8 +553,7 @@ public class InMemoryMap {
     public boolean isCurrent() {
       if (switched)
         return true;
-      else
-        return memDumpFile == null;
+      return memDumpFile == null;
     }
 
     @Override
@@ -605,18 +601,16 @@ public class InMemoryMap {
           iter = map.skvIterator(getSamplerConfig());
           if (iflag != null)
             iter.setInterruptFlag(iflag);
-        } else {
-          if (parent == null)
-            iter = new MemKeyConversionIterator(getReader());
-          else
-            synchronized (parent) {
-              // synchronize deep copy operation on parent, this prevents multiple threads from deep
-              // copying the rfile shared from parent its possible that the
-              // thread deleting an InMemoryMap and scan thread could be switching different deep
-              // copies
-              iter = new MemKeyConversionIterator(parent.getReader().deepCopy(env));
-            }
-        }
+        } else if (parent == null)
+          iter = new MemKeyConversionIterator(getReader());
+        else
+          synchronized (parent) {
+            // synchronize deep copy operation on parent, this prevents multiple threads from deep
+            // copying the rfile shared from parent its possible that the
+            // thread deleting an InMemoryMap and scan thread could be switching different deep
+            // copies
+            iter = new MemKeyConversionIterator(parent.getReader().deepCopy(env));
+          }
 
       return iter;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/MemKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/MemKey.java
@@ -38,7 +38,6 @@ public class MemKey extends Key {
   }
 
   public MemKey() {
-    super();
     this.kvCount = Integer.MAX_VALUE;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/MemKeyConversionIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/MemKeyConversionIterator.java
@@ -36,7 +36,6 @@ class MemKeyConversionIterator extends WrappingIterator implements Interruptible
   private Value currVal = null;
 
   public MemKeyConversionIterator(SortedKeyValueIterator<Key,Value> source) {
-    super();
     setSource(source);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -246,13 +246,12 @@ public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
   }
 
   private static synchronized void deleteNativeMap(long nmPtr) {
-    if (allocatedNativeMaps.contains(nmPtr)) {
-      deleteNM(nmPtr);
-      allocatedNativeMaps.remove(nmPtr);
-    } else {
+    if (!allocatedNativeMaps.contains(nmPtr)) {
       throw new RuntimeException(
           String.format("Attempt to delete native map that is not allocated 0x%016x ", nmPtr));
     }
+    deleteNM(nmPtr);
+    allocatedNativeMaps.remove(nmPtr);
   }
 
   // package private visibility for NativeMapCleanerUtil use,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/OnlineTablets.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/OnlineTablets.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
+import java.util.Collections;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -32,7 +33,7 @@ import com.google.common.collect.ImmutableSortedMap;
  * threads can access the snapshot without interfering with each other.
  */
 public class OnlineTablets {
-  private volatile ImmutableSortedMap<KeyExtent,Tablet> snapshot = ImmutableSortedMap.of();
+  private volatile SortedMap<KeyExtent,Tablet> snapshot = Collections.emptySortedMap();
   private final SortedMap<KeyExtent,Tablet> onlineTablets = new TreeMap<>();
 
   public synchronized void put(KeyExtent ke, Tablet t) {
@@ -52,7 +53,7 @@ public class OnlineTablets {
     snapshot = ImmutableSortedMap.copyOf(onlineTablets);
   }
 
-  ImmutableSortedMap<KeyExtent,Tablet> snapshot() {
+  SortedMap<KeyExtent,Tablet> snapshot() {
     return snapshot;
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TservConstraintEnv.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TservConstraintEnv.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.tserver;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
-import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.security.AuthorizationContainer;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
@@ -58,13 +57,8 @@ public class TservConstraintEnv implements SystemEnvironment {
 
   @Override
   public AuthorizationContainer getAuthorizationsContainer() {
-    return new AuthorizationContainer() {
-      @Override
-      public boolean contains(ByteSequence auth) {
-        return security.authenticatedUserHasAuthorizations(credentials, Collections
-            .singletonList(ByteBuffer.wrap(auth.getBackingArray(), auth.offset(), auth.length())));
-      }
-    };
+    return auth -> security.authenticatedUserHasAuthorizations(credentials, Collections
+        .singletonList(ByteBuffer.wrap(auth.getBackingArray(), auth.offset(), auth.length())));
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategy.java
@@ -155,7 +155,6 @@ public class DefaultCompactionStrategy extends CompactionStrategy {
     public long size;
 
     public CompactionFile(StoredTabletFile file, long size) {
-      super();
       this.file = file;
       this.size = size;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategy.java
@@ -72,37 +72,35 @@ public class ConfigurableCompactionStrategy implements CompactionSelector, Compa
 
       if (configs.isEmpty()) {
         return Set.of();
-      } else {
-        Set<CompactableFile> filesToCompact = new HashSet<>();
-        Set<SummarizerConfiguration> configsSet = configs instanceof Set
-            ? (Set<SummarizerConfiguration>) configs : new HashSet<>(configs);
+      }
+      Set<CompactableFile> filesToCompact = new HashSet<>();
+      Set<SummarizerConfiguration> configsSet =
+          configs instanceof Set ? (Set<SummarizerConfiguration>) configs : new HashSet<>(configs);
 
-        for (CompactableFile tabletFile : params.getAvailableFiles()) {
-          Map<SummarizerConfiguration,Summary> sMap = new HashMap<>();
-          Collection<Summary> summaries;
-          summaries =
-              params.getSummaries(Collections.singletonList(tabletFile), configsSet::contains);
-          for (Summary summary : summaries) {
-            sMap.put(summary.getSummarizerConfiguration(), summary);
+      for (CompactableFile tabletFile : params.getAvailableFiles()) {
+        Map<SummarizerConfiguration,Summary> sMap = new HashMap<>();
+        Collection<Summary> summaries;
+        summaries =
+            params.getSummaries(Collections.singletonList(tabletFile), configsSet::contains);
+        for (Summary summary : summaries) {
+          sMap.put(summary.getSummarizerConfiguration(), summary);
+        }
+
+        for (SummarizerConfiguration sc : configs) {
+          Summary summary = sMap.get(sc);
+
+          if (summary == null && selectNoSummary) {
+            filesToCompact.add(tabletFile);
+            break;
           }
 
-          for (SummarizerConfiguration sc : configs) {
-            Summary summary = sMap.get(sc);
-
-            if (summary == null && selectNoSummary) {
-              filesToCompact.add(tabletFile);
-              break;
-            }
-
-            if (summary != null && summary.getFileStatistics().getExtra() > 0
-                && selectExtraSummary) {
-              filesToCompact.add(tabletFile);
-              break;
-            }
+          if (summary != null && summary.getFileStatistics().getExtra() > 0 && selectExtraSummary) {
+            filesToCompact.add(tabletFile);
+            break;
           }
         }
-        return filesToCompact;
       }
+      return filesToCompact;
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/TooManyDeletesCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/TooManyDeletesCompactionStrategy.java
@@ -133,9 +133,8 @@ public class TooManyDeletesCompactionStrategy extends DefaultCompactionStrategy 
       // information here as its a blocking operation. Blocking operations are not allowed in
       // shouldCompact.
       return true;
-    } else {
-      return super.shouldCompact(request);
     }
+    return super.shouldCompact(request);
   }
 
   @Override
@@ -161,10 +160,9 @@ public class TooManyDeletesCompactionStrategy extends DefaultCompactionStrategy 
         if (numEntries == 0 && !proceed_bns) {
           shouldCompact = false;
           return;
-        } else {
-          // no summary data so use Accumulo's estimate of total entries in file
-          total += entry.getValue().getNumEntries();
         }
+        // no summary data so use Accumulo's estimate of total entries in file
+        total += entry.getValue().getNumEntries();
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionExecutor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionExecutor.java
@@ -124,12 +124,11 @@ public class CompactionExecutor {
           if (runnable instanceof TraceRunnable) {
             runnable = ((TraceRunnable) runnable).getRunnable();
           }
-          if (runnable instanceof CompactionTask) {
-            compactionTask = (CompactionTask) runnable;
-          } else {
+          if (!(runnable instanceof CompactionTask)) {
             throw new IllegalArgumentException(
                 "Unknown runnable type " + runnable.getClass().getName());
           }
+          compactionTask = (CompactionTask) runnable;
           return compactionTask.getStatus() == Status.CANCELED;
         });
       }
@@ -156,7 +155,7 @@ public class CompactionExecutor {
     var comparator =
         Comparator.comparing(CompactionExecutor::getJob, CompactionJobPrioritizer.JOB_COMPARATOR);
 
-    queue = new PriorityBlockingQueue<Runnable>(100, comparator);
+    queue = new PriorityBlockingQueue<>(100, comparator);
 
     threadPool = ThreadPools.createThreadPool(threads, threads, 60, TimeUnit.SECONDS,
         "compaction." + ceid, queue, OptionalInt.empty(), true);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
@@ -360,18 +360,13 @@ public class CompactionManager {
 
   public void start() {
     log.debug("Started compaction manager");
-    Threads.createThread("Compaction Manager", () -> mainLoop()).start();
+    Threads.createThread("Compaction Manager", this::mainLoop).start();
   }
 
   public CompactionServices getServices() {
     var serviceIds = services.keySet();
 
-    return new CompactionServices() {
-      @Override
-      public Set<CompactionServiceId> getIds() {
-        return serviceIds;
-      }
-    };
+    return () -> serviceIds;
   }
 
   public boolean isCompactionQueued(KeyExtent extent, Set<CompactionServiceId> servicesUsed) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/PrintableTable.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/PrintableTable.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.tserver.compactions;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 public class PrintableTable {
   private String[] columns;
@@ -31,29 +32,17 @@ public class PrintableTable {
     this.data = data;
   }
 
+  @Override
   public String toString() {
     int widestRow = Arrays.asList(rows).stream().mapToInt(String::length).max().getAsInt();
 
     StringBuilder sb = new StringBuilder();
 
-    for (int i = 0; i < widestRow; i++)
-      sb.append(" ");
-
-    for (int i = 0; i < columns.length; i++) {
-      sb.append("  C");
-      sb.append(i + 1);
-      sb.append("  ");
-    }
-
+    IntStream.range(0, widestRow).forEach(i -> sb.append(" "));
+    IntStream.range(0, columns.length).forEach(i -> sb.append("  C").append(i + 1).append("  "));
     sb.append("\n");
-
-    for (int i = 0; i < widestRow; i++)
-      sb.append("-");
-
-    for (int i = 0; i < columns.length; i++) {
-      sb.append(" ---- ");
-    }
-
+    IntStream.range(0, widestRow).forEach(i -> sb.append("-"));
+    IntStream.range(0, columns.length).forEach(i -> sb.append(" ---- "));
     sb.append("\n");
 
     for (int r = 0; r < rows.length; r++) {
@@ -61,25 +50,20 @@ public class PrintableTable {
 
       int[] row = data[r];
 
-      for (int c = 0; c < row.length; c++) {
-        if (row[c] == 0)
+      for (int element : row) {
+        if (element == 0)
           sb.append("      ");
         else
-          sb.append(String.format(" %4d ", row[c]));
+          sb.append(String.format(" %4d ", element));
       }
       sb.append("\n");
     }
 
     sb.append("\n");
 
-    for (int i = 0; i < columns.length; i++) {
-      sb.append(" C");
-      sb.append(i + 1);
-      sb.append("='");
-      sb.append(columns[i]);
-      sb.append("'");
-    }
-
+    IntStream.range(0, columns.length).forEach(i -> {
+      sb.append(" C").append(i + 1).append("='").append(columns[i]).append("'");
+    });
     sb.append("\n");
 
     return sb.toString();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -258,7 +258,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
       if (work.exception != null) {
         if (work.exception instanceof IOException)
           throw (IOException) work.exception;
-        else if (work.exception instanceof RuntimeException)
+        if (work.exception instanceof RuntimeException)
           throw (RuntimeException) work.exception;
         else
           throw new RuntimeException(work.exception);
@@ -273,9 +273,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
     }
 
     @Override
-    public void await() {
-      return;
-    }
+    public void await() {}
   }
 
   static final LoggerOperation NO_WAIT_LOGGER_OP = new NoWaitLoggerOperation();
@@ -628,9 +626,8 @@ public class DfsLogger implements Comparable<DfsLogger> {
   static Durability maxDurability(Durability dur1, Durability dur2) {
     if (dur1.ordinal() > dur2.ordinal()) {
       return dur1;
-    } else {
-      return dur2;
     }
+    return dur2;
   }
 
   public LoggerOperation minorCompactionFinished(long seq, int tid, Durability durability)

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogReader.java
@@ -91,7 +91,7 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
 
     @Override
     public boolean equals(Object obj) {
-      return this == obj || (obj != null && obj instanceof Index && compareTo((Index) obj) == 0);
+      return this == obj || (obj instanceof Index && compareTo((Index) obj) == 0);
     }
 
     @Override
@@ -157,13 +157,12 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
     Index elt = heap.remove();
     try {
       elt.cache();
-      if (elt.cached) {
-        copy(elt.key, key);
-        copy(elt.value, val);
-        elt.cached = false;
-      } else {
+      if (!elt.cached) {
         return false;
       }
+      copy(elt.key, key);
+      copy(elt.value, val);
+      elt.cached = false;
     } finally {
       heap.add(elt);
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -153,10 +153,9 @@ public class SortedLogRecovery {
 
     if (logsThatDefineTablet.isEmpty()) {
       return new AbstractMap.SimpleEntry<>(-1, Collections.<Path>emptyList());
-    } else {
-      return Collections.max(logsThatDefineTablet.entrySet(),
-          (o1, o2) -> Integer.compare(o1.getKey(), o2.getKey()));
     }
+    return Collections.max(logsThatDefineTablet.entrySet(),
+        (o1, o2) -> Integer.compare(o1.getKey(), o2.getKey()));
   }
 
   private String getPathSuffix(String pathString) {
@@ -296,10 +295,9 @@ public class SortedLogRecovery {
     if (tabletId == -1) {
       log.info("Tablet {} is not defined in recovery logs {} ", extent, asNames(recoveryLogs));
       return;
-    } else {
-      log.info("Found {} of {} logs with max id {} for tablet {}", logsThatDefineTablet.size(),
-          recoveryLogs.size(), tabletId, extent);
     }
+    log.info("Found {} of {} logs with max id {} for tablet {}", logsThatDefineTablet.size(),
+        recoveryLogs.size(), tabletId, extent);
 
     // Find the seq # for the last compaction that started and finished
     long recoverySeq = findRecoverySeq(logsThatDefineTablet, tabletFiles, tabletId);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogReader.java
@@ -142,38 +142,36 @@ public class LogReader {
 
     if (ke != null) {
       if (key.event == LogEvents.DEFINE_TABLET) {
-        if (key.tablet.equals(ke)) {
-          tabletIds.add(key.tabletId);
-        } else {
+        if (!key.tablet.equals(ke)) {
           return;
         }
+        tabletIds.add(key.tabletId);
       } else if (!tabletIds.contains(key.tabletId)) {
         return;
       }
     }
 
     if (row != null || rowMatcher != null) {
-      if (key.event == LogEvents.MUTATION || key.event == LogEvents.MANY_MUTATIONS) {
-        boolean found = false;
-        for (Mutation m : value.mutations) {
-          if (row != null && new Text(m.getRow()).equals(row)) {
+      if ((key.event != LogEvents.MUTATION) && (key.event != LogEvents.MANY_MUTATIONS)) {
+        return;
+      }
+      boolean found = false;
+      for (Mutation m : value.mutations) {
+        if (row != null && new Text(m.getRow()).equals(row)) {
+          found = true;
+          break;
+        }
+
+        if (rowMatcher != null) {
+          rowMatcher.reset(new String(m.getRow(), UTF_8));
+          if (rowMatcher.matches()) {
             found = true;
             break;
           }
-
-          if (rowMatcher != null) {
-            rowMatcher.reset(new String(m.getRow(), UTF_8));
-            if (rowMatcher.matches()) {
-              found = true;
-              break;
-            }
-          }
         }
+      }
 
-        if (!found) {
-          return;
-        }
-      } else {
+      if (!found) {
         return;
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManager.java
@@ -83,18 +83,17 @@ public class LargestFirstMemoryManager {
     }
 
     public boolean put(Long key, TabletInfo value) {
-      if (map.size() == max) {
-        if (key.compareTo(map.firstKey()) < 0)
-          return false;
-        try {
-          add(key, value);
-          return true;
-        } finally {
-          map.remove(map.firstKey());
-        }
-      } else {
+      if (map.size() != max) {
         add(key, value);
         return true;
+      }
+      if (key.compareTo(map.firstKey()) < 0)
+        return false;
+      try {
+        add(key, value);
+        return true;
+      } finally {
+        map.remove(map.firstKey());
       }
     }
 
@@ -193,7 +192,7 @@ public class LargestFirstMemoryManager {
           }
         } catch (IllegalArgumentException e) {
           Throwable cause = e.getCause();
-          if (cause != null && cause instanceof TableNotFoundException) {
+          if (cause instanceof TableNotFoundException) {
             log.trace("Ignoring extent for deleted table: {}", tablet);
 
             // The table might have been deleted during the iteration of the tablets

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/scan/LookupTask.java
@@ -132,15 +132,13 @@ public class LookupTask extends ScanTask<MultiScanResult> {
 
         if (lookupResult.unfinishedRanges.isEmpty()) {
           fullScans.add(entry.getKey());
+        } else if (lookupResult.closed) {
+          failures.put(entry.getKey(), lookupResult.unfinishedRanges);
         } else {
-          if (lookupResult.closed) {
-            failures.put(entry.getKey(), lookupResult.unfinishedRanges);
-          } else {
-            session.queries.put(entry.getKey(), lookupResult.unfinishedRanges);
-            partScan = entry.getKey();
-            partNextKey = lookupResult.unfinishedRanges.get(0).getStartKey();
-            partNextKeyInclusive = lookupResult.unfinishedRanges.get(0).isStartKeyInclusive();
-          }
+          session.queries.put(entry.getKey(), lookupResult.unfinishedRanges);
+          partScan = entry.getKey();
+          partNextKey = lookupResult.unfinishedRanges.get(0).getStartKey();
+          partNextKeyInclusive = lookupResult.unfinishedRanges.get(0).isStartKeyInclusive();
         }
       }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -382,13 +382,11 @@ public class CompactableUtils {
       if (cselCfg2 != null) {
         filesToDrop = Set.of();
         return CompactableUtils.selectFiles(tablet, allFiles, cselCfg2);
-      } else {
-        var plan =
-            CompactableUtils.selectFiles(CompactionKind.SELECTOR, tablet, allFiles, stratCfg2);
-        this.wp = plan.writeParameters;
-        filesToDrop = Set.copyOf(plan.deleteFiles);
-        return Set.copyOf(plan.inputFiles);
       }
+      var plan = CompactableUtils.selectFiles(CompactionKind.SELECTOR, tablet, allFiles, stratCfg2);
+      this.wp = plan.writeParameters;
+      filesToDrop = Set.copyOf(plan.deleteFiles);
+      return Set.copyOf(plan.inputFiles);
     }
 
     @Override
@@ -455,7 +453,8 @@ public class CompactableUtils {
     public AccumuloConfiguration override(AccumuloConfiguration conf, Set<CompactableFile> files) {
       if (!UserCompactionUtils.isDefault(compactionConfig.getConfigurer())) {
         return createCompactionConfiguration(tablet, files, compactionConfig.getConfigurer());
-      } else if (!CompactionStrategyConfigUtil.isDefault(compactionConfig.getCompactionStrategy())
+      }
+      if (!CompactionStrategyConfigUtil.isDefault(compactionConfig.getCompactionStrategy())
           && wp != null) {
         return createCompactionConfiguration(conf, wp);
       }
@@ -474,7 +473,8 @@ public class CompactableUtils {
       CompactionConfig compactionConfig) {
     if (kind == CompactionKind.USER) {
       return new UserCompactionHelper(compactionConfig, tablet, compactionId);
-    } else if (kind == CompactionKind.SELECTOR) {
+    }
+    if (kind == CompactionKind.SELECTOR) {
       var tconf = tablet.getTableConfiguration();
       var selectorClassName = tconf.get(Property.TABLE_COMPACTION_SELECTOR);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Compactor.java
@@ -238,10 +238,8 @@ public class Compactor implements Callable<CompactionStats> {
       try {
         mfwTmp.close(); // if the close fails it will cause the compaction to fail
       } catch (IOException ex) {
-        if (!fs.deleteRecursively(outputFile.getPath())) {
-          if (fs.exists(outputFile.getPath())) {
-            log.error("Unable to delete {}", outputFile);
-          }
+        if (!fs.deleteRecursively(outputFile.getPath()) && fs.exists(outputFile.getPath())) {
+          log.error("Unable to delete {}", outputFile);
         }
         throw ex;
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Scanner.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Scanner.java
@@ -110,7 +110,8 @@ public class Scanner {
       if (results.getResults() == null) {
         range = null;
         return new ScanBatch(new ArrayList<>(), false);
-      } else if (results.getContinueKey() == null) {
+      }
+      if (results.getContinueKey() == null) {
         return new ScanBatch(results.getResults(), false);
       } else {
         range = new Range(results.getContinueKey(), !results.isSkipContinueKey(), range.getEndKey(),
@@ -122,8 +123,7 @@ public class Scanner {
       sawException = true;
       if (tablet.isClosed())
         throw new TabletClosedException(iie);
-      else
-        throw iie;
+      throw iie;
     } catch (IOException ioe) {
       if (ShutdownUtil.isShutdownInProgress()) {
         log.debug("IOException while shutdown in progress ", ioe);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletClosedException.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletClosedException.java
@@ -23,9 +23,7 @@ public class TabletClosedException extends RuntimeException {
     super(e);
   }
 
-  public TabletClosedException() {
-    super();
-  }
+  public TabletClosedException() {}
 
   private static final long serialVersionUID = 1L;
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -181,10 +181,10 @@ public class InMemoryMapTest {
     mutate(imm, "r1", "foo:cq1", 3, "bar1");
     MemoryIterator ski2 = imm.skvIterator(null);
 
-    ski1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(), Set.of(), false);
     assertFalse(ski1.hasTop());
 
-    ski2.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski2.seek(new Range(), Set.of(), false);
     assertTrue(ski2.hasTop());
     testAndCallNext(ski2, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski2.hasTop());
@@ -205,12 +205,12 @@ public class InMemoryMapTest {
 
     MemoryIterator ski2 = imm.skvIterator(null);
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
-    ski2.seek(new Range(new Text("r3")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski2.seek(new Range(new Text("r3")), Set.of(), false);
     testAndCallNext(ski2, "r3", "foo:cq1", 3, "bara");
     testAndCallNext(ski2, "r3", "foo:cq1", 3, "bar9");
     assertFalse(ski1.hasTop());
@@ -228,20 +228,20 @@ public class InMemoryMapTest {
 
     imm.delete(0);
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(new Text("r2")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r2")), Set.of(), false);
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
@@ -259,9 +259,9 @@ public class InMemoryMapTest {
 
     imm.delete(0);
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     assertEqualsNoNext(ski1, "r1", "foo:cq1", 3, "");
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "");
     assertFalse(ski1.hasTop());
 
@@ -277,7 +277,7 @@ public class InMemoryMapTest {
     mutate(imm, "r1", "foo:cq1", 3, "bar3");
 
     MemoryIterator ski1 = imm.skvIterator(null);
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar3");
 
     imm.delete(0);
@@ -295,7 +295,7 @@ public class InMemoryMapTest {
     mutate(imm, "r1", "foo:cq3", 3, "bar3");
 
     ski1 = imm.skvIterator(null);
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
 
     imm.delete(0);
@@ -322,10 +322,10 @@ public class InMemoryMapTest {
 
     SortedKeyValueIterator<Key,Value> dc = ski1.deepCopy(new SampleIE());
 
-    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
 
-    dc.seek(new Range(newKey("r1", "foo:cq2", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(newKey("r1", "foo:cq2", 3), null), Set.of(), false);
     testAndCallNext(dc, "r1", "foo:cq2", 3, "bar2");
 
     imm.delete(0);
@@ -338,9 +338,9 @@ public class InMemoryMapTest {
     assertFalse(ski1.hasTop());
     assertFalse(dc.hasTop());
 
-    ski1.seek(new Range(newKey("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq3", 3), null), Set.of(), false);
 
-    dc.seek(new Range(newKey("r1", "foo:cq4", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(newKey("r1", "foo:cq4", 3), null), Set.of(), false);
     testAndCallNext(dc, "r1", "foo:cq4", 3, "bar4");
     assertFalse(dc.hasTop());
 
@@ -381,8 +381,8 @@ public class InMemoryMapTest {
       }
     }
 
-    dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ski1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(), Set.of(), false);
+    ski1.seek(new Range(), Set.of(), false);
 
     if (interleaving == 3) {
       imm.delete(0);
@@ -393,7 +393,7 @@ public class InMemoryMapTest {
 
     testAndCallNext(dc, "r1", "foo:cq1", 3, "bar1");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
-    dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(), Set.of(), false);
 
     if (interleaving == 4) {
       imm.delete(0);
@@ -409,7 +409,7 @@ public class InMemoryMapTest {
     assertFalse(ski1.hasTop());
 
     if (interrupt) {
-      dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+      dc.seek(new Range(), Set.of(), false);
     }
   }
 
@@ -466,10 +466,10 @@ public class InMemoryMapTest {
 
     MemoryIterator skvi1 = imm.skvIterator(null);
 
-    skvi1.seek(new Range(newKey("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    skvi1.seek(new Range(newKey("r1", "foo:cq3", 3), null), Set.of(), false);
     testAndCallNext(skvi1, "r1", "foo:cq3", 3, "bar3");
 
-    skvi1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    skvi1.seek(new Range(newKey("r1", "foo:cq1", 3), null), Set.of(), false);
     testAndCallNext(skvi1, "r1", "foo:cq1", 3, "bar1");
 
   }
@@ -484,7 +484,7 @@ public class InMemoryMapTest {
     imm.mutate(Collections.singletonList(m), 2);
 
     MemoryIterator skvi1 = imm.skvIterator(null);
-    skvi1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    skvi1.seek(new Range(), Set.of(), false);
     testAndCallNext(skvi1, "r1", "foo:cq", 3, "v2");
     testAndCallNext(skvi1, "r1", "foo:cq", 3, "v1");
   }
@@ -713,7 +713,7 @@ public class InMemoryMapTest {
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
         RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
   }
 
   @Test(expected = SampleNotPresentException.class)
@@ -725,7 +725,7 @@ public class InMemoryMapTest {
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
         RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
   }
 
   @Test
@@ -737,7 +737,7 @@ public class InMemoryMapTest {
 
     // when in mem map is empty should be able to get sample iterator with any sample config
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
     assertFalse(iter.hasTop());
   }
 
@@ -769,24 +769,24 @@ public class InMemoryMapTest {
     }
 
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
     assertEquals(expectedSample, readAll(iter));
 
     SortedKeyValueIterator<Key,Value> dc = iter.deepCopy(new SampleIE(sampleConfig2));
-    dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(), Set.of(), false);
     assertEquals(expectedSample, readAll(dc));
 
     iter = imm.skvIterator(null);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
     assertEquals(expectedAll, readAll(iter));
 
     final MemoryIterator finalIter = imm.skvIterator(sampleConfig1);
     assertThrows(SampleNotPresentException.class,
-        () -> finalIter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false));
+        () -> finalIter.seek(new Range(), Set.of(), false));
   }
 
   private TreeMap<Key,Value> readAll(SortedKeyValueIterator<Key,Value> iter) throws IOException {
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
 
     TreeMap<Key,Value> actual = new TreeMap<>();
     while (iter.hasTop()) {
@@ -846,7 +846,7 @@ public class InMemoryMapTest {
     testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
     assertFalse(iter1.hasTop());
 
-    iter1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter1.seek(new Range(), Set.of(), false);
     assertAll(iter1);
 
     iter1.seek(new Range(), newCFSet("cf1"), false);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -50,7 +50,7 @@ public class TabletServerSyncCheckTest {
     }
   }
 
-  private class TestFileSystem extends DistributedFileSystem {
+  private static class TestFileSystem extends DistributedFileSystem {
     protected final Configuration conf;
 
     public TestFileSystem(Configuration conf) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -361,32 +361,30 @@ public class DefaultCompactionStrategyTest {
 
       DefaultCompactionStrategy s = new DefaultCompactionStrategy();
 
-      if (s.shouldCompact(request)) {
-        CompactionPlan plan = s.getCompactionPlan(request);
-
-        long totalSize = 0;
-        long totalEntries = 0;
-
-        for (StoredTabletFile fr : plan.inputFiles) {
-          DataFileValue dfv = files.remove(fr);
-
-          totalSize += dfv.getSize();
-          totalEntries += dfv.getNumEntries();
-
-          totalRead += dfv.getSize();
-        }
-
-        String name =
-            "hdfs://nn1/accumulo/tables/5/t-0001/C" + String.format("%06d", nextFile) + ".rf";
-        nextFile++;
-
-        files.put(new StoredTabletFile(name), new DataFileValue(totalSize, totalEntries));
-
-        return totalSize;
-
-      } else {
+      if (!s.shouldCompact(request)) {
         return 0;
       }
+      CompactionPlan plan = s.getCompactionPlan(request);
+
+      long totalSize = 0;
+      long totalEntries = 0;
+
+      for (StoredTabletFile fr : plan.inputFiles) {
+        DataFileValue dfv = files.remove(fr);
+
+        totalSize += dfv.getSize();
+        totalEntries += dfv.getNumEntries();
+
+        totalRead += dfv.getSize();
+      }
+
+      String name =
+          "hdfs://nn1/accumulo/tables/5/t-0001/C" + String.format("%06d", nextFile) + ".rf";
+      nextFile++;
+
+      files.put(new StoredTabletFile(name), new DataFileValue(totalSize, totalEntries));
+
+      return totalSize;
     }
 
     long getTotalRead() {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -90,8 +90,7 @@ public class SortedLogRecoveryTest {
 
     @Override
     public boolean equals(Object obj) {
-      return this == obj
-          || (obj != null && obj instanceof KeyValue && 0 == compareTo((KeyValue) obj));
+      return this == obj || (obj instanceof KeyValue && 0 == compareTo((KeyValue) obj));
     }
 
     @Override
@@ -783,8 +782,7 @@ public class SortedLogRecoveryTest {
     Map<String,KeyValue[]> logs = new TreeMap<>();
     logs.put("entries", entries);
 
-    HashSet<String> filesSet = new HashSet<>();
-    filesSet.addAll(Arrays.asList(tabletFiles));
+    HashSet<String> filesSet = new HashSet<>(Arrays.asList(tabletFiles));
     List<Mutation> mutations = recover(logs, filesSet, extent);
 
     if (startMatches) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
@@ -229,7 +229,6 @@ public class LargestFirstMemoryManagerTest {
 
     public LargestFirstMemoryManagerWithExistenceCheck(Predicate<TableId> existenceCheck,
         Predicate<TableId> deletingCheck) {
-      super();
       this.existenceCheck = existenceCheck;
       this.deletingCheck = deletingCheck;
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -349,9 +349,8 @@ public class Shell extends ShellOptions implements KeywordExecutable {
         if (password == null) {
           // User cancel, e.g. Ctrl-D pressed
           throw new ParameterException("No password or token option supplied");
-        } else {
-          token = new PasswordToken(password);
         }
+        token = new PasswordToken(password);
       }
       try {
         TraceUtil.enableClientTraces(InetAddress.getLocalHost().getHostName(), "shell",
@@ -1234,9 +1233,8 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     if (formatter == null) {
       logError("Could not load the specified formatter. Using the DefaultFormatter");
       return this.defaultFormatterClass;
-    } else {
-      return formatter;
     }
+    return formatter;
   }
 
   public void setLogErrorsToConsole() {

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellCommandException.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellCommandException.java
@@ -30,7 +30,7 @@ public class ShellCommandException extends Exception {
 
     private String description;
 
-    private ErrorCode(String description) {
+    ErrorCode(String description) {
       this.description = description;
     }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellOptionsJC.java
@@ -124,18 +124,17 @@ public class ShellOptionsJC {
     if (username == null) {
       username = getClientProperties().getProperty(ClientProperty.AUTH_PRINCIPAL.getKey());
       if (username == null || username.isEmpty()) {
-        if (ClientProperty.SASL_ENABLED.getBoolean(getClientProperties())) {
-          if (!UserGroupInformation.isSecurityEnabled()) {
-            throw new IllegalArgumentException(
-                "Kerberos security is not" + " enabled. Run with --sasl or set 'sasl.enabled' in"
-                    + " accumulo-client.properties");
-          }
-          UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-          username = ugi.getUserName();
-        } else {
+        if (!ClientProperty.SASL_ENABLED.getBoolean(getClientProperties())) {
           throw new IllegalArgumentException("Username is not set. Run with '-u"
               + " myuser' or set 'auth.principal' in accumulo-client.properties");
         }
+        if (!UserGroupInformation.isSecurityEnabled()) {
+          throw new IllegalArgumentException(
+              "Kerberos security is not" + " enabled. Run with --sasl or set 'sasl.enabled' in"
+                  + " accumulo-client.properties");
+        }
+        UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+        username = ugi.getUserName();
       }
     }
     return username;

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
@@ -23,17 +23,18 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 
+import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.hadoop.io.Text;
-
-import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -68,14 +69,10 @@ public class ShellUtil {
 
   public static Map<String,String> parseMapOpt(CommandLine cl, Option opt) {
     if (cl.hasOption(opt.getLongOpt())) {
-      var builder = ImmutableMap.<String,String>builder();
-      String[] keyVals = cl.getOptionValue(opt.getLongOpt()).split(",");
-      for (String keyVal : keyVals) {
-        String[] sa = keyVal.split("=");
-        builder.put(sa[0], sa[1]);
-      }
-
-      return builder.build();
+      return Arrays.stream(cl.getOptionValue(opt.getLongOpt()).split(",")).map(kv -> {
+        String[] sa = kv.split("=");
+        return new Pair<>(sa[0], sa[1]);
+      }).collect(Collectors.toUnmodifiableMap(Pair::getFirst, Pair::getSecond));
     } else {
       return Collections.emptyMap();
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
@@ -68,14 +68,13 @@ public class ShellUtil {
   }
 
   public static Map<String,String> parseMapOpt(CommandLine cl, Option opt) {
-    if (cl.hasOption(opt.getLongOpt())) {
-      return Arrays.stream(cl.getOptionValue(opt.getLongOpt()).split(",")).map(kv -> {
-        String[] sa = kv.split("=");
-        return new Pair<>(sa[0], sa[1]);
-      }).collect(Collectors.toUnmodifiableMap(Pair::getFirst, Pair::getSecond));
-    } else {
+    if (!cl.hasOption(opt.getLongOpt())) {
       return Collections.emptyMap();
     }
+    return Arrays.stream(cl.getOptionValue(opt.getLongOpt()).split(",")).map(kv -> {
+      String[] sa = kv.split("=");
+      return new Pair<>(sa[0], sa[1]);
+    }).collect(Collectors.toUnmodifiableMap(Pair::getFirst, Pair::getSecond));
 
   }
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/Token.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Token.java
@@ -88,10 +88,8 @@ public class Token {
           if (s.startsWith(startsWith)) {
             set.add(s);
           }
-        } else {
-          if (s.toLowerCase().startsWith(startsWith.toLowerCase())) {
-            set.add(s);
-          }
+        } else if (s.toLowerCase().startsWith(startsWith.toLowerCase())) {
+          set.add(s);
         }
       }
     }
@@ -103,10 +101,8 @@ public class Token {
       if (caseSensitive) {
         if (t.equals(match))
           return true;
-      } else {
-        if (t.equalsIgnoreCase(match))
-          return true;
-      }
+      } else if (t.equalsIgnoreCase(match))
+        return true;
     }
     return false;
   }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -153,10 +153,8 @@ public class ConfigCommand extends Command {
       }
     } else {
       // display properties
-      final TreeMap<String,String> systemConfig = new TreeMap<>();
-      systemConfig
-          .putAll(shellState.getAccumuloClient().instanceOperations().getSystemConfiguration());
-
+      final TreeMap<String,String> systemConfig = new TreeMap<>(
+          shellState.getAccumuloClient().instanceOperations().getSystemConfiguration());
       final String outputFile = cl.getOptionValue(outputFileOpt.getOpt());
       final PrintFile printFile = outputFile == null ? null : new PrintFile(outputFile);
 
@@ -246,11 +244,9 @@ public class ConfigCommand extends Command {
           }
 
         }
-        if (nspVal != null) {
-          if (!systemConfig.containsKey(key) || !sysVal.equals(nspVal)) {
-            printConfLine(output, "namespace", printed ? "   @override" : key, nspVal);
-            printed = true;
-          }
+        if ((nspVal != null) && (!systemConfig.containsKey(key) || !sysVal.equals(nspVal))) {
+          printConfLine(output, "namespace", printed ? "   @override" : key, nspVal);
+          printed = true;
         }
 
         // show per-table value only if it is different (overridden)
@@ -275,8 +271,8 @@ public class ConfigCommand extends Command {
       return true;
     }
     return cl.hasOption(filterWithValuesOpt.getOpt())
-        && !(key.contains(cl.getOptionValue(filterWithValuesOpt.getOpt()))
-            || value.contains(cl.getOptionValue(filterWithValuesOpt.getOpt())));
+        && (!key.contains(cl.getOptionValue(filterWithValuesOpt.getOpt()))
+            && !value.contains(cl.getOptionValue(filterWithValuesOpt.getOpt())));
   }
 
   private void printConfHeader(List<String> output) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateTableCommand.java
@@ -144,15 +144,14 @@ public class CreateTableCommand extends Command {
     }
 
     // Copy options if flag was set
-    if (cl.hasOption(createTableOptCopyConfig.getOpt())) {
-      if (shellState.getAccumuloClient().tableOperations().exists(tableName)) {
-        final Iterable<Entry<String,String>> configuration = shellState.getAccumuloClient()
-            .tableOperations().getProperties(cl.getOptionValue(createTableOptCopyConfig.getOpt()));
-        for (Entry<String,String> entry : configuration) {
-          if (Property.isValidTablePropertyKey(entry.getKey())) {
-            shellState.getAccumuloClient().tableOperations().setProperty(tableName, entry.getKey(),
-                entry.getValue());
-          }
+    if (cl.hasOption(createTableOptCopyConfig.getOpt())
+        && shellState.getAccumuloClient().tableOperations().exists(tableName)) {
+      final Iterable<Entry<String,String>> configuration = shellState.getAccumuloClient()
+          .tableOperations().getProperties(cl.getOptionValue(createTableOptCopyConfig.getOpt()));
+      for (Entry<String,String> entry : configuration) {
+        if (Property.isValidTablePropertyKey(entry.getKey())) {
+          shellState.getAccumuloClient().tableOperations().setProperty(tableName, entry.getKey(),
+              entry.getValue());
         }
       }
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteNamespaceCommand.java
@@ -63,7 +63,7 @@ public class DeleteNamespaceCommand extends Command {
 
   protected void doTableOp(final Shell shellState, final String namespace, boolean force)
       throws Exception {
-    boolean resetContext = false;
+    boolean resetContext;
     String currentTable = shellState.getTableName();
 
     NamespaceId namespaceId = Namespaces.getNamespaceId(shellState.getContext(), namespace);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
@@ -111,9 +111,8 @@ public class FateCommand extends Command {
   private long parseTxid(String s) {
     if (FateTxId.isFormatedTid(s)) {
       return FateTxId.fromString(s);
-    } else {
-      return Long.parseLong(s, 16);
     }
+    return Long.parseLong(s, 16);
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrantCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrantCommand.java
@@ -51,33 +51,31 @@ public class GrantCommand extends TableOperation {
 
     permission = cl.getArgs()[0].split("\\.", 2);
     if (permission[0].equalsIgnoreCase("System")) {
-      if (cl.hasOption(systemOpt.getOpt())) {
-        try {
-          shellState.getAccumuloClient().securityOperations().grantSystemPermission(user,
-              SystemPermission.valueOf(permission[1]));
-          Shell.log.debug("Granted {} the {} permission", user, permission[1]);
-        } catch (IllegalArgumentException e) {
-          throw new BadArgumentException("No such system permission", fullCommand,
-              fullCommand.indexOf(cl.getArgs()[0]));
-        }
-      } else {
+      if (!cl.hasOption(systemOpt.getOpt())) {
         throw new BadArgumentException(
             "Missing required option for granting System Permission: -s ", fullCommand,
+            fullCommand.indexOf(cl.getArgs()[0]));
+      }
+      try {
+        shellState.getAccumuloClient().securityOperations().grantSystemPermission(user,
+            SystemPermission.valueOf(permission[1]));
+        Shell.log.debug("Granted {} the {} permission", user, permission[1]);
+      } catch (IllegalArgumentException e) {
+        throw new BadArgumentException("No such system permission", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
       }
     } else if (permission[0].equalsIgnoreCase("Table")) {
       super.execute(fullCommand, cl, shellState);
     } else if (permission[0].equalsIgnoreCase("Namespace")) {
-      if (cl.hasOption(optNamespace.getOpt())) {
-        try {
-          shellState.getAccumuloClient().securityOperations().grantNamespacePermission(user,
-              cl.getOptionValue(optNamespace.getOpt()), NamespacePermission.valueOf(permission[1]));
-        } catch (IllegalArgumentException e) {
-          throw new BadArgumentException("No such namespace permission", fullCommand,
-              fullCommand.indexOf(cl.getArgs()[0]));
-        }
-      } else {
+      if (!cl.hasOption(optNamespace.getOpt())) {
         throw new BadArgumentException("No namespace specified to apply permission to", fullCommand,
+            fullCommand.indexOf(cl.getArgs()[0]));
+      }
+      try {
+        shellState.getAccumuloClient().securityOperations().grantNamespacePermission(user,
+            cl.getOptionValue(optNamespace.getOpt()), NamespacePermission.valueOf(permission[1]));
+      } catch (IllegalArgumentException e) {
+        throw new BadArgumentException("No such namespace permission", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
       }
     } else {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
@@ -42,20 +42,19 @@ public class HiddenCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws Exception {
-    if (rand.nextInt(10) == 0) {
-      shellState.getTerminal().puts(InfoCmp.Capability.bell);
-      shellState.getWriter().println();
-      shellState.getWriter()
-          .println(new String(Base64.getDecoder()
-              .decode("ICAgICAgIC4tLS4KICAgICAgLyAvXCBcCiAgICAgKCAvLS1cICkKICAgICAuPl8g"
-                  + "IF88LgogICAgLyB8ICd8ICcgXAogICAvICB8Xy58Xy4gIFwKICAvIC98ICAgIC"
-                  + "AgfFwgXAogfCB8IHwgfFwvfCB8IHwgfAogfF98IHwgfCAgfCB8IHxffAogICAg"
-                  + "IC8gIF9fICBcCiAgICAvICAvICBcICBcCiAgIC8gIC8gICAgXCAgXF8KIHwvIC"
-                  + "AvICAgICAgXCB8IHwKIHxfXy8gICAgICAgIFx8X3wK"),
-              UTF_8));
-    } else {
+    if (rand.nextInt(10) != 0) {
       throw new ShellCommandException(ErrorCode.UNRECOGNIZED_COMMAND, getName());
     }
+    shellState.getTerminal().puts(InfoCmp.Capability.bell);
+    shellState.getWriter().println();
+    shellState.getWriter()
+        .println(new String(Base64.getDecoder()
+            .decode("ICAgICAgIC4tLS4KICAgICAgLyAvXCBcCiAgICAgKCAvLS1cICkKICAgICAuPl8g"
+                + "IF88LgogICAgLyB8ICd8ICcgXAogICAvICB8Xy58Xy4gIFwKICAvIC98ICAgIC"
+                + "AgfFwgXAogfCB8IHwgfFwvfCB8IHwgfAogfF98IHwgfCAgfCB8IHxffAogICAg"
+                + "IC8gIF9fICBcCiAgICAvICAvICBcICBcCiAgIC8gIC8gICAgXCAgXF8KIHwvIC"
+                + "AvICAgICAgXCB8IHwKIHxfXy8gICAgICAgIFx8X3wK"),
+            UTF_8));
     return 0;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -349,16 +349,14 @@ public class ListTabletsCommand extends Command {
       Text t = tablet.endRow();
       if (t == null)
         return "+INF";
-      else
-        return t.toString();
+      return t.toString();
     }
 
     public String getStartRow() {
       Text t = tablet.prevEndRow();
       if (t == null)
         return "-INF";
-      else
-        return t.toString();
+      return t.toString();
     }
 
     public static final String header = String.format(

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/NamespacesCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/NamespacesCommand.java
@@ -52,8 +52,7 @@ public class NamespacesCommand extends Command {
       String id = entry.getValue();
       if (cl.hasOption(namespaceIdOption.getOpt()))
         return String.format(TablesCommand.NAME_AND_ID_FORMAT, name, id);
-      else
-        return name;
+      return name;
     });
 
     shellState.printLines(it, !cl.hasOption(disablePaginationOpt.getOpt()));

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OptUtil.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OptUtil.java
@@ -55,15 +55,14 @@ public abstract class OptUtil {
 
   public static String getNamespaceOpt(final CommandLine cl, final Shell shellState)
       throws NamespaceNotFoundException, AccumuloException, AccumuloSecurityException {
-    String namespace = null;
-    if (cl.hasOption(ShellOptions.namespaceOption)) {
-      namespace = cl.getOptionValue(ShellOptions.namespaceOption);
-      if (!shellState.getAccumuloClient().namespaceOperations().exists(namespace)) {
-        throw new NamespaceNotFoundException(namespace, namespace,
-            "specified namespace that doesn't exist");
-      }
-    } else {
+    String namespace;
+    if (!cl.hasOption(ShellOptions.namespaceOption)) {
       throw new NamespaceNotFoundException(null, null, "no namespace specified");
+    }
+    namespace = cl.getOptionValue(ShellOptions.namespaceOption);
+    if (!shellState.getAccumuloClient().namespaceOperations().exists(namespace)) {
+      throw new NamespaceNotFoundException(namespace, namespace,
+          "specified namespace that doesn't exist");
     }
     return namespace;
   }
@@ -91,12 +90,12 @@ public abstract class OptUtil {
     return namespaceOpt;
   }
 
-  public static enum AdlOpt {
+  public enum AdlOpt {
     ADD("a"), DELETE("d"), LIST("l");
 
     public final String opt;
 
-    private AdlOpt(String opt) {
+    AdlOpt(String opt) {
       this.opt = opt;
     }
   }
@@ -104,7 +103,8 @@ public abstract class OptUtil {
   public static AdlOpt getAldOpt(final CommandLine cl) {
     if (cl.hasOption(AdlOpt.ADD.opt)) {
       return AdlOpt.ADD;
-    } else if (cl.hasOption(AdlOpt.DELETE.opt)) {
+    }
+    if (cl.hasOption(AdlOpt.DELETE.opt)) {
       return AdlOpt.DELETE;
     } else {
       return AdlOpt.LIST;
@@ -138,16 +138,14 @@ public abstract class OptUtil {
   public static Text getStartRow(final CommandLine cl) throws UnsupportedEncodingException {
     if (cl.hasOption(START_ROW_OPT)) {
       return new Text(cl.getOptionValue(START_ROW_OPT).getBytes(Shell.CHARSET));
-    } else {
-      return null;
     }
+    return null;
   }
 
   public static Text getEndRow(final CommandLine cl) throws UnsupportedEncodingException {
     if (cl.hasOption(END_ROW_OPT)) {
       return new Text(cl.getOptionValue(END_ROW_OPT).getBytes(Shell.CHARSET));
-    } else {
-      return null;
     }
+    return null;
   }
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/PasswdCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/PasswdCommand.java
@@ -42,9 +42,9 @@ public class PasswdCommand extends Command {
     final String currentUser = shellState.getAccumuloClient().whoami();
     final String user = cl.getOptionValue(userOpt.getOpt(), currentUser);
 
-    String password = null;
-    String passwordConfirm = null;
-    String oldPassword = null;
+    String password;
+    String passwordConfirm;
+    String oldPassword;
 
     oldPassword =
         shellState.readMaskedLine("Enter current password for '" + currentUser + "': ", '*');

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/QuotedStringTokenizer.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/QuotedStringTokenizer.java
@@ -108,28 +108,27 @@ public class QuotedStringTokenizer implements Iterable<String> {
         } else {
           token[tokenLength++] = inputBytes[i];
         }
-      } else {
-        // not in a quote, either enter a quote, end a token, start escape, or continue a token
-        if (ch == '\'' || ch == '"') {
-          if (tokenLength > 0) {
-            tokens.add(new String(token, 0, tokenLength, Shell.CHARSET));
-            tokenLength = 0;
-          }
-          inQuote = true;
-          inQuoteChar = ch;
-        } else if (ch == ' ' && tokenLength > 0) {
+      } else // not in a quote, either enter a quote, end a token, start escape, or continue a token
+      if (ch == '\'' || ch == '"') {
+        if (tokenLength > 0) {
           tokens.add(new String(token, 0, tokenLength, Shell.CHARSET));
           tokenLength = 0;
-        } else if (ch == '\\') {
-          inEscapeSequence = true;
-        } else if (ch != ' ') {
-          token[tokenLength++] = inputBytes[i];
         }
+        inQuote = true;
+        inQuoteChar = ch;
+      } else if (ch == ' ' && tokenLength > 0) {
+        tokens.add(new String(token, 0, tokenLength, Shell.CHARSET));
+        tokenLength = 0;
+      } else if (ch == '\\') {
+        inEscapeSequence = true;
+      } else if (ch != ' ') {
+        token[tokenLength++] = inputBytes[i];
       }
     }
     if (inQuote) {
       throw new BadArgumentException("missing terminating quote", input, input.length());
-    } else if (inEscapeSequence || hexChars != null) {
+    }
+    if (inEscapeSequence || hexChars != null) {
       throw new BadArgumentException("escape sequence not complete", input, input.length());
     }
     if (tokenLength > 0) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/RevokeCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/RevokeCommand.java
@@ -51,33 +51,31 @@ public class RevokeCommand extends TableOperation {
 
     permission = cl.getArgs()[0].split("\\.", 2);
     if (permission[0].equalsIgnoreCase("System")) {
-      if (cl.hasOption(systemOpt.getOpt())) {
-        try {
-          shellState.getAccumuloClient().securityOperations().revokeSystemPermission(user,
-              SystemPermission.valueOf(permission[1]));
-          Shell.log.debug("Revoked from {} the {} permission", user, permission[1]);
-        } catch (IllegalArgumentException e) {
-          throw new BadArgumentException("No such system permission", fullCommand,
-              fullCommand.indexOf(cl.getArgs()[0]));
-        }
-      } else {
+      if (!cl.hasOption(systemOpt.getOpt())) {
         throw new BadArgumentException(
             "Missing required option for granting System Permission: -s ", fullCommand,
+            fullCommand.indexOf(cl.getArgs()[0]));
+      }
+      try {
+        shellState.getAccumuloClient().securityOperations().revokeSystemPermission(user,
+            SystemPermission.valueOf(permission[1]));
+        Shell.log.debug("Revoked from {} the {} permission", user, permission[1]);
+      } catch (IllegalArgumentException e) {
+        throw new BadArgumentException("No such system permission", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
       }
     } else if (permission[0].equalsIgnoreCase("Table")) {
       super.execute(fullCommand, cl, shellState);
     } else if (permission[0].equalsIgnoreCase("Namespace")) {
-      if (cl.hasOption(optNamespace.getOpt())) {
-        try {
-          shellState.getAccumuloClient().securityOperations().revokeNamespacePermission(user,
-              cl.getOptionValue(optNamespace.getOpt()), NamespacePermission.valueOf(permission[1]));
-        } catch (IllegalArgumentException e) {
-          throw new BadArgumentException("No such namespace permission", fullCommand,
-              fullCommand.indexOf(cl.getArgs()[0]));
-        }
-      } else {
+      if (!cl.hasOption(optNamespace.getOpt())) {
         throw new BadArgumentException("No namespace specified to apply permission to", fullCommand,
+            fullCommand.indexOf(cl.getArgs()[0]));
+      }
+      try {
+        shellState.getAccumuloClient().securityOperations().revokeNamespacePermission(user,
+            cl.getOptionValue(optNamespace.getOpt()), NamespacePermission.valueOf(permission[1]));
+      } catch (IllegalArgumentException e) {
+        throw new BadArgumentException("No such namespace permission", fullCommand,
             fullCommand.indexOf(cl.getArgs()[0]));
       }
     } else {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -254,7 +254,8 @@ public class ScanCommand extends Command {
 
         return shellState.getClassLoader(cl, shellState)
             .loadClass(cl.getOptionValue(formatterOpt.getOpt())).asSubclass(Formatter.class);
-      } else if (cl.hasOption(formatterInterpeterOpt.getOpt())) {
+      }
+      if (cl.hasOption(formatterInterpeterOpt.getOpt())) {
         Shell.log.warn("Formatter option is deprecated and will be removed in a future version.");
 
         return shellState.getClassLoader(cl, shellState)
@@ -298,17 +299,16 @@ public class ScanCommand extends Command {
     if (cl.hasOption(scanOptRow.getOpt())) {
       return new Range(formatter
           .interpretRow(new Text(cl.getOptionValue(scanOptRow.getOpt()).getBytes(Shell.CHARSET))));
-    } else {
-      Text startRow = OptUtil.getStartRow(cl);
-      if (startRow != null)
-        startRow = formatter.interpretBeginRow(startRow);
-      Text endRow = OptUtil.getEndRow(cl);
-      if (endRow != null)
-        endRow = formatter.interpretEndRow(endRow);
-      final boolean startInclusive = !cl.hasOption(optStartRowExclusive.getOpt());
-      final boolean endInclusive = !cl.hasOption(optEndRowExclusive.getOpt());
-      return new Range(startRow, startInclusive, endRow, endInclusive);
     }
+    Text startRow = OptUtil.getStartRow(cl);
+    if (startRow != null)
+      startRow = formatter.interpretBeginRow(startRow);
+    Text endRow = OptUtil.getEndRow(cl);
+    if (endRow != null)
+      endRow = formatter.interpretEndRow(endRow);
+    final boolean startInclusive = !cl.hasOption(optStartRowExclusive.getOpt());
+    final boolean endInclusive = !cl.hasOption(optEndRowExclusive.getOpt());
+    return new Range(startRow, startInclusive, endRow, endInclusive);
   }
 
   protected Authorizations getAuths(final CommandLine cl, final Shell shellState)

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScriptCommand.java
@@ -114,14 +114,19 @@ public class ScriptCommand extends Command {
         String[] argList = cl.getOptionValue(args.getOpt()).split(",");
         for (String arg : argList) {
           String[] parts = arg.split("=");
-          if (parts.length == 0) {
-            continue;
-          } else if (parts.length == 1) {
-            b.put(parts[0], null);
-            argValues.add(null);
-          } else if (parts.length == 2) {
-            b.put(parts[0], parts[1]);
-            argValues.add(parts[1]);
+          switch (parts.length) {
+            case 0:
+              continue;
+            case 1:
+              b.put(parts[0], null);
+              argValues.add(null);
+              break;
+            case 2:
+              b.put(parts[0], parts[1]);
+              argValues.add(parts[1]);
+              break;
+            default:
+              break;
           }
         }
       }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/SetIterCommand.java
@@ -114,7 +114,8 @@ public class SetIterCommand extends Command {
     // Cannot continue if no name is provided
     if (name == null && configuredName == null) {
       throw new IllegalArgumentException("No provided or default name for iterator");
-    } else if (name == null) {
+    }
+    if (name == null) {
       // Fall back to the name from OptionDescriber or user input if none is provided on setiter
       // option
       name = configuredName;
@@ -284,9 +285,8 @@ public class SetIterCommand extends Command {
               if (input == null) {
                 writer.println();
                 throw new IOException("Input stream closed");
-              } else {
-                input = new String(input);
               }
+              input = new String(input);
 
               if (input.isEmpty())
                 break;
@@ -310,7 +310,8 @@ public class SetIterCommand extends Command {
       if (iteratorName == null) {
         writer.println();
         throw new IOException("Input stream closed");
-      } else if (iteratorName.isBlank()) {
+      }
+      if (iteratorName.isBlank()) {
         // Treat whitespace or empty string as no name provided
         iteratorName = null;
       }
@@ -326,7 +327,8 @@ public class SetIterCommand extends Command {
         if (input == null) {
           writer.println();
           throw new IOException("Input stream closed");
-        } else if (input.isBlank()) {
+        }
+        if (input.isBlank()) {
           break;
         }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/TablesCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/TablesCommand.java
@@ -66,8 +66,7 @@ public class TablesCommand extends Command {
         tableName = Tables.qualify(tableName).getSecond();
       if (cl.hasOption(tableIdOption.getOpt()))
         return String.format(NAME_AND_ID_FORMAT, tableName, tableId);
-      else
-        return tableName;
+      return tableName;
     });
 
     shellState.printLines(it, !cl.hasOption(disablePaginationOpt.getOpt()));

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellConfigTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellConfigTest.java
@@ -83,10 +83,8 @@ public class ShellConfigTest {
     shell.shutdown();
     output.clear();
     System.setOut(out);
-    if (config.exists()) {
-      if (!config.delete()) {
-        log.error("Unable to delete {}", config);
-      }
+    if (config.exists() && !config.delete()) {
+      log.error("Unable to delete {}", config);
     }
   }
 

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellOptionsJCTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellOptionsJCTest.java
@@ -56,7 +56,7 @@ public class ShellOptionsJCTest {
 
     jc.setProgramName("accumulo shell");
     jc.addObject(options);
-    jc.parse(new String[] {"-zh", zk});
+    jc.parse("-zh", zk);
     Properties properties = options.getClientProperties();
     assertEquals(zk, properties.getProperty(ClientProperty.INSTANCE_ZOOKEEPERS.getKey()));
   }

--- a/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/AccumuloClassLoader.java
@@ -151,19 +151,17 @@ public class AccumuloClassLoader {
       final File extDir = new File(classpath);
       if (extDir.isDirectory())
         urls.add(extDir.toURI().toURL());
-      else {
-        if (extDir.getParentFile() != null) {
-          File[] extJars =
-              extDir.getParentFile().listFiles((dir, name) -> name.matches("^" + extDir.getName()));
-          if (extJars != null && extJars.length > 0) {
-            for (File jar : extJars)
-              urls.add(jar.toURI().toURL());
-          } else {
-            log.debug("ignoring classpath entry {}", classpath);
-          }
+      else if (extDir.getParentFile() != null) {
+        File[] extJars =
+            extDir.getParentFile().listFiles((dir, name) -> name.matches("^" + extDir.getName()));
+        if (extJars != null && extJars.length > 0) {
+          for (File jar : extJars)
+            urls.add(jar.toURI().toURL());
         } else {
           log.debug("ignoring classpath entry {}", classpath);
         }
+      } else {
+        log.debug("ignoring classpath entry {}", classpath);
       }
     } else {
       urls.add(uri.toURL());

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -383,11 +383,9 @@ public class AccumuloVFSClassLoader {
             printJar(out, f.getURL().getFile(), debug, sawFirst);
             sawFirst = true;
           }
-        } else {
-          if (debug) {
-            out.print(
-                classLoaderDescription + ": Unknown classloader: " + classLoader.getClass() + "\n");
-          }
+        } else if (debug) {
+          out.print(
+              classLoaderDescription + ": Unknown classloader: " + classLoader.getClass() + "\n");
         }
       }
       out.print("\n");
@@ -425,9 +423,7 @@ public class AccumuloVFSClassLoader {
   private static synchronized ContextManager getContextManager() throws IOException {
     if (contextManager == null) {
       getClassLoader();
-      contextManager = new ContextManager(generateVfs(), () -> {
-        return getClassLoader();
-      });
+      contextManager = new ContextManager(generateVfs(), AccumuloVFSClassLoader::getClassLoader);
     }
 
     return contextManager;

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/ContextManagerTest.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/ContextManagerTest.java
@@ -98,7 +98,8 @@ public class ContextManagerTest {
     cm.setContextConfig(context -> {
       if (context.equals("CX1")) {
         return new ContextManager.ContextConfig("CX1", uri1, true);
-      } else if (context.equals("CX2")) {
+      }
+      if (context.equals("CX2")) {
         return new ContextManager.ContextConfig("CX2", uri2, true);
       }
       return null;
@@ -140,7 +141,8 @@ public class ContextManagerTest {
     cm.setContextConfig(context -> {
       if (context.equals("CX1")) {
         return new ContextManager.ContextConfig("CX1", uri1.toString(), true);
-      } else if (context.equals("CX2")) {
+      }
+      if (context.equals("CX2")) {
         return new ContextManager.ContextConfig("CX2", uri2.toString(), false);
       }
       return null;

--- a/test/src/main/java/org/apache/accumulo/harness/MiniClusterConfigurationCallback.java
+++ b/test/src/main/java/org/apache/accumulo/harness/MiniClusterConfigurationCallback.java
@@ -27,14 +27,12 @@ import org.apache.hadoop.conf.Configuration;
  */
 public interface MiniClusterConfigurationCallback {
 
-  class NoCallback implements MiniClusterConfigurationCallback {
+  static class NoCallback implements MiniClusterConfigurationCallback {
 
     private NoCallback() {}
 
     @Override
-    public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
-      return;
-    }
+    public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {}
   }
 
   MiniClusterConfigurationCallback NO_CALLBACK = new NoCallback();

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -217,9 +217,8 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
   public ClusterUser getAdminUser() {
     if (krb == null) {
       return new ClusterUser(getPrincipal(), getRootPassword());
-    } else {
-      return krb.getRootUser();
     }
+    return krb.getRootUser();
   }
 
   @Override
@@ -229,9 +228,8 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
           SharedMiniClusterBase.class.getName() + "_" + testName.getMethodName() + "_" + offset;
       // Password is the username
       return new ClusterUser(user, user);
-    } else {
-      return krb.getClientPrincipal(offset);
     }
+    return krb.getClientPrincipal(offset);
   }
 
   public static ClientInfo getClientInfo() {

--- a/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloMiniClusterConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/AccumuloMiniClusterConfiguration.java
@@ -65,14 +65,13 @@ public class AccumuloMiniClusterConfiguration extends AccumuloClusterPropertyCon
   public String getAdminPrincipal() {
     if (saslEnabled) {
       return AccumuloClusterHarness.getKdc().getRootUser().getPrincipal();
-    } else {
-      String principal = conf.get(ACCUMULO_MINI_PRINCIPAL_KEY);
-      if (principal == null) {
-        principal = ACCUMULO_MINI_PRINCIPAL_DEFAULT;
-      }
-
-      return principal;
     }
+    String principal = conf.get(ACCUMULO_MINI_PRINCIPAL_KEY);
+    if (principal == null) {
+      principal = ACCUMULO_MINI_PRINCIPAL_DEFAULT;
+    }
+
+    return principal;
   }
 
   @Override
@@ -91,14 +90,13 @@ public class AccumuloMiniClusterConfiguration extends AccumuloClusterPropertyCon
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-    } else {
-      String password = conf.get(ACCUMULO_MINI_PASSWORD_KEY);
-      if (password == null) {
-        password = ACCUMULO_MINI_PASSWORD_DEFAULT;
-      }
-
-      return new PasswordToken(password);
     }
+    String password = conf.get(ACCUMULO_MINI_PASSWORD_KEY);
+    if (password == null) {
+      password = ACCUMULO_MINI_PASSWORD_DEFAULT;
+    }
+
+    return new PasswordToken(password);
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
+++ b/test/src/main/java/org/apache/accumulo/harness/conf/StandaloneAccumuloClusterConfiguration.java
@@ -176,16 +176,15 @@ public class StandaloneAccumuloClusterConfiguration extends AccumuloClusterPrope
   @Override
   public AuthenticationToken getAdminToken() {
     File keytab = getAdminKeytab();
-    if (keytab != null) {
-      try {
-        UserGroupInformation.loginUserFromKeytab(getAdminPrincipal(), keytab.getAbsolutePath());
-        return new KerberosToken();
-      } catch (IOException e) {
-        // The user isn't logged in
-        throw new RuntimeException("Failed to create KerberosToken", e);
-      }
-    } else {
+    if (keytab == null) {
       return new PasswordToken(getPassword());
+    }
+    try {
+      UserGroupInformation.loginUserFromKeytab(getAdminPrincipal(), keytab.getAbsolutePath());
+      return new KerberosToken();
+    } catch (IOException e) {
+      // The user isn't logged in
+      throw new RuntimeException("Failed to create KerberosToken", e);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -130,13 +130,11 @@ public class AuditMessageIT extends ConfigurableMacBase {
             String pattern = ".* \\["
                 + AuditedSecurityOperation.AUDITLOG.replace("org.apache.", "").replace(".", "[.]")
                 + "\\] .*";
-            if (line.matches(pattern)) {
-              // Only include the message if startTimestamp is null. or the message occurred after
-              // the startTimestamp value
-              if ((lastAuditTimestamp == null)
-                  || (line.substring(0, 23).compareTo(lastAuditTimestamp) > 0))
-                result.add(line);
-            }
+            // Only include the message if startTimestamp is null. or the message occurred after
+            // the startTimestamp value
+            if (line.matches(pattern) && ((lastAuditTimestamp == null)
+                || (line.substring(0, 23).compareTo(lastAuditTimestamp) > 0)))
+              result.add(line);
           }
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CompactionExecutorIT.java
@@ -117,24 +117,23 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
             .build();
       }
 
-      if (kindsToProcess.contains(params.getKind())) {
-        var planBuilder = params.createPlanBuilder();
-
-        // Group files by first char, like F for flush files or C for compaction produced files.
-        // This prevents F and C files from compacting together, which makes it easy to reason about
-        // the number of expected files produced by compactions from known number of F files.
-        params.getCandidates().stream().collect(Collectors.groupingBy(TestPlanner::getFirstChar))
-            .values().forEach(files -> {
-              for (int i = filesPerCompaction; i <= files.size(); i += filesPerCompaction) {
-                planBuilder.addJob(1, executorIds.get(rand.nextInt(executorIds.size())),
-                    files.subList(i - filesPerCompaction, i));
-              }
-            });
-
-        return planBuilder.build();
-      } else {
+      if (!kindsToProcess.contains(params.getKind())) {
         return params.createPlanBuilder().build();
       }
+      var planBuilder = params.createPlanBuilder();
+
+      // Group files by first char, like F for flush files or C for compaction produced files.
+      // This prevents F and C files from compacting together, which makes it easy to reason about
+      // the number of expected files produced by compactions from known number of F files.
+      params.getCandidates().stream().collect(Collectors.groupingBy(TestPlanner::getFirstChar))
+          .values().forEach(files -> {
+            for (int i = filesPerCompaction; i <= files.size(); i += filesPerCompaction) {
+              planBuilder.addJob(1, executorIds.get(rand.nextInt(executorIds.size())),
+                  files.subList(i - filesPerCompaction, i));
+            }
+          });
+
+      return planBuilder.build();
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CompactionRateLimitingIT.java
@@ -54,7 +54,7 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
     cfg.setProperty("tserver.compaction.major.service.test.planner",
         DefaultCompactionPlanner.class.getName());
     cfg.setProperty("tserver.compaction.major.service.test.planner.opts.executors",
-        "[{'name':'all','numThreads':2}]".replaceAll("'", "\""));
+        "[{'name':'all','numThreads':2}]".replace("'", "\""));
 
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -256,7 +256,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
     try (AccumuloClient client1 = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
 
-      String user = null;
+      String user;
 
       ClusterUser user1 = getUser(0);
       user = user1.getPrincipal();
@@ -1123,9 +1123,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
     public Stats(ByteSequence row) {
       this.row = row;
-      for (int i = 0; i < data.length; i++) {
-        this.data[i] = 0;
-      }
+      Arrays.fill(this.data, 0);
       this.seq = -1;
       this.sum = 0;
     }
@@ -1305,7 +1303,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
   public void testSecurity() throws Exception {
     // test against table user does not have read and/or write permissions for
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      String user = null;
+      String user;
 
       // Create a new user
       ClusterUser user1 = getUser(0);
@@ -1600,10 +1598,9 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
               lastPos = pos;
             }
             break;
-          } else {
-            log.info("Ignoring trace output as traceCount not greater than zero: " + traceCount);
-            Thread.sleep(1000);
           }
+          log.info("Ignoring trace output as traceCount not greater than zero: " + traceCount);
+          Thread.sleep(1000);
         }
         if (tracer != null) {
           tracer.destroy();

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -213,8 +213,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
   private boolean looksLikeRelativePath(String uri) {
     if (uri.startsWith("/" + Constants.BULK_PREFIX)) {
       return uri.charAt(10) == '/';
-    } else {
-      return uri.startsWith("/" + Constants.CLONE_PREFIX);
     }
+    return uri.startsWith("/" + Constants.CLONE_PREFIX);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -91,9 +92,7 @@ public class LargeSplitRowIT extends ConfigurableMacBase {
       SortedSet<Text> partitionKeys = new TreeSet<>();
       byte[] data = new byte[(int) (ConfigurationTypeHelper
           .getFixedMemoryAsBytes(Property.TABLE_MAX_END_ROW_SIZE.getDefaultValue()) + 2)];
-      for (int i = 0; i < data.length; i++) {
-        data[i] = 'm';
-      }
+      Arrays.fill(data, (byte) 'm');
       partitionKeys.add(new Text(data));
 
       // try to add the split point that is too large, if the split point is created the test fails.

--- a/test/src/main/java/org/apache/accumulo/test/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellIT.java
@@ -96,9 +96,8 @@ public class ShellIT extends SharedMiniClusterBase {
     public int read() {
       if (offset == source.length()) {
         return '\n';
-      } else {
-        return source.charAt(offset++);
       }
+      return source.charAt(offset++);
     }
 
     public void set(String other) {
@@ -174,10 +173,8 @@ public class ShellIT extends SharedMiniClusterBase {
 
   @After
   public void teardownShell() {
-    if (config.exists()) {
-      if (!config.delete()) {
-        log.error("Unable to delete {}", config);
-      }
+    if (config.exists() && !config.delete()) {
+      log.error("Unable to delete {}", config);
     }
     shell.shutdown();
   }

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -158,8 +158,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     public int read() {
       if (offset == source.length())
         return '\n';
-      else
-        return source.charAt(offset++);
+      return source.charAt(offset++);
     }
 
     public void set(String other) {
@@ -439,7 +438,8 @@ public class ShellServerIT extends SharedMiniClusterBase {
         if (parameterTypes.length > 0 && parameterTypes[0].equals(Configuration.class)) {
           if (parameterTypes.length == 1) {
             return constructor.newInstance(conf);
-          } else if (parameterTypes.length == 2) {
+          }
+          if (parameterTypes.length == 2) {
             return constructor.newInstance(conf, null);
           }
         }
@@ -2099,9 +2099,8 @@ public class ShellServerIT extends SharedMiniClusterBase {
         Map<String,String> nameToId = client.tableOperations().tableIdMap();
         if (nameToId.containsKey(tableName)) {
           return nameToId.get(tableName);
-        } else {
-          Thread.sleep(1000);
         }
+        Thread.sleep(1000);
       }
 
       fail("Could not find ID for table: " + tableName);
@@ -2853,7 +2852,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     if (len > 32)
       desiredLen = 32;
     return new Text(
-        String.valueOf(UUID.randomUUID()).replaceAll("-", "").substring(0, desiredLen - 1));
+        String.valueOf(UUID.randomUUID()).replace("-", "").substring(0, desiredLen - 1));
   }
 
   private static String encode(final Text text, final boolean encode) {

--- a/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
@@ -174,19 +174,17 @@ public class TestBinaryRows {
 
           Iterator<Entry<Key,Value>> si = s.iterator();
 
-          if (si.hasNext()) {
-            Entry<Key,Value> e = si.next();
-            Key k = e.getKey();
-            Value v = e.getValue();
-
-            checkKeyValue(row, k, v);
-
-            if (si.hasNext()) {
-              throw new Exception("ERROR : lookup on " + row + " returned more than one result ");
-            }
-
-          } else {
+          if (!si.hasNext()) {
             throw new Exception("ERROR : lookup on " + row + " failed ");
+          }
+          Entry<Key,Value> e = si.next();
+          Key k = e.getKey();
+          Value v = e.getValue();
+
+          checkKeyValue(row, k, v);
+
+          if (si.hasNext()) {
+            throw new Exception("ERROR : lookup on " + row + " returned more than one result ");
           }
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/TestRandomDeletes.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestRandomDeletes.java
@@ -64,8 +64,7 @@ public class TestRandomDeletes {
 
     @Override
     public boolean equals(Object obj) {
-      return this == obj
-          || (obj != null && obj instanceof RowColumn && compareTo((RowColumn) obj) == 0);
+      return this == obj || (obj instanceof RowColumn && compareTo((RowColumn) obj) == 0);
     }
 
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -101,9 +101,8 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
           // This is our "assertion", but we want to re-check it if it's not what we expect
           if (responseCode == HttpURLConnection.HTTP_OK) {
             return;
-          } else {
-            errorText = FunctionalTestUtils.readAll(cnxn.getErrorStream());
           }
+          errorText = FunctionalTestUtils.readAll(cnxn.getErrorStream());
           LOG.debug("Unexpected responseCode and/or error text, will retry: '{}' '{}'",
               responseCode, errorText);
         } catch (Exception e) {

--- a/test/src/main/java/org/apache/accumulo/test/TracerRecoversAfterOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TracerRecoversAfterOfflineTableIT.java
@@ -116,10 +116,9 @@ public class TracerRecoversAfterOfflineTableIT extends ConfigurableMacBase {
               lastPos = pos;
             }
             break;
-          } else {
-            log.info("Ignoring trace output as traceCount not greater than zero: {}", traceCount);
-            Thread.sleep(1000);
           }
+          log.info("Ignoring trace output as traceCount not greater than zero: {}", traceCount);
+          Thread.sleep(1000);
         }
         if (tracer != null) {
           tracer.destroy();

--- a/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TransportCachingIT.java
@@ -61,9 +61,10 @@ public class TransportCachingIT extends AccumuloClusterHarness {
       long rpcTimeout =
           ConfigurationTypeHelper.getTimeInMillis(Property.GENERAL_RPC_TIMEOUT.getDefaultValue());
 
-      List<ThriftTransportKey> servers = tservers.stream().map(serverStr -> {
-        return new ThriftTransportKey(HostAndPort.fromString(serverStr), rpcTimeout, context);
-      }).collect(Collectors.toList());
+      List<ThriftTransportKey> servers = tservers.stream()
+          .map(serverStr -> new ThriftTransportKey(HostAndPort.fromString(serverStr), rpcTimeout,
+              context))
+          .collect(Collectors.toList());
 
       // only want to use one server for all subsequent test
       servers = servers.subList(0, 1);

--- a/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
@@ -270,16 +270,15 @@ public class VerifyIngest {
       throw new AccumuloException("saw " + errors + " errors ");
     }
 
-    if (expectedRow == (params.rows + params.startRow)) {
-      System.out.printf(
-          "%,12d records read | %,8d records/sec | %,12d bytes read |"
-              + " %,8d bytes/sec | %6.3f secs   %n",
-          recsRead, (int) ((recsRead) / ((t2 - t1) / 1000.0)), bytesRead,
-          (int) (bytesRead / ((t2 - t1) / 1000.0)), (t2 - t1) / 1000.0);
-    } else {
+    if (expectedRow != (params.rows + params.startRow)) {
       throw new AccumuloException("Did not read expected number of rows. Saw "
           + (expectedRow - params.startRow) + " expected " + params.rows);
     }
+    System.out.printf(
+        "%,12d records read | %,8d records/sec | %,12d bytes read |"
+            + " %,8d bytes/sec | %6.3f secs   %n",
+        recsRead, (int) ((recsRead) / ((t2 - t1) / 1000.0)), bytesRead,
+        (int) (bytesRead / ((t2 - t1) / 1000.0)), (t2 - t1) / 1000.0);
   }
 
 }

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -547,7 +547,8 @@ public class ServiceLockIT {
   private int parseLockWorkerName(String child) {
     if (child.startsWith("zlock#00000000-0000-0000-0000-000000000000#")) {
       return 0;
-    } else if (child.startsWith("zlock#00000000-0000-0000-0000-111111111111#")) {
+    }
+    if (child.startsWith("zlock#00000000-0000-0000-0000-111111111111#")) {
       return 1;
     } else if (child.startsWith("zlock#00000000-0000-0000-0000-222222222222#")) {
       return 2;

--- a/test/src/main/java/org/apache/accumulo/test/functional/AuthsIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AuthsIterator.java
@@ -48,7 +48,6 @@ public class AuthsIterator extends WrappingIterator {
   public Key getTopKey() {
     if (env.getAuthorizations().equals(AUTHS))
       return new Key(new Text(SUCCESS));
-    else
-      return new Key(new Text(FAIL));
+    return new Key(new Text(FAIL));
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -223,15 +223,12 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
 
       for (int k = 0; k < NUM_THREADS; k++) {
         final int idx = k;
-        threads.execute(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              bw.addMutations(allMuts.get(idx));
-              bw.flush();
-            } catch (MutationsRejectedException e) {
-              fail("Error adding mutations to batch writer");
-            }
+        threads.execute(() -> {
+          try {
+            bw.addMutations(allMuts.get(idx));
+            bw.flush();
+          } catch (MutationsRejectedException e) {
+            fail("Error adding mutations to batch writer");
           }
         });
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -112,11 +112,9 @@ public class CacheTestWriter {
 
           expectedData.put(rootDir + "/dataS", new String(data, UTF_8));
 
-        } else {
-          if (dataSExists) {
-            zk.recursiveDelete(rootDir + "/dataS", NodeMissingPolicy.FAIL);
-            dataSExists = false;
-          }
+        } else if (dataSExists) {
+          zk.recursiveDelete(rootDir + "/dataS", NodeMissingPolicy.FAIL);
+          dataSExists = false;
         }
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -84,19 +84,15 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
         List<Future<?>> futures = new ArrayList<>();
 
         for (int i = 0; i < numDeleteOps; i++) {
-          Future<?> future = es.submit(new Runnable() {
-
-            @Override
-            public void run() {
-              try {
-                cdl.countDown();
-                cdl.await();
-                c.tableOperations().delete(table);
-              } catch (TableNotFoundException e) {
-                // expected
-              } catch (InterruptedException | AccumuloException | AccumuloSecurityException e) {
-                throw new RuntimeException(e);
-              }
+          Future<?> future = es.submit(() -> {
+            try {
+              cdl.countDown();
+              cdl.await();
+              c.tableOperations().delete(table);
+            } catch (TableNotFoundException e) {
+              // expected
+            } catch (InterruptedException | AccumuloException | AccumuloSecurityException e) {
+              throw new RuntimeException(e);
             }
           });
 
@@ -183,18 +179,15 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
 
         List<Future<?>> futures = new ArrayList<>();
 
-        futures.add(es.submit(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              cdl.countDown();
-              cdl.await();
-              c.tableOperations().delete(table);
-            } catch (TableNotFoundException | TableOfflineException e) {
-              // expected
-            } catch (InterruptedException | AccumuloException | AccumuloSecurityException e) {
-              throw new RuntimeException(e);
-            }
+        futures.add(es.submit(() -> {
+          try {
+            cdl.countDown();
+            cdl.await();
+            c.tableOperations().delete(table);
+          } catch (TableNotFoundException | TableOfflineException e) {
+            // expected
+          } catch (InterruptedException | AccumuloException | AccumuloSecurityException e) {
+            throw new RuntimeException(e);
           }
         }));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
@@ -233,6 +233,6 @@ public class CreateInitialSplitsIT extends AccumuloClusterHarness {
     if (len > 32)
       desiredLen = 32;
     return new Text(
-        String.valueOf(UUID.randomUUID()).replaceAll("-", "").substring(0, desiredLen - 1));
+        String.valueOf(UUID.randomUUID()).replace("-", "").substring(0, desiredLen - 1));
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -199,9 +199,8 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
         if (found) {
           log.debug("Found fate {}", aTableName);
           return true;
-        } else {
-          Thread.sleep(150);
         }
+        Thread.sleep(150);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
         return false;
@@ -364,7 +363,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
     }
 
     // did not find appropriate fate transaction for compaction.
-    return Boolean.FALSE;
+    return false;
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/functional/HalfDeadTServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/HalfDeadTServerIT.java
@@ -145,11 +145,8 @@ public class HalfDeadTServerIT extends ConfigurableMacBase {
   @Test
   public void testTimeout() throws Exception {
     String results = test(20, true);
-    if (results != null) {
-      if (!results.contains("Session expired")) {
-        log.info(
-            "Failed to find 'Session expired' in output, but TServer did die which is expected");
-      }
+    if ((results != null) && !results.contains("Session expired")) {
+      log.info("Failed to find 'Session expired' in output, but TServer did die which is expected");
     }
   }
 
@@ -169,8 +166,7 @@ public class HalfDeadTServerIT extends ConfigurableMacBase {
       String classpath = System.getProperty("java.class.path");
       classpath = new File(cluster.getConfig().getDir(), "conf") + File.pathSeparator + classpath;
       String className = TabletServer.class.getName();
-      ArrayList<String> argList = new ArrayList<>();
-      argList.addAll(Arrays.asList(javaBin, "-cp", classpath));
+      ArrayList<String> argList = new ArrayList<>(Arrays.asList(javaBin, "-cp", classpath));
       argList.addAll(Arrays.asList(Main.class.getName(), className));
       ProcessBuilder builder = new ProcessBuilder(argList);
       Map<String,String> env = builder.environment();

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -63,12 +63,10 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloITBase;
-import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.MiniClusterHarness;
 import org.apache.accumulo.harness.TestingKdc;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -132,17 +130,11 @@ public class KerberosIT extends AccumuloITBase {
   @Before
   public void startMac() throws Exception {
     MiniClusterHarness harness = new MiniClusterHarness();
-    mac = harness.create(this, new PasswordToken("unused"), kdc,
-        new MiniClusterConfigurationCallback() {
-
-          @Override
-          public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
-            Map<String,String> site = cfg.getSiteConfig();
-            site.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "15s");
-            cfg.setSiteConfig(site);
-          }
-
-        });
+    mac = harness.create(this, new PasswordToken("unused"), kdc, (cfg, coreSite) -> {
+      Map<String,String> site = cfg.getSiteConfig();
+      site.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "15s");
+      cfg.setSiteConfig(site);
+    });
 
     mac.getConfig().setNumTservers(1);
     mac.start();
@@ -601,9 +593,8 @@ public class KerberosIT extends AccumuloITBase {
       Throwable cause = e.getCause();
       if (cause != null) {
         throw cause;
-      } else {
-        throw e;
       }
+      throw e;
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
@@ -42,11 +42,9 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloITBase;
-import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.MiniClusterHarness;
 import org.apache.accumulo.harness.TestingKdc;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -113,19 +111,14 @@ public class KerberosRenewalIT extends AccumuloITBase {
   @Before
   public void startMac() throws Exception {
     MiniClusterHarness harness = new MiniClusterHarness();
-    mac = harness.create(this, new PasswordToken("unused"), kdc,
-        new MiniClusterConfigurationCallback() {
-
-          @Override
-          public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
-            Map<String,String> site = cfg.getSiteConfig();
-            site.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "15s");
-            // Reduce the period just to make sure we trigger renewal fast
-            site.put(Property.GENERAL_KERBEROS_RENEWAL_PERIOD.getKey(), "5s");
-            cfg.setSiteConfig(site);
-            cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
-          }
-        });
+    mac = harness.create(this, new PasswordToken("unused"), kdc, (cfg, coreSite) -> {
+      Map<String,String> site = cfg.getSiteConfig();
+      site.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "15s");
+      // Reduce the period just to make sure we trigger renewal fast
+      site.put(Property.GENERAL_KERBEROS_RENEWAL_PERIOD.getKey(), "5s");
+      cfg.setSiteConfig(site);
+      cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
+    });
 
     mac.getConfig().setNumTservers(1);
     mac.start();

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -587,11 +587,9 @@ public class PermissionsIT extends AccumuloClusterHarness {
         // should have these
         if (!root_client.securityOperations().hasSystemPermission(user, p))
           throw new IllegalStateException(user + " SHOULD have system permission " + p);
-      } else {
-        // should not have these
-        if (root_client.securityOperations().hasSystemPermission(user, p))
-          throw new IllegalStateException(user + " SHOULD NOT have system permission " + p);
-      }
+      } else // should not have these
+      if (root_client.securityOperations().hasSystemPermission(user, p))
+        throw new IllegalStateException(user + " SHOULD NOT have system permission " + p);
     }
   }
 
@@ -832,12 +830,10 @@ public class PermissionsIT extends AccumuloClusterHarness {
         if (!root_client.securityOperations().hasTablePermission(user, table, p))
           throw new IllegalStateException(
               user + " SHOULD have table permission " + p + " for table " + table);
-      } else {
-        // should not have these
-        if (root_client.securityOperations().hasTablePermission(user, table, p))
-          throw new IllegalStateException(
-              user + " SHOULD NOT have table permission " + p + " for table " + table);
-      }
+      } else // should not have these
+      if (root_client.securityOperations().hasTablePermission(user, table, p))
+        throw new IllegalStateException(
+            user + " SHOULD NOT have table permission " + p + " for table " + table);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -47,7 +47,10 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.IntPredicate;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -87,7 +90,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -752,11 +754,9 @@ public class SummaryIT extends AccumuloClusterHarness {
   }
 
   private Map<String,Long> nm(Object... entries) {
-    var imb = ImmutableMap.<String,Long>builder();
-    for (int i = 0; i < entries.length; i += 2) {
-      imb.put((String) entries[i], (Long) entries[i + 1]);
-    }
-    return imb.build();
+    IntPredicate evenIndex = i -> i % 2 == 0;
+    return IntStream.range(0, entries.length).filter(evenIndex).boxed().collect(
+        Collectors.toUnmodifiableMap(i -> (String) entries[i], i -> (Long) entries[i + 1]));
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -277,11 +277,10 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
         }
         return result;
       } catch (WalMarkerException wme) {
-        if (wme.getCause() instanceof NoNodeException) {
-          log.debug("WALs changed while reading, retrying", wme);
-        } else {
+        if (!(wme.getCause() instanceof NoNodeException)) {
           throw wme;
         }
+        log.debug("WALs changed while reading, retrying", wme);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
@@ -60,7 +60,7 @@ public class YieldingIterator extends WrappingIterator {
 
   @Override
   public boolean hasTop() {
-    return (!(yield.isPresent() && yield.get().hasYielded()) && super.hasTop());
+    return ((!yield.isPresent() || !yield.get().hasYielded()) && super.hasTop());
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
@@ -134,8 +134,8 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
           TabletLocator.TabletLocation tab =
               tl.locateTablet(ctx, tls.extent.toMetaRow(), false, false);
           // add it to the set of servers with metadata
-          metadataServerSet
-              .add(new TServerInstance(tab.tablet_location, Long.valueOf(tab.tablet_session, 16)));
+          metadataServerSet.add(
+              new TServerInstance(tab.tablet_location, Long.parseLong(tab.tablet_session, 16)));
         }
       }
 
@@ -171,9 +171,8 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
         }
         if (count == 0) {
           return;
-        } else {
-          Thread.sleep(MILLISECONDS.convert(2, SECONDS));
         }
+        Thread.sleep(MILLISECONDS.convert(2, SECONDS));
       }
       throw new IllegalStateException("Tablet servers didn't die!");
     });

--- a/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
@@ -152,10 +152,9 @@ public class TokenFileIT extends AccumuloClusterHarness {
       RunningJob rj = JobClient.runJob(job);
       if (rj.isSuccessful()) {
         return 0;
-      } else {
-        System.out.println(rj.getFailureInfo());
-        return 1;
       }
+      System.out.println(rj.getFailureInfo());
+      return 1;
     }
 
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
@@ -159,10 +159,9 @@ public class TokenFileIT extends AccumuloClusterHarness {
 
       if (job.isSuccessful()) {
         return 0;
-      } else {
-        System.out.println(job.getStatus().getFailureInfo());
-        return 1;
       }
+      System.out.println(job.getStatus().getFailureInfo());
+      return 1;
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsFileTailer.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsFileTailer.java
@@ -62,7 +62,7 @@ public class MetricsFileTailer implements AutoCloseable {
   private final String metricsPrefix;
 
   private final Lock lock = new ReentrantLock();
-  private final AtomicBoolean running = new AtomicBoolean(Boolean.FALSE);
+  private final AtomicBoolean running = new AtomicBoolean(false);
 
   private AtomicLong lastUpdate = new AtomicLong(0);
   private long startTime = System.nanoTime();
@@ -247,7 +247,7 @@ public class MetricsFileTailer implements AutoCloseable {
       try {
         Thread.sleep(5_000);
       } catch (InterruptedException ex) {
-        running.set(Boolean.FALSE);
+        running.set(false);
         Thread.currentThread().interrupt();
         return;
       }
@@ -297,7 +297,7 @@ public class MetricsFileTailer implements AutoCloseable {
 
   public void startDaemonThread() {
     if (running.compareAndSet(false, true)) {
-      Thread t = new Thread(() -> this.run());
+      Thread t = new Thread(this::run);
       t.setDaemon(true);
       t.start();
     }
@@ -305,7 +305,7 @@ public class MetricsFileTailer implements AutoCloseable {
 
   @Override
   public void close() {
-    running.set(Boolean.FALSE);
+    running.set(false);
   }
 
   // utilities to block, waiting for update - call from process thread

--- a/test/src/main/java/org/apache/accumulo/test/replication/KerberosReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/KerberosReplicationIT.java
@@ -49,7 +49,6 @@ import org.apache.accumulo.harness.TestingKdc;
 import org.apache.accumulo.manager.replication.SequentialWorkAssigner;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
-import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.miniclusterImpl.ProcessReference;
 import org.apache.accumulo.server.replication.ReplicaSystemFactory;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
@@ -114,24 +113,21 @@ public class KerberosReplicationIT extends AccumuloITBase {
   }
 
   private MiniClusterConfigurationCallback getConfigCallback(final String name) {
-    return new MiniClusterConfigurationCallback() {
-      @Override
-      public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration coreSite) {
-        cfg.setNumTservers(1);
-        cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
-        cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
-        cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "2M");
-        cfg.setProperty(Property.GC_CYCLE_START, "1s");
-        cfg.setProperty(Property.GC_CYCLE_DELAY, "5s");
-        cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");
-        cfg.setProperty(Property.MANAGER_REPLICATION_SCAN_INTERVAL, "1s");
-        cfg.setProperty(Property.REPLICATION_NAME, name);
-        cfg.setProperty(Property.REPLICATION_MAX_UNIT_SIZE, "8M");
-        cfg.setProperty(Property.REPLICATION_WORK_ASSIGNER, SequentialWorkAssigner.class.getName());
-        cfg.setProperty(Property.TSERV_TOTAL_MUTATION_QUEUE_MAX, "1M");
-        coreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
-        coreSite.set("fs.defaultFS", "file:///");
-      }
+    return (cfg, coreSite) -> {
+      cfg.setNumTservers(1);
+      cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
+      cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
+      cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "2M");
+      cfg.setProperty(Property.GC_CYCLE_START, "1s");
+      cfg.setProperty(Property.GC_CYCLE_DELAY, "5s");
+      cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");
+      cfg.setProperty(Property.MANAGER_REPLICATION_SCAN_INTERVAL, "1s");
+      cfg.setProperty(Property.REPLICATION_NAME, name);
+      cfg.setProperty(Property.REPLICATION_MAX_UNIT_SIZE, "8M");
+      cfg.setProperty(Property.REPLICATION_WORK_ASSIGNER, SequentialWorkAssigner.class.getName());
+      cfg.setProperty(Property.TSERV_TOTAL_MUTATION_QUEUE_MAX, "1M");
+      coreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
+      coreSite.set("fs.defaultFS", "file:///");
     };
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiInstanceReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiInstanceReplicationIT.java
@@ -774,11 +774,10 @@ public class MultiInstanceReplicationIT extends ConfigurableMacBase {
 
         log.info("Found {} records in {}", countTable, peerTable1);
 
-        if (countTable == 0L) {
-          Thread.sleep(5000);
-        } else {
+        if (countTable != 0L) {
           break;
         }
+        Thread.sleep(5000);
       }
 
       assertTrue("Found no records in " + peerTable1 + " in the peer cluster", countTable > 0);
@@ -796,11 +795,10 @@ public class MultiInstanceReplicationIT extends ConfigurableMacBase {
 
         log.info("Found {} records in {}", countTable, peerTable2);
 
-        if (countTable == 0L) {
-          Thread.sleep(5000);
-        } else {
+        if (countTable != 0L) {
           break;
         }
+        Thread.sleep(5000);
       }
 
       assertTrue("Found no records in " + peerTable2 + " in the peer cluster", countTable > 0);

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
@@ -71,10 +71,8 @@ public class MultiTserverReplicationIT extends ConfigurableMacBase {
 
       ZooReader zreader =
           new ZooReader(context.getZooKeepers(), context.getZooKeepersSessionTimeOut());
-      Set<String> tserverHost = new HashSet<>();
-      tserverHost.addAll(zreader.getChildren(
+      Set<String> tserverHost = new HashSet<>(zreader.getChildren(
           ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZTSERVERS));
-
       Set<HostAndPort> replicationServices = new HashSet<>();
 
       for (String tserver : tserverHost) {

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -1388,18 +1388,17 @@ public class ReplicationIT extends ConfigurableMacBase {
         } catch (RuntimeException e) {
           // Catch a propagation issue, fail if it's not what we expect
           Throwable cause = e.getCause();
-          if (cause instanceof AccumuloSecurityException) {
-            AccumuloSecurityException sec = (AccumuloSecurityException) cause;
-            switch (sec.getSecurityErrorCode()) {
-              case PERMISSION_DENIED:
-                // retry -- the grant didn't happen yet
-                log.warn("Sleeping because permission was denied");
-                break;
-              default:
-                throw e;
-            }
-          } else {
+          if (!(cause instanceof AccumuloSecurityException)) {
             throw e;
+          }
+          AccumuloSecurityException sec = (AccumuloSecurityException) cause;
+          switch (sec.getSecurityErrorCode()) {
+            case PERMISSION_DENIED:
+              // retry -- the grant didn't happen yet
+              log.warn("Sleeping because permission was denied");
+              break;
+            default:
+              throw e;
           }
         }
         Thread.sleep(2000);
@@ -1503,10 +1502,9 @@ public class ReplicationIT extends ConfigurableMacBase {
 
           if (recordsFound <= 2) {
             break;
-          } else {
-            Thread.sleep(1000);
-            log.info("");
           }
+          Thread.sleep(1000);
+          log.info("");
         }
       }
       assertTrue("Found unexpected replication records in the replication table",

--- a/test/src/main/java/org/apache/accumulo/test/util/CertUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/CertUtils.java
@@ -130,9 +130,8 @@ public class CertUtils {
     public SiteConfiguration getSiteConfiguration() {
       if (accumuloPropsFile == null) {
         return SiteConfiguration.auto();
-      } else {
-        return SiteConfiguration.fromFile(new File(accumuloPropsFile)).build();
       }
+      return SiteConfiguration.fromFile(new File(accumuloPropsFile)).build();
     }
   }
 
@@ -181,7 +180,6 @@ public class CertUtils {
 
   public CertUtils(String keystoreType, String issuerDirString, String encryptionAlgorithm,
       int keysize, String signingAlgorithm) {
-    super();
     this.keystoreType = keystoreType;
     this.issuerDirString = issuerDirString;
     this.encryptionAlgorithm = encryptionAlgorithm;

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -81,7 +81,7 @@ public class SlowOps {
     try {
       client.instanceOperations().setProperty(
           Property.TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS.getKey(),
-          "[{'name':'any','numThreads':" + target + "}]".replaceAll("'", "\""));
+          "[{'name':'any','numThreads':" + target + "}]".replace("'", "\""));
       UtilWaitThread.sleep(3_000); // give it time to propagate
     } catch (AccumuloException | AccumuloSecurityException | NumberFormatException ex) {
       throw new IllegalStateException("Could not set parallel compaction limit to " + target, ex);

--- a/test/src/test/java/org/apache/accumulo/test/functional/ValueReversingIterator.java
+++ b/test/src/test/java/org/apache/accumulo/test/functional/ValueReversingIterator.java
@@ -37,33 +37,40 @@ public class ValueReversingIterator implements SortedKeyValueIterator<Key,Value>
 
   protected SortedKeyValueIterator<Key,Value> source;
 
+  @Override
   public ValueReversingIterator deepCopy(IteratorEnvironment env) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public Key getTopKey() {
     return source.getTopKey();
   }
 
+  @Override
   public Value getTopValue() {
     byte[] buf = source.getTopValue().get();
     ArrayUtils.reverse(buf);
     return new Value(buf);
   }
 
+  @Override
   public boolean hasTop() {
     return source.hasTop();
   }
 
+  @Override
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
       IteratorEnvironment env) {
     this.source = source;
   }
 
+  @Override
   public void next() throws IOException {
     source.next();
   }
 
+  @Override
   public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
       throws IOException {
     source.seek(range, columnFamilies, inclusive);


### PR DESCRIPTION
Apply various minor improvements to our Java code.

* Use builtin immutable maps/sets/lists when available:
  Utilize some Java 11 features for immutable maps, sets, and lists, to
  minimize our dependence on equivalent Guava features. Some use of Guava
  builders for these are still used, since Java 11 doesn't have convenient
  immutable collection builders, but they have been made final to ensure
  we use them correctly and don't re-assign them once built.
* Apply Eclipse save actions to clean up some code