### PR TITLE
Utilize Uninterruptibles.joinUninterruptibly in ServiceLockIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -59,6 +59,8 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.Uninterruptibles;
+
 @Category({ZooKeeperTestingServerTests.class})
 public class ServiceLockIT {
 
@@ -623,11 +625,7 @@ public class ServiceLockIT {
       assertEquals(0, zk.getChildren(parent.toString(), false).size());
 
       threads.forEach(t -> {
-        try {
-          t.join();
-        } catch (InterruptedException e) {
-          // ignore
-        }
+        Uninterruptibles.joinUninterruptibly(t);
       });
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -624,9 +624,7 @@ public class ServiceLockIT {
       workers.forEach(w -> assertNull(w.getException()));
       assertEquals(0, zk.getChildren(parent.toString(), false).size());
 
-      threads.forEach(t -> {
-        Uninterruptibles.joinUninterruptibly(t);
-      });
+      threads.forEach(Uninterruptibles::joinUninterruptibly);
     }
 
   }


### PR DESCRIPTION
Replace t.join within the try/catch of ServiceLockIT with the use of Uninterruptibles.joinUninterruptibly.