### PR TITLE
Apply automatic module names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
     <version.curator>5.5.0</version.curator>
     <version.errorprone>2.20.0</version.errorprone>
     <version.hadoop>3.3.6</version.hadoop>
+    <version.maven-javadoc-plugin>3.6.0</version.maven-javadoc-plugin>
     <version.opentelemetry>1.27.0</version.opentelemetry>
     <version.powermock>2.0.9</version.powermock>
     <version.slf4j>2.0.7</version.slf4j>
@@ -821,8 +822,7 @@
           <configuration>
             <archive>
               <manifestEntries>
-                <!-- Automatic modules do not work with the javadoc plugin - see MJAVADOC-707 -->
-                <!-- Automatic-Module-Name>${accumulo.module.name}</Automatic-Module-Name -->
+                <Automatic-Module-Name>${accumulo.module.name}</Automatic-Module-Name>
                 <Implementation-Build>${mvngit.commit.id}</Implementation-Build>
                 <Sealed>true</Sealed>
               </manifestEntries>
@@ -839,6 +839,7 @@
             <quiet>true</quiet>
             <additionalJOption>-J-Xmx512m</additionalJOption>
             <doclint>all,-missing</doclint>
+            <legacyMode>true</legacyMode>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This supersedes #1438  

Note: This doesn't currently work, because of bugs in maven-javadoc-plugin which seem to force the use of a module path, even though our dependencies don't all have modules, and we're not explicitly using modules. The maven-javadoc-plugin seems to require that we go full modular or not at all... no middle ground is apparently available.

Edit: it works now with maven-javadoc-plugin 3.6.0