### PR TITLE
Use unique test file locations for crypto tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -199,45 +199,6 @@
             </excludes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- Tests that cannot run with reuseForks=true -->
-            <excludes>
-              <exclude>**/InternerTest.java</exclude>
-              <exclude>**/NamespaceIdTest.java</exclude>
-              <exclude>**/TableIdTest.java</exclude>
-              <exclude>**/HadoopCredentialProviderTest.java</exclude>
-              <exclude>**/IdleRatioScanPrioritizerTest.java</exclude>
-              <exclude>**/TestCfCqSlice.java</exclude>
-              <exclude>**/TestCfCqSliceSeekingFilter.java</exclude>
-              <exclude>**/core/constraints/DefaultKeySizeConstraintTest.java</exclude>
-            </excludes>
-          </configuration>
-          <executions>
-            <execution>
-              <id>reuseForks-false-tests</id>
-              <goals>
-                <goal>test</goal>
-              </goals>
-              <configuration>
-                <reuseForks>false</reuseForks>
-                <excludes combine.self="override" />
-                <includes>
-                  <include>**/InternerTest.java</include>
-                  <include>**/NamespaceIdTest.java</include>
-                  <include>**/TableIdTest.java</include>
-                  <include>**/HadoopCredentialProviderTest.java</include>
-                  <include>**/IdleRatioScanPrioritizerTest.java</include>
-                  <include>**/TestCfCqSlice.java</include>
-                  <include>**/TestCfCqSliceSeekingFilter.java</include>
-                  <exclude>**/core/constraints/DefaultKeySizeConstraintTest.java</exclude>
-                </includes>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -424,6 +385,61 @@
             </executions>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- profile for running second execution of surefire without reusing forks -->
+      <!-- on by default, but disable with '-P !reuseForksFalse' or '-Dtest=SomeTest' -->
+      <id>reuseForksFalse</id>
+      <activation>
+        <property>
+          <name>!test</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <!-- Tests that cannot run with reuseForks=true -->
+                <excludes>
+                  <exclude>**/InternerTest.java</exclude>
+                  <exclude>**/NamespaceIdTest.java</exclude>
+                  <exclude>**/TableIdTest.java</exclude>
+                  <exclude>**/HadoopCredentialProviderTest.java</exclude>
+                  <exclude>**/IdleRatioScanPrioritizerTest.java</exclude>
+                  <exclude>**/TestCfCqSlice.java</exclude>
+                  <exclude>**/TestCfCqSliceSeekingFilter.java</exclude>
+                  <exclude>**/core/constraints/DefaultKeySizeConstraintTest.java</exclude>
+                </excludes>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>reuseForks-false-tests</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <reuseForks>false</reuseForks>
+                    <excludes combine.self="override" />
+                    <includes>
+                      <include>**/InternerTest.java</include>
+                      <include>**/NamespaceIdTest.java</include>
+                      <include>**/TableIdTest.java</include>
+                      <include>**/HadoopCredentialProviderTest.java</include>
+                      <include>**/IdleRatioScanPrioritizerTest.java</include>
+                      <include>**/TestCfCqSlice.java</include>
+                      <include>**/TestCfCqSliceSeekingFilter.java</include>
+                      <exclude>**/core/constraints/DefaultKeySizeConstraintTest.java</exclude>
+                    </includes>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>

--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.core.crypto;
 
+import static org.apache.accumulo.core.conf.Property.INSTANCE_CRYPTO_PREFIX;
 import static org.apache.accumulo.core.crypto.CryptoUtils.getFileDecrypter;
