### PR TITLE
Remove occurences of unnecessary parentheses

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/bloomfilter/BloomFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/bloomfilter/BloomFilter.java
@@ -208,7 +208,7 @@ public class BloomFilter extends Filter {
     }
 
     if (super.getSerialVersion() == super.getVersion()) {
-      ObjectInputStream ois = new ObjectInputStream((DataInputStream) (in));
+      ObjectInputStream ois = new ObjectInputStream((DataInputStream) in);
       try {
         bits = (BitSet) ois.readObject();
       } catch (ClassNotFoundException e) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
@@ -162,10 +162,10 @@ public class Credentials {
       return false;
     Credentials other = Credentials.class.cast(obj);
     boolean pEq = getPrincipal() == null ? (other.getPrincipal() == null)
-        : (getPrincipal().equals(other.getPrincipal()));
+        : getPrincipal().equals(other.getPrincipal());
     if (!pEq)
       return false;
-    return getToken() == null ? (other.getToken() == null) : (getToken().equals(other.getToken()));
+    return getToken() == null ? (other.getToken() == null) : getToken().equals(other.getToken());
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -728,7 +728,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     final int SELECTION_THRESHOLD = 1;
 
     // stepSize can never be greater than 1 due to the if-loop check above.
-    final double stepSize = (maxSplits + 1) / (double) (existingSplits.size());
+    final double stepSize = (maxSplits + 1) / (double) existingSplits.size();
     double selectionTrigger = 0.0;
 
     for (Text existingSplit : existingSplits) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -556,7 +556,7 @@ public enum Property {
       "The maximum number of files a compaction will open", "2.1.0"),
   TSERV_COMPACTION_SERVICE_ROOT_EXECUTORS(
       "tserver.compaction.major.service.root.planner.opts.executors",
-      ("[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]")
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':1},{'name':'huge','type':'internal','numThreads':1}]"
           .replaceAll("'", "\""),
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %} ",
@@ -574,7 +574,7 @@ public enum Property {
       "The maximum number of files a compaction will open", "2.1.0"),
   TSERV_COMPACTION_SERVICE_META_EXECUTORS(
       "tserver.compaction.major.service.meta.planner.opts.executors",
-      ("[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]")
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'huge','type':'internal','numThreads':2}]"
           .replaceAll("'", "\""),
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %} ",
@@ -592,7 +592,7 @@ public enum Property {
       "The maximum number of files a compaction will open", "2.1.0"),
   TSERV_COMPACTION_SERVICE_DEFAULT_EXECUTORS(
       "tserver.compaction.major.service.default.planner.opts.executors",
-      ("[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]")
+      "[{'name':'small','type':'internal','maxSize':'32M','numThreads':2},{'name':'medium','type':'internal','maxSize':'128M','numThreads':2},{'name':'large','type':'internal','numThreads':2}]"
           .replaceAll("'", "\""),
       PropertyType.STRING,
       "See {% jlink -f org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner %} ",

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -50,7 +50,7 @@ public class ClusterConfigParser {
   }
 
   private static String addTheDot(String key) {
-    return (key.endsWith(".")) ? "" : ".";
+    return key.endsWith(".") ? "" : ".";
   }
 
   private static void flatten(String parentKey, String key, Object value,

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/ClassSize.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/ClassSize.java
@@ -94,7 +94,7 @@ public class ClassSize {
    * @return smallest number &gt;= input that is a multiple of 8
    */
   public static int align(int num) {
-    return (int) (align((long) num));
+    return (int) align((long) num);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -59,7 +59,7 @@ public class CreateEmpty implements KeywordExecutable {
     @Override
     public void validate(String name, String value) throws ParameterException {
       String[] algorithms = Compression.getSupportedAlgorithms();
-      if (!((Arrays.asList(algorithms)).contains(value))) {
+      if (!Arrays.asList(algorithms).contains(value)) {
         throw new ParameterException(
             "Compression codec must be one of " + Arrays.toString(algorithms));
       }
@@ -102,7 +102,7 @@ public class CreateEmpty implements KeywordExecutable {
     for (String arg : opts.files) {
       Path path = new Path(arg);
       log.info("Writing to file '{}'", path);
-      FileSKVWriter writer = (new RFileOperations()).newWriterBuilder()
+      FileSKVWriter writer = new RFileOperations().newWriterBuilder()
           .forFile(arg, path.getFileSystem(conf), conf, CryptoServiceFactory.newDefaultInstance())
           .withTableConfiguration(DefaultConfiguration.getInstance()).withCompression(opts.codec)
           .build();

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/PrintInfo.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/PrintInfo.java
@@ -324,7 +324,7 @@ public class PrintInfo implements KeywordExecutable {
     byte[] noCryptoBytes = new NoFileEncrypter().getDecryptionParameters();
     try (FSDataInputStream fsDis = fs.open(path)) {
       long fileLength = fs.getFileStatus(path).getLen();
-      fsDis.seek(fileLength - 16 - Utils.Version.size() - (Long.BYTES));
+      fsDis.seek(fileLength - 16 - Utils.Version.size() - Long.BYTES);
       long cryptoParamOffset = fsDis.readLong();
       fsDis.seek(cryptoParamOffset);
       byte[] cryptoParams = CryptoUtils.readParams(fsDis);

--- a/core/src/main/java/org/apache/accumulo/core/iterators/ServerFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/ServerFilter.java
@@ -65,7 +65,7 @@ public abstract class ServerFilter extends ServerWrappingIterator {
   private void findTop() throws IOException {
     while (source.hasTop()) {
       Key top = source.getTopKey();
-      if (top.isDeleted() || (accept(top, source.getTopValue()))) {
+      if (top.isDeleted() || accept(top, source.getTopValue())) {
         break;
       }
       source.next();

--- a/core/src/main/java/org/apache/accumulo/core/iterators/SynchronizedServerFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/SynchronizedServerFilter.java
@@ -80,7 +80,7 @@ public abstract class SynchronizedServerFilter implements SortedKeyValueIterator
   private void findTop() throws IOException {
     while (source.hasTop()) {
       Key top = source.getTopKey();
-      if (top.isDeleted() || (accept(top, source.getTopValue()))) {
+      if (top.isDeleted() || accept(top, source.getTopValue())) {
         break;
       }
       source.next();

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RegExFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RegExFilter.java
@@ -96,14 +96,14 @@ public class RegExFilter extends Filter {
   @Override
   public boolean accept(Key key, Value value) {
     if (orFields)
-      return ((matches(rowMatcher, rowMatcher == null ? null : key.getRowData()))
-          || (matches(colfMatcher, colfMatcher == null ? null : key.getColumnFamilyData()))
-          || (matches(colqMatcher, colqMatcher == null ? null : key.getColumnQualifierData()))
-          || (matches(valueMatcher, value.get(), 0, value.get().length)));
-    return ((matches(rowMatcher, rowMatcher == null ? null : key.getRowData()))
-        && (matches(colfMatcher, colfMatcher == null ? null : key.getColumnFamilyData()))
-        && (matches(colqMatcher, colqMatcher == null ? null : key.getColumnQualifierData()))
-        && (matches(valueMatcher, value.get(), 0, value.get().length)));
+      return (matches(rowMatcher, rowMatcher == null ? null : key.getRowData())
+          || matches(colfMatcher, colfMatcher == null ? null : key.getColumnFamilyData())
+          || matches(colqMatcher, colqMatcher == null ? null : key.getColumnQualifierData())
+          || matches(valueMatcher, value.get(), 0, value.get().length));
+    return (matches(rowMatcher, rowMatcher == null ? null : key.getRowData())
+        && matches(colfMatcher, colfMatcher == null ? null : key.getColumnFamilyData())
+        && matches(colqMatcher, colqMatcher == null ? null : key.getColumnQualifierData())
+        && matches(valueMatcher, value.get(), 0, value.get().length));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -142,10 +142,10 @@ public class AESCryptoService implements CryptoService {
     switch (parsed.getCryptoServiceVersion()) {
       case AESCBCCryptoModule.VERSION:
         cm = new AESCBCCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-        return (cm.getDecrypter(fek));
+        return cm.getDecrypter(fek);
       case AESGCMCryptoModule.VERSION:
         cm = new AESGCMCryptoModule(this.encryptingKek, this.keyLocation, this.keyManager);
-        return (cm.getDecrypter(fek));
+        return cm.getDecrypter(fek);
       default:
         throw new CryptoException(
             "Unknown crypto module version: " + parsed.getCryptoServiceVersion());
@@ -247,7 +247,7 @@ public class AESCryptoService implements CryptoService {
     Key ret = null;
     String keyTag = params.getKeyManagerVersion() + "!" + params.getKekId();
     if (this.decryptingKeys.get(keyTag) != null) {
-      return (this.decryptingKeys.get(keyTag));
+      return this.decryptingKeys.get(keyTag);
     }
 
     switch (params.keyManagerVersion) {
@@ -263,7 +263,7 @@ public class AESCryptoService implements CryptoService {
     if (ret == null)
       throw new CryptoException("Unable to load decryption KEK");
 
-    return (ret);
+    return ret;
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/fate/util/Retry.java
+++ b/core/src/main/java/org/apache/accumulo/fate/util/Retry.java
@@ -189,7 +189,7 @@ public class Retry {
     if (backOffFactor == 1)
       currentWait = Math.min(maxWait, currentWait + waitIncrement);
     else if (backOffFactor > 1.0) {
-      waitIncrement = (long) (Math.ceil(waitFactor * this.initialWait));
+      waitIncrement = (long) Math.ceil(waitFactor * this.initialWait);
       currentWait = Math.min(maxWait, initialWait + waitIncrement);
     }
   }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestInput.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestInput.java
@@ -121,7 +121,7 @@ public class IteratorTestInput {
     // Already immutable
     this.range = requireNonNull(range);
     // Make it immutable to the test
-    this.input = Collections.unmodifiableSortedMap((requireNonNull(input)));
+    this.input = Collections.unmodifiableSortedMap(requireNonNull(input));
     this.families = Collections.unmodifiableCollection(requireNonNull(families));
     this.inclusive = inclusive;
     this.iteratorEnvironment = iterEnv == null ? new SimpleIteratorEnvironment() : iterEnv;

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -307,7 +307,7 @@ public class ServerContext extends ClientContext {
    * Check to see if this version of Accumulo can run against or upgrade the passed in data version.
    */
   public static void ensureDataVersionCompatible(int dataVersion) {
-    if (!(AccumuloDataVersion.CAN_RUN.contains(dataVersion))) {
+    if (!AccumuloDataVersion.CAN_RUN.contains(dataVersion)) {
       throw new IllegalStateException("This version of accumulo (" + Constants.VERSION
           + ") is not compatible with files stored using data version " + dataVersion);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletServerState.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletServerState.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 
 public enum TabletServerState {
   // not a valid state, reserved for internal use only
-  RESERVED((byte) (-1)),
+  RESERVED((byte) -1),
 
   // the following are normally functioning states
   NEW((byte) 0),

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -180,7 +180,7 @@ public class SecurityOperation {
               SecurityErrorCode.BAD_CREDENTIALS);
         }
       } else {
-        if (!(context.getCredentials().equals(creds))) {
+        if (!context.getCredentials().equals(creds)) {
           log.debug("Provided credentials did not match server's expected"
               + " credentials. Expected {} but got {}", context.getCredentials(), creds);
           throw new ThriftSecurityException(creds.getPrincipal(),

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -760,7 +760,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           }
 
           if (compactionThread.isInterrupted() || JOB_HOLDER.isCancelled()
-              || ((err.get() != null && err.get().getClass().equals(InterruptedException.class)))) {
+              || (err.get() != null && err.get().getClass().equals(InterruptedException.class))) {
             LOG.warn("Compaction thread was interrupted, sending CANCELLED state");
             try {
               TCompactionStatusUpdate update = new TCompactionStatusUpdate(

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -252,7 +252,7 @@ public class UpgradeCoordinator {
       final ReadOnlyTStore<UpgradeCoordinator> fate =
           new ReadOnlyStore<>(new ZooStore<>(context.getZooKeeperRoot() + Constants.ZFATE,
               context.getZooReaderWriter()));
-      if (!(fate.list().isEmpty())) {
+      if (!fate.list().isEmpty()) {
         throw new AccumuloException("Aborting upgrade because there are"
             + " outstanding FATE transactions from a previous Accumulo version."
             + " You can start the tservers and then use the shell to delete completed "

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/MemValue.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/MemValue.java
@@ -36,7 +36,7 @@ public class MemValue {
     combinedBytes[0] = (byte) (kv >>> 24);
     combinedBytes[1] = (byte) (kv >>> 16);
     combinedBytes[2] = (byte) (kv >>> 8);
-    combinedBytes[3] = (byte) (kv);
+    combinedBytes[3] = (byte) kv;
     return new Value(combinedBytes);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ThriftClientHandler.java
@@ -638,7 +638,7 @@ public class ThriftClientHandler extends ClientServiceHandler implements TabletC
       // if user has no permission to write to this table, add it to
       // the failures list
       boolean sameTable = us.currentTablet != null
-          && (us.currentTablet.getExtent().tableId().equals(keyExtent.tableId()));
+          && us.currentTablet.getExtent().tableId().equals(keyExtent.tableId());
       tableId = keyExtent.tableId();
       if (sameTable || security.canWrite(us.getCredentials(), tableId,
           Tables.getNamespaceId(server.getContext(), tableId))) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Rate.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Rate.java
@@ -46,7 +46,7 @@ public class Rate {
       throw new IllegalArgumentException("update time < last value");
     }
     double keep = 1. - ratio;
-    current = (keep * current + ratio * ((counter - lastCounter)) * 1000. / (when - lastTime));
+    current = (keep * current + ratio * (counter - lastCounter) * 1000. / (when - lastTime));
     lastTime = when;
     lastCounter = counter;
     return current;

--- a/shell/src/main/java/org/apache/accumulo/shell/ShellCompletor.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/ShellCompletor.java
@@ -119,7 +119,7 @@ public class ShellCompletor implements Completer {
             }
           }
           Collections.sort(candidates);
-          return (prefix.length());
+          return prefix.length();
         }
         // need to match current command
         // if we're in -t <table>, -u <user>, or -tn <namespace> complete those
@@ -139,7 +139,7 @@ public class ShellCompletor implements Completer {
           candidates.addAll(current_command_token.getSubcommandNames(current_string_token));
 
         Collections.sort(candidates);
-        return (prefix.length());
+        return prefix.length();
       }
 
       if (current_string_token.trim().equals("-" + Shell.tableOption))

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -62,7 +62,7 @@ public class ConfigCommand extends Command {
     final Token cmd = new Token(getName());
     final Token sub = new Token("-" + setOpt.getOpt());
     for (Property p : Property.values()) {
-      if (!(p.getKey().endsWith(".")) && !p.isExperimental()) {
+      if (!p.getKey().endsWith(".") && !p.isExperimental()) {
         sub.addSubcommand(new Token(p.toString()));
       }
     }

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/HistoryCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/HistoryCommand.java
@@ -51,7 +51,7 @@ public class HistoryCommand extends Command {
 
   @Override
   public String description() {
-    return ("generates a list of commands previously executed");
+    return "generates a list of commands previously executed";
   }
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -148,7 +148,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
     }
     System.out.println("End of captured audit messages for step " + stepName);
     if (!result.isEmpty())
-      lastAuditTimestamp = (result.get(result.size() - 1)).substring(0, 23);
+      lastAuditTimestamp = result.get(result.size() - 1).substring(0, 23);
 
     return result;
   }

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -1127,7 +1127,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       ConditionalMutation cm = new ConditionalMutation(row, cond);
 
       cm.put("meta", "seq", (seq + 1) + "");
-      cm.put("meta", "sum", (sum) + "");
+      cm.put("meta", "sum", sum + "");
 
       for (int i = 0; i < data.length; i++) {
         cm.put("data", i + "", data[i] + "");

--- a/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NewTableConfigurationIT.java
@@ -266,7 +266,7 @@ public class NewTableConfigurationIT extends SharedMiniClusterBase {
       verifyIterators(client, tableName, new String[] {"table.iterator.scan.someName=10,foo.bar"},
           true);
       client.tableOperations().removeIterator(tableName, "someName",
-          EnumSet.allOf((IteratorScope.class)));
+          EnumSet.allOf(IteratorScope.class));
       verifyIterators(client, tableName, new String[] {}, true);
       Map<String,EnumSet<IteratorScope>> iteratorList2 =
           client.tableOperations().listIterators(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifyIngest.java
@@ -264,7 +264,7 @@ public class VerifyIngest {
       System.out.printf(
           "%,12d records read | %,8d records/sec | %,12d bytes read |"
               + " %,8d bytes/sec | %6.3f secs   %n",
-          recsRead, (int) ((recsRead) / ((t2 - t1) / 1000.0)), bytesRead,
+          recsRead, (int) (recsRead / ((t2 - t1) / 1000.0)), bytesRead,
           (int) (bytesRead / ((t2 - t1) / 1000.0)), (t2 - t1) / 1000.0);
     } else {
       throw new AccumuloException("Did not read expected number of rows. Saw "

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -190,7 +190,7 @@ public class ServiceLockIT {
 
   private static ServiceLock getZooLock(ServiceLockPath parent, UUID uuid) {
     var zooKeeper = ZooSession.getAuthenticatedSession(szk.getConn(), 30000, "digest",
-        ("accumulo:secret").getBytes(UTF_8));
+        "accumulo:secret".getBytes(UTF_8));
     return new ServiceLock(zooKeeper, parent, uuid);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsSplitIT.java
@@ -127,7 +127,7 @@ public class DeleteRowsSplitIT extends AccumuloClusterHarness {
   private void generateRandomRange(Text start, Text end) {
     List<String> bunch = new ArrayList<>(ROWS);
     Collections.shuffle(bunch);
-    if (bunch.get(0).compareTo((bunch.get(1))) < 0) {
+    if (bunch.get(0).compareTo(bunch.get(1)) < 0) {
       start.set(bunch.get(0));
       end.set(bunch.get(1));
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DurabilityIT.java
@@ -182,7 +182,7 @@ public class DurabilityIT extends ConfigurableMacBase {
         Mutation m = new Mutation("" + i);
         m.put("", "", "");
         bw.addMutation(m);
-        if (i % (Math.max(1, count / 100)) == 0) {
+        if (i % Math.max(1, count / 100) == 0) {
           bw.flush();
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletIT.java
@@ -95,7 +95,7 @@ public class TabletIT extends AccumuloClusterHarness {
       int count = 0;
       for (Entry<Key,Value> elt : scanner) {
         String expected = String.format("%05d", count);
-        assert (elt.getKey().getRow().toString().equals(expected));
+        assert elt.getKey().getRow().toString().equals(expected);
         count++;
       }
       assertEquals(N, count);

--- a/test/src/main/java/org/apache/accumulo/test/util/CertUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/CertUtils.java
@@ -281,7 +281,7 @@ public class CertUtils {
     Calendar endDate = Calendar.getInstance();
     endDate.add(Calendar.YEAR, 100);
 
-    BigInteger serialNumber = BigInteger.valueOf((startDate.getTimeInMillis()));
+    BigInteger serialNumber = BigInteger.valueOf(startDate.getTimeInMillis());
     X500Name issuer =
         new X500Name(IETFUtils.rDNsFromString(issuerDirString, RFC4519Style.INSTANCE));
     JcaX509v3CertificateBuilder certGen = new JcaX509v3CertificateBuilder(issuer, serialNumber,

--- a/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SlowOps.java
@@ -128,7 +128,7 @@ public class SlowOps {
       int count = 0;
       for (Map.Entry<Key,Value> elt : scanner) {
         String expected = String.format("%05d", count);
-        assert (elt.getKey().getRow().toString().equals(expected));
+        assert elt.getKey().getRow().toString().equals(expected);
         count++;
       }
       return count;


### PR DESCRIPTION
Remove instances of unneeded parentheses in situations where the code will not be misinterpreted without them.