### PR TITLE
Create InstanceId to replace use of String

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
@@ -22,9 +22,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.clientImpl.ClientConfConverter;
 import org.apache.accumulo.core.clientImpl.ClientContext;
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.clientImpl.InstanceOperationsImpl;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -43,7 +44,6 @@ import org.apache.accumulo.core.singletons.SingletonReservation;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
-import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,7 +127,7 @@ public class ZooKeeperInstance implements Instance {
   @Override
   public String getInstanceID() {
     if (instanceId == null) {
-      instanceId = ClientContext.getInstanceID(zooCache, instanceName);
+      instanceId = ClientContext.getInstanceID(zooCache, instanceName).canonical();
     }
     ClientContext.verifyInstanceId(zooCache, instanceId, instanceName);
     return instanceId;
@@ -148,8 +148,8 @@ public class ZooKeeperInstance implements Instance {
       timer = new OpTimer().start();
     }
 
-    Location loc =
-        TabletsMetadata.getRootMetadata(ZooUtil.getRoot(getInstanceID()), zooCache).getLocation();
+    Location loc = TabletsMetadata
+        .getRootMetadata(Constants.ZROOT + "/" + getInstanceID(), zooCache).getLocation();
 
     if (timer != null) {
       timer.stop();
@@ -168,7 +168,7 @@ public class ZooKeeperInstance implements Instance {
   public String getInstanceName() {
     if (instanceName == null)
       instanceName =
-          InstanceOperationsImpl.lookupInstanceName(zooCache, UUID.fromString(getInstanceID()));
+          InstanceOperationsImpl.lookupInstanceName(zooCache, InstanceId.of(getInstanceID()));
 
     return instanceName;
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.data.InstanceId;
 
 public interface InstanceOperations {
 
@@ -154,6 +155,17 @@ public interface InstanceOperations {
    *
    * @return a String
    * @since 2.0.0
+   *
+   * @deprecated in 2.1.0 Use {@link #getInstanceId()}
    */
+  @Deprecated(since = "2.1.0")
   String getInstanceID();
+
+  /**
+   * Returns a unique ID object that identifies this instance of accumulo.
+   *
+   * @return an InstanceId
+   * @since 2.1.0
+   */
+  InstanceId getInstanceId();
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -25,6 +25,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TAuthenticationTokenIdentifier;
 import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.ThriftMessageUtil;
@@ -77,12 +79,12 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
     return impl.getExpirationDate();
   }
 
-  public void setInstanceId(String instanceId) {
-    impl.setInstanceId(instanceId);
+  public void setInstanceId(InstanceId instanceId) {
+    impl.setInstanceId(instanceId.canonical());
   }
 
-  public String getInstanceId() {
-    return impl.getInstanceId();
+  public InstanceId getInstanceId() {
+    return InstanceId.of(impl.getInstanceId());
   }
 
   public TAuthenticationTokenIdentifier getThriftIdentifier() {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -83,7 +83,10 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
   }
 
   public InstanceId getInstanceId() {
-    return InstanceId.of(requireNonNull(impl.getInstanceId(), "InstanceId is null"));
+    if (impl.getInstanceId() == null)
+      return InstanceId.of("");
+    else
+      return InstanceId.of(impl.getInstanceId());
   }
 
   public TAuthenticationTokenIdentifier getThriftIdentifier() {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -84,7 +84,7 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
   }
 
   public InstanceId getInstanceId() {
-    return InstanceId.of(impl.getInstanceId());
+    return InstanceId.of(requireNonNull(impl.getInstanceId(), "InstanceId is null"));
   }
 
   public TAuthenticationTokenIdentifier getThriftIdentifier() {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -25,7 +25,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TAuthenticationTokenIdentifier;
 import org.apache.accumulo.core.util.ByteBufferUtil;
@@ -115,7 +114,7 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
     impl.principal = tAuthTokenId.getPrincipal();
     setExpirationDate(tAuthTokenId.getExpirationDate());
     setIssueDate(tAuthTokenId.getIssueDate());
-    setInstanceId(tAuthTokenId.getInstanceId());
+    setInstanceId(InstanceId.of(tAuthTokenId.getInstanceId()));
     setKeyId(tAuthTokenId.getKeyId());
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/AuthenticationTokenIdentifier.java
@@ -114,7 +114,8 @@ public class AuthenticationTokenIdentifier extends TokenIdentifier {
     impl.principal = tAuthTokenId.getPrincipal();
     setExpirationDate(tAuthTokenId.getExpirationDate());
     setIssueDate(tAuthTokenId.getIssueDate());
-    setInstanceId(InstanceId.of(tAuthTokenId.getInstanceId()));
+    if (tAuthTokenId.getInstanceId() != null)
+      setInstanceId(InstanceId.of(tAuthTokenId.getInstanceId()));
     setKeyId(tAuthTokenId.getKeyId());
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken.AuthenticationTokenSerializer;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 
 /**
@@ -91,9 +92,10 @@ public class Credentials {
    * @throws RuntimeException
    *           if the authentication token has been destroyed (expired)
    */
-  public TCredentials toThrift(String instanceID) {
+  public TCredentials toThrift(InstanceId instanceID) {
     TCredentials tCreds = new TCredentials(getPrincipal(), getToken().getClass().getName(),
-        ByteBuffer.wrap(AuthenticationTokenSerializer.serialize(getToken())), instanceID);
+        ByteBuffer.wrap(AuthenticationTokenSerializer.serialize(getToken())),
+        instanceID.canonical());
     if (getToken().isDestroyed())
       throw new RuntimeException("Token has been destroyed",
           new AccumuloSecurityException(getPrincipal(), SecurityErrorCode.TOKEN_EXPIRED));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -46,6 +45,7 @@ import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.clientImpl.thrift.ConfigurationType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.conf.DeprecatedPropertyUtil;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.tabletserver.thrift.TabletClientService.Client;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.AddressUtil;
@@ -285,12 +285,12 @@ public class InstanceOperationsImpl implements InstanceOperations {
   /**
    * Given a zooCache and instanceId, look up the instance name.
    */
-  public static String lookupInstanceName(ZooCache zooCache, UUID instanceId) {
+  public static String lookupInstanceName(ZooCache zooCache, InstanceId instanceId) {
     checkArgument(zooCache != null, "zooCache is null");
     checkArgument(instanceId != null, "instanceId is null");
     for (String name : zooCache.getChildren(Constants.ZROOT + Constants.ZINSTANCES)) {
       var bytes = zooCache.get(Constants.ZROOT + Constants.ZINSTANCES + "/" + name);
-      var iid = UUID.fromString(new String(bytes, UTF_8));
+      InstanceId iid = InstanceId.of(new String(bytes, UTF_8));
       if (iid.equals(instanceId)) {
         return name;
       }
@@ -299,7 +299,13 @@ public class InstanceOperationsImpl implements InstanceOperations {
   }
 
   @Override
+  @Deprecated(since = "2.1.0")
   public String getInstanceID() {
+    return getInstanceId().canonical();
+  }
+
+  @Override
+  public InstanceId getInstanceId() {
     return context.getInstanceID();
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Tables.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.state.tables.TableState;
@@ -50,7 +51,7 @@ public class Tables {
 
   // Per instance cache will expire after 10 minutes in case we
   // encounter an instance not used frequently
-  private static Cache<String,TableMap> instanceToMapCache =
+  private static final Cache<InstanceId,TableMap> instanceToMapCache =
       CacheBuilder.newBuilder().expireAfterAccess(10, TimeUnit.MINUTES).build();
 
   static {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletLocator.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
@@ -81,10 +82,10 @@ public abstract class TabletLocator {
   public abstract void invalidateCache(ClientContext context, String server);
 
   private static class LocatorKey {
-    String instanceId;
+    InstanceId instanceId;
     TableId tableId;
 
-    LocatorKey(String instanceId, TableId table) {
+    LocatorKey(InstanceId instanceId, TableId table) {
       this.instanceId = instanceId;
       this.tableId = table;
     }
@@ -107,7 +108,7 @@ public abstract class TabletLocator {
 
   }
 
-  private static HashMap<LocatorKey,TabletLocator> locators = new HashMap<>();
+  private static final HashMap<LocatorKey,TabletLocator> locators = new HashMap<>();
   private static boolean enabled = true;
 
   public static synchronized void clearLocators() {

--- a/core/src/main/java/org/apache/accumulo/core/data/AbstractId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/AbstractId.java
@@ -61,7 +61,7 @@ public abstract class AbstractId<T extends AbstractId<T>> implements Comparable<
    * Returns a string of the canonical ID. This is guaranteed to be non-null.
    */
   @Override
-  public String toString() {
+  public final String toString() {
     return canonical();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/data/InstanceId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/InstanceId.java
@@ -18,42 +18,54 @@
  */
 package org.apache.accumulo.core.data;
 
+import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 /**
- * A strongly typed representation of a table ID. This class cannot be used to get a table ID from a
- * table name, but does provide the table ID string wrapped with a stronger type. The constructor
- * for this class will throw an error if the canonical parameter is null.
+ * A strongly typed representation of an Accumulo instance ID. The constructor for this class will
+ * throw an error if the canonical parameter is null.
  *
- * @since 2.0.0
+ * @since 2.1.0
  */
-public class TableId extends AbstractId<TableId> {
+public class InstanceId extends AbstractId<InstanceId> {
   private static final long serialVersionUID = 1L;
   // cache is for canonicalization/deduplication of created objects,
-  // to limit the number of TableId objects in the JVM at any given moment
+  // to limit the number of InstanceId objects in the JVM at any given moment
   // WeakReferences are used because we don't need them to stick around any longer than they need to
-  static final Cache<String,TableId> cache = CacheBuilder.newBuilder().weakValues().build();
+  static final Cache<String,InstanceId> cache = CacheBuilder.newBuilder().weakValues().build();
 
-  private TableId(final String canonical) {
+  private InstanceId(String canonical) {
     super(canonical);
   }
 
   /**
-   * Get a TableId object for the provided canonical string. This is guaranteed to be non-null.
+   * Get a InstanceId object for the provided canonical string. This is guaranteed to be non-null
    *
    * @param canonical
-   *          table ID string
-   * @return TableId object
+   *          Instance ID string
+   * @return InstanceId object
    */
-  public static TableId of(final String canonical) {
+  public static InstanceId of(final String canonical) {
     try {
-      return cache.get(canonical, () -> new TableId(canonical));
+      return cache.get(canonical, () -> new InstanceId(canonical));
     } catch (ExecutionException e) {
       throw new AssertionError(
           "This should never happen: ID constructor should never return null.");
     }
+  }
+
+  /**
+   * Get a InstanceId object for the provided uuid. This is guaranteed to be non-null
+   *
+   * @param uuid
+   *          UUID object
+   * @return InstanceId object
+   */
+  public static InstanceId of(final UUID uuid) {
+    return of(Objects.requireNonNull(uuid, "uuid cannot be null").toString());
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/data/NamespaceId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/NamespaceId.java
@@ -46,7 +46,7 @@ public class NamespaceId extends AbstractId<NamespaceId> {
    *
    * @param canonical
    *          Namespace ID string
-   * @return Namespace.ID object
+   * @return NamespaceId object
    */
   public static NamespaceId of(final String canonical) {
     try {

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooUtil.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.ZooDefs.Ids;
@@ -91,7 +92,7 @@ public class ZooUtil {
     PUBLIC.add(new ACL(Perms.READ, Ids.ANYONE_ID_UNSAFE));
   }
 
-  public static String getRoot(final String instanceId) {
+  public static String getRoot(final InstanceId instanceId) {
     return Constants.ZROOT + "/" + instanceId;
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.core.clientImpl.TabletLocator.TabletLocations;
 import org.apache.accumulo.core.clientImpl.TabletLocator.TabletServerMutations;
 import org.apache.accumulo.core.clientImpl.TabletLocatorImpl.TabletLocationObtainer;
 import org.apache.accumulo.core.clientImpl.TabletLocatorImpl.TabletServerLockChecker;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.PartialKey;
@@ -169,12 +170,14 @@ public class TabletLocatorImplTest {
   }
 
   private ClientContext context;
+  private InstanceId iid;
 
   @Before
   public void setUp() {
     context = EasyMock.createMock(ClientContext.class);
+    iid = InstanceId.of("instance1");
     EasyMock.expect(context.getRootTabletLocation()).andReturn("tserver1").anyTimes();
-    EasyMock.expect(context.getInstanceID()).andReturn("instance1").anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn(iid).anyTimes();
     replay(context);
   }
 
@@ -669,7 +672,7 @@ public class TabletLocatorImplTest {
     EasyMock.verify(context);
 
     context = EasyMock.createMock(ClientContext.class);
-    EasyMock.expect(context.getInstanceID()).andReturn("instance1").anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn(iid).anyTimes();
     EasyMock.expect(context.getRootTabletLocation()).andReturn("tserver4").anyTimes();
     replay(context);
 

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
@@ -30,6 +30,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 import org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TAuthenticationTokenIdentifier;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Test;
@@ -70,7 +71,7 @@ public class AuthenticationTokenIdentifierTest {
     dblNewToken.setKeyId(1);
     dblNewToken.setIssueDate(5L);
     dblNewToken.setExpirationDate(10L);
-    dblNewToken.setInstanceId("uuid");
+    dblNewToken.setInstanceId(InstanceId.of("uuid"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken.Authe
 import org.apache.accumulo.core.client.security.tokens.NullToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.Credentials;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class CredentialsTest {
   @Rule
   public TestName test = new TestName();
 
-  private String instanceID = test.getMethodName();
+  private InstanceId instanceID = InstanceId.of(test.getMethodName());
 
   @Test
   public void testToThrift() throws DestroyFailedException {

--- a/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
@@ -45,10 +45,11 @@ public class CredentialsTest {
   @Rule
   public TestName test = new TestName();
 
-  private InstanceId instanceID = InstanceId.of(test.getMethodName());
+  private InstanceId instanceID;
 
   @Test
   public void testToThrift() throws DestroyFailedException {
+    instanceID = InstanceId.of(test.getMethodName());
     // verify thrift serialization
     Credentials creds = new Credentials("test", new PasswordToken("testing"));
     TCredentials tCreds = creds.toThrift(instanceID);
@@ -72,6 +73,7 @@ public class CredentialsTest {
 
   @Test
   public void roundtripThrift() {
+    instanceID = InstanceId.of(test.getMethodName());
     Credentials creds = new Credentials("test", new PasswordToken("testing"));
     TCredentials tCreds = creds.toThrift(instanceID);
     Credentials roundtrip = Credentials.fromThrift(tCreds);
@@ -80,6 +82,7 @@ public class CredentialsTest {
 
   @Test
   public void testEqualsAndHashCode() {
+    instanceID = InstanceId.of(test.getMethodName());
     Credentials nullNullCreds = new Credentials(null, null);
     Credentials abcNullCreds = new Credentials("abc", new NullToken());
     Credentials cbaNullCreds = new Credentials("cba", new NullToken());
@@ -105,6 +108,7 @@ public class CredentialsTest {
 
   @Test
   public void testCredentialsSerialization() {
+    instanceID = InstanceId.of(test.getMethodName());
     Credentials creds = new Credentials("a:b-c", new PasswordToken("d-e-f".getBytes(UTF_8)));
     String serialized = creds.serialize();
     Credentials result = Credentials.deserialize(serialized);
@@ -121,6 +125,7 @@ public class CredentialsTest {
 
   @Test
   public void testToString() {
+    instanceID = InstanceId.of(test.getMethodName());
     Credentials creds = new Credentials(null, null);
     assertEquals(Credentials.class.getName() + ":null:null:<hidden>", creds.toString());
     creds = new Credentials("", new NullToken());

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -503,7 +503,7 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
         for (String name : zrw.getChildren(Constants.ZROOT + Constants.ZINSTANCES)) {
           String instanceNamePath = Constants.ZROOT + Constants.ZINSTANCES + "/" + name;
           byte[] bytes = zrw.getData(instanceNamePath);
-          String iid = new String(bytes, UTF_8);
+          InstanceId iid = InstanceId.of(new String(bytes, UTF_8));
           if (iid.equals(instanceIdFromFile)) {
             instanceName = name;
           }

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -70,6 +70,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.manager.thrift.ManagerClientService;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
@@ -490,7 +491,8 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
         throw new RuntimeException(e);
       }
 
-      String instanceIdFromFile = VolumeManager.getInstanceIDFromHdfs(instanceIdPath, hadoopConf);
+      InstanceId instanceIdFromFile =
+          VolumeManager.getInstanceIDFromHdfs(instanceIdPath, hadoopConf);
       ZooReaderWriter zrw = new ZooReaderWriter(cc.get(Property.INSTANCE_ZK_HOST),
           (int) cc.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT), cc.get(Property.INSTANCE_SECRET));
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory.ClassloaderType;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.schema.Ample;
@@ -107,7 +108,7 @@ public class ServerContext extends ClientContext {
    * Used during initialization to set the instance name and ID.
    */
   public static ServerContext initialize(SiteConfiguration siteConfig, String instanceName,
-      String instanceID) {
+      InstanceId instanceID) {
     return new ServerContext(new ServerInfo(siteConfig, instanceName, instanceID));
   }
 
@@ -121,7 +122,7 @@ public class ServerContext extends ClientContext {
   }
 
   @Override
-  public String getInstanceID() {
+  public InstanceId getInstanceID() {
     return info.getInstanceID();
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerDirs.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerDirs.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
@@ -76,14 +77,14 @@ public class ServerDirs {
     // all base dirs must have same instance id and data version, any dirs that have neither should
     // be ignored
     String firstDir = null;
-    String firstIid = null;
+    InstanceId firstIid = null;
     Integer firstVersion = null;
     // preserve order from configuration (to match user expectations a bit when volumes get sent to
     // user-implemented VolumeChoosers)
     LinkedHashSet<String> baseDirsList = new LinkedHashSet<>();
     for (String baseDir : configuredBaseDirs) {
       Path path = new Path(baseDir, Constants.INSTANCE_ID_DIR);
-      String currentIid;
+      InstanceId currentIid;
       int currentVersion;
       try {
         currentIid = VolumeManager.getInstanceIDFromHdfs(path, hadoopConf);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.util.Properties;
-import java.util.UUID;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
@@ -33,6 +32,7 @@ import org.apache.accumulo.core.clientImpl.InstanceOperationsImpl;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
@@ -47,7 +47,7 @@ public class ServerInfo implements ClientInfo {
 
   private final SiteConfiguration siteConfig;
   private final Configuration hadoopConf;
-  private final String instanceID;
+  private final InstanceId instanceID;
   private final String instanceName;
   private final String zooKeepers;
   private final int zooKeepersSessionTimeOut;
@@ -76,7 +76,7 @@ public class ServerInfo implements ClientInfo {
       throw new RuntimeException("Instance name " + instanceName + " does not exist in zookeeper. "
           + "Run \"accumulo org.apache.accumulo.server.util.ListInstances\" to see a list.");
     }
-    instanceID = new String(iidb, UTF_8);
+    instanceID = InstanceId.of(new String(iidb, UTF_8));
     if (zooCache.get(Constants.ZROOT + "/" + instanceID) == null) {
       if (instanceName == null) {
         throw new RuntimeException("Instance id " + instanceID + " does not exist in zookeeper");
@@ -103,11 +103,11 @@ public class ServerInfo implements ClientInfo {
     zooKeepers = config.get(Property.INSTANCE_ZK_HOST);
     zooKeepersSessionTimeOut = (int) config.getTimeInMillis(Property.INSTANCE_ZK_TIMEOUT);
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);
-    instanceName = InstanceOperationsImpl.lookupInstanceName(zooCache, UUID.fromString(instanceID));
+    instanceName = InstanceOperationsImpl.lookupInstanceName(zooCache, instanceID);
     credentials = SystemCredentials.get(instanceID, siteConfig);
   }
 
-  ServerInfo(SiteConfiguration config, String instanceName, String instanceID) {
+  ServerInfo(SiteConfiguration config, String instanceName, InstanceId instanceID) {
     SingletonManager.setMode(Mode.SERVER);
     siteConfig = config;
     hadoopConf = new Configuration();
@@ -133,7 +133,7 @@ public class ServerInfo implements ClientInfo {
     return volumeManager;
   }
 
-  public String getInstanceID() {
+  public InstanceId getInstanceID() {
     return instanceID;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -113,7 +113,7 @@ public class ClientServiceHandler implements ClientService.Iface {
 
   @Override
   public String getInstanceId() {
-    return context.getInstanceID();
+    return context.getInstanceID().canonical();
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigCheckUtil;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
@@ -37,13 +38,14 @@ import org.apache.accumulo.server.ServerContext;
  */
 public class ServerConfigurationFactory extends ServerConfiguration {
 
-  private static final Map<String,Map<TableId,TableConfiguration>> tableConfigs = new HashMap<>(1);
-  private static final Map<String,Map<NamespaceId,NamespaceConfiguration>> namespaceConfigs =
+  private static final Map<InstanceId,Map<TableId,TableConfiguration>> tableConfigs =
       new HashMap<>(1);
-  private static final Map<String,Map<TableId,NamespaceConfiguration>> tableParentConfigs =
+  private static final Map<InstanceId,Map<NamespaceId,NamespaceConfiguration>> namespaceConfigs =
+      new HashMap<>(1);
+  private static final Map<InstanceId,Map<TableId,NamespaceConfiguration>> tableParentConfigs =
       new HashMap<>(1);
 
-  private static void addInstanceToCaches(String iid) {
+  private static void addInstanceToCaches(InstanceId iid) {
     synchronized (tableConfigs) {
       tableConfigs.computeIfAbsent(iid, k -> new HashMap<>());
     }
@@ -69,7 +71,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
 
   private final ServerContext context;
   private final SiteConfiguration siteConfig;
-  private final String instanceID;
+  private final InstanceId instanceID;
   private ZooCacheFactory zcf = new ZooCacheFactory();
 
   public ServerConfigurationFactory(ServerContext context, SiteConfiguration siteConfig) {

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessor.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +38,10 @@ public class ZooCachePropertyAccessor {
   private static final Logger log = LoggerFactory.getLogger(ZooCachePropertyAccessor.class);
 
   static class PropCacheKey {
-    final String instanceId;
+    final InstanceId instanceId;
     final String scope;
 
-    PropCacheKey(String iid, String s) {
+    PropCacheKey(InstanceId iid, String s) {
       instanceId = iid;
       scope = s;
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooConfigurationFactory.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.ServerContext;
@@ -32,7 +33,7 @@ import org.apache.zookeeper.Watcher;
  * A factory for {@link ZooConfiguration} objects.
  */
 class ZooConfigurationFactory {
-  private static final Map<String,ZooConfiguration> instances = new HashMap<>();
+  private static final Map<InstanceId,ZooConfiguration> instances = new HashMap<>();
 
   /**
    * Gets a configuration object for the given instance with the given parent. Repeated calls will

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.hadoop.conf.Configuration;
@@ -201,7 +202,7 @@ public interface VolumeManager extends AutoCloseable {
 
   Logger log = LoggerFactory.getLogger(VolumeManager.class);
 
-  static String getInstanceIDFromHdfs(Path instanceDirectory, Configuration hadoopConf) {
+  static InstanceId getInstanceIDFromHdfs(Path instanceDirectory, Configuration hadoopConf) {
     try {
       FileSystem fs =
           VolumeConfiguration.fileSystemForPath(instanceDirectory.toString(), hadoopConf);
@@ -221,7 +222,7 @@ public interface VolumeManager extends AutoCloseable {
         throw new RuntimeException(
             "Accumulo found multiple possible instance ids in " + instanceDirectory);
       } else {
-        return files[0].getPath().getName();
+        return InstanceId.of(files[0].getPath().getName());
       }
     } catch (IOException e) {
       log.error("Problem reading instance id out of hdfs at " + instanceDirectory, e);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.UUID;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.admin.TimeType;
@@ -36,6 +35,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
@@ -71,7 +71,7 @@ class FileSystemInitializer {
   private final ZooReaderWriter zoo;
   private final String zkRoot;
 
-  FileSystemInitializer(InitialConfiguration initConfig, ZooReaderWriter zoo, UUID uuid) {
+  FileSystemInitializer(InitialConfiguration initConfig, ZooReaderWriter zoo, InstanceId uuid) {
     this.initConfig = initConfig;
     this.zoo = zoo;
     this.zkRoot = Constants.ZROOT + "/" + uuid;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -163,7 +163,7 @@ public class SecurityOperation {
   }
 
   protected void authenticate(TCredentials credentials) throws ThriftSecurityException {
-    if (!credentials.getInstanceId().equals(context.getInstanceID()))
+    if (!credentials.getInstanceId().equals(context.getInstanceID().canonical()))
       throw new ThriftSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.INVALID_INSTANCEID);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SystemCredentials.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SystemCredentials.java
@@ -69,7 +69,7 @@ public final class SystemCredentials extends Credentials {
 
   @Override
   public TCredentials toThrift(InstanceId instanceID) {
-    if (!AS_THRIFT.getInstanceId().equals(instanceID))
+    if (!AS_THRIFT.getInstanceId().equals(instanceID.canonical()))
       throw new IllegalArgumentException("Unexpected instance used for "
           + SystemCredentials.class.getSimpleName() + ": " + instanceID);
     return AS_THRIFT;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SystemCredentials.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SystemCredentials.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.commons.codec.digest.Crypt;
 import org.apache.hadoop.io.Writable;
@@ -45,12 +46,12 @@ public final class SystemCredentials extends Credentials {
 
   private final TCredentials AS_THRIFT;
 
-  public SystemCredentials(String instanceID, String principal, AuthenticationToken token) {
+  public SystemCredentials(InstanceId instanceID, String principal, AuthenticationToken token) {
     super(principal, token);
     AS_THRIFT = super.toThrift(instanceID);
   }
 
-  public static SystemCredentials get(String instanceID, SiteConfiguration siteConfig) {
+  public static SystemCredentials get(InstanceId instanceID, SiteConfiguration siteConfig) {
     String principal = SYSTEM_PRINCIPAL;
     if (siteConfig.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
       // Use the server's kerberos principal as the Accumulo principal. We could also unwrap the
@@ -67,7 +68,7 @@ public final class SystemCredentials extends Credentials {
   }
 
   @Override
-  public TCredentials toThrift(String instanceID) {
+  public TCredentials toThrift(InstanceId instanceID) {
     if (!AS_THRIFT.getInstanceId().equals(instanceID))
       throw new IllegalArgumentException("Unexpected instance used for "
           + SystemCredentials.class.getSimpleName() + ": " + instanceID);
@@ -105,7 +106,7 @@ public final class SystemCredentials extends Credentials {
       super(systemPassword);
     }
 
-    private static String hashInstanceConfigs(String instanceID, SiteConfiguration siteConfig) {
+    private static String hashInstanceConfigs(InstanceId instanceID, SiteConfiguration siteConfig) {
       String wireVersion = Integer.toString(INTERNAL_WIRE_VERSION);
       // seed the config with the version and instance id, so at least it's not empty
       var sb = new StringBuilder(wireVersion).append("\t").append(instanceID).append("\t");
@@ -120,8 +121,8 @@ public final class SystemCredentials extends Credentials {
       return Crypt.crypt(sb.toString(), SALT_PREFIX + wireVersion + SALT_SUFFIX);
     }
 
-    private static SystemToken generate(String instanceID, SiteConfiguration siteConfig) {
-      byte[] instanceIdBytes = instanceID.getBytes(UTF_8);
+    private static SystemToken generate(InstanceId instanceID, SiteConfiguration siteConfig) {
+      byte[] instanceIdBytes = instanceID.canonical().getBytes(UTF_8);
       byte[] configHash = hashInstanceConfigs(instanceID, siteConfig).getBytes(UTF_8);
 
       // the actual token is a base64-encoded composition of:

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier;
 import org.apache.accumulo.core.clientImpl.DelegationTokenImpl;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.securityImpl.thrift.TAuthenticationTokenIdentifier;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.SecretManager;
@@ -58,7 +59,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
 
   private static final Logger log = LoggerFactory.getLogger(AuthenticationTokenSecretManager.class);
 
-  private final String instanceID;
+  private final InstanceId instanceID;
   private final long tokenMaxLifetime;
   private final ConcurrentHashMap<Integer,AuthenticationKey> allKeys = new ConcurrentHashMap<>();
   private AuthenticationKey currentKey;
@@ -71,7 +72,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
    * @param tokenMaxLifetime
    *          Maximum age (in milliseconds) before a token expires and is no longer valid
    */
-  public AuthenticationTokenSecretManager(String instanceID, long tokenMaxLifetime) {
+  public AuthenticationTokenSecretManager(InstanceId instanceID, long tokenMaxLifetime) {
     requireNonNull(instanceID);
     checkArgument(tokenMaxLifetime > 0, "Max lifetime must be positive");
     this.instanceID = instanceID;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
@@ -171,8 +171,9 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
     var id = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(username));
 
     final StringBuilder svcName = new StringBuilder(DelegationTokenImpl.SERVICE_NAME);
-    svcName.append("-").append(id.getInstanceId());
-
+    if (id.getInstanceId() != null) {
+      svcName.append("-").append(id.getInstanceId());
+    }
     // Create password will update the state on the identifier given currentKey. Need to call this
     // before serializing the identifier
     byte[] password;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.MetadataTable;
@@ -66,7 +67,7 @@ public class ZKPermHandler implements PermissionHandler {
   public void initialize(ServerContext context) {
     zooCache = new ZooCache(context.getZooReaderWriter(), null);
     zoo = context.getZooReaderWriter();
-    String instanceId = context.getInstanceID();
+    InstanceId instanceId = context.getInstanceID();
     ZKUserPath = ZKSecurityTool.getInstancePath(instanceId) + "/users";
     ZKTablePath = ZKSecurityTool.getInstancePath(instanceId) + "/tables";
     ZKNamespacePath = ZKSecurityTool.getInstancePath(instanceId) + "/namespaces";

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.security.SystemPermission;
@@ -203,7 +204,7 @@ class ZKSecurityTool {
     return toReturn;
   }
 
-  public static String getInstancePath(String instanceId) {
+  public static String getInstancePath(InstanceId instanceId) {
     return Constants.ZROOT + "/" + instanceId;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.NamespaceNotFoundException;
 import org.apache.accumulo.core.clientImpl.Tables;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.state.tables.TableState;
@@ -59,11 +60,11 @@ public class TableManager {
 
   private final ServerContext context;
   private final String zkRoot;
-  private final String instanceID;
+  private final InstanceId instanceID;
   private final ZooReaderWriter zoo;
   private ZooCache zooStateCache;
 
-  public static void prepareNewNamespaceState(ZooReaderWriter zoo, String instanceId,
+  public static void prepareNewNamespaceState(ZooReaderWriter zoo, InstanceId instanceId,
       NamespaceId namespaceId, String namespace, NodeExistsPolicy existsPolicy)
       throws KeeperException, InterruptedException {
     log.debug("Creating ZooKeeper entries for new namespace {} (ID: {})", namespace, namespaceId);
@@ -75,9 +76,9 @@ public class TableManager {
     zoo.putPersistentData(zPath + Constants.ZNAMESPACE_CONF, new byte[0], existsPolicy);
   }
 
-  public static void prepareNewTableState(ZooReaderWriter zoo, String instanceId, TableId tableId,
-      NamespaceId namespaceId, String tableName, TableState state, NodeExistsPolicy existsPolicy)
-      throws KeeperException, InterruptedException {
+  public static void prepareNewTableState(ZooReaderWriter zoo, InstanceId instanceId,
+      TableId tableId, NamespaceId namespaceId, String tableName, TableState state,
+      NodeExistsPolicy existsPolicy) throws KeeperException, InterruptedException {
     // state gets created last
     log.debug("Creating ZooKeeper entries for new table {} (ID: {}) in namespace (ID: {})",
         tableName, tableId, namespaceId);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CleanZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CleanZookeeper.java
@@ -66,7 +66,7 @@ public class CleanZookeeper {
           for (String instanceName : zk.getChildren(root + Constants.ZINSTANCES)) {
             String instanceNamePath = root + Constants.ZINSTANCES + "/" + instanceName;
             byte[] id = zk.getData(instanceNamePath);
-            if (id != null && !new String(id, UTF_8).equals(context.getInstanceID())) {
+            if (id != null && !new String(id, UTF_8).equals(context.getInstanceID().canonical())) {
               try {
                 zk.recursiveDelete(instanceNamePath, NodeMissingPolicy.SKIP);
               } catch (KeeperException.NoAuthException ex) {
@@ -74,7 +74,7 @@ public class CleanZookeeper {
               }
             }
           }
-        } else if (!child.equals(context.getInstanceID())) {
+        } else if (!child.equals(context.getInstanceID().canonical())) {
           String path = root + "/" + child;
           try {
             zk.recursiveDelete(path, NodeMissingPolicy.SKIP);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ZooZap.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.singletons.SingletonManager;
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
@@ -86,7 +87,7 @@ public class ZooZap {
 
       String volDir = VolumeConfiguration.getVolumeUris(siteConf).iterator().next();
       Path instanceDir = new Path(volDir, "instance_id");
-      String iid = VolumeManager.getInstanceIDFromHdfs(instanceDir, new Configuration());
+      InstanceId iid = VolumeManager.getInstanceIDFromHdfs(instanceDir, new Configuration());
       ZooReaderWriter zoo = new ZooReaderWriter(siteConf);
 
       if (opts.zapMaster) {

--- a/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
+import org.apache.accumulo.core.data.InstanceId;
 import org.easymock.EasyMock;
 
 /**
@@ -44,7 +45,7 @@ public class MockServerContext {
     return context;
   }
 
-  public static ServerContext getWithZK(String instanceID, String zk, int zkTimeout) {
+  public static ServerContext getWithZK(InstanceId instanceID, String zk, int zkTimeout) {
     var sc = get();
     expect(sc.getZooKeeperRoot()).andReturn("/accumulo/" + instanceID).anyTimes();
     expect(sc.getInstanceID()).andReturn(instanceID).anyTimes();

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
@@ -50,7 +51,7 @@ public class NamespaceConfigurationTest {
   private static final String ZOOKEEPERS = "localhost";
   private static final int ZK_SESSION_TIMEOUT = 120000;
 
-  private String iid;
+  private InstanceId iid;
   private ServerContext context;
   private AccumuloConfiguration parent;
   private ZooCacheFactory zcf;
@@ -59,7 +60,7 @@ public class NamespaceConfigurationTest {
 
   @Before
   public void setUp() {
-    iid = UUID.randomUUID().toString();
+    iid = InstanceId.of(UUID.randomUUID());
 
     context = MockServerContext.getWithZK(iid, ZOOKEEPERS, ZK_SESSION_TIMEOUT);
     parent = createMock(AccumuloConfiguration.class);

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertSame;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
@@ -47,7 +48,7 @@ import org.junit.Test;
 public class ServerConfigurationFactoryTest {
   private static final String ZK_HOST = "localhost";
   private static final int ZK_TIMEOUT = 120000;
-  private static final String IID = "iid";
+  private static final InstanceId IID = InstanceId.of("iid");
 
   // use the same mock ZooCacheFactory and ZooCache for all tests
   private static ZooCacheFactory zcf;

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
@@ -47,7 +48,7 @@ public class TableConfigurationTest {
   private static final String ZOOKEEPERS = "localhost";
   private static final int ZK_SESSION_TIMEOUT = 120000;
 
-  private String iid;
+  private InstanceId iid;
   private ServerContext context;
   private NamespaceConfiguration parent;
   private ZooCacheFactory zcf;
@@ -56,7 +57,7 @@ public class TableConfigurationTest {
 
   @Before
   public void setUp() {
-    iid = UUID.randomUUID().toString();
+    iid = InstanceId.of(UUID.randomUUID());
     context = MockServerContext.getWithZK(iid, ZOOKEEPERS, ZK_SESSION_TIMEOUT);
     replay(context);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ZooConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ZooConfigurationFactoryTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.MockServerContext;
@@ -46,7 +47,7 @@ public class ZooConfigurationFactoryTest {
 
   @Before
   public void setUp() {
-    context = MockServerContext.getWithZK("iid", "localhost", 120000);
+    context = MockServerContext.getWithZK(InstanceId.of("iid"), "localhost", 120000);
     zcf = createMock(ZooCacheFactory.class);
     zc = createMock(ZooCache.class);
     zconff = new ZooConfigurationFactory();

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
@@ -162,7 +163,7 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
     expect(mockContext.getZooKeepers()).andReturn("").anyTimes();
     expect(mockContext.getInstanceName()).andReturn("test").anyTimes();
     expect(mockContext.getZooKeepersSessionTimeOut()).andReturn(30).anyTimes();
-    expect(mockContext.getInstanceID()).andReturn("1111").anyTimes();
+    expect(mockContext.getInstanceID()).andReturn(InstanceId.of("1111")).anyTimes();
     expect(mockContext.getZooKeeperRoot()).andReturn(Constants.ZROOT + "/1111").anyTimes();
     return mockContext;
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.master.thrift.TableInfo;
@@ -134,8 +135,8 @@ public class TableLoadBalancerTest {
   }
 
   private ServerContext createMockContext() {
-    final String instanceId =
-        UUID.nameUUIDFromBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}).toString();
+    final InstanceId instanceId =
+        InstanceId.of(UUID.nameUUIDFromBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
     return MockServerContext.getWithZK(instanceId, "10.0.0.1:1234", 30_000);
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.Map.Entry;
 
 import javax.crypto.KeyGenerator;
 import javax.security.auth.callback.Callback;
@@ -36,7 +35,6 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.rpc.SaslDigestCallbackHandler;
 import org.apache.accumulo.server.security.delegation.AuthenticationKey;
 import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
-import org.apache.hadoop.security.token.Token;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -95,8 +93,7 @@ public class SaslDigestCallbackHandlerTest {
     var secretManager = new AuthenticationTokenSecretManager(InstanceId.of("instanceid"), 1000L);
 
     secretManager.addKey(new AuthenticationKey(1, 0L, 100L, keyGen.generateKey()));
-    Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> entry =
-        secretManager.generateToken("user", cfg);
+    var entry = secretManager.generateToken("user", cfg);
     byte[] password = entry.getKey().getPassword();
     char[] encodedPassword = handler.encodePassword(password);
 

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
@@ -32,6 +32,7 @@ import javax.security.auth.callback.Callback;
 
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.rpc.SaslDigestCallbackHandler;
 import org.apache.accumulo.server.security.delegation.AuthenticationKey;
 import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
@@ -91,7 +92,7 @@ public class SaslDigestCallbackHandlerTest {
 
   @Test
   public void testTokenSerialization() throws Exception {
-    var secretManager = new AuthenticationTokenSecretManager("instanceid", 1000L);
+    var secretManager = new AuthenticationTokenSecretManager(InstanceId.of("instanceid"), 1000L);
 
     secretManager.addKey(new AuthenticationKey(1, 0L, 100L, keyGen.generateKey()));
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> entry =
@@ -106,7 +107,7 @@ public class SaslDigestCallbackHandlerTest {
 
   @Test
   public void testTokenAndIdentifierSerialization() throws Exception {
-    var secretManager = new AuthenticationTokenSecretManager("instanceid", 1000L);
+    var secretManager = new AuthenticationTokenSecretManager(InstanceId.of("instanceid"), 1000L);
     var key = new AuthenticationKey(1, 0L, 100_000L, keyGen.generateKey());
     secretManager.addKey(key);
     var entry = secretManager.generateToken("user", cfg);

--- a/server/base/src/test/java/org/apache/accumulo/server/security/SystemCredentialsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/SystemCredentialsTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.security.SystemCredentials.SystemToken;
 import org.apache.commons.codec.digest.Crypt;
@@ -44,8 +45,8 @@ public class SystemCredentialsTest {
   public TestName test = new TestName();
 
   private static SiteConfiguration siteConfig = SiteConfiguration.auto();
-  private String instanceId =
-      UUID.nameUUIDFromBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}).toString();
+  private InstanceId instanceId =
+      InstanceId.of(UUID.nameUUIDFromBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "input not from a user")
   @BeforeClass

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -42,6 +42,7 @@ import javax.crypto.KeyGenerator;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.Token;
 import org.junit.Before;
@@ -68,12 +69,12 @@ public class AuthenticationTokenSecretManagerTest {
     keyGen.init(KEY_LENGTH);
   }
 
-  private String instanceId;
+  private InstanceId instanceId;
   private DelegationTokenConfig cfg;
 
   @Before
   public void setup() {
-    instanceId = UUID.randomUUID().toString();
+    instanceId = InstanceId.of(UUID.randomUUID());
     cfg = new DelegationTokenConfig();
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcherTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcherTest.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import javax.crypto.KeyGenerator;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.WatchedEvent;
@@ -63,7 +64,7 @@ public class ZooAuthenticationKeyWatcherTest {
   }
 
   private ZooReader zk;
-  private String instanceId;
+  private InstanceId instanceId;
   private String baseNode;
   private long tokenLifetime = 7 * 24 * 60 * 60 * 1000; // 7days
   private AuthenticationTokenSecretManager secretManager;
@@ -72,7 +73,7 @@ public class ZooAuthenticationKeyWatcherTest {
   @Before
   public void setupMocks() {
     zk = createMock(ZooReader.class);
-    instanceId = UUID.randomUUID().toString();
+    instanceId = InstanceId.of(UUID.randomUUID());
     baseNode = "/accumulo/" + instanceId + Constants.ZDELEGATION_TOKEN_KEYS;
     secretManager = new AuthenticationTokenSecretManager(instanceId, tokenLifetime);
     keyWatcher = new ZooAuthenticationKeyWatcher(secretManager, zk, baseNode);

--- a/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
@@ -34,6 +34,7 @@ import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.SystemPermission;
 import org.apache.accumulo.core.security.TablePermission;
@@ -133,7 +134,7 @@ public class ZKAuthenticatorTest {
     byte[] newHash = ZKSecurityTool.createPass(rawPass.clone());
 
     // mocking zk interaction
-    ServerContext context = MockServerContext.getWithZK("example", "", 30_000);
+    ServerContext context = MockServerContext.getWithZK(InstanceId.of("example"), "", 30_000);
     ZooReaderWriter zr = createMock(ZooReaderWriter.class);
     expect(context.getZooReaderWriter()).andReturn(zr).anyTimes();
     ZooKeeper zk = createMock(ZooKeeper.class);
@@ -166,7 +167,7 @@ public class ZKAuthenticatorTest {
     byte[] outdatedHash = ZKSecurityTool.createOutdatedPass(rawPass);
 
     // mocking zk interaction
-    ServerContext context = MockServerContext.getWithZK("example", "", 30_000);
+    ServerContext context = MockServerContext.getWithZK(InstanceId.of("example"), "", 30_000);
     ZooReaderWriter zr = createMock(ZooReaderWriter.class);
     expect(context.getZooReaderWriter()).andReturn(zr).anyTimes();
     ZooKeeper zk = createMock(ZooKeeper.class);

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.clientImpl.thrift.ClientService.Processor;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.client.ClientServiceHandler;
@@ -66,7 +67,7 @@ public class TServerUtilsTest {
     expect(context.getZooKeepers()).andReturn("").anyTimes();
     expect(context.getInstanceName()).andReturn("instance").anyTimes();
     expect(context.getZooKeepersSessionTimeOut()).andReturn(1).anyTimes();
-    expect(context.getInstanceID()).andReturn("11111").anyTimes();
+    expect(context.getInstanceID()).andReturn(InstanceId.of("11111")).anyTimes();
     expect(context.getConfiguration()).andReturn(conf).anyTimes();
     expect(context.getThriftServerType()).andReturn(ThriftServerType.THREADPOOL).anyTimes();
     expect(context.getServerSslParams()).andReturn(null).anyTimes();

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerContext;
@@ -65,7 +66,7 @@ public class SimpleGarbageCollectorTest {
   public void setUp() {
     volMgr = createMock(VolumeManager.class);
     context = createMock(ServerContext.class);
-    expect(context.getInstanceID()).andReturn("mock").anyTimes();
+    expect(context.getInstanceID()).andReturn(InstanceId.of("mock")).anyTimes();
     expect(context.getZooKeepers()).andReturn("localhost").anyTimes();
     expect(context.getZooKeepersSessionTimeOut()).andReturn(30000).anyTimes();
 
@@ -73,7 +74,7 @@ public class SimpleGarbageCollectorTest {
     expect(context.getConfiguration()).andReturn(systemConfig).anyTimes();
     expect(context.getVolumeManager()).andReturn(volMgr).anyTimes();
 
-    credentials = SystemCredentials.get("mock", siteConfig);
+    credentials = SystemCredentials.get(InstanceId.of("mock"), siteConfig);
     expect(context.getPrincipal()).andReturn(credentials.getPrincipal()).anyTimes();
     expect(context.getAuthenticationToken()).andReturn(credentials.getToken()).anyTimes();
     expect(context.getCredentials()).andReturn(credentials).anyTimes();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -57,6 +57,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.clientImpl.thrift.ThriftTableOperationException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
@@ -409,7 +410,7 @@ public class Manager extends AbstractServer
     }
   }
 
-  public String getInstanceID() {
+  public InstanceId getInstanceID() {
     return getContext().getInstanceID();
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssigner.java
@@ -91,7 +91,7 @@ public abstract class DistributedWorkQueueWorkAssigner implements WorkAssigner {
    */
   protected void initializeWorkQueue(AccumuloConfiguration conf) {
     workQueue =
-        new DistributedWorkQueue(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+        new DistributedWorkQueue(ZooUtil.getRoot(client.instanceOperations().getInstanceId())
             + ReplicationConstants.ZOO_WORK_QUEUE, conf, this.workQueue.getContext());
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/SequentialWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/SequentialWorkAssigner.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationTarget;
@@ -116,7 +117,7 @@ public class SequentialWorkAssigner extends DistributedWorkQueueWorkAssigner {
   protected void cleanupFinishedWork() {
     final Iterator<Entry<String,Map<TableId,String>>> queuedWork =
         queuedWorkByPeerName.entrySet().iterator();
-    final String instanceId = client.instanceOperations().getInstanceID();
+    final InstanceId instanceId = client.instanceOperations().getInstanceId();
 
     int elementsRemoved = 0;
     // Check the status of all the work we've queued up

--- a/server/manager/src/main/java/org/apache/accumulo/manager/replication/UnorderedWorkAssigner.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/replication/UnorderedWorkAssigner.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
@@ -140,7 +141,7 @@ public class UnorderedWorkAssigner extends DistributedWorkQueueWorkAssigner {
   @Override
   protected void cleanupFinishedWork() {
     final Iterator<String> work = queuedWork.iterator();
-    final String instanceId = client.instanceOperations().getInstanceID();
+    final InstanceId instanceId = client.instanceOperations().getInstanceId();
     while (work.hasNext()) {
       String filename = work.next();
       // Null equates to the work was finished

--- a/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/state/MergeStats.java
@@ -272,7 +272,7 @@ public class MergeStats {
         ZooReaderWriter zooReaderWriter = opts.getServerContext().getZooReaderWriter();
         for (Entry<String,String> entry : tableIdMap.entrySet()) {
           final String table = entry.getKey(), tableId = entry.getValue();
-          String path = ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+          String path = ZooUtil.getRoot(client.instanceOperations().getInstanceId())
               + Constants.ZTABLES + "/" + tableId + "/merge";
           MergeInfo info = new MergeInfo();
           if (zooReaderWriter.exists(path)) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
 import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.state.tables.TableState;
@@ -48,7 +49,7 @@ import org.slf4j.LoggerFactory;
 
 class CompactionDriver extends ManagerRepo {
 
-  public static String createCompactionCancellationPath(String instanceId, TableId tableId) {
+  public static String createCompactionCancellationPath(InstanceId instanceId, TableId tableId) {
     return Constants.ZROOT + "/" + instanceId + Constants.ZTABLES + "/" + tableId.canonical()
         + Constants.ZTABLE_COMPACT_CANCEL_ID;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/delete/PreDeleteTable.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.delete;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.Repo;
@@ -33,7 +34,7 @@ import org.apache.zookeeper.KeeperException;
 
 public class PreDeleteTable extends ManagerRepo {
 
-  public static String createDeleteMarkerPath(String instanceId, TableId tableId) {
+  public static String createDeleteMarkerPath(InstanceId instanceId, TableId tableId) {
     return Constants.ZROOT + "/" + instanceId + Constants.ZTABLES + "/" + tableId.canonical()
         + Constants.ZTABLE_DELETE_MARKER;
   }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
@@ -45,10 +46,10 @@ public class ManagerReplicationCoordinatorTest {
     ZooReader reader = EasyMock.createMock(ZooReader.class);
     ServerContext context = EasyMock.createMock(ServerContext.class);
     EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
-    EasyMock.expect(context.getInstanceID()).andReturn("1234").anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn(InstanceId.of("1234")).anyTimes();
     EasyMock.expect(context.getZooReaderWriter()).andReturn(null).anyTimes();
     EasyMock.expect(manager.getContext()).andReturn(context);
-    EasyMock.expect(manager.getInstanceID()).andReturn("1234");
+    EasyMock.expect(manager.getInstanceID()).andReturn(InstanceId.of("1234"));
     EasyMock.replay(manager, context, reader);
 
     ManagerReplicationCoordinator coordinator = new ManagerReplicationCoordinator(manager, reader);
@@ -62,11 +63,11 @@ public class ManagerReplicationCoordinatorTest {
     Manager manager = EasyMock.createMock(Manager.class);
     ServerContext context = EasyMock.createMock(ServerContext.class);
     EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
-    EasyMock.expect(context.getInstanceID()).andReturn("1234").anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn(InstanceId.of("1234")).anyTimes();
     EasyMock.expect(context.getZooReaderWriter()).andReturn(null).anyTimes();
     ZooReader reader = EasyMock.createMock(ZooReader.class);
     EasyMock.expect(manager.getContext()).andReturn(context);
-    EasyMock.expect(manager.getInstanceID()).andReturn("1234");
+    EasyMock.expect(manager.getInstanceID()).andReturn(InstanceId.of("1234"));
     EasyMock.replay(manager, context, reader);
     ManagerReplicationCoordinator coordinator = new ManagerReplicationCoordinator(manager, reader);
     TServerInstance inst1 = new TServerInstance(HostAndPort.fromParts("host1", 1234), "session");
@@ -80,9 +81,9 @@ public class ManagerReplicationCoordinatorTest {
     ZooReader reader = EasyMock.createMock(ZooReader.class);
     ServerContext context = EasyMock.createMock(ServerContext.class);
     EasyMock.expect(context.getConfiguration()).andReturn(config).anyTimes();
-    EasyMock.expect(context.getInstanceID()).andReturn("1234").anyTimes();
+    EasyMock.expect(context.getInstanceID()).andReturn(InstanceId.of("1234")).anyTimes();
     EasyMock.expect(context.getZooReaderWriter()).andReturn(null).anyTimes();
-    EasyMock.expect(manager.getInstanceID()).andReturn("1234").anyTimes();
+    EasyMock.expect(manager.getInstanceID()).andReturn(InstanceId.of("1234")).anyTimes();
     EasyMock.expect(manager.getContext()).andReturn(context).anyTimes();
     EasyMock.replay(manager, context, reader);
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/SequentialWorkAssignerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/SequentialWorkAssignerTest.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.replication.ReplicationConstants;
 import org.apache.accumulo.core.replication.ReplicationTarget;
@@ -76,17 +77,18 @@ public class SequentialWorkAssignerTest {
     assigner.setQueuedWork(queuedWork);
 
     InstanceOperations opts = createMock(InstanceOperations.class);
-    expect(opts.getInstanceID()).andReturn("instance");
+    var iid = InstanceId.of("instance");
+    expect(opts.getInstanceId()).andReturn(iid);
     expect(client.instanceOperations()).andReturn(opts);
 
     // file1 replicated
-    expect(zooCache.get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
+    expect(zooCache.get(ZooUtil.getRoot(iid) + ReplicationConstants.ZOO_WORK_QUEUE + "/"
         + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file1",
             new ReplicationTarget("cluster1", "1", TableId.of("1"))))).andReturn(null);
     // file2 still needs to replicate
     expect(
         zooCache
-            .get(ZooUtil.getRoot("instance") + ReplicationConstants.ZOO_WORK_QUEUE + "/"
+            .get(ZooUtil.getRoot(iid) + ReplicationConstants.ZOO_WORK_QUEUE + "/"
                 + DistributedWorkQueueWorkAssignerHelper.getQueueKey("file2",
                     new ReplicationTarget("cluster1", "2", TableId.of("2")))))
                         .andReturn(new byte[0]);

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/UnorderedWorkAssignerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/UnorderedWorkAssignerTest.java
@@ -45,9 +45,11 @@ import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHe
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 @Deprecated
+@Ignore("Replication Tests are not stable and not currently maintained")
 public class UnorderedWorkAssignerTest {
 
   private AccumuloClient client;

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationExcepti
 import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
@@ -40,7 +41,7 @@ public class CompactionDriverTest {
   @Test
   public void testCancelId() throws Exception {
 
-    final String instance = UUID.randomUUID().toString();
+    final InstanceId instance = InstanceId.of(UUID.randomUUID());
     final long compactId = 123;
     final long cancelId = 124;
     final NamespaceId namespaceId = NamespaceId.of("13");
@@ -81,7 +82,7 @@ public class CompactionDriverTest {
   @Test
   public void testTableBeingDeleted() throws Exception {
 
-    final String instance = UUID.randomUUID().toString();
+    final InstanceId instance = InstanceId.of(UUID.randomUUID());
     final long compactId = 123;
     final long cancelId = 122;
     final NamespaceId namespaceId = NamespaceId.of("14");

--- a/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
+++ b/server/monitor/src/test/java/org/apache/accumulo/monitor/it/WebViewsIT.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.ext.MessageBodyWriter;
 
 import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.monitor.Monitor;
 import org.apache.accumulo.monitor.Monitor.MonitorFactory;
@@ -91,7 +92,7 @@ public class WebViewsIT extends JerseyTest {
   public static void createMocks() {
     ServerContext contextMock = EasyMock.createMock(ServerContext.class);
     expect(contextMock.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
-    expect(contextMock.getInstanceID()).andReturn("foo").atLeastOnce();
+    expect(contextMock.getInstanceID()).andReturn(InstanceId.of("foo")).atLeastOnce();
     expect(contextMock.getInstanceName()).andReturn("foo").anyTimes();
     expect(contextMock.getZooKeepers()).andReturn("foo:2181").anyTimes();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -62,6 +62,7 @@ import org.apache.accumulo.core.clientImpl.DurabilityImpl;
 import org.apache.accumulo.core.clientImpl.TabletLocator;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.manager.thrift.ManagerClientService;
@@ -366,7 +367,7 @@ public class TabletServer extends AbstractServer {
     config();
   }
 
-  public String getInstanceID() {
+  public InstanceId getInstanceID() {
     return getContext().getInstanceID();
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -628,7 +628,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     ClientInfo info = ClientInfo.from(accumuloClient.properties());
     writer.print("\n" + SHELL_DESCRIPTION + "\n" + "- \n" + "- version: " + Constants.VERSION + "\n"
         + "- instance name: " + info.getInstanceName() + "\n" + "- instance id: "
-        + accumuloClient.instanceOperations().getInstanceID() + "\n" + "- \n"
+        + accumuloClient.instanceOperations().getInstanceId() + "\n" + "- \n"
         + "- type 'help' for a list of available commands\n" + "- \n");
     writer.flush();
   }

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -104,7 +104,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
       ZooCache zcache = new ZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       zcache.clear();
       var path = ServiceLock
-          .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
+          .path(ZooUtil.getRoot(client.instanceOperations().getInstanceId()) + Constants.ZGC_LOCK);
       byte[] gcLockData;
       do {
         gcLockData = ServiceLock.getLockData(zcache, path, null);

--- a/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
@@ -120,7 +120,7 @@ public class ExistingMacIT extends ConfigurableMacBase {
     ZooReaderWriter zrw = new ZooReaderWriter(getCluster().getZooKeepers(), (int) zkTimeout,
         defaultConfig.get(Property.INSTANCE_SECRET));
     final String zInstanceRoot =
-        Constants.ZROOT + "/" + client.instanceOperations().getInstanceID();
+        Constants.ZROOT + "/" + client.instanceOperations().getInstanceId();
     while (!AccumuloStatus.isAccumuloOffline(zrw, zInstanceRoot)) {
       log.debug("Accumulo services still have their ZK locks held");
       Thread.sleep(1000);

--- a/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ThriftServerBindsBeforeZooKeeperLockIT.java
@@ -30,6 +30,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.util.MonitorUtil;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
@@ -134,7 +135,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   public void testManagerService() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      final String instanceID = client.instanceOperations().getInstanceID();
+      final InstanceId instanceID = client.instanceOperations().getInstanceId();
 
       // Wait for the Manager to grab its lock
       while (true) {
@@ -194,7 +195,7 @@ public class ThriftServerBindsBeforeZooKeeperLockIT extends AccumuloClusterHarne
   public void testGarbageCollectorPorts() throws Exception {
     final MiniAccumuloClusterImpl cluster = (MiniAccumuloClusterImpl) getCluster();
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      String instanceID = client.instanceOperations().getInstanceID();
+      InstanceId instanceID = client.instanceOperations().getInstanceId();
 
       // Wait for the Manager to grab its lock
       while (true) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -235,7 +235,7 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
     expectClosed(c::securityOperations);
     expectClosed(c::namespaceOperations);
     expectClosed(c::properties);
-    expectClosed(() -> c.instanceOperations().getInstanceID());
+    expectClosed(() -> c.instanceOperations().getInstanceId());
 
     // check a few table ops to ensure they fail
     expectClosed(() -> tops.create("expectFail"));

--- a/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BackupManagerIT.java
@@ -47,7 +47,7 @@ public class BackupManagerIT extends ConfigurableMacBase {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       String secret = getCluster().getSiteConfiguration().get(Property.INSTANCE_SECRET);
       ZooReaderWriter writer = new ZooReaderWriter(cluster.getZooKeepers(), 30 * 1000, secret);
-      String root = "/accumulo/" + client.instanceOperations().getInstanceID();
+      String root = "/accumulo/" + client.instanceOperations().getInstanceId();
       List<String> children;
       // wait for 2 lock entries
       do {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -161,7 +161,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
         try {
           client = ManagerClient.getConnectionWithRetry((ClientContext) accumuloClient);
           stats = client.getManagerStats(TraceUtil.traceInfo(),
-              creds.toThrift(accumuloClient.instanceOperations().getInstanceID()));
+              creds.toThrift(accumuloClient.instanceOperations().getInstanceId()));
           break;
         } catch (ThriftSecurityException exception) {
           throw new AccumuloSecurityException(exception);

--- a/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FateConcurrencyIT.java
@@ -41,6 +41,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.Tables;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.fate.AdminUtil;
@@ -252,7 +253,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
       try {
 
-        String instanceId = context.getInstanceID();
+        InstanceId instanceId = context.getInstanceID();
         ZooReaderWriter zk = new ZooReaderWriter(context.getZooKeepers(),
             context.getZooKeepersSessionTimeOut(), secret);
         ZooStore<String> zs = new ZooStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);
@@ -344,7 +345,7 @@ public class FateConcurrencyIT extends AccumuloClusterHarness {
 
       log.trace("tid: {}", tableId);
 
-      String instanceId = context.getInstanceID();
+      InstanceId instanceId = context.getInstanceID();
       ZooReaderWriter zk = new ZooReaderWriter(context.getZooKeepers(),
           context.getZooKeepersSessionTimeOut(), secret);
       ZooStore<String> zs = new ZooStore<>(ZooUtil.getRoot(instanceId) + Constants.ZFATE, zk);

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -260,7 +260,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
 
       ZooReaderWriter zk = new ZooReaderWriter(cluster.getZooKeepers(), 30000, OUR_SECRET);
       var path = ServiceLock
-          .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
+          .path(ZooUtil.getRoot(client.instanceOperations().getInstanceId()) + Constants.ZGC_LOCK);
       for (int i = 0; i < 5; i++) {
         List<String> locks;
         try {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadWriteIT.java
@@ -171,7 +171,7 @@ public class ReadWriteIT extends AccumuloClusterHarness {
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
       var zLockPath =
-          ServiceLock.path(ZooUtil.getRoot(accumuloClient.instanceOperations().getInstanceID())
+          ServiceLock.path(ZooUtil.getRoot(accumuloClient.instanceOperations().getInstanceId())
               + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -141,7 +141,7 @@ public class RestartIT extends AccumuloClusterHarness {
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
       var zLockPath = ServiceLock
-          .path(ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
+          .path(ZooUtil.getRoot(c.instanceOperations().getInstanceId()) + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
         managerLockData = ServiceLock.getLockData(zcache, zLockPath, null);
@@ -194,7 +194,7 @@ public class RestartIT extends AccumuloClusterHarness {
       ZooReader zreader = new ZooReader(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
       ZooCache zcache = new ZooCache(zreader, null);
       var zLockPath = ServiceLock
-          .path(ZooUtil.getRoot(c.instanceOperations().getInstanceID()) + Constants.ZMANAGER_LOCK);
+          .path(ZooUtil.getRoot(c.instanceOperations().getInstanceId()) + Constants.ZMANAGER_LOCK);
       byte[] managerLockData;
       do {
         managerLockData = ServiceLock.getLockData(zcache, zLockPath, null);

--- a/test/src/main/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
@@ -90,7 +90,7 @@ public class SimpleBalancerFairnessIT extends ConfigurableMacBase {
           try {
             client = ManagerClient.getConnectionWithRetry((ClientContext) c);
             stats = client.getManagerStats(TraceUtil.traceInfo(),
-                creds.toThrift(c.instanceOperations().getInstanceID()));
+                creds.toThrift(c.instanceOperations().getInstanceId()));
             break;
           } catch (ThriftNotActiveServiceException e) {
             // Let it loop, fetching a new location

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletStateChangeIteratorIT.java
@@ -306,7 +306,7 @@ public class TabletStateChangeIteratorIT extends AccumuloClusterHarness {
       HashSet<TServerInstance> tservers = new HashSet<>();
       for (String tserver : client.instanceOperations().getTabletServers()) {
         try {
-          var zPath = ServiceLock.path(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+          var zPath = ServiceLock.path(ZooUtil.getRoot(client.instanceOperations().getInstanceId())
               + Constants.ZTSERVERS + "/" + tserver);
           ClientInfo info = getClientInfo();
           long sessionId = ServiceLock.getSessionId(

--- a/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/gc/replication/CloseWriteAheadLogReferencesIT.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TableId;
@@ -119,7 +120,7 @@ public class CloseWriteAheadLogReferencesIT extends ConfigurableMacBase {
     expect(context.getZooKeepers()).andReturn("localhost").anyTimes();
     expect(context.getInstanceName()).andReturn("test").anyTimes();
     expect(context.getZooKeepersSessionTimeOut()).andReturn(30000).anyTimes();
-    expect(context.getInstanceID()).andReturn("1111").anyTimes();
+    expect(context.getInstanceID()).andReturn(InstanceId.of("1111")).anyTimes();
     expect(context.getZooKeeperRoot()).andReturn(Constants.ZROOT + "/1111").anyTimes();
 
     replay(siteConfig, context);

--- a/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/MultiTserverReplicationIT.java
@@ -74,14 +74,14 @@ public class MultiTserverReplicationIT extends ConfigurableMacBase {
           new ZooReader(context.getZooKeepers(), context.getZooKeepersSessionTimeOut());
       Set<String> tserverHost = new HashSet<>();
       tserverHost.addAll(zreader.getChildren(
-          ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZTSERVERS));
+          ZooUtil.getRoot(client.instanceOperations().getInstanceId()) + Constants.ZTSERVERS));
 
       Set<HostAndPort> replicationServices = new HashSet<>();
 
       for (String tserver : tserverHost) {
         try {
           byte[] portData =
-              zreader.getData(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+              zreader.getData(ZooUtil.getRoot(client.instanceOperations().getInstanceId())
                   + ReplicationConstants.ZOO_TSERVERS + "/" + tserver);
           HostAndPort replAddress = HostAndPort.fromString(new String(portData, UTF_8));
           replicationServices.add(replAddress);
@@ -119,7 +119,7 @@ public class MultiTserverReplicationIT extends ConfigurableMacBase {
 
       // Get the manager replication coordinator addr
       String replCoordAddr =
-          new String(zreader.getData(ZooUtil.getRoot(client.instanceOperations().getInstanceID())
+          new String(zreader.getData(ZooUtil.getRoot(client.instanceOperations().getInstanceId())
               + Constants.ZMANAGER_REPLICATION_COORDINATOR_ADDR), UTF_8);
 
       // They shouldn't be the same

--- a/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/ReplicationIT.java
@@ -209,7 +209,7 @@ public class ReplicationIT extends ConfigurableMacBase {
     ClientInfo info = ClientInfo.from(client.properties());
     ZooCache zcache = zcf.getZooCache(info.getZooKeepers(), info.getZooKeepersSessionTimeOut());
     var zkPath = ServiceLock
-        .path(ZooUtil.getRoot(client.instanceOperations().getInstanceID()) + Constants.ZGC_LOCK);
+        .path(ZooUtil.getRoot(client.instanceOperations().getInstanceId()) + Constants.ZGC_LOCK);
     log.info("Looking for GC lock at {}", zkPath);
     byte[] data = ServiceLock.getLockData(zcache, zkPath, null);
     while (data == null) {

--- a/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/server/security/SystemCredentialsIT.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.conf.SiteConfiguration;
+import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.metadata.RootTable;
@@ -63,7 +64,7 @@ public class SystemCredentialsIT extends ConfigurableMacBase {
     var siteConfig = SiteConfiguration.auto();
     try (ServerContext context = new ServerContext(siteConfig)) {
       Credentials creds;
-      String badInstanceID = SystemCredentials.class.getName();
+      InstanceId badInstanceID = InstanceId.of(SystemCredentials.class.getName());
       if (args.length < 2) {
         throw new RuntimeException("Incorrect usage; expected to be run by test only");
       }


### PR DESCRIPTION
* Create InstanceId object to replace use of String across the code
* Create new API method on InstanceOperations called getInstanceId()
* Deprecate API method InstanceOperations getInstanceID()