-import static org.apache.accumulo.core.file.rfile.RFileTest.getAccumuloConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -83,10 +83,11 @@ public class CryptoTest {
   private static final SecureRandom random = new SecureRandom();
   private static final int MARKER_INT = 0xCADEFEDD;
   private static final String MARKER_STRING = "1 2 3 4 5 6 7 8 a b c d e f g h ";
-  public static final String CRYPTO_ON_CONF = "ON";
-  public static final String CRYPTO_ON_DISABLED_CONF = "ON_DISABLED";
-  public static final String CRYPTO_OFF_CONF = "OFF";
   private static Configuration hadoopConf = new Configuration();
+
+  public enum ConfigMode {
+    CRYPTO_OFF, CRYPTO_ON, CRYPTO_ON_DISABLED
+  }
 
   @BeforeClass
   public static void setupKeyFiles() throws IOException {
@@ -105,6 +106,28 @@ public class CryptoTest {
     }
   }
 
+  @SuppressWarnings("fallthrough")
+  public static ConfigurationCopy getAccumuloConfig(ConfigMode configMode, Class<?> testClass) {
+    ConfigurationCopy cfg = new ConfigurationCopy(DefaultConfiguration.getInstance());
+    switch (configMode) {
+      case CRYPTO_ON_DISABLED:
+        cfg.set(INSTANCE_CRYPTO_PREFIX.getKey() + "enabled", "false");
+        // fall through to set remaining config
+      case CRYPTO_ON:
+        cfg.set(Property.INSTANCE_CRYPTO_SERVICE,
+            "org.apache.accumulo.core.spi.crypto.AESCryptoService");
+        cfg.set(INSTANCE_CRYPTO_PREFIX.getKey() + "key.uri", CryptoTest.keyPath(testClass));
+        break;
+      case CRYPTO_OFF:
+        break;
+    }
+    return cfg;
+  }
+
+  private ConfigurationCopy getAccumuloConfig(ConfigMode configMode) {
+    return getAccumuloConfig(configMode, getClass());
+  }
+
   public static String keyPath(Class<?> testClass) {
     return System.getProperty("user.dir") + "/target/" + testClass.getSimpleName() + "-testkeyfile";
   }
@@ -116,7 +139,7 @@ public class CryptoTest {
 
   @Test
   public void simpleGCMTest() throws Exception {
-    AccumuloConfiguration conf = getAccumuloConfig(CRYPTO_ON_CONF);
+    AccumuloConfiguration conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
 
     CryptoService cs = new AESCryptoService();
     cs.init(conf.getAllPropertiesWithPrefix(Property.INSTANCE_CRYPTO_PREFIX));
@@ -156,14 +179,14 @@ public class CryptoTest {
   @Test
   public void testAESCryptoServiceWAL() throws Exception {
     AESCryptoService cs = new AESCryptoService();
-    byte[] resultingBytes = encrypt(cs, Scope.WAL, CRYPTO_ON_CONF);
+    byte[] resultingBytes = encrypt(cs, Scope.WAL, ConfigMode.CRYPTO_ON);
 
     String stringifiedBytes = Arrays.toString(resultingBytes);
     String stringifiedMarkerBytes = getStringifiedBytes(null, MARKER_STRING, MARKER_INT);
 
     assertNotEquals(stringifiedBytes, stringifiedMarkerBytes);
 
-    decrypt(resultingBytes, Scope.WAL, CRYPTO_ON_CONF);
+    decrypt(resultingBytes, Scope.WAL, ConfigMode.CRYPTO_ON);
   }
 
   /**
@@ -173,30 +196,30 @@ public class CryptoTest {
   public void testAESCryptoServiceWALDisabled() throws Exception {
     AESCryptoService cs = new AESCryptoService();
     // make sure we can read encrypted
-    byte[] encryptedBytes = encrypt(cs, Scope.WAL, CRYPTO_ON_CONF);
+    byte[] encryptedBytes = encrypt(cs, Scope.WAL, ConfigMode.CRYPTO_ON);
     String stringEncryptedBytes = Arrays.toString(encryptedBytes);
     String stringifiedMarkerBytes = getStringifiedBytes(null, MARKER_STRING, MARKER_INT);
     assertNotEquals(stringEncryptedBytes, stringifiedMarkerBytes);
-    decrypt(encryptedBytes, Scope.WAL, CRYPTO_ON_DISABLED_CONF);
+    decrypt(encryptedBytes, Scope.WAL, ConfigMode.CRYPTO_ON_DISABLED);
 
     // make sure we don't encrypt when disabled
-    byte[] plainBytes = encrypt(cs, Scope.WAL, CRYPTO_ON_DISABLED_CONF);
+    byte[] plainBytes = encrypt(cs, Scope.WAL, ConfigMode.CRYPTO_ON_DISABLED);
     String stringPlainBytes = Arrays.toString(plainBytes);
     assertNotEquals(stringEncryptedBytes, stringPlainBytes);
-    decrypt(plainBytes, Scope.WAL, CRYPTO_ON_DISABLED_CONF);
+    decrypt(plainBytes, Scope.WAL, ConfigMode.CRYPTO_ON_DISABLED);
   }
 
   @Test
   public void testAESCryptoServiceRFILE() throws Exception {
     AESCryptoService cs = new AESCryptoService();
-    byte[] resultingBytes = encrypt(cs, Scope.RFILE, CRYPTO_ON_CONF);
+    byte[] resultingBytes = encrypt(cs, Scope.RFILE, ConfigMode.CRYPTO_ON);
 
     String stringifiedBytes = Arrays.toString(resultingBytes);
     String stringifiedMarkerBytes = getStringifiedBytes(null, MARKER_STRING, MARKER_INT);
 
     assertNotEquals(stringifiedBytes, stringifiedMarkerBytes);
 
-    decrypt(resultingBytes, Scope.RFILE, CRYPTO_ON_CONF);
+    decrypt(resultingBytes, Scope.RFILE, ConfigMode.CRYPTO_ON);
   }
 
   /**
@@ -206,23 +229,23 @@ public class CryptoTest {
   public void testAESCryptoServiceRFILEDisabled() throws Exception {
     AESCryptoService cs = new AESCryptoService();
     // make sure we can read encrypted
-    byte[] encryptedBytes = encrypt(cs, Scope.RFILE, CRYPTO_ON_CONF);
+    byte[] encryptedBytes = encrypt(cs, Scope.RFILE, ConfigMode.CRYPTO_ON);
     String stringEncryptedBytes = Arrays.toString(encryptedBytes);
     String stringifiedMarkerBytes = getStringifiedBytes(null, MARKER_STRING, MARKER_INT);
     assertNotEquals(stringEncryptedBytes, stringifiedMarkerBytes);
-    decrypt(encryptedBytes, Scope.RFILE, CRYPTO_ON_DISABLED_CONF);
+    decrypt(encryptedBytes, Scope.RFILE, ConfigMode.CRYPTO_ON_DISABLED);
 
     // make sure we don't encrypt when disabled
-    byte[] plainBytes = encrypt(cs, Scope.RFILE, CRYPTO_ON_DISABLED_CONF);
+    byte[] plainBytes = encrypt(cs, Scope.RFILE, ConfigMode.CRYPTO_ON_DISABLED);
     String stringPlainBytes = Arrays.toString(plainBytes);
     assertNotEquals(stringEncryptedBytes, stringPlainBytes);
-    decrypt(plainBytes, Scope.RFILE, CRYPTO_ON_DISABLED_CONF);
+    decrypt(plainBytes, Scope.RFILE, ConfigMode.CRYPTO_ON_DISABLED);
   }
 
   @Test
   public void testNoEncryptionWAL() throws Exception {
     CryptoService cs = CryptoServiceFactory.newDefaultInstance();
-    byte[] encryptedBytes = encrypt(cs, Scope.WAL, CRYPTO_OFF_CONF);
+    byte[] encryptedBytes = encrypt(cs, Scope.WAL, ConfigMode.CRYPTO_OFF);
 
     String stringifiedBytes = Arrays.toString(encryptedBytes);
     String stringifiedMarkerBytes =
@@ -230,13 +253,13 @@ public class CryptoTest {
 
     assertEquals(stringifiedBytes, stringifiedMarkerBytes);
 
-    decrypt(encryptedBytes, Scope.WAL, CRYPTO_OFF_CONF);
+    decrypt(encryptedBytes, Scope.WAL, ConfigMode.CRYPTO_OFF);
   }
 
   @Test
   public void testNoEncryptionRFILE() throws Exception {
     CryptoService cs = CryptoServiceFactory.newDefaultInstance();
-    byte[] encryptedBytes = encrypt(cs, Scope.RFILE, CRYPTO_OFF_CONF);
+    byte[] encryptedBytes = encrypt(cs, Scope.RFILE, ConfigMode.CRYPTO_OFF);
 
     String stringifiedBytes = Arrays.toString(encryptedBytes);
     String stringifiedMarkerBytes =
@@ -244,12 +267,12 @@ public class CryptoTest {
 
     assertEquals(stringifiedBytes, stringifiedMarkerBytes);
 
-    decrypt(encryptedBytes, Scope.RFILE, CRYPTO_OFF_CONF);
+    decrypt(encryptedBytes, Scope.RFILE, ConfigMode.CRYPTO_OFF);
   }
 
   @Test
   public void testRFileEncrypted() throws Exception {
-    AccumuloConfiguration cryptoOnConf = getAccumuloConfig(CRYPTO_ON_CONF);
+    AccumuloConfiguration cryptoOnConf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     FileSystem fs = FileSystem.getLocal(hadoopConf);
     ArrayList<Key> keys = testData();
     SummarizerConfiguration sumConf =
@@ -285,8 +308,8 @@ public class CryptoTest {
   @Test
   // This test is to ensure when Crypto is configured that it can read unencrypted files
   public void testReadNoCryptoWithCryptoConfigured() throws Exception {
-    AccumuloConfiguration cryptoOffConf = getAccumuloConfig(CRYPTO_OFF_CONF);
-    AccumuloConfiguration cryptoOnConf = getAccumuloConfig(CRYPTO_ON_CONF);
+    AccumuloConfiguration cryptoOffConf = getAccumuloConfig(ConfigMode.CRYPTO_OFF);
+    AccumuloConfiguration cryptoOnConf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     FileSystem fs = FileSystem.getLocal(hadoopConf);
     ArrayList<Key> keys = testData();
 
@@ -404,9 +427,9 @@ public class CryptoTest {
     return keys;
   }
 
-  private <C extends CryptoService> byte[] encrypt(C cs, Scope scope, String configFile)
+  private <C extends CryptoService> byte[] encrypt(C cs, Scope scope, ConfigMode configMode)
       throws Exception {
-    AccumuloConfiguration conf = getAccumuloConfig(configFile);
+    AccumuloConfiguration conf = getAccumuloConfig(configMode);
     cs.init(conf.getAllPropertiesWithPrefix(Property.INSTANCE_CRYPTO_PREFIX));
     CryptoEnvironmentImpl env = new CryptoEnvironmentImpl(scope, null);
     FileEncrypter encrypter = cs.getFileEncrypter(env);
@@ -429,9 +452,9 @@ public class CryptoTest {
     return out.toByteArray();
   }
 
-  private void decrypt(byte[] resultingBytes, Scope scope, String configFile) throws Exception {
+  private void decrypt(byte[] resultingBytes, Scope scope, ConfigMode configMode) throws Exception {
     try (DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(resultingBytes))) {
-      AccumuloConfiguration conf = getAccumuloConfig(configFile);
+      AccumuloConfiguration conf = getAccumuloConfig(configMode);
       CryptoService cs = CryptoServiceFactory.newInstance(conf, ClassloaderType.JAVA);
       FileDecrypter decrypter = getFileDecrypter(cs, scope, dataIn);
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -135,7 +135,7 @@ public class RFileTest {
 
   @BeforeClass
   public static void setupCryptoKeyFile() throws Exception {
-    CryptoTest.setupKeyFiles();
+    CryptoTest.setupKeyFiles(RFileTest.class);
   }
 
   static class SeekableByteArrayInputStream extends ByteArrayInputStream
@@ -1805,7 +1805,7 @@ public class RFileTest {
       case CryptoTest.CRYPTO_ON_CONF:
         cfg.set(Property.INSTANCE_CRYPTO_SERVICE,
             "org.apache.accumulo.core.spi.crypto.AESCryptoService");
-        cfg.set(INSTANCE_CRYPTO_PREFIX.getKey() + "key.uri", CryptoTest.keyPath);
+        cfg.set(INSTANCE_CRYPTO_PREFIX.getKey() + "key.uri", CryptoTest.keyPath(RFileTest.class));
         break;
     }
     return cfg;

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.file.rfile;
 
-import static org.apache.accumulo.core.conf.Property.INSTANCE_CRYPTO_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -57,6 +56,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType;
 import org.apache.accumulo.core.crypto.CryptoTest;
+import org.apache.accumulo.core.crypto.CryptoTest.ConfigMode;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -1705,12 +1705,12 @@ public class RFileTest {
 
   @Test(expected = NullPointerException.class)
   public void testMissingUnreleasedVersions() throws Exception {
-    runVersionTest(5, getAccumuloConfig(CryptoTest.CRYPTO_OFF_CONF));
+    runVersionTest(5, getAccumuloConfig(ConfigMode.CRYPTO_OFF));
   }
 
   @Test
   public void testOldVersions() throws Exception {
-    ConfigurationCopy defaultConf = getAccumuloConfig(CryptoTest.CRYPTO_OFF_CONF);
+    ConfigurationCopy defaultConf = getAccumuloConfig(ConfigMode.CRYPTO_OFF);
     runVersionTest(3, defaultConf);
     runVersionTest(4, defaultConf);
     runVersionTest(6, defaultConf);
@@ -1719,7 +1719,7 @@ public class RFileTest {
 
   @Test
   public void testOldVersionsWithCrypto() throws Exception {
-    ConfigurationCopy cryptoOnConf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    ConfigurationCopy cryptoOnConf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     runVersionTest(3, cryptoOnConf);
     runVersionTest(4, cryptoOnConf);
     runVersionTest(6, cryptoOnConf);
@@ -1795,149 +1795,137 @@ public class RFileTest {
     reader.close();
   }
 
-  @SuppressWarnings("fallthrough")
-  public static ConfigurationCopy getAccumuloConfig(String cryptoOn) {
-    ConfigurationCopy cfg = new ConfigurationCopy(DefaultConfiguration.getInstance());
-    switch (cryptoOn) {
-      case CryptoTest.CRYPTO_ON_DISABLED_CONF:
-        cfg.set(INSTANCE_CRYPTO_PREFIX.getKey() + "enabled", "false");
-        // fall through to set remaining config
-      case CryptoTest.CRYPTO_ON_CONF:
-        cfg.set(Property.INSTANCE_CRYPTO_SERVICE,
-            "org.apache.accumulo.core.spi.crypto.AESCryptoService");
-        cfg.set(INSTANCE_CRYPTO_PREFIX.getKey() + "key.uri", CryptoTest.keyPath(RFileTest.class));
-        break;
-    }
-    return cfg;
+  private ConfigurationCopy getAccumuloConfig(ConfigMode configMode) {
+    return CryptoTest.getAccumuloConfig(configMode, getClass());
   }
 
   @Test
   public void testEncRFile1() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test1();
     conf = null;
   }
 
   @Test
   public void testEncRFile2() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test2();
     conf = null;
   }
 
   @Test
   public void testEncRFile3() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test3();
     conf = null;
   }
 
   @Test
   public void testEncRFile4() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test4();
     conf = null;
   }
 
   @Test
   public void testEncRFile5() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test5();
     conf = null;
   }
 
   @Test
   public void testEncRFile6() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test6();
     conf = null;
   }
 
   @Test
   public void testEncRFile7() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test7();
     conf = null;
   }
 
   @Test
   public void testEncRFile8() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test8();
     conf = null;
   }
 
   @Test
   public void testEncRFile9() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test9();
     conf = null;
   }
 
   @Test
   public void testEncRFile10() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test10();
     conf = null;
   }
 
   @Test
   public void testEncRFile11() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test11();
     conf = null;
   }
 
   @Test
   public void testEncRFile12() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test12();
     conf = null;
   }
 
   @Test
   public void testEncRFile13() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test13();
     conf = null;
   }
 
   @Test
   public void testEncRFile14() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test14();
     conf = null;
   }
 
   @Test
   public void testEncRFile16() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test16();
   }
 
   @Test
   public void testEncRFile17() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test17();
   }
 
   @Test
   public void testEncRFile18() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test18();
     conf = null;
   }
 
   @Test
   public void testEncRFile19() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test19();
     conf = null;
   }
 
   @Test
   public void testEncryptedRFiles() throws Exception {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     test1();
     test2();
     test3();
@@ -2235,7 +2223,7 @@ public class RFileTest {
 
   @Test
   public void testEncSample() throws IOException {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     testSample();
     testSampleLG();
     conf = null;
@@ -2293,7 +2281,7 @@ public class RFileTest {
 
   @Test
   public void testCryptoDoesntLeakSensitive() throws IOException {
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
     // test an empty file
 
     TestRFile trf = new TestRFile(conf);
@@ -2316,7 +2304,7 @@ public class RFileTest {
   public void testRootTabletEncryption() throws Exception {
 
     // This tests that the normal set of operations used to populate a root tablet
-    conf = getAccumuloConfig(CryptoTest.CRYPTO_ON_CONF);
+    conf = getAccumuloConfig(ConfigMode.CRYPTO_ON);
 
     TestRFile testRfile = new TestRFile(conf);
     testRfile.openWriter();

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -128,33 +128,6 @@
         <directory>src/test/resources</directory>
       </testResource>
     </testResources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- Tests that cannot run with reuseForks=true -->
-          <excludes>
-            <exclude>**/AuthenticationTokenSecretManagerTest.java</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <id>reuseForks-false-tests</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <reuseForks>false</reuseForks>
-              <excludes combine.self="override" />
-              <includes>
-                <include>**/AuthenticationTokenSecretManagerTest.java</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
   <profiles>
     <profile>
@@ -178,6 +151,47 @@
             </executions>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- profile for running second execution of surefire without reusing forks -->
+      <!-- on by default, but disable with '-P !reuseForksFalse' or '-Dtest=SomeTest' -->
+      <id>reuseForksFalse</id>
+      <activation>
+        <property>
+          <name>!test</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <!-- Tests that cannot run with reuseForks=true -->
+                <excludes>
+                  <exclude>**/AuthenticationTokenSecretManagerTest.java</exclude>
+                </excludes>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>reuseForks-false-tests</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <reuseForks>false</reuseForks>
+                    <excludes combine.self="override" />
+                    <includes>
+                      <include>**/AuthenticationTokenSecretManagerTest.java</include>
+                    </includes>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -155,32 +155,50 @@
             </excludes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- Tests that cannot run with reuseForks=true -->
-            <excludes>
-              <exclude>**/AssignmentWatcherTest.java</exclude>
-            </excludes>
-          </configuration>
-          <executions>
-            <execution>
-              <id>reuseForks-false-tests</id>
-              <goals>
-                <goal>test</goal>
-              </goals>
-              <configuration>
-                <reuseForks>false</reuseForks>
-                <excludes combine.self="override" />
-                <includes>
-                  <include>**/AssignmentWatcherTest.java</include>
-                </includes>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <!-- profile for running second execution of surefire without reusing forks -->
+      <!-- on by default, but disable with '-P !reuseForksFalse' or '-Dtest=SomeTest' -->
+      <id>reuseForksFalse</id>
+      <activation>
+        <property>
+          <name>!test</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <!-- Tests that cannot run with reuseForks=true -->
+                <excludes>
+                  <exclude>**/AssignmentWatcherTest.java</exclude>
+                </excludes>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>reuseForks-false-tests</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <reuseForks>false</reuseForks>
+                    <excludes combine.self="override" />
+                    <includes>
+                      <include>**/AssignmentWatcherTest.java</include>
+                    </includes>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
* Make CryptoTest and RFileTest use unique key files, so they don't
  interfere with one another when run concurrently
* Fix tests being run twice when specified explicitly with -Dtest=
  parameter (found while testing this PR) by creating separate profile
  in pom.xml files that had a second surefire execution, that is
  automatically disabled when that property is used

Fixes #2343