### PR TITLE
Make CachableBlockFile builder require nonNull for cacheId 

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -347,7 +347,7 @@ class RFileScanner extends ScannerOptions implements Scanner {
       for (int i = 0; i < sources.length; i++) {
         // TODO may have been a bug with multiple files and caching in older version...
         FSDataInputStream inputStream = (FSDataInputStream) sources[i].getInputStream();
-        CachableBuilder cb = new CachableBuilder().cacheId("source-" + i).input(inputStream)
+        CachableBuilder cb = new CachableBuilder().cacheId(opts.in.getPaths()[i]).input(inputStream)
             .length(sources[i].getLength()).conf(opts.in.getConf()).cacheProvider(cacheProvider)
             .cryptoService(cryptoService);
         readers.add(new RFile.Reader(cb));

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -26,9 +26,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.SplittableRandom;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -74,8 +74,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 class RFileScanner extends ScannerOptions implements Scanner {
 
@@ -340,11 +338,9 @@ class RFileScanner extends ScannerOptions implements Scanner {
   }
 
   @Override
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for cache names")
   public Iterator<Entry<Key,Value>> iterator() {
     try {
-      int rand = new Random().nextInt(1000);
+      int rand = new SplittableRandom().nextInt(1_000_000);
       RFileSource[] sources = opts.in.getSources();
       List<SortedKeyValueIterator<Key,Value>> readers = new ArrayList<>(sources.length);
 

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScanner.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.SplittableRandom;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -340,7 +339,6 @@ class RFileScanner extends ScannerOptions implements Scanner {
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
     try {
-      int rand = new SplittableRandom().nextInt(1_000_000);
       RFileSource[] sources = opts.in.getSources();
       List<SortedKeyValueIterator<Key,Value>> readers = new ArrayList<>(sources.length);
 
@@ -349,9 +347,9 @@ class RFileScanner extends ScannerOptions implements Scanner {
       for (int i = 0; i < sources.length; i++) {
         // TODO may have been a bug with multiple files and caching in older version...
         FSDataInputStream inputStream = (FSDataInputStream) sources[i].getInputStream();
-        CachableBuilder cb = new CachableBuilder().input(inputStream, "cache-" + rand + i)
-            .length(sources[i].getLength()).conf(opts.in.getConf()).cacheProvider(cacheProvider)
-            .cryptoService(cryptoService);
+        CachableBuilder cb =
+            new CachableBuilder().input(inputStream, "source-" + i).length(sources[i].getLength())
+                .conf(opts.in.getConf()).cacheProvider(cacheProvider).cryptoService(cryptoService);
         readers.add(new RFile.Reader(cb));
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
@@ -52,6 +52,10 @@ class RFileScannerBuilder implements RFile.InputArguments, RFile.ScannerFSOption
       this.sources = sources;
     }
 
+    Path[] getPaths() {
+      return paths;
+    }
+
     RFileSource[] getSources() throws IOException {
       if (sources == null) {
         sources = new RFileSource[paths.length];

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileScannerBuilder.java
@@ -52,10 +52,6 @@ class RFileScannerBuilder implements RFile.InputArguments, RFile.ScannerFSOption
       this.sources = sources;
     }
 
-    Path[] getPaths() {
-      return paths;
-    }
-
     RFileSource[] getSources() throws IOException {
       if (sources == null) {
         sources = new RFileSource[paths.length];

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileSummariesRetriever.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileSummariesRetriever.java
@@ -93,9 +93,9 @@ class RFileSummariesRetriever implements SummaryInputArguments, SummaryFSOptions
     try {
       SummaryCollection all = new SummaryCollection();
       CryptoService cservice = CryptoServiceFactory.newInstance(acuconf, ClassloaderType.JAVA);
-      for (RFileSource source : sources) {
-        SummaryReader fileSummary = SummaryReader.load(in.getFileSystem().getConf(),
-            source.getInputStream(), source.getLength(), summarySelector, factory, cservice);
+      for (int i = 0; i < sources.length; i++) {
+        SummaryReader fileSummary = SummaryReader.load(in.getFileSystem().getConf(), sources[i],
+            in.getPaths()[i], summarySelector, factory, cservice);
         SummaryCollection sc = fileSummary
             .getSummaries(Collections.singletonList(new Gatherer.RowRange(startRow, endRow)));
         all.merge(sc, factory);

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileSummariesRetriever.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileSummariesRetriever.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.client.rfile.RFile.SummaryFSOptions;
@@ -44,8 +44,6 @@ import org.apache.accumulo.core.summary.SummaryCollection;
 import org.apache.accumulo.core.summary.SummaryReader;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 class RFileSummariesRetriever implements SummaryInputArguments, SummaryFSOptions, SummaryOptions {
 
@@ -87,15 +85,13 @@ class RFileSummariesRetriever implements SummaryInputArguments, SummaryFSOptions
   }
 
   @Override
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for cache names")
   public Collection<Summary> read() throws IOException {
     SummarizerFactory factory = new SummarizerFactory();
     ConfigurationCopy acuconf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     config.forEach(acuconf::set);
 
     RFileSource[] sources = in.getSources();
-    int rand = new Random().nextInt(1000);
+    int rand = new SplittableRandom().nextInt(1_000_000);
     try {
       SummaryCollection all = new SummaryCollection();
       CryptoService cservice = CryptoServiceFactory.newInstance(acuconf, ClassloaderType.JAVA);

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileSummariesRetriever.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileSummariesRetriever.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.SplittableRandom;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.client.rfile.RFile.SummaryFSOptions;
@@ -91,13 +90,12 @@ class RFileSummariesRetriever implements SummaryInputArguments, SummaryFSOptions
     config.forEach(acuconf::set);
 
     RFileSource[] sources = in.getSources();
-    int rand = new SplittableRandom().nextInt(1_000_000);
     try {
       SummaryCollection all = new SummaryCollection();
       CryptoService cservice = CryptoServiceFactory.newInstance(acuconf, ClassloaderType.JAVA);
       for (int i = 0; i < sources.length; i++) {
         SummaryReader fileSummary = SummaryReader.load(in.getFileSystem().getConf(), sources[i],
-            "cache-" + rand + i, summarySelector, factory, cservice);
+            "source-" + i, summarySelector, factory, cservice);
         SummaryCollection sc = fileSummary
             .getSummaries(Collections.singletonList(new Gatherer.RowRange(startRow, endRow)));
         all.merge(sc, factory);

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -77,11 +77,6 @@ public class CachableBlockFile {
     Configuration hadoopConf = null;
     CryptoService cryptoService = null;
 
-    public CachableBuilder cacheId(Path path) {
-      this.cacheId = pathToCacheId(path);
-      return this;
-    }
-
     public CachableBuilder conf(Configuration hadoopConf) {
       this.hadoopConf = hadoopConf;
       return this;
@@ -94,7 +89,8 @@ public class CachableBlockFile {
       return this;
     }
 
-    public CachableBuilder input(InputStream is) {
+    public CachableBuilder input(InputStream is, String cacheId) {
+      this.cacheId = cacheId;
       this.inputSupplier = () -> is;
       return this;
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/CachableBlockFile.java
@@ -77,8 +77,8 @@ public class CachableBlockFile {
     Configuration hadoopConf = null;
     CryptoService cryptoService = null;
 
-    public CachableBuilder cacheId(String id) {
-      this.cacheId = id;
+    public CachableBuilder cacheId(Path path) {
+      this.cacheId = pathToCacheId(path);
       return this;
     }
 
@@ -359,7 +359,7 @@ public class CachableBlockFile {
     }
 
     public Reader(CachableBuilder b) {
-      this.cacheId = b.cacheId;
+      this.cacheId = Objects.requireNonNull(b.cacheId);
       this.inputSupplier = b.inputSupplier;
       this.lengthSupplier = b.lengthSupplier;
       this.fileLenCache = b.fileLenCache;

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.summary;
 import java.io.DataInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import org.apache.accumulo.core.client.rfile.RFileSource;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.file.blockfile.impl.BasicCacheProvider;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
@@ -174,11 +174,11 @@ public class SummaryReader {
     return fileSummaries;
   }
 
-  public static SummaryReader load(Configuration conf, InputStream inputStream, long length,
+  public static SummaryReader load(Configuration conf, RFileSource rFileSource, Path file,
       Predicate<SummarizerConfiguration> summarySelector, SummarizerFactory factory,
       CryptoService cryptoService) throws IOException {
-    CachableBuilder cb = new CachableBuilder().input(inputStream).length(length).conf(conf)
-        .cryptoService(cryptoService);
+    CachableBuilder cb = new CachableBuilder().input(rFileSource.getInputStream())
+        .length(rFileSource.getLength()).cacheId(file).conf(conf).cryptoService(cryptoService);
     return load(new CachableBlockFile.Reader(cb), summarySelector, factory);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
@@ -174,11 +174,11 @@ public class SummaryReader {
     return fileSummaries;
   }
 
-  public static SummaryReader load(Configuration conf, RFileSource rFileSource, Path file,
+  public static SummaryReader load(Configuration conf, RFileSource source, String cacheId,
       Predicate<SummarizerConfiguration> summarySelector, SummarizerFactory factory,
       CryptoService cryptoService) throws IOException {
-    CachableBuilder cb = new CachableBuilder().input(rFileSource.getInputStream())
-        .length(rFileSource.getLength()).cacheId(file).conf(conf).cryptoService(cryptoService);
+    CachableBuilder cb = new CachableBuilder().input(source.getInputStream(), cacheId)
+        .length(source.getLength()).conf(conf).cryptoService(cryptoService);
     return load(new CachableBlockFile.Reader(cb), summarySelector, factory);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
+import static org.apache.accumulo.core.crypto.CryptoServiceFactory.newInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -28,7 +29,6 @@ import java.util.Random;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
-import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
@@ -44,7 +44,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 public class MultiLevelIndexTest {
@@ -66,8 +65,8 @@ public class MultiLevelIndexTest {
     AccumuloConfiguration aconf = DefaultConfiguration.getInstance();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     FSDataOutputStream dos = new FSDataOutputStream(baos, new FileSystem.Statistics("a"));
-    BCFile.Writer _cbw = new BCFile.Writer(dos, null, "gz", hadoopConf,
-        CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA));
+    BCFile.Writer _cbw =
+        new BCFile.Writer(dos, null, "gz", hadoopConf, newInstance(aconf, ClassloaderType.JAVA));
 
     BufferedWriter mliw = new BufferedWriter(new Writer(_cbw, maxBlockSize));
 
@@ -87,9 +86,8 @@ public class MultiLevelIndexTest {
     byte[] data = baos.toByteArray();
     SeekableByteArrayInputStream bais = new SeekableByteArrayInputStream(data);
     FSDataInputStream in = new FSDataInputStream(bais);
-    CachableBuilder cb = new CachableBuilder().input(in).length(data.length)
-        .cacheId(new Path("file1")).conf(hadoopConf)
-        .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA));
+    CachableBuilder cb = new CachableBuilder().input(in, "source-1").length(data.length)
+        .conf(hadoopConf).cryptoService(newInstance(aconf, ClassloaderType.JAVA));
     CachableBlockFile.Reader _cbr = new CachableBlockFile.Reader(cb);
 
     Reader reader = new Reader(_cbr, RFile.RINDEX_VER_8);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
-import static org.apache.accumulo.core.crypto.CryptoServiceFactory.newInstance;
+import static org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType.JAVA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
-import org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType;
+import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile.CachableBuilder;
@@ -65,8 +65,8 @@ public class MultiLevelIndexTest {
     AccumuloConfiguration aconf = DefaultConfiguration.getInstance();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     FSDataOutputStream dos = new FSDataOutputStream(baos, new FileSystem.Statistics("a"));
-    BCFile.Writer _cbw =
-        new BCFile.Writer(dos, null, "gz", hadoopConf, newInstance(aconf, ClassloaderType.JAVA));
+    BCFile.Writer _cbw = new BCFile.Writer(dos, null, "gz", hadoopConf,
+        CryptoServiceFactory.newInstance(aconf, JAVA));
 
     BufferedWriter mliw = new BufferedWriter(new Writer(_cbw, maxBlockSize));
 
@@ -87,7 +87,7 @@ public class MultiLevelIndexTest {
     SeekableByteArrayInputStream bais = new SeekableByteArrayInputStream(data);
     FSDataInputStream in = new FSDataInputStream(bais);
     CachableBuilder cb = new CachableBuilder().input(in, "source-1").length(data.length)
-        .conf(hadoopConf).cryptoService(newInstance(aconf, ClassloaderType.JAVA));
+        .conf(hadoopConf).cryptoService(CryptoServiceFactory.newInstance(aconf, JAVA));
     CachableBlockFile.Reader _cbr = new CachableBlockFile.Reader(cb);
 
     Reader reader = new Reader(_cbr, RFile.RINDEX_VER_8);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiLevelIndexTest.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 public class MultiLevelIndexTest {
@@ -86,7 +87,8 @@ public class MultiLevelIndexTest {
     byte[] data = baos.toByteArray();
     SeekableByteArrayInputStream bais = new SeekableByteArrayInputStream(data);
     FSDataInputStream in = new FSDataInputStream(bais);
-    CachableBuilder cb = new CachableBuilder().input(in).length(data.length).conf(hadoopConf)
+    CachableBuilder cb = new CachableBuilder().input(in).length(data.length)
+        .cacheId(new Path("file1")).conf(hadoopConf)
         .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA));
     CachableBlockFile.Reader _cbr = new CachableBlockFile.Reader(cb);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -88,7 +88,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.io.Text;
@@ -310,8 +309,7 @@ public class RFileTest {
       LruBlockCache indexCache = (LruBlockCache) manager.getBlockCache(CacheType.INDEX);
       LruBlockCache dataCache = (LruBlockCache) manager.getBlockCache(CacheType.DATA);
 
-      CachableBuilder cb = new CachableBuilder().cacheId(new Path("source-1")).input(in)
-          .length(fileLength).conf(conf)
+      CachableBuilder cb = new CachableBuilder().input(in, "source-1").length(fileLength).conf(conf)
           .cacheProvider(new BasicCacheProvider(indexCache, dataCache)).cryptoService(
               CryptoServiceFactory.newInstance(accumuloConfiguration, ClassloaderType.JAVA));
       reader = new RFile.Reader(cb);
@@ -1748,11 +1746,11 @@ public class RFileTest {
     aconf.set(Property.TSERV_INDEXCACHE_SIZE, Long.toString(100000000));
     BlockCacheManager manager = BlockCacheManagerFactory.getInstance(aconf);
     manager.start(new BlockCacheConfiguration(aconf));
-    CachableBuilder cb = new CachableBuilder().input(in2).length(data.length)
-        .cacheId(new Path("f1")).conf(hadoopConf)
-        .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA))
-        .cacheProvider(new BasicCacheProvider(manager.getBlockCache(CacheType.INDEX),
-            manager.getBlockCache(CacheType.DATA)));
+    CachableBuilder cb =
+        new CachableBuilder().input(in2, "cache-1").length(data.length).conf(hadoopConf)
+            .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA))
+            .cacheProvider(new BasicCacheProvider(manager.getBlockCache(CacheType.INDEX),
+                manager.getBlockCache(CacheType.DATA)));
     Reader reader = new RFile.Reader(cb);
     checkIndex(reader);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -88,6 +88,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.io.Text;
@@ -309,8 +310,9 @@ public class RFileTest {
       LruBlockCache indexCache = (LruBlockCache) manager.getBlockCache(CacheType.INDEX);
       LruBlockCache dataCache = (LruBlockCache) manager.getBlockCache(CacheType.DATA);
 
-      CachableBuilder cb = new CachableBuilder().cacheId("source-1").input(in).length(fileLength)
-          .conf(conf).cacheProvider(new BasicCacheProvider(indexCache, dataCache)).cryptoService(
+      CachableBuilder cb = new CachableBuilder().cacheId(new Path("source-1")).input(in)
+          .length(fileLength).conf(conf)
+          .cacheProvider(new BasicCacheProvider(indexCache, dataCache)).cryptoService(
               CryptoServiceFactory.newInstance(accumuloConfiguration, ClassloaderType.JAVA));
       reader = new RFile.Reader(cb);
       if (cfsi)
@@ -1746,7 +1748,8 @@ public class RFileTest {
     aconf.set(Property.TSERV_INDEXCACHE_SIZE, Long.toString(100000000));
     BlockCacheManager manager = BlockCacheManagerFactory.getInstance(aconf);
     manager.start(new BlockCacheConfiguration(aconf));
-    CachableBuilder cb = new CachableBuilder().input(in2).length(data.length).conf(hadoopConf)
+    CachableBuilder cb = new CachableBuilder().input(in2).length(data.length)
+        .cacheId(new Path("f1")).conf(hadoopConf)
         .cryptoService(CryptoServiceFactory.newInstance(aconf, ClassloaderType.JAVA))
         .cacheProvider(new BasicCacheProvider(manager.getBlockCache(CacheType.INDEX),
             manager.getBlockCache(CacheType.DATA)));


### PR DESCRIPTION
The code between the BCFile cache and the RFile API is a mess. This is an attempt to prevent cacheId from being null. I am hoping with all the tests passing we can catch all the spots where it isn't set.