### PR TITLE
Move zooReaderWriter into ClientContext

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -77,6 +77,7 @@ import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
+import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -100,6 +101,7 @@ public class ClientContext implements AccumuloClient {
   private final ClientInfo info;
   private InstanceId instanceId;
   private final ZooCache zooCache;
+  protected final ZooReaderWriter zooReaderWriter;
 
   private Credentials creds;
   private BatchWriterConfig batchWriterConfig;
@@ -157,6 +159,7 @@ public class ClientContext implements AccumuloClient {
     this.singletonReservation = Objects.requireNonNull(reservation);
     this.tableops = new TableOperationsImpl(this);
     this.namespaceops = new NamespaceOperationsImpl(this, tableops);
+    this.zooReaderWriter = new ZooReaderWriter(getConfiguration());
   }
 
   /**
@@ -720,6 +723,10 @@ public class ClientContext implements AccumuloClient {
       thriftTransportPool.shutdown();
     }
     singletonReservation.close();
+  }
+
+  public ZooReaderWriter getZooReaderWriter() {
+    return zooReaderWriter;
   }
 
   public static class ClientBuilderImpl<T>

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -81,7 +81,6 @@ public class ServerContext extends ClientContext {
   private static final Logger log = LoggerFactory.getLogger(ServerContext.class);
 
   private final ServerInfo info;
-  private final ZooReaderWriter zooReaderWriter;
   private final ServerDirs serverDirs;
 
   private TableManager tableManager;
@@ -100,7 +99,6 @@ public class ServerContext extends ClientContext {
   private ServerContext(ServerInfo info) {
     super(SingletonReservation.noop(), info, info.getSiteConfiguration());
     this.info = info;
-    zooReaderWriter = new ZooReaderWriter(info.getSiteConfiguration());
     serverDirs = info.getServerDirs();
   }
 


### PR DESCRIPTION
* Move the zooReaderWriter object into ClientContext to help in places where we need to
do things to ZK but don't have ServerContext available