### PR TITLE
Improve client table exceptions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/TableOfflineException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TableOfflineException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client;
 
+import org.apache.accumulo.core.data.TableId;
+
 public class TableOfflineException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
@@ -35,6 +37,17 @@ public class TableOfflineException extends RuntimeException {
    */
   public TableOfflineException(String msg) {
     super(msg);
+  }
+
+  /**
+   * @since 2.1.0
+   */
+  public TableOfflineException(TableId tableId, String tableName) {
+    // @formatter:off
+    super(String.format("Table %s (%s) is offline",
+        tableName == null ? "<unknown table>" : tableName,
+        tableId == null ? "<unknown id>" : tableId));
+    // @formatter:on
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
@@ -41,9 +41,7 @@ import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase;
-import org.apache.accumulo.core.client.TableDeletedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
@@ -64,7 +62,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.hadoop.io.Text;
@@ -698,11 +695,8 @@ public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
           tl.invalidateCache();
 
           while (!tl.binRanges(client, ranges, binnedRanges).isEmpty()) {
-            String tableIdStr = tableId.canonical();
-            if (!Tables.exists(client, tableId))
-              throw new TableDeletedException(tableIdStr);
-            if (Tables.getTableState(client, tableId) == TableState.OFFLINE)
-              throw new TableOfflineException(Tables.getTableOfflineMsg(client, tableId));
+            client.requireNotDeleted(tableId);
+            client.requireNotOffline(tableId, tableName);
             binnedRanges.clear();
             log.warn("Unable to locate bins for specified ranges. Retrying.");
             // sleep randomly between 100 and 200 ms

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConnectorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConnectorImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -92,9 +90,8 @@ public class ConnectorImpl extends org.apache.accumulo.core.client.Connector {
   public BatchDeleter createBatchDeleter(String tableName, Authorizations authorizations,
       int numQueryThreads, long maxMemory, long maxLatency, int maxWriteThreads)
       throws TableNotFoundException {
-    checkArgument(authorizations != null, "authorizations is null");
-    return new TabletServerBatchDeleter(context, context.getTableId(tableName), authorizations,
-        numQueryThreads, new BatchWriterConfig().setMaxMemory(maxMemory)
+    return context.createBatchDeleter(tableName, authorizations, numQueryThreads,
+        new BatchWriterConfig().setMaxMemory(maxMemory)
             .setMaxLatency(maxLatency, TimeUnit.MILLISECONDS).setMaxWriteThreads(maxWriteThreads));
   }
 
@@ -107,9 +104,8 @@ public class ConnectorImpl extends org.apache.accumulo.core.client.Connector {
   @Override
   public BatchWriter createBatchWriter(String tableName, long maxMemory, long maxLatency,
       int maxWriteThreads) throws TableNotFoundException {
-    return new BatchWriterImpl(context, context.getTableId(tableName),
-        new BatchWriterConfig().setMaxMemory(maxMemory)
-            .setMaxLatency(maxLatency, TimeUnit.MILLISECONDS).setMaxWriteThreads(maxWriteThreads));
+    return context.createBatchWriter(tableName, new BatchWriterConfig().setMaxMemory(maxMemory)
+        .setMaxLatency(maxLatency, TimeUnit.MILLISECONDS).setMaxWriteThreads(maxWriteThreads));
   }
 
   @Override
@@ -121,7 +117,7 @@ public class ConnectorImpl extends org.apache.accumulo.core.client.Connector {
   @Override
   public MultiTableBatchWriter createMultiTableBatchWriter(long maxMemory, long maxLatency,
       int maxWriteThreads) {
-    return new MultiTableBatchWriterImpl(context, new BatchWriterConfig().setMaxMemory(maxMemory)
+    return context.createMultiTableBatchWriter(new BatchWriterConfig().setMaxMemory(maxMemory)
         .setMaxLatency(maxLatency, TimeUnit.MILLISECONDS).setMaxWriteThreads(maxWriteThreads));
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -72,7 +72,6 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.NamespaceExistsException;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.TableDeletedException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
@@ -395,7 +394,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           throw new NamespaceNotFoundException(e);
         case OFFLINE:
           throw new TableOfflineException(
-              Tables.getTableOfflineMsg(context, Tables.getTableId(context, tableOrNamespaceName)));
+              e.getTableId() == null ? null : TableId.of(e.getTableId()), tableOrNamespaceName);
         case BULK_CONCURRENT_MERGE:
           throw new AccumuloBulkMergeException(e);
         default:
@@ -416,11 +415,11 @@ public class TableOperationsImpl extends TableOperationsHelper {
   }
 
   private static class SplitEnv {
-    private String tableName;
-    private TableId tableId;
-    private ExecutorService executor;
-    private CountDownLatch latch;
-    private AtomicReference<Exception> exception;
+    private final String tableName;
+    private final TableId tableId;
+    private final ExecutorService executor;
+    private final CountDownLatch latch;
+    private final AtomicReference<Exception> exception;
 
     SplitEnv(String tableName, TableId tableId, ExecutorService executor, CountDownLatch latch,
         AtomicReference<Exception> exception) {
@@ -449,7 +448,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           return;
 
         if (splits.size() <= 2) {
-          addSplits(env.tableName, new TreeSet<>(splits), env.tableId);
+          addSplits(env, new TreeSet<>(splits));
           splits.forEach(s -> env.latch.countDown());
           return;
         }
@@ -458,7 +457,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
         // split the middle split point to ensure that child task split
         // different tablets and can therefore run in parallel
-        addSplits(env.tableName, new TreeSet<>(splits.subList(mid, mid + 1)), env.tableId);
+        addSplits(env, new TreeSet<>(splits.subList(mid, mid + 1)));
         env.latch.countDown();
 
         env.executor.execute(new SplitTask(env, splits.subList(0, mid)));
@@ -504,7 +503,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           } else if (excep instanceof TableOfflineException) {
             log.debug("TableOfflineException occurred in background thread. Throwing new exception",
                 excep);
-            throw new TableOfflineException(Tables.getTableOfflineMsg(context, tableId));
+            throw new TableOfflineException(tableId, tableName);
           } else if (excep instanceof AccumuloSecurityException) {
             // base == background accumulo security exception
             AccumuloSecurityException base = (AccumuloSecurityException) excep;
@@ -526,12 +525,10 @@ public class TableOperationsImpl extends TableOperationsHelper {
     }
   }
 
-  private void addSplits(String tableName, SortedSet<Text> partitionKeys, TableId tableId)
-      throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
-      AccumuloServerException {
-    EXISTING_TABLE_NAME.validate(tableName);
+  private void addSplits(SplitEnv env, SortedSet<Text> partitionKeys) throws AccumuloException,
+      AccumuloSecurityException, TableNotFoundException, AccumuloServerException {
 
-    TabletLocator tabLocator = TabletLocator.getLocator(context, tableId);
+    TabletLocator tabLocator = TabletLocator.getLocator(context, env.tableId);
     for (Text split : partitionKeys) {
       boolean successful = false;
       int attempt = 0;
@@ -547,10 +544,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
         TabletLocation tl = tabLocator.locateTablet(context, split, false, false);
 
         if (tl == null) {
-          if (!Tables.exists(context, tableId))
-            throw new TableNotFoundException(tableId.canonical(), tableName, null);
-          else if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
-            throw new TableOfflineException(Tables.getTableOfflineMsg(context, tableId));
+          context.requireTableExists(env.tableId, env.tableName);
+          context.requireNotOffline(env.tableId, env.tableName);
           continue;
         }
 
@@ -591,15 +586,14 @@ public class TableOperationsImpl extends TableOperationsHelper {
           continue;
         } catch (ThriftSecurityException e) {
           Tables.clearCache(context);
-          if (!Tables.exists(context, tableId))
-            throw new TableNotFoundException(tableId.canonical(), tableName, null);
+          context.requireTableExists(env.tableId, env.tableName);
           throw new AccumuloSecurityException(e.user, e.code, e);
         } catch (NotServingTabletException e) {
           // Do not silently spin when we repeatedly fail to get the location for a tablet
           locationFailures++;
           if (locationFailures == 5 || locationFailures % 50 == 0) {
             log.warn("Having difficulty locating hosting tabletserver for split {} on table {}."
-                + " Seen {} failures.", split, tableName, locationFailures);
+                + " Seen {} failures.", split, env.tableName, locationFailures);
           }
 
           tabLocator.invalidateCache(tl.tablet_extent);
@@ -661,9 +655,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   private List<Text> _listSplits(String tableName)
       throws TableNotFoundException, AccumuloSecurityException {
-    EXISTING_TABLE_NAME.validate(tableName);
-
-    TableId tableId = Tables.getTableId(context, tableName);
+    TableId tableId = context.getTableId(tableName);
     TreeMap<KeyExtent,String> tabletLocations = new TreeMap<>();
     while (true) {
       try {
@@ -674,9 +666,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       } catch (AccumuloSecurityException ase) {
         throw ase;
       } catch (Exception e) {
-        if (!Tables.exists(context, tableId)) {
-          throw new TableNotFoundException(tableId.canonical(), tableName, null);
-        }
+        context.requireTableExists(tableId, tableName);
 
         if (e instanceof RuntimeException && e.getCause() instanceof AccumuloSecurityException) {
           throw (AccumuloSecurityException) e.getCause();
@@ -751,10 +741,9 @@ public class TableOperationsImpl extends TableOperationsHelper {
   public void clone(String srcTableName, String newTableName, CloneConfiguration config)
       throws AccumuloSecurityException, TableNotFoundException, AccumuloException,
       TableExistsException {
-    EXISTING_TABLE_NAME.validate(srcTableName);
     NEW_TABLE_NAME.validate(newTableName);
 
-    TableId srcTableId = Tables.getTableId(context, srcTableName);
+    TableId srcTableId = context.getTableId(srcTableName);
 
     if (config.isFlush())
       _flush(srcTableId, null, null, true);
@@ -811,9 +800,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
   @Override
   public void flush(String tableName, Text start, Text end, boolean wait)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-    EXISTING_TABLE_NAME.validate(tableName);
-    TableId tableId = Tables.getTableId(context, tableName);
-    _flush(tableId, start, end, wait);
+    _flush(context.getTableId(tableName), start, end, wait);
   }
 
   @Override
@@ -1148,10 +1135,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
     // tablets... so clear it
     tl.invalidateCache();
     while (!tl.binRanges(context, Collections.singletonList(range), binnedRanges).isEmpty()) {
-      if (!Tables.exists(context, tableId))
-        throw new TableDeletedException(tableId.canonical());
-      if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
-        throw new TableOfflineException(Tables.getTableOfflineMsg(context, tableId));
+      context.requireNotDeleted(tableId);
+      context.requireNotOffline(tableId, tableName);
 
       log.warn("Unable to locate bins for specified range. Retrying.");
       // sleep randomly between 100 and 200ms
@@ -1257,8 +1242,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         Tables.clearCache(context);
         TableState currentState = Tables.getTableState(context, tableId);
         if (currentState != expectedState) {
-          if (!Tables.exists(context, tableId))
-            throw new TableDeletedException(tableId.canonical());
+          context.requireNotDeleted(tableId);
           if (currentState == TableState.DELETING)
             throw new TableNotFoundException(tableId.canonical(), "", "Table is being deleted.");
           throw new AccumuloException("Unexpected table state " + tableId + " "
@@ -1832,20 +1816,14 @@ public class TableOperationsImpl extends TableOperationsHelper {
         .logInterval(3, TimeUnit.MINUTES).createRetry();
 
     while (!locator.binRanges(context, rangeList, binnedRanges).isEmpty()) {
-
-      if (!Tables.exists(context, tableId))
-        throw new TableNotFoundException(tableId.canonical(), tableName, null);
-      if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
-        throw new TableOfflineException(Tables.getTableOfflineMsg(context, tableId));
-
+      context.requireTableExists(tableId, tableName);
+      context.requireNotOffline(tableId, tableName);
       binnedRanges.clear();
-
       try {
         retry.waitForNextAttempt();
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
-
       locator.invalidateCache();
     }
 
@@ -1854,7 +1832,14 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   @Override
   public SummaryRetriever summaries(String tableName) {
-    EXISTING_TABLE_NAME.validate(tableName);
+    TableId tableId;
+    try {
+      tableId = context.getTableId(tableName);
+    } catch (TableNotFoundException e) {
+      // this has to be a runtime exception, because TableNotFoundException wasn't put on the
+      // interface in 2.0 and adding it now would break the API contract
+      throw new IllegalArgumentException(e);
+    }
 
     return new SummaryRetriever() {
       private Text startRow = null;
@@ -1882,9 +1867,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       @Override
       public List<Summary> retrieve()
           throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-        TableId tableId = Tables.getTableId(context, tableName);
-        if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
-          throw new TableOfflineException(Tables.getTableOfflineMsg(context, tableId));
+        context.requireNotOffline(tableId, tableName);
 
         TRowRange range =
             new TRowRange(TextUtil.getByteBuffer(startRow), TextUtil.getByteBuffer(endRow));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
@@ -139,18 +139,6 @@ public class Tables {
     return tableName;
   }
 
-  public static String getTableOfflineMsg(ClientContext context, TableId tableId) {
-    if (tableId == null)
-      return "Table <unknown table> is offline";
-
-    try {
-      String tableName = Tables.getTableName(context, tableId);
-      return "Table " + tableName + " (" + tableId.canonical() + ") is offline";
-    } catch (TableNotFoundException e) {
-      return "Table <unknown table> (" + tableId.canonical() + ") is offline";
-    }
-  }
-
   public static Map<String,TableId> getNameToIdMap(ClientContext context) {
     return getTableMap(context).getNameToIdMap();
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchDeleter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchDeleter.java
@@ -40,9 +40,9 @@ public class TabletServerBatchDeleter extends TabletServerBatchReader implements
   private TableId tableId;
   private BatchWriterConfig bwConfig;
 
-  public TabletServerBatchDeleter(ClientContext context, TableId tableId,
+  public TabletServerBatchDeleter(ClientContext context, TableId tableId, String tableName,
       Authorizations authorizations, int numQueryThreads, BatchWriterConfig bwConfig) {
-    super(context, BatchDeleter.class, tableId, authorizations, numQueryThreads);
+    super(context, BatchDeleter.class, tableId, tableName, authorizations, numQueryThreads);
     this.context = context;
     this.tableId = tableId;
     this.bwConfig = bwConfig;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -46,6 +46,7 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
 
   private final int batchReaderInstance = nextBatchReaderInstance.getAndIncrement();
   private final TableId tableId;
+  private final String tableName;
   private final int numThreads;
   private final ThreadPoolExecutor queryThreadPool;
   private final ClientContext context;
@@ -55,19 +56,20 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
 
   private ArrayList<Range> ranges = null;
 
-  public TabletServerBatchReader(ClientContext context, TableId tableId,
+  public TabletServerBatchReader(ClientContext context, TableId tableId, String tableName,
       Authorizations authorizations, int numQueryThreads) {
-    this(context, BatchScanner.class, tableId, authorizations, numQueryThreads);
+    this(context, BatchScanner.class, tableId, tableName, authorizations, numQueryThreads);
   }
 
   protected TabletServerBatchReader(ClientContext context, Class<?> scopeClass, TableId tableId,
-      Authorizations authorizations, int numQueryThreads) {
+      String tableName, Authorizations authorizations, int numQueryThreads) {
     checkArgument(context != null, "context is null");
     checkArgument(tableId != null, "tableId is null");
     checkArgument(authorizations != null, "authorizations is null");
     this.context = context;
     this.authorizations = authorizations;
     this.tableId = tableId;
+    this.tableName = tableName;
     this.numThreads = numQueryThreads;
 
     queryThreadPool = ThreadPools.createFixedThreadPool(numQueryThreads,
@@ -114,7 +116,7 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
       throw new IllegalStateException("batch reader closed");
     }
 
-    return new TabletServerBatchReaderIterator(context, tableId, authorizations, ranges, numThreads,
-        queryThreadPool, this, timeOut);
+    return new TabletServerBatchReaderIterator(context, tableId, tableName, authorizations, ranges,
+        numThreads, queryThreadPool, this, timeOut);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderTest.java
@@ -40,7 +40,8 @@ public class TabletServerBatchReaderTest {
   @Test
   public void testGetAuthorizations() {
     Authorizations expected = new Authorizations("a,b");
-    try (BatchScanner s = new TabletServerBatchReader(context, TableId.of("foo"), expected, 1)) {
+    try (BatchScanner s =
+        new TabletServerBatchReader(context, TableId.of("foo"), "fooName", expected, 1)) {
       assertEquals(expected, s.getAuthorizations());
     }
   }
@@ -48,6 +49,6 @@ public class TabletServerBatchReaderTest {
   @Test
   public void testNullAuthorizationsFails() {
     assertThrows(IllegalArgumentException.class,
-        () -> new TabletServerBatchReader(context, TableId.of("foo"), null, 1));
+        () -> new TabletServerBatchReader(context, TableId.of("foo"), "fooName", null, 1));
   }
 }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -42,7 +42,6 @@ import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase;
-import org.apache.accumulo.core.client.TableDeletedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
@@ -56,7 +55,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.hadoopImpl.mapreduce.InputTableConfig;
@@ -345,11 +343,8 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
             tl.invalidateCache();
 
             while (!tl.binRanges(context, ranges, binnedRanges).isEmpty()) {
-              String tableIdStr = tableId.canonical();
-              if (!Tables.exists(context, tableId))
-                throw new TableDeletedException(tableIdStr);
-              if (Tables.getTableState(context, tableId) == TableState.OFFLINE)
-                throw new TableOfflineException(Tables.getTableOfflineMsg(context, tableId));
+              context.requireNotDeleted(tableId);
+              context.requireNotOffline(tableId, tableName);
               binnedRanges.clear();
               log.warn("Unable to locate bins for specified ranges. Retrying.");
               // sleep randomly between 100 and 200 ms

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TableLoadBalancer.java
@@ -70,9 +70,7 @@ public class TableLoadBalancer extends TabletBalancer {
 
   protected String getLoadBalancerClassNameForTable(TableId table) {
     TableState tableState = context.getTableManager().getTableState(table);
-    if (tableState == null)
-      return null;
-    if (tableState.equals(TableState.ONLINE))
+    if (tableState == TableState.ONLINE)
       return this.context.getTableConfiguration(table).get(Property.TABLE_LOAD_BALANCER);
     return null;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -326,8 +326,7 @@ public class Manager extends AbstractServer
           for (Entry<TableId,TableCounts> entry : watcher.getStats().entrySet()) {
             TableId tableId = entry.getKey();
             TableCounts counts = entry.getValue();
-            TableState tableState = manager.getTableState(tableId);
-            if (tableState != null && tableState.equals(TableState.ONLINE)) {
+            if (manager.getTableState(tableId) == TableState.ONLINE) {
               result += counts.unassigned() + counts.assignedToDeadServers() + counts.assigned()
                   + counts.suspended();
             }
@@ -357,7 +356,7 @@ public class Manager extends AbstractServer
   public void mustBeOnline(final TableId tableId) throws ThriftTableOperationException {
     ServerContext context = getContext();
     Tables.clearCache(context);
-    if (!Tables.getTableState(context, tableId).equals(TableState.ONLINE)) {
+    if (Tables.getTableState(context, tableId) != TableState.ONLINE) {
       throw new ThriftTableOperationException(tableId.canonical(), null, TableOperation.MERGE,
           TableOperationExceptionType.OFFLINE, "table is not online");
     }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tables/TablesResource.java
@@ -103,7 +103,7 @@ public class TablesResource {
       TableInfo tableInfo = tableStats.get(tableId);
       TableState tableState = tableManager.getTableState(tableId);
 
-      if (tableInfo != null && !tableState.equals(TableState.OFFLINE)) {
+      if (tableInfo != null && tableState != TableState.OFFLINE) {
         Double holdTime = compactingByTable.get(tableId.canonical());
         if (holdTime == null) {
           holdTime = 0.;


### PR DESCRIPTION
Improve client-side table exception handling by providing tableNames
from the client to avoid looking them up later to format an exception
message.

* Add TableOfflineException constructor to provide a formatted message
  without requiring a ClientContext to look up the name or id
* Reuse code to check for TableNotFoundException, TableDeletedException,
  and TableOfflineException using convenience methods in ClientContext
* Pass along tableName alongside tableId, in some internal client-side
  code, for use in exception messages, if needed later
* Make check for requiring that a table not be offline explicit, rather
  than entangled with the tableId lookup in ClientContext
* Update ConnectorImpl to proxy to ClientContext in a few cases where
  it previously wasn't, to ensure consistent behavior and argument
  validations
* Use TableId from Thrift exception to avoid another client-side lookup
  when a fate operation throws an exception because the table is offline
* Simplify private addSplit method by passing SplitEnv, rather than
  sending env.tableId and env.tableName as separate parameters
* Remove some redundant tableName validations when they are already
  validated by context.getTableId
* Simplify and inline a private updateAuthorizationsFailures method in
  TabletServerBatchWriter that was used to gather a set of
  authorizations failures whose tables were then checked for being
  deleted
* Fix a few TableState enum comparisons from `.equals()` to `==`