### PR TITLE
Move checkTableMetaData to AssignmentHandler file

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 
 class AssignmentHandler implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(AssignmentHandler.class);
-  private static final String METADETA_ISSUE = "Saw metadeta issue when loading table : ";
+  private static final String METADATA_ISSUE = "Saw metadata issue when loading tablet : ";
   private final KeyExtent extent;
   private final int retryAttempt;
   private final TabletServer server;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -18,6 +18,13 @@
  */
 package org.apache.accumulo.tserver;
 
+import static org.apache.accumulo.server.problems.ProblemType.TABLET_LOAD;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -39,239 +46,234 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-
-import static org.apache.accumulo.server.problems.ProblemType.TABLET_LOAD;
-
 class AssignmentHandler implements Runnable {
-    private static final Logger log = LoggerFactory.getLogger(AssignmentHandler.class);
-    private static final String METADETA_ISSUE = "Saw metadeta issue when loading table : ";
-    private final KeyExtent extent;
-    private final int retryAttempt;
-    private final TabletServer server;
+  private static final Logger log = LoggerFactory.getLogger(AssignmentHandler.class);
+  private static final String METADETA_ISSUE = "Saw metadeta issue when loading table : ";
+  private final KeyExtent extent;
+  private final int retryAttempt;
+  private final TabletServer server;
 
-    public AssignmentHandler(TabletServer server, KeyExtent extent) {
-        this(server, extent, 0);
-    }
+  public AssignmentHandler(TabletServer server, KeyExtent extent) {
+    this(server, extent, 0);
+  }
 
-    public AssignmentHandler(TabletServer server, KeyExtent extent, int retryAttempt) {
-        this.server = server;
-        this.extent = extent;
-        this.retryAttempt = retryAttempt;
-    }
+  public AssignmentHandler(TabletServer server, KeyExtent extent, int retryAttempt) {
+    this.server = server;
+    this.extent = extent;
+    this.retryAttempt = retryAttempt;
+  }
 
-    @Override
-    public void run() {
-        synchronized (server.unopenedTablets) {
-            synchronized (server.openingTablets) {
-                synchronized (server.onlineTablets) {
-                    // nothing should be moving between sets, do a sanity
-                    // check
-                    Set<KeyExtent> unopenedOverlapping =
-                            KeyExtent.findOverlapping(extent, server.unopenedTablets);
-                    Set<KeyExtent> openingOverlapping =
-                            KeyExtent.findOverlapping(extent, server.openingTablets);
-                    Set<KeyExtent> onlineOverlapping =
-                            KeyExtent.findOverlapping(extent, server.onlineTablets.snapshot());
+  @Override
+  public void run() {
+    synchronized (server.unopenedTablets) {
+      synchronized (server.openingTablets) {
+        synchronized (server.onlineTablets) {
+          // nothing should be moving between sets, do a sanity
+          // check
+          Set<KeyExtent> unopenedOverlapping =
+              KeyExtent.findOverlapping(extent, server.unopenedTablets);
+          Set<KeyExtent> openingOverlapping =
+              KeyExtent.findOverlapping(extent, server.openingTablets);
+          Set<KeyExtent> onlineOverlapping =
+              KeyExtent.findOverlapping(extent, server.onlineTablets.snapshot());
 
-                    if (openingOverlapping.contains(extent) || onlineOverlapping.contains(extent)) {
-                        return;
-                    }
-
-                    if (!unopenedOverlapping.contains(extent)) {
-                        log.info("assignment {} no longer in the unopened set", extent);
-                        return;
-                    }
-
-                    if (unopenedOverlapping.size() != 1 || !openingOverlapping.isEmpty()
-                            || !onlineOverlapping.isEmpty()) {
-                        throw new IllegalStateException(
-                                "overlaps assigned " + extent + " " + !server.unopenedTablets.contains(extent) + " "
-                                        + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping);
-                    }
-                }
-
-                server.unopenedTablets.remove(extent);
-                server.openingTablets.add(extent);
-            }
-        }
-
-        // check Metadata table before accepting assignment
-        Text locationToOpen = null;
-        TabletMetadata tabletMetadata = null;
-        boolean canLoad = false;
-        try {
-            tabletMetadata = server.getContext().getAmple().readTablet(extent);
-
-            canLoad = checkTabletMetadata(extent, server.getTabletSession(), tabletMetadata);
-
-            if (canLoad && tabletMetadata.sawOldPrevEndRow()) {
-                KeyExtent fixedExtent =
-                        ManagerMetadataUtil.fixSplit(server.getContext(), tabletMetadata, server.getLock());
-
-                synchronized (server.openingTablets) {
-                    server.openingTablets.remove(extent);
-                    server.openingTablets.notifyAll();
-                    // it expected that the new extent will overlap the old one... if it does not, it
-                    // should not be added to unopenedTablets
-                    if (!KeyExtent.findOverlapping(extent, new TreeSet<>(Arrays.asList(fixedExtent)))
-                            .contains(fixedExtent)) {
-                        throw new IllegalStateException(
-                                "Fixed split does not overlap " + extent + " " + fixedExtent);
-                    }
-                    server.unopenedTablets.add(fixedExtent);
-                }
-                // split was rolled back... try again
-                new AssignmentHandler(server, fixedExtent).run();
-                return;
-
-            }
-        } catch (Exception e) {
-            synchronized (server.openingTablets) {
-                server.openingTablets.remove(extent);
-                server.openingTablets.notifyAll();
-            }
-            log.warn("Failed to verify tablet " + extent, e);
-            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
-            throw new RuntimeException(e);
-        }
-
-        if (!canLoad) {
-            log.debug("Reporting tablet {} assignment failure: unable to verify Tablet Information",
-                    extent);
-            synchronized (server.openingTablets) {
-                server.openingTablets.remove(extent);
-                server.openingTablets.notifyAll();
-            }
-            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+          if (openingOverlapping.contains(extent) || onlineOverlapping.contains(extent)) {
             return;
+          }
+
+          if (!unopenedOverlapping.contains(extent)) {
+            log.info("assignment {} no longer in the unopened set", extent);
+            return;
+          }
+
+          if (unopenedOverlapping.size() != 1 || !openingOverlapping.isEmpty()
+              || !onlineOverlapping.isEmpty()) {
+            throw new IllegalStateException(
+                "overlaps assigned " + extent + " " + !server.unopenedTablets.contains(extent) + " "
+                    + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping);
+          }
         }
 
-        Tablet tablet = null;
-        boolean successful = false;
-
-        try {
-            server.acquireRecoveryMemory(extent);
-
-            TabletResourceManager trm = server.resourceManager.createTabletResourceManager(extent,
-                    server.getTableConfiguration(extent));
-            TabletData data = new TabletData(tabletMetadata);
-
-            tablet = new Tablet(server, extent, trm, data);
-            // If a minor compaction starts after a tablet opens, this indicates a log recovery
-            // occurred. This recovered data must be minor compacted.
-            // There are three reasons to wait for this minor compaction to finish before placing the
-            // tablet in online tablets.
-            //
-            // 1) The log recovery code does not handle data written to the tablet on multiple tablet
-            // servers.
-            // 2) The log recovery code does not block if memory is full. Therefore recovering lots of
-            // tablets that use a lot of memory could run out of memory.
-            // 3) The minor compaction finish event did not make it to the logs (the file will be in
-            // metadata, preventing replay of compacted data)... but do not
-            // want a majc to wipe the file out from metadata and then have another process failure...
-            // this could cause duplicate data to replay.
-            if (tablet.getNumEntriesInMemory() > 0
-                    && !tablet.minorCompactNow(MinorCompactionReason.RECOVERY)) {
-                throw new RuntimeException("Minor compaction after recovery fails for " + extent);
-            }
-            Assignment assignment = new Assignment(extent, server.getTabletSession());
-            TabletStateStore.setLocation(server.getContext(), assignment);
-
-            synchronized (server.openingTablets) {
-                synchronized (server.onlineTablets) {
-                    server.openingTablets.remove(extent);
-                    server.onlineTablets.put(extent, tablet);
-                    server.openingTablets.notifyAll();
-                    server.recentlyUnloadedCache.remove(tablet.getExtent());
-                }
-            }
-            tablet = null; // release this reference
-            successful = true;
-        } catch (Exception e) {
-            log.warn("exception trying to assign tablet {} {}", extent, locationToOpen, e);
-
-            if (e.getMessage() != null) {
-                log.warn("{}", e.getMessage());
-            }
-
-            TableId tableId = extent.tableId();
-            ProblemReports.getInstance(server.getContext()).report(new ProblemReport(tableId, TABLET_LOAD,
-                    extent.getUUID().toString(), server.getClientAddressString(), e));
-        } finally {
-            server.releaseRecoveryMemory(extent);
-        }
-
-        if (successful) {
-            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOADED, extent));
-        } else {
-            synchronized (server.unopenedTablets) {
-                synchronized (server.openingTablets) {
-                    server.openingTablets.remove(extent);
-                    server.unopenedTablets.add(extent);
-                    server.openingTablets.notifyAll();
-                }
-            }
-            log.warn("failed to open tablet {} reporting failure to manager", extent);
-            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
-            long reschedule = Math.min((1L << Math.min(32, retryAttempt)) * 1000, 10 * 60 * 1000L);
-            log.warn(String.format("rescheduling tablet load in %.2f seconds", reschedule / 1000.));
-            this.server.getContext().getScheduledExecutor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    log.info("adding tablet {} back to the assignment pool (retry {})", extent, retryAttempt);
-                    AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
-                    if (extent.isMeta()) {
-                        if (extent.isRootTablet()) {
-                            Threads.createThread("Root tablet assignment retry", handler).start();
-                        } else {
-                            server.resourceManager.addMetaDataAssignment(extent, log, handler);
-                        }
-                    } else {
-                        server.resourceManager.addAssignment(extent, log, handler);
-                    }
-                }
-            }, reschedule, TimeUnit.MILLISECONDS);
-        }
+        server.unopenedTablets.remove(extent);
+        server.openingTablets.add(extent);
+      }
     }
 
