### PR TITLE
Added FaTE TStatus.SUBMITTED

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -459,6 +459,7 @@ public class AdminUtil<T> {
         System.out.printf("Invalid transaction ID: %016x%n", txid);
         break;
 
+      case SUBMITTED:
       case IN_PROGRESS:
       case NEW:
       case FAILED:
@@ -494,6 +495,7 @@ public class AdminUtil<T> {
         System.out.printf("Invalid transaction ID: %016x%n", txid);
         break;
 
+      case SUBMITTED:
       case IN_PROGRESS:
       case NEW:
         System.out.printf("Failing transaction: %016x (%s)%n", txid, ts);

--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -94,7 +94,6 @@ public class AgeOffStore<T> implements TStore<T> {
         try {
           switch (store.getStatus(txid)) {
             case NEW:
-            case SUBMITTED:
             case FAILED:
             case SUCCESSFUL:
               store.delete(txid);
@@ -127,7 +126,6 @@ public class AgeOffStore<T> implements TStore<T> {
       try {
         switch (store.getStatus(txid)) {
           case NEW:
-          case SUBMITTED:
           case FAILED:
           case SUCCESSFUL:
             addCandidate(txid);

--- a/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AgeOffStore.java
@@ -94,6 +94,7 @@ public class AgeOffStore<T> implements TStore<T> {
         try {
           switch (store.getStatus(txid)) {
             case NEW:
+            case SUBMITTED:
             case FAILED:
             case SUCCESSFUL:
               store.delete(txid);
@@ -126,6 +127,7 @@ public class AgeOffStore<T> implements TStore<T> {
       try {
         switch (store.getStatus(txid)) {
           case NEW:
+          case SUBMITTED:
           case FAILED:
           case SUCCESSFUL:
             addCandidate(txid);
@@ -190,6 +192,7 @@ public class AgeOffStore<T> implements TStore<T> {
     store.setStatus(tid, status);
 
     switch (status) {
+      case SUBMITTED:
       case IN_PROGRESS:
       case FAILED_IN_PROGRESS:
         removeCandidate(tid);

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -81,7 +81,7 @@ public class Fate<T> {
 
               if (deferTime == 0) {
                 prevOp = op;
-                if (status.equals(TStatus.SUBMITTED)) {
+                if (status == TStatus.SUBMITTED) {
                   store.setStatus(tid, TStatus.IN_PROGRESS);
                 }
                 op = op.call(tid, environment);

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -81,6 +81,9 @@ public class Fate<T> {
 
               if (deferTime == 0) {
                 prevOp = op;
+                if (status.equals(TStatus.SUBMITTED)) {
+                  store.setStatus(tid, TStatus.IN_PROGRESS);
+                }
                 op = op.call(tid, environment);
               } else
                 continue;
@@ -284,7 +287,7 @@ public class Fate<T> {
 
         store.setProperty(tid, DEBUG_PROP, repo.getDescription());
 
-        store.setStatus(tid, TStatus.IN_PROGRESS);
+        store.setStatus(tid, TStatus.SUBMITTED);
       }
     } finally {
       store.unreserve(tid, 0);
@@ -303,6 +306,7 @@ public class Fate<T> {
     try {
       switch (store.getStatus(tid)) {
         case NEW:
+        case SUBMITTED:
         case FAILED:
         case SUCCESSFUL:
           store.delete(tid);

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
@@ -36,8 +36,6 @@ public interface ReadOnlyTStore<T> {
   enum TStatus {
     /** Unseeded transaction */
     NEW,
-    /** Transaction that is eligible to be executed */
-    SUBMITTED,
     /** Transaction that is executing */
     IN_PROGRESS,
     /** Transaction has failed, and is in the process of being rolled back */
@@ -47,7 +45,9 @@ public interface ReadOnlyTStore<T> {
     /** Transaction has succeeded */
     SUCCESSFUL,
     /** Unrecognized or unknown transaction state */
-    UNKNOWN
+    UNKNOWN,
+    /** Transaction that is eligible to be executed */
+    SUBMITTED
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyTStore.java
@@ -36,7 +36,9 @@ public interface ReadOnlyTStore<T> {
   enum TStatus {
     /** Unseeded transaction */
     NEW,
-    /** Transaction is eligible to be executing */
+    /** Transaction that is eligible to be executed */
+    SUBMITTED,
+    /** Transaction that is executing */
     IN_PROGRESS,
     /** Transaction has failed, and is in the process of being rolled back */
     FAILED_IN_PROGRESS,

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -174,8 +174,8 @@ public class ZooStore<T> implements TStore<T> {
 
           try {
             TStatus status = TStatus.valueOf(new String(zk.getData(path + "/" + txdir), UTF_8));
-            if (status.equals(TStatus.SUBMITTED) || status.equals(TStatus.IN_PROGRESS)
-                || status.equals(TStatus.FAILED_IN_PROGRESS)) {
+            if (status == TStatus.SUBMITTED || status == TStatus.IN_PROGRESS
+                || status == TStatus.FAILED_IN_PROGRESS) {
               return tid;
             } else {
               unreserve(tid);

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -174,7 +174,8 @@ public class ZooStore<T> implements TStore<T> {
 
           try {
             TStatus status = TStatus.valueOf(new String(zk.getData(path + "/" + txdir), UTF_8));
-            if (status == TStatus.IN_PROGRESS || status == TStatus.FAILED_IN_PROGRESS) {
+            if (status.equals(TStatus.SUBMITTED) || status.equals(TStatus.IN_PROGRESS)
+                || status.equals(TStatus.FAILED_IN_PROGRESS)) {
               return tid;
             } else {
               unreserve(tid);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -56,6 +56,7 @@ public class FateMetrics implements MetricsProducer {
   private AtomicLong totalOpsGauge;
   private AtomicLong fateErrorsGauge;
   private AtomicLong newTxGauge;
+  private AtomicLong submittedTxGauge;
   private AtomicLong inProgressTxGauge;
   private AtomicLong failedInProgressTxGauge;
   private AtomicLong failedTxGauge;
@@ -95,6 +96,9 @@ public class FateMetrics implements MetricsProducer {
         case NEW:
           newTxGauge.set(vals.getValue());
           break;
+        case SUBMITTED:
+          submittedTxGauge.set(vals.getValue());
+          break;
         case IN_PROGRESS:
           inProgressTxGauge.set(vals.getValue());
           break;
@@ -130,6 +134,8 @@ public class FateMetrics implements MetricsProducer {
         Tags.concat(MetricsUtil.getCommonTags(), "type", "zk.connection"), new AtomicLong(0));
     newTxGauge = registry.gauge(METRICS_FATE_TX, Tags.concat(MetricsUtil.getCommonTags(), "state",
         ReadOnlyTStore.TStatus.NEW.name().toLowerCase()), new AtomicLong(0));
+    submittedTxGauge = registry.gauge(METRICS_FATE_TX, Tags.concat(MetricsUtil.getCommonTags(),
+        "state", ReadOnlyTStore.TStatus.SUBMITTED.name().toLowerCase()), new AtomicLong(0));
     inProgressTxGauge = registry.gauge(METRICS_FATE_TX, Tags.concat(MetricsUtil.getCommonTags(),
         "state", ReadOnlyTStore.TStatus.IN_PROGRESS.name().toLowerCase()), new AtomicLong(0));
     failedInProgressTxGauge =

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.fate.zookeeper;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.fate.AgeOffStore;
+import org.apache.accumulo.fate.Fate;
+import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
+import org.apache.accumulo.fate.Repo;
+import org.apache.accumulo.fate.ZooStore;
+import org.apache.accumulo.fate.util.UtilWaitThread;
+import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.manager.Manager;
+import org.apache.accumulo.manager.tableOps.ManagerRepo;
+import org.apache.accumulo.manager.tableOps.TraceRepo;
+import org.apache.accumulo.manager.tableOps.Utils;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
+import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
+import org.apache.zookeeper.KeeperException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ZooKeeperTestingServerTests.class})
+public class FateIT {
+
+  public static class TestOperation extends ManagerRepo {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TableId tableId;
+    private final NamespaceId namespaceId;
+
+    public TestOperation(NamespaceId namespaceId, TableId tableId) {
+      this.namespaceId = namespaceId;
+      this.tableId = tableId;
+    }
+
+    @Override
+    public long isReady(long tid, Manager manager) throws Exception {
+      return Utils.reserveNamespace(manager, namespaceId, tid, false, true, TableOperation.RENAME)
+          + Utils.reserveTable(manager, tableId, tid, true, true, TableOperation.RENAME);
+    }
+
+    @Override
+    public void undo(long tid, Manager manager) throws Exception {
+      Utils.unreserveNamespace(manager, namespaceId, tid, false);
+      Utils.unreserveTable(manager, tableId, tid, true);
+    }
+
+    @Override
+    public Repo<Manager> call(long tid, Manager environment) throws Exception {
+      FateIT.inCall();
+      return null;
+    }
+
+  }
+
+  private static ZooKeeperTestingServer szk = null;
+  private static final String ZK_ROOT = "/accumulo/" + UUID.randomUUID().toString();
+  private static final NamespaceId NS = NamespaceId.of("testNameSpace");
+  private static final TableId TID = TableId.of("testTable");
+
+  private static CountDownLatch callStarted;
+  private static CountDownLatch finishCall;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    szk = new ZooKeeperTestingServer();
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    szk.close();
+  }
+
+  @Test(timeout = 30000)
+  public void testTransactionStatus() throws Exception {
+    ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 30000, "secret");
+
+    zk.mkdirs(ZK_ROOT + Constants.ZFATE);
+    zk.mkdirs(ZK_ROOT + Constants.ZTABLE_LOCKS);
+    zk.mkdirs(ZK_ROOT + Constants.ZNAMESPACES + "/" + NS.canonical());
+    zk.mkdirs(ZK_ROOT + Constants.ZTABLE_STATE + "/" + TID.canonical());
+    zk.mkdirs(ZK_ROOT + Constants.ZTABLES + "/" + TID.canonical());
+
+    ZooStore<Manager> zooStore = new ZooStore<Manager>(ZK_ROOT + Constants.ZFATE, zk);
+    final AgeOffStore<Manager> store = new AgeOffStore<Manager>(zooStore, 1000 * 60 * 60 * 8);
+
+    Manager manager = createMock(Manager.class);
+    ServerContext sctx = createMock(ServerContext.class);
+    expect(manager.getContext()).andReturn(sctx).anyTimes();
+    expect(sctx.getZooKeeperRoot()).andReturn(ZK_ROOT).anyTimes();
+    expect(sctx.getZooReaderWriter()).andReturn(zk).anyTimes();
+    replay(manager, sctx);
+
+    Fate<Manager> fate = new Fate<Manager>(manager, store, TraceRepo::toLogString);
+    try {
+      ConfigurationCopy config = new ConfigurationCopy();
+      config.set(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "2");
+      config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, "1");
+      fate.startTransactionRunners(config);
+
+      // Wait for the transaction runner to be scheduled.
+      UtilWaitThread.sleep(3000);
+
+      callStarted = new CountDownLatch(1);
+      finishCall = new CountDownLatch(1);
+
+      long txid = fate.startTransaction();
+      assertEquals(TStatus.NEW, getTxStatus(zk, txid));
+      fate.seedTransaction(txid, new TestOperation(NS, TID), true);
+      assertEquals(TStatus.SUBMITTED, getTxStatus(zk, txid));
+      // wait for call() to be called
+      callStarted.await();
+      assertEquals(TStatus.IN_PROGRESS, getTxStatus(zk, txid));
+      // tell the op to exit the method
+      finishCall.countDown();
+      // Check that it transitions to SUCCESSFUL
+      TStatus s = getTxStatus(zk, txid);
+      while (!s.equals(TStatus.SUCCESSFUL)) {
+        s = getTxStatus(zk, txid);
+      }
+      // Check that it gets removed
+      boolean errorSeen = false;
+      while (!errorSeen) {
+        try {
+          s = getTxStatus(zk, txid);
+        } catch (KeeperException e) {
+          if (e.code() == KeeperException.Code.NONODE) {
+            errorSeen = true;
+          } else {
+            fail("Unexpected error thrown: " + e.getMessage());
+          }
+        }
+      }
+
+    } finally {
+      fate.shutdown();
+    }
+  }
+
+  public static void inCall() throws InterruptedException {
+    // signal that call started
+    callStarted.countDown();
+    // wait for the signal to exit the method
+    finishCall.await();
+  }
+
+  /*
+   * Get the status of the TX from ZK directly. Unable to call ZooStore.getStatus because this test
+   * thread does not have the reservation (the FaTE thread does)
+   */
+  private static TStatus getTxStatus(ZooReaderWriter zrw, long txid)
+      throws KeeperException, InterruptedException {
+    String txdir = String.format("%s/tx_%016x", ZK_ROOT + Constants.ZFATE, txid);
+    return TStatus.valueOf(new String(zrw.getData(txdir), UTF_8));
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -151,7 +151,7 @@ public class FateIT {
       finishCall.countDown();
       // Check that it transitions to SUCCESSFUL
       TStatus s = getTxStatus(zk, txid);
-      while (!s.equals(TStatus.SUCCESSFUL)) {
+      while (s != TStatus.SUCCESSFUL) {
         s = getTxStatus(zk, txid);
         Thread.sleep(10);
       }

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -153,12 +153,14 @@ public class FateIT {
       TStatus s = getTxStatus(zk, txid);
       while (!s.equals(TStatus.SUCCESSFUL)) {
         s = getTxStatus(zk, txid);
+        Thread.sleep(10);
       }
       // Check that it gets removed
       boolean errorSeen = false;
       while (!errorSeen) {
         try {
           s = getTxStatus(zk, txid);
+          Thread.sleep(10);
         } catch (KeeperException e) {
           if (e.code() == KeeperException.Code.NONODE) {
             errorSeen = true;
@@ -173,7 +175,7 @@ public class FateIT {
     }
   }
 
-  public static void inCall() throws InterruptedException {
+  private static void inCall() throws InterruptedException {
     // signal that call started
     callStarted.countDown();
     // wait for the signal to exit the method
@@ -186,7 +188,7 @@ public class FateIT {
    */
   private static TStatus getTxStatus(ZooReaderWriter zrw, long txid)
       throws KeeperException, InterruptedException {
-    String txdir = String.format("%s/tx_%016x", ZK_ROOT + Constants.ZFATE, txid);
+    String txdir = String.format("%s%s/tx_%016x", ZK_ROOT, Constants.ZFATE, txid);
     return TStatus.valueOf(new String(zrw.getData(txdir), UTF_8));
   }
 


### PR DESCRIPTION
When a FaTE transaction is created in the Manager its status is set
to IN_PROGRESS even though it's not actually running, it could be
waiting to run. The output from the `fate print` command will show
that the newly created transaction is IN_PROGRESS and could be
confusing to users. This change introduces the SUBMITTED state, which
is the state of the transaction after it has been created but before
it is executed.