### PR TITLE
Rename LogSorter properties to be consistent

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -671,8 +671,16 @@ public enum Property {
       "The replication to use when writing the Write-Ahead log to HDFS. If"
           + " zero, it will use the HDFS default replication setting.",
       "1.5.0"),
+  TSERV_WAL_SORT_MAX_CONCURRENT("tserver.wal.sort.concurrent.max", "2", PropertyType.COUNT,
+      "The maximum number of threads to use to sort logs during recovery", "2.1.0"),
+  @Deprecated(since = "2.1.0")
+  @ReplacedBy(property = Property.TSERV_WAL_SORT_MAX_CONCURRENT)
   TSERV_RECOVERY_MAX_CONCURRENT("tserver.recovery.concurrent.max", "2", PropertyType.COUNT,
-      "The maximum number of threads to use to sort logs during" + " recovery", "1.5.0"),
+      "The maximum number of threads to use to sort logs during recovery", "1.5.0"),
+  TSERV_WAL_SORT_BUFFER_SIZE("tserver.wal.sort.buffer.size", "10%", PropertyType.MEMORY,
+      "The amount of memory to use when sorting logs during recovery.", "2.1.0"),
+  @Deprecated(since = "2.1.0")
+  @ReplacedBy(property = Property.TSERV_WAL_SORT_BUFFER_SIZE)
   TSERV_SORT_BUFFER_SIZE("tserver.sort.buffer.size", "10%", PropertyType.MEMORY,
       "The amount of memory to use when sorting logs during recovery.", "1.5.0"),
   TSERV_WAL_SORT_FILE_PREFIX("tserver.wal.sort.file.", null, PropertyType.PREFIX,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -151,7 +151,10 @@ public class LogSorter {
         return;
       }
 
-      final long bufferSize = sortedLogConf.getAsBytes(Property.TSERV_SORT_BUFFER_SIZE);
+      @SuppressWarnings("deprecation")
+      Property prop = sortedLogConf.resolve(Property.TSERV_WAL_SORT_BUFFER_SIZE,
+          Property.TSERV_SORT_BUFFER_SIZE);
+      final long bufferSize = sortedLogConf.getAsBytes(prop);
       Thread.currentThread().setName("Sorting " + name + " for recovery");
       while (true) {
         final ArrayList<Pair<LogFileKey,LogFileValue>> buffer = new ArrayList<>();
@@ -208,7 +211,9 @@ public class LogSorter {
   public LogSorter(ServerContext context, AccumuloConfiguration conf) {
     this.context = context;
     this.sortedLogConf = extractSortedLogConfig(conf);
-    int threadPoolSize = conf.getCount(Property.TSERV_RECOVERY_MAX_CONCURRENT);
+    @SuppressWarnings("deprecation")
+    int threadPoolSize = conf.getCount(conf.resolve(Property.TSERV_WAL_SORT_MAX_CONCURRENT,
+        Property.TSERV_RECOVERY_MAX_CONCURRENT));
     this.threadPool =
         ThreadPools.createFixedThreadPool(threadPoolSize, this.getClass().getName(), false);
     this.walBlockSize = DfsLogger.getWalBlockSize(conf);


### PR DESCRIPTION
* Create tserver.wal.sort.buffer.size to replace tserver.sort.buffer.size
* Create tserver.wal.sort.concurrent.max to replace tserver.recovery.concurrent.max
* All LogSorter properties now start with tserver.wal.sort