### PR TITLE
Update parent POM, plugins, LICENSE

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -458,7 +458,6 @@
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.12</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -484,14 +483,7 @@
     <dependency>
       <groupId>org.latencyutils</groupId>
       <artifactId>LatencyUtils</artifactId>
-      <version>2.0.3</version>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hdrhistogram</groupId>
-          <artifactId>HdrHistogram</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/assemble/src/main/resources/LICENSE
+++ b/assemble/src/main/resources/LICENSE
@@ -669,6 +669,15 @@ to the terms and conditions of the following licenses.
     OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+## Various dependencies under the CC0 license / public domain
+
+* org.hdrhistogram:HdrHistogram
+    This code was Written by Gil Tene of Azul Systems, and released to the
+    public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/
+* org.latencyutils:LatencyUtils
+    This code was Written by Gil Tene of Azul Systems, and released to the
+    public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/
+
 ## Various dependencies under Eclipse Distribution License - v 1.0
 
 * com.sun.istack:istack-commons-runtime

--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AbstractInputFormat.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -83,6 +82,8 @@ import org.apache.log4j.Logger;
  */
 @Deprecated(since = "2.0.0")
 public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
+
+  private static final SecureRandom random = new SecureRandom();
 
   protected static final Class<?> CLASS = AccumuloInputFormat.class;
   protected static final Logger log = Logger.getLogger(CLASS);
