### PR TITLE
Fix IP address in GitHub Actions container

### DIFF
--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -100,6 +100,15 @@ jobs:
           !~/.m2/repository/org/apache/accumulo
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Override DNS to fix IP address for hostname
+      run: |
+        hostname_short=$(hostname -s)
+        hostname_long=$(hostname -f)
+        if ! grep -q $hostname_short /etc/hosts; then
+          actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
+          echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
+          echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
+        fi
     - name: Build with Maven (${{ matrix.profile.its }})
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" verify -PskipQA -DskipTests=false -DskipITs=false -Dtest=nomatchingtest -Dit.test="${{ matrix.profile.its }}"

--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -102,6 +102,9 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - name: Override DNS to fix IP address for hostname
       run: |
+        ip -br addr
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
         hostname_short=$(hostname -s)
         hostname_long=$(hostname -f)
         if ! grep -q $hostname_short /etc/hosts; then
@@ -109,6 +112,9 @@ jobs:
           echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
           echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
         fi
+        ip -br addr
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
     - name: Build with Maven (${{ matrix.profile.its }})
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" verify -PskipQA -DskipTests=false -DskipITs=false -Dtest=nomatchingtest -Dit.test="${{ matrix.profile.its }}"

--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -111,10 +111,10 @@ jobs:
           actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
           echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
           echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
+          ip -br addr
+          echo "'hostname -i' shows '$(hostname -i)'"
+          echo "'hostname -I' shows '$(hostname -I)'"
         fi
-        ip -br addr
-        echo "'hostname -i' shows '$(hostname -i)'"
-        echo "'hostname -I' shows '$(hostname -I)'"
     - name: Build with Maven (${{ matrix.profile.its }})
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" verify -PskipQA -DskipTests=false -DskipITs=false -Dtest=nomatchingtest -Dit.test="${{ matrix.profile.its }}"

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -78,6 +78,9 @@ jobs:
       run: git log -n1
     - name: Override DNS to fix IP address for hostname
       run: |
+        ip -br addr
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
         hostname_short=$(hostname -s)
         hostname_long=$(hostname -f)
         if ! grep -q $hostname_short /etc/hosts; then
@@ -85,6 +88,9 @@ jobs:
           echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
           echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
         fi
+        ip -br addr
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
     - name: Build with Maven
       timeout-minutes: 345
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }} ${{ github.event.inputs.utOpts }} ${{ github.event.inputs.itOpts }} ${{ github.event.inputs.addOpts }}

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -76,6 +76,15 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - name: Show the first log message
       run: git log -n1
+    - name: Override DNS to fix IP address for hostname
+      run: |
+        hostname_short=$(hostname -s)
+        hostname_long=$(hostname -f)
+        if ! grep -q $hostname_short /etc/hosts; then
+          actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
+          echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
+          echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
+        fi
     - name: Build with Maven
       timeout-minutes: 345
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }} ${{ github.event.inputs.utOpts }} ${{ github.event.inputs.itOpts }} ${{ github.event.inputs.addOpts }}

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -87,10 +87,10 @@ jobs:
           actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
           echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
           echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
+          ip -br addr
+          echo "'hostname -i' shows '$(hostname -i)'"
+          echo "'hostname -I' shows '$(hostname -I)'"
         fi
-        ip -br addr
-        echo "'hostname -i' shows '$(hostname -i)'"
-        echo "'hostname -I' shows '$(hostname -I)'"
     - name: Build with Maven
       timeout-minutes: 345
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ github.event.inputs.mvnOpts }} ${{ github.event.inputs.goals }} ${{ github.event.inputs.utOpts }} ${{ github.event.inputs.itOpts }} ${{ github.event.inputs.addOpts }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -78,6 +78,15 @@ jobs:
           !~/.m2/repository/org/apache/accumulo
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Override DNS to fix IP address for hostname
+      run: |
+        hostname_short=$(hostname -s)
+        hostname_long=$(hostname -f)
+        if ! grep -q $hostname_short /etc/hosts; then
+          actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
+          echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
+          echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
+        fi
     - name: Build with Maven (${{ matrix.profile.name }})
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -80,6 +80,9 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - name: Override DNS to fix IP address for hostname
       run: |
+        ip -br addr
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
         hostname_short=$(hostname -s)
         hostname_long=$(hostname -f)
         if ! grep -q $hostname_short /etc/hosts; then
@@ -87,6 +90,9 @@ jobs:
           echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
           echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
         fi
+        ip -br addr
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
     - name: Build with Maven (${{ matrix.profile.name }})
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -89,10 +89,10 @@ jobs:
           actual_ip=$(ip -4 addr show dev eth0 | grep -o 'inet [0-9.]*' | cut -f2 -d ' ')
           echo "Setting $hostname_long / $hostname_short to $actual_ip in /etc/hosts"
           echo "$actual_ip $hostname_long $hostname_short" | sudo tee -a /etc/hosts
+          ip -br addr
+          echo "'hostname -i' shows '$(hostname -i)'"
+          echo "'hostname -I' shows '$(hostname -I)'"
         fi
-        ip -br addr
-        echo "'hostname -i' shows '$(hostname -i)'"
-        echo "'hostname -I' shows '$(hostname -I)'"
     - name: Build with Maven (${{ matrix.profile.name }})
       timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}


### PR DESCRIPTION
Fix #2016 by adding an entry to /etc/hosts to fix incorrect DNS entries,
which return an IP for the current machine's hostname that does not
match any IP address in the machine. Adding an entry to /etc/hosts
to force the hostname to match on eth0's IP address.