-    public static boolean checkTabletMetadata(KeyExtent extent, TServerInstance instance,
-                                              TabletMetadata meta) throws AccumuloException {
+    // check Metadata table before accepting assignment
+    Text locationToOpen = null;
+    TabletMetadata tabletMetadata = null;
+    boolean canLoad = false;
+    try {
+      tabletMetadata = server.getContext().getAmple().readTablet(extent);
 
-        if (meta == null) {
-            log.info(METADETA_ISSUE + "{}, its metadata was not found.", extent);
-            return false;
+      canLoad = checkTabletMetadata(extent, server.getTabletSession(), tabletMetadata);
+
+      if (canLoad && tabletMetadata.sawOldPrevEndRow()) {
+        KeyExtent fixedExtent =
+            ManagerMetadataUtil.fixSplit(server.getContext(), tabletMetadata, server.getLock());
+
+        synchronized (server.openingTablets) {
+          server.openingTablets.remove(extent);
+          server.openingTablets.notifyAll();
+          // it expected that the new extent will overlap the old one... if it does not, it
+          // should not be added to unopenedTablets
+          if (!KeyExtent.findOverlapping(extent, new TreeSet<>(Arrays.asList(fixedExtent)))
+              .contains(fixedExtent)) {
+            throw new IllegalStateException(
+                "Fixed split does not overlap " + extent + " " + fixedExtent);
+          }
+          server.unopenedTablets.add(fixedExtent);
         }
+        // split was rolled back... try again
+        new AssignmentHandler(server, fixedExtent).run();
+        return;
 
-        if (!meta.sawPrevEndRow()) {
-            throw new AccumuloException(METADETA_ISSUE + "metadata entry does not have prev row (" + meta.getTableId()
-                    + " " + meta.getEndRow() + ")");
-        }
-
-        if (!extent.equals(meta.getExtent())) {
-            log.info(METADETA_ISSUE + "tablet extent mismatch {} {}", extent, meta.getExtent());
-            return false;
-        }
-
-        if (meta.getDirName() == null) {
-            throw new AccumuloException(
-                    METADETA_ISSUE + "metadata entry does not have directory (" + meta.getExtent() + ")");
-        }
-
-        if (meta.getTime() == null && !extent.equals(RootTable.EXTENT)) {
-            throw new AccumuloException(METADETA_ISSUE + "metadata entry does not have time (" + meta.getExtent() + ")");
-        }
-
-        TabletMetadata.Location loc = meta.getLocation();
-
-        if (loc == null || loc.getType() != TabletMetadata.LocationType.FUTURE || !instance.equals(loc)) {
-            log.info(METADETA_ISSUE + "Unexpected location {} {}", extent, loc);
-            return false;
-        }
-
-        return true;
+      }
+    } catch (Exception e) {
+      synchronized (server.openingTablets) {
+        server.openingTablets.remove(extent);
+        server.openingTablets.notifyAll();
+      }
+      log.warn("Failed to verify tablet " + extent, e);
+      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+      throw new RuntimeException(e);
     }
+
+    if (!canLoad) {
+      log.debug("Reporting tablet {} assignment failure: unable to verify Tablet Information",
+          extent);
+      synchronized (server.openingTablets) {
+        server.openingTablets.remove(extent);
+        server.openingTablets.notifyAll();
+      }
+      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+      return;
+    }
+
+    Tablet tablet = null;
+    boolean successful = false;
+
+    try {
+      server.acquireRecoveryMemory(extent);
+
+      TabletResourceManager trm = server.resourceManager.createTabletResourceManager(extent,
+          server.getTableConfiguration(extent));
+      TabletData data = new TabletData(tabletMetadata);
+
+      tablet = new Tablet(server, extent, trm, data);
+      // If a minor compaction starts after a tablet opens, this indicates a log recovery
+      // occurred. This recovered data must be minor compacted.
+      // There are three reasons to wait for this minor compaction to finish before placing the
+      // tablet in online tablets.
+      //
+      // 1) The log recovery code does not handle data written to the tablet on multiple tablet
+      // servers.
+      // 2) The log recovery code does not block if memory is full. Therefore recovering lots of
+      // tablets that use a lot of memory could run out of memory.
+      // 3) The minor compaction finish event did not make it to the logs (the file will be in
+      // metadata, preventing replay of compacted data)... but do not
+      // want a majc to wipe the file out from metadata and then have another process failure...
+      // this could cause duplicate data to replay.
+      if (tablet.getNumEntriesInMemory() > 0
+          && !tablet.minorCompactNow(MinorCompactionReason.RECOVERY)) {
+        throw new RuntimeException("Minor compaction after recovery fails for " + extent);
+      }
+      Assignment assignment = new Assignment(extent, server.getTabletSession());
+      TabletStateStore.setLocation(server.getContext(), assignment);
+
+      synchronized (server.openingTablets) {
+        synchronized (server.onlineTablets) {
+          server.openingTablets.remove(extent);
+          server.onlineTablets.put(extent, tablet);
+          server.openingTablets.notifyAll();
+          server.recentlyUnloadedCache.remove(tablet.getExtent());
+        }
+      }
+      tablet = null; // release this reference
+      successful = true;
+    } catch (Exception e) {
+      log.warn("exception trying to assign tablet {} {}", extent, locationToOpen, e);
+
+      if (e.getMessage() != null) {
+        log.warn("{}", e.getMessage());
+      }
+
+      TableId tableId = extent.tableId();
+      ProblemReports.getInstance(server.getContext()).report(new ProblemReport(tableId, TABLET_LOAD,
+          extent.getUUID().toString(), server.getClientAddressString(), e));
+    } finally {
+      server.releaseRecoveryMemory(extent);
+    }
+
+    if (successful) {
+      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOADED, extent));
+    } else {
+      synchronized (server.unopenedTablets) {
+        synchronized (server.openingTablets) {
+          server.openingTablets.remove(extent);
+          server.unopenedTablets.add(extent);
+          server.openingTablets.notifyAll();
+        }
+      }
+      log.warn("failed to open tablet {} reporting failure to manager", extent);
+      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+      long reschedule = Math.min((1L << Math.min(32, retryAttempt)) * 1000, 10 * 60 * 1000L);
+      log.warn(String.format("rescheduling tablet load in %.2f seconds", reschedule / 1000.));
+      this.server.getContext().getScheduledExecutor().schedule(new Runnable() {
+        @Override
+        public void run() {
+          log.info("adding tablet {} back to the assignment pool (retry {})", extent, retryAttempt);
+          AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
+          if (extent.isMeta()) {
+            if (extent.isRootTablet()) {
+              Threads.createThread("Root tablet assignment retry", handler).start();
+            } else {
+              server.resourceManager.addMetaDataAssignment(extent, log, handler);
+            }
+          } else {
+            server.resourceManager.addAssignment(extent, log, handler);
+          }
+        }
+      }, reschedule, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public static boolean checkTabletMetadata(KeyExtent extent, TServerInstance instance,
+      TabletMetadata meta) throws AccumuloException {
+
+    if (meta == null) {
+      log.info(METADETA_ISSUE + "{}, its metadata was not found.", extent);
+      return false;
+    }
+
+    if (!meta.sawPrevEndRow()) {
+      throw new AccumuloException(METADETA_ISSUE + "metadata entry does not have prev row ("
+          + meta.getTableId() + " " + meta.getEndRow() + ")");
+    }
+
+    if (!extent.equals(meta.getExtent())) {
+      log.info(METADETA_ISSUE + "tablet extent mismatch {} {}", extent, meta.getExtent());
+      return false;
+    }
+
+    if (meta.getDirName() == null) {
+      throw new AccumuloException(
+          METADETA_ISSUE + "metadata entry does not have directory (" + meta.getExtent() + ")");
+    }
+
+    if (meta.getTime() == null && !extent.equals(RootTable.EXTENT)) {
+      throw new AccumuloException(
+          METADETA_ISSUE + "metadata entry does not have time (" + meta.getExtent() + ")");
+    }
+
+    TabletMetadata.Location loc = meta.getLocation();
+
+    if (loc == null || loc.getType() != TabletMetadata.LocationType.FUTURE
+        || !instance.equals(loc)) {
+      log.info(METADETA_ISSUE + "Unexpected location {} {}", extent, loc);
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -242,35 +242,35 @@ class AssignmentHandler implements Runnable {
       TabletMetadata meta) throws AccumuloException {
 
     if (meta == null) {
-      log.info(METADETA_ISSUE + "{}, its metadata was not found.", extent);
+      log.info(METADATA_ISSUE + "{}, its metadata was not found.", extent);
       return false;
     }
 
     if (!meta.sawPrevEndRow()) {
-      throw new AccumuloException(METADETA_ISSUE + "metadata entry does not have prev row ("
+      throw new AccumuloException(METADATA_ISSUE + "metadata entry does not have prev row ("
           + meta.getTableId() + " " + meta.getEndRow() + ")");
     }
 
     if (!extent.equals(meta.getExtent())) {
-      log.info(METADETA_ISSUE + "tablet extent mismatch {} {}", extent, meta.getExtent());
+      log.info(METADATA_ISSUE + "tablet extent mismatch {} {}", extent, meta.getExtent());
       return false;
     }
 
     if (meta.getDirName() == null) {
       throw new AccumuloException(
-          METADETA_ISSUE + "metadata entry does not have directory (" + meta.getExtent() + ")");
+          METADATA_ISSUE + "metadata entry does not have directory (" + meta.getExtent() + ")");
     }
 
     if (meta.getTime() == null && !extent.equals(RootTable.EXTENT)) {
       throw new AccumuloException(
-          METADETA_ISSUE + "metadata entry does not have time (" + meta.getExtent() + ")");
+          METADATA_ISSUE + "metadata entry does not have time (" + meta.getExtent() + ")");
     }
 
     TabletMetadata.Location loc = meta.getLocation();
 
     if (loc == null || loc.getType() != TabletMetadata.LocationType.FUTURE
         || !instance.equals(loc)) {
-      log.info(METADETA_ISSUE + "Unexpected location {} {}", extent, loc);
+      log.info(METADATA_ISSUE + "Unexpected location {} {}", extent, loc);
       return false;
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -18,16 +18,12 @@
  */
 package org.apache.accumulo.tserver;
 
-import static org.apache.accumulo.server.problems.ProblemType.TABLET_LOAD;
-
-import java.util.Arrays;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-
+import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.manager.thrift.TabletLoadState;
+import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.manager.state.Assignment;
@@ -43,194 +39,239 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.accumulo.server.problems.ProblemType.TABLET_LOAD;
+
 class AssignmentHandler implements Runnable {
-  private static final Logger log = LoggerFactory.getLogger(AssignmentHandler.class);
-  private final KeyExtent extent;
-  private final int retryAttempt;
-  private final TabletServer server;
+    private static final Logger log = LoggerFactory.getLogger(AssignmentHandler.class);
+    private static final String METADETA_ISSUE = "Saw metadeta issue when loading table : ";
+    private final KeyExtent extent;
+    private final int retryAttempt;
+    private final TabletServer server;
 
-  public AssignmentHandler(TabletServer server, KeyExtent extent) {
-    this(server, extent, 0);
-  }
-
-  public AssignmentHandler(TabletServer server, KeyExtent extent, int retryAttempt) {
-    this.server = server;
-    this.extent = extent;
-    this.retryAttempt = retryAttempt;
-  }
-
-  @Override
-  public void run() {
-    synchronized (server.unopenedTablets) {
-      synchronized (server.openingTablets) {
-        synchronized (server.onlineTablets) {
-          // nothing should be moving between sets, do a sanity
-          // check
-          Set<KeyExtent> unopenedOverlapping =
-              KeyExtent.findOverlapping(extent, server.unopenedTablets);
-          Set<KeyExtent> openingOverlapping =
-              KeyExtent.findOverlapping(extent, server.openingTablets);
-          Set<KeyExtent> onlineOverlapping =
-              KeyExtent.findOverlapping(extent, server.onlineTablets.snapshot());
-
-          if (openingOverlapping.contains(extent) || onlineOverlapping.contains(extent)) {
-            return;
-          }
-
-          if (!unopenedOverlapping.contains(extent)) {
-            log.info("assignment {} no longer in the unopened set", extent);
-            return;
-          }
-
-          if (unopenedOverlapping.size() != 1 || !openingOverlapping.isEmpty()
-              || !onlineOverlapping.isEmpty()) {
-            throw new IllegalStateException(
-                "overlaps assigned " + extent + " " + !server.unopenedTablets.contains(extent) + " "
-                    + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping);
-          }
-        }
-
-        server.unopenedTablets.remove(extent);
-        server.openingTablets.add(extent);
-      }
+    public AssignmentHandler(TabletServer server, KeyExtent extent) {
+        this(server, extent, 0);
     }
 
-    // check Metadata table before accepting assignment
-    Text locationToOpen = null;
-    TabletMetadata tabletMetadata = null;
-    boolean canLoad = false;
-    try {
-      tabletMetadata = server.getContext().getAmple().readTablet(extent);
-
-      canLoad = TabletServer.checkTabletMetadata(extent, server.getTabletSession(), tabletMetadata);
-
-      if (canLoad && tabletMetadata.sawOldPrevEndRow()) {
-        KeyExtent fixedExtent =
-            ManagerMetadataUtil.fixSplit(server.getContext(), tabletMetadata, server.getLock());
-
-        synchronized (server.openingTablets) {
-          server.openingTablets.remove(extent);
-          server.openingTablets.notifyAll();
-          // it expected that the new extent will overlap the old one... if it does not, it
-          // should not be added to unopenedTablets
-          if (!KeyExtent.findOverlapping(extent, new TreeSet<>(Arrays.asList(fixedExtent)))
-              .contains(fixedExtent)) {
-            throw new IllegalStateException(
-                "Fixed split does not overlap " + extent + " " + fixedExtent);
-          }
-          server.unopenedTablets.add(fixedExtent);
-        }
-        // split was rolled back... try again
-        new AssignmentHandler(server, fixedExtent).run();
-        return;
-
-      }
-    } catch (Exception e) {
-      synchronized (server.openingTablets) {
-        server.openingTablets.remove(extent);
-        server.openingTablets.notifyAll();
-      }
-      log.warn("Failed to verify tablet " + extent, e);
-      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
-      throw new RuntimeException(e);
+    public AssignmentHandler(TabletServer server, KeyExtent extent, int retryAttempt) {
+        this.server = server;
+        this.extent = extent;
+        this.retryAttempt = retryAttempt;
     }
 
-    if (!canLoad) {
-      log.debug("Reporting tablet {} assignment failure: unable to verify Tablet Information",
-          extent);
-      synchronized (server.openingTablets) {
-        server.openingTablets.remove(extent);
-        server.openingTablets.notifyAll();
-      }
-      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
-      return;
-    }
+    @Override
+    public void run() {
+        synchronized (server.unopenedTablets) {
+            synchronized (server.openingTablets) {
+                synchronized (server.onlineTablets) {
+                    // nothing should be moving between sets, do a sanity
+                    // check
+                    Set<KeyExtent> unopenedOverlapping =
+                            KeyExtent.findOverlapping(extent, server.unopenedTablets);
+                    Set<KeyExtent> openingOverlapping =
+                            KeyExtent.findOverlapping(extent, server.openingTablets);
+                    Set<KeyExtent> onlineOverlapping =
+                            KeyExtent.findOverlapping(extent, server.onlineTablets.snapshot());
 
-    Tablet tablet = null;
-    boolean successful = false;
+                    if (openingOverlapping.contains(extent) || onlineOverlapping.contains(extent)) {
+                        return;
+                    }
 
-    try {
-      server.acquireRecoveryMemory(extent);
+                    if (!unopenedOverlapping.contains(extent)) {
+                        log.info("assignment {} no longer in the unopened set", extent);
+                        return;
+                    }
 
-      TabletResourceManager trm = server.resourceManager.createTabletResourceManager(extent,
-          server.getTableConfiguration(extent));
-      TabletData data = new TabletData(tabletMetadata);
+                    if (unopenedOverlapping.size() != 1 || !openingOverlapping.isEmpty()
+                            || !onlineOverlapping.isEmpty()) {
+                        throw new IllegalStateException(
+                                "overlaps assigned " + extent + " " + !server.unopenedTablets.contains(extent) + " "
+                                        + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping);
+                    }
+                }
 
-      tablet = new Tablet(server, extent, trm, data);
-      // If a minor compaction starts after a tablet opens, this indicates a log recovery
-      // occurred. This recovered data must be minor compacted.
-      // There are three reasons to wait for this minor compaction to finish before placing the
-      // tablet in online tablets.
-      //
-      // 1) The log recovery code does not handle data written to the tablet on multiple tablet
-      // servers.
-      // 2) The log recovery code does not block if memory is full. Therefore recovering lots of
-      // tablets that use a lot of memory could run out of memory.
-      // 3) The minor compaction finish event did not make it to the logs (the file will be in
-      // metadata, preventing replay of compacted data)... but do not
-      // want a majc to wipe the file out from metadata and then have another process failure...
-      // this could cause duplicate data to replay.
-      if (tablet.getNumEntriesInMemory() > 0
-          && !tablet.minorCompactNow(MinorCompactionReason.RECOVERY)) {
-        throw new RuntimeException("Minor compaction after recovery fails for " + extent);
-      }
-      Assignment assignment = new Assignment(extent, server.getTabletSession());
-      TabletStateStore.setLocation(server.getContext(), assignment);
-
-      synchronized (server.openingTablets) {
-        synchronized (server.onlineTablets) {
-          server.openingTablets.remove(extent);
-          server.onlineTablets.put(extent, tablet);
-          server.openingTablets.notifyAll();
-          server.recentlyUnloadedCache.remove(tablet.getExtent());
-        }
-      }
-      tablet = null; // release this reference
-      successful = true;
-    } catch (Exception e) {
-      log.warn("exception trying to assign tablet {} {}", extent, locationToOpen, e);
-
-      if (e.getMessage() != null) {
-        log.warn("{}", e.getMessage());
-      }
-
-      TableId tableId = extent.tableId();
-      ProblemReports.getInstance(server.getContext()).report(new ProblemReport(tableId, TABLET_LOAD,
-          extent.getUUID().toString(), server.getClientAddressString(), e));
-    } finally {
-      server.releaseRecoveryMemory(extent);
-    }
-
-    if (successful) {
-      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOADED, extent));
-    } else {
-      synchronized (server.unopenedTablets) {
-        synchronized (server.openingTablets) {
-          server.openingTablets.remove(extent);
-          server.unopenedTablets.add(extent);
-          server.openingTablets.notifyAll();
-        }
-      }
-      log.warn("failed to open tablet {} reporting failure to manager", extent);
-      server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
-      long reschedule = Math.min((1L << Math.min(32, retryAttempt)) * 1000, 10 * 60 * 1000L);
-      log.warn(String.format("rescheduling tablet load in %.2f seconds", reschedule / 1000.));
-      this.server.getContext().getScheduledExecutor().schedule(new Runnable() {
-        @Override
-        public void run() {
-          log.info("adding tablet {} back to the assignment pool (retry {})", extent, retryAttempt);
-          AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
-          if (extent.isMeta()) {
-            if (extent.isRootTablet()) {
-              Threads.createThread("Root tablet assignment retry", handler).start();
-            } else {
-              server.resourceManager.addMetaDataAssignment(extent, log, handler);
+                server.unopenedTablets.remove(extent);
+                server.openingTablets.add(extent);
             }
-          } else {
-            server.resourceManager.addAssignment(extent, log, handler);
-          }
         }
-      }, reschedule, TimeUnit.MILLISECONDS);
+
+        // check Metadata table before accepting assignment
+        Text locationToOpen = null;
+        TabletMetadata tabletMetadata = null;
+        boolean canLoad = false;
+        try {
+            tabletMetadata = server.getContext().getAmple().readTablet(extent);
+
+            canLoad = checkTabletMetadata(extent, server.getTabletSession(), tabletMetadata);
+
+            if (canLoad && tabletMetadata.sawOldPrevEndRow()) {
+                KeyExtent fixedExtent =
+                        ManagerMetadataUtil.fixSplit(server.getContext(), tabletMetadata, server.getLock());
+
+                synchronized (server.openingTablets) {
+                    server.openingTablets.remove(extent);
+                    server.openingTablets.notifyAll();
+                    // it expected that the new extent will overlap the old one... if it does not, it
+                    // should not be added to unopenedTablets
+                    if (!KeyExtent.findOverlapping(extent, new TreeSet<>(Arrays.asList(fixedExtent)))
+                            .contains(fixedExtent)) {
+                        throw new IllegalStateException(
+                                "Fixed split does not overlap " + extent + " " + fixedExtent);
+                    }
+                    server.unopenedTablets.add(fixedExtent);
+                }
+                // split was rolled back... try again
+                new AssignmentHandler(server, fixedExtent).run();
+                return;
+
+            }
+        } catch (Exception e) {
+            synchronized (server.openingTablets) {
+                server.openingTablets.remove(extent);
+                server.openingTablets.notifyAll();
+            }
+            log.warn("Failed to verify tablet " + extent, e);
+            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+            throw new RuntimeException(e);
+        }
+
+        if (!canLoad) {
+            log.debug("Reporting tablet {} assignment failure: unable to verify Tablet Information",
+                    extent);
+            synchronized (server.openingTablets) {
+                server.openingTablets.remove(extent);
+                server.openingTablets.notifyAll();
+            }
+            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+            return;
+        }
+
+        Tablet tablet = null;
+        boolean successful = false;
+
+        try {
+            server.acquireRecoveryMemory(extent);
+
+            TabletResourceManager trm = server.resourceManager.createTabletResourceManager(extent,
+                    server.getTableConfiguration(extent));
+            TabletData data = new TabletData(tabletMetadata);
+
+            tablet = new Tablet(server, extent, trm, data);
+            // If a minor compaction starts after a tablet opens, this indicates a log recovery
+            // occurred. This recovered data must be minor compacted.
+            // There are three reasons to wait for this minor compaction to finish before placing the
+            // tablet in online tablets.
+            //
+            // 1) The log recovery code does not handle data written to the tablet on multiple tablet
+            // servers.
+            // 2) The log recovery code does not block if memory is full. Therefore recovering lots of
+            // tablets that use a lot of memory could run out of memory.
+            // 3) The minor compaction finish event did not make it to the logs (the file will be in
+            // metadata, preventing replay of compacted data)... but do not
+            // want a majc to wipe the file out from metadata and then have another process failure...
+            // this could cause duplicate data to replay.
+            if (tablet.getNumEntriesInMemory() > 0
+                    && !tablet.minorCompactNow(MinorCompactionReason.RECOVERY)) {
+                throw new RuntimeException("Minor compaction after recovery fails for " + extent);
+            }
+            Assignment assignment = new Assignment(extent, server.getTabletSession());
+            TabletStateStore.setLocation(server.getContext(), assignment);
+
+            synchronized (server.openingTablets) {
+                synchronized (server.onlineTablets) {
+                    server.openingTablets.remove(extent);
+                    server.onlineTablets.put(extent, tablet);
+                    server.openingTablets.notifyAll();
+                    server.recentlyUnloadedCache.remove(tablet.getExtent());
+                }
+            }
+            tablet = null; // release this reference
+            successful = true;
+        } catch (Exception e) {
+            log.warn("exception trying to assign tablet {} {}", extent, locationToOpen, e);
+
+            if (e.getMessage() != null) {
+                log.warn("{}", e.getMessage());
+            }
+
+            TableId tableId = extent.tableId();
+            ProblemReports.getInstance(server.getContext()).report(new ProblemReport(tableId, TABLET_LOAD,
+                    extent.getUUID().toString(), server.getClientAddressString(), e));
+        } finally {
+            server.releaseRecoveryMemory(extent);
+        }
+
+        if (successful) {
+            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOADED, extent));
+        } else {
+            synchronized (server.unopenedTablets) {
+                synchronized (server.openingTablets) {
+                    server.openingTablets.remove(extent);
+                    server.unopenedTablets.add(extent);
+                    server.openingTablets.notifyAll();
+                }
+            }
+            log.warn("failed to open tablet {} reporting failure to manager", extent);
+            server.enqueueManagerMessage(new TabletStatusMessage(TabletLoadState.LOAD_FAILURE, extent));
+            long reschedule = Math.min((1L << Math.min(32, retryAttempt)) * 1000, 10 * 60 * 1000L);
+            log.warn(String.format("rescheduling tablet load in %.2f seconds", reschedule / 1000.));
+            this.server.getContext().getScheduledExecutor().schedule(new Runnable() {
+                @Override
+                public void run() {
+                    log.info("adding tablet {} back to the assignment pool (retry {})", extent, retryAttempt);
+                    AssignmentHandler handler = new AssignmentHandler(server, extent, retryAttempt + 1);
+                    if (extent.isMeta()) {
+                        if (extent.isRootTablet()) {
+                            Threads.createThread("Root tablet assignment retry", handler).start();
+                        } else {
+                            server.resourceManager.addMetaDataAssignment(extent, log, handler);
+                        }
+                    } else {
+                        server.resourceManager.addAssignment(extent, log, handler);
+                    }
+                }
+            }, reschedule, TimeUnit.MILLISECONDS);
+        }
     }
-  }
+
+    public static boolean checkTabletMetadata(KeyExtent extent, TServerInstance instance,
+                                              TabletMetadata meta) throws AccumuloException {
+
+        if (meta == null) {
+            log.info(METADETA_ISSUE + "{}, its metadata was not found.", extent);
+            return false;
+        }
+
+        if (!meta.sawPrevEndRow()) {
+            throw new AccumuloException(METADETA_ISSUE + "metadata entry does not have prev row (" + meta.getTableId()
+                    + " " + meta.getEndRow() + ")");
+        }
+
+        if (!extent.equals(meta.getExtent())) {
+            log.info(METADETA_ISSUE + "tablet extent mismatch {} {}", extent, meta.getExtent());
+            return false;
+        }
+
+        if (meta.getDirName() == null) {
+            throw new AccumuloException(
+                    METADETA_ISSUE + "metadata entry does not have directory (" + meta.getExtent() + ")");
+        }
+
+        if (meta.getTime() == null && !extent.equals(RootTable.EXTENT)) {
+            throw new AccumuloException(METADETA_ISSUE + "metadata entry does not have time (" + meta.getExtent() + ")");
+        }
+
+        TabletMetadata.Location loc = meta.getLocation();
+
+        if (loc == null || loc.getType() != TabletMetadata.LocationType.FUTURE || !instance.equals(loc)) {
+            log.info(METADETA_ISSUE + "Unexpected location {} {}", extent, loc);
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -917,43 +917,6 @@ public class TabletServer extends AbstractServer {
         30000, TimeUnit.MILLISECONDS);
   }
 
-  static boolean checkTabletMetadata(KeyExtent extent, TServerInstance instance,
-      TabletMetadata meta) throws AccumuloException {
-
-    if (meta == null) {
-      log.info("Not loading tablet {}, its metadata was not found.", extent);
-      return false;
-    }
-
-    if (!meta.sawPrevEndRow()) {
-      throw new AccumuloException("Metadata entry does not have prev row (" + meta.getTableId()
-          + " " + meta.getEndRow() + ")");
-    }
-
-    if (!extent.equals(meta.getExtent())) {
-      log.info("Tablet extent mismatch {} {}", extent, meta.getExtent());
-      return false;
-    }
-
-    if (meta.getDirName() == null) {
-      throw new AccumuloException(
-          "Metadata entry does not have directory (" + meta.getExtent() + ")");
-    }
-
-    if (meta.getTime() == null && !extent.equals(RootTable.EXTENT)) {
-      throw new AccumuloException("Metadata entry does not have time (" + meta.getExtent() + ")");
-    }
-
-    Location loc = meta.getLocation();
-
-    if (loc == null || loc.getType() != LocationType.FUTURE || !instance.equals(loc)) {
-      log.info("Unexpected location {} {}", extent, loc);
-      return false;
-    }
-
-    return true;
-  }
-
   public String getClientAddressString() {
     if (clientAddress == null) {
       return null;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -54,7 +54,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.core.clientImpl.DurabilityImpl;
 import org.apache.accumulo.core.clientImpl.TabletLocator;
@@ -70,9 +69,6 @@ import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.thrift.ReplicationServicer;

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
+import static org.apache.accumulo.tserver.AssignmentHandler.checkTabletMetadata;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +66,7 @@ public class CheckTabletMetadataTest {
     try {
       TabletMetadata tm = TabletMetadata.convertRow(tabletMeta.entrySet().iterator(),
           EnumSet.allOf(ColumnType.class), true);
-      assertFalse(TabletServer.checkTabletMetadata(ke, tsi, tm));
+      assertFalse(checkTabletMetadata(ke, tsi, tm));
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -78,7 +79,7 @@ public class CheckTabletMetadataTest {
     try {
       TabletMetadata tm = TabletMetadata.convertRow(copy.entrySet().iterator(),
           EnumSet.allOf(ColumnType.class), true);
-      assertFalse(TabletServer.checkTabletMetadata(ke, tsi, tm));
+      assertFalse(checkTabletMetadata(ke, tsi, tm));
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -101,7 +102,7 @@ public class CheckTabletMetadataTest {
 
     TabletMetadata tm = TabletMetadata.convertRow(tabletMeta.entrySet().iterator(),
         EnumSet.allOf(ColumnType.class), true);
-    assertTrue(TabletServer.checkTabletMetadata(ke, tsi, tm));
+    assertTrue(checkTabletMetadata(ke, tsi, tm));
 
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.1:9998", 4));
     assertFail(tabletMeta, ke, new TServerInstance("127.0.0.1:9998", 5));


### PR DESCRIPTION
Fixes : #2208 

Note: AssignmentHandler has a lot of spacing changes. only the method has been moved and a string constant has been introduced.