### PR TITLE
Fix and improve SummaryIT

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1832,14 +1832,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
   @Override
   public SummaryRetriever summaries(String tableName) {
-    TableId tableId;
-    try {
-      tableId = context.getTableId(tableName);
-    } catch (TableNotFoundException e) {
-      // this has to be a runtime exception, because TableNotFoundException wasn't put on the
-      // interface in 2.0 and adding it now would break the API contract
-      throw new IllegalArgumentException(e);
-    }
+    EXISTING_TABLE_NAME.validate(tableName);
 
     return new SummaryRetriever() {
       private Text startRow = null;
@@ -1867,6 +1860,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
       @Override
       public List<Summary> retrieve()
           throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+        TableId tableId = context.getTableId(tableName);
         context.requireNotOffline(tableId, tableName);
 
         TRowRange range =


### PR DESCRIPTION
Fix SummaryIT, broken by #2195; restore late table existence checks, so
table doesn't need to exist until you call retrieve() on the
SummaryRetriever

Improve SummaryIT by making it share a cluster, so it runs faster, and
by using assertThrows() instead of try-catch blocks and fail()