### PR TITLE
Run tests that use System.gc in their own fork

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -201,6 +201,8 @@
           <configuration>
             <!-- Tests that cannot run with reuseForks=true -->
             <excludes>
+              <exclude>**/InternerTest.java</exclude>
+              <exclude>**/NamespaceIdTest.java</exclude>
               <exclude>**/TableIdTest.java</exclude>
               <exclude>**/HadoopCredentialProviderTest.java</exclude>
               <exclude>**/IdleRatioScanPrioritizerTest.java</exclude>
@@ -219,6 +221,8 @@
                 <reuseForks>false</reuseForks>
                 <excludes combine.self="override" />
                 <includes>
+                  <include>**/InternerTest.java</include>
+                  <include>**/NamespaceIdTest.java</include>
                   <include>**/TableIdTest.java</include>
                   <include>**/HadoopCredentialProviderTest.java</include>
                   <include>**/IdleRatioScanPrioritizerTest.java</include>

--- a/core/src/test/java/org/apache/accumulo/core/util/InternerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/InternerTest.java
@@ -79,7 +79,7 @@ public class InternerTest {
     assertNotEquals(obj1, intern2);
   }
 
-  @Test(timeout = 10_000)
+  @Test(timeout = 20_000)
   public void testInternsGetGarbageCollected() {
     var interner = new Interner<TestObj>();
     assertEquals(0, interner.size()); // ensure empty


### PR DESCRIPTION
Move InternerTest and NamespaceIdTest to the second execution of
maven-surefire-plugin, that does not reuse forks for running tests; this
ensures all tests that call System.gc are not affected by other tests
reusing the same JVM and affecting the garbage collector behavior,
because they will run in their own JVM