### PR TITLE
Add consistency checks for lastFlushID and lastCompactID

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1403,13 +1403,15 @@ public class Tablet {
       }
 
       if (tabletMeta.getFlushId().orElse(-1) != lastFlushID) {
-        String msg = "Closed tablet " + extent + " has not been flushed before being closed.";
+        String msg = "Closed tablet " + extent + " lastFlushID is inconsistent with metadata : "
+            + tabletMeta.getFlushId().orElse(-1) + " != " + lastFlushID;
         log.error(msg);
         throw new RuntimeException(msg);
       }
 
       if (tabletMeta.getCompactId().orElse(-1) != lastCompactID) {
-        String msg = "Closed tablet " + extent + " has not been compacted before being closed.";
+        String msg = "Closed tablet " + extent + " lastCompactID is inconsistent with metadata : "
+            + tabletMeta.getCompactId().orElse(-1) + " != " + lastCompactID;
         log.error(msg);
         throw new RuntimeException(msg);
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1412,12 +1412,32 @@ public class Tablet {
 
     if (!otherLogs.isEmpty() || !currentLogs.isEmpty() || !referencedLogs.isEmpty()) {
       String msg = "Closed tablet " + extent + " has walog entries in memory currentLogs = "
-          + currentLogs + "  otherLogs = " + otherLogs + " refererncedLogs = " + referencedLogs;
+          + currentLogs + "  otherLogs = " + otherLogs + " referencedLogs = " + referencedLogs;
       log.error(msg);
       throw new RuntimeException(msg);
     }
 
-    // TODO check lastFlushID and lostCompactID - ACCUMULO-1290
+    try {
+      long flushID = getFlushID();
+      if (lastFlushID != 0 && flushID == 0) {
+        String msg = "Closed tablet " + extent + " has not been flushed before being closed.";
+        log.error(msg);
+        throw new RuntimeException(msg);
+      }
+    } catch (NoNodeException e) {
+      e.printStackTrace();
+    }
+
+    try {
+      long compactID = getCompactionID().getFirst();
+      if (lastCompactID != 0 && compactID == 0) {
+        String msg = "Closed tablet " + extent + " has not been compacted before being closed.";
+        log.error(msg);
+        throw new RuntimeException(msg);
+      }
+    } catch (NoNodeException e) {
+      e.printStackTrace();
+    }
   }
 
   private void compareToDataInMemory(TabletMetadata tabletMetadata) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1417,6 +1417,8 @@ public class Tablet {
       throw new RuntimeException(msg);
     }
 
+    // If a table hasn't been flushed before it was closed then lastFlushID will be -1 while
+    // getFlushID will be 0.
     try {
       long flushID = getFlushID();
       if (lastFlushID != 0 && flushID == 0) {
@@ -1425,9 +1427,13 @@ public class Tablet {
         throw new RuntimeException(msg);
       }
     } catch (NoNodeException e) {
-      e.printStackTrace();
+      String msg = "Failed to do close consistency check for tablet " + extent;
+      log.error(msg, e);
+      throw new RuntimeException(msg, e);
     }
 
+    // If a table hasn't been compacted before it was closed then lastCompactID will be -1 while
+    // getCompactionID will be 0.
     try {
       long compactID = getCompactionID().getFirst();
       if (lastCompactID != 0 && compactID == 0) {
@@ -1436,7 +1442,9 @@ public class Tablet {
         throw new RuntimeException(msg);
       }
     } catch (NoNodeException e) {
-      e.printStackTrace();
+      String msg = "Failed to do close consistency check for tablet " + extent;
+      log.error(msg, e);
+      throw new RuntimeException(msg, e);
     }
   }
 


### PR DESCRIPTION
Fixes #2153 

This PR addresses the following:

- Creates a consistency check for `getFlushID` & `lastFlushID`
- Creates a consistency check for `getCompactionID` & `lastCompactID`
- Removes TODO relating to change
- Fixes a minor misspelling in the area of the original change

<s>In my changes I have created two try / catch blocks surrounding the getFlushID and getCompactionID assignments. One for each consistency check. I was not sure whether the NoNodeException should be thrown, logged or just printed. If anyone has any input regarding that, I would appreciate it.</s>