### PR TITLE
bump log4j2 version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Since #2382 log4j released version 2.16.0 that has minor fixes to further mitigate log4j CVEs.  