### PR TITLE
Make build work on Java 17

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -60,17 +60,18 @@ jobs:
     strategy:
       matrix:
         profile:
-          - {name: 'unit-tests',    args: 'verify -PskipQA -DskipTests=false'}
-          - {name: 'qa-checks',     args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'hadoop-compat', args: 'package -DskipTests -Dhadoop.version=3.0.3'}
+          - {name: 'unit-tests',    javaver: 11, args: 'verify -PskipQA -DskipTests=false'}
+          - {name: 'qa-checks',     javaver: 11, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
+          - {name: 'hadoop-compat', javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3'}
+          - {name: 'jdk17',         javaver: 17, args: 'verify -DskipITs'}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.profile.javaver }}
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: ${{ matrix.profile.javaver }}
     - name: Cache local maven repository
       uses: actions/cache@v2
       with:

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
@@ -118,20 +118,12 @@ public interface AuthenticationToken extends Writable, Destroyable, Cloneable {
      * @see #deserialize(Class, byte[])
      */
     public static byte[] serialize(AuthenticationToken token) {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      DataOutputStream out = new DataOutputStream(baos);
-      try {
+      try (var baos = new ByteArrayOutputStream(); var out = new DataOutputStream(baos)) {
         token.write(out);
+        return baos.toByteArray();
       } catch (IOException e) {
         throw new RuntimeException("Bug found in serialization code", e);
       }
-      byte[] bytes = baos.toByteArray();
-      try {
-        out.close();
-      } catch (IOException e) {
-        throw new IllegalStateException("Shouldn't happen with ByteArrayOutputStream", e);
-      }
-      return bytes;
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
@@ -41,15 +41,13 @@ public class ClientPropertyTest {
     assertEquals("testpass1", new String(((PasswordToken) token).getPassword()));
 
     ClientProperty.setAuthenticationToken(props, new PasswordToken("testpass2"));
-    assertEquals("AAAAHR+LCAAAAAAAAAArSS0uKUgsLjYCANxwRH4JAAAA",
-        ClientProperty.AUTH_TOKEN.getValue(props));
+    assertEquals("/////gAAAAl0ZXN0cGFzczI=", ClientProperty.AUTH_TOKEN.getValue(props));
     token = ClientProperty.getAuthenticationToken(props);
     assertTrue(token instanceof PasswordToken);
     assertEquals("testpass2", new String(((PasswordToken) token).getPassword()));
 
     ClientProperty.setAuthenticationToken(props, new PasswordToken("testpass3"));
-    assertEquals("AAAAHR+LCAAAAAAAAAArSS0uKUgsLjYGAEpAQwkJAAAA",
-        ClientProperty.AUTH_TOKEN.getValue(props));
+    assertEquals("/////gAAAAl0ZXN0cGFzczM=", ClientProperty.AUTH_TOKEN.getValue(props));
     token = ClientProperty.getAuthenticationToken(props);
     assertTrue(token instanceof PasswordToken);
     assertEquals("testpass3", new String(((PasswordToken) token).getPassword()));

--- a/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/security/CredentialsTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import javax.security.auth.DestroyFailedException;
 
@@ -61,7 +60,7 @@ public class CredentialsTest {
     // verify that we can't serialize if it's destroyed
     creds.getToken().destroy();
     Exception e = assertThrows(RuntimeException.class, () -> creds.toThrift(instanceID));
-    assertTrue(e.getCause() instanceof AccumuloSecurityException);
+    assertEquals(AccumuloSecurityException.class, e.getCause().getClass());
     assertEquals(AccumuloSecurityException.class.cast(e.getCause()).getSecurityErrorCode(),
         SecurityErrorCode.TOKEN_EXPIRED);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
     <errorprone.version>2.11.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
+    <extraTestArgs />
     <failsafe.excludedGroups />
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
@@ -852,7 +853,7 @@
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>
-            <argLine>${unitTestMemSize}</argLine>
+            <argLine>${unitTestMemSize} ${extraTestArgs}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -866,6 +867,7 @@
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>
+            <argLine>${extraTestArgs}</argLine>
             <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
@@ -1682,6 +1684,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED</extraTestArgs>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -621,7 +621,7 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
    *          number of bytes in input file
    * @return number of seconds to wait between progress checks
    */
-  protected long calculateProgressCheckTime(long numBytes) {
+  static long calculateProgressCheckTime(long numBytes) {
     return Math.max(1, (numBytes / TEN_MEGABYTES));
   }
 

--- a/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
+++ b/server/compactor/src/test/java/org/apache/accumulo/compactor/CompactorTest.java
@@ -59,7 +59,6 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -298,24 +297,17 @@ public class CompactorTest {
 
   @Test
   public void testCheckTime() throws Exception {
-    // Instantiates class without calling constructor
-    Compactor c = Whitebox.newInstance(Compactor.class);
-    assertEquals(1, c.calculateProgressCheckTime(1024));
-    assertEquals(1, c.calculateProgressCheckTime(1048576));
-    assertEquals(1, c.calculateProgressCheckTime(10485760));
-    assertEquals(10, c.calculateProgressCheckTime(104857600));
-    assertEquals(102, c.calculateProgressCheckTime(1024 * 1024 * 1024));
+    assertEquals(1, Compactor.calculateProgressCheckTime(1024));
+    assertEquals(1, Compactor.calculateProgressCheckTime(1048576));
+    assertEquals(1, Compactor.calculateProgressCheckTime(10485760));
+    assertEquals(10, Compactor.calculateProgressCheckTime(104857600));
+    assertEquals(102, Compactor.calculateProgressCheckTime(1024 * 1024 * 1024));
   }
 
   @Test
   public void testCompactionSucceeds() throws Exception {
     UUID uuid = UUID.randomUUID();
-    Supplier<UUID> supplier = new Supplier<>() {
-      @Override
-      public UUID get() {
-        return uuid;
-      }
-    };
+    Supplier<UUID> supplier = () -> uuid;
 
     ExternalCompactionId eci = ExternalCompactionId.generate(supplier.get());
 
@@ -362,12 +354,7 @@ public class CompactorTest {
   @Test
   public void testCompactionFails() throws Exception {
     UUID uuid = UUID.randomUUID();
-    Supplier<UUID> supplier = new Supplier<>() {
-      @Override
-      public UUID get() {
-        return uuid;
-      }
-    };
+    Supplier<UUID> supplier = () -> uuid;
 
     ExternalCompactionId eci = ExternalCompactionId.generate(supplier.get());
 
@@ -416,12 +403,7 @@ public class CompactorTest {
   @Test
   public void testCompactionInterrupted() throws Exception {
     UUID uuid = UUID.randomUUID();
-    Supplier<UUID> supplier = new Supplier<>() {
-      @Override
-      public UUID get() {
-        return uuid;
-      }
-    };
+    Supplier<UUID> supplier = () -> uuid;
 
     ExternalCompactionId eci = ExternalCompactionId.generate(supplier.get());
 


### PR DESCRIPTION
Ensure it is possible to successfully build using Java 17
These changes were tested with `mvn clean verify -Psunny`

* Add JDK 17 build to GitHub Actions
* Change format of `PasswordToken` serialization so it doesn't use GZip
  from Hadoop's `WritableUtils.writeCompressedByteArray()`, which seems
  to have changed format slightly between Java 11 and 17, resulting in
  slightly different GZip header information. However, still support
  reading the old version (added tests for these)
* Pass absurd jdk adds-opens options to ensure test code has access
  parts of the JDK needed for mocking / junit testing