### PR TITLE
Clarify compact method

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -542,7 +542,7 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
           job.getIteratorSettings().getIterators()
               .forEach(tis -> iters.add(SystemIteratorUtil.toIteratorSetting(tis)));
 
-          CompactionEnvironment cenv = new CompactionEnvironment(JOB_HOLDER, queueName);
+          ExtCEnv cenv = new ExtCEnv(JOB_HOLDER, queueName);
           FileCompactor compactor = new FileCompactor(getContext(), extent, files, outputFile,
               job.isPropagateDeletes(), cenv, iters, tConfig);
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/ExtCEnv.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.server.iterators.TabletIteratorEnvironment;
 
 import com.google.common.annotations.VisibleForTesting;
 
-public class CompactionEnvironment implements CompactionEnv {
+public class ExtCEnv implements CompactionEnv {
 
   private final CompactionJobHolder jobHolder;
   private TExternalCompactionJob job;
@@ -58,7 +58,7 @@ public class CompactionEnvironment implements CompactionEnv {
     }
   }
 
-  CompactionEnvironment(CompactionJobHolder jobHolder, String queueName) {
+  ExtCEnv(CompactionJobHolder jobHolder, String queueName) {
     this.jobHolder = jobHolder;
     this.job = jobHolder.getJob();
     this.queueName = queueName;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -34,7 +33,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
-import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.CompactionStrategyConfig;
@@ -58,7 +56,6 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
-import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.metadata.CompactableFileImpl;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -73,26 +70,21 @@ import org.apache.accumulo.core.summary.Gatherer;
 import org.apache.accumulo.core.summary.SummarizerFactory;
 import org.apache.accumulo.core.summary.SummaryCollection;
 import org.apache.accumulo.core.summary.SummaryReader;
-import org.apache.accumulo.core.tabletserver.thrift.TCompactionReason;
 import org.apache.accumulo.core.util.Pair;
-import org.apache.accumulo.core.util.ratelimit.RateLimiter;
-import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
+import org.apache.accumulo.server.compaction.CompactionInfo;
 import org.apache.accumulo.server.compaction.CompactionStats;
 import org.apache.accumulo.server.compaction.FileCompactor;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionCanceledException;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionEnv;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
-import org.apache.accumulo.server.iterators.SystemIteratorEnvironment;
-import org.apache.accumulo.server.iterators.TabletIteratorEnvironment;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.tserver.compaction.CompactionPlan;
 import org.apache.accumulo.tserver.compaction.CompactionStrategy;
 import org.apache.accumulo.tserver.compaction.MajorCompactionReason;
 import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
 import org.apache.accumulo.tserver.compaction.WriteParameters;
-import org.apache.accumulo.tserver.tablet.CompactableImpl.CompactionCheck;
 import org.apache.accumulo.tserver.tablet.CompactableImpl.CompactionHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -552,88 +544,42 @@ public class CompactableUtils {
     return copy;
   }
 
-  static StoredTabletFile compact(Tablet tablet, CompactionJob job, Set<StoredTabletFile> jobFiles,
-      Long compactionId, Set<StoredTabletFile> selectedFiles, boolean propagateDeletes,
-      CompactableImpl.CompactionHelper helper, List<IteratorSetting> iters,
-      CompactionCheck compactionCheck, RateLimiter readLimiter, RateLimiter writeLimiter,
-      CompactionStats stats) throws IOException, CompactionCanceledException {
-    StoredTabletFile metaFile;
-    CompactionEnv cenv = new CompactionEnv() {
-      @Override
-      public boolean isCompactionEnabled() {
-        return compactionCheck.isCompactionEnabled();
-      }
-
-      @Override
-      public IteratorScope getIteratorScope() {
-        return IteratorScope.majc;
-      }
-
-      @Override
-      public RateLimiter getReadLimiter() {
-        return readLimiter;
-      }
-
-      @Override
-      public RateLimiter getWriteLimiter() {
-        return writeLimiter;
-      }
-
-      @Override
-      public SystemIteratorEnvironment createIteratorEnv(ServerContext context,
-          AccumuloConfiguration acuTableConf, TableId tableId) {
-        return new TabletIteratorEnvironment(context, IteratorScope.majc, !propagateDeletes,
-            acuTableConf, tableId, job.getKind());
-      }
-
-      @Override
-      public SortedKeyValueIterator<Key,Value> getMinCIterator() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public TCompactionReason getReason() {
-        switch (job.getKind()) {
-          case USER:
-            return TCompactionReason.USER;
-          case CHOP:
-            return TCompactionReason.CHOP;
-          case SELECTOR:
-          case SYSTEM:
-          default:
-            return TCompactionReason.SYSTEM;
-        }
-      }
-    };
+  /**
+   * Create the FileCompactor and finally call compact. Returns the Major CompactionStats.
+   */
+  static CompactionStats compact(Tablet tablet, CompactionJob job,
+      CompactableImpl.CompactionInfo cInfo, CompactionEnv cenv,
+      Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName)
+      throws IOException, CompactionCanceledException {
+    boolean propagateDeletes = cInfo.propagateDeletes;
 
     AccumuloConfiguration compactionConfig = getCompactionConfig(tablet.getTableConfiguration(),
-        getOverrides(job.getKind(), tablet, helper, job.getFiles()));
-
-    SortedMap<StoredTabletFile,DataFileValue> allFiles = tablet.getDatafiles();
-    HashMap<StoredTabletFile,DataFileValue> compactFiles = new HashMap<>();
-    jobFiles.forEach(file -> compactFiles.put(file, allFiles.get(file)));
-
-    TabletFile compactTmpName = tablet.getNextMapFilenameForMajc(propagateDeletes);
+        getOverrides(job.getKind(), tablet, cInfo.localHelper, job.getFiles()));
 
     FileCompactor compactor = new FileCompactor(tablet.getContext(), tablet.getExtent(),
-        compactFiles, compactTmpName, propagateDeletes, cenv, iters, compactionConfig);
+        compactFiles, tmpFileName, propagateDeletes, cenv, cInfo.iters, compactionConfig);
 
-    var mcs = compactor.call();
+    return compactor.call();
+  }
 
-    if (job.getKind() == CompactionKind.USER || job.getKind() == CompactionKind.SELECTOR) {
-      helper.getFilesToDrop().forEach(f -> {
+  /**
+   * Finish major compaction by bringing the new file online and returning the completed file.
+   */
+  static StoredTabletFile bringOnline(DatafileManager datafileManager,
+      CompactableImpl.CompactionInfo cInfo, CompactionStats stats,
+      Map<StoredTabletFile,DataFileValue> compactFiles,
+      SortedMap<StoredTabletFile,DataFileValue> allFiles, CompactionKind kind,
+      TabletFile compactTmpName) throws IOException {
+    if (kind == CompactionKind.USER || kind == CompactionKind.SELECTOR) {
+      cInfo.localHelper.getFilesToDrop().forEach(f -> {
         if (allFiles.containsKey(f)) {
           compactFiles.put(f, allFiles.get(f));
         }
       });
     }
-    // mutate the empty stats to allow returning their values
-    stats.add(mcs);
-
-    metaFile = tablet.getDatafileManager().bringMajorCompactionOnline(compactFiles.keySet(),
-        compactTmpName, compactionId, selectedFiles,
-        new DataFileValue(mcs.getFileSize(), mcs.getEntriesWritten()), Optional.empty());
-    return metaFile;
+    var dfv = new DataFileValue(stats.getFileSize(), stats.getEntriesWritten());
+    return datafileManager.bringMajorCompactionOnline(compactFiles.keySet(), compactTmpName,
+        cInfo.checkCompactionId, cInfo.selectedFiles, dfv, Optional.empty());
   }
 
   public static MajorCompactionReason from(CompactionKind ck) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -551,13 +551,12 @@ public class CompactableUtils {
       CompactableImpl.CompactionInfo cInfo, CompactionEnv cenv,
       Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName)
       throws IOException, CompactionCanceledException {
-    boolean propagateDeletes = cInfo.propagateDeletes;
 
     AccumuloConfiguration compactionConfig = getCompactionConfig(tablet.getTableConfiguration(),
         getOverrides(job.getKind(), tablet, cInfo.localHelper, job.getFiles()));
 
     FileCompactor compactor = new FileCompactor(tablet.getContext(), tablet.getExtent(),
-        compactFiles, tmpFileName, propagateDeletes, cenv, cInfo.iters, compactionConfig);
+        compactFiles, tmpFileName, cInfo.propagateDeletes, cenv, cInfo.iters, compactionConfig);
 
     return compactor.call();
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MajCEnv.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MajCEnv.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.tserver.tablet;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.spi.compaction.CompactionKind;
+import org.apache.accumulo.core.tabletserver.thrift.TCompactionReason;
+import org.apache.accumulo.core.util.ratelimit.RateLimiter;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.compaction.FileCompactor;
+import org.apache.accumulo.server.iterators.SystemIteratorEnvironment;
+import org.apache.accumulo.server.iterators.TabletIteratorEnvironment;
+
+public class MajCEnv implements FileCompactor.CompactionEnv {
+  private final CompactionKind kind;
+  private final RateLimiter readLimiter;
+  private final RateLimiter writeLimiter;
+  private final boolean propagateDeletes;
+  private final boolean enabled;
+
+  public MajCEnv(CompactionKind kind, CompactableImpl.CompactionCheck compactionCheck,
+      RateLimiter readLimiter, RateLimiter writeLimiter, boolean propagateDeletes) {
+    this.kind = kind;
+    this.readLimiter = readLimiter;
+    this.writeLimiter = writeLimiter;
+    this.propagateDeletes = propagateDeletes;
+    this.enabled = compactionCheck.isCompactionEnabled();
+  }
+
+  @Override
+  public boolean isCompactionEnabled() {
+    return enabled;
+  }
+
+  @Override
+  public IteratorUtil.IteratorScope getIteratorScope() {
+    return IteratorUtil.IteratorScope.majc;
+  }
+
+  @Override
+  public RateLimiter getReadLimiter() {
+    return readLimiter;
+  }
+
+  @Override
+  public RateLimiter getWriteLimiter() {
+    return writeLimiter;
+  }
+
+  @Override
+  public SystemIteratorEnvironment createIteratorEnv(ServerContext context,
+      AccumuloConfiguration acuTableConf, TableId tableId) {
+    return new TabletIteratorEnvironment(context, IteratorUtil.IteratorScope.majc,
+        !propagateDeletes, acuTableConf, tableId, kind);
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> getMinCIterator() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TCompactionReason getReason() {
+    switch (kind) {
+      case USER:
+        return TCompactionReason.USER;
+      case CHOP:
+        return TCompactionReason.CHOP;
+      case SELECTOR:
+      case SYSTEM:
+      default:
+        return TCompactionReason.SYSTEM;
+    }
+  }
+}

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MajCEnv.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MajCEnv.java
@@ -37,7 +37,7 @@ public class MajCEnv implements FileCompactor.CompactionEnv {
   private final RateLimiter readLimiter;
   private final RateLimiter writeLimiter;
   private final boolean propagateDeletes;
-  private final boolean enabled;
+  private final CompactableImpl.CompactionCheck compactionCheck;
 
   public MajCEnv(CompactionKind kind, CompactableImpl.CompactionCheck compactionCheck,
       RateLimiter readLimiter, RateLimiter writeLimiter, boolean propagateDeletes) {
@@ -45,12 +45,12 @@ public class MajCEnv implements FileCompactor.CompactionEnv {
     this.readLimiter = readLimiter;
     this.writeLimiter = writeLimiter;
     this.propagateDeletes = propagateDeletes;
-    this.enabled = compactionCheck.isCompactionEnabled();
+    this.compactionCheck = compactionCheck;
   }
 
   @Override
   public boolean isCompactionEnabled() {
-    return enabled;
+    return compactionCheck.isCompactionEnabled();
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinCEnv.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinCEnv.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.tserver.tablet;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.tabletserver.thrift.TCompactionReason;
+import org.apache.accumulo.core.util.ratelimit.RateLimiter;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.compaction.FileCompactor;
+import org.apache.accumulo.server.iterators.SystemIteratorEnvironment;
+import org.apache.accumulo.server.iterators.TabletIteratorEnvironment;
+import org.apache.accumulo.tserver.MinorCompactionReason;
+
+public class MinCEnv implements FileCompactor.CompactionEnv {
+  private final MinorCompactionReason reason;
+  private final SortedKeyValueIterator<Key,Value> iter;
+
+  public MinCEnv(MinorCompactionReason reason, SortedKeyValueIterator<Key,Value> iter) {
+    this.reason = reason;
+    this.iter = iter;
+  }
+
+  @Override
+  public boolean isCompactionEnabled() {
+    return true;
+  }
+
+  @Override
+  public IteratorUtil.IteratorScope getIteratorScope() {
+    return IteratorUtil.IteratorScope.minc;
+  }
+
+  @Override
+  public RateLimiter getReadLimiter() {
+    return null;
+  }
+
+  @Override
+  public RateLimiter getWriteLimiter() {
+    return null;
+  }
+
+  @Override
+  public SystemIteratorEnvironment createIteratorEnv(ServerContext context,
+      AccumuloConfiguration acuTableConf, TableId tableId) {
+    return new TabletIteratorEnvironment(context, IteratorUtil.IteratorScope.minc, acuTableConf,
+        tableId);
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key,Value> getMinCIterator() {
+    return iter;
+  }
+
+  @Override
+  public TCompactionReason getReason() {
+    switch (reason) {
+      case USER:
+        return TCompactionReason.USER;
+      case CLOSE:
+        return TCompactionReason.CLOSE;
+      case SYSTEM:
+      default:
+        return TCompactionReason.SYSTEM;
+    }
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/ExternalCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ExternalCompactionIT.java
@@ -53,8 +53,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.accumulo.compactor.CompactionEnvironment.CompactorIterEnv;
 import org.apache.accumulo.compactor.Compactor;
+import org.apache.accumulo.compactor.ExtCEnv.CompactorIterEnv;
 import org.apache.accumulo.coordinator.CompactionCoordinator;
 import org.apache.accumulo.coordinator.ExternalCompactionMetrics;
 import org.apache.accumulo.core.client.Accumulo;


### PR DESCRIPTION
* Make compact method in CompactableUtils just call compact and return
the majc stats, removing the need to mutate the object across method calls. 
* Pass the CompactionInfo object as a param to reduce the number of params 
to the compact method. 
* Pull logic from compact method and put into new bringOnline method, further 
reducing the number of params to the compact method. The bringOnline method
returns the completed StoredTabletFile 
* Replace anonymous CompactionEnv classes with 2 new classes: MinCEnv & MajCEnv
* Rename CompactionEnvironment to ExtCEnv to differentiate from the
other types of CompactionEnv implementations
* Add javadoc comments describing methods