### PR TITLE
Modify ZooKeeperTestingServer to use Junit TemporaryFolder

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -93,7 +93,7 @@ public class FateIT {
   }
 
   @ClassRule
-  public static TemporaryFolder TEMP =
+  public static final TemporaryFolder TEMP =
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
   private static ZooKeeperTestingServer szk = null;
@@ -106,7 +106,7 @@ public class FateIT {
 
   @BeforeClass
   public static void setup() throws Exception {
-    szk = new ZooKeeperTestingServer(TEMP);
+    szk = new ZooKeeperTestingServer(TEMP.newFolder());
   }
 
   @AfterClass

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -25,6 +25,7 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
@@ -51,8 +52,10 @@ import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.apache.zookeeper.KeeperException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
 @Category({ZooKeeperTestingServerTests.class})
 public class FateIT {
@@ -89,6 +92,10 @@ public class FateIT {
 
   }
 
+  @ClassRule
+  public static TemporaryFolder TEMP =
+      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+
   private static ZooKeeperTestingServer szk = null;
   private static final String ZK_ROOT = "/accumulo/" + UUID.randomUUID().toString();
   private static final NamespaceId NS = NamespaceId.of("testNameSpace");
@@ -99,7 +106,7 @@ public class FateIT {
 
   @BeforeClass
   public static void setup() throws Exception {
-    szk = new ZooKeeperTestingServer();
+    szk = new ZooKeeperTestingServer(TEMP);
   }
 
   @AfterClass

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -68,14 +68,14 @@ import com.google.common.util.concurrent.Uninterruptibles;
 public class ServiceLockIT {
 
   @ClassRule
-  public static TemporaryFolder TEMP =
+  public static final TemporaryFolder TEMP =
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
   private static ZooKeeperTestingServer szk = null;
 
   @BeforeClass
   public static void setup() throws Exception {
-    szk = new ZooKeeperTestingServer(TEMP);
+    szk = new ZooKeeperTestingServer(TEMP.newFolder());
     szk.initPaths("/accumulo/" + InstanceId.of(UUID.randomUUID()));
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -54,8 +55,10 @@ import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,11 +67,15 @@ import com.google.common.util.concurrent.Uninterruptibles;
 @Category({ZooKeeperTestingServerTests.class})
 public class ServiceLockIT {
 
+  @ClassRule
+  public static TemporaryFolder TEMP =
+      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+
   private static ZooKeeperTestingServer szk = null;
 
   @BeforeClass
   public static void setup() throws Exception {
-    szk = new ZooKeeperTestingServer();
+    szk = new ZooKeeperTestingServer(TEMP);
     szk.initPaths("/accumulo/" + InstanceId.of(UUID.randomUUID()));
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
@@ -83,7 +83,7 @@ public class ZooMutatorIT {
   @Test
   public void concurrentMutatorTest() throws Exception {
 
-    try (ZooKeeperTestingServer szk = new ZooKeeperTestingServer(tempFolder)) {
+    try (ZooKeeperTestingServer szk = new ZooKeeperTestingServer(tempFolder.newFolder())) {
       szk.initPaths("/accumulo/" + InstanceId.of(UUID.randomUUID()));
       ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 10_0000, "aPasswd");
 

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -33,13 +34,20 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
 import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
 import com.google.common.hash.Hashing;
 
 @Category({ZooKeeperTestingServerTests.class})
 public class ZooMutatorIT {
+
+  @Rule
+  public TemporaryFolder tempFolder =
+      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+
   /**
    * This test uses multiple threads to update the data in a single zookeeper node using
    * {@link ZooReaderWriter#mutateOrCreate(String, byte[], ZooReaderWriter.Mutator)} and tries to
@@ -75,7 +83,7 @@ public class ZooMutatorIT {
   @Test
   public void concurrentMutatorTest() throws Exception {
 
-    try (ZooKeeperTestingServer szk = new ZooKeeperTestingServer()) {
+    try (ZooKeeperTestingServer szk = new ZooKeeperTestingServer(tempFolder)) {
       szk.initPaths("/accumulo/" + InstanceId.of(UUID.randomUUID()));
       ZooReaderWriter zk = new ZooReaderWriter(szk.getConn(), 10_0000, "aPasswd");
 

--- a/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
@@ -18,9 +18,8 @@
  */
 package org.apache.accumulo.test.zookeeper;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.accumulo.server.util.PortUtils;
@@ -29,6 +28,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,15 +47,15 @@ public class ZooKeeperTestingServer implements AutoCloseable {
    * Instantiate a running zookeeper server - this call will block until the server is ready for
    * client connections. It will try three times, with a 5 second pause to connect.
    */
-  public ZooKeeperTestingServer() {
-    this(PortUtils.getRandomFreePort());
+  public ZooKeeperTestingServer(TemporaryFolder tmpDir) {
+    this(tmpDir, PortUtils.getRandomFreePort());
   }
 
-  private ZooKeeperTestingServer(int port) {
+  private ZooKeeperTestingServer(TemporaryFolder tmpDir, int port) {
 
     try {
 
-      Path tmpDir = Files.createTempDirectory("zk_test");
+      File zkTmpDir = tmpDir.newFolder();
 
       CountDownLatch connectionLatch = new CountDownLatch(1);
 
@@ -68,7 +68,7 @@ public class ZooKeeperTestingServer implements AutoCloseable {
 
         try {
 
-          zkServer = new TestingServer(port, tmpDir.toFile());
+          zkServer = new TestingServer(port, zkTmpDir);
           zkServer.start();
 
           started = true;

--- a/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
@@ -28,7 +28,6 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,15 +46,13 @@ public class ZooKeeperTestingServer implements AutoCloseable {
    * Instantiate a running zookeeper server - this call will block until the server is ready for
    * client connections. It will try three times, with a 5 second pause to connect.
    */
-  public ZooKeeperTestingServer(TemporaryFolder tmpDir) {
+  public ZooKeeperTestingServer(File tmpDir) {
     this(tmpDir, PortUtils.getRandomFreePort());
   }
 
-  private ZooKeeperTestingServer(TemporaryFolder tmpDir, int port) {
+  private ZooKeeperTestingServer(File tmpDir, int port) {
 
     try {
-
-      File zkTmpDir = tmpDir.newFolder();
 
       CountDownLatch connectionLatch = new CountDownLatch(1);
 
@@ -68,7 +65,7 @@ public class ZooKeeperTestingServer implements AutoCloseable {
 
         try {
 
-          zkServer = new TestingServer(port, zkTmpDir);
+          zkServer = new TestingServer(port, tmpDir);
           zkServer.start();
 
           started = true;

--- a/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
@@ -31,6 +31,8 @@ import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Uses Apache Curator to create a running zookeeper server for internal tests. The zookeeper port
  * is randomly assigned in case multiple instances are created by concurrent tests.
@@ -51,6 +53,8 @@ public class ZooKeeperTestingServer implements AutoCloseable {
   }
 
   private ZooKeeperTestingServer(File tmpDir, int port) {
+
+    Preconditions.checkArgument(tmpDir.isDirectory());
 
     try {
 


### PR DESCRIPTION
Modify ZooKeeperTestingServer to use Junit TemporaryFolder
for creating the ZooKeeper data directory instead of /tmp.
Related to #2474