### PR TITLE
Add optional extent to metadata update failure logs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.data;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.io.DataInput;
@@ -1772,4 +1773,35 @@ public class Mutation implements Writable {
     return this.useOldDeserialize ? SERIALIZED_FORMAT.VERSION1 : SERIALIZED_FORMAT.VERSION2;
   }
 
+  /**
+   * Creates a multi-lined, human-readable String for this mutation.
+   *
+   * This method creates many intermediate Strings and should not be used for large volumes of
+   * Mutations.
+   *
+   * @return A multi-lined, human-readable String for this mutation.
+   *
+   * @since 2.1.0
+   */
+  public String prettyPrint() {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append("mutation: ").append(new String(row, UTF_8)).append('\n');
+    for (ColumnUpdate update : getUpdates()) {
+      sb.append(" update: ");
+      sb.append(new String(update.getColumnFamily(), UTF_8));
+      sb.append(':');
+      sb.append(new String(update.getColumnQualifier(), UTF_8));
+      sb.append(" value ");
+
+      if (update.isDeleted()) {
+        sb.append("[delete]");
+      } else {
+        sb.append(new String(update.getValue(), UTF_8));
+      }
+      sb.append('\n');
+    }
+
+    return sb.toString();
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
@@ -920,4 +920,24 @@ public class MutationTest {
     m.estRowAndLargeValSize += (Long.MAX_VALUE / 2);
     m.put("cf", "cq2", "v");
   }
+
+  @Test
+  public void testPrettyPrint() {
+    String row = "row";
+    String fam1 = "fam1";
+    String fam2 = "fam2";
+    String qual1 = "qual1";
+    String qual2 = "qual2";
+    String value1 = "value1";
+
+    Mutation m = new Mutation("row");
+    m.put(fam1, qual1, value1);
+    m.putDelete(fam2, qual2);
+    m.getUpdates(); // serialize
+
+    String expected = "mutation: " + row + "\n update: " + fam1 + ":" + qual1 + " value " + value1
+        + "\n update: " + fam2 + ":" + qual2 + " value [delete]\n";
+
+    assertEquals(expected, m.prettyPrint());
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -147,10 +147,6 @@ public class MetadataTableUtil {
     update(context, t, zooLock, m, extent);
   }
 
-  public static void update(ServerContext context, Writer t, ServiceLock zooLock, Mutation m) {
-    update(context, t, zooLock, m, null);
-  }
-
   public static void update(ServerContext context, Writer t, ServiceLock zooLock, Mutation m,
       KeyExtent extent) {
     if (zooLock != null)
@@ -171,8 +167,7 @@ public class MetadataTableUtil {
   }
 
   private static void logUpdateFailure(Mutation m, KeyExtent extent, Exception e) {
-    String extentMsg = extent == null ? "" : " for extent: " + extent;
-    log.error("Failed to write metadata updates {} {}", extentMsg, m.prettyPrint(), e);
+    log.error("Failed to write metadata updates for extent {} {}", extent, m.prettyPrint(), e);
   }
 
   public static void updateTabletFlushID(KeyExtent extent, long flushID, ServerContext context,

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -55,7 +55,7 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
       m.put("badcolfam", "badcolqual", "3");
 
       try {
-        MetadataTableUtil.update(context, w, null, m);
+        MetadataTableUtil.update(context, w, null, m, extent);
       } catch (RuntimeException e) {
         if (e.getCause().getClass().equals(ConstraintViolationException.class)) {
           throw (ConstraintViolationException) e.getCause();


### PR DESCRIPTION
This week we saw many "Failed to do close consistency check" errors. The log showed that the accumulo.metadata table had additional RFiles that were not present in the tserver's DatafileManager.datafileSizes map. We believe that this may have been due to a temporary network drop where a bulk importing tserver sent accumulo.metadata updates - the metadata updates were persisted but the bulk importing tserver's writer client did not receive a successful response. 

We'd like to add some additional logging to MetadataTableUtil so that we can tie the failures back to particular tablets to see if these correlate. 