### PR TITLE
Fixed issue #2048 wrong name in CompactableFileImpl method

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/CompactableFileImpl.java
@@ -59,7 +59,7 @@ public class CompactableFileImpl implements CompactableFile {
     return dataFileValue.getNumEntries();
   }
 
-  public StoredTabletFile getStortedTabletFile() {
+  public StoredTabletFile getStoredTabletFile() {
     return storedTabletFile;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -544,7 +544,7 @@ public class CompactableImpl implements Compactable {
       RateLimiter writeLimiter, long queuedTime) {
 
     Set<StoredTabletFile> jobFiles = job.getFiles().stream()
-        .map(cf -> ((CompactableFileImpl) cf).getStortedTabletFile()).collect(Collectors.toSet());
+        .map(cf -> ((CompactableFileImpl) cf).getStoredTabletFile()).collect(Collectors.toSet());
 
     Long compactionId = null;
     Long checkCompactionId = null;


### PR DESCRIPTION
Name 'getStortedTabletFile' has been refactored by 'getStoredTabletFile' in method 'getStoredTabletFile()' of Class 'CompactableFileImpl'