### PR TITLE
Make Compactable File use copy of runningJobs 

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/Compactable.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/Compactable.java
@@ -19,19 +19,27 @@
 package org.apache.accumulo.tserver.compactions;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.CompactableFileImpl;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.spi.compaction.CompactionServiceId;
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
+
+import com.google.common.base.Preconditions;
 
 /**
  * Interface between compaction service and tablet.
@@ -45,16 +53,33 @@ public interface Compactable {
     public final Collection<CompactionJob> compacting;
     public final Map<String,String> executionHints;
 
-    public Files(Set<CompactableFile> allFiles, Set<CompactableFile> candidates,
-        Collection<CompactionJob> runningJobsCopy) {
+    public Files(SortedMap<StoredTabletFile,DataFileValue> allFiles,
+        Set<StoredTabletFile> candidates, Collection<CompactionJob> runningJobsCopy) {
       this(allFiles, candidates, runningJobsCopy, Map.of());
     }
 
-    public Files(Set<CompactableFile> allFiles, Set<CompactableFile> candidates,
-        Collection<CompactionJob> runningJobsCopy, Map<String,String> executionHints) {
-      this.allFiles = allFiles;
-      this.candidates = candidates;
+    public Files(SortedMap<StoredTabletFile,DataFileValue> allFiles,
+        Set<StoredTabletFile> candidates, Collection<CompactionJob> runningJobsCopy,
+        Map<String,String> executionHints) {
+
+      this.allFiles = Collections.unmodifiableSet(allFiles.entrySet().stream()
+          .map(entry -> new CompactableFileImpl(entry.getKey(), entry.getValue()))
+          .collect(Collectors.toSet()));
+      this.candidates = Collections.unmodifiableSet(candidates.stream()
+          .map(stf -> new CompactableFileImpl(stf, allFiles.get(stf))).collect(Collectors.toSet()));
+
       this.compacting = runningJobsCopy;
+
+      // Do some sanity checks on sets of files
+      Preconditions.checkArgument(this.allFiles.containsAll(this.candidates),
+          "Candidates not in set of all files %s %s", this.allFiles, this.candidates);
+      var compactingFiles =
+          compacting.stream().flatMap(job -> job.getFiles().stream()).collect(Collectors.toSet());
+      Preconditions.checkArgument(this.allFiles.containsAll(compactingFiles),
+          "Compacting files %s not in set of all files: %s", compactingFiles, this.allFiles);
+      Preconditions.checkArgument(Collections.disjoint(compactingFiles, this.candidates),
+          "Compacting and candidates overlap %s %s", compactingFiles, this.candidates);
+
       this.executionHints = executionHints;
     }
 
@@ -63,6 +88,7 @@ public interface Compactable {
       return "Files [allFiles=" + allFiles + ", candidates=" + candidates + ", compacting="
           + compacting + ", hints=" + executionHints + "]";
     }
+
   }
 
   TableId getTableId();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.tserver.tablet;
 
-import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.apache.accumulo.tserver.TabletStatsKeeper.Operation.MAJOR;
 
 import java.io.IOException;
@@ -997,38 +996,16 @@ public class CompactableImpl implements Compactable {
       if (closed)
         return Optional.empty();
 
-      var jobsCopy = Set.copyOf(runningJobs);
+      var runningJobsCopy = Set.copyOf(runningJobs);
 
       Set<StoredTabletFile> candidates = fileMgr.getCandidates(
           Collections.unmodifiableSet(files.keySet()), kind, isCompactionStratConfigured());
 
-      // Do some sanity checks on sets of files
-      Set<CompactableFile> allFiles = files.entrySet().stream()
-          .map(entry -> new CompactableFileImpl(entry.getKey(), entry.getValue()))
-          .collect(toUnmodifiableSet());
-      Set<CompactableFile> candidateFiles = candidates.stream()
-          .map(stf -> new CompactableFileImpl(stf, files.get(stf))).collect(toUnmodifiableSet());
-      Set<CompactableFile> compactingFiles =
-          jobsCopy.stream().flatMap(job -> job.getFiles().stream()).collect(Collectors.toSet());
-
-      if (!allFiles.containsAll(candidateFiles)) {
-        log.debug("Candidates {} not in set of all files {}", candidateFiles, allFiles);
-        return Optional.empty();
-      }
-      if (!allFiles.containsAll(compactingFiles)) {
-        log.debug("Compacting files {} not in set of all files: {}", compactingFiles, allFiles);
-        return Optional.empty();
-      }
-      if (!Collections.disjoint(compactingFiles, candidateFiles)) {
-        log.debug("Compacting {} and candidates overlap {}", compactingFiles, candidateFiles);
-        return Optional.empty();
-      }
-
       if (kind == CompactionKind.USER && !candidates.isEmpty()) {
         Map<String,String> hints = compactionConfig.getExecutionHints();
-        return Optional.of(new Compactable.Files(allFiles, candidateFiles, jobsCopy, hints));
+        return Optional.of(new Compactable.Files(files, candidates, runningJobsCopy, hints));
       } else {
-        return Optional.of(new Compactable.Files(allFiles, candidateFiles, jobsCopy));
+        return Optional.of(new Compactable.Files(files, candidates, runningJobsCopy));
       }
     }
   }


### PR DESCRIPTION
* Only make one copy of the runningJobs and pass it to Files constructor

~~* Move file checks outside of constructor of Files object and make them
log and return instead of throwing exceptions~~
~~* Threads were being killed quite frequently because they fail file
checks on seemingly common occurrences~~
~~* Closes #2239~~

Edit: revert changes that aren't fixed with #2252 