### PR TITLE
Add support for LZ4 and BZip2 Codecs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapred/AccumuloFileOutputFormat.java
@@ -67,7 +67,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @param job
    *          the Hadoop job instance to be configured
    * @param compressionType
-   *          one of "none", "gz", "lzo", or "snappy"
+   *          one of "none", "gz", "bzip2", "lzo", "lz4", "snappy", or "zstd"
    * @since 1.5.0
    */
   public static void setCompressionType(JobConf job, String compressionType) {

--- a/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/mapreduce/AccumuloFileOutputFormat.java
@@ -65,7 +65,7 @@ public class AccumuloFileOutputFormat extends FileOutputFormat<Key,Value> {
    * @param job
    *          the Hadoop job instance to be configured
    * @param compressionType
-   *          one of "none", "gz", "lzo", or "snappy"
+   *          one of "none", "gz", "bzip2", "lzo", "lz4", "snappy", or "zstd"
    * @since 1.5.0
    */
   public static void setCompressionType(Job job, String compressionType) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -142,8 +142,8 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    */
   public static void setCompressionType(Class<?> implementingClass, Configuration conf,
       String compressionType) {
-    if (compressionType == null
-        || !Arrays.asList("none", "gz", "bzip2", "lzo", "lz4", "snappy", "zstd").contains(compressionType))
+    if (compressionType == null || !Arrays
+        .asList("none", "gz", "bzip2", "lzo", "lz4", "snappy", "zstd").contains(compressionType))
       throw new IllegalArgumentException(
           "Compression type must be one of: none, gz, bzip2, lzo, lz4, snappy, zstd");
     setAccumuloProperty(implementingClass, conf, Property.TABLE_FILE_COMPRESSION_TYPE,

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -137,15 +137,15 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    * @param conf
    *          the Hadoop configuration object to configure
    * @param compressionType
-   *          one of "none", "gz", "lzo", "snappy", or "zstd"
+   *          one of "none", "gz", "bzip2", "lzo", "lz4", "snappy", or "zstd"
    * @since 1.6.0
    */
   public static void setCompressionType(Class<?> implementingClass, Configuration conf,
       String compressionType) {
     if (compressionType == null
-        || !Arrays.asList("none", "gz", "lzo", "snappy", "zstd").contains(compressionType))
+        || !Arrays.asList("none", "gz", "bzip2", "lzo", "lz4", "snappy", "zstd").contains(compressionType))
       throw new IllegalArgumentException(
-          "Compression type must be one of: none, gz, lzo, snappy, zstd");
+          "Compression type must be one of: none, gz, bzip2, lzo, lz4, snappy, zstd");
     setAccumuloProperty(implementingClass, conf, Property.TABLE_FILE_COMPRESSION_TYPE,
         compressionType);
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -969,7 +969,7 @@ public enum Property {
       "1.3.5"),
   TABLE_FILE_COMPRESSION_TYPE("table.file.compress.type", "gz", PropertyType.STRING,
       "Compression algorithm used on index and data blocks before they are"
-          + " written. Possible values: zstd, gz, snappy, lzo, none",
+          + " written. Possible values: zstd, gz, snappy, bzip2, lzo, lz4, none",
       "1.3.5"),
   TABLE_FILE_COMPRESSED_BLOCK_SIZE("table.file.compress.blocksize", "100k", PropertyType.BYTES,
       "The maximum size of data blocks in RFiles before they are compressed and written.", "1.3.5"),

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
@@ -81,6 +81,11 @@ public final class Compression {
   }
 
   /**
+   * Compression: bzip2
+   */
+  public static final String COMPRESSION_BZIP2 = "bzip2";
+
+  /**
    * Compression: zStandard
    */
   public static final String COMPRESSION_ZSTD = "zstd";
@@ -99,6 +104,11 @@ public final class Compression {
    * Compression: lzo
    */
   public static final String COMPRESSION_LZO = "lzo";
+
+  /**
+   * Compression: lz4
+   */
+  public static final String COMPRESSION_LZ4 = "lz4";
 
   /**
    * compression: none
@@ -137,6 +147,10 @@ public final class Compression {
    * LZO will always have the default LZO codec because the buffer size is never overridden within
    * it.
    * <p>
+   * <p>
+   * LZ4 will always have the default LZ4 codec because the buffer size is never overridden within
+   * it.
+   * <p>
    * GZ will use the default GZ codec for the compression stream, but can potentially use a
    * different codec instance for the decompression stream if the requested buffer size does not
    * match the default GZ buffer size of 32k.
@@ -145,6 +159,75 @@ public final class Compression {
    * compression stream, but will use a cached codec if the buffer size differs from the default.
    */
   public enum Algorithm {
+
+    BZIP2(COMPRESSION_BZIP2) {
+
+      /**
+       * The default codec class.
+       */
+      private static final String DEFAULT_CLAZZ = "org.apache.hadoop.io.compress.BZip2Codec";
+
+      /**
+       * Configuration option for BZip2 buffer size. Uses the default FS buffer size.
+       */
+      private static final String BUFFER_SIZE_OPT = "io.file.buffer.size";
+
+      /**
+       * Default buffer size.  Changed from default of 4096.
+       */
+      private static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
+
+      /**
+       * Whether or not the codec status has been checked. Ensures the default codec is not
+       * recreated.
+       */
+      private final AtomicBoolean checked = new AtomicBoolean(false);
+
+      private transient CompressionCodec codec = null;
+
+      @Override
+      public boolean isSupported() {
+        return codec != null;
+      }
+
+      @Override
+      public void initializeDefaultCodec() {
+        codec = initCodec(checked, DEFAULT_BUFFER_SIZE, codec);
+      }
+
+      @Override
+      CompressionCodec createNewCodec(int bufferSize) {
+        return createNewCodec(CONF_BZIP2_CLASS, DEFAULT_CLAZZ, bufferSize, BUFFER_SIZE_OPT);
+      }
+
+      @Override
+      CompressionCodec getCodec() {
+        return codec;
+      }
+
+      @Override
+      public InputStream createDecompressionStream(InputStream downStream,
+          Decompressor decompressor, int downStreamBufferSize) throws IOException {
+        if (!isSupported()) {
+          throw new IOException("BZip2 codec class not specified. Did you forget to set property "
+              + CONF_BZIP2_CLASS + "?");
+        }
+        InputStream bis = bufferStream(downStream, downStreamBufferSize);
+        CompressionInputStream cis = codec.createInputStream(bis, decompressor);
+        return new BufferedInputStream(cis, DATA_IBUF_SIZE);
+      }
+
+      @Override
+      public OutputStream createCompressionStream(OutputStream downStream, Compressor compressor,
+          int downStreamBufferSize) throws IOException {
+        if (!isSupported()) {
+          throw new IOException("BZip2 codec class not specified. Did you forget to set property "
+              + CONF_BZIP2_CLASS + "?");
+        }
+        return createFinishedOnFlushCompressionStream(downStream, compressor, downStreamBufferSize);
+      }
+
+    },
 
     LZO(COMPRESSION_LZO) {
 
@@ -209,6 +292,75 @@ public final class Compression {
         if (!isSupported()) {
           throw new IOException("LZO codec class not specified. Did you forget to set property "
               + CONF_LZO_CLASS + "?");
+        }
+        return createFinishedOnFlushCompressionStream(downStream, compressor, downStreamBufferSize);
+      }
+
+    },
+
+    LZ4(COMPRESSION_LZ4) {
+
+      /**
+       * The default codec class.
+       */
+      private static final String DEFAULT_CLAZZ = "org.apache.hadoop.io.compress.Lz4Codec";
+
+      /**
+       * Configuration option for LZ4 buffer size.
+       */
+      private static final String BUFFER_SIZE_OPT = "io.compression.codec.lz4.buffersize";
+
+      /**
+       * Default buffer size.
+       */
+      private static final int DEFAULT_BUFFER_SIZE = 256 * 1024;
+
+      /**
+       * Whether or not the codec status has been checked. Ensures the default codec is not
+       * recreated.
+       */
+      private final AtomicBoolean checked = new AtomicBoolean(false);
+
+      private transient CompressionCodec codec = null;
+
+      @Override
+      public boolean isSupported() {
+        return codec != null;
+      }
+
+      @Override
+      public void initializeDefaultCodec() {
+        codec = initCodec(checked, DEFAULT_BUFFER_SIZE, codec);
+      }
+
+      @Override
+      CompressionCodec createNewCodec(int bufferSize) {
+        return createNewCodec(CONF_LZ4_CLASS, DEFAULT_CLAZZ, bufferSize, BUFFER_SIZE_OPT);
+      }
+
+      @Override
+      CompressionCodec getCodec() {
+        return codec;
+      }
+
+      @Override
+      public InputStream createDecompressionStream(InputStream downStream,
+          Decompressor decompressor, int downStreamBufferSize) throws IOException {
+        if (!isSupported()) {
+          throw new IOException("LZ4 codec class not specified. Did you forget to set property "
+              + CONF_LZ4_CLASS + "?");
+        }
+        InputStream bis = bufferStream(downStream, downStreamBufferSize);
+        CompressionInputStream cis = codec.createInputStream(bis, decompressor);
+        return new BufferedInputStream(cis, DATA_IBUF_SIZE);
+      }
+
+      @Override
+      public OutputStream createCompressionStream(OutputStream downStream, Compressor compressor,
+          int downStreamBufferSize) throws IOException {
+        if (!isSupported()) {
+          throw new IOException("LZ4 codec class not specified. Did you forget to set property "
+              + CONF_LZ4_CLASS + "?");
         }
         return createFinishedOnFlushCompressionStream(downStream, compressor, downStreamBufferSize);
       }
@@ -455,7 +607,9 @@ public final class Compression {
           }
         });
 
+    public static final String CONF_BZIP2_CLASS = "io.compression.codec.bzip2.class";
     public static final String CONF_LZO_CLASS = "io.compression.codec.lzo.class";
+    public static final String CONF_LZ4_CLASS = "io.compression.codec.lz4.class";
     public static final String CONF_SNAPPY_CLASS = "io.compression.codec.snappy.class";
     public static final String CONF_ZSTD_CLASS = "io.compression.codec.zstd.class";
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Compression.java
@@ -147,7 +147,6 @@ public final class Compression {
    * LZO will always have the default LZO codec because the buffer size is never overridden within
    * it.
    * <p>
-   * <p>
    * LZ4 will always have the default LZ4 codec because the buffer size is never overridden within
    * it.
    * <p>
@@ -173,7 +172,7 @@ public final class Compression {
       private static final String BUFFER_SIZE_OPT = "io.file.buffer.size";
 
       /**
-       * Default buffer size.  Changed from default of 4096.
+       * Default buffer size. Changed from default of 4096.
        */
       private static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionTest.java
@@ -64,6 +64,34 @@ public class CompressionTest {
       // that is okay
     }
 
+    extClazz = System.getProperty(Compression.Algorithm.CONF_LZ4_CLASS);
+    clazz = (extClazz != null) ? extClazz : "org.apache.hadoop.io.compress.Lz4Codec";
+    try {
+      CompressionCodec codec =
+          (CompressionCodec) ReflectionUtils.newInstance(Class.forName(clazz), myConf);
+
+      assertNotNull(codec);
+
+      isSupported.put(Compression.Algorithm.LZ4, true);
+
+    } catch (ClassNotFoundException e) {
+      // that is okay
+    }
+
+    extClazz = System.getProperty(Compression.Algorithm.CONF_BZIP2_CLASS);
+    clazz = (extClazz != null) ? extClazz : "org.apache.hadoop.io.compress.BZip2Codec";
+    try {
+      CompressionCodec codec =
+          (CompressionCodec) ReflectionUtils.newInstance(Class.forName(clazz), myConf);
+
+      assertNotNull(codec);
+
+      isSupported.put(Compression.Algorithm.BZIP2, true);
+
+    } catch (ClassNotFoundException e) {
+      // that is okay
+    }
+
     extClazz = System.getProperty(Compression.Algorithm.CONF_SNAPPY_CLASS);
     clazz = (extClazz != null) ? extClazz : "org.apache.hadoop.io.compress.SnappyCodec";
     try {
@@ -73,6 +101,20 @@ public class CompressionTest {
       assertNotNull(codec);
 
       isSupported.put(Compression.Algorithm.SNAPPY, true);
+
+    } catch (ClassNotFoundException e) {
+      // that is okay
+    }
+
+    extClazz = System.getProperty(Compression.Algorithm.CONF_ZSTD_CLASS);
+    clazz = (extClazz != null) ? extClazz : "org.apache.hadoop.io.compress.ZStandardCodec";
+    try {
+      CompressionCodec codec =
+          (CompressionCodec) ReflectionUtils.newInstance(Class.forName(clazz), myConf);
+
+      assertNotNull(codec);
+
+      isSupported.put(Compression.Algorithm.ZSTANDARD, true);
 
     } catch (ClassNotFoundException e) {
       // that is okay

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/FileOutputFormatBuilder.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoop/mapreduce/FileOutputFormatBuilder.java
@@ -52,7 +52,7 @@ public interface FileOutputFormatBuilder {
      * compression may require additional libraries to be available to your Job.
      *
      * @param compressionType
-     *          one of "none", "gz", "lzo", or "snappy"
+     *          one of "none", "gz", "bzip2", "lzo", "lz4", "snappy", or "zstd"
      */
     OutputOptions<T> compression(String compressionType);
 

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -142,15 +142,15 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    * @param conf
    *          the Hadoop configuration object to configure
    * @param compressionType
-   *          one of "none", "gz", "lzo", "snappy", or "zstd"
+   *          one of "none", "gz", "bzip2", "lzo", "lz4", "snappy", or "zstd"
    * @since 1.6.0
    */
   public static void setCompressionType(Class<?> implementingClass, Configuration conf,
       String compressionType) {
     if (compressionType == null
-        || !Arrays.asList("none", "gz", "lzo", "snappy", "zstd").contains(compressionType))
+        || !Arrays.asList("none", "gz", "bzip2", "lzo", "lz4", "snappy", "zstd").contains(compressionType))
       throw new IllegalArgumentException(
-          "Compression type must be one of: none, gz, lzo, snappy, zstd");
+          "Compression type must be one of: none, gz, bzip2, lzo, lz4, snappy, zstd");
     setAccumuloProperty(implementingClass, conf, Property.TABLE_FILE_COMPRESSION_TYPE,
         compressionType);
   }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/lib/FileOutputConfigurator.java
@@ -147,8 +147,8 @@ public class FileOutputConfigurator extends ConfiguratorBase {
    */
   public static void setCompressionType(Class<?> implementingClass, Configuration conf,
       String compressionType) {
-    if (compressionType == null
-        || !Arrays.asList("none", "gz", "bzip2", "lzo", "lz4", "snappy", "zstd").contains(compressionType))
+    if (compressionType == null || !Arrays
+        .asList("none", "gz", "bzip2", "lzo", "lz4", "snappy", "zstd").contains(compressionType))
       throw new IllegalArgumentException(
           "Compression type must be one of: none, gz, bzip2, lzo, lz4, snappy, zstd");
     setAccumuloProperty(implementingClass, conf, Property.TABLE_FILE_COMPRESSION_TYPE,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategy.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategy.java
@@ -85,8 +85,8 @@ public class BasicCompactionStrategy extends DefaultCompactionStrategy {
   public static final String LARGE_FILE_COMPRESSION_THRESHOLD = "large.compress.threshold";
 
   /**
-   * Type of compression to use if large threshold is surpassed. One of "gz","lzo","snappy", or
-   * "none"
+   * Type of compression to use if large threshold is surpassed. One of "none", "gz", "bzip2",
+   * "lzo", "lz4", "snappy", or "zstd"
    */
   public static final String LARGE_FILE_COMPRESSION_TYPE = "large.compress.type";
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CompactCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CompactCommand.java
@@ -293,8 +293,8 @@ public class CompactCommand extends TableOperation {
             + " K,M, and G suffixes. Uses table settings if not specified.");
     opts.addOption(outIndexBlockSizeOpt);
     outCompressionOpt = newLAO("out-compress",
-        "Compression to use for compaction output file. Either snappy, gz, lzo,"
-            + " or none. Uses table settings if not specified.");
+        "Compression to use for compaction output file. Either snappy, gz, bzip2, lzo,"
+            + "lz4, zstd, or none. Uses table settings if not specified.");
     opts.addOption(outCompressionOpt);
     outReplication =
         newLAO("out-replication", "HDFS replication to use for compaction output file. Uses table"


### PR DESCRIPTION
Hadoop compression support for 'lz4' and 'bzip2' codecs.  Updates javadoc and normalizes comments for lz4, bzip2, and zstd.

Implements #2366