### PR TITLE
Fix initialize.java by using terminalBuilder instead of default terminal

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -121,6 +121,8 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.InfoCmp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,12 +145,14 @@ public class Initialize implements KeywordExecutable {
   private static final String TABLE_TABLETS_TABLET_DIR = "table_info";
 
   private static LineReader reader = null;
+  private static Terminal terminal = null;
   private static ZooReaderWriter zoo = null;
 
   private static LineReader getLineReader() throws IOException {
-    if (reader == null) {
-      reader = LineReaderBuilder.builder().build();
-    }
+    if (terminal == null)
+      terminal = TerminalBuilder.builder().jansi(false).build();
+    if (reader == null)
+      reader = LineReaderBuilder.builder().terminal(terminal).build();
     return reader;
   }
 


### PR DESCRIPTION
While looking at https://issues.apache.org/jira/browse/ACCUMULO-3694 and testing the 'accumulo init --reset-security' feature, I ran into an error related to jline3 and how LineReader uses a default terminal and terminal type if none is specified.  A terminal object will now be created in the same way it is done in the shell.



Error:
![image](https://user-images.githubusercontent.com/29436247/125827524-51c642f9-5eff-4434-bb01-e0b48e8e8f24.png)
