### PR TITLE
Refactor AuthenticationTokenIdentifier & DelegationTokenImpl

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/DelegationTokenConfig.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/DelegationTokenConfig.java
@@ -34,7 +34,7 @@ public class DelegationTokenConfig {
   private long lifetime = 0;
 
   /**
-   * Requests a specific lifetime for the token that is different than the default system lifetime.
+   * Requests a specific lifetime for the token that is different from the default system lifetime.
    * The lifetime must not exceed the secret key lifetime configured on the servers.
    *
    * @param lifetime

--- a/core/src/test/java/org/apache/accumulo/core/client/security/tokens/DelegationTokenImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/security/tokens/DelegationTokenImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client.security.tokens;
 
+import static org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier.createTAuthIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -35,13 +36,10 @@ public class DelegationTokenImplTest {
 
   @Test
   public void testSerialization() throws IOException {
-    AuthenticationTokenIdentifier identifier =
-        new AuthenticationTokenIdentifier("user", 1, 1000L, 2000L, "instanceid");
-    // We don't need a real serialized Token for the password
-    DelegationTokenImpl token =
-        new DelegationTokenImpl(new byte[] {'f', 'a', 'k', 'e'}, identifier);
-    assertEquals(token, token);
-    assertEquals(token.hashCode(), token.hashCode());
+    byte[] passBytes = new byte[] {'f', 'a', 'k', 'e'};
+    AuthenticationTokenIdentifier identifier = new AuthenticationTokenIdentifier(
+        createTAuthIdentifier("user", 1, 1000L, 2000L, "instanceid"));
+    DelegationTokenImpl token = new DelegationTokenImpl(passBytes, identifier);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     token.write(new DataOutputStream(baos));
@@ -49,20 +47,21 @@ public class DelegationTokenImplTest {
     DelegationTokenImpl copy = new DelegationTokenImpl();
     copy.readFields(new DataInputStream(new ByteArrayInputStream(baos.toByteArray())));
 
+    assertEquals(token.getServiceName(), copy.getServiceName());
     assertEquals(token, copy);
     assertEquals(token.hashCode(), copy.hashCode());
   }
 
   @Test
   public void testEquality() {
-    AuthenticationTokenIdentifier identifier =
-        new AuthenticationTokenIdentifier("user", 1, 1000L, 2000L, "instanceid");
+    AuthenticationTokenIdentifier identifier = new AuthenticationTokenIdentifier(
+        createTAuthIdentifier("user", 1, 1000L, 2000L, "instanceid"));
     // We don't need a real serialized Token for the password
     DelegationTokenImpl token =
         new DelegationTokenImpl(new byte[] {'f', 'a', 'k', 'e'}, identifier);
 
-    AuthenticationTokenIdentifier identifier2 =
-        new AuthenticationTokenIdentifier("user1", 1, 1000L, 2000L, "instanceid");
+    AuthenticationTokenIdentifier identifier2 = new AuthenticationTokenIdentifier(
+        createTAuthIdentifier("user1", 1, 1000L, 2000L, "instanceid"));
     // We don't need a real serialized Token for the password
     DelegationTokenImpl token2 =
         new DelegationTokenImpl(new byte[] {'f', 'a', 'k', 'e'}, identifier2);

--- a/core/src/test/java/org/apache/accumulo/core/rpc/SaslConnectionParamsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/rpc/SaslConnectionParamsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.rpc;
 
+import static org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier.createTAuthIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -107,8 +108,9 @@ public class SaslConnectionParamsTest {
 
   @Test
   public void testDelegationTokenImpl() throws Exception {
-    final DelegationTokenImpl token = new DelegationTokenImpl(new byte[0],
-        new AuthenticationTokenIdentifier("user", 1, 10L, 20L, "instanceid"));
+    final DelegationTokenImpl token =
+        new DelegationTokenImpl(new byte[0], new AuthenticationTokenIdentifier(
+            createTAuthIdentifier("user", 1, 10L, 20L, "instanceid")));
     testUser.doAs((PrivilegedExceptionAction<Void>) () -> {
       final SaslConnectionParams saslParams = createSaslParams(token);
       assertEquals(primary, saslParams.getKerberosServerPrimary());
@@ -142,8 +144,9 @@ public class SaslConnectionParamsTest {
     assertEquals(params1, params2);
     assertEquals(params1.hashCode(), params2.hashCode());
 
-    final DelegationTokenImpl delToken1 = new DelegationTokenImpl(new byte[0],
-        new AuthenticationTokenIdentifier("user", 1, 10L, 20L, "instanceid"));
+    final DelegationTokenImpl delToken1 =
+        new DelegationTokenImpl(new byte[0], new AuthenticationTokenIdentifier(
+            createTAuthIdentifier("user", 1, 10L, 20L, "instanceid")));
     SaslConnectionParams params3 = testUser
         .doAs((PrivilegedExceptionAction<SaslConnectionParams>) () -> createSaslParams(delToken1));
 
@@ -152,8 +155,9 @@ public class SaslConnectionParamsTest {
     assertNotEquals(params2, params3);
     assertNotEquals(params2.hashCode(), params3.hashCode());
 
-    final DelegationTokenImpl delToken2 = new DelegationTokenImpl(new byte[0],
-        new AuthenticationTokenIdentifier("user", 1, 10L, 20L, "instanceid"));
+    final DelegationTokenImpl delToken2 =
+        new DelegationTokenImpl(new byte[0], new AuthenticationTokenIdentifier(
+            createTAuthIdentifier("user", 1, 10L, 20L, "instanceid")));
     SaslConnectionParams params4 = testUser
         .doAs((PrivilegedExceptionAction<SaslConnectionParams>) () -> createSaslParams(delToken2));
 

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.security;
 
+import static org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier.createTAuthIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 import org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier;
+import org.apache.accumulo.core.securityImpl.thrift.TAuthenticationTokenIdentifier;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Test;
 
@@ -37,7 +39,8 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testUgi() {
     String principal = "user";
-    AuthenticationTokenIdentifier token = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier token =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     UserGroupInformation actual = token.getUser(),
         expected = UserGroupInformation.createRemoteUser(principal);
     assertEquals(expected.getAuthenticationMethod(), actual.getAuthenticationMethod());
@@ -47,9 +50,11 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testEquality() {
     String principal = "user";
-    AuthenticationTokenIdentifier token = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier token =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(token, token);
-    AuthenticationTokenIdentifier newToken = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier newToken =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(token, newToken);
     assertEquals(token.hashCode(), newToken.hashCode());
   }
@@ -57,13 +62,15 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testExtendedEquality() {
     String principal = "user";
-    AuthenticationTokenIdentifier token = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier token =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(token, token);
     AuthenticationTokenIdentifier newToken =
-        new AuthenticationTokenIdentifier(principal, 1, 5L, 10L, "uuid");
+        new AuthenticationTokenIdentifier(createTAuthIdentifier(principal, 1, 5L, 10L, "uuid"));
     assertNotEquals(token, newToken);
     assertNotEquals(token.hashCode(), newToken.hashCode());
-    AuthenticationTokenIdentifier dblNewToken = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier dblNewToken =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     dblNewToken.setKeyId(1);
     dblNewToken.setIssueDate(5L);
     dblNewToken.setExpirationDate(10L);
@@ -73,14 +80,16 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testToString() {
     String principal = "my_special_principal";
-    AuthenticationTokenIdentifier token = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier token =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertTrue(token.toString().contains(principal));
   }
 
   @Test
   public void testSerialization() throws IOException {
     String principal = "my_special_principal";
-    AuthenticationTokenIdentifier token = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier token =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(baos);
     token.write(out);
@@ -95,7 +104,8 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testTokenKind() {
     String principal = "my_special_principal";
-    AuthenticationTokenIdentifier token = new AuthenticationTokenIdentifier(principal);
+    AuthenticationTokenIdentifier token =
+        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(AuthenticationTokenIdentifier.TOKEN_KIND, token.getKind());
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
@@ -88,8 +88,7 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testSerialization() throws IOException {
     String principal = "my_special_principal";
-    AuthenticationTokenIdentifier token =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    var token = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(baos);
     token.write(out);

--- a/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/AuthenticationTokenIdentifierTest.java
@@ -39,10 +39,9 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testUgi() {
     String principal = "user";
-    AuthenticationTokenIdentifier token =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
-    UserGroupInformation actual = token.getUser(),
-        expected = UserGroupInformation.createRemoteUser(principal);
+    var token = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    UserGroupInformation actual = token.getUser();
+    UserGroupInformation expected = UserGroupInformation.createRemoteUser(principal);
     assertEquals(expected.getAuthenticationMethod(), actual.getAuthenticationMethod());
     assertEquals(expected.getUserName(), expected.getUserName());
   }
@@ -50,11 +49,9 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testEquality() {
     String principal = "user";
-    AuthenticationTokenIdentifier token =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    var token = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(token, token);
-    AuthenticationTokenIdentifier newToken =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    var newToken = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(token, newToken);
     assertEquals(token.hashCode(), newToken.hashCode());
   }
@@ -62,14 +59,13 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testExtendedEquality() {
     String principal = "user";
-    AuthenticationTokenIdentifier token =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    var token = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(token, token);
-    AuthenticationTokenIdentifier newToken =
+    var newToken =
         new AuthenticationTokenIdentifier(createTAuthIdentifier(principal, 1, 5L, 10L, "uuid"));
     assertNotEquals(token, newToken);
     assertNotEquals(token.hashCode(), newToken.hashCode());
-    AuthenticationTokenIdentifier dblNewToken =
+    var dblNewToken =
         new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     dblNewToken.setKeyId(1);
     dblNewToken.setIssueDate(5L);
@@ -80,8 +76,7 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testToString() {
     String principal = "my_special_principal";
-    AuthenticationTokenIdentifier token =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    var token = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertTrue(token.toString().contains(principal));
   }
 
@@ -103,8 +98,7 @@ public class AuthenticationTokenIdentifierTest {
   @Test
   public void testTokenKind() {
     String principal = "my_special_principal";
-    AuthenticationTokenIdentifier token =
-        new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
+    var token = new AuthenticationTokenIdentifier(new TAuthenticationTokenIdentifier(principal));
     assertEquals(AuthenticationTokenIdentifier.TOKEN_KIND, token.getKind());
   }
 
@@ -120,6 +114,5 @@ public class AuthenticationTokenIdentifierTest {
     assertEquals(token, deserializedToken);
     assertEquals(token.hashCode(), deserializedToken.hashCode());
     assertEquals(token.toString(), deserializedToken.toString());
-
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
@@ -75,8 +75,8 @@ public class SaslDigestCallbackHandlerTest {
 
   @Test
   public void testIdentifierSerialization() throws IOException {
-    AuthenticationTokenIdentifier identifier = new AuthenticationTokenIdentifier(
-        createTAuthIdentifier("user", 1, 100L, 1000L, "instanceid"));
+    var tAuthIdentifier = createTAuthIdentifier("user", 1, 100L, 1000L, "instanceid");
+    var identifier = new AuthenticationTokenIdentifier(tAuthIdentifier);
     byte[] serialized = identifier.getBytes();
     String name = handler.encodeIdentifier(serialized);
 
@@ -91,8 +91,7 @@ public class SaslDigestCallbackHandlerTest {
 
   @Test
   public void testTokenSerialization() throws Exception {
-    AuthenticationTokenSecretManager secretManager =
-        new AuthenticationTokenSecretManager("instanceid", 1000L);
+    var secretManager = new AuthenticationTokenSecretManager("instanceid", 1000L);
 
     secretManager.addKey(new AuthenticationKey(1, 0L, 100L, keyGen.generateKey()));
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> entry =
@@ -107,9 +106,7 @@ public class SaslDigestCallbackHandlerTest {
 
   @Test
   public void testTokenAndIdentifierSerialization() throws Exception {
-    AuthenticationTokenSecretManager secretManager =
-
-        new AuthenticationTokenSecretManager("instanceid", 1000L);
+    var secretManager = new AuthenticationTokenSecretManager("instanceid", 1000L);
     var key = new AuthenticationKey(1, 0L, 100_000L, keyGen.generateKey());
     secretManager.addKey(key);
     var entry = secretManager.generateToken("user", cfg);

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.server.rpc;
 
+import static org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier.createTAuthIdentifier;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -74,8 +75,8 @@ public class SaslDigestCallbackHandlerTest {
 
   @Test
   public void testIdentifierSerialization() throws IOException {
-    AuthenticationTokenIdentifier identifier =
-        new AuthenticationTokenIdentifier("user", 1, 100L, 1000L, "instanceid");
+    AuthenticationTokenIdentifier identifier = new AuthenticationTokenIdentifier(
+        createTAuthIdentifier("user", 1, 100L, 1000L, "instanceid"));
     byte[] serialized = identifier.getBytes();
     String name = handler.encodeIdentifier(serialized);
 
@@ -107,11 +108,11 @@ public class SaslDigestCallbackHandlerTest {
   @Test
   public void testTokenAndIdentifierSerialization() throws Exception {
     AuthenticationTokenSecretManager secretManager =
-        new AuthenticationTokenSecretManager("instanceid", 1000L);
 
-    secretManager.addKey(new AuthenticationKey(1, 0L, 1000 * 100L, keyGen.generateKey()));
-    Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> entry =
-        secretManager.generateToken("user", cfg);
+        new AuthenticationTokenSecretManager("instanceid", 1000L);
+    var key = new AuthenticationKey(1, 0L, 1000 * 100L, keyGen.generateKey());
+    secretManager.addKey(key);
+    var entry = secretManager.generateToken("user", cfg);
     byte[] password = entry.getKey().getPassword();
     char[] encodedPassword = handler.encodePassword(password);
     String name = handler.encodeIdentifier(entry.getValue().getBytes());

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
@@ -110,7 +110,7 @@ public class SaslDigestCallbackHandlerTest {
     AuthenticationTokenSecretManager secretManager =
 
         new AuthenticationTokenSecretManager("instanceid", 1000L);
-    var key = new AuthenticationKey(1, 0L, 1000 * 100L, keyGen.generateKey());
+    var key = new AuthenticationKey(1, 0L, 100_000L, keyGen.generateKey());
     secretManager.addKey(key);
     var entry = secretManager.generateToken("user", cfg);
     byte[] password = entry.getKey().getPassword();


### PR DESCRIPTION
* Refactor the class by removing extra constructors and making the
private impl object final. This allowed removal of null checks
* Create method in AuthenticationTokenSecretManager to set the user
overriden values. This prevents having to hang config object off of
AuthenticationTokenIdentifier
* Possibly closes #2456