### PR TITLE
Replace thrown exception with log warning for custom FileSystem implementations

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/HadoopLogCloser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/recovery/HadoopLogCloser.java
@@ -70,8 +70,7 @@ public class HadoopLogCloser implements LogCloser {
     } else if (ns instanceof LocalFileSystem || ns instanceof RawLocalFileSystem) {
       // ignore
     } else {
-      throw new IllegalStateException(
-          "Don't know how to recover a lease for " + ns.getClass().getName());
+      log.warn("Don't know how to recover a lease for " + ns.getClass().getName());
     }
     return 0;
   }


### PR DESCRIPTION
The underlying FileSystem implementation is abstracted in Accumulo, but custom FileSystem implementations are restricted by this section of code in the HadoopLogCloser. I'm working on an S3 classpath extension that would allow S3 to be used as the underlying file system, but this thrown exception makes that impossible.

Instead of throwing an exception here couldn't the log closer simply log a warning? It's very unlikely someone would mistakenly make all the configuration changes necessary in order for this like of code to be executed.

I considered making the custom FileSystem implementation extend DistributedFileSystem instead, but that class is too tightly coupled to HDFS for that route to make sense.