### PR TITLE
Unit test converting client props to BatchWriterConfig

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -284,7 +284,7 @@ public class ClientContext implements AccumuloClient {
     return saslSupplier.get();
   }
 
-  public synchronized static BatchWriterConfig getBatchWriterConfig(Properties props) {
+  public static BatchWriterConfig getBatchWriterConfig(Properties props) {
     BatchWriterConfig batchWriterConfig = new BatchWriterConfig();
 
     Long maxMemory = ClientProperty.BATCH_WRITER_MEMORY_MAX.getBytes(props);
@@ -310,7 +310,7 @@ public class ClientContext implements AccumuloClient {
     return batchWriterConfig;
   }
 
-  public BatchWriterConfig getBatchWriterConfig() {
+  public synchronized BatchWriterConfig getBatchWriterConfig() {
     ensureOpen();
     if (batchWriterConfig == null) {
       batchWriterConfig = getBatchWriterConfig(info.getProperties());

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -284,7 +284,7 @@ public class ClientContext implements AccumuloClient {
     return saslSupplier.get();
   }
 
-  public static BatchWriterConfig getBatchWriterConfig(Properties props) {
+  static BatchWriterConfig getBatchWriterConfig(Properties props) {
     BatchWriterConfig batchWriterConfig = new BatchWriterConfig();
 
     Long maxMemory = ClientProperty.BATCH_WRITER_MEMORY_MAX.getBytes(props);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -284,31 +284,36 @@ public class ClientContext implements AccumuloClient {
     return saslSupplier.get();
   }
 
-  public synchronized BatchWriterConfig getBatchWriterConfig() {
+  public synchronized static BatchWriterConfig getBatchWriterConfig(Properties props) {
+    BatchWriterConfig batchWriterConfig = new BatchWriterConfig();
+
+    Long maxMemory = ClientProperty.BATCH_WRITER_MEMORY_MAX.getBytes(props);
+    if (maxMemory != null) {
+      batchWriterConfig.setMaxMemory(maxMemory);
+    }
+    Long maxLatency = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
+    if (maxLatency != null) {
+      batchWriterConfig.setMaxLatency(maxLatency, TimeUnit.SECONDS);
+    }
+    Long timeout = ClientProperty.BATCH_WRITER_TIMEOUT_MAX.getTimeInMillis(props);
+    if (timeout != null) {
+      batchWriterConfig.setTimeout(timeout, TimeUnit.SECONDS);
+    }
+    Integer maxThreads = ClientProperty.BATCH_WRITER_THREADS_MAX.getInteger(props);
+    if (maxThreads != null) {
+      batchWriterConfig.setMaxWriteThreads(maxThreads);
+    }
+    String durability = ClientProperty.BATCH_WRITER_DURABILITY.getValue(props);
+    if (!durability.isEmpty()) {
+      batchWriterConfig.setDurability(Durability.valueOf(durability.toUpperCase()));
+    }
+    return batchWriterConfig;
+  }
+
+  public BatchWriterConfig getBatchWriterConfig() {
     ensureOpen();
     if (batchWriterConfig == null) {
-      Properties props = info.getProperties();
-      batchWriterConfig = new BatchWriterConfig();
-      Long maxMemory = ClientProperty.BATCH_WRITER_MEMORY_MAX.getBytes(props);
-      if (maxMemory != null) {
-        batchWriterConfig.setMaxMemory(maxMemory);
-      }
-      Long maxLatency = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
-      if (maxLatency != null) {
-        batchWriterConfig.setMaxLatency(maxLatency, TimeUnit.SECONDS);
-      }
-      Long timeout = ClientProperty.BATCH_WRITER_TIMEOUT_MAX.getTimeInMillis(props);
-      if (timeout != null) {
-        batchWriterConfig.setTimeout(timeout, TimeUnit.SECONDS);
-      }
-      String durability = ClientProperty.BATCH_WRITER_DURABILITY.getValue(props);
-      if (!durability.isEmpty()) {
-        batchWriterConfig.setDurability(Durability.valueOf(durability.toUpperCase()));
-      }
-      Integer maxThreads = ClientProperty.BATCH_WRITER_THREADS_MAX.getInteger(props);
-      if (maxThreads != null) {
-        batchWriterConfig.setMaxWriteThreads(maxThreads);
-      }
+      batchWriterConfig = getBatchWriterConfig(info.getProperties());
     }
     return batchWriterConfig;
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
@@ -159,7 +159,8 @@ public class ClientContextTest {
 
     assertEquals(Long.MAX_VALUE, batchWriterConfig.getMaxLatency(TimeUnit.MILLISECONDS));
 
-    assertEquals(15, batchWriterConfig.getTimeout(TimeUnit.SECONDS));
+    // getTimeout returns time in milliseconds, therefore the 15 becomes 15000.
+    assertEquals(15000, batchWriterConfig.getTimeout(TimeUnit.SECONDS));
 
     long expectedThreads = ClientProperty.BATCH_WRITER_THREADS_MAX.getInteger(props);
     assertEquals(expectedThreads, batchWriterConfig.getMaxWriteThreads());

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
@@ -157,19 +157,7 @@ public class ClientContextTest {
         .getMemoryAsBytes(ClientProperty.BATCH_WRITER_MEMORY_MAX.getValue(props));
     assertEquals(expectedMemory, batchWriterConfig.getMaxMemory());
 
-    // If the value of BATCH_WRITE_LATENCY_MAX or BATCH_WRITER_TIMEOUT_MAX, is set to zero,
-    // Long.MAX_VALUE is returned. Effectively, this will cause data to be held in memory
-    // indefinitely for BATCH_WRITE_LATENCY_MAX and for no timeout, for BATCH_WRITER_TIMEOUT_MAX.
-    // Due to this behavior, the test compares the return values differently. If a value of
-    // 0 is used, compare the return value using TimeUnit.MILLISECONDS, otherwise the value
-    // should be converted to seconds in order to match the value set in ClientProperty.
-    long expectedLatency = ClientProperty.BATCH_WRITER_LATENCY_MAX.getTimeInMillis(props);
-    if (expectedLatency == 0) {
-      expectedLatency = Long.MAX_VALUE;
-      assertEquals(expectedLatency, batchWriterConfig.getMaxLatency(TimeUnit.MILLISECONDS));
-    } else {
-      assertEquals(expectedLatency, batchWriterConfig.getMaxLatency(TimeUnit.SECONDS));
-    }
+    assertEquals(Long.MAX_VALUE, batchWriterConfig.getMaxLatency(TimeUnit.MILLISECONDS));
 
     long expectedTimeout = ClientProperty.BATCH_WRITER_TIMEOUT_MAX.getTimeInMillis(props);
     if (expectedTimeout == 0) {

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
@@ -159,13 +159,7 @@ public class ClientContextTest {
 
     assertEquals(Long.MAX_VALUE, batchWriterConfig.getMaxLatency(TimeUnit.MILLISECONDS));
 
-    long expectedTimeout = ClientProperty.BATCH_WRITER_TIMEOUT_MAX.getTimeInMillis(props);
-    if (expectedTimeout == 0) {
-      expectedTimeout = Long.MAX_VALUE;
-      assertEquals(expectedTimeout, batchWriterConfig.getTimeout(TimeUnit.MILLISECONDS));
-    } else {
-      assertEquals(expectedTimeout, batchWriterConfig.getTimeout(TimeUnit.SECONDS));
-    }
+    assertEquals(15, batchWriterConfig.getTimeout(TimeUnit.SECONDS));
 
     long expectedThreads = ClientProperty.BATCH_WRITER_THREADS_MAX.getInteger(props);
     assertEquals(expectedThreads, batchWriterConfig.getMaxWriteThreads());


### PR DESCRIPTION
Created two unit tests for the conversion of client properties to BatchWriterConfig. One using default values and another using modified values.

Refactored getBatchWriterConfig as suggested in initial ticket.

Added code in getBatchWriterConfig to allow for updating BATCH_WRTIER_THREADS_MAX as it was missing in the method as it existed.