### PR TITLE
Use numFilesCompacting+totalTabletFiles for compaction priority

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -303,15 +303,18 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
         // determine which executor to use based on the size of the files
         var ceid = getExecutor(group);
 
-        return params.createPlanBuilder().addJob(createPriority(params), ceid, group).build();
+        return params.createPlanBuilder().addJob(createPriority(params, group), ceid, group)
+            .build();
       }
     } catch (RuntimeException e) {
       throw e;
     }
   }
 
-  private static short createPriority(PlanningParameters params) {
-    return CompactionJobPrioritizer.createPriority(params.getKind(), params.getAll().size());
+  private static short createPriority(PlanningParameters params,
+      Collection<CompactableFile> group) {
+    return CompactionJobPrioritizer.createPriority(params.getKind(), params.getAll().size(),
+        group.size());
   }
 
   private long getMaxSizeToCompact(CompactionKind kind) {

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobPrioritizer.java
@@ -30,25 +30,28 @@ public class CompactionJobPrioritizer {
       Comparator.comparingInt(CompactionJob::getPriority)
           .thenComparingInt(job -> job.getFiles().size()).reversed();
 
-  public static short createPriority(CompactionKind kind, int totalFiles) {
+  public static short createPriority(CompactionKind kind, int totalFiles, int compactingFiles) {
+
+    int prio = totalFiles + compactingFiles;
+
     switch (kind) {
       case USER:
       case CHOP:
         // user-initiated compactions will have a positive priority
         // based on number of files
-        if (totalFiles > Short.MAX_VALUE) {
+        if (prio > Short.MAX_VALUE) {
           return Short.MAX_VALUE;
         }
-        return (short) totalFiles;
+        return (short) prio;
       case SELECTOR:
       case SYSTEM:
         // system-initiated compactions will have a negative priority
         // starting at -32768 and increasing based on number of files
         // maxing out at -1
-        if (totalFiles > Short.MAX_VALUE) {
+        if (prio > Short.MAX_VALUE) {
           return -1;
         } else {
-          return (short) (Short.MIN_VALUE + totalFiles);
+          return (short) (Short.MIN_VALUE + prio);
         }
       default:
         throw new AssertionError("Unknown kind " + kind);

--- a/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/compaction/CompactionPrioritizerTest.java
@@ -42,26 +42,30 @@ public class CompactionPrioritizerTest {
       files.add(CompactableFile
           .create(URI.create("hdfs://foonn/accumulo/tables/5/" + tablet + "/" + i + ".rf"), 4, 4));
     }
-    return new CompactionJobImpl(CompactionJobPrioritizer.createPriority(kind, totalFiles),
+    // TODO pass numFiles
+    return new CompactionJobImpl(
+        CompactionJobPrioritizer.createPriority(kind, totalFiles, numFiles),
         CompactionExecutorIdImpl.externalId("test"), files, kind, Optional.of(false));
   }
 
   @Test
   public void testPrioritizer() throws Exception {
-    assertEquals((short) 0, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0));
+    assertEquals((short) 0, CompactionJobPrioritizer.createPriority(CompactionKind.USER, 0, 0));
     assertEquals((short) 10000,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000));
+        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 10000, 0));
     assertEquals((short) 32767,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767));
+        CompactionJobPrioritizer.createPriority(CompactionKind.USER, 32767, 0));
     assertEquals((short) 32767,
-        CompactionJobPrioritizer.createPriority(CompactionKind.USER, Integer.MAX_VALUE));
+        CompactionJobPrioritizer.createPriority(CompactionKind.USER, Integer.MAX_VALUE, 0));
 
-    assertEquals((short) -32768, CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0));
+    assertEquals((short) -32768,
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 0, 0));
     assertEquals((short) -22768,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 10000));
-    assertEquals((short) -1, CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 32767));
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 10000, 0));
     assertEquals((short) -1,
-        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, Integer.MAX_VALUE));
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, 32767, 0));
+    assertEquals((short) -1,
+        CompactionJobPrioritizer.createPriority(CompactionKind.SYSTEM, Integer.MAX_VALUE, 0));
   }
 
   @Test
@@ -74,7 +78,7 @@ public class CompactionPrioritizerTest {
     var j6 = createJob(CompactionKind.CHOP, "t-014", 5, 40);
     var j7 = createJob(CompactionKind.CHOP, "t-015", 5, 7);
     var j8 = createJob(CompactionKind.SELECTOR, "t-014", 5, 21);
-    var j9 = createJob(CompactionKind.SELECTOR, "t-015", 7, 21);
+    var j9 = createJob(CompactionKind.SELECTOR, "t-015", 7, 20);
 
     var expected = List.of(j6, j2, j3, j1, j7, j4, j9, j8, j5);
 


### PR DESCRIPTION
Currently Accumulo uses the total number of files in a tablet as the priority for compactions that run against a tablet. So for the following queued tablet compactions

Tablet Name | Total files | Files to compact
-|-|-
A | 20 | 10
B | 22 | 3

The tablet B with 22 total files would have a higher priority than A and would compact first.  The goal of the priority is to reduce the overall number of files per tablet.  Running the compaction for A before B would better accomplish this goal because it will compact 10 files resulting in the tablet having 11 files after the compaction.  The compaction for B will compact 3 files resulting in a total of 20 file after the compaction.  However the current priority scheme chooses B before A.

This PR changes a compactions priority from totalTabletFiles to totalTableFiles+numFilesCompaction. With this scheme the compaction for tablet A would have a priority of 30 and tablet B a priority of 25, resulting the compaction A running first.

To see if this made a noticeable difference I updated [compaculation](https://github.com/keith-turner/compaculation) to use Accumulo's pluggable compaction planners and ran a test w/ the old and new prioritizations schemes.  The simulation only had a single thread for executing compactions, so that compactions would be always be queued making the prioritization really matter.  The following config was used for the compaction planner. 

```
"[{'name':'large','type':'internal','numThreads':1}]"
```

Below is a plot of the test running over 3 simulated days, adding 4 files to 4 random tablets every second.  There were 100 simulated tablets.  The plot shows the average files per tablet over time.  The new prioritization scheme has a slightly lower files per tablet over time, which is good. A compaction ratio of 3 was used for the test.

![plot-comp-prio](https://user-images.githubusercontent.com/1268739/138975822-a8082199-d635-450c-94b2-2f6a9b0a6d99.png)

The simulation produces a line for every second, which is too much data to plot (its very noisy).   The following commands were used to average  every 10,000 lines of the file into a single line.  The summary files were plotted.

```
 cat results-old-prio.txt  | datamash -W -H -f bin:10000 1 | datamash -H -g 9 mean 4 > results-old-prio-summary.txt
 cat results-new-prio.txt  | datamash -W -H -f bin:10000 1 | datamash -H -g 9 mean 4 > results-new-prio-summary.txt
```

The following are the averages of files per tablet over the entire lifetime of the two test.  The new priority scheme has a slightly lower average for the entire test at 21.15.

```
$ cat results-old-prio.txt | datamash -H -W mean 4
mean(fsumAvg)
23.754240592279
$ cat results-new-prio.txt | datamash -H -W mean 4
mean(fsumAvg)
21.1524313084
```

This a very small improvement, that would only matter when lots of compaction work is constantly queued.