### PR TITLE
Correct user-facing misspellings (Part 2)

### DIFF
--- a/assemble/bin/accumulo-util
+++ b/assemble/bin/accumulo-util
@@ -25,7 +25,7 @@ Usage: accumulo-util <command> (<argument> ...)
 Commands:
   build-native        Builds Accumulo native libraries
   dump-zoo            Dumps data in ZooKeeper
-  gen-monitor-cert    Generates Accumulo monitor certficate
+  gen-monitor-cert    Generates Accumulo monitor certificate
   load-jars-hdfs      Loads Accumulo jars in lib/ to HDFS for VFS classloader
   
 EOF

--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
@@ -174,8 +174,9 @@ public interface AccumuloClient extends AutoCloseable {
    *          the name of the table to insert data into
    * @param config
    *          configuration used to create batch writer. This config will take precedence. Any unset
-   *          values will merged with config set when the AccumuloClient was created. If no config
-   *          was set during AccumuloClient creation, BatchWriterConfig defaults will be used.
+   *          values will be merged with the config set when the AccumuloClient was created. If no
+   *          config was set during AccumuloClient creation, BatchWriterConfig defaults will be
+   *          used.
    * @return BatchWriter object for configuring and writing data to
    */
   BatchWriter createBatchWriter(String tableName, BatchWriterConfig config)
@@ -196,14 +197,14 @@ public interface AccumuloClient extends AutoCloseable {
   /**
    * Factory method to create a Multi-Table BatchWriter connected to Accumulo. Multi-table batch
    * writers can queue data for multiple tables. Also data for multiple tables can be sent to a
-   * server in a single batch. Its an efficient way to ingest data into multiple tables from a
+   * server in a single batch. It's an efficient way to ingest data into multiple tables from a
    * single process.
    *
    * @param config
    *          configuration used to create multi-table batch writer. This config will take
-   *          precedence. Any unset values will merged with config set when the AccumuloClient was
-   *          created. If no config was set during AccumuloClient creation, BatchWriterConfig
-   *          defaults will be used.
+   *          precedence. Any unset values will be merged with the config set when the
+   *          AccumuloClient was created. If no config was set during AccumuloClient creation,
+   *          BatchWriterConfig defaults will be used.
    * @return MultiTableBatchWriter object for configuring and writing data to
    */
   MultiTableBatchWriter createMultiTableBatchWriter(BatchWriterConfig config);

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/CompactionStrategyConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/CompactionStrategyConfig.java
@@ -48,7 +48,7 @@ public class CompactionStrategyConfig {
   /**
    * @param className
    *          The name of a class that implements
-   *          org.apache.accumulo.tserver.compaction.CompactionStrategy. This class must be exist on
+   *          org.apache.accumulo.tserver.compaction.CompactionStrategy. This class must exist on
    *          tservers.
    */
   public CompactionStrategyConfig(String className) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -464,7 +464,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
     /**
      * This method was written with the goal of avoiding thread contention and minimizing
      * recomputation. Configuration can be accessed frequently by many threads. Ideally, threads
-     * working on unrelated task would not impeded each other because of accessing config.
+     * working on unrelated tasks would not impede each other because of accessing config.
      *
      * To avoid thread contention, synchronization and needless calls to compare and set were
      * avoided. For example if 100 threads are all calling compare and set in a loop this could
@@ -577,7 +577,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
           }
           prioritizerOpts.put(key, val);
         } else {
-          throw new IllegalStateException("Unkown scan executor option : " + opt);
+          throw new IllegalStateException("Unknown scan executor option : " + opt);
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/Logging.java
@@ -23,7 +23,7 @@ package org.apache.accumulo.core.logging;
  */
 public class Logging {
   /**
-   * Prefix for all log messages in logical logging namespaces. When chosing suffixes, try to avoid
+   * Prefix for all log messages in logical logging namespaces. When choosing suffixes, try to avoid
    * existing source package names like {@code core}. This prefix was chosen to make it easy to
    * configure all Accumulo logging for loggers using fully qualified class names and logical
    * loggers.

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -117,8 +117,8 @@ public interface Ample {
    */
   public enum ReadConsistency {
     /**
-     * Read data in a a way that is slower, but should always yield the latest data. In addition to
-     * being slower, it possible this read consistency can place higher load on shared resource
+     * Read data in a way that is slower, but should always yield the latest data. In addition to
+     * being slower, it's possible this read consistency can place higher load on shared resource
      * which can negatively impact an entire cluster.
      */
     IMMEDIATE,

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/CompactionPlanner.java
@@ -63,7 +63,7 @@ public interface CompactionPlanner {
     String getFullyQualifiedOption(String key);
 
     /**
-     * @return an execution mananger that can be used to created thread pools within a compaction
+     * @return an execution manager that can be used to created thread pools within a compaction
      *         service.
      */
     ExecutorManager getExecutorManager();

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -139,7 +139,7 @@ public class AdminUtil<T> {
     }
 
     /**
-     * @return The timestamp of when the operation was created in ISO format wiht UTC timezone.
+     * @return The timestamp of when the operation was created in ISO format with UTC timezone.
      */
     public String getTimeCreatedFormatted() {
       return timeCreated > 0 ? new Date(timeCreated).toInstant().atZone(ZoneOffset.UTC)

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -309,7 +309,7 @@ public class MultiThreadedRFileTest {
                 "Invalid key found for row " + part + " locality " + locality + " index " + i, key,
                 trf.iter.getTopKey());
             assertEquals(
-                "Invalie value found for row " + part + " locality " + locality + " index " + i,
+                "Invalid value found for row " + part + " locality " + locality + " index " + i,
                 value, trf.iter.getTopValue());
             last = trf.iter.getTopKey();
             trf.iter.next();
@@ -345,7 +345,7 @@ public class MultiThreadedRFileTest {
               "Invalid key found for row " + part + " locality " + locality + " index " + i, key,
               trf.iter.getTopKey());
           assertEquals(
-              "Invalie value found for row " + part + " locality " + locality + " index " + i,
+              "Invalid value found for row " + part + " locality " + locality + " index " + i,
               value, trf.iter.getTopValue());
           last = trf.iter.getTopKey();
           trf.iter.next();

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloRowInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloRowInputFormatIT.java
@@ -56,7 +56,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Tests the new MR API in the hadoop-mareduce package.
+ * Tests the new MR API in the hadoop-mapreduce package.
  *
  * @since 2.0
  */

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
@@ -73,7 +73,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
 /**
- * Tests the new MR API in the hadoop-mareduce package.
+ * Tests the new MR API in the hadoop-mapreduce package.
  *
  * @since 2.0
  */

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloRowInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloRowInputFormatIT.java
@@ -53,7 +53,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Tests the new MR API in the hadoop-mareduce package.
+ * Tests the new MR API in the hadoop-mapreduce package.
  *
  * @since 2.0
  */

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compaction/MajorCompactionRequest.java
@@ -126,10 +126,10 @@ public class MajorCompactionRequest implements Cloneable {
    * summary information.
    *
    * <p>
-   * When using summaries to make compaction decisions, its important to ensure that all summary
+   * When using summaries to make compaction decisions, it's important to ensure that all summary
    * data fits in the tablet server summary cache. The size of this cache is configured by code
-   * tserver.cache.summary.size}. Also its important to use the summarySelector predicate to only
-   * retrieve the needed summary data. Otherwise uneeded summary data could be brought into the
+   * tserver.cache.summary.size}. Also it's important to use the summarySelector predicate to only
+   * retrieve the needed summary data. Otherwise unneeded summary data could be brought into the
    * cache.
    *
    * <p>

--- a/start/src/main/java/org/apache/accumulo/start/spi/KeywordExecutable.java
+++ b/start/src/main/java/org/apache/accumulo/start/spi/KeywordExecutable.java
@@ -28,7 +28,7 @@ import java.util.ServiceLoader;
  * All implementing classes who have an entry in
  * META-INF/services/{@link org.apache.accumulo.start.spi.KeywordExecutable} on the classpath will
  * be constructed by the {@link ServiceLoader}, so they should be lightweight and quickly
- * constructable with a mandatory no-argument constructor. Because of this, implementing classes
+ * constructible with a mandatory no-argument constructor. Because of this, implementing classes
  * could simply be factories which execute a different class, if that class is expensive to
  * construct or cannot have a no-argument constructor.
  *

--- a/start/src/main/java/org/apache/accumulo/start/spi/KeywordExecutable.java
+++ b/start/src/main/java/org/apache/accumulo/start/spi/KeywordExecutable.java
@@ -28,7 +28,7 @@ import java.util.ServiceLoader;
  * All implementing classes who have an entry in
  * META-INF/services/{@link org.apache.accumulo.start.spi.KeywordExecutable} on the classpath will
  * be constructed by the {@link ServiceLoader}, so they should be lightweight and quickly
- * constructible with a mandatory no-argument constructor. Because of this, implementing classes
+ * constructable with a mandatory no-argument constructor. Because of this, implementing classes
  * could simply be factories which execute a different class, if that class is expensive to
  * construct or cannot have a no-argument constructor.
  *


### PR DESCRIPTION
This pull request serves to correct more mistakes in potential user-facing areas. 

In my first PR regarding misspellings (#2400), I did not include mistakes found in Javadocs. Most of the corrections in this PR focus on Javadoc as well as a few other mistakes that were overlooked in the original.

This will be my final PR that focuses on misspellings.