### PR TITLE
Fix typo 'propogate'

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
@@ -94,7 +94,7 @@ public class ExternalCompactionMetadata {
     return ceid;
   }
 
-  public boolean getPropogateDeletes() {
+  public boolean getPropagateDeletes() {
     return propagateDeletes;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionInfo.java
@@ -81,7 +81,7 @@ public class CompactionInfo {
         type = TCompactionType.MERGE;
       else
         type = TCompactionType.MINOR;
-    else if (!compactor.willPropogateDeletes())
+    else if (!compactor.willPropagateDeletes())
       type = TCompactionType.FULL;
     else
       type = TCompactionType.MAJOR;

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -418,7 +418,7 @@ public class FileCompactor implements Callable<CompactionStats> {
     return env.getIteratorScope() == IteratorScope.minc;
   }
 
-  boolean willPropogateDeletes() {
+  boolean willPropagateDeletes() {
     return propagateDeletes;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -453,8 +453,8 @@ public class CompactableImpl implements Compactable {
       }
 
       if (propDel == null) {
-        propDel = ecMeta.getPropogateDeletes();
-      } else if (propDel != ecMeta.getPropogateDeletes()) {
+        propDel = ecMeta.getPropagateDeletes();
+      } else if (propDel != ecMeta.getPropagateDeletes()) {
         unexpectedExternal = true;
         reasons.add("Disagreement on propagateDeletes");
         break;
@@ -464,7 +464,7 @@ public class CompactableImpl implements Compactable {
 
     if (propDel != null && !propDel && count > 1) {
       unexpectedExternal = true;
-      reasons.add("Concurrent compactions not propogatingDeletes");
+      reasons.add("Concurrent compactions not propagatingDeletes");
     }
 
     Pair<Long,CompactionConfig> idAndCfg = null;


### PR DESCRIPTION
There are several places where the word 'prop**a**gate' is incorrectly spelled 'prop**o**gate'. 