### PR TITLE
Make LogReader more discoverable

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/start/KeywordStartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/start/KeywordStartIT.java
@@ -60,6 +60,7 @@ import org.apache.accumulo.tracer.TraceServer;
 import org.apache.accumulo.tracer.TracerExecutable;
 import org.apache.accumulo.tserver.TServerExecutable;
 import org.apache.accumulo.tserver.TabletServer;
+import org.apache.accumulo.tserver.logger.LogReader;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -115,6 +116,7 @@ public class KeywordStartIT {
     expectSet.put("minicluster", MiniClusterExecutable.class);
     expectSet.put("monitor", MonitorExecutable.class);
     expectSet.put("rfile-info", PrintInfo.class);
+    expectSet.put("wal-info", LogReader.class);
     expectSet.put("shell", Shell.class);
     expectSet.put("tracer", TracerExecutable.class);
     expectSet.put("tserver", TServerExecutable.class);
@@ -166,6 +168,7 @@ public class KeywordStartIT {
     expectSet.add(MiniAccumuloRunner.class);
     expectSet.add(Monitor.class);
     expectSet.add(PrintInfo.class);
+    expectSet.add(LogReader.class);
     expectSet.add(Shell.class);
     expectSet.add(SimpleGarbageCollector.class);
     expectSet.add(TabletServer.class);


### PR DESCRIPTION
Use the KeywordExecutable service to make wal-info (the WAL LogReader class) available as part of the Accumulo command line. Can be used by running:

  accumulo wal-info

Closes #2100