### PR TITLE
fixes #2239 fixed bug in gathering compaction candidates

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1001,7 +1001,9 @@ public class CompactableImpl implements Compactable {
       Set<StoredTabletFile> candidates = fileMgr.getCandidates(
           Collections.unmodifiableSet(files.keySet()), kind, isCompactionStratConfigured());
 
-      if (kind == CompactionKind.USER && !candidates.isEmpty()) {
+      if (candidates.isEmpty()) {
+        return Optional.empty();
+      } else if (kind == CompactionKind.USER) {
         Map<String,String> hints = compactionConfig.getExecutionHints();
         return Optional.of(new Compactable.Files(files, candidates, runningJobsCopy, hints));
       } else {


### PR DESCRIPTION
For the refactoring done in #2213, the semantics of the following code that existed prior to the change were not properly translated.

https://github.com/apache/accumulo/blob/146b1d3d0dc2ade6f1888c9905d83e37d98aedbe/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java#L665-L671

This caused the exceptions in #2239.  This PR reintroduces the above semantics.