### PR TITLE
Change WALOG Property Names to WAL

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
@@ -61,7 +61,9 @@ public class SiteConfigurationTest {
     assertEquals("DEFAULT", conf.get(Property.INSTANCE_SECRET));
     assertEquals("", conf.get(Property.INSTANCE_VOLUMES));
     assertEquals("120s", conf.get(Property.GENERAL_RPC_TIMEOUT));
-    assertEquals("1G", conf.get(Property.TSERV_WALOG_MAX_SIZE));
+    @SuppressWarnings("deprecation")
+    Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
+    assertEquals("1G", conf.get(conf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp)));
     assertEquals("org.apache.accumulo.core.spi.crypto.NoCryptoService",
         conf.get(Property.INSTANCE_CRYPTO_SERVICE));
   }
@@ -75,7 +77,9 @@ public class SiteConfigurationTest {
     assertEquals("mysecret", conf.get(Property.INSTANCE_SECRET));
     assertEquals("hdfs://localhost:8020/accumulo123", conf.get(Property.INSTANCE_VOLUMES));
     assertEquals("123s", conf.get(Property.GENERAL_RPC_TIMEOUT));
-    assertEquals("256M", conf.get(Property.TSERV_WALOG_MAX_SIZE));
+    @SuppressWarnings("deprecation")
+    Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
+    assertEquals("256M", conf.get(conf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp)));
     assertEquals("org.apache.accumulo.core.spi.crypto.AESCryptoService",
         conf.get(Property.INSTANCE_CRYPTO_SERVICE));
     assertEquals(System.getenv("USER"), conf.get("general.test.user.name"));

--- a/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
@@ -61,9 +61,7 @@ public class SiteConfigurationTest {
     assertEquals("DEFAULT", conf.get(Property.INSTANCE_SECRET));
     assertEquals("", conf.get(Property.INSTANCE_VOLUMES));
     assertEquals("120s", conf.get(Property.GENERAL_RPC_TIMEOUT));
-    @SuppressWarnings("deprecation")
-    Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
-    assertEquals("1G", conf.get(conf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp)));
+    assertEquals("1G", conf.get(Property.TSERV_WAL_MAX_SIZE));
     assertEquals("org.apache.accumulo.core.spi.crypto.NoCryptoService",
         conf.get(Property.INSTANCE_CRYPTO_SERVICE));
   }
@@ -77,9 +75,7 @@ public class SiteConfigurationTest {
     assertEquals("mysecret", conf.get(Property.INSTANCE_SECRET));
     assertEquals("hdfs://localhost:8020/accumulo123", conf.get(Property.INSTANCE_VOLUMES));
     assertEquals("123s", conf.get(Property.GENERAL_RPC_TIMEOUT));
-    @SuppressWarnings("deprecation")
-    Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
-    assertEquals("256M", conf.get(conf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp)));
+    assertEquals("256M", conf.get(Property.TSERV_WAL_MAX_SIZE));
     assertEquals("org.apache.accumulo.core.spi.crypto.AESCryptoService",
         conf.get(Property.INSTANCE_CRYPTO_SERVICE));
     assertEquals(System.getenv("USER"), conf.get("general.test.user.name"));

--- a/core/src/test/resources/accumulo2.properties
+++ b/core/src/test/resources/accumulo2.properties
@@ -24,6 +24,6 @@ instance.volumes=hdfs://localhost:8020/accumulo123
 instance.zookeeper.host=myhost123:2181
 table.durability=flush
 tserver.memory.maps.native.enabled=false
