### PR TITLE
Create FlushNoFileIT and fix NPE in tablet file flush code 

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -22,11 +22,13 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
@@ -143,8 +145,11 @@ public class TabletLogger {
         asFileNames(job.getFiles()));
   }
 
-  public static void flushed(KeyExtent extent, TabletFile newDatafile) {
-    fileLog.debug("Flushed {} created {} from [memory]", extent, newDatafile);
+  public static void flushed(KeyExtent extent, Optional<StoredTabletFile> newDatafile) {
+    if (newDatafile.isPresent())
+      fileLog.debug("Flushed {} created {} from [memory]", extent, newDatafile.get());
+    else
+      fileLog.debug("Flushed {} from [memory] but no file was written.", extent);
   }
 
   public static void bulkImported(KeyExtent extent, TabletFile file) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/FlushNoFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FlushNoFileIT.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.clientImpl.ClientContext;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * Tests that Accumulo will flush but not create a file that has 0 entries.
+ */
+public class FlushNoFileIT extends AccumuloClusterHarness {
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 60;
+  }
+
+  @Test
+  public void test() throws Exception {
+    try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
+
+      String tableName = getUniqueNames(1)[0];
+
+      NewTableConfiguration ntc = new NewTableConfiguration();
+      IteratorSetting iteratorSetting = new IteratorSetting(20, NullIterator.class);
+      ntc.attachIterator(iteratorSetting, EnumSet.of(IteratorUtil.IteratorScope.minc));
+      ntc.withSplits(new TreeSet<>(Set.of(new Text("a"), new Text("s"))));
+
+      c.tableOperations().create(tableName, ntc);
+      TableId tableId = TableId.of(c.tableOperations().tableIdMap().get(tableName));
+
+      try (BatchWriter bw = c.createBatchWriter(tableName)) {
+        Mutation m = new Mutation(new Text("r1"));
+        m.put("acf", tableName, "1");
+        bw.addMutation(m);
+      }
+
+      FunctionalTestUtils.checkRFiles(c, tableName, 3, 3, 0, 0);
+
+      c.tableOperations().flush(tableName, null, null, true);
+
+      FunctionalTestUtils.checkRFiles(c, tableName, 3, 3, 0, 0);
+
+      long flushId = FunctionalTestUtils.checkFlushId((ClientContext) c, tableId, 0);
+
+      try (BatchWriter bw = c.createBatchWriter(tableName)) {
+        Mutation m = new Mutation(new Text("r2"));
+        m.put("acf", tableName, "1");
+        bw.addMutation(m);
+      }
+
+      c.tableOperations().flush(tableName, null, null, true);
+
+      FunctionalTestUtils.checkRFiles(c, tableName, 3, 3, 0, 0);
+
+      long secondFlushId = FunctionalTestUtils.checkFlushId((ClientContext) c, tableId, flushId);
+      assertTrue("Flush ID did not change", secondFlushId > flushId);
+
+      try (Scanner scanner = c.createScanner(tableName)) {
+        assertEquals("Expected 0 Entries in table", 0, Iterables.size(scanner));
+      }
+    }
+  }
+
+  public static class NullIterator implements SortedKeyValueIterator<Key,Value> {
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
+        IteratorEnvironment env) {}
+
+    @Override
+    public boolean hasTop() {
+      return false;
+    }
+
+    @Override
+    public void next() throws IOException {}
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) {}
+
+    @Override
+    public Key getTopKey() {
+      return null;
+    }
+
+    @Override
+    public Value getTopValue() {
+      return null;
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This PR creates an IT to expose a bug introduced in #1605. If a flush doesn't produce any entries in `DataFileValue`, then a `StoredTabletFile` won't be created, since nothing was inserted into the metadata, and the newFile object will be null. Refactoring was done in `DatafileManager` to the bringMinorCompactionOnline() method so that it now returns the newFile. But this file could be null, if nothing was written to the metadata table. I am not sure what should be done to fix this issue but I was at least was able to reproduce it in an IT. ~~This bug is particularly nasty since Accumulo thinks the flush succeeds but the error will be thrown towards the end of the process and the file never gets created.~~

Server error printed in tablet server log:
<pre>
2021-11-02T13:23:03,134 [tablet.MinorCompactionTask] ERROR: Unknown error during minor compaction for extent: 1<<
java.lang.RuntimeException: Exception occurred during minor compaction on 1<<
        at org.apache.accumulo.tserver.tablet.Tablet.minorCompact(Tablet.java:820) ~[classes/:?]
        at org.apache.accumulo.tserver.tablet.MinorCompactionTask.run(MinorCompactionTask.java:99) [classes/:?]
        at org.apache.htrace.wrappers.TraceRunnable.run(TraceRunnable.java:57) [htrace-core-3.2.0-incubating.jar:3.2.0-incubating]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.NullPointerException
        at java.util.Objects.requireNonNull(Objects.java:221) ~[?:?]
        at java.util.ImmutableCollections$List12.<init>(ImmutableCollections.java:372) ~[?:?]
        at java.util.List.of(List.java:807) ~[?:?]
        at org.apache.accumulo.tserver.tablet.Tablet.minorCompact(Tablet.java:814) ~[classes/:?]
        ... 5 more
</pre>