### PR TITLE
Make Ample only return exact matches for KeyExtents

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
@@ -48,13 +48,7 @@ public class AmpleImpl implements Ample {
       TabletMetadata tmd = Iterables.getOnlyElement(tablets);
       Text tmpExtent = extent.prevEndRow();
       Text tmpTmd = tmd.getPrevEndRow();
-      boolean isEqual = false;
-      try {
-        isEqual = tmpExtent == tmpTmd || (tmpExtent.equals(tmpTmd));
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-      if (isEqual) {
+      if (tmpExtent == tmpTmd || tmpExtent.equals(tmpTmd)) {
         return tmd;
       } else {
         return null;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
@@ -19,12 +19,12 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata.Options;
-import org.apache.hadoop.io.Text;
 
 import com.google.common.collect.Iterables;
 
@@ -46,13 +46,7 @@ public class AmpleImpl implements Ample {
 
     try (TabletsMetadata tablets = builder.build()) {
       TabletMetadata tmd = Iterables.getOnlyElement(tablets);
-      Text tmpExtent = extent.prevEndRow();
-      Text tmpTmd = tmd.getPrevEndRow();
-      if (tmpExtent == tmpTmd || tmpExtent.equals(tmpTmd)) {
-        return tmd;
-      } else {
-        return null;
-      }
+      return Objects.equals(extent.prevEndRow(), tmd.getPrevEndRow()) ? tmd : null;
     } catch (NoSuchElementException e) {
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import java.util.NoSuchElementException;
-import java.util.Objects;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -45,8 +44,7 @@ public class AmpleImpl implements Ample {
     builder.readConsistency(readConsistency);
 
     try (TabletsMetadata tablets = builder.build()) {
-      TabletMetadata tmd = Iterables.getOnlyElement(tablets);
-      return Objects.equals(extent.prevEndRow(), tmd.getPrevEndRow()) ? tmd : null;
+      return Iterables.getOnlyElement(tablets);
     } catch (NoSuchElementException e) {
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/AmpleImpl.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata.Options;
+import org.apache.hadoop.io.Text;
 
 import com.google.common.collect.Iterables;
 
@@ -44,7 +45,20 @@ public class AmpleImpl implements Ample {
     builder.readConsistency(readConsistency);
 
     try (TabletsMetadata tablets = builder.build()) {
-      return Iterables.getOnlyElement(tablets);
+      TabletMetadata tmd = Iterables.getOnlyElement(tablets);
+      Text tmpExtent = extent.prevEndRow();
+      Text tmpTmd = tmd.getPrevEndRow();
+      boolean isEqual = false;
+      try {
+        isEqual = tmpExtent == tmpTmd || (tmpExtent.equals(tmpTmd));
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      if (isEqual) {
+        return tmd;
+      } else {
+        return null;
+      }
     } catch (NoSuchElementException e) {
       return null;
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -87,8 +87,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
   public static class Builder implements TableRangeOptions, TableOptions, RangeOptions, Options {
 
-    private List<Text> families = new ArrayList<>();
-    private List<ColumnFQ> qualifiers = new ArrayList<>();
+    private final List<Text> families = new ArrayList<>();
+    private final List<ColumnFQ> qualifiers = new ArrayList<>();
     private Ample.DataLevel level;
     private String table;
     private Range range;
@@ -98,8 +98,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     private boolean saveKeyValues;
     private TableId tableId;
     private ReadConsistency readConsistency = ReadConsistency.IMMEDIATE;
-    private AccumuloClient _client;
-    private Collection<KeyExtent> extents;
+    private final AccumuloClient _client;
+    private Collection<KeyExtent> extents = null;
 
     Builder(AccumuloClient client) {
       this._client = client;
@@ -290,7 +290,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     @Override
     public Options forTablet(KeyExtent extent) {
       forTable(extent.tableId());
-      this.range = new Range(extent.toMetaRow());
+      // this.range = new Range(extent.toMetaRow());
+      this.range = new Range(extent.toMetaRange());
       return this;
     }
 
@@ -431,8 +432,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
   private static class TabletMetadataIterator implements Iterator<TabletMetadata> {
 
     private boolean sawLast = false;
-    private Iterator<TabletMetadata> iter;
-    private Text endRow;
+    private final Iterator<TabletMetadata> iter;
+    private final Text endRow;
 
     TabletMetadataIterator(Iterator<TabletMetadata> source, Text endRow) {
       this.iter = source;
@@ -487,9 +488,9 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
         .convertToTabletMetadata();
   }
 
-  private ScannerBase scanner;
+  private final ScannerBase scanner;
 
-  private Iterable<TabletMetadata> tablets;
+  private final Iterable<TabletMetadata> tablets;
 
   private TabletsMetadata(TabletMetadata tm) {
     this.scanner = null;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -290,8 +290,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     @Override
     public Options forTablet(KeyExtent extent) {
       forTable(extent.tableId());
-      // this.range = new Range(extent.toMetaRow());
-      this.range = new Range(extent.toMetaRange());
+      this.range = extent.toMetaRange();
       return this;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -402,14 +402,12 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
     /**
      * Get the tablet metadata for this extents end row. This should only ever return a single
-     * tablet. No checking is done for prev row, so it could differ.
+     * tablet.
      */
     Options forTablet(KeyExtent extent);
 
     /**
-     * Get the tablet metadata for the given extents. This will find tablets based on end row, so
-     * it's possible the prev rows could differ for the tablets returned. If this matters, then it
-     * must be checked.
+     * Get the tablet metadata for the given extents. This will find tablets based on end row.
      */
     Options forTablets(Collection<KeyExtent> extents);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -136,7 +136,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
         boolean extentsPresent = extentsToFetch != null;
 
-        if (!fetchedColumns.isEmpty() && !extentsAreNull)
+        if (!fetchedCols.isEmpty() && extentsPresent)
           fetch(ColumnType.PREV_ROW);
 
         configureColumns(scanner);
@@ -154,7 +154,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
             }
           });
 
-          if (!extentsAreNull) {
+          if (extentsPresent) {
             return Iterators.filter(iter,
                 tabletMetadata -> extentsToFetch.contains(tabletMetadata.getExtent()));
           } else {
@@ -177,9 +177,9 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
             new IsolatedScanner(client.createScanner(resolvedTable, Authorizations.EMPTY));
         scanner.setRange(range);
 
-        boolean extentsAreNull = extentsToFetch == null;
+        boolean extentsPresent = extentsToFetch != null;
 
-        if (!fetchedCols.isEmpty() &&(checkConsistency || !extentsAreNull)) {
+        if (!fetchedCols.isEmpty() && (checkConsistency || extentsPresent)) {
           fetch(ColumnType.PREV_ROW);
         }
 
@@ -192,7 +192,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
             RowIterator rowIter = new RowIterator(scanner);
             Iterator<TabletMetadata> iter = Iterators.transform(rowIter,
                 ri -> TabletMetadata.convertRow(ri, fetchedCols, saveKeyValues));
-            if (!extentsAreNull) {
+            if (extentsPresent) {
               return Iterators.filter(iter,
                   tabletMetadata -> extentsToFetch.contains(tabletMetadata.getExtent()));
             } else {
@@ -407,7 +407,8 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
     Options forTablet(KeyExtent extent);
 
     /**
-     * Get the tablet metadata for the given extents. This will only return tablets where the end row and prev end row exactly match the given extents.  
+     * Get the tablet metadata for the given extents. This will only return tablets where the end
+     * row and prev end row exactly match the given extents.
      */
     Options forTablets(Collection<KeyExtent> extents);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -418,6 +418,10 @@ public class MetadataTableUtil {
 
     TabletMetadata tablet = context.getAmple().readTablet(extent, FILES, LOGS, PREV_ROW, DIR);
 
+    if (tablet == null) {
+      throw new RuntimeException("Tablet " + extent + " not found in metadata");
+    }
+
     result.addAll(tablet.getLogs());
 
     tablet.getFilesMap().forEach(sizes::put);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -418,9 +418,6 @@ public class MetadataTableUtil {
 
     TabletMetadata tablet = context.getAmple().readTablet(extent, FILES, LOGS, PREV_ROW, DIR);
 
-    if (!tablet.getExtent().equals(extent))
-      throw new RuntimeException("Unexpected extent " + tablet.getExtent() + " expected " + extent);
-
     result.addAll(tablet.getLogs());
 
     tablet.getFilesMap().forEach(sizes::put);

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -190,8 +190,7 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
 
         TabletMetadata tabletMeta =
             getContext().getAmple().readTablet(extent, ColumnType.ECOMP, ColumnType.PREV_ROW);
-        if (tabletMeta == null || !tabletMeta.getExtent().equals(extent)
-            || !tabletMeta.getExternalCompactions().containsKey(ecid)) {
+        if (tabletMeta == null || !tabletMeta.getExternalCompactions().containsKey(ecid)) {
           // table was deleted OR tablet was split or merged OR tablet no longer thinks compaction
           // is running for some reason
           LOG.info("Cancelling compaction {} that no longer has a metadata entry at {}", ecid,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -926,6 +926,11 @@ public class TabletServer extends AbstractServer {
   static boolean checkTabletMetadata(KeyExtent extent, TServerInstance instance,
       TabletMetadata meta) throws AccumuloException {
 
+    if (meta == null) {
+      log.info("Not loading tablet {}, its metadata was not found.", extent);
+      return false;
+    }
+
     if (!meta.sawPrevEndRow()) {
       throw new AccumuloException("Metadata entry does not have prev row (" + meta.getTableId()
           + " " + meta.getEndRow() + ")");

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1361,6 +1361,12 @@ public class Tablet {
       var tabletMeta = context.getAmple().readTablet(extent, ColumnType.FILES, ColumnType.LOGS,
           ColumnType.ECOMP, ColumnType.PREV_ROW);
 
+      if (tabletMeta == null) {
+        String msg = "Closed tablet " + extent + " not found in metadata";
+        log.error(msg);
+        throw new RuntimeException(msg);
+      }
+
       HashSet<ExternalCompactionId> ecids = new HashSet<>();
       compactable.getExternalCompactionIds(ecids::add);
       if (!tabletMeta.getExternalCompactions().keySet().equals(ecids)) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1361,13 +1361,6 @@ public class Tablet {
       var tabletMeta = context.getAmple().readTablet(extent, ColumnType.FILES, ColumnType.LOGS,
           ColumnType.ECOMP, ColumnType.PREV_ROW);
 
-      if (!tabletMeta.getExtent().equals(extent)) {
-        String msg = "Closed tablet " + extent + " does not match extent in metadata table "
-            + tabletMeta.getExtent();
-        log.error(msg);
-        throw new RuntimeException(msg);
-      }
-
       HashSet<ExternalCompactionId> ecids = new HashSet<>();
       compactable.getExternalCompactionIds(ecids::add);
       if (!tabletMeta.getExternalCompactions().keySet().equals(ecids)) {


### PR DESCRIPTION
Fixes: #2154

Marked this as WIP because there are several possible ways that this issue could be handled. Two of which are implemented in these changes:
- In `AmpleImpl.readTablet()` check that the `prevEndRow`s match before returning
- In `TabletsMetadata.forTablet()`, instead of `toMetaRow()`, use `toMetaRange()` which accounts for `prevEndRow`

There are likely other solutions to this. I wanted to create this to get feedback and discussion on this issue.

I also added small improvements to TabletsMetadata.java while I was making changes.