### PR TITLE
Remove self-assignment statement.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class was copied from Guava release 23.0 to replace the older Guava 14 version that had been
@@ -143,7 +144,7 @@ public final class HostAndPort implements Serializable {
    *           if nothing meaningful could be parsed.
    */
   public static HostAndPort fromString(String hostPortString) {
-    java.util.Objects.requireNonNull(hostPortString);
+    Objects.requireNonNull(hostPortString, "hostPortString variable was null!");
     String host;
     String portString = null;
     boolean hasBracketlessColons = false;

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -143,7 +143,7 @@ public final class HostAndPort implements Serializable {
    *           if nothing meaningful could be parsed.
    */
   public static HostAndPort fromString(String hostPortString) {
-    hostPortString = java.util.Objects.requireNonNull(hostPortString);
+    java.util.Objects.requireNonNull(hostPortString);
     String host;
     String portString = null;
     boolean hasBracketlessColons = false;


### PR DESCRIPTION
Removed a self-assignment of the hostPortString variable to itself.

If the hostPortString is non-null, nothing happens and the variable is unchanged. If the hostPortString is null, a ullPointerException is thrown. There is no need to assign it to itself.

Change suggested by errorprone analysis.