### PR TITLE
Change shell 'config' command to display sorted output

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
@@ -50,8 +50,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSortedMap;
-
 public class TableOperationsHelperTest {
 
   static class Tester extends TableOperationsHelper {
@@ -269,7 +267,7 @@ public class TableOperationsHelperTest {
       String[] parts = value.split("=", 2);
       expected.put(parts[0], parts[1]);
     }
-    Map<String,String> actual = ImmutableSortedMap.copyOf(t.getConfiguration(tablename));
+    Map<String,String> actual = Map.copyOf(t.getConfiguration(tablename));
     assertEquals(expected, actual);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
@@ -50,6 +50,8 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSortedMap;
+
 public class TableOperationsHelperTest {
 
   static class Tester extends TableOperationsHelper {
@@ -267,7 +269,7 @@ public class TableOperationsHelperTest {
       String[] parts = value.split("=", 2);
       expected.put(parts[0], parts[1]);
     }
-    Map<String,String> actual = Map.copyOf(t.getConfiguration(tablename));
+    Map<String,String> actual = ImmutableSortedMap.copyOf(t.getConfiguration(tablename));
     assertEquals(expected, actual);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -71,6 +71,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -528,8 +529,8 @@ public class Admin implements KeywordExecutable {
     File namespaceScript = new File(outputDirectory, namespace + NS_FILE_SUFFIX);
     try (BufferedWriter nsWriter = new BufferedWriter(new FileWriter(namespaceScript, UTF_8))) {
       nsWriter.write(createNsFormat.format(new String[] {namespace}));
-      Map<String,String> props =
-          Map.copyOf(accumuloClient.namespaceOperations().getConfiguration(namespace));
+      Map<String,String> props = ImmutableSortedMap
+          .copyOf(accumuloClient.namespaceOperations().getConfiguration(namespace));
       for (Entry<String,String> entry : props.entrySet()) {
         String defaultValue = getDefaultConfigValue(entry.getKey());
         if (defaultValue == null || !defaultValue.equals(entry.getValue())) {
@@ -606,7 +607,7 @@ public class Admin implements KeywordExecutable {
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(tableBackup, UTF_8))) {
       writer.write(createTableFormat.format(new String[] {tableName}));
       Map<String,String> props =
-          Map.copyOf(accumuloClient.tableOperations().getConfiguration(tableName));
+          ImmutableSortedMap.copyOf(accumuloClient.tableOperations().getConfiguration(tableName));
       for (Entry<String,String> prop : props.entrySet()) {
         if (prop.getKey().startsWith(Property.TABLE_PREFIX.getKey())) {
           String defaultValue = getDefaultConfigValue(prop.getKey());

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -47,6 +47,8 @@ import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.jline.reader.LineReader;
 
+import com.google.common.collect.ImmutableSortedMap;
+
 public class ConfigCommand extends Command {
   private Option tableOpt, deleteOpt, setOpt, filterOpt, filterWithValuesOpt, disablePaginationOpt,
       outputFileOpt, namespaceOpt;
@@ -183,7 +185,7 @@ public class ConfigCommand extends Command {
       } else if (namespace != null) {
         acuconf = shellState.getAccumuloClient().namespaceOperations().getConfiguration(namespace);
       }
-      final Map<String,String> sortedConf = Map.copyOf(acuconf);
+      final Map<String,String> sortedConf = ImmutableSortedMap.copyOf(acuconf);
 
       for (Entry<String,String> propEntry : acuconf.entrySet()) {
         final String key = propEntry.getKey();


### PR DESCRIPTION
Fixes #2149 

Fixes the bug where the `config` command inside the accumulo shell returns the properties unordered by using `ImmutableSortedMap.copyOf`.

There is only one instance that the shell output is directly effected by this so the other TreeMaps that were replaced I left alone and did not want to import additional things if it was not needed.

If there are other spots in the commit [4ea9bf1](https://github.com/apache/accumulo/commit/4ea9bf1ac916d66896eaaba329da04714a1e8cba) that would directly benefit from the `ImmutableSortedMap.copyOf` change, I can make those changes as well.