### PR TITLE
Fix faulty test: `SortedLogRecoveryTest.testMissingDefinition`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <curator.version>5.1.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
+    <errorprone.version>2.11.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <failsafe.excludedGroups />
@@ -1622,6 +1623,65 @@
         <failsafe.reuseForks>${reuseForks}</failsafe.reuseForks>
         <surefire.reuseForks>${reuseForks}</surefire.reuseForks>
       </properties>
+    </profile>
+    <profile>
+      <!-- This profile uses the Google ErrorProne tool to perform static code analysis at
+      compile time. Auto-generated code is not checked.
+      See: https://errorprone.info/bugpatterns for list of available bug patterns.-->
+      <id>errorprone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>
+                  -Xplugin:ErrorProne \
+                  -XepExcludedPaths:.*/(proto|thrift|generated-sources)/.* \
+                  -XepDisableWarningsInGeneratedCode \
+                  -XepDisableAllWarnings \
+                  <!-- error/warning patterns to ignore -->
+                  -Xep:Incomparable:OFF \
+                  -Xep:CheckReturnValue:OFF \
+                  -Xep:MustBeClosedChecker:OFF \
+                  -Xep:ReturnValueIgnored:OFF \
+                  -Xep:UnicodeInCode:OFF \
+                  <!-- error/warning patterns to specifically check -->
+                  -Xep:ExpectedExceptionChecker \
+                  -Xep:MissingOverride \
+                  <!-- Items containing 'OFF' are currently flagged by ErrorProne. The 'OFF'
+                  can be removed and the project recompiled to discover location of errors for
+                  further analysis. @SuppressWarnings can be used to ignore errors if desired. -->
+                </arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </path>
+                <path>
+                  <groupId>com.google.auto.service</groupId>
+                  <artifactId>auto-service</artifactId>
+                  <version>1.0</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -30,7 +30,6 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -113,8 +113,7 @@ public class SortedLogRecoveryTest {
 
     @Override
     public boolean equals(Object obj) {
-      return this == obj
-          || (obj instanceof KeyValue && 0 == compareTo((KeyValue) obj));
+      return this == obj || (obj instanceof KeyValue && 0 == compareTo((KeyValue) obj));
     }
 
     @Override


### PR DESCRIPTION
Closes #2489

The changes in this PR delete `SortedLogRecoveryTest.testMissingDefinition()`.

Based off the name of the test (testMissingDefinition) it seems that this test assumes that an exception will be thrown when there is no definition present. Instead, this information is just logged and does not cause an exception to be thrown:
```
[log.SortedLogRecovery] INFO : Tablet table<< is not defined in recovery logs [testlog]
```
Additionally, this test is incorrectly set up to handle the `fail()` statement which will just be caught in the catch block instead of making the test actually fail.