### PR TITLE
Add test and fix for bug in KeyBuilder

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/KeyBuilder.java
@@ -20,11 +20,6 @@ package org.apache.accumulo.core.data;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CodingErrorAction;
-
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
 
@@ -326,13 +321,7 @@ public class KeyBuilder {
     }
 
     private byte[] encodeCharSequence(CharSequence chars) {
-      CharsetEncoder encoder = UTF_8.newEncoder().onMalformedInput(CodingErrorAction.REPORT)
-          .onUnmappableCharacter(CodingErrorAction.REPORT);
-      try {
-        return encoder.encode(CharBuffer.wrap(chars)).array();
-      } catch (CharacterCodingException ex) {
-        throw new RuntimeException("KeyBuilder supports only CharSequences encoded in UTF-8", ex);
-      }
+      return chars.toString().getBytes(UTF_8);
     }
 
     @Override

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
@@ -305,4 +305,15 @@ public class KeyBuilderTest {
     keyExpected.setDeleted(false);
     assertEquals(keyExpected, keyBuilt);
   }
+
+  /**
+   * Tests bug where an underscore passed as a CharSequence was being encoded incorrectly.
+   */
+  @Test
+  public void testUnderscoreBug() {
+    Key keyBuilt1 = Key.builder().row(rowText).family("underscore_bug").build();
+    Key keyBuilt2 = Key.builder().row(rowText).family(new Text("underscore_bug")).build();
+
+    assertEquals(keyBuilt1, keyBuilt2);
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
@@ -307,12 +307,12 @@ public class KeyBuilderTest {
   }
 
   /**
-   * Tests bug where an underscore passed as a CharSequence was being encoded incorrectly.
+   * Tests bug where a String of 10 chars or longer was being encoded incorrectly.
    */
   @Test
-  public void testUnderscoreBug() {
-    Key keyBuilt1 = Key.builder().row(rowText).family("underscore_bug").build();
-    Key keyBuilt2 = Key.builder().row(rowText).family(new Text("underscore_bug")).build();
+  public void test10CharactersBug() {
+    Key keyBuilt1 = Key.builder().row(rowText).family("1234567890").build();
+    Key keyBuilt2 = Key.builder().row(rowText).family(new Text("1234567890")).build();
 
     assertEquals(keyBuilt1, keyBuilt2);
   }

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyBuilderTest.java
@@ -313,7 +313,6 @@ public class KeyBuilderTest {
   public void test10CharactersBug() {
     Key keyBuilt1 = Key.builder().row(rowText).family("1234567890").build();
     Key keyBuilt2 = Key.builder().row(rowText).family(new Text("1234567890")).build();
-
     assertEquals(keyBuilt1, keyBuilt2);
   }
 }


### PR DESCRIPTION
Found this weird bug in `KeyBuilder` while working on #2117. The Java UTF-8 Charset encoder puts an empty byte at the end of the string when there is an underscore present and I can't figure out why. Opening this PR to show the test failure, if anyone has any ideas.