### PR TITLE
Fix row encoding/decoding in LogFileKey

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/logger/LogFileKey.java
@@ -245,8 +245,8 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
    * byte in the row.
    */
   private byte getEventByte() {
-    int evenTypeInteger = eventType(event);
-    return (byte) (evenTypeInteger & 0xff);
+    int eventTypeInteger = eventType(event);
+    return (byte) (eventTypeInteger & 0xff);
   }
 
   /**
@@ -269,19 +269,20 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
     // encode the signed integer so negatives will sort properly for tabletId
     int encodedTabletId = tabletId ^ 0x80000000;
 
+    int mask = 0xff; // use a mask of int type to truncate the selected 8 bits
     row[0] = eventNum;
-    row[1] = (byte) ((encodedTabletId >>> 24) & 0xff);
-    row[2] = (byte) ((encodedTabletId >>> 16) & 0xff);
-    row[3] = (byte) ((encodedTabletId >>> 8) & 0xff);
-    row[4] = (byte) (encodedTabletId & 0xff);
-    row[5] = (byte) (seq >>> 56);
-    row[6] = (byte) (seq >>> 48);
-    row[7] = (byte) (seq >>> 40);
-    row[8] = (byte) (seq >>> 32);
-    row[9] = (byte) (seq >>> 24);
-    row[10] = (byte) (seq >>> 16);
-    row[11] = (byte) (seq >>> 8);
-    row[12] = (byte) (seq); // >>> 0
+    row[1] = (byte) ((encodedTabletId >>> 24) & mask);
+    row[2] = (byte) ((encodedTabletId >>> 16) & mask);
+    row[3] = (byte) ((encodedTabletId >>> 8) & mask);
+    row[4] = (byte) (encodedTabletId & mask);
+    row[5] = (byte) ((seq >>> 56) & mask);
+    row[6] = (byte) ((seq >>> 48) & mask);
+    row[7] = (byte) ((seq >>> 40) & mask);
+    row[8] = (byte) ((seq >>> 32) & mask);
+    row[9] = (byte) ((seq >>> 24) & mask);
+    row[10] = (byte) ((seq >>> 16) & mask);
+    row[11] = (byte) ((seq >>> 8) & mask);
+    row[12] = (byte) (seq & mask);
     return row;
   }
 
@@ -289,7 +290,13 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
    * Extract the tabletId integer from the byte encoded Row.
    */
   private static int getTabletId(byte[] row) {
-    int encoded = ((row[1] << 24) + (row[2] << 16) + (row[3] << 8) + row[4]);
+    int mask = 0xff; // use a mask of int type to convert byte to int without sign extension
+    // @formatter:off
+    int encoded = (row[1] & mask) << 24 |
+                  (row[2] & mask) << 16 |
+                  (row[3] & mask) <<  8 |
+                  (row[4] & mask);
+    // @formatter:on
     return encoded ^ 0x80000000;
   }
 
@@ -297,15 +304,16 @@ public class LogFileKey implements WritableComparable<LogFileKey> {
    * Extract the sequence long from the byte encoded Row.
    */
   private static long getSequence(byte[] row) {
+    long mask = 0xff; // use a mask of long type to convert byte to long without sign extension
     // @formatter:off
-    return (((long) row[5] << 56) +
-            ((long) (row[6] & 255) << 48) +
-            ((long) (row[7] & 255) << 40) +
-            ((long) (row[8] & 255) << 32) +
-            ((long) (row[9] & 255) << 24) +
-            ((row[10] & 255) << 16) +
-            ((row[11] & 255) << 8) +
-            ((row[12] & 255)));
+    return (row[5]  & mask) << 56 |
+           (row[6]  & mask) << 48 |
+           (row[7]  & mask) << 40 |
+           (row[8]  & mask) << 32 |
+           (row[9]  & mask) << 24 |
+           (row[10] & mask) << 16 |
+           (row[11] & mask) <<  8 |
+           (row[12] & mask);
     // @formatter:on
   }
 


### PR DESCRIPTION
Fix bitwise operations to encode and decode the tabletId and sequence
number to/from a row

This fixes #2173