### PR TITLE
Add bulk import option to ignore empty dirs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -802,6 +802,32 @@ public interface TableOperations {
    * @since 2.0.0
    */
   default ImportDestinationArguments importDirectory(String directory) {
+    return importDirectory(directory, false);
+  }
+
+  /**
+   * Bulk import the files in a directory into a table. Files can be created using
+   * {@link RFile#newWriter()}.
+   * <p>
+   * This new method of bulk import examines files in the current process outside of holding a table
+   * lock. The old bulk import method ({@link #importDirectory(String, String, String, boolean)})
+   * examines files on the server side while holding a table read lock. This version of the method
+   * provides a boolean argument which will prevent an exception from being thrown if the supplied
+   * directory contains no files.
+   * <p>
+   * This API supports adding files to online and offline tables.
+   * <p>
+   * For example, to bulk import files from the directory 'dir1' into the table 'table1' use the
+   * following code.
+   *
+   * <pre>
+   * client.tableOperations().importDirectory("dir1", true).to("table1").load();
+   * </pre>
+   *
+   * @since 2.0.0
+   */
+  default ImportDestinationArguments importDirectory(final String directory,
+      final boolean ignoreEmptyDir) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -2003,6 +2003,12 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   @Override
   public ImportDestinationArguments importDirectory(String directory) {
-    return new BulkImport(directory, context);
+    return importDirectory(directory, false);
+  }
+
+  @Override
+  public ImportDestinationArguments importDirectory(final String directory,
+      final boolean ignoreEmptyDir) {
+    return new BulkImport(directory, ignoreEmptyDir, context);
   }
 }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OptUtil.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OptUtil.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.io.Text;
 public abstract class OptUtil {
   public static final String START_ROW_OPT = "b";
   public static final String END_ROW_OPT = "e";
+  public static final String IGNORE_EMPTY_BULKDIR_OPT = "i";
 
   public static String getTableOpt(final CommandLine cl, final Shell shellState)
       throws TableNotFoundException {
@@ -51,6 +52,14 @@ public abstract class OptUtil {
     }
 
     return tableName;
+  }
+
+  public static boolean getIgnoreEmptyDirOpt(final CommandLine cl, final Shell shellState) {
+    boolean ignoreEmptyDir = false;
+    if (cl.hasOption(IGNORE_EMPTY_BULKDIR_OPT)) {
+      ignoreEmptyDir = true;
+    }
+    return ignoreEmptyDir;
   }
 
   public static String getNamespaceOpt(final CommandLine cl, final Shell shellState)
@@ -77,6 +86,17 @@ public abstract class OptUtil {
     tableOpt.setArgName("table");
     tableOpt.setRequired(false);
     return tableOpt;
+  }
+
+  public static Option ignoreEmptyDirOpt() {
+    return ignoreEmptyDirOpt("ignoreEmptyDir");
+  }
+
+  public static Option ignoreEmptyDirOpt(final String description) {
+    final Option ignoreEmptyDirOpt = new Option("i", "ignore", false, description);
+    ignoreEmptyDirOpt.setArgName("ignore");
+    ignoreEmptyDirOpt.setRequired(false);
+    return ignoreEmptyDirOpt;
   }
 
   public static Option namespaceOpt() {

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/ImportDirectoryCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/ImportDirectoryCommandTest.java
@@ -74,6 +74,8 @@ public class ImportDirectoryCommandTest {
 
     // no -t option, use current table context
     expect(cli.hasOption("t")).andReturn(false).once();
+    // no -i option supplied
+    expect(cli.hasOption("i")).andReturn(false).once();
     expect(shellState.getTableName()).andReturn("tablename").once();
 
     expect(cli.getArgs()).andReturn(cliArgs).atLeastOnce();
@@ -83,7 +85,8 @@ public class ImportDirectoryCommandTest {
     shellState.checkTableState();
     expectLastCall().once();
 
-    expect(tableOperations.importDirectory("in_dir")).andReturn(bulkImport).once();
+    // given the -i option, the ignoreEmptyBulkDir boolean is set to false
+    expect(tableOperations.importDirectory("in_dir", false)).andReturn(bulkImport).once();
     expect(bulkImport.to("tablename")).andReturn(bulkImport).once();
     expect(bulkImport.tableTime(false)).andReturn(bulkImport).once();
     bulkImport.load();
@@ -103,6 +106,8 @@ public class ImportDirectoryCommandTest {
   public void testPassTableOptCmdForm() throws Exception {
     String[] cliArgs = {"in_dir", "false"};
 
+    // -i option specified, ignore empty bulk import directory
+    expect(cli.hasOption("i")).andReturn(true).once();
     // -t option specified, table is from option
     expect(cli.hasOption("t")).andReturn(true).once();
     expect(cli.getOptionValue("t")).andReturn("passedName").once();
@@ -114,7 +119,8 @@ public class ImportDirectoryCommandTest {
 
     // shellState.checkTableState() is NOT called
 
-    expect(tableOperations.importDirectory("in_dir")).andReturn(bulkImport).once();
+    // given the -i option, the ignoreEmptyBulkDir boolean is set to true
+    expect(tableOperations.importDirectory("in_dir", true)).andReturn(bulkImport).once();
     expect(bulkImport.to("passedName")).andReturn(bulkImport).once();
     expect(bulkImport.tableTime(false)).andReturn(bulkImport).once();
     bulkImport.load();

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkIT.java
@@ -118,6 +118,15 @@ public class BulkIT extends AccumuloClusterHarness {
           false);
     } else {
       c.tableOperations().importDirectory(files.toString()).to(tableName).load();
+      // rerun using the ignore option and no error should be thrown since empty directories
+      // will not throw an exception.
+      c.tableOperations().importDirectory(files.toString(), true).to(tableName).load();
+      try {
+        // if run again, without ignore flag, an IllegalArgrumentException should be thrown
+        c.tableOperations().importDirectory(files.toString(), false).to(tableName).load();
+      } catch (IllegalArgumentException ex) {
+        // expected exception to be thrown
+      }
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -151,6 +151,14 @@ public class BulkNewIT extends SharedMiniClusterBase {
     String h1 = writeData(dir + "/f1.", aconf, 0, 332);
 
     c.tableOperations().importDirectory(dir).to(tableName).tableTime(setTime).load();
+    // running again with boolean set to true will not throw an exception
+    c.tableOperations().importDirectory(dir, true).to(tableName).tableTime(setTime).load();
+    // but if run with with boolean set to true, an IllegalArgument exception will be thrown
+    try {
+      c.tableOperations().importDirectory(dir).to(tableName).tableTime(setTime).load();
+    } catch (IllegalArgumentException ex) {
+      // expected the exception
+    }
 
     if (offline) {
       c.tableOperations().online(tableName);
@@ -461,6 +469,18 @@ public class BulkNewIT extends SharedMiniClusterBase {
       FileSystem fs = getCluster().getFileSystem();
       fs.mkdirs(new Path(dir));
       c.tableOperations().importDirectory(dir).to(tableName).load();
+    }
+  }
+
+  // Test that the ignore option does not throw an exception if the import directory contains
+  // no files.
+  @Test
+  public void testEmptyDirWithIgnoreOption() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+      String dir = getDir("/testBulkFile-");
+      FileSystem fs = getCluster().getFileSystem();
+      fs.mkdirs(new Path(dir));
+      c.tableOperations().importDirectory(dir, true).to(tableName).load();
     }
   }
 


### PR DESCRIPTION
Update the new bulk import operations to allow empty source directories to be ignored rather than throwing an exception. There is now a '-i' option that will log an info message indicating that the source directory was empty and no files were imported rather than throwing an IllegalArgumentException.

This will support the use case of users who want to write idempotent bulk import code.