### PR TITLE
Improvements to monitor external compactions page

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -37,6 +37,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -587,7 +588,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
   private final Map<HostAndPort,CompactionStats> allCompactions = new HashMap<>();
   private final RecentLogs recentLogs = new RecentLogs();
   private final ExternalCompactionInfo ecInfo = new ExternalCompactionInfo();
-  private final Map<String,TExternalCompaction> ecRunningMap = new HashMap<>();
+  private final Map<String,TExternalCompaction> ecRunningMap = new ConcurrentHashMap<>();
   private long scansFetchedNanos = 0L;
   private long compactsFetchedNanos = 0L;
   private long ecInfoFetchedNanos = 0L;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -639,7 +639,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
    * user fetches since RPC calls are going to the coordinator. This allows for fine grain updates
    * of external compaction progress.
    */
-  public synchronized Map<String,TExternalCompaction> getRunningInfo() {
+  public synchronized Map<String,TExternalCompaction> fetchRunningInfo() {
     if (coordinatorHost.isEmpty()) {
       throw new IllegalStateException(coordinatorMissingMsg);
     }
@@ -655,12 +655,13 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
 
     ecRunningMap.clear();
     if (running.getCompactions() != null) {
-      running.getCompactions().forEach((queue, ec) -> {
-        log.trace("Found Compactions running on queue {} -> {}", queue, ec);
-        ecRunningMap.put(queue, ec);
-      });
+      ecRunningMap.putAll(running.getCompactions());
     }
 
+    return ecRunningMap;
+  }
+
+  public Map<String,TExternalCompaction> getEcRunningMap() {
     return ecRunningMap;
   }
 

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/CompactorInfo.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/CompactorInfo.java
@@ -21,9 +21,11 @@ package org.apache.accumulo.monitor.rest.compactions.external;
 public class CompactorInfo {
 
   // Variable names become JSON keys
-  public long lastContact;
-  public String server;
-  public String queueName;
+  public long lastContact = 0L;
+  public String server = "";
+  public String queueName = "";
+
+  public CompactorInfo() {}
 
   public CompactorInfo(long fetchedTimeMillis, String queue, String hostAndPort) {
     lastContact = System.currentTimeMillis() - fetchedTimeMillis;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 @Path("/ec")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class ECResource {
-  private static Logger log = LoggerFactory.getLogger(ECResource.class);
+  private static final Logger log = LoggerFactory.getLogger(ECResource.class);
 
   @Inject
   private Monitor monitor;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactions.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactions.java
@@ -28,8 +28,6 @@ public class RunningCompactions {
 
   public final List<RunningCompactorInfo> running = new ArrayList<>();
 
-  public RunningCompactions() {}
-
   public RunningCompactions(Map<String,TExternalCompaction> rMap) {
     if (rMap != null) {
       var fetchedTime = System.currentTimeMillis();
@@ -37,12 +35,6 @@ public class RunningCompactions {
         running.add(new RunningCompactorInfo(fetchedTime, entry.getKey(), entry.getValue()));
       }
     }
-  }
-
-  public static RunningCompactions details(long fetchedTime, String ecid, TExternalCompaction ec) {
-    var rc = new RunningCompactions();
-    rc.running.add(new RunningCompactorDetails(fetchedTime, ecid, ec));
-    return rc;
   }
 
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactions.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactions.java
@@ -36,5 +36,4 @@ public class RunningCompactions {
       }
     }
   }
-
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -124,23 +124,20 @@
 
              // Remove from the 'open' array
              detailRows.splice( idx, 1 );
-         }
-         else {
+         } else {
              var rci = row.data();
+             var ecid = rci.ecid;
+             var idSuffix = ecid.substring(ecid.length-5, ecid.length);
              tr.addClass( 'details' );
              // put all the information into html for a single row
-             var htmlRow = "<table class='table table-bordered table-striped table-condensed'>"
+             var htmlRow = "<table class='table table-bordered table-striped table-condensed' id='table"+idSuffix+"'>"
              htmlRow += "<thead><tr><th>#</th><th>Input Files</th><th>Size</th><th>Entries</th></tr></thead>";
-             $.each( rci.inputFiles, function( key, value ) {
-               htmlRow += "<tr><td>" + key + "</td>";
-               htmlRow += "<td>" + value.metadataFileEntry + "</td>";
-               htmlRow += "<td>" + bigNumberForSize(value.size) + "</td>";
-               htmlRow += "<td>" + bigNumberForQuantity(value.entries) + "</td></tr>";
-             });
-             htmlRow += "</table>";
-             htmlRow += "Output File: " + rci.outputFile + "<br>";
-             htmlRow += rci.ecid;
+             htmlRow += "<tbody></tbody></table>";
+             htmlRow += "Output File: <span id='outputFile" + idSuffix + "'></span><br>";
+             htmlRow += ecid;
              row.child(htmlRow).show();
+             // show row then make ajax call
+             getRunningDetails(ecid, idSuffix);
 
              // Add to the 'open' array
              if ( idx === -1 ) {
@@ -187,6 +184,26 @@
         sessionStorage.ecInfo = JSON.stringify(data);
    });
  }
+
+ function getRunningDetails(ecid, idSuffix) {
+    var tableId = 'table' + idSuffix;
+    var ajaxUrl = '/rest/ec/details?ecid=' + ecid;
+    clearTableBody(tableId);
+    console.log("Ajax call to " + ajaxUrl);
+    $.getJSON(ajaxUrl, function(data) {
+       $.each( data.inputFiles, function( key, value ) {
+          var items = [];
+          items.push(createCenterCell(key, key));
+          items.push(createCenterCell(value.metadataFileEntry, value.metadataFileEntry));
+          items.push(createCenterCell(value.size, bigNumberForSize(value.size)));
+          items.push(createCenterCell(value.entries, bigNumberForQuantity(value.entries)));
+          $('<tr/>', {
+              html: items.join('')
+            }).appendTo('#' + tableId + ' tbody');
+        });
+        $('#outputFile' + idSuffix).text(data.outputFile);
+    });
+  }
 
  function refreshCompactors() {
    console.log("Refresh compactors table.");

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
@@ -131,7 +131,7 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
         RunningCompactorInfo rci = new RunningCompactorInfo(System.currentTimeMillis(), ecid, ec);
         RunningCompactorInfo previousRci = runningMap.put(ecid, rci);
         if (previousRci == null) {
-          log.debug("New ECID {} with inputFiles: {}", ecid, rci.inputFiles);
+          log.debug("New ECID {} with inputFiles: {}", ecid, rci.numFiles);
         } else {
           if (rci.progress <= previousRci.progress) {
             log.warn("{} did not progress. It went from {} to {}", ecid, previousRci.progress,


### PR DESCRIPTION
* Limits data brought to the browser from the Monitor by adding a
separate AJAX call to get the details of the compaction
* Creates a new type and endpoint for RunningCompactorDetails
* Move the files from RunningCompactorInfo to details object
* Supports #2365