### PR TITLE
Convert try-catch to assertThrows

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/client/RowIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/RowIteratorTest.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -74,10 +74,7 @@ public class RowIteratorTest {
     assertEquals(1, rows.get(1).size());
 
     RowIterator i = new RowIterator(makeIterator());
-    try {
-      i.next();
-      fail();
-    } catch (NoSuchElementException ex) {}
+    assertThrows(NoSuchElementException.class, i::next);
 
     i = new RowIterator(makeIterator("a b c d", "a 1 2 3"));
     assertTrue(i.hasNext());
@@ -87,17 +84,11 @@ public class RowIteratorTest {
     assertTrue(row.hasNext());
     row.next();
     assertFalse(row.hasNext());
-    try {
-      row.next();
-      fail();
-    } catch (NoSuchElementException ex) {}
+    assertThrows(NoSuchElementException.class, row::next);
     assertEquals(0, i.getKVCount());
     assertFalse(i.hasNext());
     assertEquals(2, i.getKVCount());
-    try {
-      i.next();
-      fail();
-    } catch (NoSuchElementException ex) {}
+    assertThrows(NoSuchElementException.class, i::next);
   }
 
   @Test
@@ -112,13 +103,7 @@ public class RowIteratorTest {
     assertEquals(2, i.getKVCount());
     assertFalse(i.hasNext());
     assertEquals(3, i.getKVCount());
-    try {
-      firstRow.hasNext();
-      fail();
-    } catch (IllegalStateException e) {}
-    try {
-      nextRow.next();
-      fail();
-    } catch (IllegalStateException e) {}
+    assertThrows(IllegalStateException.class, firstRow::hasNext);
+    assertThrows(IllegalStateException.class, nextRow::next);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/TestThrift1474.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/TestThrift1474.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.client;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -83,12 +83,7 @@ public class TestThrift1474 {
     ThriftTest.Client client = new ThriftTest.Client(protocol);
     assertTrue(client.success());
     assertFalse(client.fails());
-    try {
-      client.throwsError();
-      fail("no exception thrown");
-    } catch (ThriftSecurityException ex) {
-      // expected
-    }
+    assertThrows(ThriftSecurityException.class, client::throwsError);
     server.stop();
     thread.join();
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ScannerOptionsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ScannerOptionsTest.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.core.clientImpl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import java.util.SortedSet;
 
@@ -53,14 +52,10 @@ public class ScannerOptionsTest {
   public void testIteratorConflict() {
     try (ScannerOptions options = new ScannerOptions()) {
       options.addScanIterator(new IteratorSetting(1, "NAME", DebugIterator.class));
-      try {
-        options.addScanIterator(new IteratorSetting(2, "NAME", DebugIterator.class));
-        fail();
-      } catch (IllegalArgumentException e) {}
-      try {
-        options.addScanIterator(new IteratorSetting(1, "NAME2", DebugIterator.class));
-        fail();
-      } catch (IllegalArgumentException e) {}
+      assertThrows(IllegalArgumentException.class,
+          () -> options.addScanIterator(new IteratorSetting(2, "NAME", DebugIterator.class)));
+      assertThrows(IllegalArgumentException.class,
+          () -> options.addScanIterator(new IteratorSetting(1, "NAME2", DebugIterator.class)));
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.clientImpl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -327,23 +327,15 @@ public class TableOperationsHelperTest {
             "table.iterator.minc.otherName.opt.key=value",
             "table.iterator.scan.otherName=20,some.classname",});
 
-    try {
-      t.attachIterator("table", setting);
-      fail();
-    } catch (AccumuloException e) {
-      // expected, ignore
-    }
+    IteratorSetting finalSetting = setting; // effectively final var needed for lambda below
+    assertThrows(AccumuloException.class, () -> t.attachIterator("table", finalSetting));
     setting.setName("thirdName");
-    try {
-      t.attachIterator("table", setting);
-      fail();
-    } catch (AccumuloException e) {}
+    IteratorSetting finalSetting1 = setting; // effectively final var needed for lambda below
+    assertThrows(AccumuloException.class, () -> t.attachIterator("table", finalSetting1));
     setting.setPriority(10);
     t.setProperty("table", "table.iterator.minc.thirdName.opt.key", "value");
-    try {
-      t.attachIterator("table", setting);
-      fail();
-    } catch (AccumuloException e) {}
+    IteratorSetting finalSetting2 = setting; // effectively final var needed for lambda below
+    assertThrows(AccumuloException.class, () -> t.attachIterator("table", finalSetting2));
     t.removeProperty("table", "table.iterator.minc.thirdName.opt.key");
     t.attachIterator("table", setting);
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
@@ -314,12 +314,13 @@ public class TableOperationsHelperTest {
     assertEquals(20, setting.getPriority());
     assertEquals("some.classname", setting.getIteratorClass());
     assertTrue(setting.getOptions().isEmpty());
-    setting = t.getIteratorSetting("table", "otherName", IteratorScope.majc);
-    assertEquals(20, setting.getPriority());
-    assertEquals("some.classname", setting.getIteratorClass());
-    assertFalse(setting.getOptions().isEmpty());
-    assertEquals(Collections.singletonMap("key", "value"), setting.getOptions());
-    t.attachIterator("table", setting, EnumSet.of(IteratorScope.minc));
+
+    final IteratorSetting setting1 = t.getIteratorSetting("table", "otherName", IteratorScope.majc);
+    assertEquals(20, setting1.getPriority());
+    assertEquals("some.classname", setting1.getIteratorClass());
+    assertFalse(setting1.getOptions().isEmpty());
+    assertEquals(Collections.singletonMap("key", "value"), setting1.getOptions());
+    t.attachIterator("table", setting1, EnumSet.of(IteratorScope.minc));
     check(t, "table",
         new String[] {"table.iterator.majc.otherName=20,some.classname",
             "table.iterator.majc.otherName.opt.key=value",
@@ -327,16 +328,13 @@ public class TableOperationsHelperTest {
             "table.iterator.minc.otherName.opt.key=value",
             "table.iterator.scan.otherName=20,some.classname",});
 
-    IteratorSetting finalSetting = setting; // effectively final var needed for lambda below
-    assertThrows(AccumuloException.class, () -> t.attachIterator("table", finalSetting));
-    setting.setName("thirdName");
-    IteratorSetting finalSetting1 = setting; // effectively final var needed for lambda below
-    assertThrows(AccumuloException.class, () -> t.attachIterator("table", finalSetting1));
-    setting.setPriority(10);
+    assertThrows(AccumuloException.class, () -> t.attachIterator("table", setting1));
+    setting1.setName("thirdName");
+    assertThrows(AccumuloException.class, () -> t.attachIterator("table", setting1));
+    setting1.setPriority(10);
     t.setProperty("table", "table.iterator.minc.thirdName.opt.key", "value");
-    IteratorSetting finalSetting2 = setting; // effectively final var needed for lambda below
-    assertThrows(AccumuloException.class, () -> t.attachIterator("table", finalSetting2));
+    assertThrows(AccumuloException.class, () -> t.attachIterator("table", setting1));
     t.removeProperty("table", "table.iterator.minc.thirdName.opt.key");
-    t.attachIterator("table", setting);
+    t.attachIterator("table", setting1);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1281,8 +1282,9 @@ public class TabletLocatorImplTest {
     setLocation(tservers, "tserver2", MTE, ke1, "L1", "I1");
     setLocation(tservers, "tserver2", MTE, ke1, "L2", "I2");
 
-    assertThrows(Exception.class,
+    var e = assertThrows(IllegalStateException.class,
         () -> metaCache.locateTablet(context, new Text("a"), false, false));
+    assertTrue(e.getMessage().startsWith("Tablet has multiple locations : "));
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -22,7 +22,7 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1278,12 +1278,8 @@ public class TabletLocatorImplTest {
     setLocation(tservers, "tserver2", MTE, ke1, "L1", "I1");
     setLocation(tservers, "tserver2", MTE, ke1, "L2", "I2");
 
-    try {
-      metaCache.locateTablet(context, new Text("a"), false, false);
-      fail();
-    } catch (Exception e) {
-
-    }
+    assertThrows(Exception.class,
+        () -> metaCache.locateTablet(context, new Text("a"), false, false));
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/AbstractLexicoderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/lexicoder/AbstractLexicoderTest.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.clientImpl.lexicoder;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.client.lexicoder.AbstractLexicoder;
 import org.apache.accumulo.core.client.lexicoder.LexicoderTest;
@@ -68,30 +68,20 @@ public abstract class AbstractLexicoderTest extends LexicoderTest {
 
   protected static <T> void assertOutOfBoundsFails(AbstractLexicoder<T> lexicoder, byte[] encoded) {
     // decode null; should fail
-    try {
-      lexicoder.decode(null, 0, encoded.length);
-      fail("Should throw on null bytes.");
-    } catch (NullPointerException e) {}
+    assertThrows("Should throw on null bytes.", NullPointerException.class,
+        () -> lexicoder.decode(null, 0, encoded.length));
 
     // decode out of bounds, expect an exception
-    try {
-      lexicoder.decode(encoded, 0, encoded.length + 1);
-      fail("Should throw on exceeding length.");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("Should throw on exceeding length.", IllegalArgumentException.class,
+        () -> lexicoder.decode(encoded, 0, encoded.length + 1));
 
-    try {
-      lexicoder.decode(encoded, -1, encoded.length);
-      fail("Should throw on negative offset.");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("Should throw on negative offset.", IllegalArgumentException.class,
+        () -> lexicoder.decode(encoded, -1, encoded.length));
 
-    try {
-      lexicoder.decode(encoded, 0, -1);
-      fail("Should throw on negative length.");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("Should throw on negative length.", IllegalArgumentException.class,
+        () -> lexicoder.decode(encoded, 0, -1));
 
-    try {
-      lexicoder.decode(encoded, 1, -1);
-      fail("Should throw on negative length, even if (offset+len) is within bounds.");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("Should throw on negative length, even if (offset+len) is within bounds.",
+        IllegalArgumentException.class, () -> lexicoder.decode(encoded, 1, -1));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.data;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -883,10 +884,8 @@ public class RangeTest {
     ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
     Range r2 = new Range();
     try (DataInputStream dis = new DataInputStream(bais)) {
-      r2.readFields(dis);
-      fail("readFields allowed invalid range");
-    } catch (InvalidObjectException exc) {
-      /* good! */
+      assertThrows("readFields allowed invalid range", InvalidObjectException.class,
+          () -> r2.readFields(dis));
     }
   }
 
@@ -903,11 +902,7 @@ public class RangeTest {
     Range r =
         new Range(new Key(new Text("soup")), true, false, new Key(new Text("nuts")), true, false);
     TRange tr = r.toThrift();
-    try {
-      new Range(tr);
-      fail("Thrift constructor allowed invalid range");
-    } catch (IllegalArgumentException exc) {
-      /* good! */
-    }
+    assertThrows("Thrift constructor allowed invalid range", IllegalArgumentException.class,
+        () -> new Range(tr));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/RangeTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -621,13 +620,7 @@ public class RangeTest {
   }
 
   private void runClipTest(Range fence, Range range) {
-    try {
-      fence.clip(range);
-      fail();
-    } catch (IllegalArgumentException e) {
-
-    }
-
+    assertThrows(IllegalArgumentException.class, () -> fence.clip(range));
   }
 
   private void runClipTest(Range fence, Range range, Range expected) {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -585,40 +584,17 @@ public class RFileTest {
     trf.openWriter();
 
     trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 55), newValue("foo1"));
-    try {
-      trf.writer.append(newKey("r0", "cf1", "cq1", "L1", 55), newValue("foo1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
 
-    }
-
-    try {
-      trf.writer.append(newKey("r1", "cf0", "cq1", "L1", 55), newValue("foo1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
-
-    try {
-      trf.writer.append(newKey("r1", "cf1", "cq0", "L1", 55), newValue("foo1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
-
-    try {
-      trf.writer.append(newKey("r1", "cf1", "cq1", "L0", 55), newValue("foo1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
-
-    try {
-      trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 56), newValue("foo1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("r0", "cf1", "cq1", "L1", 55), newValue("foo1")));
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("r1", "cf0", "cq1", "L1", 55), newValue("foo1")));
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("r1", "cf1", "cq0", "L1", 55), newValue("foo1")));
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("r1", "cf1", "cq1", "L0", 55), newValue("foo1")));
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 56), newValue("foo1")));
   }
 
   @Test
@@ -1291,12 +1267,8 @@ public class RFileTest {
 
     trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
 
-    try {
-      trf.writer.append(newKey("0009", "c", "cq1", "", 4), newValue("1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("0009", "c", "cq1", "", 4), newValue("1")));
 
     trf.closeWriter();
 
@@ -1326,19 +1298,11 @@ public class RFileTest {
 
     trf.writer.startDefaultLocalityGroup();
 
-    try {
-      trf.writer.append(newKey("0008", "a", "cq1", "", 4), newValue("1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("0008", "a", "cq1", "", 4), newValue("1")));
 
-    }
-
-    try {
-      trf.writer.append(newKey("0009", "b", "cq1", "", 4), newValue("1"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.append(newKey("0009", "b", "cq1", "", 4), newValue("1")));
 
     trf.closeWriter();
 
@@ -1361,19 +1325,10 @@ public class RFileTest {
     trf.openWriter(false);
 
     trf.writer.startDefaultLocalityGroup();
-    try {
-      trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
-      fail();
-    } catch (IllegalStateException ioe) {
+    assertThrows(IllegalStateException.class,
+        () -> trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b")));
 
-    }
-
-    try {
-      trf.writer.startDefaultLocalityGroup();
-      fail();
-    } catch (IllegalStateException ioe) {
-
-    }
+    assertThrows(IllegalStateException.class, () -> trf.writer.startDefaultLocalityGroup());
 
     trf.writer.close();
   }
@@ -1387,12 +1342,8 @@ public class RFileTest {
     trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
 
     trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
-    try {
-      trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("b", "c"));
-      fail();
-    } catch (IllegalArgumentException ioe) {
-
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("b", "c")));
 
     trf.closeWriter();
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -580,21 +580,26 @@ public class RFileTest {
   @Test
   public void test4() throws IOException {
     TestRFile trf = new TestRFile(conf);
-
     trf.openWriter();
+    RFile.Writer writer = trf.writer;
 
-    trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 55), newValue("foo1"));
+    final Value foo1 = newValue("foo1");
+    final long ts = 55L;
 
-    assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("r0", "cf1", "cq1", "L1", 55), newValue("foo1")));
-    assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("r1", "cf0", "cq1", "L1", 55), newValue("foo1")));
-    assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("r1", "cf1", "cq0", "L1", 55), newValue("foo1")));
-    assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("r1", "cf1", "cq1", "L0", 55), newValue("foo1")));
-    assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("r1", "cf1", "cq1", "L1", 56), newValue("foo1")));
+    writer.append(newKey("r1", "cf1", "cq1", "L1", ts), foo1);
+
+    // @formatter:off
+    final List<Key> badKeys = List.of(
+            newKey("r0", "cf1", "cq1", "L1", ts),
+            newKey("r1", "cf0", "cq1", "L1", ts),
+            newKey("r1", "cf1", "cq0", "L1", ts),
+            newKey("r1", "cf1", "cq1", "L0", ts),
+            newKey("r1", "cf1", "cq1", "L1", ts + 1)
+    );
+    // @formatter:on
+
+    badKeys.forEach(
+        key -> assertThrows(IllegalArgumentException.class, () -> writer.append(key, foo1)));
   }
 
   @Test
@@ -1294,15 +1299,17 @@ public class RFileTest {
 
     trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
 
-    trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
+    final Value valueOf1 = newValue("1");
+
+    trf.writer.append(newKey("0007", "a", "cq1", "", 4), valueOf1);
 
     trf.writer.startDefaultLocalityGroup();
 
     assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("0008", "a", "cq1", "", 4), newValue("1")));
+        () -> trf.writer.append(newKey("0008", "a", "cq1", "", 4), valueOf1));
 
     assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.append(newKey("0009", "b", "cq1", "", 4), newValue("1")));
+        () -> trf.writer.append(newKey("0009", "b", "cq1", "", 4), valueOf1));
 
     trf.closeWriter();
 
@@ -1311,7 +1318,7 @@ public class RFileTest {
     trf.iter.seek(new Range(), EMPTY_COL_FAMS, false);
     assertTrue(trf.iter.hasTop());
     assertEquals(newKey("0007", "a", "cq1", "", 4), trf.iter.getTopKey());
-    assertEquals(newValue("1"), trf.iter.getTopValue());
+    assertEquals(valueOf1, trf.iter.getTopValue());
     trf.iter.next();
     assertFalse(trf.iter.hasTop());
 
@@ -1325,8 +1332,10 @@ public class RFileTest {
     trf.openWriter(false);
 
     trf.writer.startDefaultLocalityGroup();
+
+    Set<ByteSequence> columnFamilies = newColFamByteSequence("a", "b");
     assertThrows(IllegalStateException.class,
-        () -> trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b")));
+        () -> trf.writer.startNewLocalityGroup("lg1", columnFamilies));
 
     assertThrows(IllegalStateException.class, () -> trf.writer.startDefaultLocalityGroup());
 
@@ -1342,8 +1351,10 @@ public class RFileTest {
     trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("a", "b"));
 
     trf.writer.append(newKey("0007", "a", "cq1", "", 4), newValue("1"));
+
+    Set<ByteSequence> columnFamilies = newColFamByteSequence("b", "c");
     assertThrows(IllegalArgumentException.class,
-        () -> trf.writer.startNewLocalityGroup("lg1", newColFamByteSequence("b", "c")));
+        () -> trf.writer.startNewLocalityGroup("lg1", columnFamilies));
 
     trf.closeWriter();
   }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
@@ -245,12 +245,22 @@ public class DeletingIteratorTest {
     SortedKeyValueIterator<Key,Value> it =
         DeletingIterator.wrap(new SortedMapIterator(tm), false, Behavior.FAIL);
     it.seek(new Range(), EMPTY_COL_FAMS, false);
-    assertThrows(IllegalStateException.class, () -> {
-      while (it.hasTop()) {
-        it.getTopKey();
-        it.next();
-      }
-    });
+
+    // first entry should pass
+    it.getTopKey();
+    it.next();
+
+    // second entry should fail due to delete
+    assertThrows(IllegalStateException.class, it::getTopKey);
+    it.next();
+
+    // third entry should pass
+    it.getTopKey();
+    it.next();
+
+    // fourth entry should pass
+    it.getTopKey();
+    it.next();
   }
 
   private Range newRange(String row, long ts, boolean inclusive) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/DeletingIteratorTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.iterators.system;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -244,13 +245,12 @@ public class DeletingIteratorTest {
     SortedKeyValueIterator<Key,Value> it =
         DeletingIterator.wrap(new SortedMapIterator(tm), false, Behavior.FAIL);
     it.seek(new Range(), EMPTY_COL_FAMS, false);
-    try {
+    assertThrows(IllegalStateException.class, () -> {
       while (it.hasTop()) {
         it.getTopKey();
         it.next();
       }
-      fail();
-    } catch (IllegalStateException e) {}
+    });
   }
 
   private Range newRange(String row, long ts, boolean inclusive) {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.core.iterators.system;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -286,10 +286,8 @@ public class SourceSwitchingIteratorTest {
 
     flag.set(true);
 
-    try {
-      ssi.seek(new Range("r1"), new ArrayList<>(), false);
-      fail("expected to see IterationInterruptedException");
-    } catch (IterationInterruptedException iie) {}
+    assertThrows(IterationInterruptedException.class,
+        () -> ssi.seek(new Range("r1"), new ArrayList<>(), false));
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
@@ -280,14 +280,17 @@ public class SourceSwitchingIteratorTest {
 
     assertSame(flag, tds.iflag);
 
-    ssi.seek(new Range("r1"), new ArrayList<>(), false);
+    final Range r1Range = new Range("r1");
+    final List<ByteSequence> columnFamilies = List.of();
+
+    ssi.seek(r1Range, columnFamilies, false);
     testAndCallNext(ssi, "r1", "cf1", "cq1", 5, "v1", true);
     assertFalse(ssi.hasTop());
 
     flag.set(true);
 
     assertThrows(IterationInterruptedException.class,
-        () -> ssi.seek(new Range("r1"), new ArrayList<>(), false));
+        () -> ssi.seek(r1Range, columnFamilies, false));
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/ColumnSliceFilterTest.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.iterators.user;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -236,32 +236,20 @@ public class ColumnSliceFilterTest {
 
   @Test
   public void testStartAfterEnd() {
-    try {
-      ColumnSliceFilter.setSlice(is, "20080204", "20080202");
-      fail("IllegalArgumentException expected but not thrown");
-    } catch (IllegalArgumentException expectedException) {
-      // Exception successfully thrown
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> ColumnSliceFilter.setSlice(is, "20080204", "20080202"));
   }
 
   @Test
   public void testStartEqualToEndStartInclusiveEndExclusive() {
-    try {
-      ColumnSliceFilter.setSlice(is, "20080202", "20080202");
-      fail("IllegalArgumentException expected but not thrown");
-    } catch (IllegalArgumentException expectedException) {
-      // Exception successfully thrown
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> ColumnSliceFilter.setSlice(is, "20080202", "20080202"));
   }
 
   @Test
   public void testStartEqualToEndStartExclusiveEndInclusive() {
-    try {
-      ColumnSliceFilter.setSlice(is, "20080202", false, "20080202", true);
-      fail("IllegalArgumentException expected but not thrown");
-    } catch (IllegalArgumentException expectedException) {
-      // Exception successfully thrown
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> ColumnSliceFilter.setSlice(is, "20080202", false, "20080202", true));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -936,7 +936,8 @@ public class CombinerTest {
     assertTrue(summingArrayCombiner.validateOptions(iteratorSetting.getOptions()));
 
     summingArrayCombiner.init(new SortedMapIterator(tm1), iteratorSetting.getOptions(), SCAN_IE);
-    summingArrayCombiner.seek(new Range(), EMPTY_COL_FAMS, false);
+    final Range range = new Range();
+    summingArrayCombiner.seek(range, EMPTY_COL_FAMS, false);
 
     assertTrue(summingArrayCombiner.hasTop());
     assertEquals(newKey(1, 1, 1, 3), summingArrayCombiner.getTopKey());
@@ -952,6 +953,6 @@ public class CombinerTest {
 
     summingArrayCombiner.init(new SortedMapIterator(tm1), iteratorSetting.getOptions(), SCAN_IE);
     assertThrows(ValueFormatException.class,
-        () -> summingArrayCombiner.seek(new Range(), EMPTY_COL_FAMS, false));
+        () -> summingArrayCombiner.seek(range, EMPTY_COL_FAMS, false));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -707,7 +706,8 @@ public class CombinerTest {
     SummingArrayCombiner.setEncodingType(is, type);
     Combiner.setColumns(is, Collections.singletonList(new IteratorSetting.Column("cf001")));
 
-    ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
+    SortedMapIterator sortedMapIterator = new SortedMapIterator(tm1);
+    ai.init(sortedMapIterator, is.getOptions(), SCAN_IE);
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
@@ -722,7 +722,7 @@ public class CombinerTest {
     SummingArrayCombiner.setEncodingType(is, encoderClass);
     Combiner.setColumns(is, Collections.singletonList(new IteratorSetting.Column("cf001")));
 
-    ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
+    ai.init(sortedMapIterator, is.getOptions(), SCAN_IE);
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
@@ -737,7 +737,7 @@ public class CombinerTest {
     SummingArrayCombiner.setEncodingType(is, encoderClass.getName());
     Combiner.setColumns(is, Collections.singletonList(new IteratorSetting.Column("cf001")));
 
-    ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
+    ai.init(sortedMapIterator, is.getOptions(), SCAN_IE);
     ai.seek(new Range(), EMPTY_COL_FAMS, false);
 
     assertTrue(ai.hasTop());
@@ -752,19 +752,17 @@ public class CombinerTest {
     SummingArrayCombiner.setEncodingType(is, SummingCombiner.VAR_LEN_ENCODER.getClass().getName());
     Combiner.setColumns(is, Collections.singletonList(new IteratorSetting.Column("cf001")));
 
-    try {
-      ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
-      fail();
-    } catch (IllegalArgumentException e) {}
+    final var isOptions = is.getOptions();
+    assertThrows(IllegalArgumentException.class,
+        () -> ai.init(sortedMapIterator, isOptions, SCAN_IE));
 
     is.clearOptions();
     SummingArrayCombiner.setEncodingType(is, BadEncoder.class.getName());
     Combiner.setColumns(is, Collections.singletonList(new IteratorSetting.Column("cf001")));
 
-    try {
-      ai.init(new SortedMapIterator(tm1), is.getOptions(), SCAN_IE);
-      fail();
-    } catch (IllegalArgumentException e) {}
+    final var isOptions1 = is.getOptions();
+    assertThrows(IllegalArgumentException.class,
+        () -> ai.init(sortedMapIterator, isOptions1, SCAN_IE));
   }
 
   public static class BadEncoder implements Encoder<List<Long>> {

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/CombinerTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.iterators.user;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -950,9 +951,7 @@ public class CombinerTest {
     assertTrue(summingArrayCombiner.validateOptions(iteratorSetting.getOptions()));
 
     summingArrayCombiner.init(new SortedMapIterator(tm1), iteratorSetting.getOptions(), SCAN_IE);
-    try {
-      summingArrayCombiner.seek(new Range(), EMPTY_COL_FAMS, false);
-      fail("ValueFormatException should have been thrown");
-    } catch (ValueFormatException e) {}
+    assertThrows(ValueFormatException.class,
+        () -> summingArrayCombiner.seek(new Range(), EMPTY_COL_FAMS, false));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.core.iterators.user;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -200,10 +200,9 @@ public class FilterTest {
     AgeOffFilter.setCurrentTime(is, 1001L);
     AgeOffFilter.setNegate(is, true);
     assertTrue(((AgeOffFilter) a).validateOptions(is.getOptions()));
-    try {
-      ((AgeOffFilter) a).validateOptions(EMPTY_OPTS);
-      fail();
-    } catch (IllegalArgumentException e) {}
+    SortedKeyValueIterator<Key,Value> finalA = a; // effectively final var needed for lambda below
+    assertThrows(IllegalArgumentException.class,
+        () -> ((AgeOffFilter) finalA).validateOptions(EMPTY_OPTS));
     a.init(new SortedMapIterator(tm), is.getOptions(), null);
     a = a.deepCopy(null);
     SortedKeyValueIterator<Key,Value> copy = a.deepCopy(null);
@@ -559,10 +558,8 @@ public class FilterTest {
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     assertEquals(32, size(a));
 
-    try {
-      a.validateOptions(EMPTY_OPTS);
-      fail();
-    } catch (IllegalArgumentException e) {}
+    TimestampFilter finalA = a; // effectively final var needed for lambda below
+    assertThrows(IllegalArgumentException.class, () -> finalA.validateOptions(EMPTY_OPTS));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/FilterTest.java
@@ -199,10 +199,9 @@ public class FilterTest {
     AgeOffFilter.setTTL(is, 101L);
     AgeOffFilter.setCurrentTime(is, 1001L);
     AgeOffFilter.setNegate(is, true);
-    assertTrue(((AgeOffFilter) a).validateOptions(is.getOptions()));
-    SortedKeyValueIterator<Key,Value> finalA = a; // effectively final var needed for lambda below
-    assertThrows(IllegalArgumentException.class,
-        () -> ((AgeOffFilter) finalA).validateOptions(EMPTY_OPTS));
+    final AgeOffFilter finalA = (AgeOffFilter) a;
+    assertTrue((finalA.validateOptions(is.getOptions())));
+    assertThrows(IllegalArgumentException.class, () -> finalA.validateOptions(EMPTY_OPTS));
     a.init(new SortedMapIterator(tm), is.getOptions(), null);
     a = a.deepCopy(null);
     SortedKeyValueIterator<Key,Value> copy = a.deepCopy(null);
@@ -558,7 +557,7 @@ public class FilterTest {
     a.seek(new Range(), EMPTY_COL_FAMS, false);
     assertEquals(32, size(a));
 
-    TimestampFilter finalA = a; // effectively final var needed for lambda below
+    final TimestampFilter finalA = a;
     assertThrows(IllegalArgumentException.class, () -> finalA.validateOptions(EMPTY_OPTS));
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.core.iterators.user;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -373,12 +373,7 @@ public class TransformingIteratorTest {
   @Test
   public void testCompactionAndIllegalVisibility() throws Exception {
     setUpTransformIterator(IllegalVisCompactionKeyTransformingIterator.class);
-    try {
-      checkExpected(new TreeMap<>());
-      fail();
-    } catch (Exception e) {
-
-    }
+    assertThrows(Exception.class, () -> checkExpected(new TreeMap<>()));
   }
 
   @Test
@@ -417,17 +412,11 @@ public class TransformingIteratorTest {
 
     opts.clear();
     opts.put(TransformingIterator.MAX_BUFFER_SIZE_OPT, "A,B");
-    try {
-      ti.validateOptions(opts);
-      fail();
-    } catch (IllegalArgumentException e) {}
+    assertThrows(IllegalArgumentException.class, () -> ti.validateOptions(opts));
 
     opts.clear();
     opts.put(TransformingIterator.AUTH_OPT, Authorizations.HEADER + "~~~~");
-    try {
-      ti.validateOptions(opts);
-      fail();
-    } catch (IllegalArgumentException e) {}
+    assertThrows(IllegalArgumentException.class, () -> ti.validateOptions(opts));
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -55,24 +55,25 @@ public class TabletFileTest {
   @Test
   public void testBadPaths() {
     // 2a< srv:dir
-    assertThrows("Failed to throw error on bad path", NullPointerException.class,
-        () -> test("C0004.rf", "", "2a", "t-0003", "C0004.rf"));
-    assertThrows("Failed to throw error on bad path", NullPointerException.class,
-        () -> test("dir", "", "2a", "", ""));
+    final String message = "Failed to throw error on bad path";
 
-    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+    assertThrows(message, NullPointerException.class,
+        () -> test("C0004.rf", "", "2a", "t-0003", "C0004.rf"));
+    assertThrows(message, NullPointerException.class, () -> test("dir", "", "2a", "", ""));
+
+    assertThrows(message, IllegalArgumentException.class,
         () -> test("hdfs://localhost:8020/accumulo/tablets/2a/default_tablet/F0000070.rf",
             "hdfs://localhost:8020/accumulo", "2a", "default_tablet", "F0000070.rf"));
-    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+    assertThrows(message, IllegalArgumentException.class,
         () -> test("hdfs://localhost:8020/accumulo/2a/default_tablet/F0000070.rf",
             " hdfs://localhost:8020/accumulo", "2a", "default_tablet", " F0000070.rf"));
-    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+    assertThrows(message, IllegalArgumentException.class,
         () -> test("/accumulo/tables/2a/default_tablet/F0000070.rf", "", "2a", "default_tablet",
             "F0000070.rf"));
-    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+    assertThrows(message, IllegalArgumentException.class,
         () -> test("hdfs://localhost:8020/accumulo/tables/2a/F0000070.rf",
             "hdfs://localhost:8020/accumulo", "2a", "", "F0000070.rf"));
-    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+    assertThrows(message, IllegalArgumentException.class,
         () -> test("hdfs://localhost:8020/accumulo/tables/F0000070.rf",
             "hdfs://localhost:8020/accumulo", null, "", "F0000070.rf"));
 

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.core.metadata.schema;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -54,40 +54,28 @@ public class TabletFileTest {
 
   @Test
   public void testBadPaths() {
-    try {
-      test("C0004.rf", "", "2a", "t-0003", "C0004.rf");
-      fail("Failed to throw error on bad path");
-    } catch (NullPointerException e) {}
     // 2a< srv:dir
-    try {
-      test("dir", "", "2a", "", "");
-      fail("Failed to throw error on bad path");
-    } catch (NullPointerException e) {}
-    try {
-      test("hdfs://localhost:8020/accumulo/tablets/2a/default_tablet/F0000070.rf",
-          "hdfs://localhost:8020/accumulo", "2a", "default_tablet", "F0000070.rf");
-      fail("Failed to throw error on bad path");
-    } catch (IllegalArgumentException e) {}
-    try {
-      test("hdfs://localhost:8020/accumulo/2a/default_tablet/F0000070.rf",
-          " hdfs://localhost:8020/accumulo", "2a", "default_tablet", " F0000070.rf");
-      fail("Failed to throw error on bad path");
-    } catch (IllegalArgumentException e) {}
-    try {
-      test("/accumulo/tables/2a/default_tablet/F0000070.rf", "", "2a", "default_tablet",
-          "F0000070.rf");
-      fail("Failed to throw error on bad path");
-    } catch (IllegalArgumentException e) {}
-    try {
-      test("hdfs://localhost:8020/accumulo/tables/2a/F0000070.rf", "hdfs://localhost:8020/accumulo",
-          "2a", "", "F0000070.rf");
-      fail("Failed to throw error on bad path");
-    } catch (IllegalArgumentException e) {}
-    try {
-      test("hdfs://localhost:8020/accumulo/tables/F0000070.rf", "hdfs://localhost:8020/accumulo",
-          null, "", "F0000070.rf");
-      fail("Failed to throw error on bad path");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("Failed to throw error on bad path", NullPointerException.class,
+        () -> test("C0004.rf", "", "2a", "t-0003", "C0004.rf"));
+    assertThrows("Failed to throw error on bad path", NullPointerException.class,
+        () -> test("dir", "", "2a", "", ""));
+
+    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+        () -> test("hdfs://localhost:8020/accumulo/tablets/2a/default_tablet/F0000070.rf",
+            "hdfs://localhost:8020/accumulo", "2a", "default_tablet", "F0000070.rf"));
+    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+        () -> test("hdfs://localhost:8020/accumulo/2a/default_tablet/F0000070.rf",
+            " hdfs://localhost:8020/accumulo", "2a", "default_tablet", " F0000070.rf"));
+    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+        () -> test("/accumulo/tables/2a/default_tablet/F0000070.rf", "", "2a", "default_tablet",
+            "F0000070.rf"));
+    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+        () -> test("hdfs://localhost:8020/accumulo/tables/2a/F0000070.rf",
+            "hdfs://localhost:8020/accumulo", "2a", "", "F0000070.rf"));
+    assertThrows("Failed to throw error on bad path", IllegalArgumentException.class,
+        () -> test("hdfs://localhost:8020/accumulo/tables/F0000070.rf",
+            "hdfs://localhost:8020/accumulo", null, "", "F0000070.rf"));
+
   }
 
   private final String id = "2a";

--- a/core/src/test/java/org/apache/accumulo/core/rpc/TTimeoutTransportTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/rpc/TTimeoutTransportTest.java
@@ -24,7 +24,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,12 +68,7 @@ public class TTimeoutTransportTest {
 
     replay(addr, s, timeoutTransport);
 
-    try {
-      timeoutTransport.openSocket(addr);
-      fail("Expected to catch IOException but got none");
-    } catch (IOException e) {
-      // Expected
-    }
+    assertThrows(IOException.class, () -> timeoutTransport.openSocket(addr));
 
     verify(addr, s, timeoutTransport);
   }
@@ -103,12 +98,7 @@ public class TTimeoutTransportTest {
 
     replay(addr, s, timeoutTransport);
 
-    try {
-      timeoutTransport.createInternal(addr, timeout);
-      fail("Expected to catch TTransportException but got none");
-    } catch (TTransportException e) {
-      // Expected
-    }
+    assertThrows(TTransportException.class, () -> timeoutTransport.createInternal(addr, timeout));
 
     verify(addr, s, timeoutTransport);
   }
@@ -143,12 +133,7 @@ public class TTimeoutTransportTest {
 
     replay(addr, s, timeoutTransport);
 
-    try {
-      timeoutTransport.createInternal(addr, timeout);
-      fail("Expected to catch TTransportException but got none");
-    } catch (TTransportException e) {
-      // Expected
-    }
+    assertThrows(TTransportException.class, () -> timeoutTransport.createInternal(addr, timeout));
 
     verify(addr, s, timeoutTransport);
   }

--- a/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/ColumnVisibilityTest.java
@@ -22,8 +22,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.core.security.ColumnVisibility.quote;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Comparator;
 
@@ -36,13 +36,11 @@ import org.junit.Test;
 public class ColumnVisibilityTest {
 
   private void shouldThrow(String... strings) {
-    for (String s : strings)
-      try {
-        new ColumnVisibility(s.getBytes());
-        fail("Should throw: " + s);
-      } catch (IllegalArgumentException e) {
-        // expected
-      }
+    for (String s : strings) {
+      final byte[] sBytes = s.getBytes();
+      assertThrows("Should throw: " + s, IllegalArgumentException.class,
+          () -> new ColumnVisibility(sBytes));
+    }
   }
 
   private void shouldNotThrow(String... strings) {

--- a/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import javax.security.auth.DestroyFailedException;
 
@@ -58,15 +58,10 @@ public class CredentialsTest {
 
     // verify that we can't serialize if it's destroyed
     creds.getToken().destroy();
-    try {
-      creds.toThrift(instanceID);
-      fail();
-    } catch (Exception e) {
-      assertTrue(e instanceof RuntimeException);
-      assertTrue(e.getCause() instanceof AccumuloSecurityException);
-      assertEquals(AccumuloSecurityException.class.cast(e.getCause()).getSecurityErrorCode(),
-          SecurityErrorCode.TOKEN_EXPIRED);
-    }
+    Exception e = assertThrows(RuntimeException.class, () -> creds.toThrift(instanceID));
+    assertTrue(e.getCause() instanceof AccumuloSecurityException);
+    assertEquals(AccumuloSecurityException.class.cast(e.getCause()).getSecurityErrorCode(),
+        SecurityErrorCode.TOKEN_EXPIRED);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/security/VisibilityEvaluatorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/VisibilityEvaluatorTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.core.security;
 import static org.apache.accumulo.core.security.ColumnVisibility.quote;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.util.BadArgumentException;
@@ -62,33 +62,21 @@ public class VisibilityEvaluatorTest {
 
     // test missing separators; these should throw an exception
     for (String marking : new String[] {"one(five)", "(five)one", "(one)(two)", "a|(b(c))"}) {
-      try {
-        ct.evaluate(new ColumnVisibility(marking));
-        fail(marking + " failed to throw");
-      } catch (BadArgumentException e) {
-        // all is good
-      }
+      assertThrows(marking + " failed to throw", BadArgumentException.class,
+          () -> ct.evaluate(new ColumnVisibility(marking)));
     }
 
     // test unexpected separator
     for (String marking : new String[] {"&(five)", "|(five)", "(five)&", "five|", "a|(b)&",
         "(&five)", "(five|)"}) {
-      try {
-        ct.evaluate(new ColumnVisibility(marking));
-        fail(marking + " failed to throw");
-      } catch (BadArgumentException e) {
-        // all is good
-      }
+      assertThrows(marking + " failed to throw", BadArgumentException.class,
+          () -> ct.evaluate(new ColumnVisibility(marking)));
     }
 
     // test mismatched parentheses
     for (String marking : new String[] {"(", ")", "(a&b", "b|a)"}) {
-      try {
-        ct.evaluate(new ColumnVisibility(marking));
-        fail(marking + " failed to throw");
-      } catch (BadArgumentException e) {
-        // all is good
-      }
+      assertThrows(marking + " failed to throw", BadArgumentException.class,
+          () -> ct.evaluate(new ColumnVisibility(marking)));
     }
   }
 
@@ -141,20 +129,12 @@ public class VisibilityEvaluatorTest {
     assertEquals("a\\b\\c\\d",
         VisibilityEvaluator.unescape(new ArrayByteSequence("a\\\\b\\\\c\\\\d")).toString());
 
-    try {
-      VisibilityEvaluator.unescape(new ArrayByteSequence("a\\b"));
-      fail("Expected failure to unescape invalid escape sequence");
-    } catch (IllegalArgumentException e) {}
-
-    try {
-      VisibilityEvaluator.unescape(new ArrayByteSequence("a\\b\\c"));
-      fail("Expected failure to unescape invalid escape sequence");
-    } catch (IllegalArgumentException e) {}
-
-    try {
-      VisibilityEvaluator.unescape(new ArrayByteSequence("a\"b\\"));
-      fail("Expected failure to unescape invalid escape sequence");
-    } catch (IllegalArgumentException e) {}
+    assertThrows(IllegalArgumentException.class,
+        () -> VisibilityEvaluator.unescape(new ArrayByteSequence("a\\b")));
+    assertThrows(IllegalArgumentException.class,
+        () -> VisibilityEvaluator.unescape(new ArrayByteSequence("a\\b\\c")));
+    assertThrows(IllegalArgumentException.class,
+        () -> VisibilityEvaluator.unescape(new ArrayByteSequence("a\"b\\")));
 
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/singletons/SingletonManagerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/singletons/SingletonManagerTest.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.core.singletons;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.apache.accumulo.core.singletons.SingletonManager.Mode;
 import org.junit.Before;
@@ -121,10 +121,8 @@ public class SingletonManagerTest {
     assertEquals(new TestService(false, 0, 1), service1);
     assertEquals(new TestService(false, 1, 1), service2);
 
-    try {
-      SingletonManager.setMode(Mode.CONNECTOR);
-      fail("Should only be able to set mode to CONNECTOR once");
-    } catch (IllegalStateException e) {}
+    assertThrows("Should only be able to set mode to CONNECTOR once", IllegalStateException.class,
+        () -> SingletonManager.setMode(Mode.CONNECTOR));
 
     assertEquals(Mode.CLIENT, SingletonManager.getMode());
   }

--- a/core/src/test/java/org/apache/accumulo/core/util/AddressUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/AddressUtilTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.security.Security;
@@ -94,13 +95,12 @@ public class AddressUtilTest {
       log.error("We can't set the DNS cache period, so this test is effectively ignored.");
       return;
     }
-    try {
-      log.info("AddressUtil is (hopefully) going to spit out an error about DNS lookups. "
-          + "you can ignore it.");
-      AddressUtil.getAddressCacheNegativeTtl(null);
-      fail("The JVM Security settings cache DNS failures forever, this should cause an exception.");
-    } catch (IllegalArgumentException exception) {
-      // expected
-    }
+
+    log.info("AddressUtil is (hopefully) going to spit out an error about DNS lookups. "
+        + "you can ignore it.");
+    assertThrows(
+        "The JVM Security settings cache DNS failures forever, this should cause an exception.",
+        IllegalArgumentException.class, () -> AddressUtil.getAddressCacheNegativeTtl(null));
+
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/LocalityGroupUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/LocalityGroupUtilTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -51,14 +52,11 @@ public class LocalityGroupUtilTest {
     } catch (LocalityGroupConfigurationError err) {
       fail();
     }
-    try {
-      conf.set("table.group.lg2", "cf1");
-      conf.set("table.groups.enabled", "lg1,lg2");
-      LocalityGroupUtil.getLocalityGroups(conf);
-      fail();
-    } catch (LocalityGroupConfigurationError err) {
-      // expected, ignore
-    }
+
+    conf.set("table.group.lg2", "cf1");
+    conf.set("table.groups.enabled", "lg1,lg2");
+    assertThrows(LocalityGroupConfigurationError.class,
+        () -> LocalityGroupUtil.getLocalityGroups(conf));
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/format/FormatterConfigTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/FormatterConfigTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.text.DateFormat;
 
@@ -41,10 +41,8 @@ public class FormatterConfigTest {
   @Test
   public void testSetShownLength() {
     FormatterConfig config = new FormatterConfig();
-    try {
-      config.setShownLength(-1);
-      fail("Should throw on negative length.");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("Should throw on negative length.", IllegalArgumentException.class,
+        () -> config.setShownLength(-1));
 
     config.setShownLength(0);
     assertEquals(0, config.getShownLength());

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.hadoop.its.mapred;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,13 +106,9 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       client.securityOperations().revokeTablePermission("root", testName.getMethodName(),
           TablePermission.WRITE);
 
-      try {
-        writer.close(null);
-        fail("Did not throw exception");
-      } catch (IOException ex) {
-        log.info(ex.getMessage(), ex);
-        assertTrue(ex.getCause() instanceof MutationsRejectedException);
-      }
+      var ex = assertThrows(IOException.class, () -> writer.close(null));
+      log.info(ex.getMessage(), ex);
+      assertTrue(ex.getCause() instanceof MutationsRejectedException);
     }
   }
 

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
@@ -22,7 +22,7 @@ import static java.lang.System.currentTimeMillis;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -142,10 +142,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     // offline mode
     AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties()).table(table)
         .auths(Authorizations.EMPTY).offlineScan(true).store(job);
-    try {
-      inputFormat.getSplits(job);
-      fail("An IOException should have been thrown");
-    } catch (IOException e) {}
+    assertThrows(IOException.class, () -> inputFormat.getSplits(job));
 
     client.tableOperations().offline(table, true);
     splits = inputFormat.getSplits(job);
@@ -172,10 +169,8 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties()).table(table)
         .auths(Authorizations.EMPTY).batchScan(true).offlineScan(true).store(job);
 
-    try {
-      inputFormat.getSplits(job);
-      fail("IllegalArgumentException should have been thrown trying to batch scan offline");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("IllegalArgumentException should have been thrown trying to batch scan offline",
+        IllegalArgumentException.class, () -> inputFormat.getSplits(job));
 
     // table online tests
     client.tableOperations().online(table, true);
@@ -189,19 +184,16 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
     AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties()).table(table)
         .auths(Authorizations.EMPTY).batchScan(true).scanIsolation(true).store(job);
 
-    try {
-      inputFormat.getSplits(job);
-      fail("IllegalArgumentException should have been thrown trying to batch scan with isolation");
-    } catch (IllegalArgumentException e) {}
+    assertThrows(
+        "IllegalArgumentException should have been thrown trying to batch scan with isolation",
+        IllegalArgumentException.class, () -> inputFormat.getSplits(job));
 
     // BatchScan not available with local iterators
     AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties()).table(table)
         .auths(Authorizations.EMPTY).batchScan(true).localIterators(true).store(job);
 
-    try {
-      inputFormat.getSplits(job);
-      fail("IllegalArgumentException should have been thrown trying to batch scan locally");
-    } catch (IllegalArgumentException e) {}
+    assertThrows("IllegalArgumentException should have been thrown trying to batch scan locally",
+        IllegalArgumentException.class, () -> inputFormat.getSplits(job));
 
     AccumuloInputFormat.configure().clientProperties(getClientInfo().getProperties()).table(table)
         .auths(Authorizations.EMPTY).batchScan(true).store(job);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloInputFormatTest.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.hadoop.mapred;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -228,15 +227,13 @@ public class AccumuloInputFormatTest {
   }
 
   @Test
-  public void testJobStoreException() throws Exception {
+  public void testJobStoreException() {
     // test exception thrown when not calling store
     AccumuloInputFormat.configure().clientProperties(clientProperties).table("table")
         .auths(Authorizations.EMPTY);
     AccumuloInputFormat aif = new AccumuloInputFormat();
 
-    try {
-      aif.getSplits(job, 1);
-      fail("IllegalStateException should have been thrown for not calling store");
-    } catch (IllegalStateException e) {}
+    assertThrows("IllegalStateException should have been thrown for not calling store",
+        IllegalStateException.class, () -> aif.getSplits(job, 1));
   }
 }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloOutputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapred/AccumuloOutputFormatTest.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.hadoop.mapred;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -90,10 +90,8 @@ public class AccumuloOutputFormatTest {
     Properties cp = Accumulo.newClientProperties().to("test", "zk").as("blah", "blah").build();
 
     AccumuloOutputFormat.configure().clientProperties(cp);
-    try {
-      new AccumuloOutputFormat().checkOutputSpecs(null, job);
-      fail("IllegalStateException should have been thrown.");
-    } catch (IllegalStateException e) {}
+    assertThrows(IllegalStateException.class,
+        () -> new AccumuloOutputFormat().checkOutputSpecs(null, job));
   }
 
   @Test

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloInputFormatTest.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.hadoop.mapreduce;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -247,9 +246,7 @@ public class AccumuloInputFormatTest {
         .auths(Authorizations.EMPTY);
     AccumuloInputFormat aif = new AccumuloInputFormat();
 
-    try {
-      aif.getSplits(job);
-      fail("IllegalStateException should have been thrown for not calling store");
-    } catch (IllegalStateException e) {}
+    assertThrows("IllegalStateException should have been thrown for not calling store",
+        IllegalStateException.class, () -> aif.getSplits(job));
   }
 }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloOutputFormatTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/mapreduce/AccumuloOutputFormatTest.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.hadoop.mapreduce;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -92,10 +92,8 @@ public class AccumuloOutputFormatTest {
     Properties cp = Accumulo.newClientProperties().to("test", "zk").as("blah", "blah").build();
 
     AccumuloOutputFormat.configure().clientProperties(cp);
-    try {
-      new AccumuloOutputFormat().checkOutputSpecs(job);
-      fail("IllegalStateException should have been thrown.");
-    } catch (IllegalStateException e) {}
+    assertThrows(IllegalStateException.class,
+        () -> new AccumuloOutputFormat().checkOutputSpecs(job));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
     <curator.version>5.1.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
-    <errorprone.version>2.10.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <failsafe.excludedGroups />
@@ -1623,59 +1622,6 @@
         <failsafe.reuseForks>${reuseForks}</failsafe.reuseForks>
         <surefire.reuseForks>${reuseForks}</surefire.reuseForks>
       </properties>
-    </profile>
-    <profile>
-      <!-- This profile uses the Google errorprone tool to perform static code analysis at
-      compile time. Auto-generated code is not checked.
-      See: https://errorprone.info/bugpatterns for list of available bug patterns.-->
-      <id>errorprone</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerArgs>
-                <arg>-XDcompilePolicy=simple</arg>
-                <arg>
-                  -Xplugin:ErrorProne \
-                  -XepExcludedPaths:.*/(proto|thrift|generated-sources)/.* \
-                  -XepDisableWarningsInGeneratedCode \
-                  -XepDisableAllWarnings \
-                  <!-- error/warning patterns to ignore -->
-                  -Xep:Incomparable:OFF \
-                  -Xep:CheckReturnValue:OFF \
-                  -Xep:MustBeClosedChecker:OFF \
-                  -Xep:ReturnValueIgnored:OFF \
-                  <!-- error/warning patterns to specifically check -->
-                  -Xep:ExpectedExceptionChecker \
-                  -Xep:MissingOverride \
-                  <!-- Items containing 'OFF' are currently flagged by errorprone. The 'OFF'
-                  can be removed and the project recompiled to discover lcation of errors for
-                  further analysis. @SuppressWarnings can be used to ignore errors if desired. -->
-                </arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-              </compilerArgs>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>${errorprone.version}</version>
-                </path>
-              </annotationProcessorPaths>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <curator.version>5.1.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
+    <errorprone.version>2.10.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <failsafe.excludedGroups />
@@ -1621,6 +1622,63 @@
         <failsafe.reuseForks>${reuseForks}</failsafe.reuseForks>
         <surefire.reuseForks>${reuseForks}</surefire.reuseForks>
       </properties>
+    </profile>
+    <profile>
+      <!-- This profile uses the Google errorprone tool to perform static code analysis at
+      compile time. Auto-generated code is not checked.
+      See: https://errorprone.info/bugpatterns for list of available bug patterns.-->
+      <id>errorprone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <showWarnings>true</showWarnings>
+              <source>${maven.compiler.source}</source>
+              <source>${maven.compiler.target}}</source>
+              <encoding>UTF-8</encoding>
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>
+                  -Xplugin:ErrorProne \
+                  -XepExcludedPaths:.*/(proto|thrift|generated-sources)/.* \
+                  -XepDisableWarningsInGeneratedCode \
+                  -XepDisableAllWarnings \
+                  <!-- error/warning patterns to ignore -->
+                  -Xep:Incomparable:OFF \
+                  -Xep:CheckReturnValue:OFF \
+                  -Xep:MustBeClosedChecker:OFF \
+                  -Xep:ReturnValueIgnored:OFF \
+                  <!-- error/warning patterns to specifically check -->
+                  -Xep:ExpectedExceptionChecker \
+                  -Xep:MissingOverride \
+                  <!-- Items containing 'OFF' are currently flagged by errorprone. The 'OFF'
+                  can be removed and the project recompiled to discover lcation of errors for
+                  further analysis. @SuppressWarnings can be used to ignore errors if desired. -->
+                </arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1634,10 +1634,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <showWarnings>true</showWarnings>
-              <source>${maven.compiler.source}</source>
-              <source>${maven.compiler.target}}</source>
-              <encoding>UTF-8</encoding>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerDirsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerDirsTest.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.server;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -102,28 +102,12 @@ public class ServerDirsTest {
   private void verifySomePass(Set<String> paths) {
     Set<String> subset = paths.stream().limit(2).collect(Collectors.toSet());
     assertEquals(subset, constants.checkBaseUris(hadoopConf, paths, true));
-    try {
-      constants.checkBaseUris(hadoopConf, paths, false);
-      fail();
-    } catch (Exception e) {
-      // ignored
-    }
+    assertThrows(RuntimeException.class, () -> constants.checkBaseUris(hadoopConf, paths, false));
   }
 
   private void verifyError(Set<String> paths) {
-    try {
-      constants.checkBaseUris(hadoopConf, paths, true);
-      fail();
-    } catch (Exception e) {
-      // ignored
-    }
-
-    try {
-      constants.checkBaseUris(hadoopConf, paths, false);
-      fail();
-    } catch (Exception e) {
-      // ignored
-    }
+    assertThrows(RuntimeException.class, () -> constants.checkBaseUris(hadoopConf, paths, true));
+    assertThrows(RuntimeException.class, () -> constants.checkBaseUris(hadoopConf, paths, false));
   }
 
   private Set<String> init(File newFile, List<String> uuids, List<Integer> dataVersions)

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
@@ -127,16 +127,16 @@ public class RootTabletStateStoreTest {
     assertEquals(count, 1);
 
     KeyExtent notRoot = new KeyExtent(TableId.of("0"), null, null);
-    assertThrows(IllegalArgumentException.class,
-        () -> tstore.setLocations(List.of(new Assignment(notRoot, server))));
+    final var assignmentList = List.of(new Assignment(notRoot, server));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> tstore.setFutureLocations(List.of(new Assignment(notRoot, server))));
+    assertThrows(IllegalArgumentException.class, () -> tstore.setLocations(assignmentList));
+    assertThrows(IllegalArgumentException.class, () -> tstore.setFutureLocations(assignmentList));
 
     try {
       TabletLocationState broken =
           new TabletLocationState(notRoot, server, null, null, null, null, false);
-      assertThrows(IllegalArgumentException.class, () -> tstore.unassign(List.of(broken), null));
+      final var assignmentList1 = List.of(broken);
+      assertThrows(IllegalArgumentException.class, () -> tstore.unassign(assignmentList1, null));
     } catch (BadLocationStateException e) {
       fail("Unexpected error " + e);
     }

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server.manager.state;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
@@ -126,25 +127,18 @@ public class RootTabletStateStoreTest {
     assertEquals(count, 1);
 
     KeyExtent notRoot = new KeyExtent(TableId.of("0"), null, null);
-    try {
-      tstore.setLocations(Collections.singletonList(new Assignment(notRoot, server)));
-      fail("should not get here");
-    } catch (IllegalArgumentException ex) {}
+    assertThrows(IllegalArgumentException.class,
+        () -> tstore.setLocations(List.of(new Assignment(notRoot, server))));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> tstore.setFutureLocations(List.of(new Assignment(notRoot, server))));
 
     try {
-      tstore.setFutureLocations(Collections.singletonList(new Assignment(notRoot, server)));
-      fail("should not get here");
-    } catch (IllegalArgumentException ex) {}
-
-    TabletLocationState broken = null;
-    try {
-      broken = new TabletLocationState(notRoot, server, null, null, null, null, false);
+      TabletLocationState broken =
+          new TabletLocationState(notRoot, server, null, null, null, null, false);
+      assertThrows(IllegalArgumentException.class, () -> tstore.unassign(List.of(broken), null));
     } catch (BadLocationStateException e) {
       fail("Unexpected error " + e);
     }
-    try {
-      tstore.unassign(Collections.singletonList(broken), null);
-      fail("should not get here");
-    } catch (IllegalArgumentException ex) {}
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/zookeeper/TransactionWatcherTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/zookeeper/TransactionWatcherTest.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.server.zookeeper;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -96,12 +96,8 @@ public class TransactionWatcherTest {
     final SimpleArbitrator sa = new SimpleArbitrator();
     final TransactionWatcher txw = new TransactionWatcher(sa);
     sa.start(txType, txid);
-    try {
-      sa.start(txType, txid);
-      fail("simple arbitrator did not throw an exception");
-    } catch (Exception ex) {
-      // expected
-    }
+    assertThrows("simple arbitrator did not throw an exception", Exception.class,
+        () -> sa.start(txType, txid));
     txw.isActive(txid);
     assertFalse(txw.isActive(txid));
     txw.run(txType, txid, () -> {
@@ -115,29 +111,15 @@ public class TransactionWatcherTest {
     assertFalse(sa.transactionComplete(txType, txid));
     sa.cleanup(txType, txid);
     assertTrue(sa.transactionComplete(txType, txid));
-    try {
-      txw.run(txType, txid, () -> {
-        fail("Should not be able to start a new work on a discontinued transaction");
-        return null;
-      });
-      fail("work against stopped transaction should fail");
-    } catch (Exception ex) {
-
-    }
+    assertThrows("Should not be able to start a new work on a discontinued transaction",
+        Exception.class, () -> txw.run(txType, txid, () -> null));
     final long txid2 = 9;
     sa.start(txType, txid2);
     txw.run(txType, txid2, () -> {
       assertTrue(txw.isActive(txid2));
       sa.stop(txType, txid2);
-      try {
-        txw.run(txType, txid2, () -> {
-          fail("Should not be able to start a new work on a discontinued transaction");
-          return null;
-        });
-        fail("work against a stopped transaction should fail");
-      } catch (Exception ex) {
-        // expected
-      }
+      assertThrows("Should not be able to start a new work on a discontinued transaction",
+          Exception.class, () -> txw.run(txType, txid2, () -> null));
       assertTrue(txw.isActive(txid2));
       return null;
     });

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.manager.tableOps.bulkVer2;
 
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,7 +37,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
 import org.apache.accumulo.core.clientImpl.bulk.Bulk;
 import org.apache.accumulo.core.clientImpl.bulk.BulkSerialize;
@@ -149,15 +147,11 @@ public class PrepBulkImportTest {
         .collect(Collectors.joining(","));
   }
 
-  public void runExceptionTest(List<KeyExtent> loadRanges, List<KeyExtent> tabletRanges)
-      throws AccumuloException {
-    try {
-      runTest(loadRanges, tabletRanges);
-      fail("expected " + toRangeStrings(loadRanges) + " to fail against "
-          + toRangeStrings(tabletRanges));
-    } catch (Exception e) {
-      assertTrue(e instanceof AcceptableThriftTableOperationException);
-    }
+  public void runExceptionTest(List<KeyExtent> loadRanges, List<KeyExtent> tabletRanges) {
+    String message = "expected " + toRangeStrings(loadRanges) + " to fail against "
+        + toRangeStrings(tabletRanges);
+    assertThrows(message, AcceptableThriftTableOperationException.class,
+        () -> runTest(loadRanges, tabletRanges));
   }
 
   @Test

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
@@ -69,10 +69,10 @@ public class CompactionDriverTest {
     var e = assertThrows(AcceptableThriftTableOperationException.class,
         () -> driver.isReady(tableIdLong, manager));
 
-    assertTrue("Unexpected error thrown: " + e.getMessage(),
-        e.getTableId().equals(tableId.toString()) && e.getOp().equals(TableOperation.COMPACT)
-            && e.getType().equals(TableOperationExceptionType.OTHER)
-            && e.getDescription().equals(TableOperationsImpl.COMPACTION_CANCELED_MSG));
+    assertTrue(e.getTableId().equals(tableId.toString()));
+    assertTrue(e.getOp().equals(TableOperation.COMPACT));
+    assertTrue(e.getType().equals(TableOperationExceptionType.OTHER));
+    assertTrue(e.getDescription().equals(TableOperationsImpl.COMPACTION_CANCELED_MSG));
 
     EasyMock.verify(manager, ctx, zrw);
   }
@@ -110,10 +110,10 @@ public class CompactionDriverTest {
     var e = assertThrows(AcceptableThriftTableOperationException.class,
         () -> driver.isReady(tableIdLong, manager));
 
-    assertTrue("Unexpected error thrown: " + e.getMessage(),
-        e.getTableId().equals(tableId.toString()) && e.getOp().equals(TableOperation.COMPACT)
-            && e.getType().equals(TableOperationExceptionType.OTHER)
-            && e.getDescription().equals(TableOperationsImpl.TABLE_DELETED_MSG));
+    assertTrue(e.getTableId().equals(tableId.toString()));
+    assertTrue(e.getOp().equals(TableOperation.COMPACT));
+    assertTrue(e.getType().equals(TableOperationExceptionType.OTHER));
+    assertTrue(e.getDescription().equals(TableOperationsImpl.TABLE_DELETED_MSG));
 
     EasyMock.verify(manager, ctx, zrw);
   }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
@@ -18,7 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.compact;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
 
@@ -63,19 +64,16 @@ public class CompactionDriverTest {
 
     final CompactionDriver driver =
         new CompactionDriver(compactId, namespaceId, tableId, startRow, endRow);
-    try {
-      driver.isReady(Long.parseLong(tableId.toString()), manager);
-    } catch (AcceptableThriftTableOperationException e) {
-      if (e.getTableId().equals(tableId.toString()) && e.getOp().equals(TableOperation.COMPACT)
-          && e.getType().equals(TableOperationExceptionType.OTHER)
-          && e.getDescription().equals(TableOperationsImpl.COMPACTION_CANCELED_MSG)) {
-        // success
-      } else {
-        fail("Unexpected error thrown: " + e.getMessage());
-      }
-    } catch (Exception e) {
-      fail("Unhandled error thrown: " + e.getMessage());
-    }
+    final long tableIdLong = Long.parseLong(tableId.toString());
+
+    var e = assertThrows(AcceptableThriftTableOperationException.class,
+        () -> driver.isReady(tableIdLong, manager));
+
+    assertTrue("Unexpected error thrown: " + e.getMessage(),
+        e.getTableId().equals(tableId.toString()) && e.getOp().equals(TableOperation.COMPACT)
+            && e.getType().equals(TableOperationExceptionType.OTHER)
+            && e.getDescription().equals(TableOperationsImpl.COMPACTION_CANCELED_MSG));
+
     EasyMock.verify(manager, ctx, zrw);
   }
 
@@ -107,19 +105,16 @@ public class CompactionDriverTest {
 
     final CompactionDriver driver =
         new CompactionDriver(compactId, namespaceId, tableId, startRow, endRow);
-    try {
-      driver.isReady(Long.parseLong(tableId.toString()), manager);
-    } catch (AcceptableThriftTableOperationException e) {
-      if (e.getTableId().equals(tableId.toString()) && e.getOp().equals(TableOperation.COMPACT)
-          && e.getType().equals(TableOperationExceptionType.OTHER)
-          && e.getDescription().equals(TableOperationsImpl.TABLE_DELETED_MSG)) {
-        // success
-      } else {
-        fail("Unexpected error thrown: " + e.getMessage());
-      }
-    } catch (Exception e) {
-      fail("Unhandled error thrown: " + e.getMessage());
-    }
+    final long tableIdLong = Long.parseLong(tableId.toString());
+
+    var e = assertThrows(AcceptableThriftTableOperationException.class,
+        () -> driver.isReady(tableIdLong, manager));
+
+    assertTrue("Unexpected error thrown: " + e.getMessage(),
+        e.getTableId().equals(tableId.toString()) && e.getOp().equals(TableOperation.COMPACT)
+            && e.getType().equals(TableOperationExceptionType.OTHER)
+            && e.getDescription().equals(TableOperationsImpl.TABLE_DELETED_MSG));
+
     EasyMock.verify(manager, ctx, zrw);
   }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader9to10Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader9to10Test.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -211,10 +210,8 @@ public class Upgrader9to10Test {
     expect(fs.exists(anyObject(Path.class))).andReturn(false).anyTimes();
 
     setupMocks(c, fs, map, new ArrayList<>());
-    try {
-      Upgrader9to10.checkForRelativePaths(c, fs, tableName, volumeUpgrade);
-      fail("Expected IllegalArgumentException to be thrown");
-    } catch (IllegalArgumentException e) {}
+    assertThrows(IllegalArgumentException.class,
+        () -> Upgrader9to10.checkForRelativePaths(c, fs, tableName, volumeUpgrade));
   }
 
   @Test
@@ -228,10 +225,8 @@ public class Upgrader9to10Test {
     expect(fs.exists(anyObject(Path.class))).andReturn(false).anyTimes();
 
     setupMocks(c, fs, map, new ArrayList<>());
-    try {
-      Upgrader9to10.checkForRelativePaths(c, fs, tableName, "");
-      fail("Expected IllegalArgumentException to be thrown");
-    } catch (IllegalArgumentException e) {}
+    assertThrows(IllegalArgumentException.class,
+        () -> Upgrader9to10.checkForRelativePaths(c, fs, tableName, ""));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -420,10 +420,9 @@ public class InMemoryMapTest {
     }
 
     for (int i = 1; i <= 4; i++) {
-      try {
-        deepCopyAndDelete(i, true);
-        fail("i = " + i);
-      } catch (IterationInterruptedException iie) {}
+      final int finalI = i;
+      assertThrows("i = " + finalI, IterationInterruptedException.class,
+          () -> deepCopyAndDelete(finalI, true));
     }
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/InMemoryMapTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -677,10 +676,8 @@ public class InMemoryMapTest {
 
     assertEquals(expectedSample, readAll(iter));
     iFlag.set(true);
-    try {
-      readAll(iter);
-      fail();
-    } catch (IterationInterruptedException iie) {}
+    final var finalIter = iter;
+    assertThrows(IterationInterruptedException.class, () -> readAll(finalIter));
 
     miter.close();
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategyTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.tserver.compaction.strategies;
 import static org.apache.accumulo.tserver.compaction.DefaultCompactionStrategyTest.getServerContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -115,24 +115,14 @@ public class BasicCompactionStrategyTest {
 
   @Test
   public void testMissingType() {
-    try {
-      opts.remove(BasicCompactionStrategy.LARGE_FILE_COMPRESSION_TYPE);
-      ttcs.init(opts);
-      fail("IllegalArgumentException should have been thrown.");
-    } catch (IllegalArgumentException iae) {} catch (Throwable t) {
-      fail("IllegalArgumentException should have been thrown.");
-    }
+    opts.remove(BasicCompactionStrategy.LARGE_FILE_COMPRESSION_TYPE);
+    assertThrows(IllegalArgumentException.class, () -> ttcs.init(opts));
   }
 
   @Test
   public void testMissingThreshold() {
-    try {
-      opts.remove(BasicCompactionStrategy.LARGE_FILE_COMPRESSION_THRESHOLD);
-      ttcs.init(opts);
-      fail("IllegalArgumentException should have been thrown.");
-    } catch (IllegalArgumentException iae) {} catch (Throwable t) {
-      fail("IllegalArgumentException should have been thrown.");
-    }
+    opts.remove(BasicCompactionStrategy.LARGE_FILE_COMPRESSION_THRESHOLD);
+    assertThrows(IllegalArgumentException.class, () -> ttcs.init(opts));
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -1077,12 +1077,8 @@ public class SortedLogRecoveryTest {
     // test all the possible properties for tserver.sort.file. prefix
     String prop = Property.TSERV_WAL_SORT_FILE_PREFIX + "invalid";
     testConfig.set(prop, "snappy");
-    try {
-      new LogSorter(context, testConfig);
-      fail("Did not throw IllegalArgumentException for " + prop);
-    } catch (IllegalArgumentException e) {
-      // valid for test
-    }
+    assertThrows("Did not throw IllegalArgumentException for " + prop,
+        IllegalArgumentException.class, () -> new LogSorter(context, testConfig));
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/CloneIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CloneIT.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.HashSet;
 import java.util.Map.Entry;
@@ -395,10 +395,8 @@ public class CloneIT extends AccumuloClusterHarness {
 
         bw1.flush();
 
-        try {
-          MetadataTableUtil.checkClone(tableName, TableId.of("0"), TableId.of("1"), client, bw2);
-          fail();
-        } catch (TabletDeletedException tde) {}
+        assertThrows(TabletDeletedException.class, () -> MetadataTableUtil.checkClone(tableName,
+            TableId.of("0"), TableId.of("1"), client, bw2));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -445,14 +446,11 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         cm8.put("name", "first", cva, "john");
         cm8.put("tx", "seq", cva, "1");
 
-        try {
+        assertThrows(AccumuloSecurityException.class, () -> {
           Status status = cw2.write(cm8).getStatus();
-          fail(
-              "Writing mutation with Authorizations the user doesn't have should fail. Got status: "
-                  + status);
-        } catch (AccumuloSecurityException ase) {
-          // expected, check specific failure?
-        }
+          log.error("Writing mutation with Authorizations the user doesn't have should fail. Got "
+              + "status: {}", status);
+        });
       }
     }
   }
@@ -1323,22 +1321,19 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         assertEquals(Status.ACCEPTED, cw3.write(cm1).getStatus());
 
         // Conditional-update to a table we only have read on should fail
-        try {
+        assertThrows(AccumuloSecurityException.class, () -> {
           Status status = cw1.write(cm1).getStatus();
-          fail("Expected exception writing conditional mutation to table"
-              + " the user doesn't have write access to, Got status: " + status);
-        } catch (AccumuloSecurityException ase) {
-
-        }
+          log.error("Expected exception writing conditional mutation to table the user doesn't "
+              + "have write access to, Got status: {}", status);
+        });
 
         // Conditional-update to a table we only have writer on should fail
-        try {
+        assertThrows(AccumuloSecurityException.class, () -> {
           Status status = cw2.write(cm1).getStatus();
-          fail("Expected exception writing conditional mutation to table"
-              + " the user doesn't have read access to. Got status: " + status);
-        } catch (AccumuloSecurityException ase) {
-
-        }
+          log.error(
+              "Expected exception writing conditional mutation to table the user doesn't have read access to. Got status: {}",
+              status);
+        });
       }
     }
   }
@@ -1400,10 +1395,8 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
     String table = getUniqueNames(1)[0];
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
 
-      try {
-        client.createConditionalWriter(table);
-        fail("Creating conditional writer for table that doesn't exist should fail");
-      } catch (TableNotFoundException e) {}
+      assertThrows("Creating conditional writer for table that doesn't exist should fail",
+          TableNotFoundException.class, () -> client.createConditionalWriter(table));
 
       client.tableOperations().create(table);
 
@@ -1417,13 +1410,13 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
         Result result = cw.write(cm1);
 
-        try {
+        var ae = assertThrows(AccumuloException.class, () -> {
           Status status = result.getStatus();
-          fail("Expected exception writing conditional mutation to deleted table. Got status: "
-              + status);
-        } catch (AccumuloException ae) {
-          assertEquals(TableDeletedException.class, ae.getCause().getClass());
-        }
+          log.error(
+              "Expected exception writing conditional mutation to deleted table. Got status: {}",
+              status);
+        });
+        assertSame(TableDeletedException.class, ae.getCause().getClass());
       }
     }
   }
@@ -1445,18 +1438,15 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
         Result result = cw.write(cm1);
 
-        try {
+        var ae = assertThrows(AccumuloException.class, () -> {
           Status status = result.getStatus();
-          fail("Expected exception writing conditional mutation to offline table. Got status: "
-              + status);
-        } catch (AccumuloException ae) {
-          assertEquals(TableOfflineException.class, ae.getCause().getClass());
-        }
+          log.error("Expected exception writing conditional mutation to offline table. Got "
+              + "status: {}", status);
+        });
+        assertSame(TableOfflineException.class, ae.getCause().getClass());
 
-        try {
-          client.createConditionalWriter(table);
-          fail("Expected exception creating conditional writer to offline table");
-        } catch (TableOfflineException e) {}
+        assertThrows("Expected exception creating conditional writer to offline table",
+            TableOfflineException.class, () -> client.createConditionalWriter(table));
       }
     }
   }
@@ -1479,12 +1469,11 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
         Result result = cw.write(cm1);
 
-        try {
+        assertThrows(AccumuloException.class, () -> {
           Status status = result.getStatus();
-          fail("Expected exception using iterator which throws an error, Got status: " + status);
-        } catch (AccumuloException ae) {
-
-        }
+          log.error("Expected exception using iterator which throws an error, Got status: {}",
+              status);
+        });
 
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ExistingMacIT.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -184,12 +184,12 @@ public class ExistingMacIT extends ConfigurableMacBase {
           "conf " + new File(getCluster().getConfig().getConfDir(), "accumulo.properties"));
 
       MiniAccumuloClusterImpl accumulo2 = new MiniAccumuloClusterImpl(macConfig2);
-      try {
-        accumulo2.start();
-        fail("A 2nd MAC instance should not be able to start over an existing MAC instance");
-      } catch (RuntimeException e) {
-        // TODO check message or throw more explicit exception
-      }
+
+      RuntimeException e = assertThrows(
+          "A 2nd MAC instance should not be able to start over an existing MAC instance",
+          RuntimeException.class, accumulo2::start);
+      assertEquals("The Accumulo instance being used is already running. Aborting.",
+          e.getMessage());
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/InterruptibleScannersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/InterruptibleScannersIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 
@@ -89,9 +89,9 @@ public class InterruptibleScannersIT extends AccumuloClusterHarness {
         thread.start();
         try {
           // Use the scanner, expect problems
-          Iterators.size(scanner.iterator());
-          fail("Scan should not succeed");
-        } catch (Exception ex) {} finally {
+          assertThrows("Scan should not succeed", RuntimeException.class,
+              () -> Iterators.size(scanner.iterator()));
+        } finally {
           thread.join();
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -96,10 +96,8 @@ public class LargeSplitRowIT extends ConfigurableMacBase {
       partitionKeys.add(new Text(data));
 
       // try to add the split point that is too large, if the split point is created the test fails.
-      try {
-        client.tableOperations().addSplits(tableName, partitionKeys);
-        fail();
-      } catch (AccumuloServerException e) {}
+      assertThrows(AccumuloServerException.class,
+          () -> client.tableOperations().addSplits(tableName, partitionKeys));
 
       // Make sure that the information that was written to the table before we tried to add the
       // split

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -122,21 +122,13 @@ public class LocatorIT extends AccumuloClusterHarness {
 
       client.tableOperations().offline(tableName, true);
 
-      try {
-        client.tableOperations().locate(tableName, ranges);
-        fail();
-      } catch (TableOfflineException e) {
-        // expected
-      }
+      assertThrows(TableOfflineException.class,
+          () -> client.tableOperations().locate(tableName, ranges));
 
       client.tableOperations().delete(tableName);
 
-      try {
-        client.tableOperations().locate(tableName, ranges);
-        fail();
-      } catch (TableNotFoundException e) {
-        // expected
-      }
+      assertThrows(TableNotFoundException.class,
+          () -> client.tableOperations().locate(tableName, ranges));
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LocatorIT.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.client.admin.Locations;
+import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
@@ -88,12 +89,13 @@ public class LocatorIT extends AccumuloClusterHarness {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       String tableName = getUniqueNames(1)[0];
 
-      client.tableOperations().create(tableName);
+      TableOperations tableOps = client.tableOperations();
+      tableOps.create(tableName);
 
       Range r1 = new Range("m");
       Range r2 = new Range("o", "x");
 
-      String tableId = client.tableOperations().tableIdMap().get(tableName);
+      String tableId = tableOps.tableIdMap().get(tableName);
 
       TabletId t1 = newTabletId(tableId, null, null);
       TabletId t2 = newTabletId(tableId, "r", null);
@@ -104,31 +106,29 @@ public class LocatorIT extends AccumuloClusterHarness {
       HashSet<String> tservers = new HashSet<>(client.instanceOperations().getTabletServers());
 
       ranges.add(r1);
-      Locations ret = client.tableOperations().locate(tableName, ranges);
+      Locations ret = tableOps.locate(tableName, ranges);
       assertContains(ret, tservers, Map.of(r1, Set.of(t1)), Map.of(t1, Set.of(r1)));
 
       ranges.add(r2);
-      ret = client.tableOperations().locate(tableName, ranges);
+      ret = tableOps.locate(tableName, ranges);
       assertContains(ret, tservers, Map.of(r1, Set.of(t1), r2, Set.of(t1)),
           Map.of(t1, Set.of(r1, r2)));
 
       TreeSet<Text> splits = new TreeSet<>();
       splits.add(new Text("r"));
-      client.tableOperations().addSplits(tableName, splits);
+      tableOps.addSplits(tableName, splits);
 
-      ret = client.tableOperations().locate(tableName, ranges);
+      ret = tableOps.locate(tableName, ranges);
       assertContains(ret, tservers, Map.of(r1, Set.of(t2), r2, Set.of(t2, t3)),
           Map.of(t2, Set.of(r1, r2), t3, Set.of(r2)));
 
-      client.tableOperations().offline(tableName, true);
+      tableOps.offline(tableName, true);
 
-      assertThrows(TableOfflineException.class,
-          () -> client.tableOperations().locate(tableName, ranges));
+      assertThrows(TableOfflineException.class, () -> tableOps.locate(tableName, ranges));
 
-      client.tableOperations().delete(tableName);
+      tableOps.delete(tableName);
 
-      assertThrows(TableNotFoundException.class,
-          () -> client.tableOperations().locate(tableName, ranges));
+      assertThrows(TableNotFoundException.class, () -> tableOps.locate(tableName, ranges));
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableBatchWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableBatchWriterIT.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -219,21 +219,13 @@ public class MultiTableBatchWriterIT extends AccumuloClusterHarness {
 
       // MTBW is still caching this name to the correct table, but we should invalidate its cache
       // after seeing the rename
-      try {
-        bw1 = mtbw.getBatchWriter(table1);
-        fail("Should not be able to find this table");
-      } catch (TableNotFoundException e) {
-        // pass
-      }
+      assertThrows("Should not be able to find this table", TableNotFoundException.class,
+          () -> mtbw.getBatchWriter(table1));
 
       tops.rename(table2, newTable2);
 
-      try {
-        bw2 = mtbw.getBatchWriter(table2);
-        fail("Should not be able to find this table");
-      } catch (TableNotFoundException e) {
-        // pass
-      }
+      assertThrows("Should not be able to find this table", TableNotFoundException.class,
+          () -> mtbw.getBatchWriter(table2));
 
       bw1 = mtbw.getBatchWriter(newTable1);
       bw2 = mtbw.getBatchWriter(newTable2);
@@ -296,18 +288,11 @@ public class MultiTableBatchWriterIT extends AccumuloClusterHarness {
       tops.rename(table1, newTable1);
       tops.rename(table2, newTable2);
 
-      try {
-        bw1 = mtbw.getBatchWriter(table1);
-        fail("Should not have gotten batchwriter for " + table1);
-      } catch (TableNotFoundException e) {
-        // Pass
-      }
+      assertThrows("Should not have gotten batchwriter for " + table1, TableNotFoundException.class,
+          () -> mtbw.getBatchWriter(table1));
 
-      try {
-        bw2 = mtbw.getBatchWriter(table2);
-      } catch (TableNotFoundException e) {
-        // Pass
-      }
+      assertThrows("Should not have gotten batchwriter for " + table2, TableNotFoundException.class,
+          () -> mtbw.getBatchWriter(table2));
     } finally {
       if (mtbw != null) {
         mtbw.close();

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -369,13 +370,10 @@ public class SampleIT extends AccumuloClusterHarness {
         scanners = Arrays.asList(scanner, isoScanner, bScanner, csiScanner, oScanner);
 
         for (ScannerBase s : scanners) {
-          try {
-            countEntries(s);
-            fail("Expected SampleNotPresentException, but it did not happen : "
-                + s.getClass().getSimpleName());
-          } catch (SampleNotPresentException e) {
-
-          }
+          assertThrows(
+              "Expected SampleNotPresentException, but it did not happen : "
+                  + s.getClass().getSimpleName(),
+              SampleNotPresentException.class, () -> countEntries(s));
         }
       } finally {
         if (scanner != null) {

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,10 +64,14 @@ import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 
 public class SampleIT extends AccumuloClusterHarness {
+
+  Logger log = LoggerFactory.getLogger(AccumuloClusterHarness.class);
 
   private static final Map<String,String> OPTIONS_1 =
       Map.of("hasher", "murmur3_32", "modulus", "1009");
@@ -485,15 +488,11 @@ public class SampleIT extends AccumuloClusterHarness {
 
       scanner.setSamplerConfiguration(sc);
 
-      try {
-        for (Entry<Key,Value> entry : scanner) {
-          entry.getKey();
-        }
-        fail("Expected SampleNotPresentException, but it did not happen : "
-            + scanner.getClass().getSimpleName());
-      } catch (SampleNotPresentException e) {
-
-      }
+      final String message = "Expected SampleNotPresentException, but it did not happen : "
+          + scanner.getClass().getSimpleName();
+      assertThrows(message, SampleNotPresentException.class, () -> {
+        var ignored = scanner.iterator().next().getKey();
+      });
 
       scanner.clearSamplerConfiguration();
       for (Entry<Key,Value> entry : scanner) {

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -486,9 +486,7 @@ public class SampleIT extends AccumuloClusterHarness {
 
       final String message = "Expected SampleNotPresentException, but it did not happen : "
           + scanner.getClass().getSimpleName();
-      assertThrows(message, SampleNotPresentException.class, () -> {
-        var ignored = scanner.iterator().next().getKey();
-      });
+      assertThrows(message, SampleNotPresentException.class, () -> scanner.iterator().next());
 
       scanner.clearSamplerConfiguration();
       for (Entry<Key,Value> entry : scanner) {

--- a/test/src/main/java/org/apache/accumulo/test/SampleIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SampleIT.java
@@ -64,14 +64,10 @@ import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 
 public class SampleIT extends AccumuloClusterHarness {
-
-  Logger log = LoggerFactory.getLogger(AccumuloClusterHarness.class);
 
   private static final Map<String,String> OPTIONS_1 =
       Map.of("hasher", "murmur3_32", "modulus", "1009");

--- a/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ShellServerIT.java
@@ -1914,13 +1914,8 @@ public class ShellServerIT extends SharedMiniClusterBase {
   @Test
   public void scansWithClassLoaderContext() throws IOException {
 
-    try {
-      var clazzName = Class.forName(VALUE_REVERSING_ITERATOR);
-      log.warn("Found {} on classpath - failing test", clazzName);
-      fail("ValueReversingIterator already on the classpath");
-    } catch (ClassNotFoundException e) {
-      // expected; iterator is already on the class path
-    }
+    assertThrows("ValueReversingIterator already on the classpath", ClassNotFoundException.class,
+        () -> Class.forName(VALUE_REVERSING_ITERATOR));
 
     final String tableName = getUniqueNames(1)[0];
 

--- a/test/src/main/java/org/apache/accumulo/test/UsersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/UsersIT.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.test;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Set;
 
@@ -50,17 +50,15 @@ public class UsersIT extends AccumuloClusterHarness {
         client.securityOperations().createLocalUser(user0.getPrincipal(), token);
       }
 
-      try {
-        client.securityOperations().createLocalUser(user0.getPrincipal(),
-            new PasswordToken("better_fail"));
-        fail("Creating a user that already exists should throw an exception");
-      } catch (AccumuloSecurityException e) {
-        assertSame("Expected USER_EXISTS error", SecurityErrorCode.USER_EXISTS,
-            e.getSecurityErrorCode());
-        String msg = e.getMessage();
-        assertTrue("Error message didn't contain principal: '" + msg + "'",
-            msg.contains(user0.getPrincipal()));
-      }
+      AccumuloSecurityException e =
+          assertThrows("Creating a user that already exists should " + "throw an exception",
+              AccumuloSecurityException.class, () -> client.securityOperations()
+                  .createLocalUser(user0.getPrincipal(), new PasswordToken("better_fail")));
+      assertSame("Expected USER_EXISTS error", SecurityErrorCode.USER_EXISTS,
+          e.getSecurityErrorCode());
+      String msg = e.getMessage();
+      assertTrue("Error message didn't contain principal: '" + msg + "'",
+          msg.contains(user0.getPrincipal()));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AccumuloClientIT.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -69,13 +69,9 @@ public class AccumuloClientIT extends AccumuloClusterHarness {
     void check() throws Exception;
   }
 
-  private static void expectClosed(CloseCheck cc) throws Exception {
-    try {
-      cc.check();
-      fail();
-    } catch (IllegalStateException e) {
-      assertTrue(e.getMessage().toLowerCase().contains("closed"));
-    }
+  private static void expectClosed(CloseCheck cc) {
+    var e = assertThrows(IllegalStateException.class, cc::check);
+    assertTrue(e.getMessage().toLowerCase().contains("closed"));
   }
 
   @SuppressWarnings("deprecation")

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -443,31 +443,20 @@ public class BulkNewIT extends SharedMiniClusterBase {
       LoadPlan loadPlan = LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, null, row(333))
           .loadFileTo("f2.rf", RangeType.TABLE, null, row(666))
           .loadFileTo("f3.rf", RangeType.TABLE, null, row(666)).build();
-      try {
-        c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan).load();
-        fail();
-      } catch (IllegalArgumentException e) {
-        // ignore
-      }
+      assertThrows(IllegalArgumentException.class,
+          () -> c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan).load());
 
       // Create a plan with less files than exists in dir
-      loadPlan = LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, null, row(333)).build();
-      try {
-        c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan).load();
-        fail();
-      } catch (IllegalArgumentException e) {
-        // ignore
-      }
+      LoadPlan loadPlan1 =
+          LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, null, row(333)).build();
+      assertThrows(IllegalArgumentException.class,
+          () -> c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan1).load());
 
       // Create a plan with tablet boundary that does not exits
-      loadPlan = LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, null, row(555))
+      LoadPlan loadPlan2 = LoadPlan.builder().loadFileTo("f1.rf", RangeType.TABLE, null, row(555))
           .loadFileTo("f2.rf", RangeType.TABLE, null, row(555)).build();
-      try {
-        c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan).load();
-        fail();
-      } catch (AccumuloException e) {
-        // ignore
-      }
+      assertThrows(AccumuloException.class,
+          () -> c.tableOperations().importDirectory(dir).to(tableName).plan(loadPlan2).load());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CleanUpIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CleanUpIT.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -117,12 +118,12 @@ public class CleanUpIT extends SharedMiniClusterBase {
       m2.put("cf1", "cq1", 1, "6");
 
       bw.addMutation(m1);
-      assertThrows(Exception.class, bw::flush);
+      assertThrows(MutationsRejectedException.class, bw::flush);
 
       // expect this to fail also, want to clean up batch writer threads
-      assertThrows(Exception.class, bw::close);
+      assertThrows(MutationsRejectedException.class, bw::close);
 
-      assertThrows(Exception.class, () -> Iterables.size(scanner));
+      assertThrows(IllegalStateException.class, () -> Iterables.size(scanner));
 
       threadCount = countThreads();
       if (threadCount > 0) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/CleanUpIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CleanUpIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.util.Map.Entry;
@@ -115,28 +116,13 @@ public class CleanUpIT extends SharedMiniClusterBase {
       Mutation m2 = new Mutation("r2");
       m2.put("cf1", "cq1", 1, "6");
 
-      try {
-        bw.addMutation(m1);
-        bw.flush();
-        fail("batch writer did not fail");
-      } catch (Exception e) {
+      bw.addMutation(m1);
+      assertThrows(Exception.class, bw::flush);
 
-      }
+      // expect this to fail also, want to clean up batch writer threads
+      assertThrows(Exception.class, bw::close);
 
-      try {
-        // expect this to fail also, want to clean up batch writer threads
-        bw.close();
-        fail("batch writer close not fail");
-      } catch (Exception e) {
-
-      }
-
-      try {
-        count = Iterables.size(scanner);
-        fail("scanner did not fail");
-      } catch (Exception e) {
-
-      }
+      assertThrows(Exception.class, () -> Iterables.size(scanner));
 
       threadCount = countThreads();
       if (threadCount > 0) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrentDeleteTableIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -105,12 +105,8 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
           future.get();
         }
 
-        try {
-          c.createScanner(table, Authorizations.EMPTY);
-          fail("Expected table " + table + " to be gone.");
-        } catch (TableNotFoundException tnfe) {
-          // expected
-        }
+        assertThrows("Expected table " + table + " to be gone.", TableNotFoundException.class,
+            () -> c.createScanner(table, Authorizations.EMPTY));
 
         FunctionalTestUtils.assertNoDanglingFateLocks((ClientContext) c, getCluster());
       }
@@ -213,12 +209,8 @@ public class ConcurrentDeleteTableIT extends AccumuloClusterHarness {
           future.get();
         }
 
-        try {
-          c.createScanner(table, Authorizations.EMPTY);
-          fail("Expected table " + table + " to be gone.");
-        } catch (TableNotFoundException tnfe) {
-          // expected
-        }
+        assertThrows("Expected table " + table + " to be gone.", TableNotFoundException.class,
+            () -> c.createScanner(table, Authorizations.EMPTY));
 
         FunctionalTestUtils.assertNoDanglingFateLocks((ClientContext) c, getCluster());
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
@@ -22,10 +22,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.accumulo.cluster.ClusterUser;
@@ -95,12 +95,10 @@ public class CredentialsIT extends AccumuloClusterHarness {
     assertFalse(token.isDestroyed());
     token.destroy();
     assertTrue(token.isDestroyed());
-    try (AccumuloClient ignored = Accumulo.newClient().from(getClientInfo().getProperties())
-        .as("non_existent_user", token).build()) {
-      fail("should ignore " + ignored);
-    } catch (IllegalArgumentException e) {
-      assertEquals(e.getMessage(), "AuthenticationToken has been destroyed");
-    }
+    Properties props = getClientInfo().getProperties();
+    var e = assertThrows(IllegalArgumentException.class,
+        () -> Accumulo.newClient().from(props).as("non_existent_user", token).build().close());
+    assertEquals(e.getMessage(), "AuthenticationToken has been destroyed");
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CredentialsIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -114,17 +115,12 @@ public class CredentialsIT extends AccumuloClusterHarness {
         assertFalse(token.isDestroyed());
         token.destroy();
         assertTrue(token.isDestroyed());
-        try {
-          Iterator<Entry<Key,Value>> iter = scanner.iterator();
-          while (iter.hasNext())
-            fail();
-          fail();
-        } catch (Exception e) {
-          assertTrue(e instanceof RuntimeException);
-          assertTrue(e.getCause() instanceof AccumuloSecurityException);
-          assertEquals(AccumuloSecurityException.class.cast(e.getCause()).getSecurityErrorCode(),
-              SecurityErrorCode.TOKEN_EXPIRED);
-        }
+
+        Iterator<Entry<Key,Value>> iter = scanner.iterator();
+        var e = assertThrows(RuntimeException.class, iter::hasNext);
+        assertTrue(e.getCause() instanceof AccumuloSecurityException);
+        assertEquals(((AccumuloSecurityException) e.getCause()).getSecurityErrorCode(),
+            SecurityErrorCode.TOKEN_EXPIRED);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteFailIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Collections;
 
@@ -52,9 +52,9 @@ public class DeleteFailIT extends AccumuloClusterHarness {
       }
 
       try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
-        scanner.forEach(e -> {});
-        fail("Expected scan to fail because  deletes are present.");
-      } catch (RuntimeException e) {}
+        assertThrows("Expected scan to fail because  deletes are present.", RuntimeException.class,
+            () -> scanner.forEach(e -> {}));
+      }
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -463,22 +462,21 @@ public class KerberosIT extends AccumuloITBase {
     // make a fake user that won't have krb credentials
     UserGroupInformation userWithoutPrivs =
         UserGroupInformation.createUserForTesting("fake_user", new String[0]);
-    try {
-      // Use the delegation token to try to log in as a different user
-      userWithoutPrivs.doAs((PrivilegedExceptionAction<Void>) () -> {
-        AccumuloClient client = mac.createAccumuloClient("some_other_user", delegationToken);
-        client.securityOperations().authenticateUser("some_other_user", delegationToken);
-        return null;
-      });
-      fail("Using a delegation token as a different user should throw an exception");
-    } catch (UndeclaredThrowableException e) {
-      Throwable cause = e.getCause();
-      assertNotNull(cause);
-      // We should get an AccumuloSecurityException from trying to use a delegation token for the
-      // wrong user
-      assertTrue("Expected cause to be AccumuloSecurityException, but was " + cause.getClass(),
-          cause instanceof AccumuloSecurityException);
-    }
+    // Use the delegation token to try to log in as a different user
+    var e = assertThrows("Using a delegation token as a different user should throw an exception",
+        UndeclaredThrowableException.class,
+        () -> userWithoutPrivs.doAs((PrivilegedExceptionAction<Void>) () -> {
+          AccumuloClient client = mac.createAccumuloClient("some_other_user", delegationToken);
+          client.securityOperations().authenticateUser("some_other_user", delegationToken);
+          return null;
+        }));
+
+    Throwable cause = e.getCause();
+    assertNotNull(cause);
+    // We should get an AccumuloSecurityException from trying to use a delegation token for the
+    // wrong user
+    assertTrue("Expected cause to be AccumuloSecurityException, but was " + cause.getClass(),
+        cause instanceof AccumuloSecurityException);
   }
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path provided by test")

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -269,16 +269,14 @@ public class NativeMapIT {
 
     nm.delete();
 
-    assertThrows(IllegalStateException.class, () -> nm.put(newKey(1), newValue(1)));
+    final Key key1 = newKey(1);
+    final Value value1 = newValue(1);
 
-    assertThrows(IllegalStateException.class, () -> nm.get(newKey(1)));
-
+    assertThrows(IllegalStateException.class, () -> nm.put(key1, value1));
+    assertThrows(IllegalStateException.class, () -> nm.get(key1));
+    assertThrows(IllegalStateException.class, () -> nm.iterator(key1));
     assertThrows(IllegalStateException.class, nm::iterator);
-
-    assertThrows(IllegalStateException.class, () -> nm.iterator(newKey(1)));
-
     assertThrows(IllegalStateException.class, nm::size);
-
     assertThrows(IllegalStateException.class, iter::next);
 
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/NativeMapIT.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -268,47 +269,17 @@ public class NativeMapIT {
 
     nm.delete();
 
-    try {
-      nm.put(newKey(1), newValue(1));
-      fail();
-    } catch (IllegalStateException e) {
+    assertThrows(IllegalStateException.class, () -> nm.put(newKey(1), newValue(1)));
 
-    }
+    assertThrows(IllegalStateException.class, () -> nm.get(newKey(1)));
 
-    try {
-      nm.get(newKey(1));
-      fail();
-    } catch (IllegalStateException e) {
+    assertThrows(IllegalStateException.class, nm::iterator);
 
-    }
+    assertThrows(IllegalStateException.class, () -> nm.iterator(newKey(1)));
 
-    try {
-      nm.iterator();
-      fail();
-    } catch (IllegalStateException e) {
+    assertThrows(IllegalStateException.class, nm::size);
 
-    }
-
-    try {
-      nm.iterator(newKey(1));
-      fail();
-    } catch (IllegalStateException e) {
-
-    }
-
-    try {
-      nm.size();
-      fail();
-    } catch (IllegalStateException e) {
-
-    }
-
-    try {
-      iter.next();
-      fail();
-    } catch (IllegalStateException e) {
-
-    }
+    assertThrows(IllegalStateException.class, iter::next);
 
   }
 
@@ -319,13 +290,7 @@ public class NativeMapIT {
     insertAndVerify(nm, 1, 10, 0);
 
     nm.delete();
-
-    try {
-      nm.delete();
-      fail();
-    } catch (IllegalStateException e) {
-
-    }
+    assertThrows(IllegalStateException.class, nm::delete);
   }
 
   @Test
@@ -366,24 +331,14 @@ public class NativeMapIT {
 
     Iterator<Entry<Key,Value>> iter = nm.iterator();
 
-    try {
-      iter.next();
-      fail();
-    } catch (NoSuchElementException e) {
-
-    }
+    assertThrows(NoSuchElementException.class, iter::next);
 
     insertAndVerify(nm, 1, 1, 0);
 
     iter = nm.iterator();
     iter.next();
 
-    try {
-      iter.next();
-      fail();
-    } catch (NoSuchElementException e) {
-
-    }
+    assertThrows(NoSuchElementException.class, iter::next);
 
     nm.delete();
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.test.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -114,18 +114,11 @@ public class ScannerContextIT extends AccumuloClusterHarness {
 
       // Check that ValueReversingIterator is not already on the classpath by not setting the
       // context. This should fail.
-      try {
-        scanCheck(c, tableName, cfg, null, "tseT");
-        fail("This should have failed because context was not set");
-      } catch (Exception e) {
-        // Do nothing, this should fail as the classloader context is not set.
-      }
-      try {
-        batchCheck(c, tableName, cfg, null, "tseT");
-        fail("This should have failed because context was not set");
-      } catch (Exception e) {
-        // Do nothing, this should fail as the classloader context is not set.
-      }
+      assertThrows("This should have failed because context was not set", Exception.class,
+          () -> scanCheck(c, tableName, cfg, null, "tseT"));
+
+      assertThrows("This should have failed because context was not set", Exception.class,
+          () -> batchCheck(c, tableName, cfg, null, "tseT"));
 
       // Ensure that the value is reversed using the iterator config and classloader context
       scanCheck(c, tableName, cfg, CONTEXT, "tseT");
@@ -170,18 +163,11 @@ public class ScannerContextIT extends AccumuloClusterHarness {
 
       // Check that ValueReversingIterator is not already on the classpath by not setting the
       // context. This should fail.
-      try {
-        scanCheck(c, tableName, cfg, null, "tseT");
-        fail("This should have failed because context was not set");
-      } catch (Exception e) {
-        // Do nothing, this should fail as the classloader context is not set.
-      }
-      try {
-        batchCheck(c, tableName, cfg, null, "tseT");
-        fail("This should have failed because context was not set");
-      } catch (Exception e) {
-        // Do nothing, this should fail as the classloader context is not set.
-      }
+      assertThrows("This should have failed because context was not set", Exception.class,
+          () -> scanCheck(c, tableName, cfg, null, "tseT"));
+
+      assertThrows("This should have failed because context was not set", Exception.class,
+          () -> batchCheck(c, tableName, cfg, null, "tseT"));
 
       // Ensure that the value is reversed using the iterator config and classloader context
       scanCheck(c, tableName, cfg, CONTEXT, "tseT");

--- a/test/src/main/java/org/apache/accumulo/test/functional/TimeoutIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TimeoutIT.java
@@ -102,9 +102,8 @@ public class TimeoutIT extends AccumuloClusterHarness {
       iterSetting.addOption("sleepTime", 2000 + "");
       bs.addScanIterator(iterSetting);
 
-      assertThrows("batch scanner did not time out", TimedOutException.class, () -> {
-        var ignored = bs.iterator().next().getKey();
-      });
+      assertThrows("batch scanner did not time out", TimedOutException.class,
+          () -> bs.iterator().next());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.test.mapred;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -115,13 +115,9 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       client.securityOperations().revokeTablePermission("root", testName.getMethodName(),
           TablePermission.WRITE);
 
-      try {
-        writer.close(null);
-        fail("Did not throw exception");
-      } catch (IOException ex) {
-        log.info(ex.getMessage(), ex);
-        assertTrue(ex.getCause() instanceof MutationsRejectedException);
-      }
+      var ex = assertThrows(IOException.class, () -> writer.close(null));
+      log.info(ex.getMessage(), ex);
+      assertTrue(ex.getCause() instanceof MutationsRejectedException);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloInputFormatIT.java
@@ -23,7 +23,6 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -135,10 +134,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
 
       // offline mode
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setOfflineTableScan(job, true);
-      try {
-        inputFormat.getSplits(job);
-        fail("An exception should have been thrown");
-      } catch (IOException e) {}
+      assertThrows(IOException.class, () -> inputFormat.getSplits(job));
 
       client.tableOperations().offline(table, true);
       splits = inputFormat.getSplits(job);
@@ -163,10 +159,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setAutoAdjustRanges(job, true);
 
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setOfflineTableScan(job, true);
-      try {
-        inputFormat.getSplits(job);
-        fail("An exception should have been thrown");
-      } catch (IllegalArgumentException e) {}
+      assertThrows(IllegalArgumentException.class, () -> inputFormat.getSplits(job));
 
       client.tableOperations().online(table, true);
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setOfflineTableScan(job, false);
@@ -177,10 +170,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
 
       // BatchScan not available with isolated iterators
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setScanIsolation(job, true);
-      try {
-        inputFormat.getSplits(job);
-        fail("An exception should have been thrown");
-      } catch (IllegalArgumentException e) {}
+      assertThrows(IllegalArgumentException.class, () -> inputFormat.getSplits(job));
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setScanIsolation(job, false);
 
       // test for resumption of success
@@ -189,10 +179,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
 
       // BatchScan not available with local iterators
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setLocalIterators(job, true);
-      try {
-        inputFormat.getSplits(job);
-        fail("An exception should have been thrown");
-      } catch (IllegalArgumentException e) {}
+      assertThrows(IllegalArgumentException.class, () -> inputFormat.getSplits(job));
       org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat.setLocalIterators(job, false);
 
       // Check we are getting back correct type pf split

--- a/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/ThriftBehaviorIT.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.test.rpc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 
@@ -88,12 +87,7 @@ public class ThriftBehaviorIT {
 
   @Test
   public void echoFail() throws TException {
-    try {
-      client.echoFail(KITTY_MSG);
-      fail("Thrift client did not throw an expected exception");
-    } catch (Exception e) {
-      assertEquals(TApplicationException.class.getName(), e.getClass().getName());
-    }
+    assertThrows(TApplicationException.class, () -> client.echoFail(KITTY_MSG));
     // verify normal two-way method still passes using same client
     echoPass();
   }
@@ -105,12 +99,7 @@ public class ThriftBehaviorIT {
 
   @Test
   public void echoRuntimeFail() throws TException {
-    try {
-      client.echoRuntimeFail(KITTY_MSG);
-      fail("Thrift client did not throw an expected exception");
-    } catch (Exception e) {
-      assertEquals(TApplicationException.class.getName(), e.getClass().getName());
-    }
+    assertThrows(TApplicationException.class, () -> client.echoRuntimeFail(KITTY_MSG));
     // verify normal two-way method still passes using same client
     echoPass();
   }

--- a/test/src/test/java/org/apache/accumulo/test/util/CertUtilsTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/util/CertUtilsTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.cert.Certificate;
 
@@ -104,9 +105,11 @@ public class CertUtilsTest {
     try (FileInputStream fis = new FileInputStream(signedKeyStoreFile)) {
       signedKeyStore.load(fis, PASSWORD_CHARS);
     }
+
     Certificate signedCert = CertUtils.findCert(signedKeyStore);
+    PublicKey pubKey = signedCert.getPublicKey();
     assertThrows("signed cert should not be able to verify itself", SignatureException.class,
-        () -> signedCert.verify(signedCert.getPublicKey()));
+        () -> signedCert.verify(pubKey));
 
     signedCert.verify(rootCert.getPublicKey()); // throws exception if it can't be verified
   }
@@ -138,9 +141,10 @@ public class CertUtilsTest {
     }
     Certificate rootCert = CertUtils.findCert(rootKeyStore);
     Certificate signedCert = CertUtils.findCert(signedKeyStore);
+    PublicKey pubKey = signedCert.getPublicKey();
 
     assertThrows("signed cert should not be able to verify itself", SignatureException.class,
-        () -> signedCert.verify(signedCert.getPublicKey()));
+        () -> signedCert.verify(pubKey));
 
     signedCert.verify(rootCert.getPublicKey()); // throws exception if it can't be verified
   }

--- a/test/src/test/java/org/apache/accumulo/test/util/CertUtilsTest.java
+++ b/test/src/test/java/org/apache/accumulo/test/util/CertUtilsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.util;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -77,12 +77,9 @@ public class CertUtilsTest {
     try (FileInputStream fis = new FileInputStream(publicKeyStoreFile)) {
       keyStore.load(fis, new char[0]);
     }
-    try {
-      CertUtils.findPrivateKey(keyStore, PASSWORD_CHARS);
-      fail("expected not to find private key in keystore");
-    } catch (KeyStoreException e) {
-      assertTrue(e.getMessage().contains("private key"));
-    }
+    var e = assertThrows("expected not to find private key in keystore", KeyStoreException.class,
+        () -> CertUtils.findPrivateKey(keyStore, PASSWORD_CHARS));
+    assertTrue(e.getMessage().contains("private key"));
     Certificate cert = CertUtils.findCert(keyStore);
     cert.verify(cert.getPublicKey()); // throws exception if it can't be verified
   }
@@ -108,13 +105,8 @@ public class CertUtilsTest {
       signedKeyStore.load(fis, PASSWORD_CHARS);
     }
     Certificate signedCert = CertUtils.findCert(signedKeyStore);
-
-    try {
-      signedCert.verify(signedCert.getPublicKey());
-      fail("signed cert should not be able to verify itself");
-    } catch (SignatureException e) {
-      // expected
-    }
+    assertThrows("signed cert should not be able to verify itself", SignatureException.class,
+        () -> signedCert.verify(signedCert.getPublicKey()));
 
     signedCert.verify(rootCert.getPublicKey()); // throws exception if it can't be verified
   }
@@ -147,12 +139,8 @@ public class CertUtilsTest {
     Certificate rootCert = CertUtils.findCert(rootKeyStore);
     Certificate signedCert = CertUtils.findCert(signedKeyStore);
 
-    try {
-      signedCert.verify(signedCert.getPublicKey());
-      fail("signed cert should not be able to verify itself");
-    } catch (SignatureException e) {
-      // expected
-    }
+    assertThrows("signed cert should not be able to verify itself", SignatureException.class,
+        () -> signedCert.verify(signedCert.getPublicKey()));
 
     signedCert.verify(rootCert.getPublicKey()); // throws exception if it can't be verified
   }


### PR DESCRIPTION
There are many instances in our tests where we expect an exception to be thrown and use a try-catch block to ensure that it is. An example (where `IllegalArgumentException` will be thrown upon calling `new Range(tr)`) looks like this:
```java
    try {
      new Range(tr);
      fail("Thrift constructor allowed invalid range");
    } catch (IllegalArgumentException exc) {
      /* good! */
    }
```
This way if the expected exception is thrown, the catch block catches it and does nothing, otherwise the test will fail via the `fail()` statement. While this works, it can be more effectively handled using `assertThrows()`. Preserving functionality, the example above would be converted to:

```java
    assertThrows("Thrift constructor allowed invalid range", IllegalArgumentException.class,
        () -> new Range(tr));
```
These instances were found using the ErrorProne profile from #2447 with `-Xep:TryFailRefactoring` added as an arg in the ErrorProne plugin section in the pom.