### PR TITLE
Class can be static

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -163,7 +163,7 @@ public abstract class FileOperations {
     return new ReaderBuilder();
   }
 
-  public class FileOptions {
+  public static class FileOptions {
     // objects used by all
     public final AccumuloConfiguration tableConfiguration;
     public final String filename;
@@ -270,7 +270,7 @@ public abstract class FileOperations {
   /**
    * Helper class extended by both writers and readers.
    */
-  public class FileHelper {
+  public static class FileHelper {
     private AccumuloConfiguration tableConfiguration;
     private String filename;
     private FileSystem fs;

--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooCache.java
@@ -246,7 +246,7 @@ public class ZooCache {
     this.externalWatcher = watcher;
   }
 
-  private abstract class ZooRunnable<T> {
+  private abstract static class ZooRunnable<T> {
     /**
      * Runs an operation against ZooKeeper. Retries are performed by the retry method when
      * KeeperExceptions occur.

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -315,7 +315,7 @@ public class BulkImporter {
     return Collections.emptySet();
   }
 
-  private class AssignmentInfo {
+  private static class AssignmentInfo {
     public AssignmentInfo(KeyExtent keyExtent, Long estSize) {
       this.ke = keyExtent;
       this.estSize = estSize;
@@ -488,7 +488,7 @@ public class BulkImporter {
 
   }
 
-  private class PathSize {
+  private static class PathSize {
     public PathSize(Path mapFile, long estSize) {
       this.path = mapFile;
       this.estSize = estSize;

--- a/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/log/WalStateManager.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  */
 public class WalStateManager {
 
-  public class WalMarkerException extends Exception {
+  public static class WalMarkerException extends Exception {
     private static final long serialVersionUID = 1L;
 
     public WalMarkerException(Exception ex) {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -182,7 +182,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
 
   private ServiceLock monitorLock;
 
-  private class EventCounter {
+  private static class EventCounter {
 
     Map<String,Pair<Long,Long>> prevSamples = new HashMap<>();
     Map<String,Pair<Long,Long>> samples = new HashMap<>();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -503,7 +503,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
   }
 
   @Deprecated
-  protected class RFileClientExecReturn
+  protected static class RFileClientExecReturn
       implements ClientExecReturn<ReplicationStats,ReplicationServicer.Client> {
 
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/rpc/Mocket.java
+++ b/test/src/main/java/org/apache/accumulo/test/rpc/Mocket.java
@@ -130,7 +130,7 @@ public class Mocket {
 
   }
 
-  private class MocketServerTransport extends TServerTransport {
+  private static class MocketServerTransport extends TServerTransport {
 
     private final MocketTransport servTrans;
 


### PR DESCRIPTION
Several classes were flagged by errorprone as inner classes which could
be made static. Per errorprone justification:

"An inner class should be static unless it references members of its
enclosing class. An inner class that is made non-static unnecessarily
uses more memory and does not make the intent of the class clear."