### PR TITLE
Remove redundant information in tablets external compaction entry

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
@@ -42,7 +42,6 @@ public class ExternalCompactionMetadata {
   private final Set<StoredTabletFile> jobFiles;
   private final Set<StoredTabletFile> nextFiles;
   private final TabletFile compactTmpName;
-  private final TabletFile newFile;
   private final String compactorId;
   private final CompactionKind kind;
   private final long priority;
@@ -52,13 +51,12 @@ public class ExternalCompactionMetadata {
   private final Long compactionId;
 
   public ExternalCompactionMetadata(Set<StoredTabletFile> jobFiles, Set<StoredTabletFile> nextFiles,
-      TabletFile compactTmpName, TabletFile newFile, String compactorId, CompactionKind kind,
-      long priority, CompactionExecutorId ceid, boolean propagateDeletes,
-      boolean initiallySelectedAll, Long compactionId) {
+      TabletFile compactTmpName, String compactorId, CompactionKind kind, long priority,
+      CompactionExecutorId ceid, boolean propagateDeletes, boolean initiallySelectedAll,
+      Long compactionId) {
     this.jobFiles = Objects.requireNonNull(jobFiles);
     this.nextFiles = Objects.requireNonNull(nextFiles);
     this.compactTmpName = Objects.requireNonNull(compactTmpName);
-    this.newFile = Objects.requireNonNull(newFile);
     this.compactorId = Objects.requireNonNull(compactorId);
     this.kind = Objects.requireNonNull(kind);
     this.priority = priority;
@@ -78,10 +76,6 @@ public class ExternalCompactionMetadata {
 
   public TabletFile getCompactTmpName() {
     return compactTmpName;
-  }
-
-  public TabletFile getNewFile() {
-    return newFile;
   }
 
   public String getCompactorId() {
@@ -118,7 +112,6 @@ public class ExternalCompactionMetadata {
     List<String> inputs;
     List<String> nextFiles;
     String tmp;
-    String dest;
     String compactor;
     String kind;
     String executorId;
@@ -135,7 +128,6 @@ public class ExternalCompactionMetadata {
     jData.nextFiles =
         nextFiles.stream().map(StoredTabletFile::getMetaUpdateDelete).collect(toList());
     jData.tmp = compactTmpName.getMetaInsert();
-    jData.dest = newFile.getMetaInsert();
     jData.compactor = compactorId;
     jData.kind = kind.name();
     jData.executorId = ((CompactionExecutorIdImpl) ceid).getExternalName();
@@ -152,10 +144,9 @@ public class ExternalCompactionMetadata {
     return new ExternalCompactionMetadata(
         jData.inputs.stream().map(StoredTabletFile::new).collect(toSet()),
         jData.nextFiles.stream().map(StoredTabletFile::new).collect(toSet()),
-        new TabletFile(new Path(jData.tmp)), new TabletFile(new Path(jData.dest)), jData.compactor,
-        CompactionKind.valueOf(jData.kind), jData.priority,
-        CompactionExecutorIdImpl.externalId(jData.executorId), jData.propDels, jData.selectedAll,
-        jData.compactionId);
+        new TabletFile(new Path(jData.tmp)), jData.compactor, CompactionKind.valueOf(jData.kind),
+        jData.priority, CompactionExecutorIdImpl.externalId(jData.executorId), jData.propDels,
+        jData.selectedAll, jData.compactionId);
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 public class TabletFileTest {
@@ -38,6 +39,16 @@ public class TabletFileTest {
     assertEquals(tabletDir, tabletFile.getTabletDir());
     assertEquals(fileName, tabletFile.getFileName());
     return tabletFile;
+  }
+
+  @Test
+  public void testEquivalence() {
+    TabletFile newFile = new TabletFile(
+        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf"));
+    TabletFile tmpFile = new TabletFile(new Path(newFile.getMetaInsert() + "_tmp"));
+    TabletFile newFile2 = new TabletFile(
+        new Path(tmpFile.getMetaInsert().substring(0, tmpFile.getMetaInsert().indexOf("_tmp"))));
+    assertEquals(newFile, newFile2);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.fail;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
-import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 public class TabletFileTest {
@@ -39,16 +38,6 @@ public class TabletFileTest {
     assertEquals(tabletDir, tabletFile.getTabletDir());
     assertEquals(fileName, tabletFile.getFileName());
     return tabletFile;
-  }
-
-  @Test
-  public void testEquivalence() {
-    TabletFile newFile = new TabletFile(
-        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf"));
-    TabletFile tmpFile = new TabletFile(new Path(newFile.getMetaInsert() + "_tmp"));
-    TabletFile newFile2 = new TabletFile(
-        new Path(tmpFile.getMetaInsert().substring(0, tmpFile.getMetaInsert().indexOf("_tmp"))));
-    assertEquals(newFile, newFile2);
   }
 
   @Test

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -74,7 +74,6 @@ import org.apache.accumulo.tserver.compactions.Compactable;
 import org.apache.accumulo.tserver.compactions.CompactionManager;
 import org.apache.accumulo.tserver.compactions.ExternalCompactionJob;
 import org.apache.accumulo.tserver.managermessage.TabletStatusMessage;
-import org.apache.hadoop.fs.Path;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -973,9 +972,7 @@ public class CompactableImpl implements Compactable {
       Map<String,String> overrides =
           CompactableUtils.getOverrides(job.getKind(), tablet, cInfo.localHelper, job.getFiles());
 
-      String tmpFileName =
-          tablet.getNextMapFilename(!cInfo.propagateDeletes ? "A" : "C").getMetaInsert() + "_tmp";
-      TabletFile compactTmpName = new TabletFile(new Path(tmpFileName));
+      TabletFile compactTmpName = tablet.getNextMapFilenameForMajc(cInfo.propagateDeletes);
 
       ExternalCompactionInfo ecInfo = new ExternalCompactionInfo();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -613,8 +613,9 @@ public class CompactableUtils {
     HashMap<StoredTabletFile,DataFileValue> compactFiles = new HashMap<>();
     jobFiles.forEach(file -> compactFiles.put(file, allFiles.get(file)));
 
-    TabletFile newFile = tablet.getNextMapFilename(!propagateDeletes ? "A" : "C");
-    TabletFile compactTmpName = new TabletFile(new Path(newFile.getMetaInsert() + "_tmp"));
+    String tmpFileName =
+        tablet.getNextMapFilename(!propagateDeletes ? "A" : "C").getMetaInsert() + "_tmp";
+    TabletFile compactTmpName = new TabletFile(new Path(tmpFileName));
 
     FileCompactor compactor = new FileCompactor(tablet.getContext(), tablet.getExtent(),
         compactFiles, compactTmpName, propagateDeletes, cenv, iters, compactionConfig);
@@ -632,7 +633,7 @@ public class CompactableUtils {
     stats.add(mcs);
 
     metaFile = tablet.getDatafileManager().bringMajorCompactionOnline(compactFiles.keySet(),
-        compactTmpName, newFile, compactionId, selectedFiles,
+        compactTmpName, compactionId, selectedFiles,
         new DataFileValue(mcs.getFileSize(), mcs.getEntriesWritten()), Optional.empty());
     return metaFile;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -613,9 +613,7 @@ public class CompactableUtils {
     HashMap<StoredTabletFile,DataFileValue> compactFiles = new HashMap<>();
     jobFiles.forEach(file -> compactFiles.put(file, allFiles.get(file)));
 
-    String tmpFileName =
-        tablet.getNextMapFilename(!propagateDeletes ? "A" : "C").getMetaInsert() + "_tmp";
-    TabletFile compactTmpName = new TabletFile(new Path(tmpFileName));
+    TabletFile compactTmpName = tablet.getNextMapFilenameForMajc(propagateDeletes);
 
     FileCompactor compactor = new FileCompactor(tablet.getContext(), tablet.getExtent(),
         compactFiles, compactTmpName, propagateDeletes, cenv, iters, compactionConfig);
@@ -651,4 +649,17 @@ public class CompactableUtils {
         throw new IllegalArgumentException("Unknown kind " + ck);
     }
   }
+
+  public static TabletFile computeCompactionFileDest(TabletFile tmpFile) {
+    String newFilePath = tmpFile.getMetaInsert();
+    int idx = newFilePath.indexOf("_tmp");
+    if (idx > 0) {
+      newFilePath = newFilePath.substring(0, idx);
+    } else {
+      throw new RuntimeException(
+          "Expected compaction tmp file " + tmpFile.getMetaInsert() + " to have suffix '_tmp'");
+    }
+    return new TabletFile(new Path(newFilePath));
+  }
+
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -656,7 +656,7 @@ public class CompactableUtils {
     if (idx > 0) {
       newFilePath = newFilePath.substring(0, idx);
     } else {
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
           "Expected compaction tmp file " + tmpFile.getMetaInsert() + " to have suffix '_tmp'");
     }
     return new TabletFile(new Path(newFilePath));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -398,12 +398,18 @@ class DatafileManager {
   }
 
   StoredTabletFile bringMajorCompactionOnline(Set<StoredTabletFile> oldDatafiles,
-      TabletFile tmpDatafile, TabletFile newDatafile, Long compactionId,
-      Set<StoredTabletFile> selectedFiles, DataFileValue dfv, Optional<ExternalCompactionId> ecid)
-      throws IOException {
+      TabletFile tmpDatafile, Long compactionId, Set<StoredTabletFile> selectedFiles,
+      DataFileValue dfv, Optional<ExternalCompactionId> ecid) throws IOException {
     final KeyExtent extent = tablet.getExtent();
     VolumeManager vm = tablet.getTabletServer().getContext().getVolumeManager();
     long t1, t2;
+
+    int idx = tmpDatafile.getMetaInsert().indexOf("_tmp");
+    String newFilePath = tmpDatafile.getMetaInsert();
+    if (idx > 0) {
+      newFilePath = newFilePath.substring(0, idx);
+    }
+    TabletFile newDatafile = new TabletFile(new Path(newFilePath));
 
     if (vm.exists(newDatafile.getPath())) {
       log.error("Target map file already exist " + newDatafile, new Exception());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -404,12 +404,7 @@ class DatafileManager {
     VolumeManager vm = tablet.getTabletServer().getContext().getVolumeManager();
     long t1, t2;
 
-    int idx = tmpDatafile.getMetaInsert().indexOf("_tmp");
-    String newFilePath = tmpDatafile.getMetaInsert();
-    if (idx > 0) {
-      newFilePath = newFilePath.substring(0, idx);
-    }
-    TabletFile newDatafile = new TabletFile(new Path(newFilePath));
+    TabletFile newDatafile = CompactableUtils.computeCompactionFileDest(tmpDatafile);
 
     if (vm.exists(newDatafile.getPath())) {
       log.error("Target map file already exist " + newDatafile, new Exception());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -273,6 +273,11 @@ public class Tablet {
         + context.getUniqueNameAllocator().getNextName() + "." + extension));
   }
 
+  TabletFile getNextMapFilenameForMajc(boolean propagateDeletes) throws IOException {
+    String tmpFileName = getNextMapFilename(!propagateDeletes ? "A" : "C").getMetaInsert() + "_tmp";
+    return new TabletFile(new Path(tmpFileName));
+  }
+
   private void checkTabletDir(Path path) throws IOException {
     if (!checkedTabletDirs.contains(path)) {
       FileStatus[] files = null;

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactableUtilsTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactableUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.tserver.compaction;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.tserver.tablet.CompactableUtils;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+
+public class CompactableUtilsTest {
+
+  @Test
+  public void testEquivalence() {
+    TabletFile expected = new TabletFile(
+        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf"));
+    TabletFile tmpFile = new TabletFile(new Path(expected.getMetaInsert() + "_tmp"));
+    TabletFile dest = CompactableUtils.computeCompactionFileDest(tmpFile);
+    assertEquals(expected, dest);
+  }
+
+}


### PR DESCRIPTION
Compute the name of the newly compacted file from the tmp file in
DatafileManager.bringMajorCompactionOnline instead of pre-computing
it, passing it around, and storing it in the external metadata entry

Closes #2110