### PR TITLE
Make sorted recovery write to RFiles

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1133,7 +1133,7 @@ public class TabletServer extends AbstractServer {
 
   public void recover(VolumeManager fs, KeyExtent extent, List<LogEntry> logEntries,
       Set<String> tabletFiles, MutationReceiver mutationReceiver) throws IOException {
-    List<Path> recoveryLogs = new ArrayList<>();
+    List<Path> recoveryDirs = new ArrayList<>();
     List<LogEntry> sorted = new ArrayList<>(logEntries);
     sorted.sort((e1, e2) -> (int) (e1.timestamp - e2.timestamp));
     for (LogEntry entry : sorted) {
@@ -1148,9 +1148,9 @@ public class TabletServer extends AbstractServer {
         throw new IOException(
             "Unable to find recovery files for extent " + extent + " logEntry: " + entry);
       }
-      recoveryLogs.add(recovery);
+      recoveryDirs.add(recovery);
     }
-    logger.recover(fs, extent, recoveryLogs, tabletFiles, mutationReceiver);
+    logger.recover(fs, extent, recoveryDirs, tabletFiles, mutationReceiver);
   }
 
   public int createLogId() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -1150,7 +1150,7 @@ public class TabletServer extends AbstractServer {
       }
       recoveryDirs.add(recovery);
     }
-    logger.recover(fs, extent, recoveryDirs, tabletFiles, mutationReceiver);
+    logger.recover(getContext(), extent, recoveryDirs, tabletFiles, mutationReceiver);
   }
 
   public int createLogId() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -23,16 +23,21 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.master.thrift.RecoveryStatus;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.threads.ThreadPools;
@@ -47,10 +52,11 @@ import org.apache.accumulo.tserver.logger.LogFileValue;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.MapFile;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class LogSorter {
 
@@ -141,7 +147,7 @@ public class LogSorter {
         // Creating a 'finished' marker will cause recovery to proceed normally and the
         // empty file will be correctly ignored downstream.
         fs.mkdirs(new Path(destPath));
-        writeBuffer(destPath, Collections.emptyList(), part++);
+        writeBuffer(context, destPath, Collections.emptyList(), part++);
         fs.create(SortedLogState.getFinishedMarkerPath(destPath)).close();
         return;
       }
@@ -159,31 +165,16 @@ public class LogSorter {
             value.readFields(decryptingInput);
             buffer.add(new Pair<>(key, value));
           }
-          writeBuffer(destPath, buffer, part++);
+          writeBuffer(context, destPath, buffer, part++);
           buffer.clear();
         } catch (EOFException ex) {
-          writeBuffer(destPath, buffer, part++);
+          writeBuffer(context, destPath, buffer, part++);
           break;
         }
       }
       fs.create(new Path(destPath, "finished")).close();
       log.info("Finished log sort {} {} bytes {} parts in {}ms", name, getBytesCopied(), part,
           getSortTime());
