### PR TITLE
Fixes bug with -a server option

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -42,8 +42,8 @@ public abstract class AbstractServer implements AutoCloseable, Runnable {
   protected AbstractServer(String appName, ServerOpts opts, String[] args) {
     this.log = LoggerFactory.getLogger(getClass().getName());
     this.applicationName = appName;
-    this.hostname = Objects.requireNonNull(opts.getAddress());
     opts.parseArgs(appName, args);
+    this.hostname = Objects.requireNonNull(opts.getAddress());
     var siteConfig = opts.getSiteConfiguration();
     SecurityUtil.serverLogin(siteConfig);
     context = new ServerContext(siteConfig);


### PR DESCRIPTION
The -a option for server processes was being ignored because the impl read the
argument before arguments were parsed.