### PR TITLE
Convert all tests to assertThrows

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/cli/PasswordConverterTest.java
@@ -20,9 +20,9 @@ package org.apache.accumulo.core.cli;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
@@ -103,10 +103,10 @@ public class PasswordConverterTest {
     assertEquals(expected, password.password);
   }
 
-  @Test(expected = ParameterException.class)
-  public void testNoFile() throws FileNotFoundException {
+  @Test
+  public void testNoFile() {
     argv[1] = "file:doesnotexist";
-    new JCommander(password).parse(argv);
+    assertThrows(ParameterException.class, () -> new JCommander(password).parse(argv));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/client/BatchWriterConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/BatchWriterConfigTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.client;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -79,16 +80,16 @@ public class BatchWriterConfigTest {
     assertEquals(0, bwConfig.getMaxMemory());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeMaxMemory() {
     BatchWriterConfig bwConfig = new BatchWriterConfig();
-    bwConfig.setMaxMemory(-1);
+    assertThrows(IllegalArgumentException.class, () -> bwConfig.setMaxMemory(-1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeMaxLatency() {
     BatchWriterConfig bwConfig = new BatchWriterConfig();
-    bwConfig.setMaxLatency(-1, TimeUnit.DAYS);
+    assertThrows(IllegalArgumentException.class, () -> bwConfig.setMaxLatency(-1, TimeUnit.DAYS));
   }
 
   @Test
@@ -112,22 +113,22 @@ public class BatchWriterConfigTest {
 
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeTimeout() {
     BatchWriterConfig bwConfig = new BatchWriterConfig();
-    bwConfig.setTimeout(-1, TimeUnit.DAYS);
+    assertThrows(IllegalArgumentException.class, () -> bwConfig.setTimeout(-1, TimeUnit.DAYS));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testZeroMaxWriteThreads() {
     BatchWriterConfig bwConfig = new BatchWriterConfig();
-    bwConfig.setMaxWriteThreads(0);
+    assertThrows(IllegalArgumentException.class, () -> bwConfig.setMaxWriteThreads(0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegativeMaxWriteThreads() {
     BatchWriterConfig bwConfig = new BatchWriterConfig();
-    bwConfig.setMaxWriteThreads(-1);
+    assertThrows(IllegalArgumentException.class, () -> bwConfig.setMaxWriteThreads(-1));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/client/IteratorSettingTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/IteratorSettingTest.java
@@ -122,7 +122,7 @@ public class IteratorSettingTest {
   @Test
   public void testIteratorNameCannotContainDot() {
     assertThrows(IllegalArgumentException.class,
-        () -> new IteratorSetting(500, "iterator.name.with" + ".dots", Combiner.class.getName()));
+        () -> new IteratorSetting(500, "iterator.name.with.dots", Combiner.class.getName()));
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/IteratorSettingTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/IteratorSettingTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -118,9 +119,10 @@ public class IteratorSettingTest {
   /**
    * Iterator names cannot contain dots. Throw IllegalArgumentException is invalid name is used.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIteratorNameCannotContainDot() {
-    new IteratorSetting(500, "iterator.name.with.dots", Combiner.class.getName());
+    assertThrows(IllegalArgumentException.class,
+        () -> new IteratorSetting(500, "iterator.name.with" + ".dots", Combiner.class.getName()));
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/ZooKeeperInstanceTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/ZooKeeperInstanceTest.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.List;
 import java.util.UUID;
@@ -81,16 +82,16 @@ public class ZooKeeperInstanceTest {
     EasyMock.resetToDefault(zc);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidConstruction() {
     ClientConfiguration config = createMock(ClientConfiguration.class);
     expect(config.get(INSTANCE_ID)).andReturn(IID_STRING);
     mockNameConstruction(config);
     replay(config);
-    new ZooKeeperInstance(config);
+    assertThrows(IllegalArgumentException.class, () -> new ZooKeeperInstance(config));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidConstruction2() {
     ClientConfiguration config = createMock(ClientConfiguration.class);
     expect(config.get(INSTANCE_ID)).andReturn(null);
@@ -98,7 +99,7 @@ public class ZooKeeperInstanceTest {
     expect(config.get(INSTANCE_ZK_HOST)).andReturn("zk1");
     expect(config.get(INSTANCE_ZK_TIMEOUT)).andReturn("30");
     replay(config);
-    new ZooKeeperInstance(config);
+    assertThrows(IllegalArgumentException.class, () -> new ZooKeeperInstance(config));
   }
 
   @Test
@@ -128,25 +129,25 @@ public class ZooKeeperInstanceTest {
     assertEquals(IID_STRING, zki.getInstanceID());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetInstanceID_NoMapping() {
     ClientConfiguration config = createMock(ClientConfiguration.class);
     expect(zc.get(Constants.ZROOT + Constants.ZINSTANCES + "/instance")).andReturn(null);
     replay(zc);
     EasyMock.reset(config, zcf);
-    new ZooKeeperInstance(config, zcf);
+    assertThrows(RuntimeException.class, () -> new ZooKeeperInstance(config, zcf));
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetInstanceID_IDMissingForName() {
     expect(zc.get(Constants.ZROOT + Constants.ZINSTANCES + "/instance"))
         .andReturn(IID_STRING.getBytes(UTF_8));
     expect(zc.get(Constants.ZROOT + "/" + IID_STRING)).andReturn(null);
     replay(zc);
-    zki.getInstanceID();
+    assertThrows(RuntimeException.class, () -> zki.getInstanceID());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetInstanceID_IDMissingForID() {
     ClientConfiguration config = createMock(ClientConfiguration.class);
     mockIdConstruction(config);
@@ -154,7 +155,7 @@ public class ZooKeeperInstanceTest {
     zki = new ZooKeeperInstance(config, zcf);
     expect(zc.get(Constants.ZROOT + "/" + IID_STRING)).andReturn(null);
     replay(zc);
-    zki.getInstanceID();
+    assertThrows(RuntimeException.class, () -> zki.getInstanceID());
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/client/admin/DelegationTokenConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/admin/DelegationTokenConfigTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.client.admin;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.concurrent.TimeUnit;
 
@@ -50,18 +51,21 @@ public class DelegationTokenConfigTest {
 
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidLifetime() {
-    new DelegationTokenConfig().setTokenLifetime(-1, TimeUnit.DAYS);
+    assertThrows(IllegalArgumentException.class,
+        () -> new DelegationTokenConfig().setTokenLifetime(-1, TimeUnit.DAYS));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testSetInvalidTimeUnit() {
-    new DelegationTokenConfig().setTokenLifetime(5, null);
+    assertThrows(NullPointerException.class,
+        () -> new DelegationTokenConfig().setTokenLifetime(5, null));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testGetInvalidTimeUnit() {
-    new DelegationTokenConfig().getTokenLifetime(null);
+    assertThrows(NullPointerException.class,
+        () -> new DelegationTokenConfig().getTokenLifetime(null));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/ListLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/ListLexicoderTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.client.lexicoder;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,8 +97,9 @@ public class ListLexicoderTest extends AbstractLexicoderTest {
     assertDecodes(new ListLexicoder<>(new LongLexicoder()), data5);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testRejectsEmptyLists() {
-    new ListLexicoder<>(new LongLexicoder()).encode(emptyList());
+    assertThrows(IllegalArgumentException.class,
+        () -> new ListLexicoder<>(new LongLexicoder()).encode(emptyList()));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/lexicoder/SequenceLexicoderTest.java
@@ -22,6 +22,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,8 +74,9 @@ public class SequenceLexicoderTest extends AbstractLexicoderTest {
     assertDecodes(new SequenceLexicoder<>(new StringLexicoder()), data5);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void tesRejectsTrailingBytes() {
-    new SequenceLexicoder<>(new StringLexicoder()).decode(new byte[] {10});
+    assertThrows(IllegalArgumentException.class,
+        () -> new SequenceLexicoder<>(new StringLexicoder()).decode(new byte[] {10}));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.client.rfile;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -688,7 +689,7 @@ public class RFileClientTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testOutOfOrder() throws Exception {
     // test that exception declared in API is thrown
     Key k1 = new Key("r1", "f1", "q1");
@@ -701,11 +702,11 @@ public class RFileClientTest {
     String testFile = createTmpTestFile();
     try (RFileWriter writer = RFile.newWriter().to(testFile).withFileSystem(localFs).build()) {
       writer.append(k2, v2);
-      writer.append(k1, v1);
+      assertThrows(IllegalArgumentException.class, () -> writer.append(k1, v1));
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testOutOfOrderIterable() throws Exception {
     // test that exception declared in API is thrown
     Key k1 = new Key("r1", "f1", "q1");
@@ -721,11 +722,11 @@ public class RFileClientTest {
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
     String testFile = createTmpTestFile();
     try (RFileWriter writer = RFile.newWriter().to(testFile).withFileSystem(localFs).build()) {
-      writer.append(data);
+      assertThrows(IllegalArgumentException.class, () -> writer.append(data));
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadVis() throws Exception {
     // this test has two purposes ensure an exception is thrown and ensure the exception document in
     // the javadoc is thrown
@@ -734,11 +735,11 @@ public class RFileClientTest {
     try (RFileWriter writer = RFile.newWriter().to(testFile).withFileSystem(localFs).build()) {
       writer.startDefaultLocalityGroup();
       Key k1 = new Key("r1", "f1", "q1", "(A&(B");
-      writer.append(k1, new Value(""));
+      assertThrows(IllegalArgumentException.class, () -> writer.append(k1, new Value("")));
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadVisIterable() throws Exception {
     // test append(iterable) method
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
@@ -747,42 +748,43 @@ public class RFileClientTest {
       writer.startDefaultLocalityGroup();
       Key k1 = new Key("r1", "f1", "q1", "(A&(B");
       Entry<Key,Value> entry = new AbstractMap.SimpleEntry<>(k1, new Value(""));
-      writer.append(Collections.singletonList(entry));
+      assertThrows(IllegalArgumentException.class,
+          () -> writer.append(Collections.singletonList(entry)));
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testDoubleStart() throws Exception {
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
     String testFile = createTmpTestFile();
     try (RFileWriter writer = RFile.newWriter().to(testFile).withFileSystem(localFs).build()) {
       writer.startDefaultLocalityGroup();
-      writer.startDefaultLocalityGroup();
+      assertThrows(IllegalStateException.class, writer::startDefaultLocalityGroup);
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testAppendStartDefault() throws Exception {
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
     String testFile = createTmpTestFile();
     try (RFileWriter writer = RFile.newWriter().to(testFile).withFileSystem(localFs).build()) {
       writer.append(new Key("r1", "f1", "q1"), new Value("1"));
-      writer.startDefaultLocalityGroup();
+      assertThrows(IllegalStateException.class, writer::startDefaultLocalityGroup);
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testStartAfter() throws Exception {
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
     String testFile = createTmpTestFile();
     try (RFileWriter writer = RFile.newWriter().to(testFile).withFileSystem(localFs).build()) {
       Key k1 = new Key("r1", "f1", "q1");
       writer.append(k1, new Value(""));
-      writer.startNewLocalityGroup("lg1", "fam1");
+      assertThrows(IllegalStateException.class, () -> writer.startNewLocalityGroup("lg1", "fam1"));
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalColumn() throws Exception {
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
     String testFile = createTmpTestFile();
@@ -790,11 +792,11 @@ public class RFileClientTest {
       writer.startNewLocalityGroup("lg1", "fam1");
       Key k1 = new Key("r1", "f1", "q1");
       // should not be able to append the column family f1
-      writer.append(k1, new Value(""));
+      assertThrows(IllegalArgumentException.class, () -> writer.append(k1, new Value("")));
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testWrongGroup() throws Exception {
     LocalFileSystem localFs = FileSystem.getLocal(new Configuration());
     String testFile = createTmpTestFile();
@@ -805,7 +807,7 @@ public class RFileClientTest {
       writer.startDefaultLocalityGroup();
       // should not be able to append the column family fam1 to default locality group
       Key k2 = new Key("r1", "fam1", "q2");
-      writer.append(k2, new Value(""));
+      assertThrows(IllegalArgumentException.class, () -> writer.append(k2, new Value("")));
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/client/security/tokens/CredentialProviderTokenTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/security/tokens/CredentialProviderTokenTest.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.net.URL;
@@ -79,25 +80,25 @@ public class CredentialProviderTokenTest {
     assertArrayEquals(token.getPassword(), clone.getPassword());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void missingProperties() {
     CredentialProviderToken token = new CredentialProviderToken();
-    token.init(new Properties());
+    assertThrows(IllegalArgumentException.class, () -> token.init(new Properties()));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void missingNameProperty() {
     CredentialProviderToken token = new CredentialProviderToken();
     Properties props = new Properties();
     props.put(CredentialProviderToken.NAME_PROPERTY, "root.password");
-    token.init(props);
+    assertThrows(IllegalArgumentException.class, () -> token.init(props));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void missingProviderProperty() {
     CredentialProviderToken token = new CredentialProviderToken();
     Properties props = new Properties();
     props.put(CredentialProviderToken.CREDENTIAL_PROVIDERS_PROPERTY, keystorePath);
-    token.init(props);
+    assertThrows(IllegalArgumentException.class, () -> token.init(props));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ScannerOptionsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ScannerOptionsTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.util.SortedSet;
@@ -78,11 +79,11 @@ public class ScannerOptionsTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFetchNullColumn() {
     try (ScannerOptions options = new ScannerOptions()) {
       // Require a non-null instance of Column
-      options.fetchColumn(null);
+      assertThrows(IllegalArgumentException.class, () -> options.fetchColumn(null));
     }
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ThriftTransportKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ThriftTransportKeyTest.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
@@ -62,7 +63,7 @@ public class ThriftTransportKeyTest {
     return new SaslConnectionParams(props, token);
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testSslAndSaslErrors() {
     ClientContext clientCtx = createMock(ClientContext.class);
     SslConnectionParams sslParams = createMock(SslConnectionParams.class);
@@ -75,7 +76,9 @@ public class ThriftTransportKeyTest {
     replay(clientCtx);
 
     try {
-      new ThriftTransportKey(HostAndPort.fromParts("localhost", 9999), 120 * 1000, clientCtx);
+      assertThrows(RuntimeException.class,
+          () -> new ThriftTransportKey(HostAndPort.fromParts("localhost", 9999), 120 * 1000,
+              clientCtx));
     } finally {
       verify(clientCtx);
     }

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -99,36 +99,40 @@ public class AccumuloConfigurationTest {
     assertEquals(9999, ports[2]);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetPortRangeInvalidLow() {
     AccumuloConfiguration c = DefaultConfiguration.getInstance();
     ConfigurationCopy cc = new ConfigurationCopy(c);
     cc.set(Property.TSERV_CLIENTPORT, "1020-1026");
-    int[] ports = cc.getPort(Property.TSERV_CLIENTPORT);
-    assertEquals(3, ports.length);
-    assertEquals(1024, ports[0]);
-    assertEquals(1025, ports[1]);
-    assertEquals(1026, ports[2]);
+    assertThrows(IllegalArgumentException.class, () -> {
+      int[] ports = cc.getPort(Property.TSERV_CLIENTPORT);
+      assertEquals(3, ports.length);
+      assertEquals(1024, ports[0]);
+      assertEquals(1025, ports[1]);
+      assertEquals(1026, ports[2]);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetPortRangeInvalidHigh() {
     AccumuloConfiguration c = DefaultConfiguration.getInstance();
     ConfigurationCopy cc = new ConfigurationCopy(c);
     cc.set(Property.TSERV_CLIENTPORT, "65533-65538");
-    int[] ports = cc.getPort(Property.TSERV_CLIENTPORT);
-    assertEquals(3, ports.length);
-    assertEquals(65533, ports[0]);
-    assertEquals(65534, ports[1]);
-    assertEquals(65535, ports[2]);
+    assertThrows(IllegalArgumentException.class, () -> {
+      int[] ports = cc.getPort(Property.TSERV_CLIENTPORT);
+      assertEquals(3, ports.length);
+      assertEquals(65533, ports[0]);
+      assertEquals(65534, ports[1]);
+      assertEquals(65535, ports[2]);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetPortInvalidSyntax() {
     AccumuloConfiguration c = DefaultConfiguration.getInstance();
     ConfigurationCopy cc = new ConfigurationCopy(c);
     cc.set(Property.TSERV_CLIENTPORT, "[65533,65538]");
-    cc.getPort(Property.TSERV_CLIENTPORT);
+    assertThrows(IllegalArgumentException.class, () -> cc.getPort(Property.TSERV_CLIENTPORT));
   }
 
   private static class TestConfiguration extends AccumuloConfiguration {

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.Map;
 
 import org.apache.accumulo.core.conf.ConfigCheckUtil.ConfigCheckException;
@@ -60,23 +62,23 @@ public class ConfigCheckUtilTest {
     ConfigCheckUtil.validate(m.entrySet());
   }
 
-  @Test(expected = ConfigCheckException.class)
+  @Test
   public void testFail_Prefix() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey(), "oops");
-    ConfigCheckUtil.validate(m.entrySet());
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
   }
 
-  @Test(expected = ConfigCheckException.class)
+  @Test
   public void testFail_InstanceZkTimeoutOutOfRange() {
     m.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "10ms");
-    ConfigCheckUtil.validate(m.entrySet());
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
   }
 
-  @Test(expected = ConfigCheckException.class)
+  @Test
   public void testFail_badCryptoService() {
     m.put(Property.INSTANCE_CRYPTO_SERVICE.getKey(), "DoesNotExistCryptoService");
-    ConfigCheckUtil.validate(m.entrySet());
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigurationTypeHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigurationTypeHelperTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.conf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.function.Function;
@@ -47,29 +48,34 @@ public class ConfigurationTypeHelperTest {
         ConfigurationTypeHelper.getMemoryAsBytes("20%"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetFixedMemoryAsBytesFailureCases1() {
-    ConfigurationTypeHelper.getFixedMemoryAsBytes("42x");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getFixedMemoryAsBytes("42x"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetFixedMemoryAsBytesFailureCases2() {
-    ConfigurationTypeHelper.getFixedMemoryAsBytes("FooBar");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getFixedMemoryAsBytes("FooBar"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetFixedMemoryAsBytesFailureCases3() {
-    ConfigurationTypeHelper.getFixedMemoryAsBytes("40%");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getFixedMemoryAsBytes("40%"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetMemoryAsBytesFailureCases1() {
-    ConfigurationTypeHelper.getMemoryAsBytes("42x");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getMemoryAsBytes("42x"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetMemoryAsBytesFailureCases2() {
-    ConfigurationTypeHelper.getMemoryAsBytes("FooBar");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getMemoryAsBytes("FooBar"));
   }
 
   @Test
@@ -82,14 +88,16 @@ public class ConfigurationTypeHelperTest {
     assertEquals(42L, ConfigurationTypeHelper.getTimeInMillis("42ms"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetTimeInMillisFailureCase1() {
-    ConfigurationTypeHelper.getTimeInMillis("abc");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getTimeInMillis("abc"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetTimeInMillisFailureCase2() {
-    ConfigurationTypeHelper.getTimeInMillis("ms");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getTimeInMillis("ms"));
   }
 
   @Test
@@ -105,18 +113,19 @@ public class ConfigurationTypeHelperTest {
     assertEquals(1d, ConfigurationTypeHelper.getFraction("1."), delta);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetFractionFailureCase1() {
-    ConfigurationTypeHelper.getFraction("%");
+    assertThrows(IllegalArgumentException.class, () -> ConfigurationTypeHelper.getFraction("%"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetFractionFailureCase2() {
-    ConfigurationTypeHelper.getFraction("abc0%");
+    assertThrows(IllegalArgumentException.class,
+        () -> ConfigurationTypeHelper.getFraction("abc0%"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetFractionFailureCase3() {
-    ConfigurationTypeHelper.getFraction(".%");
+    assertThrows(IllegalArgumentException.class, () -> ConfigurationTypeHelper.getFraction(".%"));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/HadoopCredentialProviderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/HadoopCredentialProviderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.net.URL;
@@ -69,14 +70,16 @@ public class HadoopCredentialProviderTest {
     return "jceks://file" + absoluteFilePath.getAbsolutePath();
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullConfigOnGetValue() {
-    HadoopCredentialProvider.getValue(null, "alias");
+    assertThrows(NullPointerException.class,
+        () -> HadoopCredentialProvider.getValue(null, "alias"));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullAliasOnGetValue() {
-    HadoopCredentialProvider.getValue(new Configuration(false), null);
+    assertThrows(NullPointerException.class,
+        () -> HadoopCredentialProvider.getValue(new Configuration(false), null));
   }
 
   protected void checkCredentialProviders(Configuration conf, Map<String,String> expectation) {

--- a/core/src/test/java/org/apache/accumulo/core/data/ArrayByteSequenceTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ArrayByteSequenceTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.nio.ByteBuffer;
 
@@ -36,34 +37,35 @@ public class ArrayByteSequenceTest {
     abs = new ArrayByteSequence(data);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidByteBufferBounds0() {
-    abs = new ArrayByteSequence(data, -1, 0);
+    assertThrows(IllegalArgumentException.class, () -> abs = new ArrayByteSequence(data, -1, 0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidByteBufferBounds1() {
-    abs = new ArrayByteSequence(data, data.length + 1, 0);
+    assertThrows(IllegalArgumentException.class,
+        () -> abs = new ArrayByteSequence(data, data.length + 1, 0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidByteBufferBounds2() {
-    abs = new ArrayByteSequence(data, 0, -1);
+    assertThrows(IllegalArgumentException.class, () -> abs = new ArrayByteSequence(data, 0, -1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidByteBufferBounds3() {
-    abs = new ArrayByteSequence(data, 6, 2);
+    assertThrows(IllegalArgumentException.class, () -> abs = new ArrayByteSequence(data, 6, 2));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidByteAt0() {
-    abs.byteAt(-1);
+    assertThrows(IllegalArgumentException.class, () -> abs.byteAt(-1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidByteAt1() {
-    abs.byteAt(data.length);
+    assertThrows(IllegalArgumentException.class, () -> abs.byteAt(data.length));
   }
 
   @Test
@@ -72,19 +74,19 @@ public class ArrayByteSequenceTest {
     assertEquals("mile", abs.subSequence(1, 5).toString());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidSubsequence0() {
-    abs.subSequence(5, 1);
+    assertThrows(IllegalArgumentException.class, () -> abs.subSequence(5, 1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidSubsequence1() {
-    abs.subSequence(-1, 1);
+    assertThrows(IllegalArgumentException.class, () -> abs.subSequence(-1, 1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidSubsequence3() {
-    abs.subSequence(0, 10);
+    assertThrows(IllegalArgumentException.class, () -> abs.subSequence(0, 10));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/data/ConditionTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ConditionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -129,20 +130,20 @@ public class ConditionTest {
     assertArrayEquals(ITERATORS, c.getIterators());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSetIterators_DuplicateName() {
     IteratorSetting[] iterators = {new IteratorSetting(1, "first", "someclass"),
         new IteratorSetting(2, "second", "someotherclass"),
         new IteratorSetting(3, "first", "yetanotherclass")};
-    c.setIterators(iterators);
+    assertThrows(IllegalArgumentException.class, () -> c.setIterators(iterators));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSetIterators_DuplicatePriority() {
     IteratorSetting[] iterators = {new IteratorSetting(1, "first", "someclass"),
         new IteratorSetting(2, "second", "someotherclass"),
         new IteratorSetting(1, "third", "yetanotherclass")};
-    c.setIterators(iterators);
+    assertThrows(IllegalArgumentException.class, () -> c.setIterators(iterators));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/KeyTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -244,12 +245,12 @@ public class KeyTest {
     assertEquals(k, k2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testThrift_Invalid() {
     Key k = new Key("r1", "cf2", "cq2", "cv");
     TKey tk = k.toThrift();
     tk.setRow((byte[]) null);
-    new Key(tk);
+    assertThrows(IllegalArgumentException.class, () -> new Key(tk));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/LoadPlanTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.data;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,29 +32,34 @@ import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 public class LoadPlanTest {
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadRange1() {
-    LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, "a", "a").build();
+    assertThrows(IllegalArgumentException.class,
+        () -> LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, "a", "a").build());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadRange2() {
-    LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, "b", "a").build();
+    assertThrows(IllegalArgumentException.class,
+        () -> LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, "b", "a").build());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadRange3() {
-    LoadPlan.builder().loadFileTo("f1.rf", RangeType.FILE, "b", "a").build();
+    assertThrows(IllegalArgumentException.class,
+        () -> LoadPlan.builder().loadFileTo("f1.rf", RangeType.FILE, "b", "a").build());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadRange4() {
-    LoadPlan.builder().loadFileTo("f1.rf", RangeType.FILE, null, "a").build();
+    assertThrows(IllegalArgumentException.class,
+        () -> LoadPlan.builder().loadFileTo("f1.rf", RangeType.FILE, null, "a").build());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadRange5() {
-    LoadPlan.builder().loadFileTo("f1.rf", RangeType.FILE, "a", null).build();
+    assertThrows(IllegalArgumentException.class,
+        () -> LoadPlan.builder().loadFileTo("f1.rf", RangeType.FILE, "a", null).build());
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/MutationTest.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -365,7 +366,7 @@ public class MutationTest {
     assertEquals(expected, actual);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testFluentPutNull() {
     final String fam = "f16bc";
     final String qual = "q1pm2";
@@ -378,7 +379,8 @@ public class MutationTest {
     actual.at().family(fam).qualifier(qual).put(val.getBytes());
     assertEquals(expected, actual);
     assertEquals(34, actual.numBytes());
-    actual.at().family(fam).qualifier(qual).put("test2");
+    assertThrows(IllegalStateException.class,
+        () -> actual.at().family(fam).qualifier(qual).put("test2"));
   }
 
   @Test
@@ -874,13 +876,13 @@ public class MutationTest {
     assertEquals(m1, m2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testThrift_Invalid() {
     Mutation m1 = new Mutation("r1");
     m1.put("cf1", "cq1", "v1");
     TMutation tm1 = m1.toThrift();
     tm1.setRow((byte[]) null);
-    new Mutation(tm1);
+    assertThrows(IllegalArgumentException.class, () -> new Mutation(tm1));
   }
 
   /*
@@ -913,12 +915,12 @@ public class MutationTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSanityCheck() {
     Mutation m = new Mutation("too big mutation");
     m.put("cf", "cq1", "v");
     m.estRowAndLargeValSize += (Long.MAX_VALUE / 2);
-    m.put("cf", "cq2", "v");
+    assertThrows(IllegalArgumentException.class, () -> m.put("cf", "cq2", "v"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -61,25 +62,25 @@ public class ValueTest {
     assertEquals(0, v.get().length);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullBytesConstructor() {
-    new Value((byte[]) null);
+    assertThrows(NullPointerException.class, () -> new Value((byte[]) null));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullCopyConstructor() {
-    new Value((Value) null);
+    assertThrows(NullPointerException.class, () -> new Value((Value) null));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullByteBufferConstructor() {
-    new Value((ByteBuffer) null);
+    assertThrows(NullPointerException.class, () -> new Value((ByteBuffer) null));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullSet() {
     Value v = new Value();
-    v.set(null);
+    assertThrows(NullPointerException.class, () -> v.set(null));
   }
 
   @Test
@@ -199,9 +200,9 @@ public class ValueTest {
     assertEquals(v2, v1);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullCharSequence() {
-    new Value((CharSequence) null);
+    assertThrows(NullPointerException.class, () -> new Value((CharSequence) null));
   }
 
   @Test
@@ -211,8 +212,8 @@ public class ValueTest {
     assertEquals(v2, v1);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullText() {
-    new Value((Text) null);
+    assertThrows(NullPointerException.class, () -> new Value((Text) null));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1703,9 +1704,10 @@ public class RFileTest {
     trf.closeReader();
   }
 
-  @Test(expected = NullPointerException.class)
-  public void testMissingUnreleasedVersions() throws Exception {
-    runVersionTest(5, getAccumuloConfig(ConfigMode.CRYPTO_OFF));
+  @Test
+  public void testMissingUnreleasedVersions() {
+    assertThrows(NullPointerException.class,
+        () -> runVersionTest(5, getAccumuloConfig(ConfigMode.CRYPTO_OFF)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RelativeKeyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RelativeKeyTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.file.rfile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -184,14 +185,15 @@ public class RelativeKeyTest {
     assertEquals(expectedKeys.get(1), skippr.rk.getKey());
   }
 
-  @Test(expected = EOFException.class)
-  public void testSeekAfterEverythingWrongCount() throws IOException {
+  @Test
+  public void testSeekAfterEverythingWrongCount() {
     Key seekKey = new Key("s", "t", "u", "v", 1);
     Key prevKey = new Key();
     Key currKey = null;
     MutableByteSequence value = new MutableByteSequence(new byte[64], 0, 0);
 
-    RelativeKey.fastSkip(in, seekKey, value, prevKey, currKey, expectedKeys.size() + 1);
+    assertThrows(EOFException.class,
+        () -> RelativeKey.fastSkip(in, seekKey, value, prevKey, currKey, expectedKeys.size() + 1));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/iterators/SortedMapIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/SortedMapIteratorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.core.iterators;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.client.SampleNotPresentException;
@@ -28,10 +30,10 @@ import org.junit.Test;
 
 public class SortedMapIteratorTest {
 
-  @Test(expected = SampleNotPresentException.class)
+  @Test
   public void testSampleNotPresent() {
     SortedMapIterator smi = new SortedMapIterator(new TreeMap<>());
-    smi.deepCopy(new IteratorEnvironment() {
+    assertThrows(SampleNotPresentException.class, () -> smi.deepCopy(new IteratorEnvironment() {
       @Override
       public boolean isSamplingEnabled() {
         return true;
@@ -41,6 +43,6 @@ public class SortedMapIteratorTest {
       public SamplerConfiguration getSamplerConfiguration() {
         return new SamplerConfiguration(RowSampler.class.getName());
       }
-    });
+    }));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/RowEncodingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/RowEncodingIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.iterators.user;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -157,7 +158,7 @@ public class RowEncodingIteratorTest {
     assertFalse(iter.hasTop());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEncodeSome() throws IOException {
     byte[] kbVal = new byte[1024];
     // This code is shamelessly borrowed from the WholeRowIteratorTest.
@@ -173,7 +174,7 @@ public class RowEncodingIteratorTest {
     Map<String,String> bigBufferOpts = new HashMap<>();
     bigBufferOpts.put(RowEncodingIterator.MAX_BUFFER_SIZE_OPT, "1K");
     iter.init(src, bigBufferOpts, new DummyIteratorEnv());
-    iter.seek(range, new ArrayList<>(), false);
+    assertThrows(IllegalArgumentException.class, () -> iter.seek(range, new ArrayList<>(), false));
     // IllegalArgumentException should be thrown as we can't fit the whole row into its buffer
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeRowIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/WholeRowIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.iterators.user;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -42,13 +43,13 @@ import org.junit.Test;
 
 public class WholeRowIteratorTest {
 
-  @Test(expected = IOException.class)
+  @Test
   public void testBadDecodeRow() throws IOException {
     Key k = new Key(new Text("r1"), new Text("cf1234567890"));
     Value v = new Value("v1");
     Value encoded = WholeRowIterator.encodeRow(List.of(k), List.of(v));
     encoded.set(Arrays.copyOfRange(encoded.get(), 0, 10)); // truncate to 10 bytes only
-    WholeRowIterator.decodeRow(k, encoded);
+    assertThrows(IOException.class, () -> WholeRowIterator.decodeRow(k, encoded));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/LinkingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/LinkingIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.metadata.schema;
 
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.create;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,7 +85,7 @@ public class LinkingIteratorTest {
     check(tablets2, new IterFactory(tablets1, tablets2));
   }
 
-  @Test(expected = TabletDeletedException.class)
+  @Test
   public void testMerge() {
     // test for case when a tablet is merged away
     List<TabletMetadata> tablets1 = Arrays.asList(create("4", null, "f"), create("4", "f", "m"),
@@ -93,10 +94,11 @@ public class LinkingIteratorTest {
         create("4", "r", "x"), create("4", "x", null));
 
     LinkingIterator li = new LinkingIterator(new IterFactory(tablets1, tablets2), new Range());
-
-    while (li.hasNext()) {
-      li.next();
-    }
+    assertThrows(TabletDeletedException.class, () -> {
+      while (li.hasNext()) {
+        li.next();
+      }
+    });
   }
 
   @Test
@@ -140,7 +142,7 @@ public class LinkingIteratorTest {
         new KeyExtent(TableId.of("4"), null, new Text("f")).toMetaRange());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testIncompleteTable() {
     // the last tablet in a table should have a null end row. Ensure the code detects when this does
     // not happen.
@@ -149,9 +151,11 @@ public class LinkingIteratorTest {
     LinkingIterator li = new LinkingIterator(new IterFactory(tablets1, tablets1),
         TabletsSection.getRange(TableId.of("4")));
 
-    while (li.hasNext()) {
-      li.next();
-    }
+    assertThrows(IllegalStateException.class, () -> {
+      while (li.hasNext()) {
+        li.next();
+      }
+    });
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.metadata.schema;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.accumulo.core.client.admin.TimeType;
@@ -32,19 +33,19 @@ public class MetadataTimeTest {
   private static final MetadataTime l1234 = new MetadataTime(1234, TimeType.LOGICAL);
   private static final MetadataTime l5678 = new MetadataTime(5678, TimeType.LOGICAL);
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetInstance_InvalidType() {
-    MetadataTime.parse("X1234");
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.parse("X1234"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetInstance_Logical_ParseFailure() {
-    MetadataTime.parse("LABCD");
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.parse("LABCD"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetInstance_Millis_ParseFailure() {
-    MetadataTime.parse("MABCD");
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.parse("MABCD"));
   }
 
   @Test
@@ -77,9 +78,9 @@ public class MetadataTimeTest {
     assertEquals(TimeType.LOGICAL, MetadataTime.getType('L'));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValueOfOtherChar() {
-    MetadataTime.getType('x');
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.getType('x'));
   }
 
   @Test
@@ -104,14 +105,14 @@ public class MetadataTimeTest {
     assertEquals("L45678", new MetadataTime(45678, TimeType.LOGICAL).encode());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testCompareTypesDiffer1() {
-    m1234.compareTo(l1234);
+    assertThrows(IllegalArgumentException.class, () -> m1234.compareTo(l1234));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testCompareTypesDiffer2() {
-    l1234.compareTo(m1234);
+    assertThrows(IllegalArgumentException.class, () -> l1234.compareTo(m1234));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -30,6 +30,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.EnumSet;
@@ -160,7 +161,7 @@ public class TabletMetadataTest {
     assertFalse(tm.hasCurrent());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testFutureAndCurrent() {
     KeyExtent extent = new KeyExtent(TableId.of("5"), new Text("df"), new Text("da"));
 
@@ -170,7 +171,8 @@ public class TabletMetadataTest {
 
     SortedMap<Key,Value> rowMap = toRowMap(mutation);
 
-    TabletMetadata.convertRow(rowMap.entrySet().iterator(), EnumSet.allOf(ColumnType.class), false);
+    assertThrows(IllegalStateException.class, () -> TabletMetadata
+        .convertRow(rowMap.entrySet().iterator(), EnumSet.allOf(ColumnType.class), false));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/replication/ReplicationSchemaTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/replication/ReplicationSchemaTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.replication;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -41,26 +42,26 @@ public class ReplicationSchemaTest {
     assertEquals(file, extractedFile.toString());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void failOnNullKeyForFileExtract() {
     Text extractedFile = new Text();
-    StatusSection.getFile(null, extractedFile);
+    assertThrows(NullPointerException.class, () -> StatusSection.getFile(null, extractedFile));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void failOnNullBufferForFileExtract() {
     String file = "hdfs://foo:8020/bar";
     Key k = new Key(file);
     Text extractedFile = null;
-    StatusSection.getFile(k, extractedFile);
+    assertThrows(NullPointerException.class, () -> StatusSection.getFile(k, extractedFile));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void failOnExtractEmptyFile() {
     String file = "";
     Key k = new Key(file);
     Text extractedFile = new Text();
-    StatusSection.getFile(k, extractedFile);
+    assertThrows(IllegalArgumentException.class, () -> StatusSection.getFile(k, extractedFile));
     assertEquals(file, extractedFile.toString());
   }
 
@@ -78,30 +79,30 @@ public class ReplicationSchemaTest {
     assertEquals(tableId, StatusSection.getTableId(k));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void failOnNullKeyForTableIdExtract() {
     Text extractedFile = new Text();
-    StatusSection.getFile(null, extractedFile);
+    assertThrows(NullPointerException.class, () -> StatusSection.getFile(null, extractedFile));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void failOnNullBufferForTableIdExtract() {
     String file = "hdfs://foo:8020/bar";
     Key k = new Key(file);
     Text extractedFile = null;
-    StatusSection.getFile(k, extractedFile);
+    assertThrows(NullPointerException.class, () -> StatusSection.getFile(k, extractedFile));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void failOnIncorrectStatusColfam() {
     Key k = new Key("file", WorkSection.NAME.toString(), "");
-    StatusSection.getFile(k, new Text());
+    assertThrows(IllegalArgumentException.class, () -> StatusSection.getFile(k, new Text()));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void failOnIncorrectWorkColfam() {
     Key k = new Key("file", StatusSection.NAME.toString(), "");
-    WorkSection.getFile(k, new Text());
+    assertThrows(IllegalArgumentException.class, () -> WorkSection.getFile(k, new Text()));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthorizationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthorizationsTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.security;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
@@ -93,12 +94,13 @@ public class AuthorizationsTest {
     assertArrayEquals(expected.getAuthorizationsArray(), actual.getAuthorizationsArray());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testUnmodifiableList() {
     Authorizations expected = new Authorizations("foo");
     Authorizations actual = new Authorizations("foo");
 
     assertArrayEquals(expected.getAuthorizationsArray(), actual.getAuthorizationsArray());
-    actual.getAuthorizationsBB().add(ByteBuffer.wrap(new byte[] {'a'}));
+    assertThrows(UnsupportedOperationException.class,
+        () -> actual.getAuthorizationsBB().add(ByteBuffer.wrap(new byte[] {'a'})));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.spi.fs;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.Set;
@@ -121,12 +122,13 @@ public class SpaceAwareVolumeChooserTest {
 
   }
 
-  @Test(expected = UncheckedExecutionException.class)
+  @Test
   public void testNoFreeSpace() throws IOException {
+    assertThrows(UncheckedExecutionException.class, () -> {
+      testSpecificSetup(0L, 0L, null, 1, false);
 
-    testSpecificSetup(0L, 0L, null, 1, false);
-
-    makeChoices();
+      makeChoices();
+    });
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 
@@ -97,20 +98,23 @@ public class FastFormatTest {
         new String(FastFormat.toZeroPaddedString(1296, 7, 36, new byte[] {'P', 'A'}), UTF_8));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegative1() {
-    FastFormat.toZeroPaddedString(-5, 1, 36, new byte[] {});
+    assertThrows(IllegalArgumentException.class,
+        () -> FastFormat.toZeroPaddedString(-5, 1, 36, new byte[] {}));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNegative2() {
     byte[] str = new byte[8];
-    FastFormat.toZeroPaddedString(str, 0, -5, 1, 36, new byte[] {});
+    assertThrows(IllegalArgumentException.class,
+        () -> FastFormat.toZeroPaddedString(str, 0, -5, 1, 36, new byte[] {}));
   }
 
-  @Test(expected = ArrayIndexOutOfBoundsException.class)
+  @Test
   public void testArrayOutOfBounds() {
     byte[] str = new byte[8];
-    FastFormat.toZeroPaddedString(str, 4, 64L, 4, 16, new byte[] {'P'});
+    assertThrows(ArrayIndexOutOfBoundsException.class,
+        () -> FastFormat.toZeroPaddedString(str, 4, 64L, 4, 16, new byte[] {'P'}));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/OpTimerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/OpTimerTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
@@ -85,7 +86,7 @@ public class OpTimerTest {
   /**
    * Verify that IllegalStateException is thrown when calling stop when timer has not been started.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void verifyExceptionCallingStopWhenNotStarted() {
 
     OpTimer timer = new OpTimer();
@@ -93,13 +94,13 @@ public class OpTimerTest {
     assertFalse(timer.isRunning());
 
     // should throw exception - not running
-    timer.stop();
+    assertThrows(IllegalStateException.class, timer::stop);
   }
 
   /**
    * Verify that IllegalStateException is thrown when calling start on running timer.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void verifyExceptionCallingStartWhenRunning() {
 
     OpTimer timer = new OpTimer().start();
@@ -114,13 +115,13 @@ public class OpTimerTest {
     assertTrue(timer.isRunning());
 
     // should throw exception - already running
-    timer.start();
+    assertThrows(IllegalStateException.class, timer::start);
   }
 
   /**
    * Verify that IllegalStateException is thrown when calling stop when not running.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void verifyExceptionCallingStopWhenNotRunning() {
 
     OpTimer timer = new OpTimer().start();
@@ -139,7 +140,7 @@ public class OpTimerTest {
     assertFalse(timer.isRunning());
 
     // should throw exception
-    timer.stop();
+    assertThrows(IllegalStateException.class, timer::stop);
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/util/UnsynchronizedBufferTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/UnsynchronizedBufferTest.java
@@ -125,9 +125,9 @@ public class UnsynchronizedBufferTest {
         Arrays.equals(hadoopBytes, accumuloBytes));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNextArraySizeNegative() {
-    UnsynchronizedBuffer.nextArraySize(-1);
+    assertThrows(IllegalArgumentException.class, () -> UnsynchronizedBuffer.nextArraySize(-1));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/format/DefaultFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/DefaultFormatterTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.util.format;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Collections;
 import java.util.Map;
@@ -44,16 +45,16 @@ public class DefaultFormatterTest {
     df = new DefaultFormatter();
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testDoubleInitialize() {
     final FormatterConfig timestampConfig = new FormatterConfig().setPrintTimestamps(true);
     df.initialize(empty, timestampConfig);
-    df.initialize(empty, timestampConfig);
+    assertThrows(IllegalStateException.class, () -> df.initialize(empty, timestampConfig));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testNextBeforeInitialize() {
-    df.hasNext();
+    assertThrows(IllegalStateException.class, df::hasNext);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/format/HexFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/HexFormatterTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.util.format;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
@@ -68,14 +69,14 @@ public class HexFormatterTest {
     assertEquals(bytes, formatter.interpretRow(new Text(row)));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInterpretBadRow0() {
-    formatter.interpretRow(new Text("!"));
+    assertThrows(IllegalArgumentException.class, () -> formatter.interpretRow(new Text("!")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInterpretBadRow1() {
-    formatter.interpretRow(new Text("z"));
+    assertThrows(IllegalArgumentException.class, () -> formatter.interpretRow(new Text("z")));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooReaderWriterTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooReaderWriterTest.java
@@ -25,6 +25,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.accumulo.fate.util.Retry.RetryFactory;
@@ -94,7 +95,7 @@ public class ZooReaderWriterTest {
     verify(zk, zrw, retryFactory, retry);
   }
 
-  @Test(expected = SessionExpiredException.class)
+  @Test
   public void testMutateNodeCreationFails() throws Exception {
     final String path = "/foo";
     final byte[] value = {0};
@@ -107,7 +108,7 @@ public class ZooReaderWriterTest {
 
     replay(zk, zrw, retryFactory, retry);
 
-    zrw.mutateOrCreate(path, value, mutator);
+    assertThrows(SessionExpiredException.class, () -> zrw.mutateOrCreate(path, value, mutator));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooSessionTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooSessionTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.fate.zookeeper;
 
+import static org.junit.Assert.assertThrows;
+
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.Test;
 
@@ -26,10 +28,12 @@ public class ZooSessionTest {
   private static final int MINIMUM_TIMEOUT = 10000;
   private static final String UNKNOWN_HOST = "hostname.that.should.not.exist.example.com:2181";
 
-  @Test(expected = RuntimeException.class, timeout = MINIMUM_TIMEOUT * 4)
-  public void testUnknownHost() throws Exception {
-    ZooKeeper session = ZooSession.connect(UNKNOWN_HOST, MINIMUM_TIMEOUT, null, null, null);
-    session.close();
+  @Test(timeout = MINIMUM_TIMEOUT * 4)
+  public void testUnknownHost() {
+    assertThrows(RuntimeException.class, () -> {
+      ZooKeeper session = ZooSession.connect(UNKNOWN_HOST, MINIMUM_TIMEOUT, null, null, null);
+      session.close();
+    });
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -118,10 +119,10 @@ public class ServerContextTest {
     });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testCanRun() {
     // ensure this fails with older versions
-    ServerContext.ensureDataVersionCompatible(7);
+    assertThrows(IllegalStateException.class, () -> ServerContext.ensureDataVersionCompatible(7));
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
@@ -85,16 +86,13 @@ public class TabletLocationStateTest {
     assertTrue(tls.chopped);
   }
 
-  @Test(expected = TabletLocationState.BadLocationStateException.class)
-  public void testConstruction_FutureAndCurrent() throws Exception {
+  @Test
+  public void testConstruction_FutureAndCurrent() {
     expect(keyExtent.toMetaRow()).andReturn(new Text("entry"));
     replay(keyExtent);
-    try {
-      new TabletLocationState(keyExtent, future, current, last, null, walogs, true);
-    } catch (TabletLocationState.BadLocationStateException e) {
-      assertEquals(new Text("entry"), e.getEncodedEndRow());
-      throw (e);
-    }
+    var e = assertThrows(TabletLocationState.BadLocationStateException.class,
+        () -> new TabletLocationState(keyExtent, future, current, last, null, walogs, true));
+    assertEquals(new Text("entry"), e.getEncodedEndRow());
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
@@ -67,9 +68,9 @@ public class ProblemReportingIteratorTest {
     assertEquals(RESOURCE, pri.getResource());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testInit() {
-    pri.init(null, null, null);
+    assertThrows(UnsupportedOperationException.class, () -> pri.init(null, null, null));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandlerTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.rpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -101,31 +102,34 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     assertEquals(KerberosToken.class, cache.get(KerberosToken.CLASS_NAME));
   }
 
-  @Test(expected = ThriftSecurityException.class)
-  public void testMissingPrincipal() throws Exception {
+  @Test
+  public void testMissingPrincipal() {
     final String principal = "root";
     TCredentials tcreds = new TCredentials(principal, KerberosToken.CLASS_NAME,
         ByteBuffer.allocate(0), UUID.randomUUID().toString());
     UGIAssumingProcessor.rpcPrincipal.set(null);
-    proxy.updateArgs(new Object[] {new Object(), tcreds});
+    assertThrows(ThriftSecurityException.class,
+        () -> proxy.updateArgs(new Object[] {new Object(), tcreds}));
   }
 
-  @Test(expected = ThriftSecurityException.class)
-  public void testMismatchedPrincipal() throws Exception {
+  @Test
+  public void testMismatchedPrincipal() {
     final String principal = "root";
     TCredentials tcreds = new TCredentials(principal, KerberosToken.CLASS_NAME,
         ByteBuffer.allocate(0), UUID.randomUUID().toString());
     UGIAssumingProcessor.rpcPrincipal.set(principal + "foobar");
-    proxy.updateArgs(new Object[] {new Object(), tcreds});
+    assertThrows(ThriftSecurityException.class,
+        () -> proxy.updateArgs(new Object[] {new Object(), tcreds}));
   }
 
-  @Test(expected = ThriftSecurityException.class)
-  public void testWrongTokenType() throws Exception {
+  @Test
+  public void testWrongTokenType() {
     final String principal = "root";
     TCredentials tcreds = new TCredentials(principal, PasswordToken.class.getName(),
         ByteBuffer.allocate(0), UUID.randomUUID().toString());
     UGIAssumingProcessor.rpcPrincipal.set(principal);
-    proxy.updateArgs(new Object[] {new Object(), tcreds});
+    assertThrows(ThriftSecurityException.class,
+        () -> proxy.updateArgs(new Object[] {new Object(), tcreds}));
   }
 
   @Test
@@ -155,8 +159,8 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     proxy.updateArgs(new Object[] {new Object(), tcreds});
   }
 
-  @Test(expected = ThriftSecurityException.class)
-  public void testDisallowedImpersonationForUser() throws Exception {
+  @Test
+  public void testDisallowedImpersonationForUser() {
     final String proxyServer = "proxy";
     // let "otherproxy" impersonate, but not "proxy"
     cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION, "otherproxy:*");
@@ -165,11 +169,12 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     TCredentials tcreds = new TCredentials("client", KerberosToken.class.getName(),
         ByteBuffer.allocate(0), UUID.randomUUID().toString());
     UGIAssumingProcessor.rpcPrincipal.set(proxyServer);
-    proxy.updateArgs(new Object[] {new Object(), tcreds});
+    assertThrows(ThriftSecurityException.class,
+        () -> proxy.updateArgs(new Object[] {new Object(), tcreds}));
   }
 
-  @Test(expected = ThriftSecurityException.class)
-  public void testDisallowedImpersonationForMultipleUsers() throws Exception {
+  @Test
+  public void testDisallowedImpersonationForMultipleUsers() {
     final String proxyServer = "proxy";
     // let "otherproxy" impersonate, but not "proxy"
     cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION,
@@ -179,7 +184,8 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     TCredentials tcreds = new TCredentials("client1", KerberosToken.class.getName(),
         ByteBuffer.allocate(0), UUID.randomUUID().toString());
     UGIAssumingProcessor.rpcPrincipal.set(proxyServer);
-    proxy.updateArgs(new Object[] {new Object(), tcreds});
+    assertThrows(ThriftSecurityException.class,
+        () -> proxy.updateArgs(new Object[] {new Object(), tcreds}));
   }
 
   @Test
@@ -195,8 +201,8 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     proxy.updateArgs(new Object[] {new Object(), tcreds});
   }
 
-  @Test(expected = ThriftSecurityException.class)
-  public void testDisallowedImpersonationFromSpecificHost() throws Exception {
+  @Test
+  public void testDisallowedImpersonationFromSpecificHost() {
     final String proxyServer = "proxy", client = "client", host = "host.domain.com";
     cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION, proxyServer + ":" + client);
     cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_HOST_IMPERSONATION, host);
@@ -206,6 +212,7 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     UGIAssumingProcessor.rpcPrincipal.set(proxyServer);
     // The RPC came from a different host than is allowed
     TServerUtils.clientAddress.set("otherhost.domain.com");
-    proxy.updateArgs(new Object[] {new Object(), tcreds});
+    assertThrows(ThriftSecurityException.class,
+        () -> proxy.updateArgs(new Object[] {new Object(), tcreds}));
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationKeyTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationKeyTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.server.security.delegation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,9 +47,9 @@ public class AuthenticationKeyTest {
     keyGen.init(KEY_LENGTH);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testNullSecretKey() {
-    new AuthenticationKey(0, 0, 0, null);
+    assertThrows(NullPointerException.class, () -> new AuthenticationKey(0, 0, 0, null));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -211,7 +212,7 @@ public class AuthenticationTokenSecretManagerTest {
         Arrays.equals(password, password2));
   }
 
-  @Test(expected = InvalidToken.class)
+  @Test
   public void testExpiredPasswordsThrowError() throws Exception {
     // start of the test
     long then = System.currentTimeMillis();
@@ -237,10 +238,10 @@ public class AuthenticationTokenSecretManagerTest {
     AuthenticationTokenIdentifier id = new AuthenticationTokenIdentifier();
     id.readFields(new DataInputStream(new ByteArrayInputStream(token.getIdentifier())));
 
-    secretManager.retrievePassword(id);
+    assertThrows(InvalidToken.class, () -> secretManager.retrievePassword(id));
   }
 
-  @Test(expected = InvalidToken.class)
+  @Test
   public void testTokenIssuedInFuture() throws Exception {
     // start of the test
     long then = System.currentTimeMillis();
@@ -265,10 +266,10 @@ public class AuthenticationTokenSecretManagerTest {
     // Increase the value of issueDate
     id.setIssueDate(Long.MAX_VALUE);
 
-    secretManager.retrievePassword(id);
+    assertThrows(InvalidToken.class, () -> secretManager.retrievePassword(id));
   }
 
-  @Test(expected = InvalidToken.class)
+  @Test
   public void testRolledManagerKey() throws Exception {
     // start of the test
     long then = System.currentTimeMillis();
@@ -300,7 +301,7 @@ public class AuthenticationTokenSecretManagerTest {
     secretManager.removeKey(authKey1.getKeyId());
 
     // Should fail -- authKey1 (presumably) expired, cannot authenticate
-    secretManager.retrievePassword(id);
+    assertThrows(InvalidToken.class, () -> secretManager.retrievePassword(id));
   }
 
   @Test(timeout = 20 * 1000)
@@ -391,7 +392,7 @@ public class AuthenticationTokenSecretManagerTest {
         approximateLifetime <= cfg.getTokenLifetime(TimeUnit.MILLISECONDS));
   }
 
-  @Test(expected = AccumuloException.class)
+  @Test
   public void testInvalidRequestedExpirationDate() throws Exception {
     // start of the test
     long then = System.currentTimeMillis();
@@ -409,6 +410,7 @@ public class AuthenticationTokenSecretManagerTest {
     cfg.setTokenLifetime(tokenLifetime + 1, TimeUnit.MILLISECONDS);
 
     // Should throw an exception
-    secretManager.generateToken("user@EXAMPLE.COM", cfg);
+    assertThrows(AccumuloException.class,
+        () -> secretManager.generateToken("user@EXAMPLE.COM", cfg));
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
@@ -101,14 +102,14 @@ public class TabletTimeTest {
     assertNull(TabletTime.maxMetadataTime(nullTime, nullTime));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMaxMetadataTime_DifferentTypes1() {
-    TabletTime.maxMetadataTime(l1234, m5678);
+    assertThrows(IllegalArgumentException.class, () -> TabletTime.maxMetadataTime(l1234, m5678));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMaxMetadataTime_DifferentTypes2() {
-    TabletTime.maxMetadataTime(m1234, l5678);
+    assertThrows(IllegalArgumentException.class, () -> TabletTime.maxMetadataTime(m1234, l5678));
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
@@ -26,6 +26,7 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -173,7 +174,7 @@ public class TServerUtilsTest {
   }
 
   @SuppressFBWarnings(value = "UNENCRYPTED_SERVER_SOCKET", justification = "socket for testing")
-  @Test(expected = UnknownHostException.class)
+  @Test
   public void testStartServerUsedPort() throws Exception {
     int port = getFreePort(1024);
     InetAddress addr = InetAddress.getByName("localhost");
@@ -181,7 +182,7 @@ public class TServerUtilsTest {
     conf.set(Property.TSERV_CLIENTPORT, Integer.toString(port));
     try (ServerSocket s = new ServerSocket(port, 50, addr)) {
       assertNotNull(s);
-      startServer();
+      assertThrows(UnknownHostException.class, this::startServer);
     }
   }
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.gc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -528,34 +529,36 @@ public class GarbageCollectionTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadFileRef1() {
-    badRefTest("/F00.rf");
+    assertThrows(IllegalArgumentException.class, () -> badRefTest("/F00.rf"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadFileRef2() {
-    badRefTest("../F00.rf");
+    assertThrows(IllegalArgumentException.class, () -> badRefTest("../F00.rf"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadFileRef3() {
-    badRefTest("hdfs://foo.com:6000/accumulo/F00.rf");
+    assertThrows(IllegalArgumentException.class,
+        () -> badRefTest("hdfs://foo.com:6000/accumulo/F00.rf"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadFileRef4() {
-    badRefTest("hdfs://foo.com:6000/accumulo/tbls/5/F00.rf");
+    assertThrows(IllegalArgumentException.class,
+        () -> badRefTest("hdfs://foo.com:6000/accumulo/tbls/5/F00.rf"));
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testBadFileRef5() {
-    badRefTest("F00.rf");
+    assertThrows(RuntimeException.class, () -> badRefTest("F00.rf"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadFileRef6() {
-    badRefTest("/accumulo/tbls/5/F00.rf");
+    assertThrows(IllegalArgumentException.class, () -> badRefTest("/accumulo/tbls/5/F00.rf"));
   }
 
   @Test

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.replication;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Collections;
 import java.util.TreeSet;
@@ -54,20 +55,23 @@ public class ManagerReplicationCoordinatorTest {
     assertEquals(inst1, coordinator.getRandomTServer(Collections.singleton(inst1), 0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void invalidOffset() {
-    Manager manager = EasyMock.createMock(Manager.class);
-    ServerContext context = EasyMock.createMock(ServerContext.class);
-    EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
-    ZooReader reader = EasyMock.createMock(ZooReader.class);
-    EasyMock.expect(manager.getContext()).andReturn(context);
-    EasyMock.expect(manager.getInstanceID()).andReturn("1234");
-    EasyMock.replay(manager, reader);
+    assertThrows(IllegalArgumentException.class, () -> {
+      Manager manager = EasyMock.createMock(Manager.class);
+      ServerContext context = EasyMock.createMock(ServerContext.class);
+      EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
+      ZooReader reader = EasyMock.createMock(ZooReader.class);
+      EasyMock.expect(manager.getContext()).andReturn(context);
+      EasyMock.expect(manager.getInstanceID()).andReturn("1234");
+      EasyMock.replay(manager, reader);
 
-    ManagerReplicationCoordinator coordinator = new ManagerReplicationCoordinator(manager, reader);
-    TServerInstance inst1 = new TServerInstance(HostAndPort.fromParts("host1", 1234), "session");
+      ManagerReplicationCoordinator coordinator =
+          new ManagerReplicationCoordinator(manager, reader);
+      TServerInstance inst1 = new TServerInstance(HostAndPort.fromParts("host1", 1234), "session");
 
-    assertEquals(inst1, coordinator.getRandomTServer(Collections.singleton(inst1), 1));
+      assertEquals(inst1, coordinator.getRandomTServer(Collections.singleton(inst1), 1));
+    });
   }
 
   @Test

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/AccumuloTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/AccumuloTest.java
@@ -22,6 +22,7 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.FileNotFoundException;
 
@@ -89,12 +90,14 @@ public class AccumuloTest {
     assertEquals(-1, serverDirs.getAccumuloPersistentVersion(fs, path));
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetAccumuloPersistentVersion_Fail() throws Exception {
-    expect(fs.listStatus(path)).andThrow(new FileNotFoundException());
-    replay(fs);
+    assertThrows(RuntimeException.class, () -> {
+      expect(fs.listStatus(path)).andThrow(new FileNotFoundException());
+      replay(fs);
 
-    assertEquals(-1, serverDirs.getAccumuloPersistentVersion(fs, path));
+      assertEquals(-1, serverDirs.getAccumuloPersistentVersion(fs, path));
+    });
   }
 
   @Test

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader9to10Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader9to10Test.java
@@ -26,6 +26,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -91,14 +92,16 @@ public class Upgrader9to10Test {
         Upgrader9to10.switchToAllVolumes(resolved));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBadRelativeDeleteTooShort() {
-    Upgrader9to10.resolveRelativeDelete("/5a", VOL_PROP);
+    assertThrows(IllegalStateException.class,
+        () -> Upgrader9to10.resolveRelativeDelete("/5a", VOL_PROP));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBadRelativeDeleteTooLong() throws Exception {
-    Upgrader9to10.resolveRelativeDelete("/5a/5a/t-0005/F0009.rf", VOL_PROP);
+    assertThrows(IllegalStateException.class,
+        () -> Upgrader9to10.resolveRelativeDelete("/5a/5a/t-0005/F0009.rf", VOL_PROP));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -696,7 +696,7 @@ public class InMemoryMapTest {
     expectedAll.put(k1, new Value(val));
   }
 
-  @Test(expected = SampleNotPresentException.class)
+  @Test
   public void testDifferentSampleConfig() throws Exception {
     SamplerConfigurationImpl sampleConfig = new SamplerConfigurationImpl(RowSampler.class.getName(),
         Map.of("hasher", "murmur3_32", "modulus", "7"));
@@ -713,10 +713,10 @@ public class InMemoryMapTest {
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
         RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), Set.of(), false);
+    assertThrows(SampleNotPresentException.class, () -> iter.seek(new Range(), Set.of(), false));
   }
 
-  @Test(expected = SampleNotPresentException.class)
+  @Test
   public void testNoSampleConfig() throws Exception {
     InMemoryMap imm = newInMemoryMap(false, tempFolder.newFolder().getAbsolutePath());
 
@@ -725,7 +725,7 @@ public class InMemoryMapTest {
     SamplerConfigurationImpl sampleConfig2 = new SamplerConfigurationImpl(
         RowSampler.class.getName(), Map.of("hasher", "murmur3_32", "modulus", "9"));
     MemoryIterator iter = imm.skvIterator(sampleConfig2);
-    iter.seek(new Range(), Set.of(), false);
+    assertThrows(SampleNotPresentException.class, () -> iter.seek(new Range(), Set.of(), false));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.tserver;
 
+import static org.junit.Assert.assertThrows;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -39,15 +41,17 @@ import org.junit.Test;
 public class TabletServerSyncCheckTest {
   private static final String DFS_SUPPORT_APPEND = "dfs.support.append";
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testFailureOnExplicitAppendFalseConf() {
     Configuration conf = new Configuration();
     conf.set(DFS_SUPPORT_APPEND, "false");
 
     FileSystem fs = new TestFileSystem(conf);
-    try (var vm = new TestVolumeManagerImpl(Map.of("foo", new VolumeImpl(fs, "/")))) {
-      vm.ensureSyncIsEnabled();
-    }
+    assertThrows(RuntimeException.class, () -> {
+      try (var vm = new TestVolumeManagerImpl(Map.of("foo", new VolumeImpl(fs, "/")))) {
+        vm.ensureSyncIsEnabled();
+      }
+    });
   }
 
   private class TestFileSystem extends DistributedFileSystem {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.tserver.log;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -143,8 +144,8 @@ public class LogFileKeyTest {
     testToFromKey(Integer.MAX_VALUE, 0);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNegativeSeq() throws IOException {
-    testToFromKey(1, -1);
+  @Test
+  public void testNegativeSeq() {
+    assertThrows(IllegalArgumentException.class, () -> testToFromKey(1, -1));
   }
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
@@ -25,6 +25,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Map;
 
@@ -58,7 +59,7 @@ public class ReplicationProcessorTest {
     verify(context);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void noPeerConfigurationThrowsAnException() {
     ServerContext context = createMock(ServerContext.class);
 
@@ -67,7 +68,7 @@ public class ReplicationProcessorTest {
     replay(context);
 
     ReplicationProcessor proc = new ReplicationProcessor(context);
-    proc.getPeerType("foo");
+    assertThrows(IllegalArgumentException.class, () -> proc.getPeerType("foo"));
     verify(context);
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletMutationPrepAttemptTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletMutationPrepAttemptTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.tserver.tablet;
 import static org.easymock.EasyMock.mock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -40,28 +41,28 @@ public class TabletMutationPrepAttemptTest {
     assertTrue(prepared.tabletClosed());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void callGetSessionWhenClosed() {
     PreparedMutations prepared = new PreparedMutations();
-    prepared.getCommitSession();
+    assertThrows(IllegalStateException.class, prepared::getCommitSession);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void callGetNonViolatorsWhenClosed() {
     PreparedMutations prepared = new PreparedMutations();
-    prepared.getNonViolators();
+    assertThrows(IllegalStateException.class, prepared::getNonViolators);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void callGetViolatorsWhenClosed() {
     PreparedMutations prepared = new PreparedMutations();
-    prepared.getViolators();
+    assertThrows(IllegalStateException.class, prepared::getViolators);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void callGetViolationsWhenClosed() {
     PreparedMutations prepared = new PreparedMutations();
-    prepared.getViolations();
+    assertThrows(IllegalStateException.class, prepared::getViolations);
   }
 
   @Test

--- a/shell/src/test/java/org/apache/accumulo/shell/ShellUtilTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/ShellUtilTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.shell;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -64,8 +65,8 @@ public class ShellUtilTest {
     assertEquals(List.of(new Text("line1"), new Text("line2")), output);
   }
 
-  @Test(expected = FileNotFoundException.class)
-  public void testWithMissingFile() throws IOException {
-    ShellUtil.scanFile("missingFile.txt", false);
+  @Test
+  public void testWithMissingFile() {
+    assertThrows(FileNotFoundException.class, () -> ShellUtil.scanFile("missingFile.txt", false));
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1489,7 +1490,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNoConditions() throws AccumuloException, AccumuloSecurityException,
       TableExistsException, TableNotFoundException {
     String table = getUniqueNames(1)[0];
@@ -1503,7 +1504,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         cm1.put("tx", "seq", "1");
         cm1.put("data", "x", "a");
 
-        cw.write(cm1);
+        assertThrows(IllegalArgumentException.class, () -> cw.write(cm1));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaSplitIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,12 +82,13 @@ public class MetaSplitIT extends AccumuloClusterHarness {
     }
   }
 
-  @Test(expected = AccumuloException.class)
-  public void testRootTableSplit() throws Exception {
+  @Test
+  public void testRootTableSplit() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       SortedSet<Text> splits = new TreeSet<>();
       splits.add(new Text("5"));
-      client.tableOperations().addSplits(RootTable.NAME, splits);
+      assertThrows(AccumuloException.class,
+          () -> client.tableOperations().addSplits(RootTable.NAME, splits));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -98,13 +99,13 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
    * Attempt to set a locality group with overlapping groups. This test should throw an
    * IllegalArgumentException indicating that groups overlap.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testOverlappingGroupsFail() {
     NewTableConfiguration ntc = new NewTableConfiguration();
     Map<String,Set<Text>> lgroups = new HashMap<>();
     lgroups.put("lg1", Set.of(new Text("colFamA"), new Text("colFamB")));
     lgroups.put("lg2", Set.of(new Text("colFamC"), new Text("colFamB")));
-    ntc.setLocalityGroups(lgroups);
+    assertThrows(IllegalArgumentException.class, () -> ntc.setLocalityGroups(lgroups));
   }
 
   /**
@@ -208,7 +209,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
   /**
    * Verify that properties set using NewTableConfiguration must be table properties.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testInvalidTablePropertiesSet() {
     NewTableConfiguration ntc = new NewTableConfiguration();
     Map<String,String> props = new HashMap<>();
@@ -221,7 +222,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
     // These properties should result in an illegalArgumentException
     props.put("invalidProp1", "value1");
     props.put("invalidProp2", "value2");
-    ntc.setProperties(props);
+    assertThrows(IllegalArgumentException.class, () -> ntc.setProperties(props));
   }
 
   /**
@@ -431,48 +432,53 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
   /**
    * Verify iterator conflicts are discovered
    */
-  @Test(expected = IllegalArgumentException.class)
-  public void testIteratorConflictFound1()
-      throws AccumuloException, AccumuloSecurityException, TableExistsException {
+  @Test
+  public void testIteratorConflictFound1() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      String tableName = getUniqueNames(2)[0];
+      assertThrows(IllegalArgumentException.class, () -> {
+        String tableName = getUniqueNames(2)[0];
 
-      NewTableConfiguration ntc = new NewTableConfiguration();
-      IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
-      ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
-      setting = new IteratorSetting(12, "someName", "foo2.bar");
-      ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
-      client.tableOperations().create(tableName, ntc);
+        NewTableConfiguration ntc = new NewTableConfiguration();
+        IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+        ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+        setting = new IteratorSetting(12, "someName", "foo2.bar");
+
+        ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+        client.tableOperations().create(tableName, ntc);
+      });
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testIteratorConflictFound2()
-      throws AccumuloException, AccumuloSecurityException, TableExistsException {
+  @Test
+  public void testIteratorConflictFound2() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      String tableName = getUniqueNames(2)[0];
+      assertThrows(IllegalArgumentException.class, () -> {
+        String tableName = getUniqueNames(2)[0];
 
-      NewTableConfiguration ntc = new NewTableConfiguration();
-      IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
-      ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
-      setting = new IteratorSetting(10, "anotherName", "foo2.bar");
-      ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
-      client.tableOperations().create(tableName, ntc);
+        NewTableConfiguration ntc = new NewTableConfiguration();
+        IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+        ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+        setting = new IteratorSetting(10, "anotherName", "foo2.bar");
+        ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+        client.tableOperations().create(tableName, ntc);
+      });
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testIteratorConflictFound3()
-      throws AccumuloException, AccumuloSecurityException, TableExistsException {
+  @Test
+  public void testIteratorConflictFound3() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      String tableName = getUniqueNames(2)[0];
+      assertThrows(IllegalArgumentException.class, () -> {
 
-      NewTableConfiguration ntc = new NewTableConfiguration();
-      IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
-      ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
-      setting = new IteratorSetting(12, "someName", "foo.bar");
-      ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
-      client.tableOperations().create(tableName, ntc);
+        String tableName = getUniqueNames(2)[0];
+
+        NewTableConfiguration ntc = new NewTableConfiguration();
+        IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+        ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+        setting = new IteratorSetting(12, "someName", "foo.bar");
+        ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+        client.tableOperations().create(tableName, ntc);
+      });
     }
   }
 
@@ -601,7 +607,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
   /**
    * Verify that disjoint check works as expected with setProperties
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSetPropertiesDisjointCheck() {
     NewTableConfiguration ntc = new NewTableConfiguration();
 
@@ -612,13 +618,13 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
     Map<String,String> props = new HashMap<>();
     props.put("table.key1", "val1");
     props.put("table.group.lg1", "cat");
-    ntc.setProperties(props);
+    assertThrows(IllegalArgumentException.class, () -> ntc.setProperties(props));
   }
 
   /**
    * Verify checkDisjoint works with locality groups.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSetLocalityGroupsDisjointCheck() {
     NewTableConfiguration ntc = new NewTableConfiguration();
 
@@ -628,13 +634,13 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
 
     Map<String,Set<Text>> lgroups = new HashMap<>();
     lgroups.put("lg1", Set.of(new Text("dog")));
-    ntc.setLocalityGroups(lgroups);
+    assertThrows(IllegalArgumentException.class, () -> ntc.setLocalityGroups(lgroups));
   }
 
   /**
    * Verify checkDisjoint works with iterators groups.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testAttachIteratorDisjointCheck() {
     NewTableConfiguration ntc = new NewTableConfiguration();
 
@@ -643,7 +649,8 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
     ntc.setProperties(props);
 
     IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
-    ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+    assertThrows(IllegalArgumentException.class,
+        () -> ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan)));
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
@@ -442,7 +442,6 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
         IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
         ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
         setting = new IteratorSetting(12, "someName", "foo2.bar");
-
         ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
         client.tableOperations().create(tableName, ntc);
       });
@@ -469,7 +468,6 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
   public void testIteratorConflictFound3() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       assertThrows(IllegalArgumentException.class, () -> {
-
         String tableName = getUniqueNames(2)[0];
 
         NewTableConfiguration ntc = new NewTableConfiguration();

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2656,7 +2657,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
    *
    * The splits file will be empty.
    */
-  @Test(expected = org.apache.accumulo.core.client.TableNotFoundException.class)
+  @Test
   public void testCreateTableWithEmptySplitFile()
       throws IOException, AccumuloSecurityException, TableNotFoundException, AccumuloException {
     String splitsFile = System.getProperty("user.dir") + "/target/splitFile";
@@ -2665,8 +2666,10 @@ public class ShellServerIT extends SharedMiniClusterBase {
       SortedSet<Text> expectedSplits = readSplitsFromFile(splitsFile);
       final String tableName = getUniqueNames(1)[0];
       ts.exec("createtable " + tableName + " -sf " + splitsFile, false);
-      Collection<Text> createdSplits = client.tableOperations().listSplits(tableName);
-      assertEquals(expectedSplits, new TreeSet<>(createdSplits));
+      assertThrows(TableNotFoundException.class, () -> {
+        Collection<Text> createdSplits = client.tableOperations().listSplits(tableName);
+        assertEquals(expectedSplits, new TreeSet<>(createdSplits));
+      });
     } finally {
       Files.delete(Paths.get(splitsFile));
     }

--- a/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.test;
 
+import static org.junit.Assert.assertThrows;
+
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -27,11 +29,12 @@ import org.junit.Test;
 
 public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
 
-  @Test(expected = AccumuloException.class)
-  public void testNoFiles() throws Exception {
+  @Test
+  public void testNoFiles() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       // Should throw an error as this property can't be changed in ZooKeeper
-      client.instanceOperations().setProperty(Property.GENERAL_RPC_TIMEOUT.getKey(), "60s");
+      assertThrows(AccumuloException.class, () -> client.instanceOperations()
+          .setProperty(Property.GENERAL_RPC_TIMEOUT.getKey(), "60s"));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -471,13 +471,14 @@ public class BulkNewIT extends SharedMiniClusterBase {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyDir() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       String dir = getDir("/testBulkFile-");
       FileSystem fs = getCluster().getFileSystem();
       fs.mkdirs(new Path(dir));
-      c.tableOperations().importDirectory(dir).to(tableName).load();
+      assertThrows(IllegalArgumentException.class,
+          () -> c.tableOperations().importDirectory(dir).to(tableName).load());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -333,17 +334,19 @@ public class CloneTestIT extends AccumuloClusterHarness {
     }
   }
 
-  @Test(expected = AccumuloException.class)
-  public void testCloneRootTable() throws Exception {
+  @Test
+  public void testCloneRootTable() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().clone(RootTable.NAME, "rc1", true, null, null);
+      assertThrows(AccumuloException.class,
+          () -> client.tableOperations().clone(RootTable.NAME, "rc1", true, null, null));
     }
   }
 
-  @Test(expected = AccumuloException.class)
-  public void testCloneMetadataTable() throws Exception {
+  @Test
+  public void testCloneMetadataTable() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      client.tableOperations().clone(MetadataTable.NAME, "mc1", true, null, null);
+      assertThrows(AccumuloException.class,
+          () -> client.tableOperations().clone(MetadataTable.NAME, "mc1", true, null, null));
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -116,12 +117,12 @@ public class ReadWriteIT extends AccumuloClusterHarness {
     return 6 * 60;
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void invalidInstanceName() {
     try (AccumuloClient client =
         Accumulo.newClient().to("fake_instance_name", cluster.getZooKeepers())
             .as(getAdminPrincipal(), getAdminToken()).build()) {
-      client.instanceOperations().getTabletServers();
+      assertThrows(RuntimeException.class, () -> client.instanceOperations().getTabletServers());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
@@ -22,6 +22,7 @@ import static java.lang.System.currentTimeMillis;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -439,7 +440,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     }
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void testGetSplitsNoReadPermission() throws Exception {
     Job job = Job.getInstance();
 
@@ -472,7 +473,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat aif =
           new org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat();
 
-      aif.getSplits(job);
+      assertThrows(IOException.class, () -> aif.getSplits(job));
     }
   }
 


### PR DESCRIPTION
The goal of this PR is to convert all usage of the older `@Test(expected = ...` form of exception testing to the newer `assertThrows()`.

An example conversion:
```java
  @Test(expected = IllegalArgumentException.class)
  public void testNegativeTimeout() {
    BatchWriterConfig bwConfig = new BatchWriterConfig();
    bwConfig.setTimeout(-1, TimeUnit.DAYS);
  }
```
Would become:
```java
  @Test
  public void testNegativeTimeout() {
    BatchWriterConfig bwConfig = new BatchWriterConfig();
    assertThrows(IllegalArgumentException.class, () -> bwConfig.setTimeout(-1, TimeUnit.DAYS));
  }
```

I used this command to verify all tests that were changed still pass:
`mvn clean verify -Dit.test=ConditionalWriterIT,ReadWriteIT,KerberosIT,MetaConstraintRetryIT,ShellServerIT,BulkNewIT,ZooKeeperPropertiesIT,AccumuloInputFormatIT,NewTableConfigurationIT,MetaSplitIT,CloneTestIT -Dtest=ZooReaderWriterTest,TabletMetadataTest,TCredentialsUpdatingInvocationHandlerTest,AuthorizationsTest,FastFormatTest,ReplicationProcessorTest,TabletLocationStateTest,RelativeKeyTest,InMemoryMapTest,GarbageCollectionTest,OpTimerTest,ConfigCheckUtilTest,ScannerOptionsTest,ConfigurationTypeHelperTest,LogFileKeyTest,DefaultFormatterTest,SortedMapIteratorTest,TabletServerSyncCheckTest,LoadPlanTest,MetadataTimeTest,Upgrader9to10Test,ZooAuthenticationKeyDistributorTest,AuthenticationTokenSecretManagerTest,MutationTest,AccumuloConfigurationTest,ArrayByteSequenceTest,ListLexicoderTest,HadoopCredentialProviderTest,WholeRowIteratorTest,ConditionTest,ProblemReportingIteratorTest,UnsynchronizedBufferTest,TabletTimeTest,ManagerReplicationCoordinatorTest,IteratorSettingTest,TabletMutationPrepAttemptTest,ZooSessionTest,ValueTest,TServerUtilsTest,SpaceAwareVolumeChooserTest,RFileTest,BatchWriterConfigTest,LinkingIteratorTest,HexFormatterTest,RFileClientTest,CredentialProviderTokenTest,PasswordConverterTest,ReplicationSchemaTest,ServerContextTest,DelegationTokenConfigTest,KeyTest,ThriftTransportKeyTest,SequenceLexicoderTest,AccumuloTest,AuthenticationKeyTest,RowEncodingIteratorTest,ShellUtilTest,ZooKeeperInstanceTest -Dspotbugs.skip -Dtimeout.factor=1`