### PR TITLE
Remove unnecessary TServerUtils stop method

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
@@ -29,6 +29,8 @@ import org.apache.thrift.transport.TNonblockingServerTransport;
 import org.apache.thrift.transport.TNonblockingSocket;
 import org.apache.thrift.transport.TNonblockingTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class implements a custom non-blocking thrift server that stores the client address in
@@ -36,6 +38,7 @@ import org.apache.thrift.transport.TTransportException;
  */
 public class CustomNonBlockingServer extends THsHaServer {
 
+  private static final Logger log = LoggerFactory.getLogger(CustomNonBlockingServer.class);
   private final Field selectAcceptThreadField;
 
   public CustomNonBlockingServer(Args args) {
@@ -46,6 +49,16 @@ public class CustomNonBlockingServer extends THsHaServer {
       selectAcceptThreadField.setAccessible(true);
     } catch (Exception e) {
       throw new RuntimeException("Failed to access required field in Thrift code.", e);
+    }
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    try {
+      getInvoker().shutdownNow();
+    } catch (Exception e) {
+      log.error("Unable to call shutdownNow", e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.server.rpc;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -690,28 +689,6 @@ public class TServerUtils {
       }
     }
     return serverAddress;
-  }
-
-  /**
-   * Stop a Thrift TServer. Existing connections will keep our thread running; use reflection to
-   * forcibly shut down the threadpool.
-   *
-   * @param s
-   *          The TServer to stop
-   */
-  public static void stopTServer(TServer s) {
-    if (s == null) {
-      return;
-    }
-    s.stop();
-    try {
-      Field f = s.getClass().getDeclaredField("executorService_");
-      f.setAccessible(true);
-      ExecutorService es = (ExecutorService) f.get(s);
-      es.shutdownNow();
-    } catch (Exception e) {
-      log.error("Unable to call shutdownNow", e);
-    }
   }
 
   /**

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -831,7 +831,9 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     } finally {
       // Shutdown local thrift server
       LOG.info("Stopping Thrift Servers");
-      TServerUtils.stopTServer(compactorAddress.server);
+      if (compactorAddress.server != null) {
+        compactorAddress.server.stop();
+      }
 
       try {
         LOG.debug("Closing filesystems");

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -49,7 +49,6 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.compaction.RetryableThriftCall.RetriesExceededException;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.accumulo.server.rpc.ServerAddress;
-import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.easymock.EasyMock;
@@ -322,7 +321,6 @@ public class CompactorTest {
 
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.methods(Halt.class, "halt"));
-    PowerMock.suppress(PowerMock.methods(TServerUtils.class, "stopTServer"));
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
@@ -375,7 +373,6 @@ public class CompactorTest {
 
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.methods(Halt.class, "halt"));
-    PowerMock.suppress(PowerMock.methods(TServerUtils.class, "stopTServer"));
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
@@ -430,7 +427,6 @@ public class CompactorTest {
 
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.methods(Halt.class, "halt"));
-    PowerMock.suppress(PowerMock.methods(TServerUtils.class, "stopTServer"));
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -1232,7 +1232,10 @@ public class Manager extends AbstractServer
     } catch (InterruptedException e) {
       throw new IllegalStateException("Exception stopping replication workers", e);
     }
-    TServerUtils.stopTServer(replServer.get());
+    var nullableReplServer = replServer.get();
+    if (nullableReplServer != null) {
+      nullableReplServer.stop();
+    }
 
     // Signal that we want it to stop, and wait for it to do so.
     if (authenticationTokenKeyManager != null) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -906,10 +906,14 @@ public class TabletServer extends AbstractServer {
       }
     }
     log.debug("Stopping Replication Server");
-    TServerUtils.stopTServer(this.replServer);
+    if (this.replServer != null) {
+      this.replServer.stop();
+    }
 
     log.debug("Stopping Thrift Servers");
-    TServerUtils.stopTServer(server);
+    if (server != null) {
+      server.stop();
+    }
 
     try {
       log.debug("Closing filesystems");

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
@@ -88,12 +88,7 @@ public class ThriftBehaviorIT {
 
   @Test
   public void echoFail() throws TException {
-    try {
-      client.echoFail(KITTY_MSG);
-      fail("Thrift client did not throw an expected exception");
-    } catch (Exception e) {
-      assertEquals(TApplicationException.class.getName(), e.getClass().getName());
-    }
+    assertThrows(TApplicationException.class, () -> client.echoFail(KITTY_MSG));
     // verify normal two-way method still passes using same client
     echoPass();
   }


### PR DESCRIPTION
With newer versions of Thrift, the executor service used inside the
server is reachable by calling `getInvoker()`. So, it is no longer
necessary to use reflection to try to access the private field to shut
it down. This change removes that reflection code and shuts down the
executor service in the stop() method of our custom subclass. Since that
is substantially simpler, it is no longer necessary to have a dedicated
static utility method to stop a server. That method is removed and
stop() is called directly.