### PR TITLE
Exception and cancellation changes in Compactor process

### DIFF
--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -711,10 +711,11 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
           compactionThread.join();
           LOG.trace("Compaction thread finished.");
 
-   if(err.get() != null){
-           //maybe the error occured because the table was deleted or something like that, so force a cancel check to possibly reduce noise in the logs
-          checkIfCanceled();
-   }
+          if (err.get() != null) {
+            // maybe the error occured because the table was deleted or something like that, so
+            // force a cancel check to possibly reduce noise in the logs
+            checkIfCanceled();
+          }
 
           if (compactionThread.isInterrupted() || JOB_HOLDER.isCancelled()
               || ((err.get() != null && err.get().getClass().equals(InterruptedException.class)))) {

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -711,7 +711,10 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
           compactionThread.join();
           LOG.trace("Compaction thread finished.");
 
+   if(err.get() != null){
+           //maybe the error occured because the table was deleted or something like that, so force a cancel check to possibly reduce noise in the logs
           checkIfCanceled();
+   }
 
           if (compactionThread.isInterrupted() || JOB_HOLDER.isCancelled()
               || ((err.get() != null && err.get().getClass().equals(InterruptedException.class)))) {

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -184,7 +184,7 @@ public class Compactor extends AbstractServer implements CompactorService.Iface 
         TimeUnit.MILLISECONDS);
   }
 
-  protected synchronized void checkIfCanceled() {
+  protected void checkIfCanceled() {
     TExternalCompactionJob job = JOB_HOLDER.getJob();
     if (job != null) {
       try {

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -220,6 +220,9 @@ public class CompactorTest {
     }
 
     @Override
+    protected synchronized void checkIfCanceled() {}
+
+    @Override
     protected Runnable createCompactionJob(TExternalCompactionJob job, LongAdder totalInputEntries,
         LongAdder totalInputBytes, CountDownLatch started, CountDownLatch stopped,
         AtomicReference<Throwable> err) {
@@ -337,6 +340,7 @@ public class CompactorTest {
     EasyMock.expect(conf.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT)).andReturn(86400000L);
 
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    EasyMock.expect(context.getConfiguration()).andReturn(conf);
     ZooReaderWriter zrw = PowerMock.createNiceMock(ZooReaderWriter.class);
     ZooKeeper zk = PowerMock.createNiceMock(ZooKeeper.class);
     EasyMock.expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
@@ -390,6 +394,7 @@ public class CompactorTest {
     EasyMock.expect(conf.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT)).andReturn(86400000L);
 
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    EasyMock.expect(context.getConfiguration()).andReturn(conf);
     ZooReaderWriter zrw = PowerMock.createNiceMock(ZooReaderWriter.class);
     ZooKeeper zk = PowerMock.createNiceMock(ZooKeeper.class);
     EasyMock.expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
@@ -443,6 +448,7 @@ public class CompactorTest {
     EasyMock.expect(conf.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT)).andReturn(86400000L);
 
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    EasyMock.expect(context.getConfiguration()).andReturn(conf);
     ZooReaderWriter zrw = PowerMock.createNiceMock(ZooReaderWriter.class);
     ZooKeeper zk = PowerMock.createNiceMock(ZooKeeper.class);
     EasyMock.expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalDoNothingCompactor.java
@@ -53,6 +53,9 @@ public class ExternalDoNothingCompactor extends Compactor implements Iface {
       LongAdder totalInputBytes, CountDownLatch started, CountDownLatch stopped,
       AtomicReference<Throwable> err) {
 
+    // Set this to true so that only 1 external compaction is run
+    this.shutdown = true;
+
     return new Runnable() {
       @Override
       public void run() {
@@ -76,7 +79,6 @@ public class ExternalDoNothingCompactor extends Compactor implements Iface {
         } catch (Exception e) {
           LOG.error("Compaction failed", e);
           err.set(e);
-          throw new RuntimeException("Compaction failed", e);
         } finally {
           stopped.countDown();
         }


### PR DESCRIPTION
The Thread in the Compactor that runs the FileCompactor was throwing an
exception as part of the error handling routine. It's not necessary for
that to occur to convey the exception information to the main thread,
the exception information was already being conveyed. This will reduce
the error logging in the Compactor log regarding the uncaught exception
being thrown and handled by the AccumuloUncaughtExceptionHandler.

Another background thread checks every 5 seconds to determine whether
or not the current compaction should be canceled. Call this method
when the compaction completes in case something happens that would
cause the compaction to be canceled and it has not been noticed yet.

Closes #2350