-tserver.walog.max.size=256M
+tserver.wal.max.size=256M
 general.test.user.name=${env:USER}
 general.test.user.dir=${sys:DIR}

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -146,7 +146,7 @@ public class MiniAccumuloConfigImpl {
       mergeProp(Property.TSERV_INDEXCACHE_SIZE.getKey(), "10M");
       mergeProp(Property.TSERV_SUMMARYCACHE_SIZE.getKey(), "10M");
       mergeProp(Property.TSERV_MAXMEM.getKey(), "40M");
-      mergeProp(Property.TSERV_WALOG_MAX_SIZE.getKey(), "100M");
+      mergeProp(Property.TSERV_WAL_MAX_SIZE.getKey(), "100M");
       mergeProp(Property.TSERV_NATIVEMAP_ENABLED.getKey(), "false");
       // since there is a small amount of memory, check more frequently for majc... setting may not
       // be needed in 1.5

--- a/server/base/src/main/java/org/apache/accumulo/server/master/recovery/HadoopLogCloser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/recovery/HadoopLogCloser.java
@@ -36,7 +36,7 @@ public class HadoopLogCloser extends org.apache.accumulo.server.manager.recovery
 
   public HadoopLogCloser() {
     log.warn("{} has been deprecated. Please update property {} to {} instead.",
-        getClass().getName(), Property.MANAGER_WALOG_CLOSER_IMPLEMETATION.getKey(),
+        getClass().getName(), Property.MANAGER_WAL_CLOSER_IMPLEMENTATION.getKey(),
         org.apache.accumulo.server.manager.recovery.HadoopLogCloser.class.getName());
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -197,9 +197,11 @@ public class RecoveryManager {
         synchronized (this) {
           if (!closeTasksQueued.contains(sortId) && !sortsQueued.contains(sortId)) {
             AccumuloConfiguration aconf = manager.getConfiguration();
+            @SuppressWarnings("deprecation")
             LogCloser closer = Property.createInstanceFromPropertyName(aconf,
-                Property.MANAGER_WALOG_CLOSER_IMPLEMETATION, LogCloser.class,
-                new HadoopLogCloser());
+                aconf.resolve(Property.MANAGER_WAL_CLOSER_IMPLEMENTATION,
+                    Property.MANAGER_WALOG_CLOSER_IMPLEMETATION),
+                LogCloser.class, new HadoopLogCloser());
             Long delay = recoveryDelay.get(sortId);
             if (delay == null) {
               delay = aconf.getTimeInMillis(Property.MANAGER_RECOVERY_DELAY);

--- a/server/manager/src/test/resources/conf/accumulo-site.xml
+++ b/server/manager/src/test/resources/conf/accumulo-site.xml
@@ -82,7 +82,7 @@
   </property>
 
   <property>
-    <name>tserver.walog.max.size</name>
+    <name>tserver.wal.max.size</name>
     <value>100M</value>
   </property>
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -309,11 +309,9 @@ public class TabletServer extends AbstractServer {
     final long minBlockSize =
         context.getHadoopConf().getLong("dfs.namenode.fs-limits.min-block-size", 0);
     if (minBlockSize != 0 && minBlockSize > walMaxSize) {
-      @SuppressWarnings("deprecation")
-      Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
       throw new RuntimeException("Unable to start TabletServer. Logger is set to use blocksize "
           + walMaxSize + " but hdfs minimum block size is " + minBlockSize
-          + ". Either increase the " + aconf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp)
+          + ". Either increase the " + Property.TSERV_WAL_MAX_SIZE
           + " or decrease dfs.namenode.fs-limits.min-block-size in hdfs-site.xml.");
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -300,23 +300,35 @@ public class TabletServer extends AbstractServer {
           }
         }), 5000, 5000, TimeUnit.MILLISECONDS);
 
-    final long walogMaxSize = aconf.getAsBytes(Property.TSERV_WALOG_MAX_SIZE);
-    final long walogMaxAge = aconf.getTimeInMillis(Property.TSERV_WALOG_MAX_AGE);
+    @SuppressWarnings("deprecation")
+    final long walMaxSize =
+        aconf.getAsBytes(aconf.resolve(Property.TSERV_WAL_MAX_SIZE, Property.TSERV_WALOG_MAX_SIZE));
+    @SuppressWarnings("deprecation")
+    final long walMaxAge = aconf
+        .getTimeInMillis(aconf.resolve(Property.TSERV_WAL_MAX_AGE, Property.TSERV_WALOG_MAX_AGE));
     final long minBlockSize =
         context.getHadoopConf().getLong("dfs.namenode.fs-limits.min-block-size", 0);
-    if (minBlockSize != 0 && minBlockSize > walogMaxSize) {
+    if (minBlockSize != 0 && minBlockSize > walMaxSize) {
+      @SuppressWarnings("deprecation")
+      Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
       throw new RuntimeException("Unable to start TabletServer. Logger is set to use blocksize "
-          + walogMaxSize + " but hdfs minimum block size is " + minBlockSize
-          + ". Either increase the " + Property.TSERV_WALOG_MAX_SIZE
+          + walMaxSize + " but hdfs minimum block size is " + minBlockSize
+          + ". Either increase the " + aconf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp)
           + " or decrease dfs.namenode.fs-limits.min-block-size in hdfs-site.xml.");
     }
 
+    @SuppressWarnings("deprecation")
     final long toleratedWalCreationFailures =
-        aconf.getCount(Property.TSERV_WALOG_TOLERATED_CREATION_FAILURES);
+        aconf.getCount(aconf.resolve(Property.TSERV_WAL_TOLERATED_CREATION_FAILURES,
+            Property.TSERV_WALOG_TOLERATED_CREATION_FAILURES));
+    @SuppressWarnings("deprecation")
     final long walFailureRetryIncrement =
-        aconf.getTimeInMillis(Property.TSERV_WALOG_TOLERATED_WAIT_INCREMENT);
+        aconf.getTimeInMillis(aconf.resolve(Property.TSERV_WAL_TOLERATED_WAIT_INCREMENT,
+            Property.TSERV_WALOG_TOLERATED_WAIT_INCREMENT));
+    @SuppressWarnings("deprecation")
     final long walFailureRetryMax =
-        aconf.getTimeInMillis(Property.TSERV_WALOG_TOLERATED_MAXIMUM_WAIT_DURATION);
+        aconf.getTimeInMillis(aconf.resolve(Property.TSERV_WAL_TOLERATED_MAXIMUM_WAIT_DURATION,
+            Property.TSERV_WALOG_TOLERATED_MAXIMUM_WAIT_DURATION));
     final RetryFactory walCreationRetryFactory =
         Retry.builder().maxRetries(toleratedWalCreationFailures)
             .retryAfter(walFailureRetryIncrement, TimeUnit.MILLISECONDS)
@@ -331,8 +343,8 @@ public class TabletServer extends AbstractServer {
         .maxWait(walFailureRetryMax, TimeUnit.MILLISECONDS).backOffFactor(1.5)
         .logInterval(3, TimeUnit.MINUTES).createFactory();
 
-    logger = new TabletServerLogger(this, walogMaxSize, syncCounter, flushCounter,
-        walCreationRetryFactory, walWritingRetryFactory, walogMaxAge);
+    logger = new TabletServerLogger(this, walMaxSize, syncCounter, flushCounter,
+        walCreationRetryFactory, walWritingRetryFactory, walMaxAge);
     this.resourceManager = new TabletServerResourceManager(context);
     this.security = AuditedSecurityOperation.getInstance(context);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -469,10 +469,12 @@ public class DfsLogger implements Comparable<DfsLogger> {
     log.debug("Got new write-ahead log: {}", this);
   }
 
+  @SuppressWarnings("deprecation")
   static long getWalBlockSize(AccumuloConfiguration conf) {
     long blockSize = conf.getAsBytes(Property.TSERV_WAL_BLOCKSIZE);
     if (blockSize == 0)
-      blockSize = (long) (conf.getAsBytes(Property.TSERV_WALOG_MAX_SIZE) * 1.1);
+      blockSize = (long) (conf.getAsBytes(
+          conf.resolve(Property.TSERV_WAL_MAX_SIZE, Property.TSERV_WALOG_MAX_SIZE)) * 1.1);
     return blockSize;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1925,8 +1925,9 @@ public class Tablet {
 
     // grab this outside of tablet lock.
     @SuppressWarnings("deprecation")
-    int maxLogs = tableConfiguration.getCount(tableConfiguration
-        .resolve(Property.TSERV_WAL_MAX_REFERENCED, Property.TSERV_WALOG_MAX_REFERENCED));
+    int maxLogs = tableConfiguration
+        .getCount(tableConfiguration.resolve(Property.TSERV_WAL_MAX_REFERENCED, tableConfiguration
+            .resolve(Property.TSERV_WALOG_MAX_REFERENCED, Property.TABLE_MINC_LOGS_MAX)));
 
     String reason = null;
     synchronized (this) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1926,7 +1926,7 @@ public class Tablet {
     // grab this outside of tablet lock.
     @SuppressWarnings("deprecation")
     int maxLogs = tableConfiguration.getCount(tableConfiguration
-        .resolve(Property.TSERV_WALOG_MAX_REFERENCED, Property.TABLE_MINC_LOGS_MAX));
+        .resolve(Property.TSERV_WAL_MAX_REFERENCED, Property.TSERV_WALOG_MAX_REFERENCED));
 
     String reason = null;
     synchronized (this) {

--- a/test/src/main/java/org/apache/accumulo/test/MetaRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaRecoveryIT.java
@@ -52,7 +52,7 @@ public class MetaRecoveryIT extends ConfigurableMacBase {
     cfg.setProperty(Property.GC_CYCLE_DELAY, "1s");
     cfg.setProperty(Property.GC_CYCLE_START, "1s");
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "1048576");
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "1048576");
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/TabletServerGivesUpIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TabletServerGivesUpIT.java
@@ -41,9 +41,9 @@ public class TabletServerGivesUpIT extends ConfigurableMacBase {
     cfg.useMiniDFS(true);
     cfg.setNumTservers(1);
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "10s");
-    cfg.setProperty(Property.TSERV_WALOG_TOLERATED_CREATION_FAILURES, "10");
-    cfg.setProperty(Property.TSERV_WALOG_TOLERATED_WAIT_INCREMENT, "0s");
-    cfg.setProperty(Property.TSERV_WALOG_TOLERATED_MAXIMUM_WAIT_DURATION, "0s");
+    cfg.setProperty(Property.TSERV_WAL_TOLERATED_CREATION_FAILURES, "10");
+    cfg.setProperty(Property.TSERV_WAL_TOLERATED_WAIT_INCREMENT, "0s");
+    cfg.setProperty(Property.TSERV_WAL_TOLERATED_MAXIMUM_WAIT_DURATION, "0s");
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UnusedWALIT.java
@@ -60,7 +60,7 @@ public class UnusedWALIT extends ConfigurableMacBase {
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     final long logSize = 1024 * 1024 * 10;
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "5s");
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, Long.toString(logSize));
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, Long.toString(logSize));
     cfg.setNumTservers(1);
     // use raw local file system so walogs sync and flush will work
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -88,13 +87,10 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       InstanceOperations iops = client.instanceOperations();
       Map<String,String> conf = iops.getSystemConfiguration();
-      AccumuloConfiguration aconf = getCluster().getSiteConfiguration();
-      @SuppressWarnings("deprecation")
-      Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
       majcDelay = conf.get(Property.TSERV_MAJC_DELAY.getKey());
-      walSize = conf.get(aconf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp).getKey());
+      walSize = conf.get(Property.TSERV_WAL_MAX_SIZE.getKey());
       iops.setProperty(Property.TSERV_MAJC_DELAY.getKey(), "1");
-      iops.setProperty(aconf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp).getKey(), "1M");
+      iops.setProperty(Property.TSERV_WAL_MAX_SIZE.getKey(), "1M");
 
       getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
       getClusterControl().startAllServers(ServerType.TABLET_SERVER);
@@ -106,12 +102,8 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
     if (majcDelay != null) {
       try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
         InstanceOperations iops = client.instanceOperations();
-        AccumuloConfiguration conf = getServerContext().getConfiguration();
-        @SuppressWarnings("deprecation")
-        Property deprecatedProp = Property.TSERV_WALOG_MAX_SIZE;
         iops.setProperty(Property.TSERV_MAJC_DELAY.getKey(), majcDelay);
-        iops.setProperty(conf.resolve(Property.TSERV_WAL_MAX_SIZE, deprecatedProp).getKey(),
-            walSize);
+        iops.setProperty(Property.TSERV_WAL_MAX_SIZE.getKey(), walSize);
       }
       getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
       getClusterControl().startAllServers(ServerType.TABLET_SERVER);

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartStressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartStressIT.java
@@ -53,7 +53,7 @@ public class RestartStressIT extends AccumuloClusterHarness {
     Map<String,String> opts = cfg.getSiteConfig();
     opts.put(Property.TSERV_MAXMEM.getKey(), "100K");
     opts.put(Property.TSERV_MAJC_DELAY.getKey(), "100ms");
-    opts.put(Property.TSERV_WALOG_MAX_SIZE.getKey(), "1M");
+    opts.put(Property.TSERV_WAL_MAX_SIZE.getKey(), "1M");
     opts.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "15s");
     opts.put(Property.MANAGER_RECOVERY_DELAY.getKey(), "1s");
     cfg.setSiteConfig(opts);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.test.functional;
 import static org.apache.accumulo.core.conf.Property.GC_CYCLE_DELAY;
 import static org.apache.accumulo.core.conf.Property.GC_CYCLE_START;
 import static org.apache.accumulo.core.conf.Property.INSTANCE_ZK_TIMEOUT;
-import static org.apache.accumulo.core.conf.Property.TSERV_WALOG_MAX_SIZE;
+import static org.apache.accumulo.core.conf.Property.TSERV_WAL_MAX_SIZE;
 import static org.apache.accumulo.core.conf.Property.TSERV_WAL_REPLICATION;
 import static org.apache.accumulo.core.security.Authorizations.EMPTY;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
@@ -80,7 +80,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     cfg.setProperty(GC_CYCLE_DELAY, "1s");
     cfg.setProperty(GC_CYCLE_START, "0s");
-    cfg.setProperty(TSERV_WALOG_MAX_SIZE, "1M");
+    cfg.setProperty(TSERV_WAL_MAX_SIZE, "1M");
     cfg.setProperty(TSERV_WAL_REPLICATION, "1");
     cfg.setProperty(INSTANCE_ZK_TIMEOUT, "15s");
     cfg.setNumTservers(1);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WriteAheadLogIT.java
@@ -39,7 +39,7 @@ public class WriteAheadLogIT extends AccumuloClusterHarness {
   }
 
   public static void setupConfig(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "2M");
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "2M");
     cfg.setProperty(Property.GC_CYCLE_DELAY, "1");
     cfg.setProperty(Property.GC_CYCLE_START, "1");
     cfg.setProperty(Property.MANAGER_RECOVERY_DELAY, "1s");

--- a/test/src/main/java/org/apache/accumulo/test/replication/CyclicReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/CyclicReplicationIT.java
@@ -177,7 +177,7 @@ public class CyclicReplicationIT {
           ConfigurableMacBase.getSslDir(manager1Dir));
 
       manager1Cfg.setProperty(Property.REPLICATION_NAME, manager1Cfg.getInstanceName());
-      manager1Cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "5M");
+      manager1Cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "5M");
       manager1Cfg.setProperty(Property.REPLICATION_THREADCHECK, "5m");
       manager1Cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");
       manager1Cfg.setProperty(Property.MANAGER_REPLICATION_SCAN_INTERVAL, "1s");
