### PR TITLE
Bump log4j2 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Based on the announcement, 2.15.0 didn't fully fix the issue previously reported. 2.16.0 reportedly does.