### PR TITLE
Avoid recreating ServiceEnvironment

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactionConfigurer.java
@@ -34,7 +34,7 @@ public interface CompactionConfigurer {
   /**
    * @since 2.1.0
    */
-  public interface InitParamaters {
+  public interface InitParameters {
     TableId getTableId();
 
     Map<String,String> getOptions();
@@ -42,7 +42,7 @@ public interface CompactionConfigurer {
     PluginEnvironment getEnvironment();
   }
 
-  void init(InitParamaters iparams);
+  void init(InitParameters iparams);
 
   /**
    * @since 2.1.0

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompressionConfigurer.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompressionConfigurer.java
@@ -58,7 +58,7 @@ public class CompressionConfigurer implements CompactionConfigurer {
   private String largeCompress;
 
   @Override
-  public void init(InitParamaters iparams) {
+  public void init(InitParameters iparams) {
     var options = iparams.getOptions();
 
     String largeThresh = options.get(LARGE_FILE_COMPRESSION_THRESHOLD);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -19,6 +19,8 @@
 package org.apache.accumulo.server;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -32,10 +34,12 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   private final ServerContext srvCtx;
   private final Configuration conf;
+  private final Map<TableId,Configuration> tableConfigs;
 
   public ServiceEnvironmentImpl(ServerContext ctx) {
     this.srvCtx = ctx;
     this.conf = new ConfigurationImpl(srvCtx.getConfiguration());
+    this.tableConfigs = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -45,7 +49,8 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   @Override
   public Configuration getConfiguration(TableId tableId) {
-    return new ConfigurationImpl(srvCtx.getTableConfiguration(tableId));
+    return tableConfigs.computeIfAbsent(tableId,
+        tid -> new ConfigurationImpl(srvCtx.getTableConfiguration(tid)));
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -34,12 +34,11 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
 
   private final ServerContext srvCtx;
   private final Configuration conf;
-  private final Map<TableId,Configuration> tableConfigs;
+  private final Map<TableId,Configuration> tableConfigs = new ConcurrentHashMap<>();
 
   public ServiceEnvironmentImpl(ServerContext ctx) {
     this.srvCtx = ctx;
     this.conf = new ConfigurationImpl(srvCtx.getConfiguration());
-    this.tableConfigs = new ConcurrentHashMap<>();
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/TableConfiguration.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.Constants;
@@ -47,8 +46,6 @@ import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
 import org.apache.accumulo.server.conf.ZooCachePropertyAccessor.PropCacheKey;
-
-import com.google.common.base.Suppliers;
 
 public class TableConfiguration extends AccumuloConfiguration {
 
@@ -217,9 +214,7 @@ public class TableConfiguration extends AccumuloConfiguration {
 
     newDispatcher.init(new ScanDispatcher.InitParameters() {
 
-      // scan dispatcher are in the critical path for scans, so only create ServiceEnv if needed.
-      private final Supplier<ServiceEnvironment> senvSupplier =
-          Suppliers.memoize(() -> new ServiceEnvironmentImpl(context));
+      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(context);
 
       @Override
       public TableId getTableId() {
@@ -233,7 +228,7 @@ public class TableConfiguration extends AccumuloConfiguration {
 
       @Override
       public ServiceEnvironment getServiceEnv() {
-        return senvSupplier.get();
+        return senv;
       }
     });
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
@@ -42,12 +42,14 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
   private final Scope scope;
   private final Optional<TableId> tableId;
   private final Text endRow;
+  private final ServiceEnvironment senv;
 
   public VolumeChooserEnvironmentImpl(Scope scope, ServerContext context) {
     this.context = context;
     this.scope = Objects.requireNonNull(scope);
     this.tableId = Optional.empty();
     this.endRow = null;
+    this.senv = new ServiceEnvironmentImpl(context);
   }
 
   public VolumeChooserEnvironmentImpl(TableId tableId, Text endRow, ServerContext context) {
@@ -55,6 +57,7 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
     this.scope = Scope.TABLE;
     this.tableId = Optional.of(tableId);
     this.endRow = endRow;
+    this.senv = new ServiceEnvironmentImpl(context);
   }
 
   public VolumeChooserEnvironmentImpl(Scope scope, TableId tableId, Text endRow,
@@ -63,6 +66,7 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
     this.scope = Objects.requireNonNull(scope);
     this.tableId = Optional.of(tableId);
     this.endRow = endRow;
+    this.senv = new ServiceEnvironmentImpl(context);
   }
 
   /**
@@ -100,7 +104,7 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
 
   @Override
   public ServiceEnvironment getServiceEnv() {
-    return new ServiceEnvironmentImpl(context);
+    return senv;
   }
 
   @Override

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
@@ -22,13 +22,17 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.fs.VolumeChooser;
+import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class VolumeManagerImplTest {
@@ -75,7 +79,28 @@ public class VolumeManagerImplTest {
     conf.set(Property.GENERAL_VOLUME_CHOOSER, WrongVolumeChooser.class.getName());
     try (var vm = VolumeManagerImpl.get(conf, hadoopConf)) {
       org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment chooserEnv =
-          new VolumeChooserEnvironmentImpl(TableId.of("sometable"), null, null);
+          new VolumeChooserEnvironment() {
+
+            @Override
+            public Optional<TableId> getTable() {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ServiceEnvironment getServiceEnv() {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Text getEndRow() {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Scope getChooserScope() {
+              throw new UnsupportedOperationException();
+            }
+          };
       assertThrows(RuntimeException.class, () -> vm.choose(chooserEnv, volumes));
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -180,8 +180,7 @@ public class TabletServerResourceManager {
         Comparator<ScanInfo> comparator =
             factory.createComparator(new ScanPrioritizer.CreateParameters() {
 
-              private final Supplier<ServiceEnvironment> senvSupplier =
-                  Suppliers.memoize(() -> new ServiceEnvironmentImpl(context));
+              private final ServiceEnvironment senv = new ServiceEnvironmentImpl(context);
 
               @Override
               public Map<String,String> getOptions() {
@@ -190,7 +189,7 @@ public class TabletServerResourceManager {
 
               @Override
               public ServiceEnvironment getServiceEnv() {
-                return senvSupplier.get();
+                return senv;
               }
             });
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategy.java
@@ -171,7 +171,7 @@ public class ConfigurableCompactionStrategy implements CompactionSelector, Compa
 
   @Override
   public void init(
-      org.apache.accumulo.core.client.admin.compaction.CompactionConfigurer.InitParamaters iparams) {
+      org.apache.accumulo.core.client.admin.compaction.CompactionConfigurer.InitParameters iparams) {
     Set<Entry<String,String>> es = iparams.getOptions().entrySet();
     for (Entry<String,String> entry : es) {
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -87,6 +87,7 @@ public class CompactionService {
 
     private final Map<String,String> plannerOpts;
     private final Map<CompactionExecutorId,Integer> requestedExecutors;
+    private final ServiceEnvironment senv = new ServiceEnvironmentImpl(serverCtx);
 
     CpInitParams(Map<String,String> plannerOpts) {
       this.plannerOpts = plannerOpts;
@@ -95,7 +96,7 @@ public class CompactionService {
 
     @Override
     public ServiceEnvironment getServiceEnvironment() {
-      return new ServiceEnvironmentImpl(serverCtx);
+      return senv;
     }
 
     @Override
@@ -229,6 +230,8 @@ public class CompactionService {
 
     PlanningParameters params = new PlanningParameters() {
 
+      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(serverCtx);
+
       @Override
       public TableId getTableId() {
         return compactable.getTableId();
@@ -236,7 +239,7 @@ public class CompactionService {
 
       @Override
       public ServiceEnvironment getServiceEnvironment() {
-        return new ServiceEnvironmentImpl(serverCtx);
+        return senv;
       }
 
       @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -714,9 +714,11 @@ public class CompactableImpl implements Compactable {
 
       var dispatch = dispatcher.dispatch(new DispatchParameters() {
 
+        private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
+
         @Override
         public ServiceEnvironment getServiceEnv() {
-          return new ServiceEnvironmentImpl(tablet.getContext());
+          return senv;
         }
 
         @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -226,10 +226,9 @@ public class CompactableUtils {
     CompactionConfigurer configurer = CompactableUtils.newInstance(tablet.getTableConfiguration(),
         cfg.getClassName(), CompactionConfigurer.class);
 
-    configurer.init(new CompactionConfigurer.InitParamaters() {
+    final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
 
-      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
-
+    configurer.init(new CompactionConfigurer.InitParameters() {
       @Override
       public Map<String,String> getOptions() {
         return cfg.getOptions();
@@ -247,9 +246,6 @@ public class CompactableUtils {
     });
 
     var overrides = configurer.override(new CompactionConfigurer.InputParameters() {
-
-      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
-
       @Override
       public Collection<CompactableFile> getInputFiles() {
         return files;
@@ -290,10 +286,10 @@ public class CompactableUtils {
 
     CompactionSelector selector = newInstance(tablet.getTableConfiguration(),
         selectorConfig.getClassName(), CompactionSelector.class);
+
+    final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
+
     selector.init(new CompactionSelector.InitParamaters() {
-
-      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
-
       @Override
       public Map<String,String> getOptions() {
         return selectorConfig.getOptions();
@@ -311,9 +307,6 @@ public class CompactableUtils {
     });
 
     Selection selection = selector.select(new CompactionSelector.SelectionParameters() {
-
-      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
-
       @Override
       public PluginEnvironment getEnvironment() {
         return senv;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -66,6 +66,7 @@ import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.spi.cache.BlockCache;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.summary.Gatherer;
@@ -226,6 +227,9 @@ public class CompactableUtils {
         cfg.getClassName(), CompactionConfigurer.class);
 
     configurer.init(new CompactionConfigurer.InitParamaters() {
+
+      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
+
       @Override
       public Map<String,String> getOptions() {
         return cfg.getOptions();
@@ -233,7 +237,7 @@ public class CompactableUtils {
 
       @Override
       public PluginEnvironment getEnvironment() {
-        return new ServiceEnvironmentImpl(tablet.getContext());
+        return senv;
       }
 
       @Override
@@ -243,6 +247,9 @@ public class CompactableUtils {
     });
 
     var overrides = configurer.override(new CompactionConfigurer.InputParameters() {
+
+      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
+
       @Override
       public Collection<CompactableFile> getInputFiles() {
         return files;
@@ -250,7 +257,7 @@ public class CompactableUtils {
 
       @Override
       public PluginEnvironment getEnvironment() {
-        return new ServiceEnvironmentImpl(tablet.getContext());
+        return senv;
       }
 
       @Override
@@ -285,6 +292,8 @@ public class CompactableUtils {
         selectorConfig.getClassName(), CompactionSelector.class);
     selector.init(new CompactionSelector.InitParamaters() {
 
+      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
+
       @Override
       public Map<String,String> getOptions() {
         return selectorConfig.getOptions();
@@ -292,7 +301,7 @@ public class CompactableUtils {
 
       @Override
       public PluginEnvironment getEnvironment() {
-        return new ServiceEnvironmentImpl(tablet.getContext());
+        return senv;
       }
 
       @Override
@@ -303,9 +312,11 @@ public class CompactableUtils {
 
     Selection selection = selector.select(new CompactionSelector.SelectionParameters() {
 
+      private final ServiceEnvironment senv = new ServiceEnvironmentImpl(tablet.getContext());
+
       @Override
       public PluginEnvironment getEnvironment() {
-        return new ServiceEnvironmentImpl(tablet.getContext());
+        return senv;
       }
 
       @Override

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
@@ -53,7 +53,7 @@ public class ConfigurableCompactionStrategyTest {
 
     Map<String,String> opts = new HashMap<>();
 
-    var initParams = new CompactionConfigurer.InitParamaters() {
+    var initParams = new CompactionConfigurer.InitParameters() {
 
       @Override
       public TableId getTableId() {


### PR DESCRIPTION
While reviewing code in ConfigurationImpl to assess #947, I noticed that ConigurationImpl was doing some caching however the way that ConigurationImpl is made availabe for use could continually create new instances invalidating the caching.  This change makes it so that when ServiceEnvironmentImpl is exposed to plugins it does not continually create new instances, which would cause new instances of ConfigurationImpl to be creatd.