### PR TITLE
closes #1377 - first stab at checking we hit all the tables

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionEnvironment.java
@@ -41,6 +41,20 @@ import org.apache.accumulo.server.replication.proto.Replication.Status;
 public interface GarbageCollectionEnvironment {
 
   /**
+   * Return true if this for the RootTable, usually setup in the constructor
+   *
+   * @return true if the GCE is for the RootTable
+   */
+  boolean isRootTable();
+
+  /**
+   * Return true if this for the MetadataTable, usually setup in the constructor
+   *
+   * @return true if the GCE is for the MetadataTable
+   */
+  boolean isMetadataTable();
+
+  /**
    * Return a list of paths to files and dirs which are candidates for deletion from a given table,
    * {@link RootTable#NAME} or {@link MetadataTable#NAME}
    *
@@ -73,6 +87,15 @@ public interface GarbageCollectionEnvironment {
    */
   Iterator<Entry<Key,Value>> getReferenceIterator()
       throws TableNotFoundException, AccumuloException, AccumuloSecurityException;
+
+  /**
+   * Return a list of TableIDs for which we are considering deletes. For the root table this would
+   * be the metadata table. For the metadata table, this would be all of the other tables in the
+   * system.
+   *
+   * @return The table ids
+   */
+  Set<String> getCandidateTableIDs();
 
   /**
    * Return the set of tableIDs for the given instance this GarbageCollector is running over


### PR DESCRIPTION
closes #1377 - ensure all tables are checked ...

... when removing references to candidates that are still in use.

This is done by getting tableIds from zookeeper at the start of the
reference scan and at the end of the reference scan.  During the
reference scans, the list of tableID is tracked.  After all candidates
that are still in use have been removed, there is a one more consistency
check to ensure we looked at all tables.