@@ -203,7 +203,7 @@ public class CyclicReplicationIT {
       this.updatePeerConfigFromPrimary(manager1Cfg, manager2Cfg);
 
       manager2Cfg.setProperty(Property.REPLICATION_NAME, manager2Cfg.getInstanceName());
-      manager2Cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "5M");
+      manager2Cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "5M");
       manager2Cfg.setProperty(Property.REPLICATION_THREADCHECK, "5m");
       manager2Cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");
       manager2Cfg.setProperty(Property.MANAGER_REPLICATION_SCAN_INTERVAL, "1s");

--- a/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/GarbageCollectorCommunicatesWithTServersIT.java
@@ -104,7 +104,7 @@ public class GarbageCollectorCommunicatesWithTServersIT extends ConfigurableMacB
     cfg.setProperty(Property.MANAGER_REPLICATION_SCAN_INTERVAL, "240s");
     cfg.setProperty(Property.REPLICATION_DRIVER_DELAY, "240s");
     // Pull down the maximum size of the wal so we can test close()'ing it.
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "1M");
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "1M");
     coreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/replication/KerberosReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/KerberosReplicationIT.java
@@ -120,7 +120,7 @@ public class KerberosReplicationIT extends AccumuloITBase {
         cfg.setNumTservers(1);
         cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
         cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
-        cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "2M");
+        cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "2M");
         cfg.setProperty(Property.GC_CYCLE_START, "1s");
         cfg.setProperty(Property.GC_CYCLE_DELAY, "5s");
         cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiInstanceReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiInstanceReplicationIT.java
