### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -790,6 +790,8 @@
               <arg>-Xmaxwarns</arg>
               <arg>5</arg>
             </compilerArgs>
+          	<fork>true</fork>
+          	<useIncrementalCompilation>true</useIncrementalCompilation>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
