### PR TITLE
Expresion of type int may overflow before assignment to long.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
@@ -197,15 +197,15 @@ public final class Utils {
       case 9:
       case 8:
       case 7:
-        return ((firstByte + 52) << 8) | in.readUnsignedByte();
+        return ((firstByte + 52L) << 8) | in.readUnsignedByte();
       case 6:
       case 5:
       case 4:
       case 3:
-        return ((firstByte + 88) << 16) | in.readUnsignedShort();
+        return ((firstByte + 88L) << 16) | in.readUnsignedShort();
       case 2:
       case 1:
-        return ((firstByte + 112) << 24) | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
+        return ((firstByte + 112L) << 24) | (in.readUnsignedShort() << 8) | in.readUnsignedByte();
       case 0:
         int len = firstByte + 129;
         switch (len) {

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -633,7 +633,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     // get the total number of compactors assigned to this queue
     int numCompactors = ExternalCompactionUtil.countCompactors(queueName, getContext());
     // Aim for around 3 compactors checking in every second
-    long sleepTime = numCompactors * 1000 / 3;
+    long sleepTime = numCompactors * 1000L / 3;
     // Ensure a compactor sleeps at least around a second
     sleepTime = Math.max(1000, sleepTime);
     // Ensure a compactor sleep not too much more than 5 mins

--- a/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerReplicationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/replication/UnorderedWorkAssignerReplicationIT.java
@@ -286,7 +286,7 @@ public class UnorderedWorkAssignerReplicationIT extends ConfigurableMacBase {
         return true;
       });
 
-      long timeoutSeconds = timeoutFactor * 30;
+      long timeoutSeconds = timeoutFactor * 30L;
       try {
         future.get(timeoutSeconds, TimeUnit.SECONDS);
       } catch (TimeoutException e) {


### PR DESCRIPTION
From errorpone bug pattern description:

Performing an arithmetic expression on arguments of type int and then
assigning the result to a long is error-prone. The result is widened to
a long as the final step, and the intermediate results may overflow.