### PR TITLE
Document some cache props as requiring restart

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1377,9 +1377,16 @@ public enum Property {
             || key.startsWith(TABLE_COMPACTION_SELECTOR_OPTS.getKey())));
   }
 
-  private static final EnumSet<Property> fixedProperties =
-      EnumSet.of(Property.TSERV_CLIENTPORT, Property.TSERV_NATIVEMAP_ENABLED,
-          Property.TSERV_SCAN_MAX_OPENFILES, Property.MANAGER_CLIENTPORT, Property.GC_PORT);
+  private static final EnumSet<Property> fixedProperties = EnumSet.of(
+      // port options
+      GC_PORT, MANAGER_CLIENTPORT, TSERV_CLIENTPORT,
+
+      // tserver cache options
+      TSERV_CACHE_MANAGER_IMPL, TSERV_DATACACHE_SIZE, TSERV_INDEXCACHE_SIZE,
+      TSERV_SUMMARYCACHE_SIZE,
+
+      // others
+      TSERV_NATIVEMAP_ENABLED, TSERV_SCAN_MAX_OPENFILES);
 
   /**
    * Checks if the given property may be changed via Zookeeper, but not recognized until the restart


### PR DESCRIPTION
Add certain blockcache-related properties to the "fixed" properties
list, which will ensure they are documented as not taking effect until
after a restart. This is already the current behavior, because the cache
manager is instantiated as a singleton only at tserver startup, but this
helps ensure that is predictably the case, and will document it as
requiring a restart in our property documentation.

Also organize the fixed properties into logical groups, just to make it
easier to maintain slightly.