### PR TITLE
Specify blockName in CachedBlock exceptions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/CachedBlock.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/CachedBlock.java
@@ -86,7 +86,7 @@ public class CachedBlock implements HeapSize, Comparable<CachedBlock> {
   @Override
   public long heapSize() {
     if (recordedSize < 0) {
-      throw new IllegalStateException("Block was evicted");
+      throw new IllegalStateException("Block was evicted: " + blockName);
     }
     return recordedSize;
   }
@@ -157,7 +157,7 @@ public class CachedBlock implements HeapSize, Comparable<CachedBlock> {
       return _recordSize(totalSize);
     }
 
-    throw new IllegalStateException("Block was evicted");
+    throw new IllegalStateException("Block was evicted: " + blockName);
   }
 
   public synchronized long evicted(AtomicLong totalSize) {
@@ -169,6 +169,6 @@ public class CachedBlock implements HeapSize, Comparable<CachedBlock> {
       return tmp;
     }
 
-    throw new IllegalStateException("already evicted");
+    throw new IllegalStateException("Block was already evicted: " + blockName);
   }
 }


### PR DESCRIPTION
Add blockName to CachedBlock's IllegalStateExceptions, to make the
exceptions more informative and easier to troubleshoot when things go
wrong. This would have helped debug issue #1973 more easily.