### PR TITLE
Prevents compaction when tablet does not know of files

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -1110,6 +1110,18 @@ public class CompactableImpl implements Compactable {
       cInfo.localCompactionCfg = this.compactionConfig;
     }
 
+    // Check to ensure the tablet actually has these files now that they are reserved. Compaction
+    // jobs are queued for some period of time and then they try to run. Things could change while
+    // they are queued. This check ensures that the files a job is reserving still exists in the
+    // tablet. Without this check the compaction could run and then fail to commit on the tablet.
+    // The tablet and this class have separate locks that should not be held at the same time. This
+    // check is done after the file are exclusively reserved in this class to avoid race conditions.
+    if (!tablet.getDatafiles().keySet().containsAll(cInfo.jobFiles)) {
+      // The tablet does not know of all these files, so unreserve them.
+      completeCompaction(job, cInfo.jobFiles, null);
+      return Optional.empty();
+    }
+
     return Optional.of(cInfo);
   }
 


### PR DESCRIPTION
I noticed when looking into #2239 that when a compaction job starts and reserves files that there is no check to ensure the tablet still has those files.  I think this race condition is unlikely to occur, but not impossible.  This PR add a check for this.  This check prevents unnecessary work from occurring.  The code is correct without the check in that it would currently fail after the compaction runs if this situation were to occur.