### PR TITLE
Remove redundant native map loading

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/NativeMap.java
@@ -46,7 +46,6 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.accumulo.core.util.PreAllocatedArray;
-import org.apache.accumulo.tserver.memory.NativeMapLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,10 +65,6 @@ import com.google.common.annotations.VisibleForTesting;
 public class NativeMap implements Iterable<Map.Entry<Key,Value>> {
 
   private static final Logger log = LoggerFactory.getLogger(NativeMap.class);
-
-  static {
-    NativeMapLoader.load();
-  }
 
   private final AtomicLong nmPtr = new AtomicLong(0);
 


### PR DESCRIPTION
Remove redundant call to NativeMapLoader.load() in NativeMap, which
isn't needed because the TabletServerResourceManager already loads it
when the tserver starts up. This static initializer caused problems with
test references to NativeMap, and tried to load the native map library
before the test had a chance to load it from the search path.

Instead, if NativeMap is attempted to be used without loading the native
library, it will just naturally throw an UnsatisfiedLinkError.

This fixes #2450