### PR TITLE
Remove continue point from Garbage Collector

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -198,7 +198,7 @@ public interface Ample {
     throw new UnsupportedOperationException();
   }
 
-  default Iterator<String> getGcCandidates(DataLevel level, String continuePoint) {
+  default Iterator<String> getGcCandidates(DataLevel level) {
     throw new UnsupportedOperationException();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -78,7 +78,7 @@ public class ListVolumesUsed {
         + " deletes section (volume replacement occurs at deletion time)");
     volumes.clear();
 
-    Iterator<String> delPaths = context.getAmple().getGcCandidates(level, "");
+    Iterator<String> delPaths = context.getAmple().getGcCandidates(level);
     while (delPaths.hasNext()) {
       volumes.add(getTableURI(delPaths.next()));
     }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -296,14 +296,14 @@ public class GarbageCollectionAlgorithm {
 
     while (candidatesIter.hasNext()) {
       List<String> batchOfCandidates = gce.readCandidatesThatFitInMemory(candidatesIter);
-      collectBatch(gce, batchOfCandidates);
+      deleteBatch(gce, batchOfCandidates);
     }
   }
 
   /**
    * Given a sub-list of possible deletion candidates, process and remove valid deletion candidates.
    */
-  private void collectBatch(GarbageCollectionEnvironment gce, List<String> currentBatch)
+  private void deleteBatch(GarbageCollectionEnvironment gce, List<String> currentBatch)
       throws TableNotFoundException, IOException {
 
     long origSize = currentBatch.size();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -291,7 +291,7 @@ public class GarbageCollectionAlgorithm {
   }
 
   /**
-   * Given a sub-list of possible delection candidates, process and remove valid deletion
+   * Given a sub-list of possible deletion candidates, process and remove valid deletion
    * candidates.
    */
   public void collectBatch(GarbageCollectionEnvironment gce, List<String> currentBatch)

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -291,8 +291,7 @@ public class GarbageCollectionAlgorithm {
   }
 
   /**
-   * Given a sub-list of possible deletion candidates, process and remove valid deletion
-   * candidates.
+   * Given a sub-list of possible deletion candidates, process and remove valid deletion candidates.
    */
   public void collectBatch(GarbageCollectionEnvironment gce, List<String> currentBatch)
       throws TableNotFoundException, IOException {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -303,7 +303,7 @@ public class GarbageCollectionAlgorithm {
   /**
    * Given a sub-list of possible deletion candidates, process and remove valid deletion candidates.
    */
-  public void collectBatch(GarbageCollectionEnvironment gce, List<String> currentBatch)
+  private void collectBatch(GarbageCollectionEnvironment gce, List<String> currentBatch)
       throws TableNotFoundException, IOException {
 
     long origSize = currentBatch.size();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.gc;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -39,10 +40,22 @@ import org.apache.accumulo.server.replication.proto.Replication.Status;
 public interface GarbageCollectionEnvironment {
 
   /**
-   * Process all possible deletion candidates for a given table, deleting candidates that meet all
-   * necessary conditions.
+   * Return an iterator which points to a list of paths to files and dirs which are candidates for
+   * deletion from a given table, {@link RootTable#NAME} or {@link MetadataTable#NAME}
+   *
+   * @return an iterator referencing a List containing deletion candidates
    */
-  void processCandidates() throws TableNotFoundException, IOException;
+  Iterator<String> getCandidates() throws TableNotFoundException;
+
+  /**
+   * Given an iterator to a deletion candidate list, return a sub-list of candidates which fit
+   * within provided memory constraints.
+   *
+   * @param candidatesIter
+   *          iterator referencing a List of possible deletion candidates
+   * @return a List of possible deletion candidates
+   */
+  List<String> readCandidatesThatFitInMemory(Iterator<String> candidatesIter);
 
   /**
    * Fetch a list of paths for all bulk loads in progress (blip) from a given table,

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.gc;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -40,19 +39,10 @@ import org.apache.accumulo.server.replication.proto.Replication.Status;
 public interface GarbageCollectionEnvironment {
 
   /**
-   * Return a list of paths to files and dirs which are candidates for deletion from a given table,
-   * {@link RootTable#NAME} or {@link MetadataTable#NAME}
-   *
-   * @param continuePoint
-   *          A row to resume from if a previous invocation was stopped due to finding an extremely
-   *          large number of candidates to remove which would have exceeded memory limitations
-   * @param candidates
-   *          A collection of candidates files for deletion, may not be the complete collection of
-   *          files for deletion at this point in time
-   * @return true if the results are short due to insufficient memory, otherwise false
+   * Process all possible deletion candidates for a given table, deleting candidates that meet all
+   * necessary conditions.
    */
-  boolean getCandidates(String continuePoint, List<String> candidates)
-      throws TableNotFoundException;
+  void processCandidates() throws TableNotFoundException, IOException;
 
   /**
    * Fetch a list of paths for all bulk loads in progress (blip) from a given table,

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -209,18 +209,12 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
     }
 
     @Override
-    public void processCandidates() throws TableNotFoundException, IOException {
-
-      Iterator<String> candidates = getContext().getAmple().getGcCandidates(level);
-
-      while (candidates.hasNext()) {
-        List<String> candidatesBatch = readCandidatesThatFitInMemory(candidates);
-        new GarbageCollectionAlgorithm().collectBatch(this, candidatesBatch);
-      }
-      return;
+    public Iterator<String> getCandidates() throws TableNotFoundException {
+      return getContext().getAmple().getGcCandidates(level);
     }
 
-    private List<String> readCandidatesThatFitInMemory(Iterator<String> candidates) {
+    @Override
+    public List<String> readCandidatesThatFitInMemory(Iterator<String> candidates) {
       long candidateLength = 0;
       // Converting the bytes to approximate number of characters for batch size.
       long candidateBatchSize = getCandidateBatchSize() / 2;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -209,29 +209,35 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
     }
 
     @Override
-    public boolean getCandidates(String continuePoint, List<String> result)
-        throws TableNotFoundException {
+    public void processCandidates() throws TableNotFoundException, IOException {
 
-      Iterator<String> candidates = getContext().getAmple().getGcCandidates(level, continuePoint);
+      Iterator<String> candidates = getContext().getAmple().getGcCandidates(level);
+
+      while (candidates.hasNext()) {
+        List<String> candidatesBatch = readCandidatesThatFitInMemory(candidates);
+        new GarbageCollectionAlgorithm().collectBatch(this, candidatesBatch);
+      }
+      return;
+    }
+
+    private List<String> readCandidatesThatFitInMemory(Iterator<String> candidates) {
       long candidateLength = 0;
       // Converting the bytes to approximate number of characters for batch size.
       long candidateBatchSize = getCandidateBatchSize() / 2;
 
-      result.clear();
+      List<String> candidatesBatch = new ArrayList<>();
 
       while (candidates.hasNext()) {
         String candidate = candidates.next();
         candidateLength += candidate.length();
-        result.add(candidate);
+        candidatesBatch.add(candidate);
         if (candidateLength > candidateBatchSize) {
-          log.info(
-              "Candidate batch of size {} has exceeded the"
-                  + " threshold. Attempting to delete what has been gathered so far.",
-              candidateLength);
-          return true;
+          log.info("Candidate batch of size {} has exceeded the threshold. Attempting to delete "
+              + "what has been gathered so far.", candidateLength);
+          return candidatesBatch;
         }
       }
-      return false;
+      return candidatesBatch;
     }
 
     @Override

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -39,7 +39,6 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +57,8 @@ public class GarbageCollectionTest {
     ArrayList<TableId> tablesDirsToDelete = new ArrayList<>();
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
 
-    @Override public void processCandidates() throws TableNotFoundException, IOException {
+    @Override
+    public void processCandidates() throws TableNotFoundException, IOException {
 
       Iterator<String> candidatesIter = candidates.iterator();
 
@@ -83,26 +83,31 @@ public class GarbageCollectionTest {
       return candidatesBatch;
     }
 
-    @Override public Stream<String> getBlipPaths() {
+    @Override
+    public Stream<String> getBlipPaths() {
       return blips.stream();
     }
 
-    @Override public Stream<Reference> getReferences() {
+    @Override
+    public Stream<Reference> getReferences() {
       return references.values().stream();
     }
 
-    @Override public Set<TableId> getTableIDs() {
+    @Override
+    public Set<TableId> getTableIDs() {
       return tableIds;
     }
 
-    @Override public void delete(SortedMap<String,String> candidateMap) {
+    @Override
+    public void delete(SortedMap<String,String> candidateMap) {
       // These collected deletes will actually be deleted at the end of the collect process.
       // Otherwise, a ConcurrentModificationException is thrown due to the candidates being updated
       // while an active iterator is tracking the candidates list.
       deletes.addAll(candidateMap.values());
     }
 
-    @Override public void deleteTableDirIfEmpty(TableId tableID) {
+    @Override
+    public void deleteTableDirIfEmpty(TableId tableID) {
       tablesDirsToDelete.add(tableID);
     }
 
@@ -123,13 +128,14 @@ public class GarbageCollectionTest {
       references.remove(tableId + ":" + endRow);
     }
 
-    @Override public void incrementCandidatesStat(long i) {
-    }
+    @Override
+    public void incrementCandidatesStat(long i) {}
 
-    @Override public void incrementInUseStat(long i) {
-    }
+    @Override
+    public void incrementInUseStat(long i) {}
 
-    @Override public Iterator<Entry<String,Status>> getReplicationNeededIterator() {
+    @Override
+    public Iterator<Entry<String,Status>> getReplicationNeededIterator() {
       return filesToReplicate.entrySet().iterator();
     }
   }
@@ -145,7 +151,8 @@ public class GarbageCollectionTest {
   // This test was created to help track down a ConcurrentModificationException error that was
   // occurring with the unit tests once the GC was refactored to use a single iterator for the
   // collect process. This was a minimal test case that would cause the exception to occur.
-  @Test public void minimalDelete() throws Exception {
+  @Test
+  public void minimalDelete() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
@@ -163,7 +170,8 @@ public class GarbageCollectionTest {
     assertRemoved(gce, "hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
   }
 
-  @Test public void testBasic() throws Exception {
+  @Test
+  public void testBasic() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
@@ -206,11 +214,12 @@ public class GarbageCollectionTest {
   }
 
   /*
-  Additional test with more candidates. Also, not a multiple of 3 as the test above. Since
-  the unit tests always return 3 candidates in a batch, some edge cases could be missed if
-  that was always the case.
+   * Additional test with more candidates. Also, not a multiple of 3 as the test above. Since the
+   * unit tests always return 3 candidates in a batch, some edge cases could be missed if that was
+   * always the case.
    */
-  @Test public void testBasic2() throws Exception {
+  @Test
+  public void testBasic2() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
@@ -299,7 +308,8 @@ public class GarbageCollectionTest {
         "hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
   }
 
-  @Test public void testRelative() throws Exception {
+  @Test
+  public void testRelative() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/t0/F000.rf");
@@ -353,7 +363,8 @@ public class GarbageCollectionTest {
 
   }
 
-  @Test public void testBlip() throws Exception {
+  @Test
+  public void testBlip() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/b-0");
@@ -392,7 +403,8 @@ public class GarbageCollectionTest {
     assertRemoved(gce);
   }
 
-  @Test public void testDirectories() throws Exception {
+  @Test
+  public void testDirectories() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/t-0");
@@ -455,7 +467,8 @@ public class GarbageCollectionTest {
     assertRemoved(gce);
   }
 
-  @Test public void testCustomDirectories() throws Exception {
+  @Test
+  public void testCustomDirectories() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/t-0");
@@ -535,31 +548,38 @@ public class GarbageCollectionTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class) public void testBadFileRef1() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadFileRef1() {
     badRefTest("/F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class) public void testBadFileRef2() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadFileRef2() {
     badRefTest("../F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class) public void testBadFileRef3() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadFileRef3() {
     badRefTest("hdfs://foo.com:6000/accumulo/F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class) public void testBadFileRef4() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadFileRef4() {
     badRefTest("hdfs://foo.com:6000/accumulo/tbls/5/F00.rf");
   }
 
-  @Test(expected = RuntimeException.class) public void testBadFileRef5() {
+  @Test(expected = RuntimeException.class)
+  public void testBadFileRef5() {
     badRefTest("F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class) public void testBadFileRef6() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testBadFileRef6() {
     badRefTest("/accumulo/tbls/5/F00.rf");
   }
 
-  @Test public void testBadDeletes() throws Exception {
+  @Test
+  public void testBadDeletes() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -581,7 +601,8 @@ public class GarbageCollectionTest {
     assertRemoved(gce);
   }
 
-  @Test public void test() throws Exception {
+  @Test
+  public void test() throws Exception {
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
@@ -629,7 +650,8 @@ public class GarbageCollectionTest {
 
   }
 
-  @Test public void testDeleteTableDir() throws Exception {
+  @Test
+  public void testDeleteTableDir() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -655,7 +677,8 @@ public class GarbageCollectionTest {
 
   }
 
-  @Test public void finishedReplicationRecordsDontPreventDeletion() throws Exception {
+  @Test
+  public void finishedReplicationRecordsDontPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -673,7 +696,8 @@ public class GarbageCollectionTest {
     assertEquals(2, gce.deletes.size());
   }
 
-  @Test public void openReplicationRecordsPreventDeletion() throws Exception {
+  @Test
+  public void openReplicationRecordsPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -692,7 +716,8 @@ public class GarbageCollectionTest {
     assertEquals("hdfs://foo.com:6000/accumulo/tables/2/t-00002/A000002.rf", gce.deletes.get(0));
   }
 
-  @Test public void newReplicationRecordsPreventDeletion() throws Exception {
+  @Test
+  public void newReplicationRecordsPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -711,7 +736,8 @@ public class GarbageCollectionTest {
     assertEquals("hdfs://foo.com:6000/accumulo/tables/2/t-00002/A000002.rf", gce.deletes.get(0));
   }
 
-  @Test public void bulkImportReplicationRecordsPreventDeletion() throws Exception {
+  @Test
+  public void bulkImportReplicationRecordsPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -68,7 +68,7 @@ public class GarbageCollectionTest {
       }
       // Remove all candidates that were tagged for deletion now that the processing of
       // candidates is complete for this round. This was removed from the 'delete' method
-      // due to that causing a ConcurrentModificationException. T
+      // due to that causing a ConcurrentModificationException.
       this.candidates.removeAll(deletes);
       return;
     }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.gc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,12 +35,18 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GarbageCollectionTest {
+
+  private static final Logger log = LoggerFactory.getLogger(GarbageCollectionTest.class);
+
   static class TestGCE implements GarbageCollectionEnvironment {
     TreeSet<String> candidates = new TreeSet<>();
     ArrayList<String> blips = new ArrayList<>();
@@ -51,13 +58,29 @@ public class GarbageCollectionTest {
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
 
     @Override
-    public boolean getCandidates(String continuePoint, List<String> ret) {
-      Iterator<String> iter = candidates.tailSet(continuePoint, false).iterator();
-      while (iter.hasNext() && ret.size() < 3) {
-        ret.add(iter.next());
-      }
+    public void processCandidates() throws TableNotFoundException, IOException {
 
-      return ret.size() == 3;
+      Iterator<String> candidatesIter = candidates.iterator();
+
+      while (candidatesIter.hasNext()) {
+        List<String> candidatesBatch = readCandidatesThatFitInMemory(candidatesIter);
+        new GarbageCollectionAlgorithm().collectBatch(this, candidatesBatch);
+      }
+      // Remove all candidates that were tagged for deletion now that the processing of
+      // candidates is complete for this round. This was removed from the 'delete' method
+      // due to that causing a ConcurrentModificationException. T
+      this.candidates.removeAll(deletes);
+      return;
+    }
+
+    private List<String> readCandidatesThatFitInMemory(Iterator<String> candidatesIter) {
+      List<String> candidatesBatch = new ArrayList<>();
+      candidatesBatch.clear();
+
+      while (candidatesIter.hasNext() && candidatesBatch.size() < 3) {
+        candidatesBatch.add(candidatesIter.next());
+      }
+      return candidatesBatch;
     }
 
     @Override
@@ -77,8 +100,10 @@ public class GarbageCollectionTest {
 
     @Override
     public void delete(SortedMap<String,String> candidateMap) {
+      // These collected deletes will actually be deleted at the end of the collect process.
+      // Otherwise, a ConcurrentModificationException is thrown due to the candidates being updated
+      // while an active iterator is tracking the candidates list.
       deletes.addAll(candidateMap.values());
-      this.candidates.removeAll(candidateMap.values());
     }
 
     @Override
@@ -123,6 +148,28 @@ public class GarbageCollectionTest {
     assertEquals(0, gce.deletes.size());
   }
 
+  // This test was created to help track down a ConcurrentModificationException error that was
+  // occurring with the unit tests once the GC was refactored to use a single iterator for the
+  // collect process. This was a minimal test case that would cause the exception to occur.
+  @Test
+  public void minimalDelete() throws Exception {
+    TestGCE gce = new TestGCE();
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/6/t0/F006.rf");
+
+    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    gce.addFileReference("6", null, "hdfs://foo.com:6000/accumulo/tables/6/t0/F006.rf");
+
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+    gca.collect(gce);
+
+    assertRemoved(gce, "hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+  }
+
   @Test
   public void testBasic() throws Exception {
     TestGCE gce = new TestGCE();
@@ -164,6 +211,101 @@ public class GarbageCollectionTest {
     assertRemoved(gce, "hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf",
         "hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
 
+  }
+
+  /*
+  Additional test with more candidates. Also, not a multiple of 3 as the test above. Since
+  the unit tests always return 3 candidates in a batch, some edge cases could be missed if
+  that was always the case.
+   */
+  @Test
+  public void testBasic2() throws Exception {
+    TestGCE gce = new TestGCE();
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/5/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/5/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/6/t1/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/6/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/6/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/7/t0/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/7/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/7/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/8/t0/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/8/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/8/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/9/t0/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/9/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/9/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/10/t0/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/10/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/10/t0/F001.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/11/t0/F005.rf");
+
+    gce.candidates.add("hdfs://foo:6000/accumulo/tables/11/t0/F000.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/11/t0/F001.rf");
+
+    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gce.addFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gce.addFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0//F002.rf");
+    gce.addFileReference("5", null, "hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
+
+    GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
+
+    gca.collect(gce);
+    // items to be removed from candidates
+    String[] toBeRemoved = {"hdfs://foo.com:6000/accumulo/tables/5/t0/F001.rf",
+        "hdfs://foo:6000/accumulo/tables/5/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/6/t1/F005.rf",
+        "hdfs://foo:6000/accumulo/tables/6/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/6/t0/F001.rf",
+        "hdfs://foo.com:6000/accumulo/tables/7/t0/F005.rf",
+        "hdfs://foo:6000/accumulo/tables/7/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/7/t0/F001.rf",
+        "hdfs://foo.com:6000/accumulo/tables/8/t0/F005.rf",
+        "hdfs://foo:6000/accumulo/tables/8/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/8/t0/F001.rf",
+        "hdfs://foo.com:6000/accumulo/tables/9/t0/F005.rf",
+        "hdfs://foo:6000/accumulo/tables/9/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/9/t0/F001.rf",
+        "hdfs://foo.com:6000/accumulo/tables/10/t0/F005.rf",
+        "hdfs://foo:6000/accumulo/tables/10/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/10/t0/F001.rf",
+        "hdfs://foo.com:6000/accumulo/tables/11/t0/F005.rf",
+        "hdfs://foo:6000/accumulo/tables/11/t0/F000.rf",
+        "hdfs://foo.com:6000/accumulo/tables/11/t0/F001.rf"};
+    assertRemoved(gce, toBeRemoved);
+
+    // Remove the reference to this flush file, run the GC which should not trim it from the
+    // candidates, and assert that it's gone
+    gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F000.rf");
+    gca.collect(gce);
+    assertRemoved(gce, "hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
+
+    // Removing a reference to a file that wasn't in the candidates should do nothing
+    gce.removeFileReference("4", null, "hdfs://foo.com:6000/accumulo/tables/4/t0/F002.rf");
+    gca.collect(gce);
+    assertRemoved(gce);
+
+    // Remove the reference to a file in the candidates should cause it to be removed
+    gce.removeFileReference("4", null, "hdfs://foo:6000/accumulo/tables/4/t0/F001.rf");
+    gca.collect(gce);
+    assertRemoved(gce, "hdfs://foo.com:6000/accumulo/tables/4/t0/F001.rf");
+
+    // Adding more candidates which do no have references should be removed
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf");
+    gce.candidates.add("hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
+    gca.collect(gce);
+    assertRemoved(gce, "hdfs://foo.com:6000/accumulo/tables/4/t0/F003.rf",
+        "hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
   }
 
   @Test

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,8 +58,7 @@ public class GarbageCollectionTest {
     ArrayList<TableId> tablesDirsToDelete = new ArrayList<>();
     TreeMap<String,Status> filesToReplicate = new TreeMap<>();
 
-    @Override
-    public void processCandidates() throws TableNotFoundException, IOException {
+    @Override public void processCandidates() throws TableNotFoundException, IOException {
 
       Iterator<String> candidatesIter = candidates.iterator();
 
@@ -83,31 +83,26 @@ public class GarbageCollectionTest {
       return candidatesBatch;
     }
 
-    @Override
-    public Stream<String> getBlipPaths() {
+    @Override public Stream<String> getBlipPaths() {
       return blips.stream();
     }
 
-    @Override
-    public Stream<Reference> getReferences() {
+    @Override public Stream<Reference> getReferences() {
       return references.values().stream();
     }
 
-    @Override
-    public Set<TableId> getTableIDs() {
+    @Override public Set<TableId> getTableIDs() {
       return tableIds;
     }
 
-    @Override
-    public void delete(SortedMap<String,String> candidateMap) {
+    @Override public void delete(SortedMap<String,String> candidateMap) {
       // These collected deletes will actually be deleted at the end of the collect process.
       // Otherwise, a ConcurrentModificationException is thrown due to the candidates being updated
       // while an active iterator is tracking the candidates list.
       deletes.addAll(candidateMap.values());
     }
 
-    @Override
-    public void deleteTableDirIfEmpty(TableId tableID) {
+    @Override public void deleteTableDirIfEmpty(TableId tableID) {
       tablesDirsToDelete.add(tableID);
     }
 
@@ -128,14 +123,13 @@ public class GarbageCollectionTest {
       references.remove(tableId + ":" + endRow);
     }
 
-    @Override
-    public void incrementCandidatesStat(long i) {}
+    @Override public void incrementCandidatesStat(long i) {
+    }
 
-    @Override
-    public void incrementInUseStat(long i) {}
+    @Override public void incrementInUseStat(long i) {
+    }
 
-    @Override
-    public Iterator<Entry<String,Status>> getReplicationNeededIterator() {
+    @Override public Iterator<Entry<String,Status>> getReplicationNeededIterator() {
       return filesToReplicate.entrySet().iterator();
     }
   }
@@ -151,8 +145,7 @@ public class GarbageCollectionTest {
   // This test was created to help track down a ConcurrentModificationException error that was
   // occurring with the unit tests once the GC was refactored to use a single iterator for the
   // collect process. This was a minimal test case that would cause the exception to occur.
-  @Test
-  public void minimalDelete() throws Exception {
+  @Test public void minimalDelete() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
@@ -170,8 +163,7 @@ public class GarbageCollectionTest {
     assertRemoved(gce, "hdfs://foo.com:6000/accumulo/tables/5/t0/F005.rf");
   }
 
-  @Test
-  public void testBasic() throws Exception {
+  @Test public void testBasic() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
@@ -218,8 +210,7 @@ public class GarbageCollectionTest {
   the unit tests always return 3 candidates in a batch, some edge cases could be missed if
   that was always the case.
    */
-  @Test
-  public void testBasic2() throws Exception {
+  @Test public void testBasic2() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("hdfs://foo:6000/accumulo/tables/4/t0/F000.rf");
@@ -308,8 +299,7 @@ public class GarbageCollectionTest {
         "hdfs://foo.com:6000/accumulo/tables/4/t0/F004.rf");
   }
 
-  @Test
-  public void testRelative() throws Exception {
+  @Test public void testRelative() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/t0/F000.rf");
@@ -363,8 +353,7 @@ public class GarbageCollectionTest {
 
   }
 
-  @Test
-  public void testBlip() throws Exception {
+  @Test public void testBlip() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/b-0");
@@ -403,8 +392,7 @@ public class GarbageCollectionTest {
     assertRemoved(gce);
   }
 
-  @Test
-  public void testDirectories() throws Exception {
+  @Test public void testDirectories() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/t-0");
@@ -467,8 +455,7 @@ public class GarbageCollectionTest {
     assertRemoved(gce);
   }
 
-  @Test
-  public void testCustomDirectories() throws Exception {
+  @Test public void testCustomDirectories() throws Exception {
     TestGCE gce = new TestGCE();
 
     gce.candidates.add("/4/t-0");
@@ -548,38 +535,31 @@ public class GarbageCollectionTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadFileRef1() {
+  @Test(expected = IllegalArgumentException.class) public void testBadFileRef1() {
     badRefTest("/F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadFileRef2() {
+  @Test(expected = IllegalArgumentException.class) public void testBadFileRef2() {
     badRefTest("../F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadFileRef3() {
+  @Test(expected = IllegalArgumentException.class) public void testBadFileRef3() {
     badRefTest("hdfs://foo.com:6000/accumulo/F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadFileRef4() {
+  @Test(expected = IllegalArgumentException.class) public void testBadFileRef4() {
     badRefTest("hdfs://foo.com:6000/accumulo/tbls/5/F00.rf");
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testBadFileRef5() {
+  @Test(expected = RuntimeException.class) public void testBadFileRef5() {
     badRefTest("F00.rf");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testBadFileRef6() {
+  @Test(expected = IllegalArgumentException.class) public void testBadFileRef6() {
     badRefTest("/accumulo/tbls/5/F00.rf");
   }
 
-  @Test
-  public void testBadDeletes() throws Exception {
+  @Test public void testBadDeletes() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -601,8 +581,7 @@ public class GarbageCollectionTest {
     assertRemoved(gce);
   }
 
-  @Test
-  public void test() throws Exception {
+  @Test public void test() throws Exception {
 
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
@@ -650,8 +629,7 @@ public class GarbageCollectionTest {
 
   }
 
-  @Test
-  public void testDeleteTableDir() throws Exception {
+  @Test public void testDeleteTableDir() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -677,8 +655,7 @@ public class GarbageCollectionTest {
 
   }
 
-  @Test
-  public void finishedReplicationRecordsDontPreventDeletion() throws Exception {
+  @Test public void finishedReplicationRecordsDontPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -696,8 +673,7 @@ public class GarbageCollectionTest {
     assertEquals(2, gce.deletes.size());
   }
 
-  @Test
-  public void openReplicationRecordsPreventDeletion() throws Exception {
+  @Test public void openReplicationRecordsPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -716,8 +692,7 @@ public class GarbageCollectionTest {
     assertEquals("hdfs://foo.com:6000/accumulo/tables/2/t-00002/A000002.rf", gce.deletes.get(0));
   }
 
-  @Test
-  public void newReplicationRecordsPreventDeletion() throws Exception {
+  @Test public void newReplicationRecordsPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();
@@ -736,8 +711,7 @@ public class GarbageCollectionTest {
     assertEquals("hdfs://foo.com:6000/accumulo/tables/2/t-00002/A000002.rf", gce.deletes.get(0));
   }
 
-  @Test
-  public void bulkImportReplicationRecordsPreventDeletion() throws Exception {
+  @Test public void bulkImportReplicationRecordsPreventDeletion() throws Exception {
     GarbageCollectionAlgorithm gca = new GarbageCollectionAlgorithm();
 
     TestGCE gce = new TestGCE();

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -90,6 +90,9 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
     cfg.setProperty(Property.GC_PORT, "0");
     cfg.setProperty(Property.TSERV_MAXMEM, "5K");
     cfg.setProperty(Property.TSERV_MAJC_DELAY, "1");
+    // reduce the batch size significantly in order to cause the integration tests to have
+    // to process many batches of deletion candidates.
+    cfg.setProperty(Property.GC_CANDIDATE_BATCH_SIZE, "256K");
 
     // use raw local file system so walogs sync and flush will work
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());


### PR DESCRIPTION
Updated Garbage Collection code to no longer use a continue point when processing deletion candidates. The GC  now uses an iterator that lasts during the lifetime of a GC cycle.

The GarbageCollectionTest was updated to work with the update, as was the GC integration test.

Closes #1351