### PR TITLE
Swap in reload4j instead of log4j1.2

### DIFF
--- a/assemble/bin/accumulo
+++ b/assemble/bin/accumulo
@@ -109,20 +109,12 @@ shell)   export ACCUMULO_OPTS="${ACCUMULO_GENERAL_OPTS} ${ACCUMULO_SHELL_OPTS}" 
 esac
 
 XML_FILES="${ACCUMULO_CONF_DIR}"
-LOG4J_JAR=$(find -H "${HADOOP_PREFIX}/lib" "${HADOOP_PREFIX}"/share/hadoop/common/lib -regex '.*/log4j-[0-9.]*[.]jar$' -print 2>/dev/null | head -1)
-SLF4J_JARS="${ACCUMULO_HOME}/lib/slf4j-api.jar:${ACCUMULO_HOME}/lib/slf4j-log4j12.jar"
-
-# The `find` command could fail for environmental reasons or bad configuration
-# Avoid trying to run Accumulo when we can't find the jar
-if [[ -z "${LOG4J_JAR}" && -z "${CLASSPATH}" ]]; then
-   echo "Could not locate Log4j jar in Hadoop installation at ${HADOOP_PREFIX}"
-   exit 1
-fi
+SLF4J_JARS="${ACCUMULO_HOME}/lib/slf4j-api.jar:${ACCUMULO_HOME}/lib/slf4j-reload4j.jar:${ACCUMULO_HOME}/lib/reload4j.jar"
 
 if [[ -n "$CLASSPATH" ]]; then
-  CLASSPATH="${XML_FILES}:${START_JAR}:${SLF4J_JARS}:${LOG4J_JAR}:${CLASSPATH}"
+  CLASSPATH="${XML_FILES}:${START_JAR}:${SLF4J_JARS}:${CLASSPATH}"
 else
-  CLASSPATH="${XML_FILES}:${START_JAR}:${SLF4J_JARS}:${LOG4J_JAR}"
+  CLASSPATH="${XML_FILES}:${START_JAR}:${SLF4J_JARS}"
 fi
 
 if [[ -z "${JAVA_HOME}" || ! -d "${JAVA_HOME}" ]]; then

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -28,6 +28,11 @@
   <description>Apache Accumulo packages.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <optional>true</optional>
@@ -242,7 +247,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -30,6 +30,7 @@
         pom.xml section which executes the maven-dependency-plugin to generate a
         version listing for packaged artifacts -->
         <include>${groupId}:${artifactId}-*</include>
+        <include>ch.qos.reload4j:reload4j</include>
         <include>com.beust:jcommander</include>
         <include>com.google.code.gson:gson</include>
         <include>com.google.guava:guava</include>
@@ -55,7 +56,7 @@
         <include>org.eclipse.jetty:jetty-servlet</include>
         <include>org.eclipse.jetty:jetty-util</include>
         <include>org.slf4j:slf4j-api</include>
-        <include>org.slf4j:slf4j-log4j12</include>
+        <include>org.slf4j:slf4j-reload4j</include>
       </includes>
       <excludes>
         <exclude>${groupId}:${artifactId}-docs</exclude>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,6 +27,10 @@
   <description>Apache Accumulo core libraries.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -72,10 +76,6 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-fate</artifactId>
     </dependency>
@@ -119,7 +119,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -30,6 +30,13 @@
     <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
   </dependencies>
@@ -109,7 +116,7 @@
             <phase>compile</phase>
             <configuration>
               <mainClass>org.apache.accumulo.core.conf.ConfigurationDocGen</mainClass>
-              <classpathScope>compile</classpathScope>
+              <classpathScope>runtime</classpathScope>
               <arguments>
                 <argument>--generate-html</argument>
                 <argument>${project.build.directory}/config.html</argument>
@@ -124,7 +131,7 @@
             <phase>compile</phase>
             <configuration>
               <mainClass>org.apache.accumulo.core.conf.ConfigurationDocGen</mainClass>
-              <classpathScope>compile</classpathScope>
+              <classpathScope>runtime</classpathScope>
               <arguments>
                 <argument>--generate-asciidoc</argument>
                 <argument>${project.build.directory}/asciidoc/appendices/config.txt</argument>

--- a/examples/simple/pom.xml
+++ b/examples/simple/pom.xml
@@ -28,6 +28,10 @@
   <description>Simple Apache Accumulo examples.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -51,10 +55,6 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>

--- a/fate/pom.xml
+++ b/fate/pom.xml
@@ -27,16 +27,16 @@
   <description>A FAult-Tolerant Executor library used by Apache Accumulo.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -26,14 +26,14 @@
   <name>Apache Accumulo Iterator Test Harness</name>
   <description>A library for testing Apache Accumulo Iterators.</description>
   <dependencies>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
     <!--TODO Don't force downstream users to have JUnit -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>

--- a/maven-plugin/src/it/plugin-test/pom.xml
+++ b/maven-plugin/src/it/plugin-test/pom.xml
@@ -36,6 +36,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>
@@ -64,10 +68,6 @@
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-minicluster</artifactId>
     </dependency>
@@ -81,7 +81,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -27,6 +27,10 @@
   <description>A library for launching and running a standalone instance of Apache Accumulo for testing.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -46,10 +50,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -113,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/impl/MiniAccumuloClusterImpl.java
