### PR TITLE
Update CheckForMetadataProblems Utility Output

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -50,59 +50,60 @@ public class CheckForMetadataProblems {
   private static void checkTable(TableId tableId, TreeSet<KeyExtent> tablets) {
     // sanity check of metadata table entries
     // make sure tablets has no holes, and that it starts and ends w/ null
+    String tableName;
 
     try {
-      String tableName = Tables.getTableName(opts.getServerContext(), tableId);
-
-      if (tablets.isEmpty()) {
-        System.out.println(
-            "...No entries found in metadata table for table " + tableName + " (" + tableId + ")");
-        sawProblems = true;
-        return;
-      }
-
-      if (tablets.first().prevEndRow() != null) {
-        System.out.println("...First entry for table " + tableName + " (" + tableId + ") " + " - "
-            + tablets.first() + " - has non null prev end row");
-        sawProblems = true;
-        return;
-      }
-
-      if (tablets.last().endRow() != null) {
-        System.out.println("...Last entry for table " + tableName + " (" + tableId + ") - "
-            + tablets.last() + " - has non null end row");
-        sawProblems = true;
-        return;
-      }
-
-      Iterator<KeyExtent> tabIter = tablets.iterator();
-      Text lastEndRow = tabIter.next().endRow();
-      boolean everythingLooksGood = true;
-      while (tabIter.hasNext()) {
-        KeyExtent tabke = tabIter.next();
-        boolean broke = false;
-        if (tabke.prevEndRow() == null) {
-          System.out.println("Table " + tableName + " (" + tableId
-              + ") has null prev end row in middle of table " + tabke);
-          broke = true;
-        } else if (!tabke.prevEndRow().equals(lastEndRow)) {
-          System.out.println("...Table " + tableName + " (" + tableId + ") has a hole "
-              + tabke.prevEndRow() + " != " + lastEndRow);
-          broke = true;
-        }
-        if (broke) {
-          everythingLooksGood = false;
-        }
-
-        lastEndRow = tabke.endRow();
-      }
-      if (everythingLooksGood)
-        System.out.println("...All is well for table " + tableName + " (" + tableId + ")");
-      else
-        sawProblems = true;
+      tableName = Tables.getTableName(opts.getServerContext(), tableId);
     } catch (TableNotFoundException e) {
-      System.out.println("...Table name lookup failed. This table does not exist");
+      tableName = null;
     }
+
+    if (tablets.isEmpty()) {
+      System.out.println(
+          "...No entries found in metadata table for table " + tableName + " (" + tableId + ")");
+      sawProblems = true;
+      return;
+    }
+
+    if (tablets.first().prevEndRow() != null) {
+      System.out.println("...First entry for table " + tableName + " (" + tableId + ") " + " - "
+          + tablets.first() + " - has non null prev end row");
+      sawProblems = true;
+      return;
+    }
+
+    if (tablets.last().endRow() != null) {
+      System.out.println("...Last entry for table " + tableName + " (" + tableId + ") - "
+          + tablets.last() + " - has non null end row");
+      sawProblems = true;
+      return;
+    }
+
+    Iterator<KeyExtent> tabIter = tablets.iterator();
+    Text lastEndRow = tabIter.next().endRow();
+    boolean everythingLooksGood = true;
+    while (tabIter.hasNext()) {
+      KeyExtent tabke = tabIter.next();
+      boolean broke = false;
+      if (tabke.prevEndRow() == null) {
+        System.out.println("Table " + tableName + " (" + tableId
+            + ") has null prev end row in middle of table " + tabke);
+        broke = true;
+      } else if (!tabke.prevEndRow().equals(lastEndRow)) {
+        System.out.println("...Table " + tableName + " (" + tableId + ") has a hole "
+            + tabke.prevEndRow() + " != " + lastEndRow);
+        broke = true;
+      }
+      if (broke) {
+        everythingLooksGood = false;
+      }
+
+      lastEndRow = tabke.endRow();
+    }
+    if (everythingLooksGood)
+      System.out.println("...All is well for table " + tableName + " (" + tableId + ")");
+    else
+      sawProblems = true;
   }
 
   private static void checkMetadataAndRootTableEntries(String tableNameToCheck, ServerUtilOpts opts)

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -86,7 +86,7 @@ public class CheckForMetadataProblems {
       KeyExtent tabke = tabIter.next();
       boolean broke = false;
       if (tabke.prevEndRow() == null) {
-        System.out.println("Table " + tableName + " (" + tableId
+        System.out.println("...Table " + tableName + " (" + tableId
             + ") has null prev end row in middle of table " + tabke);
         broke = true;
       } else if (!tabke.prevEndRow().equals(lastEndRow)) {


### PR DESCRIPTION
Fixes #2166 

This PR updates the output of the CheckForMetadataProblems utility. It previously included a mix of table ids and names.

The output now offers more information and is much more easily read.

Some changes and additions that are included:

- `checkTable` function now accepts a String tableName 
- Uses `Tables.getTableID()` and `Tables.getTableName()` to get information about the specific tables
- Places the client scanner inside of the try block in `checkMetadataAndRootTableEntries()`
- Updates potential error messages that were not shown in the output in the initial ticket.

During my testing I did notice that there is an extra line that shows some log info about the path to accumulo.properties that gets displayed before the expected output. I am not sure if this is a big issue that it is displayed, but if there is a way to not have it displayed that would probably be best.