### PR TITLE
Wrap only method that throws with assertThrows

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/client/admin/NewTableConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/admin/NewTableConfigurationTest.java
@@ -19,19 +19,25 @@
 package org.apache.accumulo.core.client.admin;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.client.summary.Summarizer;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.client.summary.summarizers.FamilySummarizer;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
 import org.junit.Test;
@@ -162,4 +168,121 @@ public class NewTableConfigurationTest {
         ntcSummarization3.getProperties().get("table.summarizer.s2"));
 
   }
+
+  /**
+   * Verify that you cannot have overlapping locality groups.
+   *
+   * Attempt to set a locality group with overlapping groups. This test should throw an
+   * IllegalArgumentException indicating that groups overlap.
+   */
+  @Test
+  public void testOverlappingGroupsFail() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    Map<String,Set<Text>> lgroups = new HashMap<>();
+    lgroups.put("lg1", Set.of(new Text("colFamA"), new Text("colFamB")));
+    lgroups.put("lg2", Set.of(new Text("colFamC"), new Text("colFamB")));
+    assertThrows(IllegalArgumentException.class, () -> ntc.setLocalityGroups(lgroups));
+  }
+
+  /**
+   * Verify iterator conflicts are discovered
+   */
+  @Test
+  public void testIteratorConflictFound1() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+    ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+    IteratorSetting setting2 = new IteratorSetting(12, "someName", "foo2.bar");
+    assertThrows(IllegalArgumentException.class,
+        () -> ntc.attachIterator(setting2, EnumSet.of(IteratorScope.scan)));
+  }
+
+  @Test
+  public void testIteratorConflictFound2() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+    ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+    IteratorSetting setting2 = new IteratorSetting(10, "anotherName", "foo2.bar");
+    assertThrows(IllegalArgumentException.class,
+        () -> ntc.attachIterator(setting2, EnumSet.of(IteratorScope.scan)));
+  }
+
+  @Test
+  public void testIteratorConflictFound3() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+    ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan));
+    IteratorSetting setting2 = new IteratorSetting(12, "someName", "foo.bar");
+    assertThrows(IllegalArgumentException.class,
+        () -> ntc.attachIterator(setting2, EnumSet.of(IteratorScope.scan)));
+  }
+
+  /**
+   * Verify that properties set using NewTableConfiguration must be table properties.
+   */
+  @Test
+  public void testInvalidTablePropertiesSet() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+    Map<String,String> props = new HashMap<>();
+
+    // These properties should work just with no issue
+    props.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "prop1", "val1");
+    props.put(Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "prop2", "val2");
+    ntc.setProperties(props);
+
+    // These properties should result in an illegalArgumentException
+    props.put("invalidProp1", "value1");
+    props.put("invalidProp2", "value2");
+    assertThrows(IllegalArgumentException.class, () -> ntc.setProperties(props));
+  }
+
+  /**
+   * Verify checkDisjoint works with iterators groups.
+   */
+  @Test
+  public void testAttachIteratorDisjointCheck() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+
+    Map<String,String> props = new HashMap<>();
+    props.put("table.iterator.scan.someName", "10");
+    ntc.setProperties(props);
+
+    IteratorSetting setting = new IteratorSetting(10, "someName", "foo.bar");
+    assertThrows(IllegalArgumentException.class,
+        () -> ntc.attachIterator(setting, EnumSet.of(IteratorScope.scan)));
+  }
+
+  /**
+   * Verify that disjoint check works as expected with setProperties
+   */
+  @Test
+  public void testSetPropertiesDisjointCheck() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+
+    Map<String,Set<Text>> lgroups = new HashMap<>();
+    lgroups.put("lg1", Set.of(new Text("dog")));
+    ntc.setLocalityGroups(lgroups);
+
+    Map<String,String> props = new HashMap<>();
+    props.put("table.key1", "val1");
+    props.put("table.group.lg1", "cat");
+    assertThrows(IllegalArgumentException.class, () -> ntc.setProperties(props));
+  }
+
+  /**
+   * Verify checkDisjoint works with locality groups.
+   */
+  @Test
+  public void testSetLocalityGroupsDisjointCheck() {
+    NewTableConfiguration ntc = new NewTableConfiguration();
+
+    Map<String,String> props = new HashMap<>();
+    props.put("table.group.lg1", "cat");
+    ntc.setProperties(props);
+
+    Map<String,Set<Text>> lgroups = new HashMap<>();
+    lgroups.put("lg1", Set.of(new Text("dog")));
+    assertThrows(IllegalArgumentException.class, () -> ntc.setLocalityGroups(lgroups));
+  }
+
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
@@ -124,11 +124,8 @@ public class SpaceAwareVolumeChooserTest {
 
   @Test
   public void testNoFreeSpace() throws IOException {
-    assertThrows(UncheckedExecutionException.class, () -> {
-      testSpecificSetup(0L, 0L, null, 1, false);
-
-      makeChoices();
-    });
+    testSpecificSetup(0L, 0L, null, 1, false);
+    assertThrows(UncheckedExecutionException.class, this::makeChoices);
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributorTest.java
@@ -129,42 +129,30 @@ public class ZooAuthenticationKeyDistributorTest {
   }
 
   @Test
-  public void testMissingAcl() {
+  public void testMissingAcl() throws Exception {
     ZooAuthenticationKeyDistributor distributor =
         new ZooAuthenticationKeyDistributor(zrw, baseNode);
-    assertThrows(IllegalStateException.class, () -> {
-      // Attempt to create the directory and fail
-      expect(zrw.exists(baseNode)).andReturn(true);
-      expect(zrw.getACL(eq(baseNode))).andReturn(Collections.emptyList());
+    // Attempt to create the directory and fail
+    expect(zrw.exists(baseNode)).andReturn(true);
+    expect(zrw.getACL(eq(baseNode))).andReturn(Collections.emptyList());
 
-      replay(zrw);
-
-      try {
-        distributor.initialize();
-      } finally {
-        verify(zrw);
-      }
-    });
+    replay(zrw);
+    assertThrows(IllegalStateException.class, distributor::initialize);
+    verify(zrw);
   }
 
   @Test
-  public void testBadAcl() {
+  public void testBadAcl() throws Exception {
     ZooAuthenticationKeyDistributor distributor =
         new ZooAuthenticationKeyDistributor(zrw, baseNode);
-    assertThrows(IllegalStateException.class, () -> {
-      // Attempt to create the directory and fail
-      expect(zrw.exists(baseNode)).andReturn(true);
-      expect(zrw.getACL(eq(baseNode))).andReturn(Collections.singletonList(
-          new ACL(ZooUtil.PRIVATE.get(0).getPerms(), new Id("digest", "somethingweird"))));
+    // Attempt to create the directory and fail
+    expect(zrw.exists(baseNode)).andReturn(true);
+    expect(zrw.getACL(eq(baseNode))).andReturn(Collections.singletonList(
+        new ACL(ZooUtil.PRIVATE.get(0).getPerms(), new Id("digest", "somethingweird"))));
 
-      replay(zrw);
-
-      try {
-        distributor.initialize();
-      } finally {
-        verify(zrw);
-      }
-    });
+    replay(zrw);
+    assertThrows(IllegalStateException.class, distributor::initialize);
+    verify(zrw);
   }
 
   @Test

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
@@ -45,9 +45,11 @@ public class ManagerReplicationCoordinatorTest {
     ZooReader reader = EasyMock.createMock(ZooReader.class);
     ServerContext context = EasyMock.createMock(ServerContext.class);
     EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn("1234").anyTimes();
+    EasyMock.expect(context.getZooReaderWriter()).andReturn(null).anyTimes();
     EasyMock.expect(manager.getContext()).andReturn(context);
     EasyMock.expect(manager.getInstanceID()).andReturn("1234");
-    EasyMock.replay(manager, reader);
+    EasyMock.replay(manager, context, reader);
 
     ManagerReplicationCoordinator coordinator = new ManagerReplicationCoordinator(manager, reader);
     TServerInstance inst1 = new TServerInstance(HostAndPort.fromParts("host1", 1234), "session");
@@ -57,21 +59,19 @@ public class ManagerReplicationCoordinatorTest {
 
   @Test
   public void invalidOffset() {
-    assertThrows(IllegalArgumentException.class, () -> {
-      Manager manager = EasyMock.createMock(Manager.class);
-      ServerContext context = EasyMock.createMock(ServerContext.class);
-      EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
-      ZooReader reader = EasyMock.createMock(ZooReader.class);
-      EasyMock.expect(manager.getContext()).andReturn(context);
-      EasyMock.expect(manager.getInstanceID()).andReturn("1234");
-      EasyMock.replay(manager, reader);
-
-      ManagerReplicationCoordinator coordinator =
-          new ManagerReplicationCoordinator(manager, reader);
-      TServerInstance inst1 = new TServerInstance(HostAndPort.fromParts("host1", 1234), "session");
-
-      assertEquals(inst1, coordinator.getRandomTServer(Collections.singleton(inst1), 1));
-    });
+    Manager manager = EasyMock.createMock(Manager.class);
+    ServerContext context = EasyMock.createMock(ServerContext.class);
+    EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn("1234").anyTimes();
+    EasyMock.expect(context.getZooReaderWriter()).andReturn(null).anyTimes();
+    ZooReader reader = EasyMock.createMock(ZooReader.class);
+    EasyMock.expect(manager.getContext()).andReturn(context);
+    EasyMock.expect(manager.getInstanceID()).andReturn("1234");
+    EasyMock.replay(manager, context, reader);
+    ManagerReplicationCoordinator coordinator = new ManagerReplicationCoordinator(manager, reader);
+    TServerInstance inst1 = new TServerInstance(HostAndPort.fromParts("host1", 1234), "session");
+    assertThrows(IllegalArgumentException.class,
+        () -> coordinator.getRandomTServer(Collections.singleton(inst1), 1));
   }
 
   @Test

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/AccumuloTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/AccumuloTest.java
@@ -92,12 +92,9 @@ public class AccumuloTest {
 
   @Test
   public void testGetAccumuloPersistentVersion_Fail() throws Exception {
-    assertThrows(RuntimeException.class, () -> {
-      expect(fs.listStatus(path)).andThrow(new FileNotFoundException());
-      replay(fs);
-
-      assertEquals(-1, serverDirs.getAccumuloPersistentVersion(fs, path));
-    });
+    expect(fs.listStatus(path)).andThrow(new FileNotFoundException());
+    replay(fs);
+    assertThrows(RuntimeException.class, () -> serverDirs.getAccumuloPersistentVersion(fs, path));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -47,11 +47,8 @@ public class TabletServerSyncCheckTest {
     conf.set(DFS_SUPPORT_APPEND, "false");
 
     FileSystem fs = new TestFileSystem(conf);
-    assertThrows(RuntimeException.class, () -> {
-      try (var vm = new TestVolumeManagerImpl(Map.of("foo", new VolumeImpl(fs, "/")))) {
-        vm.ensureSyncIsEnabled();
-      }
-    });
+    assertThrows(RuntimeException.class,
+        () -> new TestVolumeManagerImpl(Map.of("foo", new VolumeImpl(fs, "/"))));
   }
 
   private class TestFileSystem extends DistributedFileSystem {

--- a/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaConstraintRetryIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -55,15 +56,9 @@ public class MetaConstraintRetryIT extends AccumuloClusterHarness {
       Mutation m = new Mutation(extent.toMetaRow());
       // unknown columns should cause constraint violation
       m.put("badcolfam", "badcolqual", "3");
-      assertThrows(ConstraintViolationException.class, () -> {
-        try {
-          MetadataTableUtil.update(context, w, null, m, extent);
-        } catch (RuntimeException e) {
-          if (e.getCause().getClass().equals(ConstraintViolationException.class)) {
-            throw (ConstraintViolationException) e.getCause();
-          }
-        }
-      });
+      var e = assertThrows(RuntimeException.class,
+          () -> MetadataTableUtil.update(context, w, null, m, extent));
+      assertEquals(ConstraintViolationException.class, e.getCause().getClass());
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -2663,13 +2663,10 @@ public class ShellServerIT extends SharedMiniClusterBase {
     String splitsFile = System.getProperty("user.dir") + "/target/splitFile";
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       generateSplitsFile(splitsFile, 0, 0, false, false, false, false, false);
-      SortedSet<Text> expectedSplits = readSplitsFromFile(splitsFile);
       final String tableName = getUniqueNames(1)[0];
       ts.exec("createtable " + tableName + " -sf " + splitsFile, false);
-      assertThrows(TableNotFoundException.class, () -> {
-        Collection<Text> createdSplits = client.tableOperations().listSplits(tableName);
-        assertEquals(expectedSplits, new TreeSet<>(createdSplits));
-      });
+      assertThrows(TableNotFoundException.class,
+          () -> client.tableOperations().listSplits(tableName));
     } finally {
       Files.delete(Paths.get(splitsFile));
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -585,28 +585,21 @@ public class KerberosIT extends AccumuloITBase {
     UserGroupInformation root = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
         rootUser.getPrincipal(), rootUser.getKeytab().getAbsolutePath());
     log.info("Logged in as {}", rootUser.getPrincipal());
-    assertThrows(AccumuloException.class, () -> {
+    var e = assertThrows(UndeclaredThrowableException.class, () -> {
       // As the "root" user, open up the connection and get a delegation token
-      try {
-        root.doAs((PrivilegedExceptionAction<AuthenticationToken>) () -> {
-          AccumuloClient client =
-              mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken());
+      root.doAs((PrivilegedExceptionAction<AuthenticationToken>) () -> {
+        try (AccumuloClient client =
+            mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken())) {
           log.info("Created client as {}", rootUser.getPrincipal());
           assertEquals(rootUser.getPrincipal(), client.whoami());
 
           // Should fail
           return client.securityOperations().getDelegationToken(
               new DelegationTokenConfig().setTokenLifetime(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
-        });
-      } catch (UndeclaredThrowableException e) {
-        Throwable cause = e.getCause();
-        if (cause != null) {
-          throw cause;
-        } else {
-          throw e;
         }
-      }
+      });
     });
+    assertEquals(AccumuloException.class, e.getCause().getClass());
   }
 
   @Test
@@ -619,13 +612,14 @@ public class KerberosIT extends AccumuloITBase {
     // As the "root" user, open up the connection and get a delegation token
     final AuthenticationToken dt =
         root.doAs((PrivilegedExceptionAction<AuthenticationToken>) () -> {
-          AccumuloClient client =
-              mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken());
-          log.info("Created client as {}", rootUser.getPrincipal());
-          assertEquals(rootUser.getPrincipal(), client.whoami());
+          try (AccumuloClient client =
+              mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken())) {
+            log.info("Created client as {}", rootUser.getPrincipal());
+            assertEquals(rootUser.getPrincipal(), client.whoami());
 
-          return client.securityOperations().getDelegationToken(
-              new DelegationTokenConfig().setTokenLifetime(5, TimeUnit.MINUTES));
+            return client.securityOperations().getDelegationToken(
+                new DelegationTokenConfig().setTokenLifetime(5, TimeUnit.MINUTES));
+          }
         });
 
     AuthenticationTokenIdentifier identifier = ((DelegationTokenImpl) dt).getIdentifier();
@@ -639,14 +633,14 @@ public class KerberosIT extends AccumuloITBase {
     UserGroupInformation.loginUserFromKeytab(rootUser.getPrincipal(),
         rootUser.getKeytab().getAbsolutePath());
 
-    final AccumuloClient client =
-        mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken());
+    try (AccumuloClient client =
+        mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken())) {
 
-    // The server-side implementation should prevent the revocation of the 'root' user's systems
-    // permissions
-    // because once they're gone, it's possible that they could never be restored.
-    assertThrows(AccumuloSecurityException.class, () -> client.securityOperations()
-        .revokeSystemPermission(rootUser.getPrincipal(), SystemPermission.GRANT));
+      // The server-side implementation should prevent the revocation of the 'root' user's systems
+      // permissions because once they're gone, it's possible that they could never be restored.
+      assertThrows(AccumuloSecurityException.class, () -> client.securityOperations()
+          .revokeSystemPermission(rootUser.getPrincipal(), SystemPermission.GRANT));
+    }
   }
 
   /**


### PR DESCRIPTION
Improve assertThrows changes by limiting the wrapping of methods to only
the method that actually throws the exception.

Found and fixed a few EasyMock replay problems in
ManagerReplicationCoordinatorTest that only worked with a specific test
execution order, and wouldn't work when tests were run individually.

Moved some NewTableConfigurationIT tests to NewTableConfigurationTest,
because they didn't need to be integration tests, as they are expected
to fail during construction of the NewTableConfiguration, and don't
require the NTC to be used to actually create a table on a test
instance.

Replace complicated try-catch blocks that check for e.getCause() with an
assertThrows that preserves the thrown exception and checks .getCause()
directly with a subsequent assertEquals statement.

Add a few missing try-with-resources blocks for AutoCloseable
AccumuloClients in KerberosIT