### PR TITLE
Fix history test inside ShellServerIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -285,6 +285,11 @@ public class ShellServerIT extends SharedMiniClusterBase {
             output.get().contains(s));
       shell.resetExitCode();
     }
+
+    void writeToHistory(String cmd) {
+      input.set(cmd);
+      reader.readLine();
+    }
   }
 
   private static final NoOpErrorMessageCallback noop = new NoOpErrorMessageCallback();
@@ -1431,18 +1436,15 @@ public class ShellServerIT extends SharedMiniClusterBase {
     }
   }
 
-  // TODO - evaluate this test is testing what is expected or history is working.
   @Test
   public void history() throws Exception {
-    final String table = name.getMethodName();
+    final String table = getUniqueNames(1)[0];
 
     ts.exec("history -c", true);
-    ts.exec("createtable " + table);
-    ts.exec("deletetable -f " + table);
-    // TODO - this may be passing only because method name is history.
+    ts.writeToHistory("createtable " + table);
+    ts.writeToHistory("deletetable -f " + table);
     ts.exec("history", true, table, true);
-    // TODO - what is this testing?
-    ts.exec("history", true, "history", true);
+    ts.exec("history", true, "foo", false);
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1440,11 +1440,16 @@ public class ShellServerIT extends SharedMiniClusterBase {
   public void history() throws Exception {
     final String table = getUniqueNames(1)[0];
 
-    ts.exec("history -c", true);
+    // test clear history command works
+    ts.writeToHistory("foo");
+    ts.exec("history -c", true, "foo", false);
+
+    // write to history file. Does not execute functions
     ts.writeToHistory("createtable " + table);
     ts.writeToHistory("deletetable -f " + table);
+
+    // test that history command prints contents of history file
     ts.exec("history", true, table, true);
-    ts.exec("history", true, "foo", false);
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1442,14 +1442,21 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
     // test clear history command works
     ts.writeToHistory("foo");
-    ts.exec("history -c", true, "foo", false);
+    ts.exec("history", true, "foo", true);
+    ts.exec("history -c", true);
+    ts.exec("history", true, "foo", false);
 
-    // write to history file. Does not execute functions
+    // Verify commands are not currently in history then write to history file. Does not execute
+    // table ops.
+    ts.exec("history", true, table, false);
+    ts.exec("history", true, "createtable", false);
+    ts.exec("history", true, "deletetable", false);
     ts.writeToHistory("createtable " + table);
     ts.writeToHistory("deletetable -f " + table);
 
     // test that history command prints contents of history file
-    ts.exec("history", true, table, true);
+    ts.exec("history", true, "createtable " + table, true);
+    ts.exec("history", true, "deletetable -f " + table, true);
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")


### PR DESCRIPTION
Fixes #2091.

The history command was failing due to the executed commands not being written to the history file. This change will write the expected commands to the history file but solely for the history test at this moment since some tests broke with the change.  