@@ -629,7 +630,6 @@ public abstract class AbstractInputFormat<K,V> implements InputFormat<K,V> {
     log.setLevel(logLevel);
     validateOptions(job);
 
-    Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     Map<String,org.apache.accumulo.core.client.mapreduce.InputTableConfig> tableConfigs =
         getInputTableConfigs(job);

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AbstractInputFormat.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -85,6 +84,8 @@ import org.apache.log4j.Logger;
  */
 @Deprecated(since = "2.0.0")
 public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
+
+  private static final SecureRandom random = new SecureRandom();
 
   protected static final Class<?> CLASS = AccumuloInputFormat.class;
   protected static final Logger log = Logger.getLogger(CLASS);
@@ -664,7 +665,6 @@ public abstract class AbstractInputFormat<K,V> extends InputFormat<K,V> {
     log.setLevel(logLevel);
     validateOptions(job);
 
-    Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     Map<String,InputTableConfig> tableConfigs = getInputTableConfigs(job);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -154,6 +153,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 
 public class TableOperationsImpl extends TableOperationsHelper {
+
+  private static final SecureRandom random = new SecureRandom();
 
   public static final String CLONE_EXCLUDE_PREFIX = "!";
   public static final String COMPACTION_CANCELED_MSG = "Compaction canceled";
@@ -1129,7 +1130,6 @@ public class TableOperationsImpl extends TableOperationsHelper {
     if (maxSplits == 1)
       return Collections.singleton(range);
 
-    Random random = new SecureRandom();
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<>();
     TableId tableId = Tables.getTableId(context, tableName);
     TabletLocator tl = TabletLocator.getLocator(context, tableId);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -26,7 +26,6 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -79,7 +78,7 @@ public class ThriftScanner {
 
   public static final Map<TabletType,Set<String>> serversWaitedForWrites =
       new EnumMap<>(TabletType.class);
-  private static Random secureRandom = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   static {
     for (TabletType ttype : TabletType.values()) {
@@ -230,7 +229,7 @@ public class ThriftScanner {
   static long pause(long millis, long maxSleep) throws InterruptedException {
     Thread.sleep(millis);
     // wait 2 * last time, with +-10% random jitter
-    return (long) (Math.min(millis * 2, maxSleep) * (.9 + secureRandom.nextDouble() / 5));
+    return (long) (Math.min(millis * 2, maxSleep) * (.9 + random.nextDouble() / 5));
   }
 
   public static List<KeyValue> scan(ClientContext context, ScanState scanState, long timeOut)

--- a/core/src/main/java/org/apache/accumulo/core/crypto/CryptoUtils.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/CryptoUtils.java
@@ -21,36 +21,14 @@ package org.apache.accumulo.core.crypto;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.SecureRandom;
 import java.util.Objects;
 
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
-import org.apache.accumulo.core.spi.crypto.CryptoService.CryptoException;
 import org.apache.accumulo.core.spi.crypto.FileDecrypter;
 import org.apache.commons.io.IOUtils;
 
 public class CryptoUtils {
-
-  public static SecureRandom newSha1SecureRandom() {
-    return newSecureRandom("SHA1PRNG", "SUN");
-  }
-
-  private static SecureRandom newSecureRandom(String secureRNG, String secureRNGProvider) {
-    SecureRandom secureRandom = null;
-    try {
-      secureRandom = SecureRandom.getInstance(secureRNG, secureRNGProvider);
-
-      // Immediately seed the generator
-      byte[] throwAway = new byte[16];
-      secureRandom.nextBytes(throwAway);
-    } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
-      throw new CryptoException("Unable to generate secure random.", e);
-    }
-    return secureRandom;
-  }
 
   /**
    * Read the decryption parameters from the DataInputStream

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -64,6 +64,8 @@ import org.slf4j.LoggerFactory;
  * functionality.
  */
 public class BloomFilterLayer {
+
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger LOG = LoggerFactory.getLogger(BloomFilterLayer.class);
   public static final String BLOOM_FILE_NAME = "acu_bloom";
   public static final int HASH_COUNT = 5;
@@ -441,12 +443,10 @@ public class BloomFilterLayer {
   public static void main(String[] args) throws IOException {
     PrintStream out = System.out;
 
-    SecureRandom r = new SecureRandom();
-
     HashSet<Integer> valsSet = new HashSet<>();
 
     for (int i = 0; i < 100000; i++) {
-      valsSet.add(r.nextInt(Integer.MAX_VALUE));
+      valsSet.add(random.nextInt(Integer.MAX_VALUE));
     }
 
     ArrayList<Integer> vals = new ArrayList<>(valsSet);
@@ -498,7 +498,7 @@ public class BloomFilterLayer {
 
     int hits = 0;
     for (int i = 0; i < 5000; i++) {
-      int row = r.nextInt(Integer.MAX_VALUE);
+      int row = random.nextInt(Integer.MAX_VALUE);
       String fi = String.format("%010d", row);
       // bmfr.seek(new Range(new Text("r"+fi)));
       org.apache.accumulo.core.data.Key k1 =

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -25,7 +25,6 @@ import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -68,7 +67,7 @@ public class ThriftUtil {
 
   public static final String GSSAPI = "GSSAPI", DIGEST_MD5 = "DIGEST-MD5";
 
-  private static final Random SASL_BACKOFF_RAND = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
   private static final int RELOGIN_MAX_BACKOFF = 5000;
 
   /**
@@ -425,7 +424,7 @@ public class ThriftUtil {
 
         // Avoid the replay attack protection, sleep 1 to 5000ms
         try {
-          Thread.sleep((SASL_BACKOFF_RAND.nextInt(RELOGIN_MAX_BACKOFF) + 1));
+          Thread.sleep(random.nextInt(RELOGIN_MAX_BACKOFF) + 1);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           return;

--- a/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancer.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -94,6 +93,7 @@ import com.google.common.collect.Multimap;
  */
 public class HostRegexTableLoadBalancer extends TableLoadBalancer {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final String PROP_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey();
 
   private static final Logger LOG = LoggerFactory.getLogger(HostRegexTableLoadBalancer.class);
@@ -417,7 +417,6 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
               if (outOfBoundsTablets == null) {
                 continue;
               }
-              Random random = new SecureRandom();
               for (TabletStatistics ts : outOfBoundsTablets) {
                 if (migrations.contains(ts.getTabletId())) {
                   LOG.debug("Migration for out of bounds tablet {} has already been requested",

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/RandomVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/RandomVolumeChooser.java
@@ -19,14 +19,13 @@
 package org.apache.accumulo.core.spi.fs;
 
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.Set;
 
 /**
  * @since 2.1.0
  */
 public class RandomVolumeChooser implements VolumeChooser {
-  protected final Random random = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   @Override
   public String choose(VolumeChooserEnvironment env, Set<String> options) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.core.spi.fs;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.NavigableMap;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
@@ -46,6 +46,8 @@ import com.google.common.cache.LoadingCache;
  * @since 2.1.0
  */
 public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
+
+  private static final SecureRandom random = new SecureRandom();
 
   public static final String RECOMPUTE_INTERVAL = "spaceaware.volume.chooser.recompute.interval";
 
@@ -86,7 +88,7 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
           .build(new CacheLoader<>() {
             @Override
             public WeightedRandomCollection load(Set<String> key) {
-              return new WeightedRandomCollection(key, env, random);
+              return new WeightedRandomCollection(key, env);
             }
           });
     }
@@ -96,12 +98,9 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
 
   private class WeightedRandomCollection {
     private final NavigableMap<Double,String> map = new TreeMap<>();
-    private final Random random;
     private double total = 0;
 
-    public WeightedRandomCollection(Set<String> options, VolumeChooserEnvironment env,
-        Random random) {
-      this.random = random;
+    private WeightedRandomCollection(Set<String> options, VolumeChooserEnvironment env) {
 
       if (options.size() < 1) {
         throw new IllegalStateException("Options was empty! No valid volumes to choose from.");

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -62,7 +62,7 @@ public class ZooStore<T> implements TStore<T> {
   private String lastReserved = "";
   private Set<Long> reserved;
   private Map<Long,Long> defered;
-  private SecureRandom idgenerator;
+  private static final SecureRandom random = new SecureRandom();
   private long statusChangeEvents = 0;
   private int reservationsWaiting = 0;
 
@@ -107,7 +107,6 @@ public class ZooStore<T> implements TStore<T> {
     this.zk = zk;
     this.reserved = new HashSet<>();
     this.defered = new HashMap<>();
-    this.idgenerator = new SecureRandom();
 
     zk.putPersistentData(path, new byte[0], NodeExistsPolicy.SKIP);
   }
@@ -117,7 +116,7 @@ public class ZooStore<T> implements TStore<T> {
     while (true) {
       try {
         // looking at the code for SecureRandom, it appears to be thread safe
-        long tid = idgenerator.nextLong() & 0x7fffffffffffffffL;
+        long tid = random.nextLong() & 0x7fffffffffffffffL;
         zk.putPersistentData(getTXPath(tid), TStatus.NEW.name().getBytes(UTF_8),
             NodeExistsPolicy.FAIL);
         return tid;

--- a/core/src/main/java/org/apache/accumulo/fate/util/Retry.java
+++ b/core/src/main/java/org/apache/accumulo/fate/util/Retry.java
@@ -22,7 +22,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -49,7 +48,7 @@ public class Retry {
 
   private boolean hasNeverLogged;
   private long lastRetryLog;
-  private static Random rand = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
   private double currentBackOffFactor;
   private boolean doTimeJitter = true;
 
@@ -178,7 +177,7 @@ public class Retry {
 
   public void waitForNextAttempt() throws InterruptedException {
 
-    double waitFactor = (1 + (rand.nextDouble() - 0.5) / 10.0) * currentBackOffFactor;
+    double waitFactor = (1 + (random.nextDouble() - 0.5) / 10.0) * currentBackOffFactor;
     if (!doTimeJitter)
       waitFactor = currentBackOffFactor;
     currentBackOffFactor = currentBackOffFactor * backOffFactor;

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -62,7 +62,7 @@ public class ZooCache {
   private final HashMap<String,List<String>> childrenCache;
 
   private final ZooReader zReader;
-  private final SecureRandom secureRandom = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   private volatile boolean closed = false;
 
@@ -302,7 +302,7 @@ public class ZooCache {
         }
         LockSupport.parkNanos(sleepTime);
         if (sleepTime < 10_000) {
-          sleepTime = (int) (sleepTime + sleepTime * secureRandom.nextDouble());
+          sleepTime = (int) (sleepTime + sleepTime * random.nextDouble());
         }
       }
     }

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooSession.java
@@ -63,7 +63,7 @@ public class ZooSession {
 
   private static Map<String,ZooSessionInfo> sessions = new HashMap<>();
 
-  private static final SecureRandom secureRandom = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   static {
     SingletonManager.register(new SingletonService() {
@@ -172,7 +172,7 @@ public class ZooSession {
         }
         UtilWaitThread.sleep(sleepTime);
         if (sleepTime < 10000)
-          sleepTime = sleepTime + (long) (sleepTime * secureRandom.nextDouble());
+          sleepTime = sleepTime + (long) (sleepTime * random.nextDouble());
       }
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
@@ -42,6 +42,8 @@ import com.beust.jcommander.ParameterException;
 
 public class PasswordConverterTest {
 
+  private static final SecureRandom random = new SecureRandom();
+
   private class Password {
     @Parameter(names = "--password", converter = ClientOpts.PasswordConverter.class)
     String password;
@@ -77,7 +79,7 @@ public class PasswordConverterTest {
 
   @Test
   public void testPass() {
-    String expected = String.valueOf(new SecureRandom().nextDouble());
+    String expected = String.valueOf(random.nextDouble());
     argv[1] = "pass:" + expected;
     new JCommander(password).parse(argv);
     assertEquals(expected, password.password);

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -36,7 +36,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -72,6 +71,8 @@ import org.junit.Test;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RFileClientTest {
+
+  private static final SecureRandom random = new SecureRandom();
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path is set by test, not user")
   private String createTmpTestFile() throws IOException {
@@ -517,16 +518,13 @@ public class RFileClientTest {
     Scanner scanner = RFile.newScanner().from(testFile).withFileSystem(localFs)
         .withIndexCache(1000000).withDataCache(10000000).build();
 
-    Random rand = new SecureRandom();
-
-    for (int i = 0; i < 100; i++) {
-      int r = rand.nextInt(10000);
+    random.ints(100, 0, 10_000).forEach(r -> {
       scanner.setRange(new Range(rowStr(r)));
       Iterator<Entry<Key,Value>> iter = scanner.iterator();
       assertTrue(iter.hasNext());
       assertEquals(rowStr(r), iter.next().getKey().getRow().toString());
       assertFalse(iter.hasNext());
-    }
+    });
 
     scanner.close();
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -25,7 +25,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +39,8 @@ import org.junit.Test;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 public class ConcurrentKeyExtentCacheTest {
+
+  private static final SecureRandom random = new SecureRandom();
 
   private static List<KeyExtent> extents = new ArrayList<>();
   private static Set<KeyExtent> extentsSet = new HashSet<>();
@@ -96,17 +97,16 @@ public class ConcurrentKeyExtentCacheTest {
 
   @Test
   public void testExactEndRows() {
-    Random rand = new SecureRandom();
 
     TestCache tc = new TestCache();
 
-    rand.ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).sequential()
+    random.ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).sequential()
         .forEach(lookupRow -> testLookup(tc, lookupRow));
     assertEquals(extentsSet, tc.seen);
 
     // try parallel
     TestCache tc2 = new TestCache();
-    rand.ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).parallel()
+    random.ints(20000, 0, 256).mapToObj(i -> new Text(String.format("%02x", i))).parallel()
         .forEach(lookupRow -> testLookup(tc2, lookupRow));
     assertEquals(extentsSet, tc.seen);
   }
@@ -115,14 +115,13 @@ public class ConcurrentKeyExtentCacheTest {
   public void testRandom() {
     TestCache tc = new TestCache();
 
-    Random rand = new SecureRandom();
-    rand.ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
+    random.ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).sequential()
         .forEach(lookupRow -> testLookup(tc, lookupRow));
     assertEquals(extentsSet, tc.seen);
 
     // try parallel
     TestCache tc2 = new TestCache();
-    rand.ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).parallel()
+    random.ints(20000).mapToObj(i -> new Text(String.format("%08x", i))).parallel()
         .forEach(lookupRow -> testLookup(tc2, lookupRow));
     assertEquals(extentsSet, tc2.seen);
   }

--- a/core/src/test/java/org/apache/accumulo/core/crypto/BlockedIOStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/BlockedIOStreamTest.java
@@ -28,13 +28,15 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Random;
 
 import org.apache.accumulo.core.crypto.streams.BlockedInputStream;
 import org.apache.accumulo.core.crypto.streams.BlockedOutputStream;
 import org.junit.Test;
 
 public class BlockedIOStreamTest {
+
+  private static final SecureRandom random = new SecureRandom();
+
   @Test
   public void testLargeBlockIO() throws IOException {
     writeRead(1024, 2048);
@@ -85,18 +87,17 @@ public class BlockedIOStreamTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     // buffer will be size 12
     BlockedOutputStream blockOut = new BlockedOutputStream(baos, 16, 16);
-    Random r = new SecureRandom();
 
     byte[] undersized = new byte[11];
     byte[] perfectSized = new byte[12];
     byte[] overSized = new byte[13];
     byte[] perfectlyOversized = new byte[13];
-    byte filler = (byte) r.nextInt();
+    byte filler = (byte) random.nextInt();
 
-    r.nextBytes(undersized);
-    r.nextBytes(perfectSized);
-    r.nextBytes(overSized);
-    r.nextBytes(perfectlyOversized);
+    random.nextBytes(undersized);
+    random.nextBytes(perfectSized);
+    random.nextBytes(overSized);
+    random.nextBytes(perfectlyOversized);
 
     // 1 block
     blockOut.write(undersized);
@@ -129,13 +130,12 @@ public class BlockedIOStreamTest {
     int blockSize = 16;
     // buffer will be size 12
     BlockedOutputStream blockOut = new BlockedOutputStream(baos, blockSize, blockSize);
-    Random r = new SecureRandom();
 
     int size = 1024 * 1024 * 128;
     byte[] giant = new byte[size];
     byte[] pattern = new byte[1024];
 
-    r.nextBytes(pattern);
+    random.nextBytes(pattern);
 
     for (int i = 0; i < size / 1024; i++) {
       System.arraycopy(pattern, 0, giant, i * 1024, 1024);

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -80,14 +80,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class CryptoTest {
 
-  public static final int MARKER_INT = 0xCADEFEDD;
-  public static final String MARKER_STRING = "1 2 3 4 5 6 7 8 a b c d e f g h ";
+  private static final SecureRandom random = new SecureRandom();
+  private static final int MARKER_INT = 0xCADEFEDD;
+  private static final String MARKER_STRING = "1 2 3 4 5 6 7 8 a b c d e f g h ";
   public static final String CRYPTO_ON_CONF = "ON";
   public static final String CRYPTO_ON_DISABLED_CONF = "ON_DISABLED";
   public static final String CRYPTO_OFF_CONF = "OFF";
   public static final String keyPath =
       System.getProperty("user.dir") + "/target/CryptoTest-testkeyfile";
-  public static final String emptyKeyPath =
+  private static final String emptyKeyPath =
       System.getProperty("user.dir") + "/target/CryptoTest-emptykeyfile";
   private static Configuration hadoopConf = new Configuration();
 
@@ -320,14 +321,13 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsGeneratesKey() throws NoSuchAlgorithmException,
       NoSuchProviderException, NoSuchPaddingException, InvalidKeyException {
-    SecureRandom sr = SecureRandom.getInstance("SHA1PRNG", "SUN");
     // verify valid key sizes (corresponds to 128, 192, and 256 bits)
     for (int i : new int[] {16, 24, 32}) {
-      verifyKeySizeForCBC(sr, i);
+      verifyKeySizeForCBC(random, i);
     }
     // verify invalid key sizes
     for (int i : new int[] {1, 2, 8, 11, 15, 64, 128}) {
-      assertThrows(InvalidKeyException.class, () -> verifyKeySizeForCBC(sr, i));
+      assertThrows(InvalidKeyException.class, () -> verifyKeySizeForCBC(random, i));
     }
   }
 
@@ -343,9 +343,8 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsWrapAndUnwrap()
       throws NoSuchAlgorithmException, NoSuchProviderException {
-    SecureRandom sr = SecureRandom.getInstance("SHA1PRNG", "SUN");
-    java.security.Key kek = AESCryptoService.generateKey(sr, 16);
-    java.security.Key fek = AESCryptoService.generateKey(sr, 16);
+    java.security.Key kek = AESCryptoService.generateKey(random, 16);
+    java.security.Key fek = AESCryptoService.generateKey(random, 16);
     byte[] wrapped = AESCryptoService.wrapKey(fek, kek);
     assertFalse(Arrays.equals(fek.getEncoded(), wrapped));
     java.security.Key unwrapped = AESCryptoService.unwrapKey(wrapped, kek);
@@ -355,9 +354,8 @@ public class CryptoTest {
   @Test
   public void testAESKeyUtilsFailUnwrapWithWrongKEK()
       throws NoSuchAlgorithmException, NoSuchProviderException {
-    SecureRandom sr = SecureRandom.getInstance("SHA1PRNG", "SUN");
-    java.security.Key kek = AESCryptoService.generateKey(sr, 16);
-    java.security.Key fek = AESCryptoService.generateKey(sr, 16);
+    java.security.Key kek = AESCryptoService.generateKey(random, 16);
+    java.security.Key fek = AESCryptoService.generateKey(random, 16);
     byte[] wrongBytes = kek.getEncoded();
     wrongBytes[0]++;
     java.security.Key wrongKek = new SecretKeySpec(wrongBytes, "AES");

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -26,7 +26,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Random;
 
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -54,7 +53,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class BloomFilterLayerLookupTest {
 
   private static final Logger log = LoggerFactory.getLogger(BloomFilterLayerLookupTest.class);
-  private static Random random = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   @Rule
   public TestName testName = new TestName();

--- a/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/blockfile/cache/TestLruBlockCache.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Random;
 
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -52,6 +51,8 @@ import org.junit.Test;
  * and do what they should, and that cached blocks are accessible when expected to be.
  */
 public class TestLruBlockCache {
+
+  private static final SecureRandom random = new SecureRandom();
 
   @Test
   public void testConfiguration() {
@@ -506,9 +507,8 @@ public class TestLruBlockCache {
 
   private Block[] generateRandomBlocks(int numBlocks, long maxSize) {
     Block[] blocks = new Block[numBlocks];
-    Random r = new SecureRandom();
     for (int i = 0; i < numBlocks; i++) {
-      blocks[i] = new Block("block" + i, r.nextInt((int) maxSize) + 1);
+      blocks[i] = new Block("block" + i, random.nextInt((int) maxSize) + 1);
     }
     return blocks;
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
-import java.util.Random;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +75,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MultiThreadedRFileTest {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger LOG = LoggerFactory.getLogger(MultiThreadedRFileTest.class);
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
 
@@ -293,41 +294,42 @@ public class MultiThreadedRFileTest {
   }
 
   private void validate(TestRFile trf) throws IOException {
-    Random random = new SecureRandom();
-    for (int iteration = 0; iteration < 10; iteration++) {
-      int part = random.nextInt(4);
+    random.ints(10, 0, 4).forEach(part -> {
+      try {
+        Range range = new Range(getKey(part, 0, 0), true, getKey(part, 4, 2048), true);
+        trf.iter.seek(range, EMPTY_COL_FAMS, false);
 
-      Range range = new Range(getKey(part, 0, 0), true, getKey(part, 4, 2048), true);
-      trf.iter.seek(range, EMPTY_COL_FAMS, false);
-
-      Key last = null;
-      for (int locality = 0; locality < 4; locality++) {
-        for (int i = 0; i < 2048; i++) {
-          Key key = getKey(part, locality, i);
-          Value value = getValue(i);
-          assertTrue("No record found for row " + part + " locality " + locality + " index " + i,
-              trf.iter.hasTop());
-          assertEquals(
-              "Invalid key found for row " + part + " locality " + locality + " index " + i, key,
-              trf.iter.getTopKey());
-          assertEquals(
-              "Invalie value found for row " + part + " locality " + locality + " index " + i,
-              value, trf.iter.getTopValue());
-          last = trf.iter.getTopKey();
-          trf.iter.next();
+        Key last = null;
+        for (int locality = 0; locality < 4; locality++) {
+          for (int i = 0; i < 2048; i++) {
+            Key key = getKey(part, locality, i);
+            Value value = getValue(i);
+            assertTrue("No record found for row " + part + " locality " + locality + " index " + i,
+                trf.iter.hasTop());
+            assertEquals(
+                "Invalid key found for row " + part + " locality " + locality + " index " + i, key,
+                trf.iter.getTopKey());
+            assertEquals(
+                "Invalie value found for row " + part + " locality " + locality + " index " + i,
+                value, trf.iter.getTopValue());
+            last = trf.iter.getTopKey();
+            trf.iter.next();
+          }
         }
-      }
-      if (trf.iter.hasTop()) {
-        assertFalse("Found " + trf.iter.getTopKey() + " after " + last + " in " + range,
-            trf.iter.hasTop());
-      }
+        if (trf.iter.hasTop()) {
+          assertFalse("Found " + trf.iter.getTopKey() + " after " + last + " in " + range,
+              trf.iter.hasTop());
+        }
 
-      range = new Range(getKey(4, 4, 0), true, null, true);
-      trf.iter.seek(range, EMPTY_COL_FAMS, false);
-      if (trf.iter.hasTop()) {
-        assertFalse("Found " + trf.iter.getTopKey() + " in " + range, trf.iter.hasTop());
+        range = new Range(getKey(4, 4, 0), true, null, true);
+        trf.iter.seek(range, EMPTY_COL_FAMS, false);
+        if (trf.iter.hasTop()) {
+          assertFalse("Found " + trf.iter.getTopKey() + " in " + range, trf.iter.hasTop());
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
       }
-    }
+    });
 
     Range range = new Range((Key) null, null);
     trf.iter.seek(range, EMPTY_COL_FAMS, false);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -45,7 +45,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.sample.RowSampler;
@@ -105,6 +104,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class RFileTest {
+
+  private static final SecureRandom random = new SecureRandom();
 
   public static class SampleIE implements IteratorEnvironment {
 
@@ -537,9 +538,8 @@ public class RFileTest {
 
     // test seeking to random location and reading all data from that point
     // there was an off by one bug with this in the transient index
-    Random rand = new SecureRandom();
     for (int i = 0; i < 12; i++) {
-      index = rand.nextInt(expectedKeys.size());
+      index = random.nextInt(expectedKeys.size());
       trf.seek(expectedKeys.get(index));
       for (; index < expectedKeys.size(); index++) {
         assertTrue(trf.iter.hasTop());
@@ -1659,17 +1659,15 @@ public class RFileTest {
 
     Set<ByteSequence> cfs = Collections.emptySet();
 
-    Random rand = new SecureRandom();
-
     for (int count = 0; count < 100; count++) {
 
-      int start = rand.nextInt(2300);
+      int start = random.nextInt(2300);
       Range range = new Range(newKey(formatString("r_", start), "cf1", "cq1", "L1", 42),
           newKey(formatString("r_", start + 100), "cf1", "cq1", "L1", 42));
 
       trf.reader.seek(range, cfs, false);
 
-      int numToScan = rand.nextInt(100);
+      int numToScan = random.nextInt(100);
 
       for (int j = 0; j < numToScan; j++) {
         assertTrue(trf.reader.hasTop());
@@ -1685,8 +1683,8 @@ public class RFileTest {
       // seek a little forward from the last range and read a few keys within the unconsumed portion
       // of the last range
 
-      int start2 = start + numToScan + rand.nextInt(3);
-      int end2 = start2 + rand.nextInt(3);
+      int start2 = start + numToScan + random.nextInt(3);
+      int end2 = start2 + random.nextInt(3);
 
       range = new Range(newKey(formatString("r_", start2), "cf1", "cq1", "L1", 42),
           newKey(formatString("r_", end2), "cf1", "cq1", "L1", 42));
@@ -2020,10 +2018,6 @@ public class RFileTest {
     sample.seek(new Range(), columnFamilies, inclusive);
     assertEquals(sampleData, toList(sample));
 
-    Random rand = new SecureRandom();
-    long seed = rand.nextLong();
-    rand.setSeed(seed);
-
     // randomly seek sample iterator and verify
     for (int i = 0; i < 33; i++) {
       Key startKey = null;
@@ -2034,29 +2028,29 @@ public class RFileTest {
       boolean endInclusive = false;
       int endIndex = sampleData.size();
 
-      if (rand.nextBoolean()) {
-        startIndex = rand.nextInt(sampleData.size());
+      if (random.nextBoolean()) {
+        startIndex = random.nextInt(sampleData.size());
         startKey = sampleData.get(startIndex).getKey();
-        startInclusive = rand.nextBoolean();
+        startInclusive = random.nextBoolean();
         if (!startInclusive) {
           startIndex++;
         }
       }
 
-      if (startIndex < endIndex && rand.nextBoolean()) {
-        endIndex -= rand.nextInt(endIndex - startIndex);
+      if (startIndex < endIndex && random.nextBoolean()) {
+        endIndex -= random.nextInt(endIndex - startIndex);
         endKey = sampleData.get(endIndex - 1).getKey();
-        endInclusive = rand.nextBoolean();
+        endInclusive = random.nextBoolean();
         if (!endInclusive) {
           endIndex--;
         }
       } else if (startIndex == endIndex) {
-        endInclusive = rand.nextBoolean();
+        endInclusive = random.nextBoolean();
       }
 
       sample.seek(new Range(startKey, startInclusive, endKey, endInclusive), columnFamilies,
           inclusive);
-      assertEquals("seed: " + seed, sampleData.subList(startIndex, endIndex), toList(sample));
+      assertEquals(sampleData.subList(startIndex, endIndex), toList(sample));
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RollingStatsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RollingStatsTest.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.file.rfile;
 import static org.junit.Assert.assertTrue;
 
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.function.IntSupplier;
 
 import org.apache.commons.math3.distribution.NormalDistribution;
@@ -32,9 +31,10 @@ import org.junit.Test;
 
 import com.google.common.math.DoubleMath;
 
-public class RolllingStatsTest {
+public class RollingStatsTest {
 
   private static final double TOLERANCE = 1.0 / 1000;
+  private static final SecureRandom random = new SecureRandom();
 
   private static void assertFuzzyEquals(double expected, double actual) {
     assertTrue(String.format("expected: %f, actual: %f diff: %f", expected, actual,
@@ -62,7 +62,6 @@ public class RolllingStatsTest {
 
   private static class StatTester {
 
-    Random rand = new SecureRandom();
     private DescriptiveStatistics ds;
     private RollingStats rs;
     private RollingStats rsp;
@@ -81,7 +80,7 @@ public class RolllingStatsTest {
       rsp.addValue(v);
       checkAgreement(ds, rs);
 
-      if (rand.nextDouble() < 0.001) {
+      if (random.nextDouble() < 0.001) {
         checkAgreement(ds, rsp);
       }
     }
@@ -95,9 +94,8 @@ public class RolllingStatsTest {
   public void testFewSizes() {
     StatTester st = new StatTester(1019);
     int[] keySizes = {103, 113, 123, 2345};
-    Random rand = new SecureRandom();
     for (int i = 0; i < 10000; i++) {
-      st.addValue(keySizes[rand.nextInt(keySizes.length)]);
+      st.addValue(keySizes[random.nextInt(keySizes.length)]);
     }
     st.check();
   }
@@ -121,10 +119,8 @@ public class RolllingStatsTest {
 
       StatTester st = new StatTester(windowSize);
 
-      Random rand = new SecureRandom();
-
       for (int i = 0; i < 1000; i++) {
-        int v = 200 + rand.nextInt(50);
+        int v = 200 + random.nextInt(50);
 
         st.addValue(v);
       }
@@ -176,16 +172,14 @@ public class RolllingStatsTest {
   @Test
   public void testSpikes() {
 
-    Random rand = new SecureRandom();
-
     StatTester st = new StatTester(3017);
 
     for (int i = 0; i < 13; i++) {
 
       // write small keys
-      int numSmall = 1000 + rand.nextInt(1000);
+      int numSmall = 1000 + random.nextInt(1000);
       for (int s = 0; s < numSmall; s++) {
-        int sks = 50 + rand.nextInt(100);
+        int sks = 50 + random.nextInt(100);
         // simulate row with multiple cols
         for (int c = 0; c < 3; c++) {
           st.addValue(sks);
@@ -193,9 +187,9 @@ public class RolllingStatsTest {
       }
 
       // write a few large keys
-      int numLarge = 1 + rand.nextInt(1);
+      int numLarge = 1 + random.nextInt(1);
       for (int l = 0; l < numLarge; l++) {
-        int lks = 500000 + rand.nextInt(1000000);
+        int lks = 500000 + random.nextInt(1000000);
         for (int c = 0; c < 3; c++) {
           st.addValue(lks);
         }

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedInputStreamTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
@@ -32,9 +31,10 @@ import org.junit.Test;
 
 public class RateLimitedInputStreamTest {
 
+  private static final SecureRandom random = new SecureRandom();
+
   @Test
   public void permitsAreProperlyAcquired() throws Exception {
-    Random randGen = new SecureRandom();
     // Create variables for tracking behaviors of mock object
     AtomicLong rateLimiterPermitsAcquired = new AtomicLong();
     // Construct mock object
@@ -49,7 +49,7 @@ public class RateLimitedInputStreamTest {
     long bytesRetrieved = 0;
     try (InputStream is = new RateLimitedInputStream(new RandomInputStream(), rateLimiter)) {
       for (int i = 0; i < 100; ++i) {
-        int count = Math.abs(randGen.nextInt()) % 65536;
+        int count = Math.abs(random.nextInt()) % 65536;
         int countRead = is.read(new byte[count]);
         assertEquals(count, countRead);
         bytesRetrieved += count;
@@ -59,11 +59,10 @@ public class RateLimitedInputStreamTest {
   }
 
   private static class RandomInputStream extends InputStream implements Seekable {
-    private final Random r = new SecureRandom();
 
     @Override
     public int read() {
-      return r.nextInt() & 0xff;
+      return random.nextInt() & 0xff;
     }
 
     @Override

--- a/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/streams/RateLimitedOutputStreamTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.OutputStream;
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
@@ -34,9 +33,10 @@ import com.google.common.io.CountingOutputStream;
 
 public class RateLimitedOutputStreamTest {
 
+  private static final SecureRandom random = new SecureRandom();
+
   @Test
   public void permitsAreProperlyAcquired() throws Exception {
-    Random randGen = new SecureRandom();
     // Create variables for tracking behaviors of mock object
     AtomicLong rateLimiterPermitsAcquired = new AtomicLong();
     // Construct mock object
@@ -52,7 +52,7 @@ public class RateLimitedOutputStreamTest {
     try (RateLimitedOutputStream os =
         new RateLimitedOutputStream(new NullOutputStream(), rateLimiter)) {
       for (int i = 0; i < 100; ++i) {
-        byte[] bytes = new byte[Math.abs(randGen.nextInt() % 65536)];
+        byte[] bytes = new byte[Math.abs(random.nextInt() % 65536)];
         os.write(bytes);
         bytesWritten += bytes.length;
       }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IndexedDocIteratorTest.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -47,6 +46,7 @@ import org.junit.Test;
 
 public class IndexedDocIteratorTest {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
   private static final byte[] nullByte = {0};
 
@@ -69,7 +69,6 @@ public class IndexedDocIteratorTest {
       Text[] columnFamilies, Text[] otherColumnFamilies, HashSet<Text> docs,
       Text[] negatedColumns) {
     StringBuilder sb = new StringBuilder();
-    Random r = new SecureRandom();
     Value v = new Value();
     TreeMap<Key,Value> map = new TreeMap<>();
     boolean[] negateMask = new boolean[columnFamilies.length];
@@ -94,7 +93,7 @@ public class IndexedDocIteratorTest {
         doc.append(nullByte, 0, 1);
         doc.append(String.format("%010d", docid).getBytes(), 0, 10);
         for (int j = 0; j < columnFamilies.length; j++) {
-          if (r.nextFloat() < hitRatio) {
+          if (random.nextFloat() < hitRatio) {
             Text colq = new Text(columnFamilies[j]);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());
@@ -117,7 +116,7 @@ public class IndexedDocIteratorTest {
           docs.add(doc);
         }
         for (Text cf : otherColumnFamilies) {
-          if (r.nextFloat() < hitRatio) {
+          if (random.nextFloat() < hitRatio) {
             Text colq = new Text(cf);
             colq.append(nullByte, 0, 1);
             colq.append(doc.getBytes(), 0, doc.getLength());

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/IntersectingIteratorTest.java
@@ -26,7 +26,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Random;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -46,6 +45,7 @@ import org.junit.rules.TestName;
 
 public class IntersectingIteratorTest {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
   private static IteratorEnvironment env = new DefaultIteratorEnvironment();
 
@@ -60,7 +60,6 @@ public class IntersectingIteratorTest {
   private TreeMap<Key,Value> createSortedMap(float hitRatio, int numRows, int numDocsPerRow,
       Text[] columnFamilies, Text[] otherColumnFamilies, HashSet<Text> docs,
       Text[] negatedColumns) {
-    Random r = new SecureRandom();
     Value v = new Value();
     TreeMap<Key,Value> map = new TreeMap<>();
     boolean[] negateMask = new boolean[columnFamilies.length];
@@ -78,7 +77,7 @@ public class IntersectingIteratorTest {
         boolean docHits = true;
         Text doc = new Text(String.format("%010d", docid));
         for (int j = 0; j < columnFamilies.length; j++) {
-          if (r.nextFloat() < hitRatio) {
+          if (random.nextFloat() < hitRatio) {
             Key k = new Key(row, columnFamilies[j], doc);
             map.put(k, v);
             if (negateMask[j])
@@ -92,7 +91,7 @@ public class IntersectingIteratorTest {
           docs.add(doc);
         }
         for (Text cf : otherColumnFamilies) {
-          if (r.nextFloat() < hitRatio) {
+          if (random.nextFloat() < hitRatio) {
             Key k = new Key(row, cf, doc);
             map.put(k, v);
           }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
@@ -26,7 +26,6 @@ import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -46,6 +45,7 @@ import org.junit.Test;
 
 public abstract class TestCfCqSlice {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final Range INFINITY = new Range();
   private static final Lexicoder<Long> LONG_LEX = new ReadableLongLexicoder(4);
   private static final AtomicLong ROW_ID_GEN = new AtomicLong();
@@ -380,8 +380,6 @@ public abstract class TestCfCqSlice {
           getFilterClass().getDeclaredConstructor().newInstance();
       skvi.init(parent, options, null);
       skvi.seek(range, EMPTY_CF_SET, false);
-
-      Random random = new SecureRandom();
 
       while (skvi.hasTop()) {
         Key k = skvi.getTopKey();

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenTest.java
@@ -20,10 +20,9 @@ package org.apache.accumulo.core.security;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import java.security.SecureRandom;
-import java.util.Random;
+import java.util.stream.IntStream;
 
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken.AuthenticationTokenSerializer;
@@ -32,15 +31,16 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.junit.Test;
 
 public class AuthenticationTokenTest {
+
+  private static final SecureRandom random = new SecureRandom();
+
   @Test
   public void testSerializeDeserializeToken() {
-    Random random = new SecureRandom();
     byte[] randomBytes = new byte[12];
-    random.nextBytes(randomBytes);
-    boolean allZero = true;
-    for (byte b : randomBytes)
-      allZero = allZero && b == 0;
-    assertFalse(allZero);
+    do {
+      // random fill, but avoid all zeros case
+      random.nextBytes(randomBytes);
+    } while (IntStream.range(0, randomBytes.length).allMatch(i -> randomBytes[i] == 0));
 
     byte[] serialized = AuthenticationTokenSerializer.serialize(new PasswordToken(randomBytes));
     PasswordToken passwordToken =

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/GroupBalancerTest.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -49,6 +48,8 @@ import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class GroupBalancerTest {
+
+  private static final SecureRandom random = new SecureRandom();
 
   private static final Function<TabletId,String> partitioner =
       input -> (input == null || input.getEndRow() == null) ? null
@@ -323,11 +324,10 @@ public class GroupBalancerTest {
   @Test
   public void bigTest() {
     TabletServers tservers = new TabletServers();
-    Random rand = new SecureRandom();
 
     for (int g = 1; g <= 60; g++) {
       for (int t = 1; t <= 241; t++) {
-        tservers.addTablet(String.format("%02d:%d", g, t), "192.168.1." + (rand.nextInt(249) + 1),
+        tservers.addTablet(String.format("%02d:%d", g, t), "192.168.1." + (random.nextInt(249) + 1),
             9997);
       }
     }
@@ -342,11 +342,10 @@ public class GroupBalancerTest {
   @Test
   public void bigTest2() {
     TabletServers tservers = new TabletServers();
-    Random rand = new SecureRandom();
 
     for (int g = 1; g <= 60; g++) {
-      for (int t = 1; t <= rand.nextInt(1000); t++) {
-        tservers.addTablet(String.format("%02d:%d", g, t), "192.168.1." + (rand.nextInt(249) + 1),
+      for (int t = 1; t <= random.nextInt(1000); t++) {
+        tservers.addTablet(String.format("%02d:%d", g, t), "192.168.1." + (random.nextInt(249) + 1),
             9997);
       }
     }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapred/AccumuloRecordReader.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -72,6 +71,8 @@ import org.slf4j.LoggerFactory;
  * @see org.apache.accumulo.hadoopImpl.mapreduce.AccumuloRecordReader
  */
 public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
+
+  private static final SecureRandom random = new SecureRandom();
   // class to serialize configuration under in the job
   private final Class<?> CLASS;
   private static final Logger log = LoggerFactory.getLogger(AccumuloRecordReader.class);
@@ -286,7 +287,6 @@ public abstract class AccumuloRecordReader<K,V> implements RecordReader<K,V> {
   public static InputSplit[] getSplits(JobConf job, Class<?> callingClass) throws IOException {
     validateOptions(job, callingClass);
 
-    Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     Map<String,InputTableConfig> tableConfigs =
         InputConfigurator.getInputTableConfigs(callingClass, job);

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/AccumuloRecordReader.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -73,6 +72,7 @@ import org.slf4j.LoggerFactory;
  * the user's K/V types.
  */
 public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(AccumuloRecordReader.class);
   // class to serialize configuration under in the job
   private final Class<?> CLASS;
@@ -318,7 +318,6 @@ public abstract class AccumuloRecordReader<K,V> extends RecordReader<K,V> {
   public static List<InputSplit> getSplits(JobContext context, Class<?> callingClass)
       throws IOException {
     validateOptions(context, callingClass);
-    Random random = new SecureRandom();
     LinkedList<InputSplit> splits = new LinkedList<>();
     try (AccumuloClient client = createClient(context, callingClass)) {
       Map<String,InputTableConfig> tableConfigs =

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/IsolatedDeepCopiesTestCase.java
@@ -23,7 +23,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Random;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.ByteSequence;
@@ -44,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class IsolatedDeepCopiesTestCase extends OutputVerifyingTestCase {
   private static final Logger log = LoggerFactory.getLogger(IsolatedDeepCopiesTestCase.class);
 
-  private final Random random = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   @Override
   public IteratorTestOutput test(IteratorTestInput testInput) {

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/MultipleHasTopCalls.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.iteratortest.testcases;
 
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.util.Random;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.Key;
@@ -40,11 +39,7 @@ import org.apache.accumulo.iteratortest.IteratorTestUtil;
  */
 public class MultipleHasTopCalls extends OutputVerifyingTestCase {
 
-  private final Random random;
-
-  public MultipleHasTopCalls() {
-    this.random = new SecureRandom();
-  }
+  private static final SecureRandom random = new SecureRandom();
 
   @Override
   public IteratorTestOutput test(IteratorTestInput testInput) {

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/testcases/ReSeekTestCase.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.iteratortest.testcases;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Collection;
-import java.util.Random;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.data.ByteSequence;
@@ -39,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * Test case that verifies that an iterator can use the generated instance from {@code deepCopy}.
  */
 public class ReSeekTestCase extends OutputVerifyingTestCase {
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(ReSeekTestCase.class);
 
   /**
@@ -46,12 +46,6 @@ public class ReSeekTestCase extends OutputVerifyingTestCase {
    * client, recreate and reseek the iterator.
    */
   private static final int RESEEK_INTERVAL = 4;
-
-  private final Random random;
-
-  public ReSeekTestCase() {
-    this.random = new SecureRandom();
-  }
 
   @Override
   public IteratorTestOutput test(IteratorTestInput testInput) {

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>24</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>
@@ -140,7 +140,8 @@
     <maven.compiler.target>11</maven.compiler.target>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <micrometer.metrics.version>1.7.5</micrometer.metrics.version>
+    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
+    <minimalMavenBuildVersion>3.5.0</minimalMavenBuildVersion>
     <powermock.version>2.0.9</powermock.version>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-12-17T22:06:50Z</project.build.outputTimestamp>
@@ -163,6 +164,62 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.12.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>1.7.5</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.platform</groupId>
+        <artifactId>jakarta.jakartaee-bom</artifactId>
+        <version>9.1.0-RC1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.14.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>11.0.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-bom</artifactId>
+        <version>3.0.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-bom</artifactId>
+        <version>3.0.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey</groupId>
+        <artifactId>jersey-bom</artifactId>
+        <version>3.0.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
         <version>1.81</version>
@@ -180,7 +237,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.2.3</version>
+        <version>4.4.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -517,6 +574,11 @@
         <version>4.0.1</version>
       </dependency>
       <dependency>
+        <groupId>org.hdrhistogram</groupId>
+        <artifactId>HdrHistogram</artifactId>
+        <version>2.1.12</version>
+      </dependency>
+      <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>7.0.1.Final</version>
@@ -535,6 +597,17 @@
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
         <version>3.20.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.latencyutils</groupId>
+        <artifactId>LatencyUtils</artifactId>
+        <version>2.0.3</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <!-- converge transitive dependency version between powermock and easymock -->
@@ -572,62 +645,6 @@
         <artifactId>snakeyaml</artifactId>
         <version>1.29</version>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.12.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${micrometer.metrics.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.platform</groupId>
-        <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>9.1.0-RC1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.14.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-bom</artifactId>
-        <version>11.0.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.hk2</groupId>
-        <artifactId>hk2-bom</artifactId>
-        <version>3.0.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-bom</artifactId>
-        <version>3.0.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jersey</groupId>
-        <artifactId>jersey-bom</artifactId>
-        <version>3.0.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -649,7 +666,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.0.rc2</version>
+          <version>4.1</version>
           <configuration>
             <header>${session.executionRootDirectory}/contrib/license-header.txt</header>
             <excludes combine.children="append">
@@ -675,7 +692,7 @@
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>2.1.0</version>
+          <version>2.2.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
@@ -683,7 +700,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.2.0</version>
+          <version>4.4.2.2</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -714,15 +731,17 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.13.1</version>
+          <version>3.0.0</version>
           <configuration>
-            <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
-            <lineSeparator>\n</lineSeparator>
             <expandEmptyElements>false</expandEmptyElements>
+            <keepBlankLines>false</keepBlankLines>
+            <lineSeparator>\n</lineSeparator>
             <nrOfIndentSpace>2</nrOfIndentSpace>
+            <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <sortDependencies>scope,groupId,artifactId</sortDependencies>
             <sortProperties>true</sortProperties>
+            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
             <verifyFail>Stop</verifyFail>
           </configuration>
         </plugin>
@@ -768,11 +787,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.2</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
             <archive>
@@ -786,7 +800,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.2.0</version>
           <configuration>
             <quiet>true</quiet>
             <additionalJOption>-J-Xmx512m</additionalJOption>
@@ -811,7 +824,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.9.1</version>
           <configuration>
             <skipDeploy>true</skipDeploy>
           </configuration>
@@ -862,29 +874,29 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.15.0</version>
+          <version>2.17.0</version>
           <configuration>
-            <configFile>${eclipseFormatterStyle}</configFile>
             <compilerCompliance>${maven.compiler.source}</compilerCompliance>
             <compilerSource>${maven.compiler.source}</compilerSource>
             <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
+            <configFile>${eclipseFormatterStyle}</configFile>
             <excludes>
               <exclude>**/thrift/*.java</exclude>
               <exclude>**/proto/*.java</exclude>
             </excludes>
             <lineEnding>LF</lineEnding>
             <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
-            <skipJsFormatting>true</skipJsFormatting>
-            <skipHtmlFormatting>true</skipHtmlFormatting>
-            <skipXmlFormatting>true</skipXmlFormatting>
-            <skipJsonFormatting>true</skipJsonFormatting>
+            <removeTrailingWhitespace>true</removeTrailingWhitespace>
             <skipCssFormatting>true</skipCssFormatting>
+            <skipHtmlFormatting>true</skipHtmlFormatting>
+            <skipJsFormatting>true</skipJsFormatting>
+            <skipJsonFormatting>true</skipJsonFormatting>
+            <skipXmlFormatting>true</skipXmlFormatting>
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.13</version>
           <configuration>
             <excludes combine.children="append">
               <exclude>src/main/resources/META-INF/services/*</exclude>
@@ -905,7 +917,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.6.1</version>
+          <version>1.6.2</version>
           <configuration>
             <removeUnused>true</removeUnused>
             <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -989,20 +1001,13 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <!-- must be same id as in the apache parent pom, to override the version -->
-            <id>enforce-maven-version</id>
+            <id>enforce-accumulo-rules</id>
             <goals>
               <goal>enforce</goal>
             </goals>
             <phase>validate</phase>
             <configuration>
               <rules>
-                <requireMavenVersion>
-                  <version>[3.5.0,)</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>[11,)</version>
-                </requireJavaVersion>
                 <dependencyConvergence />
                 <bannedDependencies>
                   <excludes>
@@ -1115,7 +1120,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.42</version>
+            <version>9.1</version>
           </dependency>
         </dependencies>
         <executions>

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancer.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -92,6 +91,7 @@ import com.google.common.collect.Multimap;
 @Deprecated(since = "2.1.0")
 public class HostRegexTableLoadBalancer extends TableLoadBalancer {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final String PROP_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey();
 
   private static final Logger LOG = LoggerFactory.getLogger(HostRegexTableLoadBalancer.class);
@@ -426,7 +426,6 @@ public class HostRegexTableLoadBalancer extends TableLoadBalancer {
               if (outOfBoundsTablets == null) {
                 continue;
               }
-              Random random = new SecureRandom();
               for (TabletStats ts : outOfBoundsTablets) {
                 KeyExtent ke = KeyExtent.fromThrift(ts.getExtent());
                 if (migrations.contains(ke)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -50,10 +50,10 @@ import org.slf4j.LoggerFactory;
 class ZKSecurityTool {
   private static final Logger log = LoggerFactory.getLogger(ZKSecurityTool.class);
   private static final int SALT_LENGTH = 8;
+  private static final SecureRandom random = new SecureRandom();
 
   // Generates a byte array salt of length SALT_LENGTH
   private static byte[] generateSalt() {
-    final SecureRandom random = new SecureRandom();
     byte[] salt = new byte[SALT_LENGTH];
     random.nextBytes(salt);
     return salt;

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.server.tablets;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.security.SecureRandom;
-import java.util.Random;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.util.FastFormat;
@@ -39,18 +38,17 @@ public class UniqueNameAllocator {
   private long next = 0;
   private long maxAllocated = 0;
   private String nextNamePath;
-  private Random rand;
+  private static final SecureRandom random = new SecureRandom();
 
   public UniqueNameAllocator(ServerContext context) {
     this.context = context;
     nextNamePath = Constants.ZROOT + "/" + context.getInstanceID() + Constants.ZNEXT_FILE;
-    rand = new SecureRandom();
   }
 
   public synchronized String getNextName() {
 
     while (next >= maxAllocated) {
-      final int allocate = 100 + rand.nextInt(100);
+      final int allocate = 100 + random.nextInt(100);
 
       try {
         byte[] max = context.getZooReaderWriter().mutateExisting(nextNamePath, currentValue -> {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -59,6 +59,8 @@ import org.slf4j.LoggerFactory;
 
 public class FileUtil {
 
+  private static final SecureRandom random = new SecureRandom();
+
   public static class FileInfo {
     Key firstKey = new Key();
     Key lastKey = new Key();
@@ -87,7 +89,7 @@ public class FileUtil {
     Path result = null;
     while (result == null) {
       result = new Path(tabletDirectory + Path.SEPARATOR + "tmp/idxReduce_"
-          + String.format("%09d", new SecureRandom().nextInt(Integer.MAX_VALUE)));
+          + String.format("%09d", random.nextInt(Integer.MAX_VALUE)));
       try {
         fs.getFileStatus(result);
         result = null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RandomWriter.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.server.util;
 import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.cli.ClientOpts;
 import org.apache.accumulo.core.client.Accumulo;
@@ -42,11 +41,11 @@ public class RandomWriter {
   private static int num_columns_per_row = 1;
   private static int num_payload_bytes = 1024;
   private static final Logger log = LoggerFactory.getLogger(RandomWriter.class);
+  private static final SecureRandom random = new SecureRandom();
 
   public static class RandomMutationGenerator implements Iterable<Mutation>, Iterator<Mutation> {
     private long max_mutations;
     private int mutations_so_far = 0;
-    private Random r = new SecureRandom();
     private static final Logger log = LoggerFactory.getLogger(RandomMutationGenerator.class);
 
     public RandomMutationGenerator(long num_mutations) {
@@ -60,13 +59,13 @@ public class RandomWriter {
 
     @Override
     public Mutation next() {
-      Text row_value =
-          new Text(Long.toString(((r.nextLong() & 0x7fffffffffffffffL) / 177) % 100000000000L));
+      Text row_value = new Text(
+          Long.toString(((random.nextLong() & 0x7fffffffffffffffL) / 177) % 100000000000L));
       Mutation m = new Mutation(row_value);
       for (int column = 0; column < num_columns_per_row; column++) {
         Text column_fam = new Text("col_fam");
         byte[] bytes = new byte[num_payload_bytes];
-        r.nextBytes(bytes);
+        random.nextBytes(bytes);
         m.put(column_fam, new Text("" + column), new Value(bytes));
       }
       mutations_so_far++;

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -24,7 +24,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DistributedWorkQueue {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final String LOCKS_NODE = "locks";
 
   private static final Logger log = LoggerFactory.getLogger(DistributedWorkQueue.class);
@@ -71,7 +71,6 @@ public class DistributedWorkQueue {
     if (numTask.get() >= threadPool.getCorePoolSize())
       return;
 
-    Random random = new SecureRandom();
     Collections.shuffle(children, random);
     try {
       for (final String child : children) {
@@ -166,7 +165,7 @@ public class DistributedWorkQueue {
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config, ServerContext context) {
     // Preserve the old delay and period
-    this(path, config, context, new SecureRandom().nextInt(60 * 1000), 60 * 1000);
+    this(path, config, context, random.nextInt(60_000), 60_000);
   }
 
   public DistributedWorkQueue(String path, AccumuloConfiguration config, ServerContext context,

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodec.java
@@ -54,6 +54,8 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public class VersionedPropEncryptCodec extends VersionedPropCodec {
 
+  private static final SecureRandom random = new SecureRandom();
+
   // testing version (999 or higher)
   public static final int EXPERIMENTAL_CIPHER_ENCODING_1_0 = 999;
 
@@ -220,7 +222,7 @@ public class VersionedPropEncryptCodec extends VersionedPropCodec {
     // utils
     public static GCMParameterSpec buildGCMParameterSpec() {
       byte[] iv = new byte[16];
-      new SecureRandom().nextBytes(iv);
+      random.nextBytes(iv);
       return new GCMParameterSpec(128, iv);
     }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -45,6 +44,8 @@ import org.junit.Test;
 
 @Deprecated(since = "2.1.0")
 public class GroupBalancerTest {
+
+  private static final SecureRandom random = new SecureRandom();
 
   private static Function<KeyExtent,String> partitioner = new Function<>() {
 
@@ -324,12 +325,11 @@ public class GroupBalancerTest {
   @Test
   public void bigTest() {
     TabletServers tservers = new TabletServers();
-    Random rand = new SecureRandom();
 
     for (int g = 1; g <= 60; g++) {
       for (int t = 1; t <= 241; t++) {
         tservers.addTablet(String.format("%02d:%d", g, t),
-            "192.168.1." + (rand.nextInt(249) + 1) + ":9997");
+            "192.168.1." + (random.nextInt(249) + 1) + ":9997");
       }
     }
 
@@ -343,12 +343,11 @@ public class GroupBalancerTest {
   @Test
   public void bigTest2() {
     TabletServers tservers = new TabletServers();
-    Random rand = new SecureRandom();
 
     for (int g = 1; g <= 60; g++) {
-      for (int t = 1; t <= rand.nextInt(1000); t++) {
+      for (int t = 1; t <= random.nextInt(1000); t++) {
         tservers.addTablet(String.format("%02d:%d", g, t),
-            "192.168.1." + (rand.nextInt(249) + 1) + ":9997");
+            "192.168.1." + (random.nextInt(249) + 1) + ":9997");
       }
     }
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -105,9 +106,9 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Preconditions;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class Compactor extends AbstractServer implements CompactorService.Iface {
+
+  private static final SecureRandom random = new SecureRandom();
 
   public static class CompactorServerOpts extends ServerOpts {
     @Parameter(required = true, names = {"-q", "--queue"}, description = "compaction queue name")
@@ -590,8 +591,6 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
     return supplier;
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "random used for jitter, not security functions")
   protected long getWaitTimeBetweenCompactionChecks() {
     // get the total number of compactors assigned to this queue
     int numCompactors = ExternalCompactionUtil.countCompactors(queueName, getContext());
@@ -603,7 +602,7 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
     sleepTime = Math.min(300_000L, sleepTime);
     // Add some random jitter to the sleep time, that averages out to sleep time. This will spread
     // compactors out evenly over time.
-    sleepTime = (long) (.9 * sleepTime + sleepTime * .2 * Math.random());
+    sleepTime = (long) (.9 * sleepTime + sleepTime * .2 * random.nextDouble());
     LOG.trace("Sleeping {}ms based on {} compactors", sleepTime, numCompactors);
     return sleepTime;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinator.java
@@ -23,7 +23,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.security.SecureRandom;
 import java.util.Iterator;
-import java.util.Random;
 import java.util.Set;
 
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
@@ -46,10 +45,10 @@ import org.slf4j.LoggerFactory;
  * Choose a tserver to service a replication task
  */
 public class ManagerReplicationCoordinator implements ReplicationCoordinator.Iface {
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(ManagerReplicationCoordinator.class);
 
   private final Manager manager;
-  private final Random rand;
   private final ZooReader reader;
   private final SecurityOperation security;
 
@@ -60,8 +59,6 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
 
   protected ManagerReplicationCoordinator(Manager manager, ZooReader reader) {
     this.manager = manager;
-    this.rand = new SecureRandom();
-    this.rand.setSeed(358923462L);
     this.reader = reader;
     this.security = AuditedSecurityOperation.getInstance(manager.getContext());
   }
@@ -85,7 +82,7 @@ public class ManagerReplicationCoordinator implements ReplicationCoordinator.Ifa
           "No tservers are available for replication");
     }
 
-    TServerInstance tserver = getRandomTServer(tservers, rand.nextInt(tservers.size()));
+    TServerInstance tserver = getRandomTServer(tservers, random.nextInt(tservers.size()));
     String replServiceAddr;
     try {
       replServiceAddr = new String(reader.getData(manager.getZooKeeperRoot()

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -63,6 +62,8 @@ import org.slf4j.LoggerFactory;
 class LoadFiles extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;
+
+  private static final SecureRandom random = new SecureRandom();
 
   private static ExecutorService threadPool = null;
   private static final Logger log = LoggerFactory.getLogger(LoadFiles.class);
@@ -135,7 +136,6 @@ class LoadFiles extends ManagerRepo {
 
       // Use the threadpool to assign files one-at-a-time to the server
       final List<String> loaded = Collections.synchronizedList(new ArrayList<>());
-      final Random random = new SecureRandom();
       final TServerInstance[] servers;
       String prop = conf.get(Property.MANAGER_BULK_TSERVER_REGEX);
       if (prop == null || "".equals(prop)) {

--- a/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
+++ b/server/tracer/src/main/java/org/apache/accumulo/tracer/ZooTraceClient.java
@@ -28,7 +28,6 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -68,7 +67,7 @@ public class ZooTraceClient extends AsyncSpanReceiver<String,Client> implements 
   private ZooReader zoo = null;
   private String path;
   private boolean pathExists = false;
-  private final Random random = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
   private final List<String> hosts = new ArrayList<>();
   private long retryPause = 5000L;
   private SingletonReservation reservation;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -37,7 +37,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -167,6 +166,7 @@ import com.google.common.collect.Iterators;
 
 public class TabletServer extends AbstractServer {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(TabletServer.class);
   private static final long TIME_BETWEEN_GC_CHECKS = 5000;
   private static final long TIME_BETWEEN_LOCATOR_CACHE_CLEARS = 60 * 60 * 1000;
@@ -375,9 +375,9 @@ public class TabletServer extends AbstractServer {
   }
 
   private static long jitter() {
-    Random r = new SecureRandom();
     // add a random 10% wait
-    return (long) ((1. + (r.nextDouble() / 10)) * TabletServer.TIME_BETWEEN_LOCATOR_CACHE_CLEARS);
+    return (long) ((1. + (random.nextDouble() / 10))
+        * TabletServer.TIME_BETWEEN_LOCATOR_CACHE_CLEARS);
   }
 
   final SessionManager sessionManager;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -49,6 +48,7 @@ import org.slf4j.LoggerFactory;
 
 public class MinorCompactor extends FileCompactor {
 
+  private static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(MinorCompactor.class);
 
   private final TabletServer tabletServer;
@@ -131,8 +131,6 @@ public class MinorCompactor extends FileCompactor {
         } catch (CompactionCanceledException e) {
           throw new IllegalStateException(e);
         }
-
-        Random random = new SecureRandom();
 
         int sleep = sleepTime + random.nextInt(sleepTime);
         log.debug("MinC failed sleeping {} ms before retrying", sleep);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/HiddenCommand.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Random;
 
 import org.apache.accumulo.shell.Shell;
 import org.apache.accumulo.shell.Shell.Command;
@@ -32,7 +31,7 @@ import org.apache.commons.cli.CommandLine;
 import org.jline.utils.InfoCmp;
 
 public class HiddenCommand extends Command {
-  private static Random rand = new SecureRandom();
+  private static final SecureRandom random = new SecureRandom();
 
   @Override
   public String description() {
@@ -42,7 +41,7 @@ public class HiddenCommand extends Command {
   @Override
   public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
       throws Exception {
-    if (rand.nextInt(10) == 0) {
+    if (random.nextInt(10) == 0) {
       shellState.getTerminal().puts(InfoCmp.Capability.bell);
       shellState.getWriter().println();
       shellState.getWriter()

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -69,7 +69,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-statsd</artifactId>
-      <version>${micrometer.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloITBase.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.harness;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
@@ -36,6 +37,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * Methods, setup and/or infrastructure which are common to any Accumulo integration test.
  */
 public class AccumuloITBase {
+  public static final SecureRandom random = new SecureRandom();
   private static final Logger log = LoggerFactory.getLogger(AccumuloITBase.class);
 
   @Rule

--- a/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
+++ b/test/src/main/java/org/apache/accumulo/harness/SharedMiniClusterBase.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.lang.StackWalker.StackFrame;
-import java.security.SecureRandom;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
@@ -162,7 +161,7 @@ public abstract class SharedMiniClusterBase extends AccumuloITBase implements Cl
         StackWalker.getInstance(RETAIN_CLASS_REFERENCE).walk(findCallerITClass).map(Class::getName);
     // use the calling class name, or default to a unique name if IT class can't be found
     return callerClassName.orElse(String.format("UnknownITClass-{}-{}", System.currentTimeMillis(),
-        new SecureRandom().nextInt(Short.MAX_VALUE)));
+        random.nextInt(Short.MAX_VALUE)));
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
+++ b/test/src/main/java/org/apache/accumulo/test/ChaoticLoadBalancer.java
@@ -18,13 +18,13 @@
  */
 package org.apache.accumulo.test;
 
-import java.security.SecureRandom;
+import static org.apache.accumulo.harness.AccumuloITBase.random;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -54,7 +54,6 @@ public class ChaoticLoadBalancer implements TabletBalancer {
   private static final Logger log = LoggerFactory.getLogger(ChaoticLoadBalancer.class);
 
   protected BalancerEnvironment environment;
-  Random r = new SecureRandom();
 
   public ChaoticLoadBalancer() {}
 
@@ -86,7 +85,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     }
 
     for (TabletId tabletId : params.unassignedTablets().keySet()) {
-      int index = r.nextInt(tServerArray.size());
+      int index = random.nextInt(tServerArray.size());
       TabletServerId dest = tServerArray.get(index);
       params.addAssignment(tabletId, dest);
       long remaining = toAssign.get(dest) - 1;
@@ -116,7 +115,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
     }
     problemReporter.clearProblemReportTimes();
 
-    boolean moveMetadata = r.nextInt(4) == 0;
+    boolean moveMetadata = random.nextInt(4) == 0;
     long totalTablets = 0;
     for (Entry<TabletServerId,TServerStatus> e : params.currentStatus().entrySet()) {
       long tabletCount = 0;
@@ -138,7 +137,7 @@ public class ChaoticLoadBalancer implements TabletBalancer {
           continue;
         try {
           for (TabletStatistics ts : getOnlineTabletsForTable(e.getKey(), id)) {
-            int index = r.nextInt(underCapacityTServer.size());
+            int index = random.nextInt(underCapacityTServer.size());
             TabletServerId dest = underCapacityTServer.get(index);
             if (dest.equals(e.getKey()))
               continue;

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +33,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -110,6 +108,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Iterables;
 
 public class ConditionalWriterIT extends SharedMiniClusterBase {
+
   private static final Logger log = LoggerFactory.getLogger(ConditionalWriterIT.class);
 
   @Override
@@ -875,11 +874,10 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       ArrayList<byte[]> rows = new ArrayList<>(num);
       ArrayList<ConditionalMutation> cml = new ArrayList<>(num);
 
-      Random r = new SecureRandom();
       byte[] e = new byte[0];
 
       for (int i = 0; i < num; i++) {
-        rows.add(FastFormat.toZeroPaddedString(abs(r.nextLong()), 16, 16, e));
+        rows.add(FastFormat.toZeroPaddedString(abs(random.nextLong()), 16, 16, e));
       }
 
       for (int i = 0; i < num; i++) {
@@ -949,7 +947,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       ColumnVisibility cvaob = new ColumnVisibility("A|B");
       ColumnVisibility cvaab = new ColumnVisibility("A&B");
 
-      switch ((new SecureRandom()).nextInt(3)) {
+      switch (random.nextInt(3)) {
         case 1:
           client.tableOperations().addSplits(tableName, nss("6"));
           break;
@@ -1172,21 +1170,20 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
     public void run() {
       try (Scanner scanner =
           new IsolatedScanner(client.createScanner(tableName, Authorizations.EMPTY))) {
-        Random rand = new SecureRandom();
 
         for (int i = 0; i < 20; i++) {
-          int numRows = rand.nextInt(10) + 1;
+          int numRows = random.nextInt(10) + 1;
 
           ArrayList<ByteSequence> changes = new ArrayList<>(numRows);
           ArrayList<ConditionalMutation> mutations = new ArrayList<>();
 
           for (int j = 0; j < numRows; j++)
-            changes.add(rows.get(rand.nextInt(rows.size())));
+            changes.add(rows.get(random.nextInt(rows.size())));
 
           for (ByteSequence row : changes) {
             scanner.setRange(new Range(row.toString()));
             Stats stats = new Stats(scanner.iterator());
-            stats.set(rand.nextInt(10), rand.nextInt(Integer.MAX_VALUE));
+            stats.set(random.nextInt(10), random.nextInt(Integer.MAX_VALUE));
             mutations.add(stats.toMutation());
           }
 
@@ -1218,9 +1215,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
       NewTableConfiguration ntc = new NewTableConfiguration();
 
-      Random rand = new SecureRandom();
-
-      switch (rand.nextInt(3)) {
+      switch (random.nextInt(3)) {
         case 1:
           ntc = ntc.withSplits(nss("4"));
           break;
@@ -1237,7 +1232,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
         for (int i = 0; i < 1000; i++) {
           rows.add(new ArrayByteSequence(
-              FastFormat.toZeroPaddedString(abs(rand.nextLong()), 16, 16, new byte[0])));
+              FastFormat.toZeroPaddedString(abs(random.nextLong()), 16, 16, new byte[0])));
         }
 
         ArrayList<ConditionalMutation> mutations = new ArrayList<>();

--- a/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ImportExportIT.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -67,8 +66,6 @@ import org.slf4j.LoggerFactory;
 public class ImportExportIT extends AccumuloClusterHarness {
 
   private static final Logger log = LoggerFactory.getLogger(ImportExportIT.class);
-
-  private SecureRandom r = new SecureRandom();
 
   @Override
   protected int defaultTimeoutSeconds() {
@@ -142,7 +139,7 @@ public class ImportExportIT extends AccumuloClusterHarness {
       while ((line = reader.readLine()) != null) {
         Path p = new Path(line.substring(5));
         assertTrue("File doesn't exist: " + p, fs.exists(p));
-        Path importDir = importDirAry[r.nextInt(importDirAry.length)];
+        Path importDir = importDirAry[random.nextInt(importDirAry.length)];
         Path dest = new Path(importDir, p.getName());
         assertFalse("Did not expect " + dest + " to exist", fs.exists(dest));
         FileUtil.copy(fs, p, fs, dest, false, fs.getConf());

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -22,10 +22,8 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -87,7 +85,6 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
     final String tableName = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       c.tableOperations().create(tableName);
-      Random random = new SecureRandom();
       try (BatchWriter bw = c.createBatchWriter(tableName)) {
         for (int i = 0; i < 50000; i++) {
           byte[] row = new byte[100];

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -23,9 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -86,7 +84,6 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
       final Thread agitator = agitator(stop);
       agitator.start();
       System.out.println("writing");
-      final Random random = new SecureRandom();
       for (i = 0; i < 1_000_000; i++) {
         // make non-negative avoiding Math.abs, because that can still be negative
         long randomRow = random.nextLong() & Long.MAX_VALUE;

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -39,7 +39,6 @@ import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -51,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -1039,11 +1037,8 @@ public class ShellServerIT extends SharedMiniClusterBase {
     assertEquals(2, countFiles(cloneId));
 
     // create two large files
-    Random rand = new SecureRandom();
     StringBuilder sb = new StringBuilder("insert b v q ");
-    for (int i = 0; i < 10000; i++) {
-      sb.append('a' + rand.nextInt(26));
-    }
+    random.ints(10_000, 0, 26).forEach(i -> sb.append('a' + i));
 
     ts.exec(sb.toString());
     ts.exec("flush -w");
@@ -2953,14 +2948,11 @@ public class ShellServerIT extends SharedMiniClusterBase {
     return splits;
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
   private Collection<Text> generateBinarySplits(final int numItems, final int len) {
     Set<Text> splits = new HashSet<>();
-    Random rand = new Random();
     for (int i = 0; i < numItems; i++) {
       byte[] split = new byte[len];
-      rand.nextBytes(split);
+      random.nextBytes(split);
       splits.add(new Text(split));
     }
     return splits;

--- a/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableConfigurationUpdateIT.java
@@ -21,9 +21,7 @@ package org.apache.accumulo.test;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -115,7 +113,6 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
 
     @Override
     public Exception call() {
-      Random r = new SecureRandom();
       countDown.countDown();
       try {
         countDown.await();
@@ -126,17 +123,13 @@ public class TableConfigurationUpdateIT extends AccumuloClusterHarness {
 
       String t = Thread.currentThread().getName() + " ";
       try {
-        for (int i = 0; i < iterations; i++) {
-          // if (i % 10000 == 0) {
-          // log.info(t + " " + i);
-          // }
-          int choice = r.nextInt(randMax);
+        random.ints(iterations, 0, randMax).forEach(choice -> {
           if (choice < 1) {
             tableConf.invalidateCache();
           } else {
             tableConf.get(prop);
           }
-        }
+        });
       } catch (Exception e) {
         log.error(t, e);
         return e;

--- a/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestBinaryRows.java
@@ -19,11 +19,10 @@
 package org.apache.accumulo.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.harness.AccumuloITBase.random;
 
-import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -160,12 +159,10 @@ public class TestBinaryRows {
     } else if (opts.mode.equals("randomLookups")) {
       int numLookups = 1000;
 
-      Random r = new SecureRandom();
-
       long t1 = System.currentTimeMillis();
 
       for (int i = 0; i < numLookups; i++) {
-        long row = ((r.nextLong() & 0x7fffffffffffffffL) % opts.num) + opts.start;
+        long row = ((random.nextLong() & 0x7fffffffffffffffL) % opts.num) + opts.start;
 
         try (Scanner s = accumuloClient.createScanner(opts.tableName, opts.auths)) {
           Key startKey = new Key(encodeLong(row), CF_BYTES, CQ_BYTES, new byte[0], Long.MAX_VALUE);

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -224,8 +224,10 @@ public class TestIngest {
     return new Text(FastFormat.toZeroPaddedString(rowid + startRow, 10, 10, ROW_PREFIX));
   }
 
-  public static byte[] genRandomValue(Random random, byte[] dest, int seed, int row, int col) {
-    random.setSeed((row ^ seed) ^ col);
+  @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},
+      justification = "predictable random with specific seed is intended for this test")
+  public static byte[] genRandomValue(byte[] dest, int seed, int row, int col) {
+    var random = new Random((row ^ seed) ^ col);
     random.nextBytes(dest);
     toPrintableChars(dest);
     return dest;
@@ -248,8 +250,6 @@ public class TestIngest {
     }
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
   public static void ingest(AccumuloClient accumuloClient, FileSystem fs, IngestParams params)
       throws IOException, AccumuloException, AccumuloSecurityException, TableNotFoundException,
       MutationsRejectedException, TableExistsException {
@@ -258,7 +258,6 @@ public class TestIngest {
     byte[][] bytevals = generateValues(params.dataSize);
 
     byte[] randomValue = new byte[params.dataSize];
-    Random random = new Random();
 
     long bytesWritten = 0;
 
@@ -317,8 +316,7 @@ public class TestIngest {
           } else {
             byte[] value;
             if (params.random != null) {
-              value =
-                  genRandomValue(random, randomValue, params.random, rowid + params.startRow, j);
+              value = genRandomValue(randomValue, params.random, rowid + params.startRow, j);
             } else {
               value = bytevals[j % bytevals.length];
             }
@@ -341,8 +339,7 @@ public class TestIngest {
           } else {
             byte[] value;
             if (params.random != null) {
-              value =
-                  genRandomValue(random, randomValue, params.random, rowid + params.startRow, j);
+              value = genRandomValue(randomValue, params.random, rowid + params.startRow, j);
             } else {
               value = bytevals[j % bytevals.length];
             }

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -21,8 +21,6 @@ package org.apache.accumulo.test;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertTrue;
 
-import java.security.SecureRandom;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -61,7 +59,6 @@ public class TotalQueuedIT extends ConfigurableMacBase {
 
   @Test
   public void test() throws Exception {
-    Random random = new SecureRandom();
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       c.instanceOperations().setProperty(Property.TSERV_TOTAL_MUTATION_QUEUE_MAX.getKey(),
           "" + SMALL_QUEUE_SIZE);

--- a/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -46,8 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.Parameter;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class VerifyIngest {
 
@@ -110,8 +107,6 @@ public class VerifyIngest {
     }
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
   public static void verifyIngest(AccumuloClient accumuloClient, VerifyParams params)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     byte[][] bytevals = TestIngest.generateValues(params.dataSize);
@@ -128,7 +123,6 @@ public class VerifyIngest {
     long t1 = System.currentTimeMillis();
 
     byte[] randomValue = new byte[params.dataSize];
-    Random random = new Random();
 
     Key endKey = new Key(new Text("row_" + String.format("%010d", params.rows + params.startRow)));
 
@@ -157,8 +151,7 @@ public class VerifyIngest {
 
           byte[] ev;
           if (params.random != null) {
-            ev = TestIngest.genRandomValue(random, randomValue, params.random, expectedRow,
-                expectedCol);
+            ev = TestIngest.genRandomValue(randomValue, params.random, expectedRow, expectedCol);
           } else {
             ev = bytevals[expectedCol % bytevals.length];
           }
@@ -229,8 +222,7 @@ public class VerifyIngest {
 
             byte[] value;
             if (params.random != null) {
-              value = TestIngest.genRandomValue(random, randomValue, params.random, expectedRow,
-                  colNum);
+              value = TestIngest.genRandomValue(randomValue, params.random, expectedRow, colNum);
             } else {
               value = bytevals[colNum % bytevals.length];
             }

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.security.SecureRandom;
-import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -53,7 +51,6 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
 
   private static final byte[] HEXCHARS = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
       0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66};
-  private static final Random random = new SecureRandom();
 
   public static byte[] randomHex(int n) {
     byte[] binary = new byte[n];

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -75,18 +74,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class CompactionExecutorIT extends SharedMiniClusterBase {
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
   public static class TestPlanner implements CompactionPlanner {
 
     private int filesPerCompaction;
     private List<CompactionExecutorId> executorIds;
     private EnumSet<CompactionKind> kindsToProcess = EnumSet.noneOf(CompactionKind.class);
-    private Random rand = new Random();
 
     @Override
     public void init(InitParameters params) {
@@ -110,10 +104,11 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
 
     @Override
     public CompactionPlan makePlan(PlanningParameters params) {
-
       if (Boolean.parseBoolean(params.getExecutionHints().getOrDefault("compact_all", "false"))) {
-        return params.createPlanBuilder().addJob((short) 1,
-            executorIds.get(rand.nextInt(executorIds.size())), params.getCandidates()).build();
+        return params
+            .createPlanBuilder().addJob((short) 1,
+                executorIds.get(random.nextInt(executorIds.size())), params.getCandidates())
+            .build();
       }
 
       if (kindsToProcess.contains(params.getKind())) {
@@ -125,7 +120,7 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
         params.getCandidates().stream().collect(Collectors.groupingBy(TestPlanner::getFirstChar))
             .values().forEach(files -> {
               for (int i = filesPerCompaction; i <= files.size(); i += filesPerCompaction) {
-                planBuilder.addJob((short) 1, executorIds.get(rand.nextInt(executorIds.size())),
+                planBuilder.addJob((short) 1, executorIds.get(random.nextInt(executorIds.size())),
                     files.subList(i - filesPerCompaction, i));
               }
             });

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionRateLimitingIT.java
@@ -20,9 +20,7 @@ package org.apache.accumulo.test.compaction;
 
 import static org.junit.Assert.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.Map;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -76,16 +74,15 @@ public class CompactionRateLimitingIT extends ConfigurableMacBase {
 
         client.tableOperations().create(tableName, ntc);
         try (BatchWriter bw = client.createBatchWriter(tableName)) {
-          Random r = new SecureRandom();
           while (bytesWritten < BYTES_TO_WRITE) {
             byte[] rowKey = new byte[32];
-            r.nextBytes(rowKey);
+            random.nextBytes(rowKey);
 
             byte[] qual = new byte[32];
-            r.nextBytes(qual);
+            random.nextBytes(qual);
 
             byte[] value = new byte[1024];
-            r.nextBytes(value);
+            random.nextBytes(value);
 
             Mutation m = new Mutation(rowKey);
             m.put(new byte[0], qual, value);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/UserCompactionStrategyIT.java
@@ -25,13 +25,11 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -321,13 +319,11 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   }
 
   void writeRandomValue(AccumuloClient c, String tableName, int size) throws Exception {
-    Random rand = new SecureRandom();
-
     byte[] data1 = new byte[size];
-    rand.nextBytes(data1);
+    random.nextBytes(data1);
 
     try (BatchWriter bw = c.createBatchWriter(tableName)) {
-      Mutation m1 = new Mutation("r" + rand.nextInt(909090));
+      Mutation m1 = new Mutation("r" + random.nextInt(909090));
       m1.put("data", "bl0b", new Value(data1));
       bw.addMutation(m1);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
@@ -20,12 +20,10 @@ package org.apache.accumulo.test.functional;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -86,7 +84,6 @@ public class BatchScanSplitIT extends AccumuloClusterHarness {
 
       System.out.println("splits : " + splits);
 
-      Random random = new SecureRandom();
       HashMap<Text,Value> expected = new HashMap<>();
       ArrayList<Range> ranges = new ArrayList<>();
       for (int i = 0; i < 100; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,7 +30,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -110,7 +108,6 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
   private void runFlushTest(AccumuloClient client, String tableName) throws Exception {
     BatchWriter bw = client.createBatchWriter(tableName);
     try (Scanner scanner = client.createScanner(tableName, Authorizations.EMPTY)) {
-      Random r = new SecureRandom();
 
       for (int i = 0; i < 4; i++) {
         for (int j = 0; j < NUM_TO_FLUSH; j++) {
@@ -126,7 +123,7 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
         // do a few random lookups into the data just flushed
 
         for (int k = 0; k < 10; k++) {
-          int rowToLookup = r.nextInt(NUM_TO_FLUSH) + i * NUM_TO_FLUSH;
+          int rowToLookup = random.nextInt(NUM_TO_FLUSH) + i * NUM_TO_FLUSH;
 
           scanner.setRange(new Range(new Text(String.format("r_%10d", rowToLookup))));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BloomFilterIT.java
@@ -18,14 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -181,7 +179,6 @@ public class BloomFilterIT extends AccumuloClusterHarness {
 
   private long query(AccumuloClient c, String table, int depth, long start, long end, int num,
       int step) throws Exception {
-    Random r = new SecureRandom();
 
     HashSet<Long> expected = new HashSet<>();
     List<Range> ranges = new ArrayList<>(num);
@@ -189,7 +186,7 @@ public class BloomFilterIT extends AccumuloClusterHarness {
     Text row = new Text("row"), cq = new Text("cq"), cf = new Text("cf");
 
     for (int i = 0; i < num; ++i) {
-      Long k = ((r.nextLong() & 0x7fffffffffffffffL) % (end - start)) + start;
+      Long k = ((random.nextLong() & 0x7fffffffffffffffL) % (end - start)) + start;
       key.set(String.format("k_%010d", k));
       Range range = null;
       Key acuKey;

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -20,15 +20,14 @@ package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
+import static org.apache.accumulo.harness.AccumuloITBase.random;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Random;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -67,22 +66,20 @@ public class CacheTestWriter {
 
     ArrayList<String> children = new ArrayList<>();
 
-    Random r = new SecureRandom();
-
     while (count++ < numVerifications) {
 
       Map<String,String> expectedData = null;
       // change children in dir
 
-      for (int u = 0; u < r.nextInt(4) + 1; u++) {
+      for (int u = 0; u < random.nextInt(4) + 1; u++) {
         expectedData = new TreeMap<>();
 
-        if (r.nextFloat() < .5) {
+        if (random.nextFloat() < .5) {
           String child = UUID.randomUUID().toString();
           zk.putPersistentData(rootDir + "/dir/" + child, new byte[0], NodeExistsPolicy.SKIP);
           children.add(child);
         } else if (!children.isEmpty()) {
-          int index = r.nextInt(children.size());
+          int index = random.nextInt(children.size());
           String child = children.remove(index);
           zk.recursiveDelete(rootDir + "/dir/" + child, NodeMissingPolicy.FAIL);
         }
@@ -93,15 +90,15 @@ public class CacheTestWriter {
 
         // change values
         for (int i = 0; i < numData; i++) {
-          byte[] data = Long.toString(r.nextLong(), 16).getBytes(UTF_8);
+          byte[] data = Long.toString(random.nextLong(), 16).getBytes(UTF_8);
           zk.putPersistentData(rootDir + "/data" + i, data, NodeExistsPolicy.OVERWRITE);
           expectedData.put(rootDir + "/data" + i, new String(data, UTF_8));
         }
 
         // test a data node that does not always exists...
-        if (r.nextFloat() < .5) {
+        if (random.nextFloat() < .5) {
 
-          byte[] data = Long.toString(r.nextLong(), 16).getBytes(UTF_8);
+          byte[] data = Long.toString(random.nextLong(), 16).getBytes(UTF_8);
 
           if (dataSExists) {
             zk.putPersistentData(rootDir + "/dataS", data, NodeExistsPolicy.OVERWRITE);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -21,12 +21,10 @@ package org.apache.accumulo.test.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -274,9 +272,8 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
   private void writeData(AccumuloClient c, String table)
       throws TableNotFoundException, MutationsRejectedException {
     try (BatchWriter bw = c.createBatchWriter(table)) {
-      Random rand = new SecureRandom();
       for (int i = 0; i < 1_000; i++) {
-        Mutation m = new Mutation(String.format("%09x", rand.nextInt(100_000 * 1_000)));
+        Mutation m = new Mutation(String.format("%09x", random.nextInt(100_000_000)));
         m.put("m", "order", "" + i);
         bw.addMutation(m);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableCompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConfigurableCompactionIT.java
@@ -24,11 +24,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -155,13 +153,11 @@ public class ConfigurableCompactionIT extends ConfigurableMacBase {
     client.tableOperations().flush(tablename, null, null, true);
   }
 
-  static final Random r = new SecureRandom();
-
   private void makeFile(AccumuloClient client, String tablename) throws Exception {
     try (BatchWriter bw = client.createBatchWriter(tablename)) {
       byte[] empty = {};
       byte[] row = new byte[10];
-      r.nextBytes(row);
+      random.nextBytes(row);
       Mutation m = new Mutation(row, 0, 10);
       m.put(empty, empty, empty);
       bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateInitialSplitsIT.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -47,8 +46,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class CreateInitialSplitsIT extends AccumuloClusterHarness {
 
@@ -207,15 +204,12 @@ public class CreateInitialSplitsIT extends AccumuloClusterHarness {
     return generateBinarySplits(numItems, len, false);
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
   private SortedSet<Text> generateBinarySplits(final int numItems, final int len,
       final boolean useB64) {
     SortedSet<Text> splits = new TreeSet<>();
-    Random rand = new Random();
     for (int i = 0; i < numItems; i++) {
       byte[] split = new byte[len];
-      rand.nextBytes(split);
+      random.nextBytes(split);
       splits.add(encode(new Text(split), useB64));
     }
     return splits;

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateStarvationIT.java
@@ -18,10 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -60,11 +58,10 @@ public class FateStarvationIT extends AccumuloClusterHarness {
       c.tableOperations().flush(tableName, null, null, true);
 
       List<Text> splits = new ArrayList<>(TestIngest.getSplitPoints(0, 100000, 67));
-      Random rand = new SecureRandom();
 
       for (int i = 0; i < 100; i++) {
-        int idx1 = rand.nextInt(splits.size() - 1);
-        int idx2 = rand.nextInt(splits.size() - (idx1 + 1)) + idx1 + 1;
+        int idx1 = random.nextInt(splits.size() - 1);
+        int idx2 = random.nextInt(splits.size() - (idx1 + 1)) + idx1 + 1;
 
         c.tableOperations().compact(tableName, splits.get(idx1), splits.get(idx2), false, false);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
@@ -113,16 +113,15 @@ public class LargeRowIT extends AccumuloClusterHarness {
     }
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
+  @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},
+      justification = "predictable random with specific seed is intended for this test")
   @Test
   public void run() throws Exception {
-    Random r = new Random();
+    var random = new Random(SEED + 1);
     byte[] rowData = new byte[ROW_SIZE];
-    r.setSeed(SEED + 1);
     TreeSet<Text> splitPoints = new TreeSet<>();
     for (int i = 0; i < NUM_PRE_SPLITS; i++) {
-      r.nextBytes(rowData);
+      random.nextBytes(rowData);
       TestIngest.toPrintableChars(rowData);
       splitPoints.add(new Text(rowData));
     }
@@ -157,17 +156,16 @@ public class LargeRowIT extends AccumuloClusterHarness {
     basicTest(c, PRE_SPLIT_TABLE_NAME, NUM_PRE_SPLITS);
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
+  @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},
+      justification = "predictable random with specific seed is intended for this test")
   private void basicTest(AccumuloClient c, String table, int expectedSplits) throws Exception {
     try (BatchWriter bw = c.createBatchWriter(table)) {
 
-      Random r = new Random();
+      var random = new Random(SEED);
       byte[] rowData = new byte[ROW_SIZE];
-      r.setSeed(SEED);
 
       for (int i = 0; i < NUM_ROWS; i++) {
-        r.nextBytes(rowData);
+        random.nextBytes(rowData);
         TestIngest.toPrintableChars(rowData);
         Mutation mut = new Mutation(new Text(rowData));
         mut.put("", "", Integer.toString(i));
@@ -196,19 +194,17 @@ public class LargeRowIT extends AccumuloClusterHarness {
     FunctionalTestUtils.checkSplits(c, table, expectedSplits, expectedSplits);
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
+  @SuppressFBWarnings(value = {"PREDICTABLE_RANDOM", "DMI_RANDOM_USED_ONLY_ONCE"},
+      justification = "predictable random with specific seed is intended for this test")
   private void verify(AccumuloClient c, String table) throws Exception {
-    Random r = new Random();
+    var random = new Random(SEED);
     byte[] rowData = new byte[ROW_SIZE];
-
-    r.setSeed(SEED);
 
     try (Scanner scanner = c.createScanner(table, Authorizations.EMPTY)) {
 
       for (int i = 0; i < NUM_ROWS; i++) {
 
-        r.nextBytes(rowData);
+        random.nextBytes(rowData);
         TestIngest.toPrintableChars(rowData);
 
         scanner.setRange(new Range(new Text(rowData)));

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManyWriteAheadLogsIT.java
@@ -20,12 +20,10 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertTrue;
 
-import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -135,8 +133,6 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
 
       c.tableOperations().create(rollWALsTable);
 
-      Random rand = new SecureRandom();
-
       Set<String> allWalsSeen = new HashSet<>();
 
       addOpenWals(context, allWalsSeen);
@@ -160,7 +156,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           for (int j = 0; j < 10; j++) {
             int row = startRow + j;
             Mutation m = new Mutation(String.format("%05x", row));
-            rand.nextBytes(val);
+            random.nextBytes(val);
             m.put("f", "q", "v");
 
             manyWALsWriter.addMutation(m);
@@ -170,7 +166,7 @@ public class ManyWriteAheadLogsIT extends AccumuloClusterHarness {
           // write a lot of data to second table to forces the logs to roll
           for (int j = 0; j < 1000; j++) {
             Mutation m = new Mutation(String.format("%03d", j));
-            rand.nextBytes(val);
+            random.nextBytes(val);
 
             m.put("f", "q", Base64.getEncoder().encodeToString(val));
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MaxOpenIT.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -43,8 +42,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * A functional test that exercises hitting the max open file limit on a tablet server. This test
@@ -139,8 +136,6 @@ public class MaxOpenIT extends AccumuloClusterHarness {
     }
   }
 
-  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
-      justification = "predictable random is okay for testing")
   private long batchScan(AccumuloClient c, String tableName, List<Range> ranges, int threads)
       throws Exception {
     try (BatchScanner bs = c.createBatchScanner(tableName, TestIngest.AUTHS, threads)) {
@@ -152,7 +147,6 @@ public class MaxOpenIT extends AccumuloClusterHarness {
       long t1 = System.currentTimeMillis();
 
       byte[] rval = new byte[50];
-      Random random = new Random();
 
       for (Entry<Key,Value> entry : bs) {
         count++;
@@ -163,7 +157,7 @@ public class MaxOpenIT extends AccumuloClusterHarness {
           throw new Exception("unexcepted row " + row);
         }
 
-        rval = TestIngest.genRandomValue(random, rval, 2, row, col);
+        rval = TestIngest.genRandomValue(rval, 2, row, col);
 
         if (entry.getValue().compareTo(rval) != 0) {
           throw new Exception("unexcepted value row=" + row + " col=" + col);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MonitorSslIT.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.Map;
 
@@ -57,7 +56,7 @@ public class MonitorSslIT extends ConfigurableMacBase {
   public static void initHttps() throws NoSuchAlgorithmException, KeyManagementException {
     SSLContext ctx = SSLContext.getInstance("TLSv1.2");
     TrustManager[] tm = {new TestTrustManager()};
-    ctx.init(new KeyManager[0], tm, new SecureRandom());
+    ctx.init(new KeyManager[0], tm, random);
     SSLContext.setDefault(ctx);
     HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
     HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.harness.AccumuloITBase.random;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -28,14 +29,12 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Random;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.Constants;
@@ -457,11 +456,11 @@ public class NativeMapIT {
   }
 
   // random length random field
-  private static byte[] getRandomBytes(Random r, int maxLen) {
-    int len = r.nextInt(maxLen);
+  private static byte[] getRandomBytes(int maxLen) {
+    int len = random.nextInt(maxLen);
 
     byte[] f = new byte[len];
-    r.nextBytes(f);
+    random.nextBytes(f);
 
     return f;
   }
@@ -473,15 +472,13 @@ public class NativeMapIT {
     // insert things with varying field sizes and value sizes
 
     // generate random data
-    Random r = new SecureRandom();
-
     ArrayList<Pair<Key,Value>> testData = new ArrayList<>();
 
     for (int i = 0; i < 100000; i++) {
 
-      Key k = new Key(getRandomBytes(r, 97), getRandomBytes(r, 13), getRandomBytes(r, 31),
-          getRandomBytes(r, 11), (r.nextLong() & 0x7fffffffffffffffL), false, false);
-      Value v = new Value(getRandomBytes(r, 511));
+      Key k = new Key(getRandomBytes(97), getRandomBytes(13), getRandomBytes(31),
+          getRandomBytes(11), (random.nextLong() & 0x7fffffffffffffffL), false, false);
+      Value v = new Value(getRandomBytes(511));
 
       testData.add(new Pair<>(k, v));
     }
@@ -520,10 +517,10 @@ public class NativeMapIT {
       System.out.println("test 11 nm mem " + nm.getMemoryUsed());
 
       // insert data again w/ different value
-      Collections.shuffle(testData, r);
+      Collections.shuffle(testData, random);
       // insert unsorted data
       for (Pair<Key,Value> pair : testData) {
-        pair.getSecond().set(getRandomBytes(r, 511));
+        pair.getSecond().set(getRandomBytes(511));
         nm.put(pair.getFirst(), pair.getSecond());
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -26,7 +26,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
-import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -154,7 +153,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
               "Using HTTPS since monitor ssl keystore configuration was observed in accumulo configuration");
           SSLContext ctx = SSLContext.getInstance("TLSv1.2");
           TrustManager[] tm = {new TestTrustManager()};
-          ctx.init(new KeyManager[0], tm, new SecureRandom());
+          ctx.init(new KeyManager[0], tm, random);
           SSLContext.setDefault(ctx);
           HttpsURLConnection.setDefaultSSLSocketFactory(ctx.getSocketFactory());
           HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -24,13 +24,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -91,8 +89,6 @@ public class ScanIdIT extends AccumuloClusterHarness {
   private static final int NUM_SCANNERS = 8;
 
   private static final int NUM_DATA_ROWS = 100;
-
-  private static final Random random = new SecureRandom();
 
   private static final ExecutorService pool = Executors.newFixedThreadPool(NUM_SCANNERS);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SummaryIT.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,7 +43,6 @@ import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -878,7 +876,6 @@ public class SummaryIT extends SharedMiniClusterBase {
     final String table = getUniqueNames(1)[0];
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
 
-      Random rand = new SecureRandom();
       int q = 0;
 
       SortedSet<Text> partitionKeys = new TreeSet<>();
@@ -895,8 +892,8 @@ public class SummaryIT extends SharedMiniClusterBase {
         // this loop should cause a varying number of files and compactions
         try (BatchWriter bw = c.createBatchWriter(table)) {
           for (int i = 0; i < 10000; i++) {
-            String row = String.format("%06d", rand.nextInt(1_000_000));
-            String fam = String.format("%03d", rand.nextInt(100));
+            String row = String.format("%06d", random.nextInt(1_000_000));
+            String fam = String.format("%03d", random.nextInt(100));
             String qual = String.format("%06d", q++);
             write(bw, row, fam, qual, "val");
             famCounts.merge(fam, 1L, Long::sum);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -39,7 +38,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -176,18 +174,17 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
 
   private void writeSomeData(AccumuloClient client, String tableName, int row, int col)
       throws Exception {
-    Random rand = new SecureRandom();
     try (BatchWriter bw = client.createBatchWriter(tableName)) {
       byte[] rowData = new byte[10];
       byte[] cq = new byte[10];
       byte[] value = new byte[10];
 
       for (int r = 0; r < row; r++) {
-        rand.nextBytes(rowData);
+        random.nextBytes(rowData);
         Mutation m = new Mutation(rowData);
         for (int c = 0; c < col; c++) {
-          rand.nextBytes(cq);
-          rand.nextBytes(value);
+          random.nextBytes(cq);
+          random.nextBytes(value);
           m.put(CF, new Text(cq), new Value(value));
         }
         bw.addMutation(m);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -20,10 +20,9 @@ package org.apache.accumulo.test.functional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
+import static org.apache.accumulo.harness.AccumuloITBase.random;
 
-import java.security.SecureRandom;
 import java.util.HashMap;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -101,8 +100,6 @@ public class ZombieTServer {
   private static final Logger log = LoggerFactory.getLogger(ZombieTServer.class);
 
   public static void main(String[] args) throws Exception {
-    Random random = new SecureRandom();
-    random.setSeed(System.currentTimeMillis() % 1000);
     int port = random.nextInt(30000) + 2000;
     var context = new ServerContext(SiteConfiguration.auto());
     TransactionWatcher watcher = new TransactionWatcher(context);

--- a/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.UnknownHostException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -82,7 +80,6 @@ import com.google.common.collect.SetMultimap;
 
 public class SuspendedTabletsIT extends ConfigurableMacBase {
   private static final Logger log = LoggerFactory.getLogger(SuspendedTabletsIT.class);
-  private static final Random RANDOM = new SecureRandom();
   private static ExecutorService THREAD_POOL;
 
   public static final int TSERVERS = 3;
@@ -109,6 +106,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
         HostAndPortRegexTableLoadBalancer.class.getName());
   }
 
+  @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
@@ -160,7 +158,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
       // kill tablet servers that are not hosting the metadata table.
       List<ProcessReference> procs = getCluster().getProcesses().get(ServerType.TABLET_SERVER)
           .stream().filter(p -> !metadataTserverProcess.equals(p)).collect(Collectors.toList());
-      Collections.shuffle(procs, RANDOM);
+      Collections.shuffle(procs, random);
       assertEquals("Not enough tservers exist", TSERVERS - 1, procs.size());
       assertTrue("Attempting to kill more tservers (" + count + ") than exist in the cluster ("
           + procs.size() + ")", procs.size() >= count);
@@ -204,7 +202,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
           tserverSet.size());
 
       List<TServerInstance> tserversList = new ArrayList<>(tserverSet);
-      Collections.shuffle(tserversList, RANDOM);
+      Collections.shuffle(tserversList, random);
 
       for (int i1 = 0; i1 < count; ++i1) {
         final String tserverName = tserversList.get(i1).getHostPortSession();

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -18,9 +18,10 @@
  */
 package org.apache.accumulo.test.performance.scan;
 
+import static org.apache.accumulo.harness.AccumuloITBase.random;
+
 import java.io.IOException;
 import java.net.InetAddress;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
@@ -88,6 +88,7 @@ import com.beust.jcommander.Parameter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class CollectTabletStats {
+
   private static final Logger log = LoggerFactory.getLogger(CollectTabletStats.class);
 
   static class CollectOptions extends ServerUtilOpts {
@@ -378,9 +379,8 @@ public class CollectTabletStats {
   private static List<KeyExtent> selectRandomTablets(int numThreads, List<KeyExtent> candidates) {
     List<KeyExtent> tabletsToTest = new ArrayList<>();
 
-    Random rand = new SecureRandom();
     for (int i = 0; i < numThreads; i++) {
-      int rindex = rand.nextInt(candidates.size());
+      int rindex = random.nextInt(candidates.size());
       tabletsToTest.add(candidates.get(rindex));
       Collections.swap(candidates, rindex, candidates.size() - 1);
       candidates = candidates.subList(0, candidates.size() - 1);

--- a/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.test.zookeeper;
 
+import static org.apache.accumulo.harness.AccumuloITBase.random;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.SecureRandom;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.curator.test.TestingServer;
@@ -43,8 +43,6 @@ public class ZooKeeperTestingServer implements AutoCloseable {
 
   private TestingServer zkServer;
   private final ZooKeeper zoo;
-
-  private static final Random rand = new SecureRandom();
 
   /**
    * Instantiate a running zookeeper server - this call will block until the server is ready for
@@ -105,7 +103,7 @@ public class ZooKeeperTestingServer implements AutoCloseable {
   private static int getPort() {
     final int minPort = 50_000;
     final int maxPort = 65_000;
-    return rand.nextInt((maxPort - minPort) + 1) + minPort;
+    return random.nextInt((maxPort - minPort) + 1) + minPort;
   }
 
   public ZooKeeper getZooKeeper() {


### PR DESCRIPTION
Update Apache parent POM to 24

* Take advantage of enforcer rules built-in to Apache parent POM
  * Use minimalJavaBuildVersion and minimalMavenBuildVersion properties
  * Remove redundant enforcer checks in our POM
* Remove redundant version information and plugin definitions from
  Apache POM that aren't overridden

Update build plugin versions to latest

* Sort BOM dependencies in dependencyManagement before others (a change
  in behavior with latest sortpom-maven-plugin that's not possible to
  override, but this makes more sense anyway)
* Sort sortpom-maven-plugin's options, ensure blank lines are removed (a
  change in the default that is overridable), and ensure space before
  the closing slash on empty elements to keep it consistent with other
  plugins that update the POM
* Update spotbugs-related Random issues (and minor Random tweaks)
  * Always assign SecureRandom objects to SecureRandom variables, so
    spotbugs doesn't flag them as insecure Random usages
  * Allow SecureRandom objects to be reused using a static final
    instance for many classes, to avoid one-off object uses (usually
    private, except for a public instance for sharing across ITs)
  * While fixing Random-related spotbugs issues, apply naming
    consistently
  * Remove use of explicit SHA1PRNG implementation of SecureRandom,
    preferring non-blocking native implementation (default), and relying
    on users to configure their SecureRandom provider through Java
    security settings if they want something different from the default
  * Remove incorrect attempts to try to seed SecureRandom objects with a
    predictable seed (SecureRandom default implementation isn't
    predictable, even with a specific seed, since it uses the OS's
    native random source)
  * Remove unneeded spotbugs warnings suppressions
  * Use a fixed-length stream of random numbers in several places where
    a loop was used to iterate a fixed number of times and the loop
    variable wasn't needed
  * For the rare cases where we use a predictable random with a known
    seed for testing, pass the seed in the constructor to avoid useless
    initiationalization steps to do the initial seed only to
    reinitialize immediately with a call to setSeed

Fix pom/license issues related to micrometer (re #2305)

* Move metrics-related dependency versions and transitive dependency
  exclusions into project's parent pom's dependencyManagement section
* Update LICENSE to include CC0 artifacts used for metrics dependencies
* Remove property for micrometer version that is only used once for the
  micrometer BOM

Other

* Rename incorrect filename RolllingStatsTest.java to
  RollingStatsTest.java to match the class name RollingStatsTest
* Update AuthenticationTokenTest to use IntStream.allMatch to loop until
  a byte array is generated that isn't all zeros, instead of using
  assertFalse, which has a (rare) chance of failing the test
  unnecessarily