### PR TITLE
External Compaction status percentage incorrect in logs #2308

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -235,7 +235,6 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
    *
    * @param clientAddress
    *          address of this Compactor
-   *
    * @throws KeeperException
    *           zookeeper error
    * @throws InterruptedException
@@ -679,7 +678,8 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
               CompactionInfo info = running.get(0);
               if (info != null) {
                 if (inputEntries > 0) {
-                  percentComplete = Float.toString((info.getEntriesRead() / inputEntries) * 100);
+                  percentComplete =
+                      Float.toString((info.getEntriesRead() / (float) inputEntries) * 100);
                 }
                 String message = String.format(
                     "Compaction in progress, read %d of %d input entries ( %s %s ), written %d entries",


### PR DESCRIPTION
Casted one of the percentComplete variable to float to prevent result always being 0.0.
Closes #2308 