### PR TITLE
Use builtin immutable maps/sets/lists when available

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
@@ -53,7 +53,7 @@ import org.apache.accumulo.core.data.Key;
  * <pre>
  * <code>
  * new SamplerConfiguration(RowColumnSampler.class.getName()).setOptions(
- *   ImmutableMap.of("hasher","murmur3_32","modulus","1009","qualifier","true"));
+ *   Map.of("hasher","murmur3_32","modulus","1009","qualifier","true"));
  * </code>
  * </pre>
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/RowSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/RowSampler.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.data.Key;
  * <pre>
  * <code>
  * new SamplerConfiguration(RowSampler.class.getName()).setOptions(
- *   ImmutableMap.of("hasher","murmur3_32","modulus","1009"));
+ *   Map.of("hasher","murmur3_32","modulus","1009"));
  * </code>
  * </pre>
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -182,13 +182,12 @@ public class SummarizerConfiguration {
    * @since 2.0.0
    */
   public static class Builder {
-    private String className;
-    private ImmutableMap.Builder<String,String> imBuilder;
+    private final String className;
+    private final ImmutableMap.Builder<String,String> imBuilder = ImmutableMap.builder();
     private String configId = null;
 
     private Builder(String className) {
       this.className = className;
-      this.imBuilder = ImmutableMap.builder();
     }
 
     /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableMap.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableMap.java
@@ -55,8 +55,8 @@ public class TableMap {
 
     List<String> tableIds = zooCache.getChildren(context.getZooKeeperRoot() + Constants.ZTABLES);
     Map<NamespaceId,String> namespaceIdToNameMap = new HashMap<>();
-    var tableNameToIdBuilder = ImmutableMap.<String,TableId>builder();
-    var tableIdToNameBuilder = ImmutableMap.<TableId,String>builder();
+    final var tableNameToIdBuilder = ImmutableMap.<String,TableId>builder();
+    final var tableIdToNameBuilder = ImmutableMap.<TableId,String>builder();
 
     // use StringBuilder to construct zPath string efficiently across many tables
     StringBuilder zPathBuilder = new StringBuilder();

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -198,7 +198,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
   }
 
   public Map<String,String> getAllPropertiesWithPrefixStripped(Property prefix) {
-    var builder = ImmutableMap.<String,String>builder();
+    final var builder = ImmutableMap.<String,String>builder();
     getAllPropertiesWithPrefix(prefix).forEach((k, v) -> {
       String optKey = k.substring(prefix.getKey().length());
       builder.put(optKey, v);

--- a/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
@@ -197,7 +197,7 @@ public class LoadPlan {
 
   public static Builder builder() {
     return new Builder() {
-      ImmutableList.Builder<Destination> fmb = ImmutableList.builder();
+      final ImmutableList.Builder<Destination> fmb = ImmutableList.builder();
 
       @Override
       public Builder loadFileTo(String fileName, RangeType rangeType, Text startRow, Text endRow) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -298,14 +298,12 @@ public class TabletMetadata {
     Objects.requireNonNull(rowIter);
 
     TabletMetadata te = new TabletMetadata();
-    ImmutableSortedMap.Builder<Key,Value> kvBuilder = null;
-    if (buildKeyValueMap) {
-      kvBuilder = ImmutableSortedMap.naturalOrder();
-    }
+    final ImmutableSortedMap.Builder<Key,Value> kvBuilder =
+        buildKeyValueMap ? ImmutableSortedMap.naturalOrder() : null;
 
-    var filesBuilder = ImmutableMap.<StoredTabletFile,DataFileValue>builder();
-    var scansBuilder = ImmutableList.<StoredTabletFile>builder();
-    var logsBuilder = ImmutableList.<LogEntry>builder();
+    final var filesBuilder = ImmutableMap.<StoredTabletFile,DataFileValue>builder();
+    final var scansBuilder = ImmutableList.<StoredTabletFile>builder();
+    final var logsBuilder = ImmutableList.<LogEntry>builder();
     final var loadedFilesBuilder = ImmutableMap.<TabletFile,Long>builder();
     ByteSequence row = null;
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/HintScanPrioritizer.java
@@ -18,14 +18,14 @@
  */
 package org.apache.accumulo.core.spi.scan;
 
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
 import java.util.Comparator;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.ScannerBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * When configured for a scan executor, this prioritizer allows scanners to set priorities as
@@ -115,16 +115,10 @@ public class HintScanPrioritizer implements ScanPrioritizer {
     int defaultPriority = Integer
         .parseInt(params.getOptions().getOrDefault("default_priority", Integer.MAX_VALUE + ""));
 
-    var tpb = ImmutableMap.<String,Integer>builder();
-
-    params.getOptions().forEach((k, v) -> {
-      if (k.startsWith(PRIO_PREFIX)) {
-        String type = k.substring(PRIO_PREFIX.length());
-        tpb.put(type, Integer.parseInt(v));
-      }
-    });
-
-    Map<String,Integer> typePriorities = tpb.build();
+    Map<String,Integer> typePriorities =
+        params.getOptions().entrySet().stream().filter(e -> e.getKey().startsWith(PRIO_PREFIX))
+            .collect(toUnmodifiableMap(e -> e.getKey().substring(PRIO_PREFIX.length()),
+                e -> Integer.parseInt(e.getValue())));
 
     HintProblemAction hpa = HintProblemAction.valueOf(params.getOptions()
         .getOrDefault("bad_hint_action", HintProblemAction.LOG.name()).toUpperCase());

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarySerializer.java
@@ -537,7 +537,7 @@ class SummarySerializer {
 
   private static Map<String,Long> readSummary(DataInputStream in, String[] symbols)
       throws IOException {
-    var imb = ImmutableMap.<String,Long>builder();
+    final var imb = ImmutableMap.<String,Long>builder();
     int numEntries = WritableUtils.readVInt(in);
 
     for (int i = 0; i < numEntries; i++) {

--- a/core/src/main/java/org/apache/accumulo/core/util/ConfigurationImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ConfigurationImpl.java
@@ -32,8 +32,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.PropertyType;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
 
-import com.google.common.collect.ImmutableMap;
-
 public class ConfigurationImpl implements Configuration {
 
   private final AccumuloConfiguration acfg;
@@ -110,13 +108,9 @@ public class ConfigurationImpl implements Configuration {
 
   private Map<String,String> buildCustom(Property customPrefix) {
     // This could be optimized as described in #947
-    Map<String,String> props = acfg.getAllPropertiesWithPrefix(customPrefix);
-    var builder = ImmutableMap.<String,String>builder();
-    props.forEach((k, v) -> {
-      builder.put(k.substring(customPrefix.getKey().length()), v);
-    });
-
-    return builder.build();
+    return acfg.getAllPropertiesWithPrefix(customPrefix).entrySet().stream().collect(
+        Collectors.toUnmodifiableMap(e -> e.getKey().substring(customPrefix.getKey().length()),
+            Entry::getValue));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.util;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,18 +53,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 
 public class LocalityGroupUtil {
 
   private static final Logger log = LoggerFactory.getLogger(LocalityGroupUtil.class);
 
-  // using an ImmutableSet here for more efficient comparisons in LocalityGroupIterator
-  public static final Set<ByteSequence> EMPTY_CF_SET = Set.of();
-
   /**
    * Create a set of families to be passed into the SortedKeyValueIterator seek call from a supplied
-   * set of columns. We are using the ImmutableSet to enable faster comparisons down in the
+   * set of columns. We are using the immutable set to enable faster comparisons down in the
    * LocalityGroupIterator.
    *
    * @param columns
@@ -71,11 +69,10 @@ public class LocalityGroupUtil {
    */
   public static Set<ByteSequence> families(Collection<Column> columns) {
     if (columns.isEmpty()) {
-      return EMPTY_CF_SET;
+      return Set.of();
     }
-    var builder = ImmutableSet.<ByteSequence>builder();
-    columns.forEach(c -> builder.add(new ArrayByteSequence(c.getColumnFamily())));
-    return builder.build();
+    return columns.stream().map(c -> new ArrayByteSequence(c.getColumnFamily()))
+        .collect(toUnmodifiableSet());
   }
 
   @SuppressWarnings("serial")
@@ -129,18 +126,16 @@ public class LocalityGroupUtil {
         String group = property.substring(prefix.length());
         String[] parts = group.split("\\.");
         group = parts[0];
-        if (result.containsKey(group)) {
-          if (parts.length == 1) {
-            Set<ByteSequence> colFamsSet = decodeColumnFamilies(value);
-            if (!Collections.disjoint(all, colFamsSet)) {
-              colFamsSet.retainAll(all);
-              throw new LocalityGroupConfigurationError("Column families " + colFamsSet
-                  + " in group " + group + " is already used by another locality group");
-            }
-
-            all.addAll(colFamsSet);
-            result.put(group, colFamsSet);
+        if (result.containsKey(group) && (parts.length == 1)) {
+          Set<ByteSequence> colFamsSet = decodeColumnFamilies(value);
+          if (!Collections.disjoint(all, colFamsSet)) {
+            colFamsSet.retainAll(all);
+            throw new LocalityGroupConfigurationError("Column families " + colFamsSet + " in group "
+                + group + " is already used by another locality group");
           }
+
+          all.addAll(colFamsSet);
+          result.put(group, colFamsSet);
         }
       }
     }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/FirstEntryInRowIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/FirstEntryInRowIteratorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -30,7 +31,6 @@ import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iteratorsImpl.system.CountingIterator;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.junit.Test;
 
 public class FirstEntryInRowIteratorTest {
@@ -44,7 +44,7 @@ public class FirstEntryInRowIteratorTest {
 
     feiri.init(counter, iteratorSetting.getOptions(), env);
 
-    feiri.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
+    feiri.seek(range, Set.of(), false);
     while (feiri.hasTop()) {
       resultMap.put(feiri.getTopKey(), feiri.getTopValue());
       feiri.next();

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/MultiIteratorTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.ByteSequence;
@@ -37,7 +38,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
@@ -79,11 +79,11 @@ public class MultiIteratorTest {
       Range range = new Range(prevEndRow, false, endRow, true);
       if (init)
         for (SortedKeyValueIterator<Key,Value> iter : iters)
-          iter.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
+          iter.seek(range, Set.of(), false);
       mi = new MultiIterator(iters, range);
 
       if (init)
-        mi.seek(range, LocalityGroupUtil.EMPTY_CF_SET, false);
+        mi.seek(range, Set.of(), false);
     }
 
     if (seekKey != null)

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/LargeRowFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/LargeRowFilterTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -35,7 +36,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.junit.Test;
 
 public class LargeRowFilterTest {
@@ -82,7 +82,7 @@ public class LargeRowFilterTest {
       genTestData(expectedData, i);
 
       LargeRowFilter lrfi = setupIterator(testData, i, IteratorScope.scan);
-      lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+      lrfi.seek(new Range(), Set.of(), false);
 
       TreeMap<Key,Value> filteredData = new TreeMap<>();
 
@@ -111,7 +111,7 @@ public class LargeRowFilterTest {
 
       // seek to each row... rows that exceed max columns should be filtered
       for (int j = 1; j <= i; j++) {
-        lrfi.seek(new Range(genRow(j), genRow(j)), LocalityGroupUtil.EMPTY_CF_SET, false);
+        lrfi.seek(new Range(genRow(j), genRow(j)), Set.of(), false);
 
         while (lrfi.hasTop()) {
           assertEquals(genRow(j), lrfi.getTopKey().getRow().toString());
@@ -133,16 +133,12 @@ public class LargeRowFilterTest {
     LargeRowFilter lrfi = setupIterator(testData, 13, IteratorScope.scan);
 
     // test seeking to the middle of a row
-    lrfi.seek(
-        new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
-            new Key(genRow(15)).followingKey(PartialKey.ROW), false),
-        LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
+        new Key(genRow(15)).followingKey(PartialKey.ROW), false), Set.of(), false);
     assertFalse(lrfi.hasTop());
 
-    lrfi.seek(
-        new Range(new Key(genRow(10), "cf001", genCQ(4), 5), true,
-            new Key(genRow(10)).followingKey(PartialKey.ROW), false),
-        LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(new Key(genRow(10), "cf001", genCQ(4), 5), true,
+        new Key(genRow(10)).followingKey(PartialKey.ROW), false), Set.of(), false);
     TreeMap<Key,Value> expectedData = new TreeMap<>();
     genRow(expectedData, 10, 4, 10);
 
@@ -162,7 +158,7 @@ public class LargeRowFilterTest {
     genTestData(testData, 20);
 
     LargeRowFilter lrfi = setupIterator(testData, 13, IteratorScope.majc);
-    lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(), Set.of(), false);
 
     TreeMap<Key,Value> compactedData = new TreeMap<>();
     while (lrfi.hasTop()) {
@@ -178,7 +174,7 @@ public class LargeRowFilterTest {
     // because there are suppression markers.. if there was a bug and data
     // was not suppressed, increasing the threshold would expose the bug
     lrfi = setupIterator(compactedData, 20, IteratorScope.scan);
-    lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(), Set.of(), false);
 
     // only expect to see 13 rows
     TreeMap<Key,Value> expectedData = new TreeMap<>();
@@ -195,10 +191,8 @@ public class LargeRowFilterTest {
 
     // try seeking to the middle of row 15... row has data and suppression marker... this seeks past
     // the marker but before the column
-    lrfi.seek(
-        new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
-            new Key(genRow(15)).followingKey(PartialKey.ROW), false),
-        LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(new Key(genRow(15), "cf001", genCQ(4), 5), true,
+        new Key(genRow(15)).followingKey(PartialKey.ROW), false), Set.of(), false);
     assertFalse(lrfi.hasTop());
 
     // test seeking w/ column families
@@ -224,7 +218,7 @@ public class LargeRowFilterTest {
     genRow(expectedData, 4, 0, 5);
 
     LargeRowFilter lrfi = setupIterator(testData, 13, IteratorScope.scan);
-    lrfi.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    lrfi.seek(new Range(), Set.of(), false);
 
     TreeMap<Key,Value> filteredData = new TreeMap<>();
     while (lrfi.hasTop()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
@@ -45,8 +46,6 @@ import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.conf.ZooCachePropertyAccessor.PropCacheKey;
-
-import com.google.common.collect.ImmutableMap;
 
 public class TableConfiguration extends AccumuloConfiguration {
 
@@ -183,11 +182,8 @@ public class TableConfiguration extends AccumuloConfiguration {
     private ParsedIteratorConfig(List<IterInfo> ii, Map<String,Map<String,String>> opts,
         String context) {
       this.tableIters = List.copyOf(ii);
-      var imb = ImmutableMap.<String,Map<String,String>>builder();
-      for (Entry<String,Map<String,String>> entry : opts.entrySet()) {
-        imb.put(entry.getKey(), Map.copyOf(entry.getValue()));
-      }
-      tableOpts = imb.build();
+      tableOpts = opts.entrySet().stream()
+          .collect(Collectors.toUnmodifiableMap(Entry::getKey, e -> Map.copyOf(e.getValue())));
       this.context = context;
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,6 @@ import org.apache.accumulo.core.file.rfile.RFileOperations;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.metadata.TabletFile;
-import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.conf.Configuration;
@@ -56,8 +56,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableSortedMap;
 
 public class FileUtil {
 
@@ -237,7 +235,7 @@ public class FileUtil {
       if (prevEndRow == null)
         prevEndRow = new Text();
 
-      long numKeys = 0;
+      long numKeys;
 
       numKeys = countIndexEntries(context, prevEndRow, endRow, mapFiles, true, readers);
 
@@ -322,7 +320,7 @@ public class FileUtil {
 
       long t1 = System.currentTimeMillis();
 
-      long numKeys = 0;
+      long numKeys;
 
       numKeys = countIndexEntries(context, prevEndRow, endRow, mapFiles,
           tmpDir == null ? useIndex : false, readers);
@@ -337,7 +335,7 @@ public class FileUtil {
           return findMidPoint(context, tabletDirectory, prevEndRow, endRow, origMapFiles, minSplit,
               false);
         }
-        return ImmutableSortedMap.of();
+        return Collections.emptySortedMap();
       }
 
       List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<>(readers);
@@ -443,9 +441,8 @@ public class FileUtil {
         else
           reader = FileOperations.getInstance().newScanReaderBuilder()
               .forFile(file.getPathStr(), ns, ns.getConf(), context.getCryptoService())
-              .withTableConfiguration(acuConf).overRange(new Range(prevEndRow, false, null, true),
-                  LocalityGroupUtil.EMPTY_CF_SET, false)
-              .build();
+              .withTableConfiguration(acuConf)
+              .overRange(new Range(prevEndRow, false, null, true), Set.of(), false).build();
 
         while (reader.hasTop()) {
           Key key = reader.getTopKey();
@@ -472,9 +469,8 @@ public class FileUtil {
       else
         readers.add(FileOperations.getInstance().newScanReaderBuilder()
             .forFile(file.getPathStr(), ns, ns.getConf(), context.getCryptoService())
-            .withTableConfiguration(acuConf).overRange(new Range(prevEndRow, false, null, true),
-                LocalityGroupUtil.EMPTY_CF_SET, false)
-            .build());
+            .withTableConfiguration(acuConf)
+            .overRange(new Range(prevEndRow, false, null, true), Set.of(), false).build());
 
     }
     return numKeys;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1188,7 +1188,7 @@ public class Manager extends AbstractServer
           try {
             if ((replServer.get() == null)
                 && !getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
-              log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
+              log.info("{} was set, starting repl services.", Property.REPLICATION_NAME.getKey());
               replServer.set(setupReplication());
             }
           } catch (UnknownHostException | KeeperException | InterruptedException e) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptySortedMap;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
@@ -211,10 +212,8 @@ public class Manager extends AbstractServer
 
   Fate<Manager> fate;
 
-  volatile SortedMap<TServerInstance,TabletServerStatus> tserverStatus =
-      Collections.unmodifiableSortedMap(new TreeMap<>());
-  volatile SortedMap<TabletServerId,TServerStatus> tserverStatusForBalancer =
-      Collections.unmodifiableSortedMap(new TreeMap<>());
+  volatile SortedMap<TServerInstance,TabletServerStatus> tserverStatus = emptySortedMap();
+  volatile SortedMap<TabletServerId,TServerStatus> tserverStatusForBalancer = emptySortedMap();
   final ServerBulkImportStatus bulkImportStatus = new ServerBulkImportStatus();
 
   private final AtomicBoolean managerInitialized = new AtomicBoolean(false);
@@ -615,10 +614,8 @@ public class Manager extends AbstractServer
                 if (tls.chopped) {
                   return TabletGoalState.UNASSIGNED;
                 }
-              } else {
-                if (tls.chopped && tls.walogs.isEmpty()) {
-                  return TabletGoalState.UNASSIGNED;
-                }
+              } else if (tls.chopped && tls.walogs.isEmpty()) {
+                return TabletGoalState.UNASSIGNED;
               }
 
               return TabletGoalState.HOSTED;
@@ -1189,11 +1186,10 @@ public class Manager extends AbstractServer
     ThreadPools.createGeneralScheduledExecutorService(getConfiguration())
         .scheduleWithFixedDelay(() -> {
           try {
-            if (replServer.get() == null) {
-              if (!getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
-                log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
-                replServer.set(setupReplication());
-              }
+            if ((replServer.get() == null)
+                && !getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
+              log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
+              replServer.set(setupReplication());
             }
           } catch (UnknownHostException | KeeperException | InterruptedException e) {
             log.error("Error occurred starting replication services. ", e);
@@ -1497,10 +1493,9 @@ public class Manager extends AbstractServer
 
       Set<TServerInstance> unexpected = new HashSet<>(deleted);
       unexpected.removeAll(this.serversToShutdown);
-      if (!unexpected.isEmpty()) {
-        if (stillManager() && !getManagerGoalState().equals(ManagerGoalState.CLEAN_STOP)) {
-          log.warn("Lost servers {}", unexpected);
-        }
+      if (!unexpected.isEmpty()
+          && (stillManager() && !getManagerGoalState().equals(ManagerGoalState.CLEAN_STOP))) {
+        log.warn("Lost servers {}", unexpected);
       }
       serversToShutdown.removeAll(deleted);
       badServers.keySet().removeAll(deleted);
@@ -1582,10 +1577,8 @@ public class Manager extends AbstractServer
 
     for (TableId tableId : Tables.getIdToNameMap(context).keySet()) {
       TableState state = manager.getTableState(tableId);
-      if (state != null) {
-        if (state == TableState.ONLINE) {
-          result.add(tableId);
-        }
+      if ((state != null) && (state == TableState.ONLINE)) {
+        result.add(tableId);
       }
     }
     return result;
@@ -1620,16 +1613,12 @@ public class Manager extends AbstractServer
   }
 
   public void assignedTablet(KeyExtent extent) {
-    if (extent.isMeta()) {
-      if (getManagerState().equals(ManagerState.UNLOAD_ROOT_TABLET)) {
-        setManagerState(ManagerState.UNLOAD_METADATA_TABLETS);
-      }
+    if (extent.isMeta() && getManagerState().equals(ManagerState.UNLOAD_ROOT_TABLET)) {
+      setManagerState(ManagerState.UNLOAD_METADATA_TABLETS);
     }
-    if (extent.isRootTablet()) {
-      // probably too late, but try anyhow
-      if (getManagerState().equals(ManagerState.STOP)) {
-        setManagerState(ManagerState.UNLOAD_ROOT_TABLET);
-      }
+    // probably too late, but try anyhow
+    if (extent.isRootTablet() && getManagerState().equals(ManagerState.STOP)) {
+      setManagerState(ManagerState.UNLOAD_ROOT_TABLET);
     }
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -106,7 +106,7 @@ abstract class TabletGroupWatcher extends Thread {
   private final TabletStateStore store;
   private final TabletGroupWatcher dependentWatcher;
   final TableStats stats = new TableStats();
-  private SortedSet<TServerInstance> lastScanServers = ImmutableSortedSet.of();
+  private SortedSet<TServerInstance> lastScanServers = Collections.emptySortedSet();
 
   TabletGroupWatcher(Manager manager, TabletStateStore store, TabletGroupWatcher dependentWatcher) {
     this.manager = manager;
@@ -198,7 +198,7 @@ abstract class TabletGroupWatcher extends Thread {
         if (currentTServers.isEmpty()) {
           eventListener.waitForEvents(Manager.TIME_TO_WAIT_BETWEEN_SCANS);
           synchronized (this) {
-            lastScanServers = ImmutableSortedSet.of();
+            lastScanServers = Collections.emptySortedSet();
           }
           continue;
         }
@@ -254,19 +254,17 @@ abstract class TabletGroupWatcher extends Thread {
           }
 
           // if we are shutting down all the tabletservers, we have to do it in order
-          if (goal == TabletGoalState.SUSPENDED && state == TabletState.HOSTED) {
-            if (manager.serversToShutdown.equals(currentTServers.keySet())) {
-              if (dependentWatcher != null && dependentWatcher.assignedOrHosted() > 0) {
-                goal = TabletGoalState.HOSTED;
-              }
+          if ((goal == TabletGoalState.SUSPENDED && state == TabletState.HOSTED)
+              && manager.serversToShutdown.equals(currentTServers.keySet())) {
+            if (dependentWatcher != null && dependentWatcher.assignedOrHosted() > 0) {
+              goal = TabletGoalState.HOSTED;
             }
           }
 
           if (goal == TabletGoalState.HOSTED) {
-            if (state != TabletState.HOSTED && !tls.walogs.isEmpty()) {
-              if (manager.recoveryManager.recoverLogs(tls.extent, tls.walogs))
-                continue;
-            }
+            if ((state != TabletState.HOSTED && !tls.walogs.isEmpty())
+                && manager.recoveryManager.recoverLogs(tls.extent, tls.walogs))
+              continue;
             switch (state) {
               case HOSTED:
                 if (location.equals(manager.migrations.get(tls.extent)))

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -80,7 +80,7 @@ public class PrepBulkImportTest {
   }
 
   Iterable<List<KeyExtent>> powerSet(KeyExtent... extents) {
-    Set<Set<KeyExtent>> powerSet = Sets.powerSet(Set.copyOf(Arrays.asList(extents)));
+    Set<Set<KeyExtent>> powerSet = Sets.powerSet(Set.of(extents));
 
     return Iterables.transform(powerSet, set -> {
       List<KeyExtent> list = new ArrayList<>(set);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/OnlineTablets.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/OnlineTablets.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
+import java.util.Collections;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -32,7 +33,7 @@ import com.google.common.collect.ImmutableSortedMap;
  * threads can access the snapshot without interfering with each other.
  */
 public class OnlineTablets {
-  private volatile ImmutableSortedMap<KeyExtent,Tablet> snapshot = ImmutableSortedMap.of();
+  private volatile SortedMap<KeyExtent,Tablet> snapshot = Collections.emptySortedMap();
   private final SortedMap<KeyExtent,Tablet> onlineTablets = new TreeMap<>();
 
   public synchronized void put(KeyExtent ke, Tablet t) {
@@ -52,7 +53,7 @@ public class OnlineTablets {
     snapshot = ImmutableSortedMap.copyOf(onlineTablets);
   }
 
-  ImmutableSortedMap<KeyExtent,Tablet> snapshot() {
+  SortedMap<KeyExtent,Tablet> snapshot() {
     return snapshot;
   }
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -181,10 +181,10 @@ public class InMemoryMapTest {
     mutate(imm, "r1", "foo:cq1", 3, "bar1");
     MemoryIterator ski2 = imm.skvIterator(null);
 
-    ski1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(), Set.of(), false);
     assertFalse(ski1.hasTop());
 
-    ski2.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski2.seek(new Range(), Set.of(), false);
     assertTrue(ski2.hasTop());
     testAndCallNext(ski2, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski2.hasTop());
@@ -205,12 +205,12 @@ public class InMemoryMapTest {
 
     MemoryIterator ski2 = imm.skvIterator(null);
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
-    ski2.seek(new Range(new Text("r3")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski2.seek(new Range(new Text("r3")), Set.of(), false);
     testAndCallNext(ski2, "r3", "foo:cq1", 3, "bara");
     testAndCallNext(ski2, "r3", "foo:cq1", 3, "bar9");
     assertFalse(ski1.hasTop());
@@ -228,20 +228,20 @@ public class InMemoryMapTest {
 
     imm.delete(0);
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(new Text("r2")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r2")), Set.of(), false);
     assertFalse(ski1.hasTop());
 
-    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar2");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
     assertFalse(ski1.hasTop());
@@ -259,9 +259,9 @@ public class InMemoryMapTest {
 
     imm.delete(0);
 
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     assertEqualsNoNext(ski1, "r1", "foo:cq1", 3, "");
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "");
     assertFalse(ski1.hasTop());
 
@@ -277,7 +277,7 @@ public class InMemoryMapTest {
     mutate(imm, "r1", "foo:cq1", 3, "bar3");
 
     MemoryIterator ski1 = imm.skvIterator(null);
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar3");
 
     imm.delete(0);
@@ -295,7 +295,7 @@ public class InMemoryMapTest {
     mutate(imm, "r1", "foo:cq3", 3, "bar3");
 
     ski1 = imm.skvIterator(null);
-    ski1.seek(new Range(new Text("r1")), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(new Text("r1")), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
 
     imm.delete(0);
@@ -322,10 +322,10 @@ public class InMemoryMapTest {
 
     SortedKeyValueIterator<Key,Value> dc = ski1.deepCopy(new SampleIE());
 
-    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq1", 3), null), Set.of(), false);
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
 
-    dc.seek(new Range(newKey("r1", "foo:cq2", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(newKey("r1", "foo:cq2", 3), null), Set.of(), false);
     testAndCallNext(dc, "r1", "foo:cq2", 3, "bar2");
 
     imm.delete(0);
@@ -338,9 +338,9 @@ public class InMemoryMapTest {
     assertFalse(ski1.hasTop());
     assertFalse(dc.hasTop());
 
-    ski1.seek(new Range(newKey("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    ski1.seek(new Range(newKey("r1", "foo:cq3", 3), null), Set.of(), false);
 
-    dc.seek(new Range(newKey("r1", "foo:cq4", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(newKey("r1", "foo:cq4", 3), null), Set.of(), false);
     testAndCallNext(dc, "r1", "foo:cq4", 3, "bar4");
     assertFalse(dc.hasTop());
 
@@ -381,8 +381,8 @@ public class InMemoryMapTest {
       }
     }
 
-    dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
-    ski1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(), Set.of(), false);
+    ski1.seek(new Range(), Set.of(), false);
 
     if (interleaving == 3) {
       imm.delete(0);
@@ -393,7 +393,7 @@ public class InMemoryMapTest {
 
     testAndCallNext(dc, "r1", "foo:cq1", 3, "bar1");
     testAndCallNext(ski1, "r1", "foo:cq1", 3, "bar1");
-    dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(), Set.of(), false);
 
     if (interleaving == 4) {
       imm.delete(0);
@@ -409,7 +409,7 @@ public class InMemoryMapTest {
     assertFalse(ski1.hasTop());
 
     if (interrupt) {
-      dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+      dc.seek(new Range(), Set.of(), false);
     }
   }
 
@@ -466,10 +466,10 @@ public class InMemoryMapTest {
 
     MemoryIterator skvi1 = imm.skvIterator(null);
 
-    skvi1.seek(new Range(newKey("r1", "foo:cq3", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    skvi1.seek(new Range(newKey("r1", "foo:cq3", 3), null), Set.of(), false);
     testAndCallNext(skvi1, "r1", "foo:cq3", 3, "bar3");
 
-    skvi1.seek(new Range(newKey("r1", "foo:cq1", 3), null), LocalityGroupUtil.EMPTY_CF_SET, false);
+    skvi1.seek(new Range(newKey("r1", "foo:cq1", 3), null), Set.of(), false);
     testAndCallNext(skvi1, "r1", "foo:cq1", 3, "bar1");
 
   }
@@ -484,7 +484,7 @@ public class InMemoryMapTest {
     imm.mutate(Collections.singletonList(m), 2);
 
     MemoryIterator skvi1 = imm.skvIterator(null);
-    skvi1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    skvi1.seek(new Range(), Set.of(), false);
     testAndCallNext(skvi1, "r1", "foo:cq", 3, "v2");
     testAndCallNext(skvi1, "r1", "foo:cq", 3, "v1");
   }
@@ -713,7 +713,7 @@ public class InMemoryMapTest {
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
         RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
   }
 
   @Test(expected = SampleNotPresentException.class)
@@ -725,7 +725,7 @@ public class InMemoryMapTest {
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
         RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
   }
 
   @Test
@@ -737,7 +737,7 @@ public class InMemoryMapTest {
 
     // when in mem map is empty should be able to get sample iterator with any sample config
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
     assertFalse(iter.hasTop());
   }
 
@@ -769,24 +769,24 @@ public class InMemoryMapTest {
     }
 
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
     assertEquals(expectedSample, readAll(iter));
 
     SortedKeyValueIterator<Key,Value> dc = iter.deepCopy(new SampleIE(sampleConfig2));
-    dc.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    dc.seek(new Range(), Set.of(), false);
     assertEquals(expectedSample, readAll(dc));
 
     iter = imm.skvIterator(null);
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
     assertEquals(expectedAll, readAll(iter));
 
     final MemoryIterator finalIter = imm.skvIterator(sampleConfig1);
     assertThrows(SampleNotPresentException.class,
-        () -> finalIter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false));
+        () -> finalIter.seek(new Range(), Set.of(), false));
   }
 
   private TreeMap<Key,Value> readAll(SortedKeyValueIterator<Key,Value> iter) throws IOException {
-    iter.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter.seek(new Range(), Set.of(), false);
 
     TreeMap<Key,Value> actual = new TreeMap<>();
     while (iter.hasTop()) {
@@ -846,7 +846,7 @@ public class InMemoryMapTest {
     testAndCallNext(iter1, "r2", "cf2:x", 3, "5");
     assertFalse(iter1.hasTop());
 
-    iter1.seek(new Range(), LocalityGroupUtil.EMPTY_CF_SET, false);
+    iter1.seek(new Range(), Set.of(), false);
     assertAll(iter1);
 
     iter1.seek(new Range(), newCFSet("cf1"), false);

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellUtil.java
@@ -23,17 +23,18 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 
+import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.hadoop.io.Text;
-
-import com.google.common.collect.ImmutableMap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -68,14 +69,10 @@ public class ShellUtil {
 
   public static Map<String,String> parseMapOpt(CommandLine cl, Option opt) {
     if (cl.hasOption(opt.getLongOpt())) {
-      var builder = ImmutableMap.<String,String>builder();
-      String[] keyVals = cl.getOptionValue(opt.getLongOpt()).split(",");
-      for (String keyVal : keyVals) {
-        String[] sa = keyVal.split("=");
-        builder.put(sa[0], sa[1]);
-      }
-
-      return builder.build();
+      return Arrays.stream(cl.getOptionValue(opt.getLongOpt()).split(",")).map(kv -> {
+        String[] sa = kv.split("=");
+        return new Pair<>(sa[0], sa[1]);
+      }).collect(Collectors.toUnmodifiableMap(Pair::getFirst, Pair::getSecond));
     } else {
       return Collections.emptyMap();
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -47,7 +47,10 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.IntPredicate;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -87,7 +90,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -752,11 +754,9 @@ public class SummaryIT extends AccumuloClusterHarness {
   }
 
   private Map<String,Long> nm(Object... entries) {
-    var imb = ImmutableMap.<String,Long>builder();
-    for (int i = 0; i < entries.length; i += 2) {
-      imb.put((String) entries[i], (Long) entries[i + 1]);
-    }
-    return imb.build();
+    IntPredicate evenIndex = i -> i % 2 == 0;
+    return IntStream.range(0, entries.length).filter(evenIndex).boxed().collect(
+        Collectors.toUnmodifiableMap(i -> (String) entries[i], i -> (Long) entries[i + 1]));
   }
 
   @Test


### PR DESCRIPTION
Utilize some Java 11 features for immutable maps, sets, and lists, to
minimize our dependence on equivalent Guava features. Some use of Guava
builders for these are still used, since Java 11 doesn't have convenient
immutable collection builders, but they have been made final to ensure
we use them correctly and don't re-assign them once built.