### PR TITLE
Split compact method into two more specific methods

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactableFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/compaction/CompactableFile.java
@@ -23,6 +23,8 @@ import java.net.URI;
 import org.apache.accumulo.core.metadata.CompactableFileImpl;
 
 /**
+ * A single file ready to compact, that will come in a set of possible candidates.
+ *
  * @since 2.1.0
  */
 public interface CompactableFile {

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.spi.compaction;
 
 import java.util.Collection;
+import java.util.Set;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.spi.compaction.CompactionPlanner.PlanningParameters;
@@ -55,5 +56,13 @@ public interface CompactionPlan {
     CompactionPlan build();
   }
 
+  /**
+   * Return the set of compaction candidates.
+   */
+  Set<CompactableFile> getCandidates();
+
+  /**
+   * Return the set of jobs this plan will submit for compaction.
+   */
   Collection<CompactionJob> getJobs();
 }

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlan.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.spi.compaction;
 
 import java.util.Collection;
-import java.util.Set;
 
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.spi.compaction.CompactionPlanner.PlanningParameters;
@@ -55,11 +54,6 @@ public interface CompactionPlan {
 
     CompactionPlan build();
   }
-
-  /**
-   * Return the set of compaction candidates.
-   */
-  Set<CompactableFile> getCandidates();
 
   /**
    * Return the set of jobs this plan will submit for compaction.

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
@@ -37,14 +37,21 @@ import com.google.common.base.Preconditions;
 public class CompactionPlanImpl implements CompactionPlan {
 
   private final Collection<CompactionJob> jobs;
+  private final Set<CompactableFile> candidates;
 
-  private CompactionPlanImpl(Collection<CompactionJob> jobs) {
+  private CompactionPlanImpl(Collection<CompactionJob> jobs, Set<CompactableFile> candidates) {
     this.jobs = List.copyOf(jobs);
+    this.candidates = candidates;
   }
 
   @Override
   public Collection<CompactionJob> getJobs() {
     return jobs;
+  }
+
+  @Override
+  public Set<CompactableFile> getCandidates() {
+    return candidates;
   }
 
   @Override
@@ -54,11 +61,11 @@ public class CompactionPlanImpl implements CompactionPlan {
 
   public static class BuilderImpl implements CompactionPlan.Builder {
 
-    private CompactionKind kind;
+    private final CompactionKind kind;
     private ArrayList<CompactionJob> jobs = new ArrayList<>();
-    private Set<CompactableFile> allFiles;
-    private Set<CompactableFile> seenFiles = new HashSet<>();
-    private Set<CompactableFile> candidates;
+    private final Set<CompactableFile> allFiles;
+    private final Set<CompactableFile> seenFiles = new HashSet<>();
+    private final Set<CompactableFile> candidates;
 
     public BuilderImpl(CompactionKind kind, Set<CompactableFile> allFiles,
         Set<CompactableFile> candidates) {
@@ -87,7 +94,7 @@ public class CompactionPlanImpl implements CompactionPlan {
 
     @Override
     public CompactionPlan build() {
-      return new CompactionPlanImpl(jobs);
+      return new CompactionPlanImpl(jobs, candidates);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlanImpl.java
@@ -37,21 +37,14 @@ import com.google.common.base.Preconditions;
 public class CompactionPlanImpl implements CompactionPlan {
 
   private final Collection<CompactionJob> jobs;
-  private final Set<CompactableFile> candidates;
 
-  private CompactionPlanImpl(Collection<CompactionJob> jobs, Set<CompactableFile> candidates) {
+  private CompactionPlanImpl(Collection<CompactionJob> jobs) {
     this.jobs = List.copyOf(jobs);
-    this.candidates = candidates;
   }
 
   @Override
   public Collection<CompactionJob> getJobs() {
     return jobs;
-  }
-
-  @Override
-  public Set<CompactableFile> getCandidates() {
-    return candidates;
   }
 
   @Override
@@ -94,7 +87,7 @@ public class CompactionPlanImpl implements CompactionPlan {
 
     @Override
     public CompactionPlan build() {
-      return new CompactionPlanImpl(jobs, candidates);
+      return new CompactionPlanImpl(jobs);
     }
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionManager.java
@@ -254,7 +254,7 @@ public class CompactionManager {
               new HashSet<>(runningExternalCompactions.keySet());
           for (Compactable compactable : compactables) {
             last = compactable;
-            compact(compactable);
+            submitCompaction(compactable);
             // remove anything from snapshot that tablets know are running
             compactable.getExternalCompactionIds(runningEcids::remove);
           }
@@ -267,7 +267,7 @@ public class CompactionManager {
               compactablesToCheck.poll(maxTimeBetweenChecks - passed, TimeUnit.MILLISECONDS);
           if (compactable != null) {
             last = compactable;
-            compact(compactable);
+            submitCompaction(compactable);
           }
         }
 
@@ -290,7 +290,10 @@ public class CompactionManager {
     }
   }
 
-  private void compact(Compactable compactable) {
+  /**
+   * Get each configured service for the compactable tablet and submit for compaction
+   */
+  private void submitCompaction(Compactable compactable) {
     for (CompactionKind ctype : CompactionKind.values()) {
       var csid = compactable.getConfiguredService(ctype);
       var service = services.get(csid);
@@ -308,7 +311,7 @@ public class CompactionManager {
       }
 
       if (service != null) {
-        service.compact(ctype, compactable, compactablesToCheck::add);
+        service.submitCompaction(ctype, compactable, compactablesToCheck::add);
       }
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -238,8 +238,9 @@ public class CompactionService {
       try {
         planningExecutor.execute(() -> {
           try {
-            Optional<CompactionPlan> plan = getCompactionPlan(kind, compactable);
-            plan.ifPresent(cp -> submitCompactionJob(cp, compactable, completionCallback));
+            var files = compactable.getFiles(...);
+            Optional<CompactionPlan> plan = getCompactionPlan(kind, files, compactable.getExtent());
+            plan.ifPresent(cp -> submitCompactionJob(cp, files, compactable.getExtent(), completionCallback));
           } finally {
             queuedForPlanning.get(kind).remove(compactable.getExtent());
           }
@@ -374,7 +375,7 @@ public class CompactionService {
 
       if (!jobs.isEmpty()) {
         log.trace("Submitted compaction plan {} id:{} files:{} plan:{}", compactable.getExtent(),
-            myId, plan.getCandidates(), plan);
+            myId, files, plan);
       }
     } else {
       log.trace("Did not submit compaction plan {} id:{} files:{} plan:{}", compactable.getExtent(),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -679,7 +679,7 @@ public class CompactableImpl implements Compactable {
 
   private void checkifChopComplete(Set<StoredTabletFile> allFiles) {
 
-    boolean completed = false;
+    boolean completed;
 
     synchronized (this) {
       completed = fileMgr.finishChop(allFiles);
@@ -846,7 +846,7 @@ public class CompactableImpl implements Compactable {
     }
 
     Pair<Long,CompactionConfig> idAndCfg = null;
-    if (extKind != null && extKind == CompactionKind.USER) {
+    if (extKind == CompactionKind.USER) {
       try {
         idAndCfg = tablet.getCompactionID();
         if (!idAndCfg.getFirst().equals(cid)) {
@@ -869,7 +869,6 @@ public class CompactableImpl implements Compactable {
     }
 
     if (extKind != null) {
-
       if (extKind == CompactionKind.USER) {
         this.chelper = CompactableUtils.getHelper(extKind, tablet, cid, idAndCfg.getSecond());
         this.compactionConfig = idAndCfg.getSecond();
@@ -1011,7 +1010,7 @@ public class CompactableImpl implements Compactable {
   }
 
   class CompactionCheck {
-    private Supplier<Boolean> memoizedCheck;
+    private final Supplier<Boolean> memoizedCheck;
 
     public CompactionCheck(CompactionServiceId service, CompactionKind kind, Long compactionId) {
       this.memoizedCheck = Suppliers.memoizeWithExpiration(() -> {


### PR DESCRIPTION
* Split compact method in CompactionService into to 2 methods:
getCompactionPlan() and submitCompactionJob()
* Rename other compact() in CompactionManager and CompactionService to submitCompaction()
* Add javadoc comments to various methods
* Add final to various private members
* Drop redundant enum check and boolean assignment

Edit: ~~Add getCandidates() method to CompactionPlan~~