-    }
-
-    private void writeBuffer(String destPath, List<Pair<LogFileKey,LogFileValue>> buffer, int part)
-        throws IOException {
-      Path path = new Path(destPath, String.format("part-r-%05d", part));
-      FileSystem ns = context.getVolumeManager().getFileSystemByPath(path);
-
-      try (MapFile.Writer output = new MapFile.Writer(ns.getConf(), ns.makeQualified(path),
-          MapFile.Writer.keyClass(LogFileKey.class),
-          MapFile.Writer.valueClass(LogFileValue.class))) {
-        buffer.sort(Comparator.comparing(Pair::getFirst));
-        for (Pair<LogFileKey,LogFileValue> entry : buffer) {
-          output.append(entry.getFirst(), entry.getSecond());
-        }
-      }
     }
 
     synchronized void close() throws IOException {
@@ -222,6 +213,47 @@ public class LogSorter {
     this.threadPool =
         ThreadPools.createFixedThreadPool(threadPoolSize, this.getClass().getName(), false);
     this.walBlockSize = DfsLogger.getWalBlockSize(conf);
+  }
+
+  @VisibleForTesting
+  // TODO improve performance of conversion to Key/Value
+  public static void writeBuffer(ServerContext context, String destPath,
+      List<Pair<LogFileKey,LogFileValue>> buffer, int part) throws IOException {
+    String filename = String.format("part-r-%05d.rf", part);
+    Path path = new Path(destPath, filename);
+    FileSystem fs = context.getVolumeManager().getFileSystemByPath(path);
+    Path fullPath = fs.makeQualified(path);
+
+    // convert the LogFileKeys to Keys and collect the mutations
+    Map<Key,List<Mutation>> keyListMap = new HashMap<>();
+    for (Pair<LogFileKey,LogFileValue> pair : buffer) {
+      var logFileKey = pair.getFirst();
+      var logFileValue = pair.getSecond();
+      Key k = logFileKey.toKey();
+      var list = keyListMap.putIfAbsent(k, logFileValue.mutations);
+      if (list != null) {
+        var muts = new ArrayList<>(list);
+        muts.addAll(logFileValue.mutations);
+        keyListMap.put(logFileKey.toKey(), muts);
+      }
+    }
+
+    // serialize the mutations into value and sort the keys
+    Map<Key,Value> convertedPairs = new TreeMap<>();
+    for (Map.Entry<Key,List<Mutation>> e : keyListMap.entrySet()) {
+      LogFileValue val = new LogFileValue();
+      val.mutations = e.getValue();
+      convertedPairs.put(e.getKey(), val.toValue());
+    }
+
+    try (var writer = FileOperations.getInstance().newWriterBuilder()
+        .forFile(fullPath.toString(), fs, fs.getConf(), context.getCryptoService())
+        .withTableConfiguration(DefaultConfiguration.getInstance()).build()) {
+      writer.startDefaultLocalityGroup();
+      for (var entry : convertedPairs.entrySet()) {
+        writer.append(entry.getKey(), entry.getValue());
+      }
+    }
   }
 
   public void startWatchingForRecoveryLogs(ThreadPoolExecutor distWorkQThreadPool)

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogReader.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogReader.java
@@ -138,7 +138,7 @@ public class RecoveryLogReader implements CloseableIterator<Entry<LogFileKey,Log
     }
     if (!foundFinish)
       throw new IOException(
-          "Sort \"" + SortedLogState.FINISHED.getMarker() + "\" flag not found in " + directory);
+          "Sort '" + SortedLogState.FINISHED.getMarker() + "' flag not found in " + directory);
 
     iter = new SortCheckIterator(new RangeIterator(start, end));
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -40,7 +40,6 @@ import org.apache.accumulo.tserver.logger.LogFileValue;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,7 @@ public class RecoveryLogsIterator
    * Scans the files in each recoveryLogDir over the range [start,end].
    */
   RecoveryLogsIterator(ServerContext context, List<Path> recoveryLogDirs, LogFileKey start,
-      LogFileKey end, boolean checkFirstKey, LogEvents... colFamToFetch) throws IOException {
+      LogFileKey end, boolean checkFirstKey) throws IOException {
 
     List<Iterator<Entry<Key,Value>>> iterators = new ArrayList<>(recoveryLogDirs.size());
     scanners = new ArrayList<>();
@@ -81,8 +80,7 @@ public class RecoveryLogsIterator
       for (Path log : logFiles) {
         var scanner = RFile.newScanner().from(log.toString()).withFileSystem(fs)
             .withTableProperties(context.getConfiguration()).build();
-        for (var cf : colFamToFetch)
-          scanner.fetchColumnFamily(new Text(cf.name()));
+
         scanner.setRange(range);
         Iterator<Entry<Key,Value>> scanIter = scanner.iterator();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -130,7 +130,7 @@ public class RecoveryLogsIterator implements Iterator<Entry<Key,Value>>, AutoClo
       Path fullLogPath = ns.makeQualified(child.getPath());
       try (var scanner = RFile.newScanner().from(fullLogPath.toString())
           .withFileSystem(fs.getFileSystemByPath(fullLogPath)).build()) {
-        validateFirstKey(scanner.iterator());
+        validateFirstKey(scanner.iterator(), fullLogPath);
       }
       logFiles.add(fullLogPath);
     }
@@ -143,12 +143,12 @@ public class RecoveryLogsIterator implements Iterator<Entry<Key,Value>>, AutoClo
   /**
    * Check that the first entry in the WAL is OPEN
    */
-  private void validateFirstKey(Iterator<Map.Entry<Key,Value>> iterator) throws IOException {
+  private void validateFirstKey(Iterator<Map.Entry<Key,Value>> iterator, Path fullLogPath) throws IOException {
     if (iterator.hasNext()) {
       Key firstKey = iterator.next().getKey();
       LogFileKey key = LogFileKey.fromKey(firstKey);
       if (key.event != LogEvents.OPEN) {
-        throw new IllegalStateException("First log entry value is not OPEN");
+        throw new IllegalStateException("First log entry is not OPEN " + fullLogPath);
       }
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -141,7 +141,7 @@ public class RecoveryLogsIterator
     }
     if (!foundFinish)
       throw new IOException(
-          "Sort \"" + SortedLogState.FINISHED.getMarker() + "\" flag not found in " + directory);
+          "Sort '" + SortedLogState.FINISHED.getMarker() + "' flag not found in " + directory);
     return logFiles;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -78,6 +78,7 @@ public class SortedLogRecovery {
     key.tabletId = Integer.MAX_VALUE;
     key.seq = Long.MAX_VALUE;
     key.tablet = extent;
+    key.filename = "dummy_filename";
     return key;
   }
 
@@ -96,6 +97,7 @@ public class SortedLogRecovery {
     key.tabletId = -1;
     key.seq = 0;
     key.tablet = extent;
+    key.filename = "dummy_filename";
     return key;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -25,7 +25,6 @@ import static org.apache.accumulo.tserver.logger.LogEvents.COMPACTION_START;
 import static org.apache.accumulo.tserver.logger.LogEvents.DEFINE_TABLET;
 import static org.apache.accumulo.tserver.logger.LogEvents.MANY_MUTATIONS;
 import static org.apache.accumulo.tserver.logger.LogEvents.MUTATION;
-import static org.apache.accumulo.tserver.logger.LogEvents.OPEN;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -105,7 +104,7 @@ public class SortedLogRecovery {
     int tabletId = -1;
 
     try (var rli = new RecoveryLogsIterator(context, recoveryLogDirs, minKey(DEFINE_TABLET),
-        maxKey(DEFINE_TABLET), true, DEFINE_TABLET, OPEN)) {
+        maxKey(DEFINE_TABLET), true)) {
 
       KeyExtent alternative = extent;
       if (extent.isRootTablet()) {
@@ -205,9 +204,8 @@ public class SortedLogRecovery {
     long lastFinish = 0;
     long recoverySeq = 0;
 
-    try (RecoveryLogsIterator rli =
-        new RecoveryLogsIterator(context, recoveryLogs, minKey(COMPACTION_START, tabletId),
-            maxKey(COMPACTION_START, tabletId), false, COMPACTION_START, COMPACTION_FINISH)) {
+    try (RecoveryLogsIterator rli = new RecoveryLogsIterator(context, recoveryLogs,
+        minKey(COMPACTION_START, tabletId), maxKey(COMPACTION_START, tabletId), false)) {
 
       DeduplicatingIterator ddi = new DeduplicatingIterator(rli);
 
@@ -262,8 +260,7 @@ public class SortedLogRecovery {
 
     LogFileKey end = maxKey(MUTATION, tabletId);
 
-    try (RecoveryLogsIterator rli = new RecoveryLogsIterator(context, recoveryLogs, start, end,
-        false, MUTATION, MANY_MUTATIONS)) {
+    try (var rli = new RecoveryLogsIterator(context, recoveryLogs, start, end, false)) {
       while (rli.hasNext()) {
         Entry<LogFileKey,LogFileValue> entry = rli.next();
         LogFileKey logFileKey = entry.getKey();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/SortedLogRecovery.java
@@ -70,22 +70,21 @@ public class SortedLogRecovery {
     this.context = context;
   }
 
-  static LogFileKey maxKey(LogEvents event, KeyExtent extent) {
+  static LogFileKey maxKey(LogEvents event) {
     LogFileKey key = new LogFileKey();
     key.event = event;
     key.tabletId = Integer.MAX_VALUE;
     key.seq = Long.MAX_VALUE;
-    key.tablet = extent;
     return key;
   }
 
   static LogFileKey maxKey(LogEvents event, int tabletId) {
-    LogFileKey key = maxKey(event, null);
+    LogFileKey key = maxKey(event);
     key.tabletId = tabletId;
     return key;
   }
 
-  static LogFileKey minKey(LogEvents event, KeyExtent extent) {
+  static LogFileKey minKey(LogEvents event) {
     LogFileKey key = new LogFileKey();
     key.event = event;
     // see GitHub issue #477. There was a bug that caused -1 to end up in tabletId. If this happens
@@ -93,12 +92,11 @@ public class SortedLogRecovery {
     // fail if the id is actually -1 in data.
     key.tabletId = -1;
     key.seq = 0;
-    key.tablet = extent;
     return key;
   }
 
   static LogFileKey minKey(LogEvents event, int tabletId) {
-    LogFileKey key = minKey(event, null);
+    LogFileKey key = minKey(event);
     key.tabletId = tabletId;
     return key;
   }
@@ -106,8 +104,8 @@ public class SortedLogRecovery {
   private int findMaxTabletId(KeyExtent extent, List<Path> recoveryLogDirs) throws IOException {
     int tabletId = -1;
 
-    try (var rli = new RecoveryLogsIterator(context, recoveryLogDirs, minKey(DEFINE_TABLET, extent),
-        maxKey(DEFINE_TABLET, extent), true, DEFINE_TABLET, OPEN)) {
+    try (var rli = new RecoveryLogsIterator(context, recoveryLogDirs, minKey(DEFINE_TABLET),
+        maxKey(DEFINE_TABLET), true, DEFINE_TABLET, OPEN)) {
 
       KeyExtent alternative = extent;
       if (extent.isRootTablet()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -530,11 +530,11 @@ public class TabletServerLogger {
     return seq;
   }
 
-  public void recover(VolumeManager fs, KeyExtent extent, List<Path> logs, Set<String> tabletFiles,
-      MutationReceiver mr) throws IOException {
+  public void recover(VolumeManager fs, KeyExtent extent, List<Path> recoveryDirs,
+      Set<String> tabletFiles, MutationReceiver mr) throws IOException {
     try {
       SortedLogRecovery recovery = new SortedLogRecovery(fs);
-      recovery.recover(extent, logs, tabletFiles, mr);
+      recovery.recover(extent, recoveryDirs, tabletFiles, mr);
     } catch (Exception e) {
       throw new IOException(e);
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.util.Halt;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.accumulo.fate.util.Retry.RetryFactory;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
@@ -530,10 +531,10 @@ public class TabletServerLogger {
     return seq;
   }
 
-  public void recover(VolumeManager fs, KeyExtent extent, List<Path> recoveryDirs,
+  public void recover(ServerContext context, KeyExtent extent, List<Path> recoveryDirs,
       Set<String> tabletFiles, MutationReceiver mr) throws IOException {
     try {
-      SortedLogRecovery recovery = new SortedLogRecovery(fs);
+      SortedLogRecovery recovery = new SortedLogRecovery(context);
       recovery.recover(extent, recoveryDirs, tabletFiles, mr);
     } catch (Exception e) {
       throw new IOException(e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -27,6 +27,7 @@ import static org.apache.accumulo.tserver.logger.LogEvents.OPEN;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -341,7 +341,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
           buffer.reset(bytes, bytes.length);
           logFileKey.tablet = KeyExtent.readFrom(buffer);
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new UncheckedIOException(e);
         }
         break;
       case COMPACTION_FINISH:

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -245,6 +245,8 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
    * Format the row using 13 bytes. 1 for event number + 4 for tabletId + 8 for sequence
    */
   private byte[] formatRow(byte eventNum, int tabletId, long seq) {
+    // These will not sort properly when encoded if negative.  Negative is not expected currently, defending against future changes and/or bugs.
+    Preconditions.checkArgument(eventNum >=0 && seq >= 0);
     byte[] row = new byte[13];
     // encode the signed integer so negatives will sort properly
     int encodedTabletId = tabletId ^ 0x80000000;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -214,7 +214,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
    */
   public Key toKey() throws IOException {
     byte[] formattedRow;
-    Text family = new Text(event.name());
+    String family = event.name();
     var kb = Key.builder();
     switch (event) {
       case OPEN:

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -259,7 +259,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
 
     logFileKey.tabletId = tabletId;
     logFileKey.seq = seq;
-    logFileKey.event = LogEvents.valueOf(key.getColumnFamily().toString());
+    logFileKey.event = LogEvents.valueOf(key.getColumnFamilyData().toString());
 
     // handle special cases of what is stored in the qualifier
     switch (logFileKey.event) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -222,7 +222,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
         return kb.row(formattedRow).family(family).qualifier(tserverSession).build();
       case COMPACTION_START:
         formattedRow = formatRow(tabletId, seq);
-        return kb.row(formattedRow).family(family).qualifier(new Text(filename)).build();
+        return kb.row(formattedRow).family(family).qualifier(filename).build();
       case MUTATION:
       case MANY_MUTATIONS:
       case COMPACTION_FINISH:

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -330,7 +330,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
     // handle special cases of what is stored in the qualifier
     switch (logFileKey.event) {
       case OPEN:
-        logFileKey.tserverSession = key.getColumnQualifier().toString();
+        logFileKey.tserverSession = key.getColumnQualifierData().toString();
         break;
       case COMPACTION_START:
         logFileKey.filename = key.getColumnQualifier().toString();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -333,7 +333,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
         logFileKey.tserverSession = key.getColumnQualifierData().toString();
         break;
       case COMPACTION_START:
-        logFileKey.filename = key.getColumnQualifier().toString();
+        logFileKey.filename = key.getColumnQualifierData().toString();
         break;
       case DEFINE_TABLET:
         try (DataInputBuffer buffer = new DataInputBuffer()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -29,6 +29,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -250,7 +251,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
   /**
    * Get the byte encoded row for this LogFileKey as a Text object.
    */
-  public Text formatRow() {
+  private Text formatRow() {
     return new Text(formatRow(tabletId, seq));
   }
 
@@ -305,6 +306,10 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
             ((row[11] & 255) << 8) +
             ((row[12] & 255)));
     // @formatter:on
+  }
+
+  public static Range toRange(LogFileKey start, LogFileKey end) {
+    return new Range(start.formatRow(), end.formatRow());
   }
 
   /**

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -220,10 +220,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
         return kb.row(formattedRow).family(family).qualifier(new Text(tserverSession)).build();
       case COMPACTION_START:
         formattedRow = formatRow(eventNum, tabletId, seq);
-        if (filename != null)
-          return kb.row(formattedRow).family(family).qualifier(new Text(filename)).build();
-        else
-          return kb.row(formattedRow).family(family).build();
+        return kb.row(formattedRow).family(family).qualifier(new Text(filename)).build();
       case MUTATION:
       case MANY_MUTATIONS:
       case COMPACTION_FINISH:

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -219,7 +219,7 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
     switch (event) {
       case OPEN:
         formattedRow = formatRow(0, 0);
-        return kb.row(formattedRow).family(family).qualifier(new Text(tserverSession)).build();
+        return kb.row(formattedRow).family(family).qualifier(tserverSession).build();
       case COMPACTION_START:
         formattedRow = formatRow(tabletId, seq);
         return kb.row(formattedRow).family(family).qualifier(new Text(filename)).build();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 
+import com.google.common.base.Preconditions;
+
 public class LogFileKey implements WritableComparable<LogFileKey> {
 
   public LogEvents event;
@@ -245,10 +247,11 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
    * Format the row using 13 bytes. 1 for event number + 4 for tabletId + 8 for sequence
    */
   private byte[] formatRow(byte eventNum, int tabletId, long seq) {
-    // These will not sort properly when encoded if negative.  Negative is not expected currently, defending against future changes and/or bugs.
-    Preconditions.checkArgument(eventNum >=0 && seq >= 0);
+    // These will not sort properly when encoded if negative. Negative is not expected currently,
+    // defending against future changes and/or bugs.
+    Preconditions.checkArgument(eventNum >= 0 && seq >= 0);
     byte[] row = new byte[13];
-    // encode the signed integer so negatives will sort properly
+    // encode the signed integer so negatives will sort properly for tabletId
     int encodedTabletId = tabletId ^ 0x80000000;
 
     row[0] = eventNum;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -277,6 +277,13 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
         logFileKey.tablet = KeyExtent.readFrom(buffer);
         buffer.close();
         break;
+	case COMPACTION_FINISH:
+	case MANY_MUTATIONS:
+	case MUTATION:
+	        // nothing to do
+		break;
+	default:
+		throw new AssertionError();
     }
 
     return logFileKey;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
@@ -110,10 +110,13 @@ public class LogFileValue implements Writable {
   /**
    * Get the mutations from the Value
    */
-  public static LogFileValue fromValue(Value value) throws IOException {
+  public static LogFileValue fromValue(Value value) {
     LogFileValue logFileValue = new LogFileValue();
-    var bais = new ByteArrayInputStream(value.get());
-    logFileValue.readFields(new DataInputStream(bais));
+    try (var bais = new ByteArrayInputStream(value.get())) {
+      logFileValue.readFields(new DataInputStream(bais));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     return logFileValue;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
@@ -20,8 +20,12 @@ package org.apache.accumulo.tserver.logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
+import java.io.DataInputStream;
 import java.io.DataOutput;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +33,7 @@ import java.util.List;
 
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.hadoop.io.Writable;
 
@@ -91,6 +96,25 @@ public class LogFileValue implements Writable {
   @Override
   public String toString() {
     return format(this, 5);
+  }
+
+  /**
+   * Convert list of mutations to a byte array and use to create a Value
+   */
+  public Value toValue() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    write(new DataOutputStream(baos));
+    return new Value(baos.toByteArray());
+  }
+
+  /**
+   * Get the mutations from the Value
+   */
+  public static LogFileValue fromValue(Value value) throws IOException {
+    LogFileValue logFileValue = new LogFileValue();
+    var bais = new ByteArrayInputStream(value.get());
+    logFileValue.readFields(new DataInputStream(bais));
+    return logFileValue;
   }
 
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
@@ -115,7 +115,7 @@ public class LogFileValue implements Writable {
     try (var bais = new ByteArrayInputStream(value.get())) {
       logFileValue.readFields(new DataInputStream(bais));
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
     return logFileValue;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileValue.java
@@ -27,6 +27,7 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
@@ -163,6 +164,7 @@ public class SortedLogRecoveryTest {
       expect(context.getVolumeManager()).andReturn(fs).anyTimes();
       expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())
           .anyTimes();
+      expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
       replay(context);
       final Path workdirPath = new Path("file://" + workdir);
       fs.deleteRecursively(workdirPath);
@@ -187,7 +189,7 @@ public class SortedLogRecoveryTest {
         dirs.add(new Path(destPath));
       }
       // Recover
-      SortedLogRecovery recovery = new SortedLogRecovery(fs);
+      SortedLogRecovery recovery = new SortedLogRecovery(context);
       CaptureMutations capture = new CaptureMutations();
       recovery.recover(extent, dirs, files, capture);
       verify(context);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -112,11 +112,6 @@ public class SortedLogRecoveryTest {
     public int compareTo(KeyValue o) {
       return key.compareTo(o.key);
     }
-
-    @Override
-    public String toString() {
-      return "" + key + " #muts:" + value.mutations.size();
-    }
   }
 
   private static KeyValue createKeyValue(LogEvents type, long seq, int tid,
@@ -388,33 +383,6 @@ public class SortedLogRecoveryTest {
     // Verify recovered data
     assertEquals(1, mutations.size());
     assertEquals(m, mutations.get(0));
-  }
-
-  @Test
-  public void testMutationsSameSeq() throws IOException {
-    // Create a test log
-    KeyExtent other = new KeyExtent(TableId.of("other"), null, null);
-    Mutation ignored = new ServerMutation(new Text("ignored"));
-    ignored.put(cf, cq, value);
-    Mutation m = new ServerMutation(new Text("row1"));
-    Mutation m2 = new ServerMutation(new Text("row1"));
-    Mutation m3 = new ServerMutation(new Text("row1"));
-    m.put(cf, cq, value);
-    m2.put(new Text("cf2"), new Text("cq2"), value);
-    m3.put(new Text("cf3"), new Text("cq3"), value);
-    KeyValue[] entries = {createKeyValue(OPEN, 0, -1, "1"),
-        createKeyValue(DEFINE_TABLET, 1, 1, other), createKeyValue(DEFINE_TABLET, 1, 3, extent),
-        createKeyValue(MUTATION, 1, 1, ignored), createKeyValue(MUTATION, 1, 3, m),
-        createKeyValue(MUTATION, 1, 3, m2), createKeyValue(MUTATION, 1, 3, m3)};
-    Map<String,KeyValue[]> logs = new TreeMap<>();
-    logs.put("testlog", entries);
-    // Recover
-    List<Mutation> mutations = recover(logs, extent);
-    // Verify recovered data
-    assertEquals(3, mutations.size());
-    assertEquals(m, mutations.get(0));
-    assertEquals(m2, mutations.get(1));
-    assertEquals(m3, mutations.get(2));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
@@ -73,6 +74,8 @@ public class TestUpgradePathForWALogs {
     String path = workDir.getAbsolutePath();
     assertTrue(workDir.delete());
     VolumeManager fs = VolumeManagerImpl.getLocalForTesting(path);
+    expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())
+        .anyTimes();
     expect(context.getVolumeManager()).andReturn(fs).anyTimes();
     replay(context);
   }

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -61,7 +61,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
 
   @Override
   protected int defaultTimeoutSeconds() {
-    return 5 * 60;
+    return 8 * 60;
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -61,7 +61,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
 
   @Override
   protected int defaultTimeoutSeconds() {
-    return 8 * 60;
+    return 5 * 60;
   }
 
   @Test


### PR DESCRIPTION
* Change LogSorter and SortedLogRecovery to write/read RFile instead of MapFile
* Rewrite LogSorter writeBuffer method and make static to test
* Create toKey() and fromKey() methods in LogFileKey for converting WAL keys
* Create toValue() and FromValue() methods in LogFileValue for converting WAL values
* Byte encode the rows of the Key to sort WAL events properly
* Make RecoveryLogsIterator convert Key Value pairs on next()