### PR TITLE
Fix coordinator check in Monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -171,6 +171,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
   private Exception problemException;
   private GCStatus gcStatus;
   private Optional<HostAndPort> coordinatorHost = Optional.empty();
+  private long coordinatorCheckNanos = 0L;
   private CompactionCoordinatorService.Client coordinatorClient;
   private final String coordinatorMissingMsg =
       "Error getting the compaction coordinator. Check that it is running. It is not "
@@ -378,10 +379,14 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
         this.problemException = e;
       }
 
-      if (coordinatorHost.isEmpty()) {
+      // check for compaction coordinator host and only notify its discovery
+      Optional<HostAndPort> previousHost;
+      if (System.nanoTime() - coordinatorCheckNanos > fetchTimeNanos) {
+        previousHost = coordinatorHost;
         coordinatorHost = ExternalCompactionUtil.findCompactionCoordinator(context);
-      } else {
-        log.info("External Compaction Coordinator found at {}", coordinatorHost.get());
+        coordinatorCheckNanos = System.nanoTime();
+        if (previousHost.isEmpty() && coordinatorHost.isPresent())
+          log.info("External Compaction Coordinator found at {}", coordinatorHost.get());
       }
 
     } finally {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
@@ -46,7 +46,7 @@ public class ECResource {
   @GET
   public CoordinatorInfo getCoordinator() {
     var cc = monitor.getCompactorsInfo();
-    log.info("Got coordinator from monitor = {}", cc);
+    log.info("Got coordinator from monitor = {}", cc.getCoordinatorHost());
     return new CoordinatorInfo(cc.getCoordinatorHost(), cc);
   }
 


### PR DESCRIPTION
* Monitor would stop checking for the coordinator once it found it
* This fix will detect if the coordinator moves or is no longer available