### PR TITLE
Fix accumulo-env.sh variables

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -31,13 +31,13 @@
 ############################
 
 ## Accumulo logs directory. Referenced by logger config.
-export ACCUMULO_LOG_DIR="${ACCUMULO_LOG_DIR:-${basedir}/logs}"
+ACCUMULO_LOG_DIR="${ACCUMULO_LOG_DIR:-${basedir}/logs}"
 ## Hadoop installation
-export HADOOP_HOME="${HADOOP_HOME:-/path/to/hadoop}"
+HADOOP_HOME="${HADOOP_HOME:-/path/to/hadoop}"
 ## Hadoop configuration
-export HADOOP_CONF_DIR="${HADOOP_CONF_DIR:-${HADOOP_HOME}/etc/hadoop}"
+HADOOP_CONF_DIR="${HADOOP_CONF_DIR:-${HADOOP_HOME}/etc/hadoop}"
 ## Zookeeper installation
-export ZOOKEEPER_HOME="${ZOOKEEPER_HOME:-/path/to/zookeeper}"
+ZOOKEEPER_HOME="${ZOOKEEPER_HOME:-/path/to/zookeeper}"
 
 ##########################
 # Build CLASSPATH variable
@@ -68,7 +68,7 @@ export CLASSPATH
 ##################################################################
 
 ## JVM options set for all processes. Extra options can be passed in by setting ACCUMULO_JAVA_OPTS to an array of options.
-JAVA_OPTS=("${ACCUMULO_JAVA_OPTS[@]}"
+JAVA_OPTS=($ACCUMULO_JAVA_OPTS
   '-XX:OnOutOfMemoryError=kill -9 %p'
   '-XX:-OmitStackTraceInFastThrow'
   '-Djava.net.preferIPv4Stack=true'
@@ -114,8 +114,6 @@ case "$cmd" in
     true
     ;;
 esac
-
-export JAVA_OPTS
 
 ############################
 # Variables set to a default


### PR DESCRIPTION
* Remove unneeded/useless exports; they don't need to be exported by
  default, since the env script is sourced by bin/accumulo, and they
  don't need to be passed to child processes; the user can modify their
  own env script if they need these to be passed to their child
  processes because of their specific needs
* Treat ACCUMULO_JAVA_OPTS as scalar variable containing space-delimited
  command-line options to prepend to JAVA_OPTS in accumulo-env.sh rather
  than assume it's an array, because arrays can't currently be exported
  in bash, so it's not possible for users to have set it in their
  environment as an array to be picked up here