### PR TITLE
Make DeleteTable fate lock reentrant

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -75,7 +75,7 @@ import org.apache.accumulo.manager.tableOps.clone.CloneTable;
 import org.apache.accumulo.manager.tableOps.compact.CompactRange;
 import org.apache.accumulo.manager.tableOps.compact.cancel.CancelCompactions;
 import org.apache.accumulo.manager.tableOps.create.CreateTable;
-import org.apache.accumulo.manager.tableOps.delete.DeleteTable;
+import org.apache.accumulo.manager.tableOps.delete.PreDeleteTable;
 import org.apache.accumulo.manager.tableOps.merge.TableRangeOp;
 import org.apache.accumulo.manager.tableOps.namespace.create.CreateNamespace;
 import org.apache.accumulo.manager.tableOps.namespace.delete.DeleteNamespace;
@@ -321,8 +321,8 @@ class FateServiceHandler implements FateService.Iface {
 
         if (!canDeleteTable)
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
-        manager.fate.seedTransaction(opid, new TraceRepo<>(new DeleteTable(namespaceId, tableId)),
-            autoCleanup);
+        manager.fate.seedTransaction(opid,
+            new TraceRepo<>(new PreDeleteTable(namespaceId, tableId)), autoCleanup);
         break;
       }
       case TABLE_ONLINE: {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/Utils.java
@@ -27,6 +27,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 import java.util.function.Function;
 
 import org.apache.accumulo.core.Constants;
@@ -151,6 +153,58 @@ public class Utils {
         + Base64.getEncoder().encodeToString(directory.getBytes(UTF_8));
     ZooReservation.release(env.getContext().getZooReaderWriter(), resvPath,
         String.format("%016x", tid));
+  }
+
+  private static boolean hasReadLock(ServerContext context, AbstractId<?> id, long tid)
+      throws KeeperException, InterruptedException {
+    byte[] lockData = String.format("%016x", tid).getBytes(UTF_8);
+    var fLockPath =
+        FateLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical());
+    FateLock qlock = new FateLock(context.getZooReaderWriter(), fLockPath);
+    Lock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
+    if (lock == null) {
+      return false;
+    } else if (lock instanceof ReadLock) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public static boolean hasNamespaceReadLock(Manager env, NamespaceId nsId, long tid)
+      throws KeeperException, InterruptedException {
+    return hasReadLock(env.getContext(), nsId, tid);
+  }
+
+  public static boolean hasTableReadLock(Manager env, TableId tableId, long tid)
+      throws KeeperException, InterruptedException {
+    return hasReadLock(env.getContext(), tableId, tid);
+  }
+
+  private static boolean hasWriteLock(ServerContext context, AbstractId<?> id, long tid)
+      throws KeeperException, InterruptedException {
+    byte[] lockData = String.format("%016x", tid).getBytes(UTF_8);
+    var fLockPath =
+        FateLock.path(context.getZooKeeperRoot() + Constants.ZTABLE_LOCKS + "/" + id.canonical());
+    FateLock qlock = new FateLock(context.getZooReaderWriter(), fLockPath);
+    Lock lock = DistributedReadWriteLock.recoverLock(qlock, lockData);
+    if (lock == null) {
+      return false;
+    } else if (lock instanceof WriteLock) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public static boolean hasNamespaceWriteLock(Manager env, NamespaceId nsId, long tid)
+      throws KeeperException, InterruptedException {
+    return hasWriteLock(env.getContext(), nsId, tid);
+  }
+
+  public static boolean hasTableWriteLock(Manager env, TableId tableId, long tid)
+      throws KeeperException, InterruptedException {
+    return hasWriteLock(env.getContext(), tableId, tid);
   }
 
   private static Lock getLock(ServerContext context, AbstractId<?> id, long tid,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 public class CancelCompactions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  private TableId tableId;
-  private NamespaceId namespaceId;
+  protected TableId tableId;
+  protected NamespaceId namespaceId;
 
   private static final Logger log = LoggerFactory.getLogger(CancelCompactions.class);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 public class CancelCompactions extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
-  protected TableId tableId;
-  protected NamespaceId namespaceId;
+  private TableId tableId;
+  private NamespaceId namespaceId;
 
   private static final Logger log = LoggerFactory.getLogger(CancelCompactions.class);
 
@@ -54,7 +54,6 @@ public class CancelCompactions extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(long tid, Manager environment) throws Exception {
-
     mutateZooKeeper(tid, tableId, environment);
     return new FinishCancelCompaction(namespaceId, tableId);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/DeleteTable.java
@@ -26,7 +26,6 @@ import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
-import org.apache.accumulo.manager.tableOps.compact.cancel.CancelCompactions;
 
 public class DeleteTable extends ManagerRepo {
 
@@ -42,19 +41,6 @@ public class DeleteTable extends ManagerRepo {
 
   @Override
   public long isReady(long tid, Manager env) throws Exception {
-
-    // Before attempting to delete the table, cancel any running user
-    // compactions.
-    if (Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.COMPACT_CANCEL)
-        + Utils.reserveTable(env, tableId, tid, false, true, TableOperation.COMPACT_CANCEL) == 0) {
-      try {
-        CancelCompactions.mutateZooKeeper(tid, tableId, env);
-      } finally {
-        Utils.unreserveTable(env, tableId, tid, false);
-        Utils.unreserveNamespace(env, namespaceId, tid, false);
-      }
-    }
-
     return Utils.reserveNamespace(env, namespaceId, tid, false, false, TableOperation.DELETE)
         + Utils.reserveTable(env, tableId, tid, true, true, TableOperation.DELETE);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -18,24 +18,43 @@
  */
 package org.apache.accumulo.manager.tableOps.delete;
 
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.manager.tableOps.compact.cancel.CancelCompactions;
 
-public class PreDeleteTable extends CancelCompactions {
+public class PreDeleteTable extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
 
+  private TableId tableId;
+  private NamespaceId namespaceId;
+
   public PreDeleteTable(NamespaceId namespaceId, TableId tableId) {
-    super(namespaceId, tableId);
+    this.tableId = tableId;
+    this.namespaceId = namespaceId;
+  }
+
+  @Override
+  public long isReady(long tid, Manager env) throws Exception {
+    return Utils.reserveNamespace(env, namespaceId, tid, false, true, TableOperation.DELETE)
+        + Utils.reserveTable(env, tableId, tid, false, true, TableOperation.DELETE);
   }
 
   @Override
   public Repo<Manager> call(long tid, Manager environment) throws Exception {
     CancelCompactions.mutateZooKeeper(tid, tableId, environment);
     return new DeleteTable(namespaceId, tableId);
+  }
+
+  @Override
+  public void undo(long tid, Manager env) {
+    Utils.unreserveTable(env, tableId, tid, false);
+    Utils.unreserveNamespace(env, namespaceId, tid, false);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.tableOps.delete;
+
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.fate.Repo;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.compact.cancel.CancelCompactions;
+
+public class PreDeleteTable extends CancelCompactions {
+
+  private static final long serialVersionUID = 1L;
+
+  public PreDeleteTable(NamespaceId namespaceId, TableId tableId) {
+    super(namespaceId, tableId);
+  }
+
+  @Override
+  public Repo<Manager> call(long tid, Manager environment) throws Exception {
+    CancelCompactions.mutateZooKeeper(tid, tableId, environment);
+    return new DeleteTable(namespaceId, tableId);
+  }
+
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -47,8 +47,13 @@ public class PreDeleteTable extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(long tid, Manager environment) throws Exception {
-    CancelCompactions.mutateZooKeeper(tid, tableId, environment);
-    return new DeleteTable(namespaceId, tableId);
+    try {
+      CancelCompactions.mutateZooKeeper(tid, tableId, environment);
+      return new DeleteTable(namespaceId, tableId);
+    } finally {
+      Utils.unreserveTable(environment, tableId, tid, false);
+      Utils.unreserveNamespace(environment, namespaceId, tid, false);
+    }
   }
 
   @Override


### PR DESCRIPTION
Check to see if the locks are already held for deleting the table.
If they are, then we likely already canceled the compactions. Related
to #2030