@@ -109,7 +109,7 @@ public class MultiInstanceReplicationIT extends ConfigurableMacBase {
     cfg.setNumTservers(1);
     cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "2M");
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "2M");
     cfg.setProperty(Property.GC_CYCLE_START, "1s");
     cfg.setProperty(Property.GC_CYCLE_DELAY, "5s");
     cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -140,7 +140,7 @@ public class ReplicationIT extends ConfigurableMacBase {
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
     cfg.setProperty(Property.MANAGER_REPLICATION_SCAN_INTERVAL, "1s");
     cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "1M");
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "1M");
     cfg.setProperty(Property.GC_CYCLE_START, "1s");
     cfg.setProperty(Property.GC_CYCLE_DELAY, "0");
     cfg.setProperty(Property.REPLICATION_NAME, "manager");

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerReplicationIT.java
@@ -116,7 +116,7 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
     cfg.setNumTservers(1);
     cfg.setClientProperty(ClientProperty.INSTANCE_ZOOKEEPERS_TIMEOUT, "15s");
     cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
-    cfg.setProperty(Property.TSERV_WALOG_MAX_SIZE, "2M");
+    cfg.setProperty(Property.TSERV_WAL_MAX_SIZE, "2M");
     cfg.setProperty(Property.GC_CYCLE_START, "1s");
     cfg.setProperty(Property.GC_CYCLE_DELAY, "5s");
     cfg.setProperty(Property.REPLICATION_WORK_ASSIGNMENT_SLEEP, "1s");


### PR DESCRIPTION
Fixes #2146 

This fix makes the property names regarding write ahead logs uniform. All properties that used `walog` were tagged as deprecated and with a `@ReplacedBy` tag to its respected `wal` replacement. 

For some uses of the new property names, the `conf.resolve()` function was used in order to read the values from whichever key the user used (whether it be the deprecated or new one).

While making these changes I decided to exclude the use of the `resolve` function in the ITs where the new properties were used. From what I understood, there would be no real reason to resolve the usages. There were also some places where Null Pointer Exceptions would occur if they were to be resolved. Please let me know if this was wrong.

I also found a section in `HadoopLogCloser` where I did not see a way to properly resolve the usage of the new property name. If this is a place where the resolve function needs to be used please mention it.

Lastly, there are places where I create a Property variable `deprecatedProp` in an attempt to make the deprecation suppression area as specific as possible. I am not sure if there is a "cleaner" way of going about this, or if the suppression could be more general.