### PR TITLE
Fix trivial warnings

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/constraints/Constraint.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/constraints/Constraint.java
@@ -90,10 +90,6 @@ public interface Constraint {
    *
    * Violation codes must be non-negative. Negative violation codes are reserved for system use.
    *
-   * New API equivalent of
-   * {@link org.apache.accumulo.core.constraints.Constraint#check(org.apache.accumulo.core.constraints.Constraint.Environment, Mutation)}
-   * but renamed to prevent ambiguous method call errors.
-   *
    * @param env
    *          constraint environment
    * @param mutation

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -39,12 +39,8 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GarbageCollectionTest {
-
-  private static final Logger log = LoggerFactory.getLogger(GarbageCollectionTest.class);
 
   static class TestGCE implements GarbageCollectionEnvironment {
     TreeSet<String> candidates = new TreeSet<>();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -72,7 +72,6 @@ import org.apache.accumulo.core.summary.SummaryCollection;
 import org.apache.accumulo.core.summary.SummaryReader;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServiceEnvironmentImpl;
-import org.apache.accumulo.server.compaction.CompactionInfo;
 import org.apache.accumulo.server.compaction.CompactionStats;
 import org.apache.accumulo.server.compaction.FileCompactor;
 import org.apache.accumulo.server.compaction.FileCompactor.CompactionCanceledException;


### PR DESCRIPTION
* Remove unused import
* Remove unused log field in test class
* Remove misleading javadoc about renamed constraint check method that
  wasn't renamed