### PR TITLE
Sanity check table properties prior to creation of fate operation

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -201,6 +201,14 @@ class FateServiceHandler implements FateService.Iface {
         if (!manager.security.canCreateTable(c, tableName, namespaceId))
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
+        for (Map.Entry<String,String> entry : options.entrySet()) {
+          if (!Property.isTablePropertyValid(entry.getKey(), entry.getValue())) {
+            throw new ThriftTableOperationException(null, tableName, tableOp,
+                TableOperationExceptionType.OTHER,
+                "Property or value not valid " + entry.getKey() + "=" + entry.getValue());
+          }
+        }
+
         manager.fate.seedTransaction(opid,
             new TraceRepo<>(new CreateTable(c.getPrincipal(), tableName, timeType, options,
                 splitsPath, splitCount, splitsDirsPath, initialTableState, namespaceId)),


### PR DESCRIPTION
Fixes #2196.

A check has been added to `FateServiceHandler` to check the properties before the create table operation is kicked off. This check makes use of the return value of the already-in-place `TablePropUtil.setTableProperty`

A redundant check is added to `PopulateZookeeper`.

These two additions essentially do the same thing, so [it has been mentioned](https://github.com/apache/accumulo/issues/2196#issuecomment-879415745) that a single static method could be added and used in these two places. I wanted to get some feedback on the trade off between these changes which make use of the existing code, and the possibility of using a single method here instead.