### PR TITLE
reduce root table mutation logging to single line

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/RootTabletMetadata.java
@@ -52,7 +52,7 @@ import com.google.gson.GsonBuilder;
  */
 public class RootTabletMetadata {
 
-  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final Gson GSON = new GsonBuilder().create();
 
   private static final ByteSequence CURR_LOC_FAM =
       new ArrayByteSequence(CurrentLocationColumnFamily.STR_NAME);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -103,11 +103,10 @@ public class RootTabletMutatorImpl extends TabletMutatorBase implements Ample.Ta
       // TODO examine implementation of getZooReaderWriter().mutate()
       context.getZooReaderWriter().mutateOrCreate(zpath, new byte[0], currVal -> {
         String currJson = new String(currVal, UTF_8);
-        log.debug("Before mutating : {}, ", currJson);
         var rtm = RootTabletMetadata.fromJson(currJson);
         rtm.update(mutation);
         String newJson = rtm.toJson();
-        log.debug("After mutating : {} ", newJson);
+        log.debug("mutation: from:[{}] to: [{}]", currJson, newJson);
         return newJson.getBytes(UTF_8);
       });
 


### PR DESCRIPTION
The root table mutation was pretty printing the mutation json object, causing the log statement to extend over multiple lines. This change removes the pretty print and combines the form / to so that it is one (very long line)

The information seemed useful, but trace may be a better level, but I was unsure.

I also tried using guava Map.compare, but the result did not seem much easier to read than just removing pretty printing.

# Sample log statements - not the same statement, but representative samples:
<details>
  <summary>Click to expand!</summary>
Before:

```  
2021-12-07T01:18:14,946 [metadata.RootTabletMutatorImpl] DEBUG: Before mutating : {
  "version": 1,
  "columnValues": {
    "file": {
      "file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testExternalCompactionsSucceedsRunWithTableOffline/accumulo/tables/+r/root_tablet/A000000f.rf": "1040,15",
      "file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testExternalCompactionsSucceedsRunWithTableOffline/accumulo/tables/+r/root_tablet/F000000g.rf": "423,4"
    },
    "last": {
      "100000b611e0006": "ip-127-0-0-1:34523"
    },
    "loc": {
      "100000b611e0006": "ip-127-0-0-1:34523"
    },
    "srv": {
      "dir": "root_tablet",
      "flush": "8",
      "lock": "tservers/ip-127-0-0-1:34523/zlock#923249b7-97f5-4862-b11a-679d12295a5a#0000000000$100000b611e0006",
      "time": "L20"
    },
    "~tab": {
      "~pr": "\u0000"
    }
  }
}, 
2021-12-07T01:18:14,947 [metadata.RootTabletMutatorImpl] DEBUG: After mutating : {
  "version": 1,
  "columnValues": {
    "file": {
      "file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testExternalCompactionsSucceedsRunWithTableOffline/accumulo/tables/+r/root_tablet/A000000h.rf": "1041,15"
    },
    "last": {
      "100000b611e0006": "ip-127-0-0-1:34523"
    },
    "loc": {
      "100000b611e0006": "ip-127-0-0-1:34523"
    },
    "srv": {
      "dir": "root_tablet",
      "flush": "8",
      "lock": "tservers/ip-127-0-0-1:34523/zlock#923249b7-97f5-4862-b11a-679d12295a5a#0000000000$100000b611e0006",
      "time": "L20"
    },
    "~tab": {
      "~pr": "\u0000"
    }
  }
}

```
After
```
2021-12-06T18:15:00,768 [metadata.RootTabletMutatorImpl] DEBUG: mutation: from:[{"version":1,"columnValues":{"file":{"file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testDeleteTableCancelsExternalCompaction/accumulo/tables/+r/root_tablet/00000_00000.rf":"0,0","file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testDeleteTableCancelsExternalCompaction/accumulo/tables/+r/root_tablet/F0000001.rf":"1044,14","file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testDeleteTableCancelsExternalCompaction/accumulo/tables/+r/root_tablet/F0000008.rf":"1136,14"},"last":{"100014a72660006":"ip-127-0-0-1:46323"},"loc":{"100014a72660006":"ip-127-0-0-1:46323"},"srv":{"dir":"root_tablet","flush":"2","lock":"tservers/ip-127-0-0-1:46323/zlock#243cd081-5afb-40c5-8099-71c97f801f3d#0000000000$100014a72660006","time":"L12"},"~tab":{"~pr":"\u0000"}}}] to: [{"version":1,"columnValues":{"file":{"file:[dir...]/test/target/mini-tests/org.apache.accumulo.test.compaction.ExternalCompaction_2_IT_testDeleteTableCancelsExternalCompaction/accumulo/tables/+r/root_tablet/A0000009.rf":"1209,17"},"last":{"100014a72660006":"ip-10-113-12-166:46323"},"loc":{"100014a72660006":"ip-127-0-0-1:46323"},"srv":{"dir":"root_tablet","flush":"2","lock":"tservers/ip-127-0-0-1:46323/zlock#243cd081-5afb-40c5-8099-71c97f801f3d#0000000000$100014a72660006","time":"L12"},"~tab":{"~pr":"\u0000"}}}]

```
</details>