### PR TITLE
Recreated the SimpleTimer functionality with the new ThreadPools class

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -189,6 +189,10 @@ public class ThreadPools {
     return result;
   }
 
+  /*
+   * If you need the server-side shared ScheduledThreadPoolExecutor, then use
+   * ServerContext.getSharedGenericScheduledExecutorService()
+   */
   public static ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     return (ScheduledThreadPoolExecutor) createExecutorService(conf,

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -191,7 +191,7 @@ public class ThreadPools {
 
   /*
    * If you need the server-side shared ScheduledThreadPoolExecutor, then use
-   * ServerContext.getSharedGenericScheduledExecutorService()
+   * ServerContext.getScheduledExecutor()
    */
   public static ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -412,7 +412,7 @@ public class ServerContext extends ClientContext {
   }
 
   private void monitorSwappiness(AccumuloConfiguration config) {
-    getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(() -> {
+    getScheduledExecutor().scheduleWithFixedDelay(() -> {
       try {
         String procFile = "/proc/sys/vm/swappiness";
         File swappiness = new File(procFile);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -436,7 +436,10 @@ public class ServerContext extends ClientContext {
     }, 1000, 10 * 60 * 1000, TimeUnit.MILLISECONDS);
   }
 
-  public ScheduledThreadPoolExecutor getSharedGenericScheduledExecutorService() {
+  /**
+   * return a shared scheduled executor
+   */
+  public synchronized ScheduledThreadPoolExecutor getScheduledExecutor() {
     if (sharedScheduledThreadPool == null) {
       sharedScheduledThreadPool = (ScheduledThreadPoolExecutor) ThreadPools
           .createExecutorService(getConfiguration(), Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE);

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.core.iteratorsImpl.system.TimeSettingIterator;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.problems.ProblemReport;
 import org.apache.accumulo.server.problems.ProblemReportingIterator;
@@ -164,9 +163,8 @@ public class FileManager {
     this.reservedReaders = new HashMap<>();
 
     this.maxIdleTime = context.getConfiguration().getTimeInMillis(Property.TSERV_MAX_IDLE);
-    ThreadPools.createGeneralScheduledExecutorService(context.getConfiguration())
-        .scheduleWithFixedDelay(new IdleFileCloser(), maxIdleTime, maxIdleTime / 2,
-            TimeUnit.MILLISECONDS);
+    this.context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
+        new IdleFileCloser(), maxIdleTime, maxIdleTime / 2, TimeUnit.MILLISECONDS);
 
     this.slowFilePermitMillis =
         context.getConfiguration().getTimeInMillis(Property.TSERV_SLOW_FILEPERMIT_MILLIS);

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -162,12 +162,12 @@ public class FileManager {
     this.openFiles = new HashMap<>();
     this.reservedReaders = new HashMap<>();
 
-    this.maxIdleTime = context.getConfiguration().getTimeInMillis(Property.TSERV_MAX_IDLE);
-    this.context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
-        new IdleFileCloser(), maxIdleTime, maxIdleTime / 2, TimeUnit.MILLISECONDS);
+    this.maxIdleTime = this.context.getConfiguration().getTimeInMillis(Property.TSERV_MAX_IDLE);
+    this.context.getScheduledExecutor().scheduleWithFixedDelay(new IdleFileCloser(), maxIdleTime,
+        maxIdleTime / 2, TimeUnit.MILLISECONDS);
 
     this.slowFilePermitMillis =
-        context.getConfiguration().getTimeInMillis(Property.TSERV_SLOW_FILEPERMIT_MILLIS);
+        this.context.getConfiguration().getTimeInMillis(Property.TSERV_SLOW_FILEPERMIT_MILLIS);
   }
 
   private static int countReaders(Map<String,List<OpenReader>> files) {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -253,8 +253,8 @@ public class LiveTServerSet implements Watcher {
 
   public synchronized void startListeningForTabletServerChanges() {
     scanServers();
-    this.context.getSharedGenericScheduledExecutorService()
-        .scheduleWithFixedDelay(this::scanServers, 0, 5000, TimeUnit.MILLISECONDS);
+    this.context.getScheduledExecutor().scheduleWithFixedDelay(this::scanServers, 0, 5000,
+        TimeUnit.MILLISECONDS);
   }
 
   public synchronized void scanServers() {

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.core.util.Halt;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.ServerServices;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCache.ZcStat;
@@ -254,7 +253,7 @@ public class LiveTServerSet implements Watcher {
 
   public synchronized void startListeningForTabletServerChanges() {
     scanServers();
-    ThreadPools.createGeneralScheduledExecutorService(context.getConfiguration())
+    this.context.getSharedGenericScheduledExecutorService()
         .scheduleWithFixedDelay(this::scanServers, 0, 5000, TimeUnit.MILLISECONDS);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -30,11 +30,10 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.apache.zookeeper.WatchedEvent;
@@ -58,7 +57,7 @@ public class DistributedWorkQueue {
   private ThreadPoolExecutor threadPool;
   private ZooReaderWriter zoo;
   private String path;
-  private AccumuloConfiguration config;
+  private ServerContext context;
   private long timerInitialDelay, timerPeriod;
 
   private AtomicInteger numTask = new AtomicInteger(0);
@@ -163,18 +162,22 @@ public class DistributedWorkQueue {
     void process(String workID, byte[] data);
   }
 
-  public DistributedWorkQueue(String path, AccumuloConfiguration config) {
+  public DistributedWorkQueue(String path, ServerContext context) {
     // Preserve the old delay and period
-    this(path, config, new SecureRandom().nextInt(60 * 1000), 60 * 1000);
+    this(path, context, new SecureRandom().nextInt(60 * 1000), 60 * 1000);
   }
 
-  public DistributedWorkQueue(String path, AccumuloConfiguration config, long timerInitialDelay,
+  public DistributedWorkQueue(String path, ServerContext context, long timerInitialDelay,
       long timerPeriod) {
     this.path = path;
-    this.config = config;
+    this.context = context;
     this.timerInitialDelay = timerInitialDelay;
     this.timerPeriod = timerPeriod;
-    zoo = new ZooReaderWriter(config);
+    zoo = new ZooReaderWriter(context.getConfiguration());
+  }
+
+  public ServerContext getContext() {
+    return context;
   }
 
   public ZooReaderWriter getZooReaderWriter() {
@@ -220,20 +223,19 @@ public class DistributedWorkQueue {
     lookForWork(processor, children);
 
     // Add a little jitter to avoid all the tservers slamming zookeeper at once
-    ThreadPools.createGeneralScheduledExecutorService(config)
-        .scheduleWithFixedDelay(new Runnable() {
-          @Override
-          public void run() {
-            log.debug("Looking for work in {}", path);
-            try {
-              lookForWork(processor, zoo.getChildren(path));
-            } catch (KeeperException e) {
-              log.error("Failed to look for work", e);
-            } catch (InterruptedException e) {
-              log.info("Interrupted looking for work", e);
-            }
-          }
-        }, timerInitialDelay, timerPeriod, TimeUnit.MILLISECONDS);
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(new Runnable() {
+      @Override
+      public void run() {
+        log.debug("Looking for work in {}", path);
+        try {
+          lookForWork(processor, zoo.getChildren(path));
+        } catch (KeeperException e) {
+          log.error("Failed to look for work", e);
+        } catch (InterruptedException e) {
+          log.info("Interrupted looking for work", e);
+        }
+      }
+    }, timerInitialDelay, timerPeriod, TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -253,12 +253,11 @@ public class Manager extends AbstractServer
     if (newState == ManagerState.STOP) {
       // Give the server a little time before shutdown so the client
       // thread requesting the stop can return
-      ThreadPools.createGeneralScheduledExecutorService(getConfiguration())
-          .scheduleWithFixedDelay(() -> {
-            // This frees the main thread and will cause the manager to exit
-            clientService.stop();
-            Manager.this.nextEvent.event("stopped event loop");
-          }, 100L, 1000L, TimeUnit.MILLISECONDS);
+      getContext().getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(() -> {
+        // This frees the main thread and will cause the manager to exit
+        clientService.stop();
+        Manager.this.nextEvent.event("stopped event loop");
+      }, 100L, 1000L, TimeUnit.MILLISECONDS);
     }
 
     if (oldState != newState && (newState == ManagerState.HAVE_LOCK)) {
@@ -1130,8 +1129,8 @@ public class Manager extends AbstractServer
       fate = new Fate<>(this, store, TraceRepo::toLogString);
       fate.startTransactionRunners(getConfiguration());
 
-      ThreadPools.createGeneralScheduledExecutorService(getConfiguration())
-          .scheduleWithFixedDelay(store::ageOff, 63000, 63000, TimeUnit.MILLISECONDS);
+      context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(store::ageOff,
+          63000, 63000, TimeUnit.MILLISECONDS);
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception setting up FaTE cleanup thread", e);
     }
@@ -1182,18 +1181,17 @@ public class Manager extends AbstractServer
 
     // if the replication name is ever set, then start replication services
     final AtomicReference<TServer> replServer = new AtomicReference<>();
-    ThreadPools.createGeneralScheduledExecutorService(getConfiguration())
-        .scheduleWithFixedDelay(() -> {
-          try {
-            if ((replServer.get() == null)
-                && !getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
-              log.info("{} was set, starting repl services.", Property.REPLICATION_NAME.getKey());
-              replServer.set(setupReplication());
-            }
-          } catch (UnknownHostException | KeeperException | InterruptedException e) {
-            log.error("Error occurred starting replication services. ", e);
-          }
-        }, 0, 5000, TimeUnit.MILLISECONDS);
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(() -> {
+      try {
+        if ((replServer.get() == null)
+            && !getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
+          log.info("{} was set, starting repl services.", Property.REPLICATION_NAME.getKey());
+          replServer.set(setupReplication());
+        }
+      } catch (UnknownHostException | KeeperException | InterruptedException e) {
+        log.error("Error occurred starting replication services. ", e);
+      }
+    }, 0, 5000, TimeUnit.MILLISECONDS);
 
     // Register metrics modules
     int failureCount = new ManagerMetricsFactory(getConfiguration()).register(this);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -253,7 +253,7 @@ public class Manager extends AbstractServer
     if (newState == ManagerState.STOP) {
       // Give the server a little time before shutdown so the client
       // thread requesting the stop can return
-      getContext().getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(() -> {
+      getContext().getScheduledExecutor().scheduleWithFixedDelay(() -> {
         // This frees the main thread and will cause the manager to exit
         clientService.stop();
         Manager.this.nextEvent.event("stopped event loop");
@@ -1129,8 +1129,8 @@ public class Manager extends AbstractServer
       fate = new Fate<>(this, store, TraceRepo::toLogString);
       fate.startTransactionRunners(getConfiguration());
 
-      context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(store::ageOff,
-          63000, 63000, TimeUnit.MILLISECONDS);
+      context.getScheduledExecutor().scheduleWithFixedDelay(store::ageOff, 63000, 63000,
+          TimeUnit.MILLISECONDS);
     } catch (KeeperException | InterruptedException e) {
       throw new IllegalStateException("Exception setting up FaTE cleanup thread", e);
     }
@@ -1181,7 +1181,7 @@ public class Manager extends AbstractServer
 
     // if the replication name is ever set, then start replication services
     final AtomicReference<TServer> replServer = new AtomicReference<>();
-    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(() -> {
+    context.getScheduledExecutor().scheduleWithFixedDelay(() -> {
       try {
         if ((replServer.get() == null)
             && !getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -77,7 +77,7 @@ public class RecoveryManager {
     try {
       List<String> workIDs =
           new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY,
-              manager.getConfiguration()).getWorkQueued();
+              manager.getContext()).getWorkQueued();
       sortsQueued.addAll(workIDs);
     } catch (Exception e) {
       log.warn("{}", e.getMessage(), e);
@@ -128,8 +128,8 @@ public class RecoveryManager {
   private void initiateSort(String sortId, String source, final String destination)
       throws KeeperException, InterruptedException {
     String work = source + "|" + destination;
-    new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY,
-        manager.getConfiguration()).addWork(sortId, work.getBytes(UTF_8));
+    new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY, manager.getContext())
+        .addWork(sortId, work.getBytes(UTF_8));
 
     synchronized (this) {
       sortsQueued.add(sortId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -77,7 +77,7 @@ public class RecoveryManager {
     try {
       List<String> workIDs =
           new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY,
-              manager.getContext()).getWorkQueued();
+              manager.getConfiguration(), manager.getContext()).getWorkQueued();
       sortsQueued.addAll(workIDs);
     } catch (Exception e) {
       log.warn("{}", e.getMessage(), e);
@@ -128,8 +128,8 @@ public class RecoveryManager {
   private void initiateSort(String sortId, String source, final String destination)
       throws KeeperException, InterruptedException {
     String work = source + "|" + destination;
-    new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY, manager.getContext())
-        .addWork(sortId, work.getBytes(UTF_8));
+    new DistributedWorkQueue(manager.getZooKeeperRoot() + Constants.ZRECOVERY,
+        manager.getConfiguration(), manager.getContext()).addWork(sortId, work.getBytes(UTF_8));
 
     synchronized (this) {
       sortsQueued.add(sortId);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssigner.java
@@ -91,7 +91,7 @@ public abstract class DistributedWorkQueueWorkAssigner implements WorkAssigner {
   protected void initializeWorkQueue(AccumuloConfiguration conf) {
     workQueue =
         new DistributedWorkQueue(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
-            + ReplicationConstants.ZOO_WORK_QUEUE, this.workQueue.getContext());
+            + ReplicationConstants.ZOO_WORK_QUEUE, conf, this.workQueue.getContext());
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssigner.java
@@ -91,7 +91,7 @@ public abstract class DistributedWorkQueueWorkAssigner implements WorkAssigner {
   protected void initializeWorkQueue(AccumuloConfiguration conf) {
     workQueue =
         new DistributedWorkQueue(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
-            + ReplicationConstants.ZOO_WORK_QUEUE, conf);
+            + ReplicationConstants.ZOO_WORK_QUEUE, this.workQueue.getContext());
   }
 
   @Override

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CopyFailed.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CopyFailed.java
@@ -143,7 +143,7 @@ class CopyFailed extends ManagerRepo {
     if (!loadedFailures.isEmpty()) {
       DistributedWorkQueue bifCopyQueue = new DistributedWorkQueue(
           Constants.ZROOT + "/" + manager.getInstanceID() + Constants.ZBULK_FAILED_COPYQ,
-          manager.getConfiguration());
+          manager.getContext());
 
       HashSet<String> workIds = new HashSet<>();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CopyFailed.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CopyFailed.java
@@ -143,7 +143,7 @@ class CopyFailed extends ManagerRepo {
     if (!loadedFailures.isEmpty()) {
       DistributedWorkQueue bifCopyQueue = new DistributedWorkQueue(
           Constants.ZROOT + "/" + manager.getInstanceID() + Constants.ZBULK_FAILED_COPYQ,
-          manager.getContext());
+          manager.getConfiguration(), manager.getContext());
 
       HashSet<String> workIds = new HashSet<>();
 

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -300,8 +300,8 @@ public class TraceServer implements Watcher, AutoCloseable {
   }
 
   public void run() {
-    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(this::flush,
-        SCHEDULE_DELAY, SCHEDULE_PERIOD, TimeUnit.MILLISECONDS);
+    context.getScheduledExecutor().scheduleWithFixedDelay(this::flush, SCHEDULE_DELAY,
+        SCHEDULE_PERIOD, TimeUnit.MILLISECONDS);
     server.serve();
   }
 

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/TraceServer.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.AgeOffFilter;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.server.ServerContext;
@@ -301,9 +300,8 @@ public class TraceServer implements Watcher, AutoCloseable {
   }
 
   public void run() {
-    ThreadPools.createGeneralScheduledExecutorService(context.getConfiguration())
-        .scheduleWithFixedDelay(this::flush, SCHEDULE_DELAY, SCHEDULE_PERIOD,
-            TimeUnit.MILLISECONDS);
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(this::flush,
+        SCHEDULE_DELAY, SCHEDULE_PERIOD, TimeUnit.MILLISECONDS);
     server.serve();
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -29,7 +29,6 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.manager.state.Assignment;
 import org.apache.accumulo.server.manager.state.TabletStateStore;
@@ -216,24 +215,22 @@ class AssignmentHandler implements Runnable {
       server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
       long reschedule = Math.min((1L << Math.min(32, retryAttempt)) * 1000, 10 * 60 * 1000L);
       log.warn(String.format("rescheduling tablet load in %.2f seconds", reschedule / 1000.));
-      ThreadPools.createGeneralScheduledExecutorService(server.getConfiguration())
-          .schedule(new Runnable() {
-            @Override
-            public void run() {
-              log.info("adding tablet {} back to the assignment pool (retry {})", extent,
-                  retryAttempt);
-              AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
-              if (extent.isMeta()) {
-                if (extent.isRootTablet()) {
-                  Threads.createThread("Root tablet assignment retry", handler).start();
-                } else {
-                  server.resourceManager.addMetaDataAssignment(extent, log, handler);
-                }
-              } else {
-                server.resourceManager.addAssignment(extent, log, handler);
-              }
+      this.server.getContext().getSharedGenericScheduledExecutorService().schedule(new Runnable() {
+        @Override
+        public void run() {
+          log.info("adding tablet {} back to the assignment pool (retry {})", extent, retryAttempt);
+          AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
+          if (extent.isMeta()) {
+            if (extent.isRootTablet()) {
+              Threads.createThread("Root tablet assignment retry", handler).start();
+            } else {
+              server.resourceManager.addMetaDataAssignment(extent, log, handler);
             }
-          }, reschedule, TimeUnit.MILLISECONDS);
+          } else {
+            server.resourceManager.addAssignment(extent, log, handler);
+          }
+        }
+      }, reschedule, TimeUnit.MILLISECONDS);
     }
   }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -215,7 +215,7 @@ class AssignmentHandler implements Runnable {
       server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
       long reschedule = Math.min((1L << Math.min(32, retryAttempt)) * 1000, 10 * 60 * 1000L);
       log.warn(String.format("rescheduling tablet load in %.2f seconds", reschedule / 1000.));
-      this.server.getContext().getSharedGenericScheduledExecutorService().schedule(new Runnable() {
+      this.server.getContext().getScheduledExecutor().schedule(new Runnable() {
         @Override
         public void run() {
           log.info("adding tablet {} back to the assignment pool (retry {})", extent, retryAttempt);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -227,6 +227,7 @@ public class TabletServer extends AbstractServer {
 
   private final ZooAuthenticationKeyWatcher authKeyWatcher;
   private final WalStateManager walMarker;
+  private final ServerContext context;
 
   public static void main(String[] args) throws Exception {
     try (TabletServer tserver = new TabletServer(new ServerOpts(), args)) {
@@ -236,13 +237,13 @@ public class TabletServer extends AbstractServer {
 
   protected TabletServer(ServerOpts opts, String[] args) {
     super("tserver", opts, args);
-    ServerContext context = super.getContext();
+    context = super.getContext();
     context.setupCrypto();
     this.managerLockCache = new ZooCache(context.getZooReaderWriter(), null);
     final AccumuloConfiguration aconf = getConfiguration();
     log.info("Version " + Constants.VERSION);
     log.info("Instance " + getInstanceID());
-    this.sessionManager = new SessionManager(aconf);
+    this.sessionManager = new SessionManager(context);
     this.logSorter = new LogSorter(context, aconf);
     this.replWorker = new ReplicationWorker(context);
     this.statsKeeper = new TabletStatsKeeper();
@@ -257,7 +258,7 @@ public class TabletServer extends AbstractServer {
     // This thread will calculate and log out the busiest tablets based on ingest count and
     // query count every #{logBusiestTabletsDelay}
     if (numBusyTabletsToLog > 0) {
-      ThreadPools.createGeneralScheduledExecutorService(aconf)
+      context.getSharedGenericScheduledExecutorService()
           .scheduleWithFixedDelay(Threads.createNamedRunnable("BusyTabletLogger", new Runnable() {
             private BusiestTracker ingestTracker =
                 BusiestTracker.newBusiestIngestTracker(numBusyTabletsToLog);
@@ -284,7 +285,7 @@ public class TabletServer extends AbstractServer {
           }), logBusyTabletsDelay, logBusyTabletsDelay, TimeUnit.MILLISECONDS);
     }
 
-    ThreadPools.createGeneralScheduledExecutorService(aconf)
+    context.getSharedGenericScheduledExecutorService()
         .scheduleWithFixedDelay(Threads.createNamedRunnable("TabletRateUpdater", new Runnable() {
           @Override
           public void run() {
@@ -349,7 +350,7 @@ public class TabletServer extends AbstractServer {
     scanMetrics = new TabletServerScanMetrics();
     mincMetrics = new TabletServerMinCMetrics();
     ceMetrics = new CompactionExecutorsMetrics();
-    ThreadPools.createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
         TabletLocator::clearLocators, jitter(), jitter(), TimeUnit.MILLISECONDS);
     walMarker = new WalStateManager(context);
 
@@ -425,8 +426,8 @@ public class TabletServer extends AbstractServer {
 
   private class MajorCompactor implements Runnable {
 
-    public MajorCompactor(AccumuloConfiguration config) {
-      CompactionWatcher.startWatching(config);
+    public MajorCompactor(ServerContext context) {
+      CompactionWatcher.startWatching(context);
     }
 
     @Override
@@ -764,7 +765,7 @@ public class TabletServer extends AbstractServer {
         .createExecutorService(getConfiguration(), Property.TSERV_WORKQ_THREADS);
 
     bulkFailedCopyQ = new DistributedWorkQueue(
-        getContext().getZooKeeperRoot() + Constants.ZBULK_FAILED_COPYQ, getConfiguration());
+        getContext().getZooKeeperRoot() + Constants.ZBULK_FAILED_COPYQ, getContext());
     try {
       bulkFailedCopyQ.startProcessing(new BulkFailedCopyProcessor(getContext()),
           distWorkQThreadPool);
@@ -780,7 +781,7 @@ public class TabletServer extends AbstractServer {
     }
     final AccumuloConfiguration aconf = getConfiguration();
     // if the replication name is ever set, then start replication services
-    ThreadPools.createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(() -> {
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(() -> {
       if (this.replServer == null) {
         if (!getConfiguration().get(Property.REPLICATION_NAME).isEmpty()) {
           log.info(Property.REPLICATION_NAME.getKey() + " was set, starting repl services.");
@@ -790,7 +791,7 @@ public class TabletServer extends AbstractServer {
     }, 0, 5000, TimeUnit.MILLISECONDS);
 
     final long CLEANUP_BULK_LOADED_CACHE_MILLIS = 15 * 60 * 1000;
-    ThreadPools.createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
         new BulkImportCacheCleaner(this), CLEANUP_BULK_LOADED_CACHE_MILLIS,
         CLEANUP_BULK_LOADED_CACHE_MILLIS, TimeUnit.MILLISECONDS);
 
@@ -913,7 +914,7 @@ public class TabletServer extends AbstractServer {
     Runnable replicationWorkThreadPoolResizer = () -> {
       ThreadPools.resizePool(replicationThreadPool, aconf, Property.REPLICATION_WORKER_THREADS);
     };
-    ThreadPools.createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
         replicationWorkThreadPoolResizer, 10000, 30000, TimeUnit.MILLISECONDS);
   }
 
@@ -1006,7 +1007,7 @@ public class TabletServer extends AbstractServer {
 
   private void config() {
     log.info("Tablet server starting on {}", getHostname());
-    Threads.createThread("Split/MajC initiator", new MajorCompactor(getConfiguration())).start();
+    Threads.createThread("Split/MajC initiator", new MajorCompactor(context)).start();
 
     clientAddress = HostAndPort.fromParts(getHostname(), 0);
 
@@ -1016,7 +1017,7 @@ public class TabletServer extends AbstractServer {
 
     Runnable gcDebugTask = () -> gcLogger.logGCInfo(getConfiguration());
 
-    ThreadPools.createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(gcDebugTask, 0,
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(gcDebugTask, 0,
         TIME_BETWEEN_GC_CHECKS, TimeUnit.MILLISECONDS);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -276,8 +276,8 @@ public class LogSorter {
   public void startWatchingForRecoveryLogs(ThreadPoolExecutor distWorkQThreadPool)
       throws KeeperException, InterruptedException {
     this.threadPool = distWorkQThreadPool;
-    new DistributedWorkQueue(context.getZooKeeperRoot() + Constants.ZRECOVERY, context)
-        .startProcessing(new LogProcessor(), this.threadPool);
+    new DistributedWorkQueue(context.getZooKeeperRoot() + Constants.ZRECOVERY, sortedLogConf,
+        context).startProcessing(new LogProcessor(), this.threadPool);
   }
 
   public List<RecoveryStatus> getLogSorts() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -276,7 +276,7 @@ public class LogSorter {
   public void startWatchingForRecoveryLogs(ThreadPoolExecutor distWorkQThreadPool)
       throws KeeperException, InterruptedException {
     this.threadPool = distWorkQThreadPool;
-    new DistributedWorkQueue(context.getZooKeeperRoot() + Constants.ZRECOVERY, sortedLogConf)
+    new DistributedWorkQueue(context.getZooKeeperRoot() + Constants.ZRECOVERY, context)
         .startProcessing(new LogProcessor(), this.threadPool);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationWorker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationWorker.java
@@ -61,11 +61,12 @@ public class ReplicationWorker implements Runnable {
         log.debug("Configuration DistributedWorkQueue with delay and period of {} and {}", delay,
             period);
         workQueue = new DistributedWorkQueue(
-            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, conf, delay, period);
+            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, context, delay,
+            period);
       } else {
         log.debug("Configuring DistributedWorkQueue with default delay and period");
         workQueue = new DistributedWorkQueue(
-            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, conf);
+            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, context);
       }
 
       workQueue.startProcessing(new ReplicationProcessor(context), executor);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationWorker.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/ReplicationWorker.java
@@ -61,12 +61,12 @@ public class ReplicationWorker implements Runnable {
         log.debug("Configuration DistributedWorkQueue with delay and period of {} and {}", delay,
             period);
         workQueue = new DistributedWorkQueue(
-            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, context, delay,
+            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, conf, context, delay,
             period);
       } else {
         log.debug("Configuring DistributedWorkQueue with default delay and period");
         workQueue = new DistributedWorkQueue(
-            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, context);
+            context.getZooKeeperRoot() + ReplicationConstants.ZOO_WORK_QUEUE, conf, context);
       }
 
       workQueue.startProcessing(new ReplicationProcessor(context), executor);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -88,8 +88,8 @@ public class SessionManager {
       }
     };
 
-    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(r, 0,
-        Math.max(maxIdle / 2, 1000), TimeUnit.MILLISECONDS);
+    context.getScheduledExecutor().scheduleWithFixedDelay(r, 0, Math.max(maxIdle / 2, 1000),
+        TimeUnit.MILLISECONDS);
   }
 
   public long createSession(Session session, boolean reserve) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.tabletserver.thrift.ScanState;
 import org.apache.accumulo.core.tabletserver.thrift.ScanType;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.threads.ThreadPools;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.tserver.scan.ScanRunState;
 import org.apache.accumulo.tserver.scan.ScanTask;
 import org.apache.accumulo.tserver.session.Session.State;
@@ -65,10 +66,10 @@ public class SessionManager {
   private final Long expiredSessionMarker = (long) -1;
   private final AccumuloConfiguration aconf;
 
-  public SessionManager(AccumuloConfiguration conf) {
-    aconf = conf;
-    maxUpdateIdle = conf.getTimeInMillis(Property.TSERV_UPDATE_SESSION_MAXIDLE);
-    maxIdle = conf.getTimeInMillis(Property.TSERV_SESSION_MAXIDLE);
+  public SessionManager(ServerContext context) {
+    this.aconf = context.getConfiguration();
+    maxUpdateIdle = aconf.getTimeInMillis(Property.TSERV_UPDATE_SESSION_MAXIDLE);
+    maxIdle = aconf.getTimeInMillis(Property.TSERV_SESSION_MAXIDLE);
 
     SecureRandom sr;
     try {
@@ -87,7 +88,7 @@ public class SessionManager {
       }
     };
 
-    ThreadPools.createGeneralScheduledExecutorService(conf).scheduleWithFixedDelay(r, 0,
+    context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(r, 0,
         Math.max(maxIdle / 2, 1000), TimeUnit.MILLISECONDS);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionWatcher.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionWatcher.java
@@ -108,7 +108,7 @@ public class CompactionWatcher implements Runnable {
 
   public static synchronized void startWatching(ServerContext context) {
     if (!watching) {
-      context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
+      context.getScheduledExecutor().scheduleWithFixedDelay(
           new CompactionWatcher(context.getConfiguration()), 10000, 10000, TimeUnit.MILLISECONDS);
       watching = true;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionWatcher.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactionWatcher.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.util.threads.ThreadPools;
+import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.CompactionInfo;
 import org.apache.accumulo.server.compaction.FileCompactor;
 import org.slf4j.LoggerFactory;
@@ -106,10 +106,10 @@ public class CompactionWatcher implements Runnable {
     }
   }
 
-  public static synchronized void startWatching(AccumuloConfiguration config) {
+  public static synchronized void startWatching(ServerContext context) {
     if (!watching) {
-      ThreadPools.createGeneralScheduledExecutorService(config).scheduleWithFixedDelay(
-          new CompactionWatcher(config), 10000, 10000, TimeUnit.MILLISECONDS);
+      context.getSharedGenericScheduledExecutorService().scheduleWithFixedDelay(
+          new CompactionWatcher(context.getConfiguration()), 10000, 10000, TimeUnit.MILLISECONDS);
       watching = true;
     }
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
@@ -45,7 +45,7 @@ public class AssignmentWatcherTest {
     assignments = new HashMap<>();
     context = EasyMock.createMock(ServerContext.class);
     conf = EasyMock.createNiceMock(AccumuloConfiguration.class);
-    watcher = new AssignmentWatcher(context, assignments);
+    watcher = new AssignmentWatcher(conf, context, assignments);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class AssignmentWatcherTest {
     EasyMock.expect(context.getConfiguration()).andReturn(conf).anyTimes();
     EasyMock.expect(conf.getCount(EasyMock.isA(Property.class))).andReturn(1).anyTimes();
     EasyMock.expect(conf.getTimeInMillis(EasyMock.isA(Property.class))).andReturn(0L).anyTimes();
-    EasyMock.expect(context.getSharedGenericScheduledExecutorService())
+    EasyMock.expect(context.getScheduledExecutor())
         .andReturn((ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1)).anyTimes();
     assignments.put(new KeyExtent(TableId.of("1"), null, null), run);
 


### PR DESCRIPTION
Commit e62ace6a9d37572d95999f5412c6148efbba50b9 removed SimpleTimer in favor of
a new ThreadPools class that centralized the creation of thread pools. However, I
missed the fact that SimpleTimer used a shared thread pool. This change reintroduces
a shared generic ScheduledThreadPoolExecutor that can be obtained by calling
ServerContext.getSharedGenericScheduledExecutorService().

Closes #2280