### PR TITLE
Serialization of a map of key, value pairs map to / from byte array.

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
@@ -89,7 +89,7 @@ public interface PropEncoding {
   int getExpectedVersion();
 
   /**
-   * Serialize the version information an the properties.
+   * Serialize the version information and the properties.
    *
    * @return an array of bytes for storage.
    */

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
@@ -80,7 +80,7 @@ public interface PropEncoding {
   /**
    * The version is incremented with a call to toBytes() - this method returns the value that should
    * reflect the current version in the backing store. The expected usage is that the properties
-   * will be serialized inti a byte array with a call {@link #toBytes()} - that will increment the
+   * will be serialized into a byte array with a call {@link #toBytes()} - that will increment the
    * data version - then, the {@link #getExpectedVersion()} will reflect the value that is currently
    * in zookeeper and is the value passed to the zookeeper setData methods.
    *

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
@@ -70,7 +70,7 @@ public interface PropEncoding {
   /**
    * Properties are store with a data version for serialization. This allows for comparison of
    * properties and can be used to ensure that vales being written to the backend store have not
-   * changed. The data version is incremented when serialized with toBytes()) so that the instance
+   * changed. The data version is incremented when serialized with toBytes() so that the instance
    * value is consistent with the store value.
    *
    * @return the data version when the properties were serialized.

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncoding.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.time.Instant;
+import java.util.Map;
+
+public interface PropEncoding {
+
+  /**
+   * Add a property. If the property already exists it is overwritten.
+   *
+   * @param key
+   *          the name of the property
+   * @param value
+   *          the value of the property.
+   */
+  void addProperty(String key, String value);
+
+  /**
+   * Add multiple properties. If a property already exists it is overwritten.
+   *
+   * @param properties
+   *          A map of key, value pairs.
+   */
+  void addProperties(Map<String,String> properties);
+
+  /**
+   * Get a store property or null if it does not exist.
+   *
+   * @param key
+   *          the name of the property.
+   * @return the property value.
+   */
+  String getProperty(String key);
+
+  /**
+   * Delete a property.
+   *
+   * @param key
+   *          the name of the property.
+   * @return the previous value if the property was present.
+   */
+  String removeProperty(String key);
+
+  /**
+   * Properties are timestamped when the properties are serialized for storage. This is to allow
+   * easy comparison of properties that could have been retrieved at different times.
+   *
+   * @return the timestamp when the properties were serialized.
+   */
+  Instant getTimestamp();
+
+  /**
+   * Properties are store with a data version for serialization. This allows for comparison of
+   * properties and can be used to ensure that vales being written to the backend store have not
+   * changed. The data version is incremented when serialized with toBytes()) so that the instance
+   * value is consistent with the store value.
+   *
+   * @return the data version when the properties were serialized.
+   */
+  int getDataVersion();
+
+  /**
+   * The version is incremented with a call to toBytes() - this method returns the value that should
+   * reflect the current version in the backing store. The expected usage is that the properties
+   * will be serialized inti a byte array with a call {@link #toBytes()} - that will increment the
+   * data version - then, the {@link #getExpectedVersion()} will reflect the value that is currently
+   * in zookeeper and is the value passed to the zookeeper setData methods.
+   *
+   * @return the expected version current in the backend store.
+   */
+  int getExpectedVersion();
+
+  /**
+   * Serialize the version information an the properties.
+   *
+   * @return an array of bytes for storage.
+   */
+  byte[] toBytes();
+
+  /**
+   * Provide user-friend display string.
+   *
+   * @param prettyPrint
+   *          if true, insert new lines to improve readability.
+   * @return a formatted string, with optional new lines.
+   */
+  String print(boolean prettyPrint);
+
+  /**
+   * Get an unmodifiable map with all of the property, values.
+   *
+   * @return An unmodifiable view of the property key, values.
+   */
+  Map<String,String> getAllProperties();
+
+  /**
+   * Determine if the stage of the props is compressed or not.
+   *
+   * @return true if the underlying encoded props are compressed when stored.
+   */
+  boolean isCompressed();
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class PropEncodingV1 implements PropEncoding {
+
+  private Header header;
+
+  private final Map<String,String> props = new HashMap<>();
+
+  /**
+   * Create a default instance, compressed = true, and timestamp = now.
+   */
+  public PropEncodingV1() {
+    this(Integer.MIN_VALUE, true, Instant.now());
+  }
+
+  /**
+   * Instantiate an instance.
+   *
+   * @param dataVersion
+   *          should match current zookeeper dataVersion, or a negative value for initial instance.
+   * @param compressed
+   *          if true, compress the data.
+   * @param timestamp
+   *          timestamp for the data.
+   */
+  public PropEncodingV1(final int dataVersion, final boolean compressed, final Instant timestamp) {
+    header = new Header(dataVersion, timestamp, compressed);
+  }
+
+  /**
+   * (Re) Construct instance from byte array.
+   *
+   * @param bytes
+   *          a previously encoded instance in a byte array.
+   */
+  public PropEncodingV1(final byte[] bytes) {
+
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+        DataInputStream dis = new DataInputStream(bis)) {
+
+      header = new Header(dis);
+
+      if (header.isCompressed()) {
+        uncompressProps(bis);
+      } else {
+        readProps(dis);
+      }
+
+    } catch (IOException ex) {
+      throw new IllegalStateException("Encountered error deserializing properties", ex);
+    }
+  }
+
+  @Override
+  public void addProperty(String k, String v) {
+    props.put(k, v);
+  }
+
+  @Override
+  public void addProperties(Map<String,String> properties) {
+    if (Objects.nonNull(properties)) {
+      props.putAll(properties);
+    }
+  }
+
+  @Override
+  public String getProperty(final String key) {
+    return props.get(key);
+  }
+
+  @Override
+  public Map<String,String> getAllProperties() {
+    return Collections.unmodifiableMap(props);
+  }
+
+  @Override
+  public String removeProperty(final String key) {
+    return props.remove(key);
+  }
+
+  @Override
+  public Instant getTimestamp() {
+    return header.getTimestamp();
+  }
+
+  @Override
+  public int getDataVersion() {
+    return header.getDataVersion();
+  }
+
+  @Override
+  public int getExpectedVersion() {
+    var version = getDataVersion();
+    return Math.max(0, version - 1);
+  }
+
+  @Override
+  public boolean isCompressed() {
+    return header.isCompressed();
+  }
+
+  @Override
+  public byte[] toBytes() {
+
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos)) {
+
+      int nextVersion = Math.max(0, header.getDataVersion() + 1);
+
+      header = new Header(nextVersion, Instant.now(), header.isCompressed());
+      header.writeHeader(dos);
+
+      if (header.isCompressed()) {
+        compressProps(bos);
+      } else {
+        writeProps(dos);
+      }
+      dos.flush();
+      return bos.toByteArray();
+
+    } catch (IOException ex) {
+      throw new IllegalStateException("Encountered error serializing properties", ex);
+    }
+  }
+
+  private void writeProps(final DataOutputStream dos) throws IOException {
+
+    dos.writeInt(props.size());
+
+    props.forEach((k, v) -> writeKV(k, v, dos));
+
+    dos.flush();
+  }
+
+  private void compressProps(final ByteArrayOutputStream bos) {
+
+    try (GZIPOutputStream gzipOut = new GZIPOutputStream(bos);
+        DataOutputStream dos = new DataOutputStream(gzipOut)) {
+
+      writeProps(dos);
+
+      gzipOut.flush();
+      gzipOut.finish();
+
+    } catch (IOException ex) {
+      throw new IllegalStateException("Encountered error compressing properties", ex);
+    }
+  }
+
+  private void readProps(final DataInputStream dis) throws IOException {
+
+    int items = dis.readInt();
+
+    for (int i = 0; i < items; i++) {
+      Map.Entry<String,String> e = readKV(dis);
+      props.put(e.getKey(), e.getValue());
+    }
+  }
+
+  private void uncompressProps(final ByteArrayInputStream bis) throws IOException {
+
+    try (GZIPInputStream gzipIn = new GZIPInputStream(bis);
+        DataInputStream dis = new DataInputStream(gzipIn)) {
+      readProps(dis);
+    }
+  }
+
+  private void writeKV(final String k, final String v, final DataOutputStream dos) {
+    try {
+      dos.writeUTF(k);
+      dos.writeUTF(v);
+    } catch (IOException ex) {
+      throw new IllegalStateException(
+          String.format("Exception encountered writing props k:'%s', v:'%s", k, v), ex);
+    }
+  }
+
+  private Map.Entry<String,String> readKV(final DataInputStream dis) {
+    try {
+      String k = dis.readUTF();
+      String v = dis.readUTF();
+      return new AbstractMap.SimpleEntry<>(k, v);
+
+    } catch (IOException ex) {
+      throw new IllegalStateException("Could not read property key value pair", ex);
+    }
+  }
+
+  @Override
+  public String print(boolean prettyPrint) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("encoding=").append(header.getEncodingVer());
+    pretty(prettyPrint, sb);
+    sb.append("dataVersion=").append(header.getDataVersion());
+    pretty(prettyPrint, sb);
+    sb.append("timestamp=").append(header.getTimestampISO());
+    pretty(prettyPrint, sb);
+
+    Map<String,String> sorted = new TreeMap<>(props);
+    sorted.forEach((k, v) -> {
+      if (prettyPrint) {
+        sb.append("  ");
+      }
+      sb.append(k).append("=").append(v);
+      pretty(prettyPrint, sb);
+    });
+    return sb.toString();
+  }
+
+  private void pretty(final boolean prettyPrint, final StringBuilder sb) {
+    if (prettyPrint) {
+      sb.append("\n");
+    } else {
+      sb.append(", ");
+    }
+  }
+
+  /**
+   * Serialization metadata. This data should be written / appear in the encoded bytes first so that
+   * decisions can be made that may make deserilization unnecessary.
+   *
+   * The header values are:
+   * <ul>
+   * <li>encodingVersion - allows for future changes to the encoding schema</li>
+   * <li>dataVersion - allows for quick comparison by comparing versions numbers</li>
+   * <li>timestamp - could allow for deconfliction of concurrent updates</li>
+   * <li>compressed - when true, the rest of the payload is compressed</li>
+   * </ul>
+   */
+  private static class Header {
+
+    private final String encodingVer = "1.0";
+    private final int dataVersion;
+    private final Instant timestamp;
+    private final boolean compressed;
+
+    private static final DateTimeFormatter tsFormatter =
+        DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
+
+    public Header(final int dataVersion, final Instant timestamp, final boolean compressed) {
+      this.dataVersion = dataVersion;
+      this.timestamp = timestamp;
+      this.compressed = compressed;
+    }
+
+    public Header(final DataInputStream dis) throws IOException {
+
+      // temporary - would need to change if multiple, compatible versions are developed.
+      String ver = dis.readUTF();
+      if (encodingVer.compareTo(ver) != 0) {
+        throw new IllegalStateException(
+            "Invalid encoding version " + ver + ", expected " + encodingVer);
+      }
+      dataVersion = dis.readInt();
+      timestamp = tsFormatter.parse(dis.readUTF(), Instant::from);
+      compressed = dis.readBoolean();
+    }
+
+    public String getEncodingVer() {
+      return encodingVer;
+    }
+
+    /**
+     * Get the data version - -1 signals the data has not been written out.
+     *
+     * @return -1 if initial version, otherwise the current data version.
+     */
+    public int getDataVersion() {
+      if (dataVersion < 0) {
+        return -1;
+      }
+      return dataVersion;
+    }
+
+    public Instant getTimestamp() {
+      return timestamp;
+    }
+
+    public String getTimestampISO() {
+      return tsFormatter.format(timestamp);
+    }
+
+    public boolean isCompressed() {
+      return compressed;
+    }
+
+    public void writeHeader(final DataOutputStream dos) throws IOException {
+      dos.writeUTF(encodingVer);
+      dos.writeInt(dataVersion);
+      dos.writeUTF(tsFormatter.format(timestamp));
+      dos.writeBoolean(compressed);
+    }
+
+    @Override
+    public String toString() {
+      return "Header{" + "encodingVer='" + encodingVer + '\'' + ", dataVersion=" + dataVersion
+          + ", timestamp=" + timestamp + ", compressed=" + compressed + '}';
+    }
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
@@ -126,8 +126,7 @@ public class PropEncodingV1 implements PropEncoding {
 
   @Override
   public int getExpectedVersion() {
-    var version = getDataVersion();
-    return Math.max(0, version - 1);
+    return Math.max(0, getDataVersion() - 1);
   }
 
   @Override
@@ -244,7 +243,11 @@ public class PropEncodingV1 implements PropEncoding {
   }
 
   private void pretty(final boolean prettyPrint, final StringBuilder sb) {
-    prettyPrint ? sb.append("\n") : sb.append(", ");
+    if (prettyPrint) {
+      sb.append("\n");
+    } else {
+      sb.append(", ");
+    }
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
@@ -243,11 +243,7 @@ public class PropEncodingV1 implements PropEncoding {
   }
 
   private void pretty(final boolean prettyPrint, final StringBuilder sb) {
-    if (prettyPrint) {
-      sb.append("\n");
-    } else {
-      sb.append(", ");
-    }
+    sb.append(prettyPrint ? "\n" : ", ");
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
@@ -244,11 +244,7 @@ public class PropEncodingV1 implements PropEncoding {
   }
 
   private void pretty(final boolean prettyPrint, final StringBuilder sb) {
-    if (prettyPrint) {
-      sb.append("\n");
-    } else {
-      sb.append(", ");
-    }
+    prettyPrint ? sb.append("\n") : sb.append(", ");
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropEncodingV1.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -83,7 +84,7 @@ public class PropEncodingV1 implements PropEncoding {
       }
 
     } catch (IOException ex) {
-      throw new IllegalStateException("Encountered error deserializing properties", ex);
+      throw new UncheckedIOException("Encountered error deserializing properties", ex);
     }
   }
 
@@ -292,13 +293,15 @@ public class PropEncodingV1 implements PropEncoding {
     }
 
     /**
-     * Get the data version - -1 signals the data has not been written out.
+     * Get the data version - a negative value signals the data has not been written out. Avoids
+     * using -1 because that has significance in ZooKeeper - writing a ZooKeeper node with a version
+     * of -1 disables the ZooKeeper expected version checking and just over writes the node.
      *
-     * @return -1 if initial version, otherwise the current data version.
+     * @return negative value if initial version, otherwise the current data version.
      */
     public int getDataVersion() {
       if (dataVersion < 0) {
-        return -1;
+        return -2;
       }
       return dataVersion;
     }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/PropEncodingV1Test.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/PropEncodingV1Test.java
@@ -84,7 +84,7 @@ public class PropEncodingV1Test {
 
     int ver = props.getDataVersion();
 
-    var createdTs = props.getTimestamp();
+    Instant createdTs = props.getTimestamp();
 
     byte[] bytes = props.toBytes();
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/PropEncodingV1Test.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/PropEncodingV1Test.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PropEncodingV1Test {
+
+  private static final Logger log = LoggerFactory.getLogger(PropEncodingV1Test.class);
+
+  @Test
+  public void defaultConstructor() {
+    PropEncoding props = new PropEncodingV1();
+
+    // on first write, the znode version expected should be 0.
+    // expected should never be -1. That would just overwrite any znode
+    assertEquals(0, props.getExpectedVersion());
+
+    byte[] bytes = props.toBytes();
+    PropEncodingV1 decoded = new PropEncodingV1(bytes);
+
+    // initial version in ZooKeeper expected to be 0.
+    assertEquals(0, decoded.getDataVersion());
+    assertEquals(0, props.getExpectedVersion());
+
+  }
+
+  @Test
+  public void propValidation() {
+    Map<String,String> propMap = new HashMap<>();
+    propMap.put("k1", "v1");
+    propMap.put("k2", "v2");
+
+    PropEncoding props = new PropEncodingV1();
+    props.addProperties(propMap);
+
+    assertEquals(propMap, props.getAllProperties());
+
+    props.addProperty("k3", "v3");
+    assertEquals(3, props.getAllProperties().size());
+
+    props.removeProperty("k2");
+
+    assertEquals(2, props.getAllProperties().size());
+    assertEquals("v1", props.getProperty("k1"));
+    assertNull("v1", props.getProperty("k2"));
+    assertEquals("v3", props.getProperty("k3"));
+
+  }
+
+  @Test
+  public void compressedEncodeTest() {
+
+    PropEncoding props = new PropEncodingV1(1, true, Instant.now());
+    fillMap(props);
+
+    Map<String,String> propValues = props.getAllProperties();
+
+    int ver = props.getDataVersion();
+
+    var createdTs = props.getTimestamp();
+
+    byte[] bytes = props.toBytes();
+
+    // timestamp updated on serialization
+    assertNotEquals(createdTs, props.getTimestamp());
+    assertEquals(props.getDataVersion(), ver + 1);
+
+    // expected should be "previous" value that would the node version in ZooKeeper
+    assertEquals(ver, props.getExpectedVersion());
+
+    log.debug("compressed encoded length: {}", bytes.length);
+    PropEncodingV1 decoded = new PropEncodingV1(bytes);
+
+    log.info("Decoded:\n{}", decoded.print(true));
+
+    assertEquals(propValues, decoded.getAllProperties());
+  }
+
+  @Test
+  public void uncompressedEncodeTest() {
+
+    PropEncoding props = new PropEncodingV1(1, false, Instant.now());
+    fillMap(props);
+
+    byte[] bytes = props.toBytes();
+
+    log.debug("uncompressed encoded length: {}", bytes.length);
+
+    PropEncodingV1 decoded = new PropEncodingV1(bytes);
+
+    log.info("Decoded:\n{}", decoded.print(true));
+
+  }
+
+  @Test
+  public void acceptNullProps() {
+    PropEncoding props = new PropEncodingV1(1, false, Instant.now());
+    props.addProperties(null);
+  }
+
+  private void fillMap(final PropEncoding props) {
+    props.addProperty("key1", "value1");
+    props.addProperty("key2", "value2");
+    props.addProperty("key3", "value3");
+    props.addProperty("key4", "value4");
+  }
+}


### PR DESCRIPTION
This is the first PR in moving towards a refactored ZooKeeper property
storage.  Intented to replace the storing indididual properties in ZooKeeper to be
stored / managed as a group, that is stored on a single node.

- Provides a header that maintains schema version, data version, and timestamp.
- Optional compresson of the byte storage array.