### PR TITLE
Create RunningCompactionInfo in core for reuse

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompaction.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompaction.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
+import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
 import org.apache.accumulo.core.tabletserver.thrift.TExternalCompactionJob;
 
 public class RunningCompaction {
@@ -32,10 +33,13 @@ public class RunningCompaction {
   private final Map<Long,TCompactionStatusUpdate> updates = new TreeMap<>();
 
   public RunningCompaction(TExternalCompactionJob job, String compactorAddress, String queueName) {
-    super();
     this.job = job;
     this.compactorAddress = compactorAddress;
     this.queueName = queueName;
+  }
+
+  public RunningCompaction(TExternalCompaction tEC) {
+    this(tEC.getJob(), tEC.getCompactor(), tEC.getQueueName());
   }
 
   public Map<Long,TCompactionStatusUpdate> getUpdates() {

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompactionInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/RunningCompactionInfo.java
@@ -16,13 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.monitor.rest.compactions.external;
+package org.apache.accumulo.core.util.compaction;
 
-import java.util.Map;
+import static java.util.Objects.requireNonNull;
+
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-
-import jakarta.validation.constraints.NotNull;
 
 import org.apache.accumulo.core.compaction.thrift.TCompactionStatusUpdate;
 import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
@@ -30,46 +29,41 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RunningCompactorInfo extends CompactorInfo {
-  private static final Logger log = LoggerFactory.getLogger(RunningCompactorInfo.class);
+public class RunningCompactionInfo {
+  private static final Logger log = LoggerFactory.getLogger(RunningCompactionInfo.class);
 
-  // Variable names become JSON keys
-  public String ecid;
-  public String kind;
-  public String tableId;
-  public int numFiles;
-  public float progress = 0f;
-  public long duration;
-  public String status;
-  public long lastUpdate;
-
-  public RunningCompactorInfo() {
-    super();
-  }
-
-  public RunningCompactorInfo(long fetchedTime, String ecid, @NotNull TExternalCompaction ec) {
-    super(fetchedTime, ec.getQueueName(), ec.getCompactor());
-    this.ecid = ecid;
-    var updates = ec.getUpdates();
-    var job = ec.getJob();
-    kind = job.getKind().name();
-    tableId = KeyExtent.fromThrift(job.extent).tableId().canonical();
-    numFiles = job.files.size();
-    updateProgress(updates);
-    log.debug("Parsed running compaction {} for {} with progress = {}%", status, ecid, progress);
-  }
+  // DO NOT CHANGE Variable names - they map to JSON keys in the Monitor
+  public final String server;
+  public final String queueName;
+  public final String ecid;
+  public final String kind;
+  public final String tableId;
+  public final int numFiles;
+  public final float progress;
+  public final long duration;
+  public final String status;
+  public final long lastUpdate;
 
   /**
-   * Calculate progress: the percentage of bytesRead out of bytesToBeCompacted of the last update.
-   * Also update the status.
+   * Info parsed about the external running compaction. Calculate the progress, which is defined as
+   * the percentage of bytesRead / bytesToBeCompacted of the last update.
    */
-  private void updateProgress(Map<Long,TCompactionStatusUpdate> updates) {
-    if (updates.isEmpty()) {
-      progress = 0f;
-      status = "na";
-    }
+  public RunningCompactionInfo(TExternalCompaction ec) {
+    requireNonNull(ec, "Thrift external compaction is null.");
+    var updates = requireNonNull(ec.getUpdates(), "Missing Thrift external compaction updates");
+    var job = requireNonNull(ec.getJob(), "Thrift external compaction job is null");
+
+    server = ec.getCompactor();
+    queueName = ec.getQueueName();
+    ecid = job.getExternalCompactionId();
+    kind = job.getKind().name();
+    tableId = KeyExtent.fromThrift(job.getExtent()).tableId().canonical();
+    numFiles = job.getFiles().size();
+
+    // parse the updates map
     long nowMillis = System.currentTimeMillis();
     long startedMillis = nowMillis;
+    float percent = 0f;
     long updateMillis;
     TCompactionStatusUpdate last;
 
@@ -92,28 +86,33 @@ public class RunningCompactorInfo extends CompactorInfo {
       updateMillis = lastEntry.getKey();
     } else {
       log.debug("No updates found for {}", ecid);
+      lastUpdate = nowMillis;
+      progress = percent;
+      status = "na";
       return;
     }
 
     long sinceLastUpdateSeconds = TimeUnit.MILLISECONDS.toSeconds(nowMillis - updateMillis);
     log.debug("Time since Last update {} - {} = {} seconds", nowMillis, updateMillis,
         sinceLastUpdateSeconds);
+
+    var total = last.getEntriesToBeCompacted();
+    if (total > 0) {
+      percent = (last.getEntriesRead() / (float) total) * 100;
+    }
+    lastUpdate = nowMillis - updateMillis;
+    progress = percent;
+
+    if (updates.isEmpty()) {
+      status = "na";
+    } else {
+      status = last.state.name();
+    }
+    log.debug("Parsed running compaction {} for {} with progress = {}%", status, ecid, progress);
     if (sinceLastUpdateSeconds > 30) {
       log.debug("Compaction hasn't progressed from {} in {} seconds.", progress,
           sinceLastUpdateSeconds);
     }
-
-    float percent;
-    var total = last.getEntriesToBeCompacted();
-    if (total <= 0) {
-      percent = 0f;
-    } else {
-      percent = (last.getEntriesRead() / (float) total) * 100;
-    }
-
-    lastUpdate = nowMillis - updateMillis;
-    status = last.state.name();
-    progress = percent;
   }
 
   @Override

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/CompactorInfo.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/CompactorInfo.java
@@ -21,9 +21,9 @@ package org.apache.accumulo.monitor.rest.compactions.external;
 public class CompactorInfo {
 
   // Variable names become JSON keys
-  public long lastContact;
-  public String server;
-  public String queueName;
+  public final long lastContact;
+  public final String server;
+  public final String queueName;
 
   public CompactorInfo(long fetchedTimeMillis, String queue, String hostAndPort) {
     lastContact = System.currentTimeMillis() - fetchedTimeMillis;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/CompactorInfo.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/CompactorInfo.java
@@ -21,11 +21,9 @@ package org.apache.accumulo.monitor.rest.compactions.external;
 public class CompactorInfo {
 
   // Variable names become JSON keys
-  public long lastContact = 0L;
-  public String server = "";
-  public String queueName = "";
-
-  public CompactorInfo() {}
+  public long lastContact;
+  public String server;
+  public String queueName;
 
   public CompactorInfo(long fetchedTimeMillis, String queue, String hostAndPort) {
     lastContact = System.currentTimeMillis() - fetchedTimeMillis;

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/ECResource.java
@@ -77,10 +77,9 @@ public class ECResource {
       ecMap = monitor.fetchRunningInfo();
       externalCompaction = ecMap.get(ecid);
       if (externalCompaction == null) {
-        log.warn("Failed to find details for ECID: {}", ecid);
-        return new RunningCompactorDetails();
+        throw new IllegalStateException("Failed to find details for ECID: " + ecid);
       }
     }
-    return new RunningCompactorDetails(System.currentTimeMillis(), ecid, externalCompaction);
+    return new RunningCompactorDetails(externalCompaction);
   }
 }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactions.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactions.java
@@ -23,16 +23,16 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
+import org.apache.accumulo.core.util.compaction.RunningCompactionInfo;
 
 public class RunningCompactions {
 
-  public final List<RunningCompactorInfo> running = new ArrayList<>();
+  public final List<RunningCompactionInfo> running = new ArrayList<>();
 
   public RunningCompactions(Map<String,TExternalCompaction> rMap) {
     if (rMap != null) {
-      var fetchedTime = System.currentTimeMillis();
       for (var entry : rMap.entrySet()) {
-        running.add(new RunningCompactorInfo(fetchedTime, entry.getKey(), entry.getValue()));
+        running.add(new RunningCompactionInfo(entry.getValue()));
       }
     }
   }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactorDetails.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/compactions/external/RunningCompactorDetails.java
@@ -23,18 +23,15 @@ import java.util.List;
 
 import org.apache.accumulo.core.compaction.thrift.TExternalCompaction;
 import org.apache.accumulo.core.tabletserver.thrift.InputFile;
+import org.apache.accumulo.core.util.compaction.RunningCompactionInfo;
 
-public class RunningCompactorDetails extends RunningCompactorInfo {
+public class RunningCompactorDetails extends RunningCompactionInfo {
   // Variable names become JSON keys
-  public List<CompactionInputFile> inputFiles = new ArrayList<>();
-  public String outputFile;
+  public final List<CompactionInputFile> inputFiles;
+  public final String outputFile;
 
-  public RunningCompactorDetails() {
-    super();
-  }
-
-  public RunningCompactorDetails(long fetchedTime, String ecid, TExternalCompaction ec) {
-    super(fetchedTime, ecid, ec);
+  public RunningCompactorDetails(TExternalCompaction ec) {
+    super(ec);
     var job = ec.getJob();
     inputFiles = convertInputFiles(job.files);
     outputFile = job.outputFile;

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
@@ -36,11 +36,11 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.compaction.thrift.TCompactionState;
 import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.util.compaction.RunningCompactionInfo;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
-import org.apache.accumulo.monitor.rest.compactions.external.RunningCompactorInfo;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TException;
@@ -63,7 +63,7 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
     STARTED, QUARTER, HALF, THREE_QUARTERS
   }
 
-  Map<String,RunningCompactorInfo> runningMap = new HashMap<>();
+  Map<String,RunningCompactionInfo> runningMap = new HashMap<>();
   List<EC_PROGRESS> progressList = new ArrayList<>();
 
   private final AtomicBoolean compactionFinished = new AtomicBoolean(false);
@@ -128,8 +128,8 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
     if (ecMap != null) {
       ecMap.forEach((ecid, ec) -> {
         // returns null if it's a new mapping
-        RunningCompactorInfo rci = new RunningCompactorInfo(System.currentTimeMillis(), ecid, ec);
-        RunningCompactorInfo previousRci = runningMap.put(ecid, rci);
+        RunningCompactionInfo rci = new RunningCompactionInfo(ec);
+        RunningCompactionInfo previousRci = runningMap.put(ecid, rci);
         if (previousRci == null) {
           log.debug("New ECID {} with inputFiles: {}", ecid, rci.numFiles);
         } else {


### PR DESCRIPTION
* Create RunningCompactionInfo in core to be reused outside the Monitor
* Moves the logic for parsing progress from running compactions to core so that
server utilities can get the progress as well