### PR TITLE
Remove unnecessary line in javadoc of TransformingIterator

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -72,8 +72,7 @@ import org.slf4j.LoggerFactory;
  * fetch column families that are known to not transform at all).
  * <p>
  * If the implementing iterator is transforming column visibilities, then users must be careful NOT
- * to fetch column qualifiers from the scanner. The reason for this is due to ACCUMULO-??? (insert
- * issue number).
+ * to fetch column qualifiers from the scanner.
  * <p>
  * If the implementing iterator is transforming column visibilities, then the user should be sure to
  * supply authorizations via the {@link #AUTH_OPT} iterator option (note that this is only necessary


### PR DESCRIPTION
In reference to JIRA ticket: https://issues.apache.org/jira/browse/ACCUMULO-4149

I am not quite sure what JIRA issue the Javadoc was referencing (I tried to investigate but came up empty) but it was also discussed that referencing JIRA issues directly in a Javadoc was unnecessary. Removing the line to clean up the doc but I am open to suggestions if more information should be added to that paragraph. 
