### PR TITLE
Test converting client props to ConditionalWriterConfig

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -318,23 +318,28 @@ public class ClientContext implements AccumuloClient {
     return batchWriterConfig;
   }
 
+  static ConditionalWriterConfig getConditionalWriterConfig(Properties props) {
+    ConditionalWriterConfig conditionalWriterConfig = new ConditionalWriterConfig();
+
+    Long timeout = ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX.getTimeInMillis(props);
+    if (timeout != null) {
+      conditionalWriterConfig.setTimeout(timeout, TimeUnit.SECONDS);
+    }
+    String durability = ClientProperty.CONDITIONAL_WRITER_DURABILITY.getValue(props);
+    if (!durability.isEmpty()) {
+      conditionalWriterConfig.setDurability(Durability.valueOf(durability.toUpperCase()));
+    }
+    Integer maxThreads = ClientProperty.CONDITIONAL_WRITER_THREADS_MAX.getInteger(props);
+    if (maxThreads != null) {
+      conditionalWriterConfig.setMaxWriteThreads(maxThreads);
+    }
+    return conditionalWriterConfig;
+  }
+
   public synchronized ConditionalWriterConfig getConditionalWriterConfig() {
     ensureOpen();
     if (conditionalWriterConfig == null) {
-      Properties props = info.getProperties();
-      conditionalWriterConfig = new ConditionalWriterConfig();
-      Long timeout = ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX.getTimeInMillis(props);
-      if (timeout != null) {
-        conditionalWriterConfig.setTimeout(timeout, TimeUnit.SECONDS);
-      }
-      String durability = ClientProperty.CONDITIONAL_WRITER_DURABILITY.getValue(props);
-      if (!durability.isEmpty()) {
-        conditionalWriterConfig.setDurability(Durability.valueOf(durability.toUpperCase()));
-      }
-      Integer maxThreads = ClientProperty.CONDITIONAL_WRITER_THREADS_MAX.getInteger(props);
-      if (maxThreads != null) {
-        conditionalWriterConfig.setMaxWriteThreads(maxThreads);
-      }
+      conditionalWriterConfig = getConditionalWriterConfig(info.getProperties());
     }
     return conditionalWriterConfig;
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.ConditionalWriterConfig;
 import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ClientProperty;
@@ -168,6 +169,60 @@ public class ClientContextTest {
     Durability expectedDurability =
         Durability.valueOf(ClientProperty.BATCH_WRITER_DURABILITY.getValue(props).toUpperCase());
     assertEquals(expectedDurability, batchWriterConfig.getDurability());
+  }
+
+  @Test
+  public void testGetConditionalWriterConfigUsingDefaults() {
+    Properties props = new Properties();
+    ConditionalWriterConfig conditionalWriterConfig =
+        ClientContext.getConditionalWriterConfig(props);
+    assertNotNull(conditionalWriterConfig);
+
+    // If the value of BATCH_WRITER_TIMEOUT_MAX is set to zero, Long.MAX_VALUE is returned.
+    // Effectively, this indicates there is no timeout for BATCH_WRITER_TIMEOUT_MAX. Due to this
+    // behavior, the test compares the return values differently. If a value of 0 is used, compare
+    // the return value using TimeUnit.MILLISECONDS, otherwise the value should be converted to
+    // seconds in order to match the value set in ClientProperty.
+    long expectedTimeout = ConfigurationTypeHelper
+        .getTimeInMillis(ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX.getDefaultValue());
+    if (expectedTimeout == 0) {
+      assertEquals(Long.MAX_VALUE, conditionalWriterConfig.getTimeout(TimeUnit.MILLISECONDS));
+    } else {
+      assertEquals(expectedTimeout, conditionalWriterConfig.getTimeout(TimeUnit.SECONDS));
+    }
+
+    int expectedThreads =
+        Integer.parseInt(ClientProperty.CONDITIONAL_WRITER_THREADS_MAX.getDefaultValue());
+    assertEquals(expectedThreads, conditionalWriterConfig.getMaxWriteThreads());
+
+    Durability expectedDurability = Durability
+        .valueOf(ClientProperty.CONDITIONAL_WRITER_DURABILITY.getDefaultValue().toUpperCase());
+    assertEquals(expectedDurability, conditionalWriterConfig.getDurability());
+  }
+
+  @Test
+  public void testGetConditionalWriterConfigNotUsingDefaults() {
+    Properties props = new Properties();
+
+    // set properties to non-default values
+    props.setProperty(ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX.getKey(), "17");
+    props.setProperty(ClientProperty.CONDITIONAL_WRITER_THREADS_MAX.getKey(), "14");
+    props.setProperty(ClientProperty.CONDITIONAL_WRITER_DURABILITY.getKey(),
+        Durability.SYNC.name());
+
+    ConditionalWriterConfig conditionalWriterConfig =
+        ClientContext.getConditionalWriterConfig(props);
+    assertNotNull(conditionalWriterConfig);
+
+    // getTimeout returns time in milliseconds, therefore the 17 becomes 17000.
+    assertEquals(17000, conditionalWriterConfig.getTimeout(TimeUnit.SECONDS));
+
+    long expectedThreads = ClientProperty.CONDITIONAL_WRITER_THREADS_MAX.getInteger(props);
+    assertEquals(expectedThreads, conditionalWriterConfig.getMaxWriteThreads());
+
+    Durability expectedDurability = Durability
+        .valueOf(ClientProperty.CONDITIONAL_WRITER_DURABILITY.getValue(props).toUpperCase());
+    assertEquals(expectedDurability, conditionalWriterConfig.getDurability());
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
@@ -179,10 +179,10 @@ public class ClientContextTest {
     assertNotNull(conditionalWriterConfig);
 
     // If the value of CONDITIONAL_WRITER_TIMEOUT_MAX is set to zero, Long.MAX_VALUE is returned.
-    // Effectively, this indicates there is no timeout for BATCH_WRITER_TIMEOUT_MAX. Due to this
-    // behavior, the test compares the return values differently. If a value of 0 is used, compare
-    // the return value using TimeUnit.MILLISECONDS, otherwise the value should be converted to
-    // seconds in order to match the value set in ClientProperty.
+    // Effectively, this indicates there is no timeout for CONDITIONAL_WRITER_TIMEOUT_MAX. Due to
+    // this behavior, the test compares the return values differently. If a value of 0 is used,
+    // compare the return value using TimeUnit.MILLISECONDS, otherwise the value should be
+    // converted to seconds in order to match the value set in ClientProperty.
     long expectedTimeout = ConfigurationTypeHelper
         .getTimeInMillis(ClientProperty.CONDITIONAL_WRITER_TIMEOUT_MAX.getDefaultValue());
     if (expectedTimeout == 0) {

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientContextTest.java
@@ -178,7 +178,7 @@ public class ClientContextTest {
         ClientContext.getConditionalWriterConfig(props);
     assertNotNull(conditionalWriterConfig);
 
-    // If the value of BATCH_WRITER_TIMEOUT_MAX is set to zero, Long.MAX_VALUE is returned.
+    // If the value of CONDITIONAL_WRITER_TIMEOUT_MAX is set to zero, Long.MAX_VALUE is returned.
     // Effectively, this indicates there is no timeout for BATCH_WRITER_TIMEOUT_MAX. Due to this
     // behavior, the test compares the return values differently. If a value of 0 is used, compare
     // the return value using TimeUnit.MILLISECONDS, otherwise the value should be converted to


### PR DESCRIPTION
Created two unit tests for the conversion of client properties to ConditionalWriterConfig. One using default values and another using modified values.

Refactored getConditionalWriterConfig into two methods to facilitate unit testing.

Closes #2131 