### PR TITLE
Removes chatty logging in coordinator

### DIFF
--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -405,7 +405,7 @@ public class CompactionCoordinator extends AbstractServer
           SecurityErrorCode.PERMISSION_DENIED).asThriftException();
     }
     final String queue = queueName.intern();
-    LOG.debug("getCompactionJob called for queue {} by compactor {}", queue, compactorAddress);
+    LOG.trace("getCompactionJob called for queue {} by compactor {}", queue, compactorAddress);
     TIME_COMPACTOR_LAST_CHECKED.put(queue, System.currentTimeMillis());
 
     TExternalCompactionJob result = null;
@@ -447,7 +447,7 @@ public class CompactionCoordinator extends AbstractServer
     }
 
     if (result == null) {
-      LOG.debug("No tservers found for queue {}, returning empty job to compactor {}", queue,
+      LOG.trace("No tservers found for queue {}, returning empty job to compactor {}", queue,
           compactorAddress);
       result = new TExternalCompactionJob();
     }


### PR DESCRIPTION
Noticed the following log messages were very chatty and constantly reporting that a compactor asked for work and there was none.

```
2021-06-04T03:47:45,756 [coordinator.CompactionCoordinator] DEBUG: getCompactionJob called for queue DCQ1 by compactor 10.2.0.236:9133
2021-06-04T03:47:45,756 [coordinator.CompactionCoordinator] DEBUG: No tservers found for queue DCQ1, returning empty job to compactor 10.2.0.236:9133
2021-06-04T03:47:45,995 [coordinator.CompactionCoordinator] DEBUG: getCompactionJob called for queue DCQ1 by compactor 10.2.1.15:9133
2021-06-04T03:47:45,995 [coordinator.CompactionCoordinator] DEBUG: No tservers found for queue DCQ1, returning empty job to compactor 10.2.1.15:9133
2021-06-04T03:47:46,008 [coordinator.CompactionCoordinator] DEBUG: getCompactionJob called for queue DCQ1 by compactor 10.2.1.36:9133
2021-06-04T03:47:46,008 [coordinator.CompactionCoordinator] DEBUG: No tservers found for queue DCQ1, returning empty job to compactor 10.2.1.36:9133
2021-06-04T03:47:46,088 [coordinator.CompactionCoordinator] DEBUG: getCompactionJob called for queue DCQ1 by compactor 10.2.0.78:9133
2021-06-04T03:47:46,088 [coordinator.CompactionCoordinator] DEBUG: No tservers found for queue DCQ1, returning empty job to compactor 10.2.0.78:9133
2021-06-04T03:47:46,224 [coordinator.CompactionCoordinator] DEBUG: getCompactionJob called for queue DCQ1 by compactor 10.2.0.93:9133
2021-06-04T03:47:46,224 [coordinator.CompactionCoordinator] DEBUG: No tservers found for queue DCQ1, returning empty job to compactor 10.2.0.93:9133
```