### PR TITLE
Versioned properties (refactored)

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/EncodingOptions.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/EncodingOptions.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.StringJoiner;
+
+/**
+ * Serialization metadata to allow for evolution of the encoding used for property storage. This
+ * info is expected to be stored first in the serialization and uncompressed so that the handling of
+ * subsequent fields and data can be processed correctly.
+ * <p>
+ * Instances of this class are immutable.
+ */
+public class EncodingOptions {
+
+  public static final EncodingOptions COMPRESSED_V1 =
+      new EncodingOptions(EncodingOptions.EncodingVersion.V1_0, true);
+
+  public static final EncodingOptions UNCOMPRESSED_V1 =
+      new EncodingOptions(EncodingOptions.EncodingVersion.V1_0, false);
+
+  private final EncodingVersion encodingVersion;
+  private final boolean compress;
+
+  public EncodingOptions(EncodingVersion encodingVersion, final boolean compress) {
+    this.encodingVersion = encodingVersion;
+    this.compress = compress;
+  }
+
+  public EncodingOptions(final DataInputStream dis) throws IOException {
+    encodingVersion = EncodingVersion.byId(dis.readInt());
+    compress = dis.readBoolean();
+  }
+
+  public void encode(final DataOutputStream dos) throws IOException {
+    dos.writeInt(encodingVersion.id);
+    dos.writeBoolean(compress);
+  }
+
+  public EncodingVersion getEncodingVersion() {
+    return encodingVersion;
+  }
+
+  public boolean isCompressed() {
+    return compress;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", EncodingOptions.class.getSimpleName() + "[", "]")
+        .add("encodingVersion=" + encodingVersion).toString();
+  }
+
+  /**
+   * Provides a strong typing of the known encoding versions and allows the version id to be encoded
+   * as an integer. Adding an encoding type must be done as as an addition and not change or delete
+   * previous versions to preserve compatibility.
+   */
+  public enum EncodingVersion {
+
+    INVALID(-1), V1_0(1);
+
+    // a unique id to identify the version
+    public final Integer id;
+
+    EncodingVersion(final Integer id) {
+      this.id = id;
+    }
+
+    /**
+     * An integer id for serialization so that version detection / selection on a serialized stream
+     * can be done with an integer comparison instead of string comparison (if name used) and to
+     * provide independence from declaration order (if enum ordinal was used.)
+     *
+     * @param id
+     *          the id used in serialization
+     * @return the EncodingVersion
+     */
+    static EncodingVersion byId(final Integer id) {
+      switch (id) {
+        case 1:
+          return V1_0;
+        default:
+          return INVALID;
+      }
+    }
+
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/GzipPropEncoding.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/GzipPropEncoding.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Initial property encoding that (optionally) uses gzip to compress the property map. The encoding
+ * version supported is EncodingVersion.V1_0.
+ */
+public class GzipPropEncoding implements PropSerdes {
+
+  private final EncodingOptions encodingOpts;
+
+  public GzipPropEncoding(final EncodingOptions encodingOpts) {
+    this.encodingOpts = encodingOpts;
+  }
+
+  /**
+   * Serialize the versioned properties. The version information on the properties is updated if the
+   * data is successfully serialized.
+   *
+   * @param vProps
+   *          the versioned properties.
+   * @return a byte array with the serialized properties.
+   */
+  @Override
+  public byte[] toBytes(final VersionedProperties vProps) {
+
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos)) {
+
+      // write header - version id, isCompressed
+      encodingOpts.encode(dos);
+
+      // write updated property versioning info (data version, time stamp)
+      vProps.getVersionInfo().encode(dos);
+
+      // write the property map keys, values.
+      if (encodingOpts.isCompressed()) {
+        writeMapCompressed(bos, vProps.getAllProperties());
+      } else {
+        writeMap(dos, vProps.getAllProperties());
+      }
+
+      dos.flush();
+
+      return bos.toByteArray();
+
+    } catch (IOException ex) {
+      throw new IllegalStateException("Encountered error serializing properties", ex);
+    }
+  }
+
+  @Override
+  public VersionedProperties fromBytes(final byte[] bytes) {
+
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+        DataInputStream dis = new DataInputStream(bis)) {
+
+      // read header - version and isCompressed.
+      EncodingOptions opts = new EncodingOptions(dis);
+
+      // read property versioning info (data version, time stamp)
+      VersionInfo info = readVersionInfo(dis);
+
+      // read the property map keys, values
+      Map<String,String> aMap;
+      if (opts.isCompressed()) {
+        aMap = readCompressedMap(bis);
+      } else {
+        aMap = readMap(dis);
+      }
+
+      return new VersionedPropertiesImpl(info, aMap);
+
+    } catch (IOException ex) {
+      throw new UncheckedIOException("Encountered error deserializing properties", ex);
+    }
+  }
+
+  private VersionInfo readVersionInfo(DataInputStream dis) throws IOException {
+    return new VersionInfo(dis);
+  }
+
+  private Map<String,String> readCompressedMap(ByteArrayInputStream bis) throws IOException {
+
+    try (GZIPInputStream gzipIn = new GZIPInputStream(bis);
+        DataInputStream dis = new DataInputStream(gzipIn)) {
+      return readMap(dis);
+    }
+  }
+
+  private Map<String,String> readMap(DataInputStream dis) throws IOException {
+
+    Map<String,String> aMap = new HashMap<>();
+    int items = dis.readInt();
+
+    for (int i = 0; i < items; i++) {
+      Map.Entry<String,String> e = readKV(dis);
+      aMap.put(e.getKey(), e.getValue());
+    }
+    return aMap;
+  }
+
+  private void writeMapCompressed(final ByteArrayOutputStream bos, final Map<String,String> aMap)
+      throws IOException {
+
+    try (GZIPOutputStream gzipOut = new GZIPOutputStream(bos);
+        DataOutputStream dos = new DataOutputStream(gzipOut)) {
+
+      writeMap(dos, aMap);
+
+      gzipOut.flush();
+      gzipOut.finish();
+
+    } catch (IOException ex) {
+      throw new IOException("Encountered error compressing properties", ex);
+    }
+  }
+
+  private void writeMap(final DataOutputStream dos, final Map<String,String> aMap)
+      throws IOException {
+
+    dos.writeInt(aMap.size());
+
+    aMap.forEach((k, v) -> writeKV(k, v, dos));
+
+    dos.flush();
+  }
+
+  private void writeKV(final String k, final String v, final DataOutputStream dos) {
+    try {
+      dos.writeUTF(k);
+      dos.writeUTF(v);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(
+          String.format("Exception encountered writing props k:'%s', v:'%s", k, v), ex);
+    }
+  }
+
+  private Map.Entry<String,String> readKV(final DataInputStream dis) throws IOException {
+    String k = dis.readUTF();
+    String v = dis.readUTF();
+    return new AbstractMap.SimpleEntry<>(k, v);
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropSerdes.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropSerdes.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+/**
+ * Serialize / Deserialize versioned properties into a byte array.
+ */
+public interface PropSerdes {
+
+  /**
+   * Serialize the versioned properties into a byte array.
+   *
+   * @param versionedProps
+   *          the versioned properties.
+   * @return a byte array.
+   */
+  byte[] toBytes(VersionedProperties versionedProps);
+
+  /**
+   * Deserialize a byte array amd create an instance of versioned properties.
+   *
+   * @param bytes
+   *          a byte array of previously serialized versioned properties.
+   * @return an instance of versioned properties.
+   */
+  VersionedProperties fromBytes(byte[] bytes);
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropSerdesEncoderFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/PropSerdesEncoderFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+/**
+ * Create an serialization / deserialization encoder based on serialization version and additional
+ * information used in the serialization process.
+ */
+public class PropSerdesEncoderFactory {
+
+  private final PropSerdes serdes;
+
+  public PropSerdesEncoderFactory(final EncodingOptions encodingOptions) {
+
+    // currently only one version supported - this would need to be extended to support others.
+    if (encodingOptions.getEncodingVersion().equals(EncodingOptions.EncodingVersion.V1_0)) {
+      serdes = new GzipPropEncoding(encodingOptions);
+    } else {
+      throw new IllegalArgumentException("Unsupported encoding options " + encodingOptions);
+    }
+
+  }
+
+  /**
+   * Get the serialization / deserialization encoder created.
+   *
+   * @return a serialization / deserialization encoder.
+   */
+  public PropSerdes getSerdes() {
+    return serdes;
+  }
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionInfo.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Serialization metadata used to verify cached values match stored values. Storing the metadata
+ * with the properties allows for comparison of properties and can be used to ensure that vales
+ * being written to the backend store have not changed. This metadata should be written / appear
+ * early in the encoded bytes and be uncompressed so that decisions can be made that may make
+ * deserialization unnecessary.
+ * <p>
+ * Note: Avoid using -1 because that has significance in ZooKeeper - writing a ZooKeeper node with a
+ * version of -1 disables the ZooKeeper expected version checking and just overwrites the node.
+ * <p>
+ * Instances of this class are immutable.
+ */
+public class VersionInfo {
+
+  // flag value for initialization - on store the version will be 0.
+  public static final int NO_VERSION = -2;
+
+  private static final DateTimeFormatter tsFormatter =
+      DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
+
+  private final int dataVersion;
+  private final Instant timestamp;
+
+  /**
+   * Instantiate an instance with the provided version and timestamp.
+   *
+   * @param dataVersion
+   *          the data version used for comparisons with the ZooKeeper node version or
+   *          {@link #NO_VERSION} if it has not yet been committed to the backend store.
+   * @param timestamp
+   *          the timestamp this version was created or updated.
+   */
+  private VersionInfo(final int dataVersion, final Instant timestamp) {
+    this.dataVersion = dataVersion;
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Instantiate an instance reading from a {@link java.io.DataInputStream}. Normally the underlying
+   * data stream would be read from ZooKeeper.
+   *
+   * @param dis
+   *          a {@link java.io.DataInputStream}
+   * @throws IOException
+   *           if an exception occurs reading from the input stream
+   */
+  public VersionInfo(final DataInputStream dis) throws IOException {
+    dataVersion = dis.readInt();
+    timestamp = tsFormatter.parse(dis.readUTF(), Instant::from);
+  }
+
+  /**
+   * Get the current data version. The version should match the node version of the stored data.
+   * This value returned should be used on data writes as the expected version. If the data write
+   * fails do to unexpected version, it signals that the node version has changed.
+   *
+   * @return 0 for initial version, otherwise the data version when the properties were serialized.
+   */
+  public int getDataVersion() {
+    return Math.max(dataVersion, 0);
+  }
+
+  /**
+   * Calculates the version that should be stored when serialized. The serialized version, when
+   * stored, should match the version that will be assigned. This way, data reading the serialized
+   * version can compare the stored version with the node version at any time to detect if the node
+   * version has been updated.
+   * <p>
+   * The initialization of the data version to a negative value allows this value to be calculated
+   * correctly for the first serialization. On the first store, the expected version will be 0.
+   *
+   * @return the next version number that should be serialized, or 0 if this is the initial version.
+   */
+  public int getNextVersion() {
+    return Math.max(dataVersion + 1, 0);
+  }
+
+  /**
+   * Properties are timestamped when the properties are serialized for storage. This is to allow
+   * easy comparison of properties that could have been retrieved at different times.
+   *
+   * @return the timestamp when the properties were serialized.
+   */
+  public Instant getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Get a String formatted version of the timestamp.
+   *
+   * @return the timestamp formatted as an ISO time.
+   */
+  public String getTimestampISO() {
+    return tsFormatter.format(timestamp);
+  }
+
+  /**
+   * Write updated version version info to a {@link java.io.DataOutputStream} the stream is not
+   * closed by this method. The info written has the expected data version and a current timestamp.
+   * The version info of this instance is not modified - only the serialized version.
+   *
+   * @param dos
+   *          a DataOutputStream
+   * @throws IOException
+   *           if an exception occurs writing to the stream.
+   */
+  public void encode(final DataOutputStream dos) throws IOException {
+    dos.writeInt(getNextVersion());
+    dos.writeUTF(tsFormatter.format(Instant.now()));
+  }
+
+  /**
+   * Create a human friendly string useful for debugging that is easier to read than toString.
+   *
+   * @param prettyPrint
+   *          if true separate values with new lines.
+   * @return a formatted string
+   */
+  public String print(boolean prettyPrint) {
+    return "dataVersion=" + getDataVersion() + (prettyPrint ? "\n" : ", ") + "timestamp="
+        + getTimestampISO() + (prettyPrint ? "\n" : ", ");
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", VersionInfo.class.getSimpleName() + "[", "]").add(print(false))
+        .toString();
+  }
+
+  public static class Builder {
+
+    private int dataVersion = NO_VERSION;
+    private Instant timestamp;
+
+    public VersionInfo build() {
+      if (Objects.isNull(timestamp)) {
+        timestamp = Instant.now();
+      }
+      return new VersionInfo(dataVersion, timestamp);
+    }
+
+    public Builder withTimestamp(final Instant timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public Builder withDataVersion(final int dataVersion) {
+      this.dataVersion = dataVersion;
+      return this;
+    }
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedProperties.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedProperties.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface VersionedProperties {
+
+  /**
+   * Add a property. If the property already exists it is overwritten.
+   *
+   * @param key
+   *          the name of the property
+   * @param value
+   *          the value of the property.
+   */
+  void addProperty(String key, String value);
+
+  /**
+   * Add multiple properties. If a property already exists it is overwritten.
+   *
+   * @param properties
+   *          A map of key, value pairs.
+   */
+  void addProperties(Map<String,String> properties);
+
+  /**
+   * Get a stored property or null if it does not exist.
+   *
+   * @param key
+   *          the name of the property.
+   * @return the property value.
+   */
+  String getProperty(String key);
+
+  /**
+   * Get an unmodifiable map with all property, values.
+   *
+   * @return An unmodifiable view of the property key, values.
+   */
+  Map<String,String> getAllProperties();
+
+  /**
+   * Delete a property.
+   *
+   * @param key
+   *          the name of the property.
+   * @return the previous value if the property was present.
+   */
+  String removeProperty(String key);
+
+  /**
+   * Delete multiple properties provided as a collection of keys.
+   *
+   * @param keys
+   *          a collection of keys
+   * @return the number of properties actually removed.
+   */
+  int removeProperties(Collection<String> keys);
+
+  /**
+   * Get the versioning information for the instance.
+   *
+   * @return the versioning information.
+   */
+  VersionInfo getVersionInfo();
+
+  /**
+   * Provide user-friend display string of the version information and the property key / value
+   * pairs.
+   *
+   * @param prettyPrint
+   *          if true, insert new lines to improve readability.
+   * @return a formatted string, with optional new lines.
+   */
+  String print(boolean prettyPrint);
+
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+
+public class VersionedPropertiesImpl implements VersionedProperties {
+
+  private final Map<String,String> props;
+  private final VersionInfo versionInfo;
+
+  /**
+   * Instantiate an initial instance with default version info and empty map.
+   */
+  public VersionedPropertiesImpl() {
+    this(new VersionInfo.Builder().build(), new HashMap<>());
+  }
+
+  /**
+   * Instantiate an initial instance with default version info and provided property map.
+   *
+   * @param props
+   *          optional map of initial property key, value pairs. The properties are assumed to have
+   *          been previously validated (if required)
+   */
+  public VersionedPropertiesImpl(final Map<String,String> props) {
+    this(new VersionInfo.Builder().build(), props);
+  }
+
+  /**
+   * Instantiate an instance with empty properties and provided version info
+   *
+   * @param versionInfo
+   *          version info with data version and timestamp.
+   */
+  public VersionedPropertiesImpl(final VersionInfo versionInfo) {
+    this(versionInfo, new HashMap<>());
+  }
+
+  /**
+   * Instantiate an instance and set the initial properties to the provided values.
+   *
+   * @param versionInfo
+   *          version info with data version and timestamp.
+   * @param props
+   *          optional map of initial property key, value pairs. The properties are assumed to have
+   *          been previously validated (if required)
+   */
+  public VersionedPropertiesImpl(final VersionInfo versionInfo, final Map<String,String> props) {
+
+    Objects.requireNonNull(props, "Initial properties map cannot be null");
+    this.versionInfo = versionInfo;
+    this.props = new HashMap<>(props);
+
+  }
+
+  @Override
+  public void addProperty(String k, String v) {
+    props.put(k, v);
+  }
+
+  @Override
+  public void addProperties(Map<String,String> properties) {
+    if (Objects.nonNull(properties)) {
+      props.putAll(properties);
+    }
+  }
+
+  @Override
+  public String getProperty(final String key) {
+    return props.get(key);
+  }
+
+  @Override
+  public Map<String,String> getAllProperties() {
+    return Collections.unmodifiableMap(props);
+  }
+
+  @Override
+  public String removeProperty(final String key) {
+    return props.remove(key);
+  }
+
+  @Override
+  public int removeProperties(final Collection<String> keys) {
+    int count = 0;
+    for (String k : keys) {
+      if (props.remove(k) != null) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @Override
+  public VersionInfo getVersionInfo() {
+    return versionInfo;
+  }
+
+  @Override
+  public String print(boolean prettyPrint) {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append(versionInfo.print(prettyPrint));
+
+    Map<String,String> sorted = new TreeMap<>(props);
+    sorted.forEach((k, v) -> {
+      if (prettyPrint) {
+        sb.append("  ");
+      }
+      sb.append(k).append("=").append(v);
+      sb.append(prettyPrint ? "\n" : ", ");
+    });
+    return sb.toString();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", VersionedPropertiesImpl.class.getSimpleName() + "[", "]")
+        .add("versionInfo=" + versionInfo).add("props=" + props).toString();
+  }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/PropSerdesEncoderFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/PropSerdesEncoderFactoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import static org.apache.accumulo.server.conf.codec.EncodingOptions.COMPRESSED_V1;
+import static org.apache.accumulo.server.conf.codec.EncodingOptions.UNCOMPRESSED_V1;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PropSerdesEncoderFactoryTest {
+
+  private static final Logger log = LoggerFactory.getLogger(PropSerdesEncoderFactoryTest.class);
+
+  @Test
+  public void roundTripUncompressed() {
+
+    VersionInfo versionInfo = new VersionInfo.Builder().build();
+
+    VersionedProperties vProps = new VersionedPropertiesImpl(versionInfo);
+    vProps.addProperty("k1", "v1");
+
+    PropSerdesEncoderFactory encoderFactory = new PropSerdesEncoderFactory(UNCOMPRESSED_V1);
+
+    byte[] encodedMapBytes = encoderFactory.getSerdes().toBytes(vProps);
+
+    VersionedProperties decodedProps = encoderFactory.getSerdes().fromBytes(encodedMapBytes);
+
+    log.info("Decoded: {}", decodedProps.getAllProperties());
+
+    assertEquals(vProps.getAllProperties(), decodedProps.getAllProperties());
+  }
+
+  @Test
+  public void roundTripCompressed() {
+
+    VersionInfo versionInfo = new VersionInfo.Builder().build();
+
+    VersionedProperties vProps = new VersionedPropertiesImpl(versionInfo);
+    vProps.addProperty("k1", "v1");
+
+    PropSerdesEncoderFactory encoderFactory = new PropSerdesEncoderFactory(COMPRESSED_V1);
+
+    byte[] encodedMapBytes = encoderFactory.getSerdes().toBytes(vProps);
+
+    VersionedProperties decodedProps = encoderFactory.getSerdes().fromBytes(encodedMapBytes);
+
+    log.info("Decoded: {}", decodedProps.getAllProperties());
+
+    assertEquals(vProps.getAllProperties(), decodedProps.getAllProperties());
+  }
+
+  /**
+   * Validate versioning with something other than default.
+   */
+  @Test
+  public void roundTripVersioning() {
+
+    int aVersion = 13;
+
+    VersionInfo versionInfo = new VersionInfo.Builder().withDataVersion(aVersion).build();
+
+    VersionedProperties vProps = new VersionedPropertiesImpl(versionInfo);
+    vProps.addProperty("k1", "v1");
+
+    PropSerdesEncoderFactory encoderFactory = new PropSerdesEncoderFactory(COMPRESSED_V1);
+
+    byte[] encodedMapBytes = encoderFactory.getSerdes().toBytes(vProps);
+
+    VersionedProperties decodedProps = encoderFactory.getSerdes().fromBytes(encodedMapBytes);
+
+    log.info("Decoded: {}", decodedProps.getAllProperties());
+
+    assertEquals(vProps.getAllProperties(), decodedProps.getAllProperties());
+
+    // validate that the expected node version matches original version.
+    assertEquals(aVersion, vProps.getVersionInfo().getDataVersion());
+
+    // validate encoded version incremented.
+    assertEquals(aVersion + 1, decodedProps.getVersionInfo().getDataVersion());
+    assertEquals(vProps.getVersionInfo().getNextVersion(),
+        decodedProps.getVersionInfo().getDataVersion());
+
+  }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionInfoTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+import org.junit.Test;
+
+public class VersionInfoTest {
+
+  @Test
+  public void getInitialDataVersion() {
+    VersionInfo info = new VersionInfo.Builder().build();
+    assertEquals(0, info.getDataVersion());
+
+    // the initial version for write should be 0
+    assertEquals("Initial expected version should be 0", 0, info.getNextVersion());
+  }
+
+  @Test
+  public void getTimestamp() {
+    VersionInfo info = new VersionInfo.Builder().build();
+    assertTrue("timestamp should be now or earlier",
+        info.getTimestamp().compareTo(Instant.now()) <= 0);
+  }
+
+  @Test
+  public void encodeRoundTrip() throws IOException {
+
+    int aDataVersion = 37;
+    Instant now = Instant.now();
+    VersionInfo info =
+        new VersionInfo.Builder().withDataVersion(aDataVersion).withTimestamp(now).build();
+
+    byte[] encoded;
+
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos)) {
+
+      info.encode(dos);
+      dos.flush();
+      encoded = bos.toByteArray();
+    }
+
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(encoded);
+        DataInputStream dis = new DataInputStream(bis)) {
+
+      VersionInfo decoded = new VersionInfo(dis);
+
+      assertEquals(aDataVersion + 1, decoded.getDataVersion());
+
+      // time in serialized version should be after test start time.
+      assertTrue(now.compareTo(decoded.getTimestamp()) <= 0);
+    }
+  }
+
+  @Test
+  public void prettyTest() {
+    VersionInfo info = new VersionInfo.Builder().build();
+    assertFalse(info.toString().contains("\n"));
+    assertTrue(info.print(true).contains("\n"));
+  }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesImplTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.conf.codec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class VersionedPropertiesImplTest {
+
+  @Test
+  public void noProperties() {
+    VersionedProperties vProps = new VersionedPropertiesImpl();
+
+    assertNull(vProps.getProperty("key1"));
+    assertEquals(Collections.emptyMap(), vProps.getAllProperties());
+  }
+
+  @Test
+  public void addProperty() {
+    VersionedProperties vProps = new VersionedPropertiesImpl();
+    vProps.addProperty("key1", "value1");
+    assertEquals("value1", vProps.getProperty("key1"));
+    assertEquals(1, vProps.getAllProperties().size());
+    assertEquals("value1", vProps.getAllProperties().get("key1"));
+  }
+
+  @Test
+  public void addProperties() {
+    VersionedProperties vProps = new VersionedPropertiesImpl();
+    vProps.addProperty("key1", "value1");
+    assertEquals("value1", vProps.getProperty("key1"));
+    assertEquals(1, vProps.getAllProperties().size());
+    assertEquals("value1", vProps.getAllProperties().get("key1"));
+
+    Map<String,String> moreProps = new HashMap<>();
+    moreProps.put("key1", "newValue");
+    moreProps.put("key2", "value2");
+    moreProps.put("key3", "value3");
+    vProps.addProperties(moreProps);
+
+    assertEquals("newValue", vProps.getProperty("key1"));
+    assertEquals("value2", vProps.getProperty("key2"));
+    assertEquals("value3", vProps.getProperty("key3"));
+    assertEquals(3, vProps.getAllProperties().size());
+
+  }
+
+  @Test
+  public void initProperties() {
+    Map<String,String> initProps = new HashMap<>();
+    initProps.put("key1", "value1");
+    initProps.put("key2", "value2");
+    initProps.put("key3", "value3");
+    VersionedProperties vProps = new VersionedPropertiesImpl(initProps);
+
+    vProps.addProperty("key4", "value4");
+
+    assertEquals("value1", vProps.getProperty("key1"));
+    assertEquals("value2", vProps.getProperty("key2"));
+    assertEquals("value3", vProps.getProperty("key3"));
+    assertEquals("value4", vProps.getProperty("key4"));
+
+    assertEquals(4, vProps.getAllProperties().size());
+
+  }
+
+  @Test
+  public void removeProperty() {
+    VersionedProperties vProps = new VersionedPropertiesImpl();
+    vProps.addProperty("key1", "value1");
+    vProps.addProperty("key2", "value2");
+
+    assertEquals("value1", vProps.getProperty("key1"));
+    assertEquals("value2", vProps.getProperty("key2"));
+    assertEquals(2, vProps.getAllProperties().size());
+
+    vProps.removeProperty("key2");
+
+    assertEquals("value1", vProps.getProperty("key1"));
+    assertNull(vProps.getProperty("key2"));
+    assertEquals(1, vProps.getAllProperties().size());
+
+    vProps.addProperty("key2", "value2");
+    vProps.addProperty("key3", "value3");
+    vProps.addProperty("key4", "value4");
+
+    assertEquals("value1", vProps.getProperty("key1"));
+    assertEquals("value2", vProps.getProperty("key2"));
+    assertEquals("value3", vProps.getProperty("key3"));
+    assertEquals("value4", vProps.getProperty("key4"));
+    assertEquals(4, vProps.getAllProperties().size());
+
+    Set<String> keys = new HashSet<>();
+    keys.add("key1");
+    keys.add("key2");
+    keys.add("key3");
+
+    int count = vProps.removeProperties(keys);
+    assertEquals("Expected 3 keys to be removed", 3, count);
+    assertEquals("value4", vProps.getProperty("key4"));
+    assertEquals(1, vProps.getAllProperties().size());
+
+  }
+}


### PR DESCRIPTION
This replaces PR #2194 Refactored to address PR comments

This the first step in moving towards a refactored ZooKeeper property storage. Intended to replace using individual nodes in ZooKeeper to save properties to a versioned group that is stored on a ZooKeeper single node.  The PR contains the changes that provide serialization / deserialization of the properties along with maintaining versioning information.

- Designed to allow evolution of the storage scheme.
- Provides a header that maintains schema version, data version, and timestamp.
- Optional compression of the byte storage array.

