### PR TITLE
Rename new Class loader variable to contextName

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/common/ContextClassLoaderFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/common/ContextClassLoaderFactory.java
@@ -46,16 +46,16 @@ package org.apache.accumulo.core.spi.common;
 public interface ContextClassLoaderFactory {
 
   /**
-   * Get the class loader for the given context. Callers should not cache the ClassLoader result as
-   * it may change if/when the ClassLoader reloads. Implementations should throw a RuntimeException
-   * of some type (such as IllegalArgumentException) if the provided context is not supported or
-   * fails to be constructed.
+   * Get the class loader for the given contextName. Callers should not cache the ClassLoader result
+   * as it may change if/when the ClassLoader reloads. Implementations should throw a
+   * RuntimeException of some type (such as IllegalArgumentException) if the provided contextName is
+   * not supported or fails to be constructed.
    *
-   * @param context
-   *          the context that represents a class loader that is managed by this factory (can be
-   *          null)
-   * @return the class loader for the given context
+   * @param contextName
+   *          the name of the context that represents a class loader that is managed by this factory
+   *          (can be null)
+   * @return the class loader for the given contextName
    */
-  ClassLoader getClassLoader(String context);
+  ClassLoader getClassLoader(String contextName);
 
 }

--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -414,12 +414,12 @@ public class AccumuloVFSClassLoader {
     }
   }
 
-  public static ClassLoader getContextClassLoader(String context) {
+  public static ClassLoader getContextClassLoader(String contextName) {
     try {
-      return getContextManager().getClassLoader(context);
+      return getContextManager().getClassLoader(contextName);
     } catch (IOException e) {
-      throw new UncheckedIOException("Error getting context class loader for context: " + context,
-          e);
+      throw new UncheckedIOException(
+          "Error getting context class loader for context: " + contextName, e);
     }
   }
 


### PR DESCRIPTION
* Rename new class loader variable from context to contextName to avoid
confusion with other types of context objects