### PR TITLE
Add new property to configure rfile sorted recovery

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -675,6 +675,11 @@ public enum Property {
       "The maximum number of threads to use to sort logs during" + " recovery", "1.5.0"),
   TSERV_SORT_BUFFER_SIZE("tserver.sort.buffer.size", "10%", PropertyType.MEMORY,
       "The amount of memory to use when sorting logs during recovery.", "1.5.0"),
+  TSERV_WAL_SORT_FILE_PREFIX("tserver.wal.sort.file.", null, PropertyType.PREFIX,
+      "The rfile properties to use when sorting logs during recovery. Most of the properties"
+          + " that begin with 'table.file' can be used here. For example, to set the compression"
+          + " of the sorted recovery files to snappy use 'tserver.sort.file.compress.type=snappy'",
+      "2.1.0"),
   TSERV_WORKQ_THREADS("tserver.workq.threads", "2", PropertyType.COUNT,
       "The number of threads for the distributed work queue. These threads are"
           + " used for copying failed bulk import RFiles.",

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -678,7 +678,7 @@ public enum Property {
   TSERV_WAL_SORT_FILE_PREFIX("tserver.wal.sort.file.", null, PropertyType.PREFIX,
       "The rfile properties to use when sorting logs during recovery. Most of the properties"
           + " that begin with 'table.file' can be used here. For example, to set the compression"
-          + " of the sorted recovery files to snappy use 'tserver.sort.file.compress.type=snappy'",
+          + " of the sorted recovery files to snappy use 'tserver.wal.sort.file.compress.type=snappy'",
       "2.1.0"),
   TSERV_WORKQ_THREADS("tserver.workq.threads", "2", PropertyType.COUNT,
       "The number of threads for the distributed work queue. These threads are"

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
@@ -696,7 +696,7 @@ public final class Compression {
     return supportedAlgorithms.toArray(new String[0]);
   }
 
-  static Algorithm getCompressionAlgorithmByName(final String name) {
+  public static Algorithm getCompressionAlgorithmByName(final String name) {
     Algorithm[] algorithms = Algorithm.class.getEnumConstants();
     for (Algorithm algorithm : algorithms) {
       if (algorithm.getName().equals(name)) {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -1118,7 +1118,7 @@ public class SortedLogRecoveryTest {
               createKeyValue(COMPACTION_FINISH, 2, 1, null),
               createKeyValue(COMPACTION_START, 4, 1, "/t1/f1"),
               createKeyValue(COMPACTION_FINISH, 5, 1, null),
-              createKeyValue(MUTATION, 3, 1, ignored), createKeyValue(MUTATION, 5, 1, m),};
+              createKeyValue(MUTATION, 3, 1, ignored), createKeyValue(MUTATION, 5, 1, m)};
       String dest = workdir + "/testLogSortedProperties";
 
       List<Pair<LogFileKey,LogFileValue>> buffer = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -57,6 +57,8 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
 
     // use raw local file system so walogs sync and flush will work
     hadoopCoreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());
+    // test sorted rfile recovery options
+    cfg.setProperty(Property.TSERV_WAL_SORT_FILE_PREFIX + "compress.type", "none");
   }
 
   @Override


### PR DESCRIPTION
* Closes #2187 
* Create new property prefix "tserver.wal.sort.file." to configure the
rfiles written during sorted recovery
* Add method to LogSorter to convert the sort file properties to table
files properties
* Create new tests in SortedLogRecoveryTest
* Make method public in Compression to use in test
* Add property to MultiTableRecoveryIT to allow testing in an IT