### PR TITLE
ConditionalWriterConfig - update create method and props gathering

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
@@ -276,6 +276,8 @@ public interface AccumuloClient extends AutoCloseable {
    * @return ConditionalWriter object for writing ConditionalMutations
    * @throws TableNotFoundException
    *           when the specified table doesn't exist
+   *
+   * @since 2.1.0
    */
   ConditionalWriter createConditionalWriter(String tableName) throws TableNotFoundException;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
@@ -268,6 +268,18 @@ public interface AccumuloClient extends AutoCloseable {
       throws TableNotFoundException;
 
   /**
+   * Factory method to create a ConditionalWriter connected to Accumulo.
+   *
+   * @param tableName
+   *          the name of the table to query data from
+   *
+   * @return ConditionalWriter object for writing ConditionalMutations
+   * @throws TableNotFoundException
+   *           when the specified table doesn't exist
+   */
+  ConditionalWriter createConditionalWriter(String tableName) throws TableNotFoundException;
+
+  /**
    * Get the current user for this AccumuloClient
    *
    * @return the user name

--- a/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriterConfig.java
@@ -20,7 +20,8 @@ package org.apache.accumulo.core.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static org.apache.accumulo.core.conf.ClientProperty.*;
+import static org.apache.accumulo.core.conf.ClientProperty.CONDITIONAL_WRITER_THREADS_MAX;
+import static org.apache.accumulo.core.conf.ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX;
 
 import java.util.concurrent.TimeUnit;
 
@@ -200,8 +201,8 @@ public class ConditionalWriterConfig {
    * given to this config.
    *
    * @param other
-   *          Another BatchWriterConfig
-   * @return Merged BatchWriterConfig
+   *          Another ConditionalWriterConfig
+   * @return Merged ConditionalWriterConfig
    * @since 2.0.0
    */
   public ConditionalWriterConfig merge(ConditionalWriterConfig other) {

--- a/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriterConfig.java
@@ -34,16 +34,13 @@ import org.apache.accumulo.core.security.Authorizations;
 public class ConditionalWriterConfig {
 
   private static final Long DEFAULT_TIMEOUT = getDefaultTimeout();
-  private Long timeout = null;
-
   private static final Integer DEFAULT_MAX_WRITE_THREADS =
       Integer.parseInt(CONDITIONAL_WRITER_THREADS_MAX.getDefaultValue());
+
+  private Long timeout = null;
   private Integer maxWriteThreads = null;
-
-  private Authorizations auths = Authorizations.EMPTY;
-
+  private Authorizations auths = null;
   private Durability durability = null;
-
   private String classLoaderContext = null;
 
   /**
@@ -130,7 +127,7 @@ public class ConditionalWriterConfig {
   }
 
   public Authorizations getAuthorizations() {
-    return auths;
+    return auths != null ? auths : Authorizations.EMPTY;
   }
 
   public long getTimeout(TimeUnit timeUnit) {
@@ -142,19 +139,13 @@ public class ConditionalWriterConfig {
   }
 
   public Durability getDurability() {
-    if (durability == null) {
-      return Durability.DEFAULT;
-    }
-    return durability;
+    return durability != null ? durability : Durability.DEFAULT;
   }
 
   private static long getDefaultTimeout() {
     long defVal =
         ConfigurationTypeHelper.getTimeInMillis(CONDITIONAL_WRITER_TIMEOUT_MAX.getDefaultValue());
-    if (defVal == 0L)
-      return Long.MAX_VALUE;
-    else
-      return defVal;
+    return defVal != 0L ? defVal : Long.MAX_VALUE;
   }
 
   /**
@@ -211,7 +202,7 @@ public class ConditionalWriterConfig {
     result.timeout = merge(this.timeout, other.timeout);
     result.maxWriteThreads = merge(this.maxWriteThreads, other.maxWriteThreads);
     result.durability = merge(this.durability, other.durability);
-    result.auths = this.auths;
+    result.auths = merge(this.auths, other.auths);
     return result;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriterConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ConditionalWriterConfig.java
@@ -42,19 +42,9 @@ public class ConditionalWriterConfig {
 
   private Authorizations auths = Authorizations.EMPTY;
 
-  private Durability durability = Durability.DEFAULT;
-  private boolean isDurabilitySet = false;
+  private Durability durability = null;
 
   private String classLoaderContext = null;
-
-  private static long getDefaultTimeout() {
-    long defVal =
-        ConfigurationTypeHelper.getTimeInMillis(CONDITIONAL_WRITER_TIMEOUT_MAX.getDefaultValue());
-    if (defVal == 0L)
-      return Long.MAX_VALUE;
-    else
-      return defVal;
-  }
 
   /**
    * A set of authorization labels that will be checked against the column visibility of each key in
@@ -136,7 +126,6 @@ public class ConditionalWriterConfig {
    */
   public ConditionalWriterConfig setDurability(Durability durability) {
     this.durability = durability;
-    isDurabilitySet = true;
     return this;
   }
 
@@ -153,7 +142,19 @@ public class ConditionalWriterConfig {
   }
 
   public Durability getDurability() {
+    if (durability == null) {
+      return Durability.DEFAULT;
+    }
     return durability;
+  }
+
+  private static long getDefaultTimeout() {
+    long defVal =
+        ConfigurationTypeHelper.getTimeInMillis(CONDITIONAL_WRITER_TIMEOUT_MAX.getDefaultValue());
+    if (defVal == 0L)
+      return Long.MAX_VALUE;
+    else
+      return defVal;
   }
 
   /**
@@ -203,18 +204,14 @@ public class ConditionalWriterConfig {
    * @param other
    *          Another ConditionalWriterConfig
    * @return Merged ConditionalWriterConfig
-   * @since 2.0.0
+   * @since 2.1.0
    */
   public ConditionalWriterConfig merge(ConditionalWriterConfig other) {
     ConditionalWriterConfig result = new ConditionalWriterConfig();
     result.timeout = merge(this.timeout, other.timeout);
     result.maxWriteThreads = merge(this.maxWriteThreads, other.maxWriteThreads);
-    result.auths = merge(this.auths, other.auths);
-    if (this.isDurabilitySet) {
-      result.durability = this.durability;
-    } else if (other.isDurabilitySet) {
-      result.durability = other.durability;
-    }
+    result.durability = merge(this.durability, other.durability);
+    result.auths = this.auths;
     return result;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -95,21 +95,21 @@ public class ClientContext implements AccumuloClient {
 
   private static final Logger log = LoggerFactory.getLogger(ClientContext.class);
 
-  private ClientInfo info;
+  private final ClientInfo info;
   private String instanceId;
   private final ZooCache zooCache;
 
   private Credentials creds;
   private BatchWriterConfig batchWriterConfig;
   private ConditionalWriterConfig conditionalWriterConfig;
-  private AccumuloConfiguration serverConf;
-  private Configuration hadoopConf;
+  private final AccumuloConfiguration serverConf;
+  private final Configuration hadoopConf;
 
   // These fields are very frequently accessed (each time a connection is created) and expensive to
   // compute, so cache them.
-  private Supplier<Long> timeoutSupplier;
-  private Supplier<SaslConnectionParams> saslSupplier;
-  private Supplier<SslConnectionParams> sslSupplier;
+  private final Supplier<Long> timeoutSupplier;
+  private final Supplier<SaslConnectionParams> saslSupplier;
+  private final Supplier<SslConnectionParams> sslSupplier;
   private TCredentials rpcCreds;
 
   private volatile boolean closed = false;
@@ -119,7 +119,7 @@ public class ClientContext implements AccumuloClient {
   private NamespaceOperations namespaceops = null;
   private InstanceOperations instanceops = null;
   private ReplicationOperations replicationops = null;
-  private SingletonReservation singletonReservation;
+  private final SingletonReservation singletonReservation;
 
   private void ensureOpen() {
     if (closed) {
@@ -284,7 +284,7 @@ public class ClientContext implements AccumuloClient {
     return saslSupplier.get();
   }
 
-  public BatchWriterConfig getBatchWriterConfig() {
+  public synchronized BatchWriterConfig getBatchWriterConfig() {
     ensureOpen();
     if (batchWriterConfig == null) {
       Properties props = info.getProperties();
@@ -313,7 +313,7 @@ public class ClientContext implements AccumuloClient {
     return batchWriterConfig;
   }
 
-  public ConditionalWriterConfig getConditionalWriterConfig() {
+  public synchronized ConditionalWriterConfig getConditionalWriterConfig() {
     ensureOpen();
     if (conditionalWriterConfig == null) {
       Properties props = info.getProperties();
@@ -690,7 +690,7 @@ public class ClientContext implements AccumuloClient {
 
     private Properties properties = new Properties();
     private AuthenticationToken token = null;
-    private Function<ClientBuilderImpl<T>,T> builderFunction;
+    private final Function<ClientBuilderImpl<T>,T> builderFunction;
 
     public ClientBuilderImpl(Function<ClientBuilderImpl<T>,T> builderFunction) {
       this.builderFunction = builderFunction;

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -76,14 +76,16 @@ public enum ClientProperty {
 
   // ConditionalWriter
   CONDITIONAL_WRITER_TIMEOUT_MAX("conditional.writer.timeout.max", "0", PropertyType.TIMEDURATION,
-      "Maximum amount of time an unresponsive server will be re-tried.", "2.0.0", false),
+      "Maximum amount of time an unresponsive server will be re-tried. A value of 0 will use "
+          + "Long.MAX_VALUE.",
+      "2.1.0", false),
   CONDITIONAL_WRITER_THREADS_MAX("conditional.writer.threads.max", "3", PropertyType.COUNT,
-      "Maximum number of threads to use for writing data to tablet servers.", "2.0.0", false),
+      "Maximum number of threads to use for writing data to tablet servers.", "2.1.0", false),
   CONDITIONAL_WRITER_DURABILITY("conditional.writer.durability", "default", PropertyType.DURABILITY,
-      Property.TABLE_DURABILITY.getDescription() + " Setting this property will "
-          + "change the durability for the ConditionalWriter session. A value of "
-          + "\"default\" will use the table's durability setting. ",
-      "2.0.0", false),
+      Property.TABLE_DURABILITY.getDescription() + " Setting this property will change the "
+          + "durability for the ConditionalWriter session. A value of \"default\" will use the"
+          + " table's durability setting. ",
+      "2.1.0", false),
 
   // Scanner
   SCANNER_BATCH_SIZE("scanner.batch.size", "1000", PropertyType.COUNT,

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -74,6 +74,17 @@ public enum ClientProperty {
           + " use the table's durability setting. ",
       "2.0.0", false),
 
+  // ConditionalWriter
+  CONDITIONAL_WRITER_TIMEOUT_MAX("conditional.writer.timeout.max", "0", PropertyType.TIMEDURATION,
+      "Maximum amount of time an unresponsive server will be re-tried.", "2.0.0", false),
+  CONDITIONAL_WRITER_THREADS_MAX("conditional.writer.threads.max", "3", PropertyType.COUNT,
+      "Maximum number of threads to use for writing data to tablet servers.", "2.0.0", false),
+  CONDITIONAL_WRITER_DURABILITY("conditional.writer.durability", "default", PropertyType.DURABILITY,
+      Property.TABLE_DURABILITY.getDescription() + " Setting this property will "
+          + "change the durability for the ConditionalWriter session. A value of "
+          + "\"default\" will use the table's durability setting. ",
+      "2.0.0", false),
+
   // Scanner
   SCANNER_BATCH_SIZE("scanner.batch.size", "1000", PropertyType.COUNT,
       "Number of key/value pairs that will be fetched at time from tablet server", "2.0.0", false),
@@ -117,12 +128,12 @@ public enum ClientProperty {
 
   public static final String TRACE_SPAN_RECEIVER_PREFIX = "trace.span.receiver";
 
-  private String key;
-  private String defaultValue;
-  private PropertyType type;
-  private String description;
-  private String since;
-  private boolean required;
+  private final String key;
+  private final String defaultValue;
+  private final PropertyType type;
+  private final String description;
+  private final String since;
+  private final boolean required;
 
   ClientProperty(String key, String defaultValue, PropertyType type, String description,
       String since, boolean required) {
@@ -218,7 +229,7 @@ public enum ClientProperty {
     if (value.isEmpty()) {
       return false;
     }
-    return Boolean.valueOf(value);
+    return Boolean.parseBoolean(value);
   }
 
   public void setBytes(Properties properties, Long bytes) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -31,7 +31,6 @@ import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
-import org.apache.accumulo.core.client.ConditionalWriterConfig;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -229,7 +228,7 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
     assertEquals(0, SingletonManager.getReservationCount());
 
     expectClosed(() -> c.createScanner(tableName, Authorizations.EMPTY));
-    expectClosed(() -> c.createConditionalWriter(tableName, new ConditionalWriterConfig()));
+    expectClosed(() -> c.createConditionalWriter(tableName));
     expectClosed(() -> c.createBatchWriter(tableName));
     expectClosed(c::tableOperations);
     expectClosed(c::instanceOperations);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SessionDurabilityIT.java
@@ -149,11 +149,12 @@ public class SessionDurabilityIT extends ConfigurableMacBase {
 
   private void conditionWriteSome(AccumuloClient c, String tableName, int n,
       ConditionalWriterConfig cfg) throws Exception {
-    ConditionalWriter cw = c.createConditionalWriter(tableName, cfg);
-    for (int i = 0; i < n; i++) {
-      ConditionalMutation m = new ConditionalMutation(i + "", new Condition("", ""));
-      m.put("", "", "X");
-      assertEquals(Status.ACCEPTED, cw.write(m).getStatus());
+    try (ConditionalWriter cw = c.createConditionalWriter(tableName, cfg)) {
+      for (int i = 0; i < n; i++) {
+        ConditionalMutation m = new ConditionalMutation(i + "", new Condition("", ""));
+        m.put("", "", "X");
+        assertEquals(Status.ACCEPTED, cw.write(m).getStatus());
+      }
     }
   }
 


### PR DESCRIPTION
Closes #680

Two main changes:
 - Create an overloaded createConditionalMutation(String tableName) method which creates a new ConditionalWriterConfig() so the config is optional to pass
 - Allow client properties to be set in the client properties file