### PR TITLE
Add retry counter for log recovery with MinC

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -138,15 +138,15 @@ public class MinorCompactor extends Compactor {
           // If the minor compaction stalls for too long during recovery, it can interfere with
           // other tables loading
           // Throw exception if this happens so assignments can be rescheduled.
+          ProblemReports.getInstance(tabletServer.getContext()).report(
+              new ProblemReport(getExtent().tableId(), ProblemType.FILE_WRITE, outputFileName, e));
           if (retryCounter >= 4 && mincReason.equals(MinorCompactionReason.RECOVERY)) {
-            log.warn("Minc is stuck for too long during recovery, throwing error for reschedule.");
-            ProblemReports.getInstance(tabletServer.getContext()).report(new ProblemReport(
-                getExtent().tableId(), ProblemType.FILE_WRITE, outputFileName, e));
+            log.warn(
+                "MinC ({}) is stuck for too long during recovery, throwing error to reschedule.",
+                getExtent(), e);
             throw new IllegalStateException(e);
           }
           log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), outputFileName, e);
-          ProblemReports.getInstance(tabletServer.getContext()).report(
-              new ProblemReport(getExtent().tableId(), ProblemType.FILE_WRITE, outputFileName, e));
           reportedProblem = true;
           retryCounter++;
         } catch (CompactionCanceledException e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -144,7 +144,7 @@ public class MinorCompactor extends Compactor {
             log.warn(
                 "MinC ({}) is stuck for too long during recovery, throwing error to reschedule.",
                 getExtent(), e);
-            throw new IllegalStateException(e);
+            throw new RuntimeException(e);
           }
           log.warn("MinC failed ({}) to create {} retrying ...", e.getMessage(), outputFileName, e);
           reportedProblem = true;


### PR DESCRIPTION
Potential fix for #2035. 

The issue with #2035 occurs at https://github.com/apache/accumulo/blob/30ce59fd94f51b60a30ced328156f02d3223330b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java#L175

If an iterator is misconfigured, this line will never complete and hang in `MinorCompactor.java`. This potential fix adds a retry counter (only a small amount of retries for testing purposes), solely used when the reason for the minor compaction is recovery. The exception thrown is just a placeholder for now. 

The result from this change is the exception thrown allows the assignments to get rescheduled so other tablets can be loaded in. 