### PR TITLE
Revert "Move AbstractLexicoder to API (#1400)"

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BigIntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BigIntegerLexicoder.java
@@ -24,6 +24,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.clientImpl.lexicoder.FixedByteArrayOutputStream;
 
 /**

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BytesLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BytesLexicoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * For each of the methods, this lexicoder just passes the input through untouched. It is meant to
  * be combined with other lexicoders like the {@link ReverseLexicoder}.

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DateLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DateLexicoder.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.core.client.lexicoder;
 
 import java.util.Date;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder for date objects. It preserves the native Java sort order for Date.
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DoubleLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/DoubleLexicoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder for preserving the native Java sort order of Double values.
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/FloatLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/FloatLexicoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder for preserving the native Java sort order of Float values.
  *

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/IntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/IntegerLexicoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder for signed integers. The encoding sorts Integer.MIN_VALUE first and Integer.MAX_VALUE
  * last. The encoding sorts -2 before -1. It corresponds to the sort order of Integer.

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ListLexicoder.java
@@ -26,6 +26,8 @@ import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder to encode/decode a Java List to/from a byte array where the concatenation of each
  * encoded element sorts lexicographically.

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.escape;
 import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.split;
 import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.util.ComparablePair;
 
 /**

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ReverseLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ReverseLexicoder.java
@@ -21,6 +21,8 @@ package org.apache.accumulo.core.client.lexicoder;
 import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.escape;
 import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder that flips the sort order from another lexicoder. If this is applied to
  * {@link DateLexicoder}, the most recent date will be sorted first and the oldest date will be

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoder.java
@@ -27,6 +27,8 @@ import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A Lexicoder to encode/decode a Java List to/from a byte array where the concatenation of each
  * encoded element sorts lexicographically.

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/StringLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/StringLexicoder.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.core.client.lexicoder;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * This lexicoder encodes/decodes a given String to/from bytes without further processing. It can be
  * combined with other encoders like the {@link ReverseLexicoder} to flip the default sort order.

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/TextLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/TextLexicoder.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UIntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UIntegerLexicoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * A lexicoder for an unsigned integer. It sorts 0 before -1 and does not preserve the native sort
  * order of a Java integer because Java does not contain an unsigned integer. If Java had an

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ULongLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/ULongLexicoder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.client.lexicoder;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
+
 /**
  * Unsigned long lexicoder. The lexicographic encoding sorts first 0l and -1l last. This encoding
  * does not correspond to the sort of Long because it does not consider the sign bit. If Java had an

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UUIDLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UUIDLexicoder.java
@@ -24,6 +24,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.clientImpl.lexicoder.FixedByteArrayOutputStream;
 
 /**

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/lexicoder/AbstractLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/lexicoder/AbstractLexicoder.java
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.client.lexicoder;
+package org.apache.accumulo.core.clientImpl.lexicoder;
+
+import org.apache.accumulo.core.client.lexicoder.AbstractEncoder;
+import org.apache.accumulo.core.client.lexicoder.Lexicoder;
 
 public abstract class AbstractLexicoder<T> extends AbstractEncoder<T> implements Lexicoder<T> {}

--- a/core/src/main/java/org/apache/accumulo/core/iterators/LongCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/LongCombiner.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.client.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.client.lexicoder.Encoder;
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.io.WritableUtils;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/BigDecimalCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/BigDecimalCombiner.java
@@ -25,7 +25,7 @@ import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.accumulo.core.client.lexicoder.AbstractLexicoder;
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SummingArrayCombiner.java
@@ -33,8 +33,8 @@ import java.util.Map;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.lexicoder.AbstractEncoder;
-import org.apache.accumulo.core.client.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.client.lexicoder.Encoder;
+import org.apache.accumulo.core.clientImpl.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/AbstractLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/AbstractLexicoderTest.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.clientImpl.lexicoder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import org.apache.accumulo.core.client.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.client.lexicoder.LexicoderTest;
 import org.apache.commons.lang3.ArrayUtils;
 


### PR DESCRIPTION
This reverts commit 2e8144ec89e74d37c7ff97d301051fea747e05c7.

The move of this class breaks API compatibility in the class hierarchy. I am not sure how the parent class being in the `clientImpl` is not picked up by the apilyzer plugin. It could be since the super class of AbstractLexicoder in `clientImpl` happens to be in the public API that it doesn't actually expose any internal class. While it is awkward that AbstractLexicoder is in a different non-API package, it seems that it ultimately doesn't matter for the public API.