### PR TITLE
Cache the credentials because they are expensive to fetch

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -85,7 +85,7 @@ public class ServerInfo implements ClientInfo {
           + instanceName + " does not exist in zookeeper");
     }
     serverDirs = new ServerDirs(siteConfig, hadoopConf);
-    credentials = loadCredentials();
+    credentials = SystemCredentials.get(instanceID, siteConfig);
   }
 
   ServerInfo(SiteConfiguration config) {
@@ -104,7 +104,7 @@ public class ServerInfo implements ClientInfo {
     zooKeepersSessionTimeOut = (int) config.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT);
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);
     instanceName = InstanceOperationsImpl.lookupInstanceName(zooCache, UUID.fromString(instanceID));
-    credentials = loadCredentials();
+    credentials = SystemCredentials.get(instanceID, siteConfig);
   }
 
   ServerInfo(SiteConfiguration config, String instanceName, String instanceID) {
@@ -122,7 +122,7 @@ public class ServerInfo implements ClientInfo {
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);
     this.instanceName = instanceName;
     serverDirs = new ServerDirs(siteConfig, hadoopConf);
-    credentials = loadCredentials();
+    credentials = SystemCredentials.get(instanceID, siteConfig);
   }
 
   public SiteConfiguration getSiteConfiguration() {
@@ -177,10 +177,6 @@ public class ServerInfo implements ClientInfo {
   @Override
   public String getInstanceName() {
     return instanceName;
-  }
-
-  private Credentials loadCredentials() {
-    return SystemCredentials.get(getInstanceID(), getSiteConfiguration());
   }
 
   public Credentials getCredentials() {

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -54,6 +54,7 @@ public class ServerInfo implements ClientInfo {
   private final VolumeManager volumeManager;
   private final ZooCache zooCache;
   private final ServerDirs serverDirs;
+  private Credentials credentials;
 
   ServerInfo(SiteConfiguration siteConfig, String instanceName, String zooKeepers,
       int zooKeepersSessionTimeOut) {
@@ -176,7 +177,10 @@ public class ServerInfo implements ClientInfo {
   }
 
   public Credentials getCredentials() {
-    return SystemCredentials.get(getInstanceID(), getSiteConfiguration());
+    if (credentials == null) {
+      credentials = SystemCredentials.get(getInstanceID(), getSiteConfiguration());
+    }
+    return credentials;
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -54,7 +54,7 @@ public class ServerInfo implements ClientInfo {
   private final VolumeManager volumeManager;
   private final ZooCache zooCache;
   private final ServerDirs serverDirs;
-  private Credentials credentials;
+  private final Credentials credentials;
 
   ServerInfo(SiteConfiguration siteConfig, String instanceName, String zooKeepers,
       int zooKeepersSessionTimeOut) {
@@ -85,6 +85,7 @@ public class ServerInfo implements ClientInfo {
           + instanceName + " does not exist in zookeeper");
     }
     serverDirs = new ServerDirs(siteConfig, hadoopConf);
+    credentials = loadCredentials();
   }
 
   ServerInfo(SiteConfiguration config) {
@@ -103,6 +104,7 @@ public class ServerInfo implements ClientInfo {
     zooKeepersSessionTimeOut = (int) config.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT);
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);
     instanceName = InstanceOperationsImpl.lookupInstanceName(zooCache, UUID.fromString(instanceID));
+    credentials = loadCredentials();
   }
 
   ServerInfo(SiteConfiguration config, String instanceName, String instanceID) {
@@ -120,6 +122,7 @@ public class ServerInfo implements ClientInfo {
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);
     this.instanceName = instanceName;
     serverDirs = new ServerDirs(siteConfig, hadoopConf);
+    credentials = loadCredentials();
   }
 
   public SiteConfiguration getSiteConfiguration() {
@@ -176,10 +179,11 @@ public class ServerInfo implements ClientInfo {
     return instanceName;
   }
 
+  private Credentials loadCredentials() {
+    return SystemCredentials.get(getInstanceID(), getSiteConfiguration());
+  }
+  
   public Credentials getCredentials() {
-    if (credentials == null) {
-      credentials = SystemCredentials.get(getInstanceID(), getSiteConfiguration());
-    }
     return credentials;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -93,7 +93,7 @@ public class ServerInfo implements ClientInfo {
     siteConfig = config;
     hadoopConf = new Configuration();
     try {
-      volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
+   volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
@@ -182,7 +182,7 @@ public class ServerInfo implements ClientInfo {
   private Credentials loadCredentials() {
     return SystemCredentials.get(getInstanceID(), getSiteConfiguration());
   }
-  
+
   public Credentials getCredentials() {
     return credentials;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -93,7 +93,7 @@ public class ServerInfo implements ClientInfo {
     siteConfig = config;
     hadoopConf = new Configuration();
     try {
-   volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
+      volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
See the discussion and the thread dumps at https://lists.apache.org/thread/rwt4nomkmhty1dy4tsp620sf49o3qnbx

Without this improvement  org.apache.accumulo.test.functional.ConcurrentDeleteTableIT takes 785.503 s on my machine, and I need to use -Dtimeout.factor=3 to pass.
With this improvement the test now passes in 127.771 s, i.e. almost 6 times faster!

```
"tablet migration-Worker-1" #4380 daemon prio=5 os_prio=0 cpu=68425.44ms elapsed=75.42s tid=0x0000fffeac074800 nid=0x33077e runnable  [0x0000fffe8f3fd000]
   java.lang.Thread.State: RUNNABLE
        at sun.security.provider.SHA5.implCompressCheck(java.base@11.0.11/SHA5.java:232)
        at sun.security.provider.SHA5.implCompress(java.base@11.0.11/SHA5.java:221)
        at sun.security.provider.DigestBase.engineUpdate(java.base@11.0.11/DigestBase.java:124)
        at java.security.MessageDigest$Delegate.engineUpdate(java.base@11.0.11/MessageDigest.java:623)
        at java.security.MessageDigest.update(java.base@11.0.11/MessageDigest.java:345)
        at org.apache.commons.codec.digest.Sha2Crypt.sha2Crypt(Sha2Crypt.java:421)
        at org.apache.commons.codec.digest.Sha2Crypt.sha512Crypt(Sha2Crypt.java:585)
        at org.apache.commons.codec.digest.Crypt.crypt(Crypt.java:78)
        at org.apache.commons.codec.digest.Crypt.crypt(Crypt.java:167)
        at org.apache.accumulo.server.security.SystemCredentials$SystemToken.hashInstanceConfigs(SystemCredentials.java:120)
        at org.apache.accumulo.server.security.SystemCredentials$SystemToken.generate(SystemCredentials.java:125)
        at org.apache.accumulo.server.security.SystemCredentials.get(SystemCredentials.java:66)
        at org.apache.accumulo.server.ServerInfo.getCredentials(ServerInfo.java:179)
        at org.apache.accumulo.server.ServerInfo.getPrincipal(ServerInfo.java:148)
        at org.apache.accumulo.server.ServerInfo.getProperties(ServerInfo.java:169)
        at org.apache.accumulo.core.clientImpl.ClientContext.getProperties(ClientContext.java:236)
        at org.apache.accumulo.core.clientImpl.ClientContext.createScanner(ClientContext.java:635)
        at org.apache.accumulo.core.metadata.schema.TabletsMetadata$Builder.buildNonRoot(TabletsMetadata.java:177)
        at org.apache.accumulo.core.metadata.schema.TabletsMetadata$Builder.build(TabletsMetadata.java:125)
        at org.apache.accumulo.core.metadata.schema.AmpleImpl.readTablet(AmpleImpl.java:46)
        at org.apache.accumulo.core.metadata.schema.Ample.readTablet(Ample.java:141)
        at org.apache.accumulo.tserver.tablet.Tablet.closeConsistencyCheck(Tablet.java:1379)
        at org.apache.accumulo.tserver.tablet.Tablet.completeClose(Tablet.java:1331)
        - locked <0x00000000f1585830> (a org.apache.accumulo.tserver.tablet.Tablet)
        at org.apache.accumulo.tserver.tablet.Tablet.close(Tablet.java:1221)
        at org.apache.accumulo.tserver.UnloadTabletHandler.run(UnloadTabletHandler.java:92)
        at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:207)
        at io.opentelemetry.context.Context$$Lambda$209/0x000000010035c840.run(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.11/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.11/ThreadPoolExecutor.java:628)
        at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:207)
        at io.opentelemetry.context.Context$$Lambda$209/0x000000010035c840.run(Unknown Source)
        at java.lang.Thread.run(java.base@11.0.11/Thread.java:829)
```