@@ -364,6 +364,11 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
   Process _exec(Class<?> clazz, ServerType serverType, Map<String,String> configOverrides,
       String... args) throws IOException {
     List<String> jvmOpts = new ArrayList<>();
+    if (serverType == ServerType.ZOOKEEPER) {
+      // disable zookeeper's log4j 1.2 jmx support, which requires old versions of log4j 1.2
+      // and won't work with reload4j or log4j2
+      jvmOpts.add("-Dzookeeper.jmx.log4j.disable=true");
+    }
     jvmOpts.add("-Xmx" + config.getMemory(serverType));
     if (configOverrides != null && !configOverrides.isEmpty()) {
       File siteFile = File.createTempFile("accumulo-site", ".xml", config.getConfDir());

--- a/pom.xml
+++ b/pom.xml
@@ -159,10 +159,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <!-- 1.2.18.4 can't be used because ZK complains that the JMX stuff is missing -->
         <groupId>ch.qos.reload4j</groupId>
         <artifactId>reload4j</artifactId>
-        <version>1.2.18.3</version>
+        <version>1.2.18.4</version>
       </dependency>
       <dependency>
         <groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <rat.consoleOutput>true</rat.consoleOutput>
     <!-- surefire/failsafe plugin option -->
     <reuseForks>false</reuseForks>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.35</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.excludedGroups />
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
@@ -158,6 +158,12 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <!-- 1.2.18.4 can't be used because ZK complains that the JMX stuff is missing -->
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>1.2.18.3</version>
+      </dependency>
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
@@ -239,11 +245,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.1</version>
-      </dependency>
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
       </dependency>
       <dependency>
         <groupId>org.apache.accumulo</groupId>
@@ -389,6 +390,16 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -414,12 +425,32 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-minicluster</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-minikdc</artifactId>
         <!-- this version works better with java 11 than Hadoop 2 versions -->
         <version>3.0.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -470,6 +501,16 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>${zookeeper.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -548,12 +589,12 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
+        <artifactId>slf4j-nop</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-nop</artifactId>
+        <artifactId>slf4j-reload4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
     </dependencies>
@@ -869,6 +910,31 @@
                   <regexMessage>You should specify the Hadoop profile by major Hadoop generation, i.e. 2 or 3, not by a version number.
     Use hadoop.version to use a particular Hadoop version within that generation.</regexMessage>
                 </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-accumulo-rules</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <!-- we redirect logging to reload4j, so we should have those bridges instead -->
+                    <exclude>ch.qos.logback:*</exclude>
+                    <exclude>log4j:*</exclude>
+                    <exclude>org.apache.logging.log4j:*</exclude>
+                    <exclude>org.slf4j:*</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- only allow API and reload4j jars, but no other slf4j implementations -->
+                    <include>org.slf4j:slf4j-api</include>
+                    <include>org.slf4j:slf4j-reload4j</include>
+                  </includes>
+                </bannedDependencies>
               </rules>
             </configuration>
           </execution>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -27,6 +27,10 @@
   <description>A server for Apache Accumulo that proxies connections from any language supported by Apache Thrift.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -42,10 +46,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -28,6 +28,10 @@
   <description>A common base library for Apache Accumulo servers.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -69,10 +73,6 @@
       <artifactId>jline</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>
@@ -102,7 +102,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -28,6 +28,10 @@
   <description>The garbage collecting server for Apache Accumulo to clean up unused files.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -39,10 +43,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/server/master/pom.xml
+++ b/server/master/pom.xml
@@ -28,6 +28,10 @@
   <description>The master server for Apache Accumulo for load balacing and other system-wide operations.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -43,10 +47,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -28,6 +28,10 @@
   <description>A web server for monitoring Apache Accumulo.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>
@@ -47,10 +51,6 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -112,7 +112,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/server/native/pom.xml
+++ b/server/native/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/tracer/pom.xml
+++ b/server/tracer/pom.xml
@@ -28,13 +28,13 @@
   <description>The tracer server for Apache Accumulo to listen for, and store, distributed tracing messages.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -28,6 +28,10 @@
   <description>The tablet server for Apache Accumulo to host tablets of data tables.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -55,10 +59,6 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -94,7 +94,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -27,6 +27,10 @@
   <description>An interactive shell for accessing Apache Accumulo via a command line interface.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -70,10 +74,6 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -27,16 +27,16 @@
   <description>A library for launching Apache Accumulo services.</description>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -79,6 +79,11 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -30,6 +30,10 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
     </dependency>
@@ -69,10 +73,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -180,7 +180,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -302,7 +302,7 @@
                   <exclude>com.google.auto</exclude>
                   <exclude>javax.servlet:servlet-api</exclude>
                   <exclude>org.apache.accumulo:accumulo-native</exclude>
-                  <exclude>org.slf4j:slf4j-log4j12</exclude>
+                  <exclude>org.slf4j:slf4j-reload4j</exclude>
                 </excludes>
               </artifactSet>
               <shadedArtifactAttached>true</shadedArtifactAttached>


### PR DESCRIPTION
For the 1.10.x branch, use reload4j instead of the EOL log4j1.2, which
contains several CVEs and is no longer supported by its Apache project.
Reload4j is the continuation of log4j1.2, forked from the Apache
project by the original log4j1 creator. It is largely a drop-in
replacement for log4j1.2.