### PR TITLE
Synchronize method shared between FaTE ops

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/cancel/CancelCompactions.java
@@ -64,7 +64,7 @@ public class CancelCompactions extends ManagerRepo {
     Utils.unreserveNamespace(env, namespaceId, tid, false);
   }
 
-  public static void mutateZooKeeper(long tid, TableId tableId, Manager environment)
+  public static synchronized void mutateZooKeeper(long tid, TableId tableId, Manager environment)
       throws Exception {
     String zCompactID = Constants.ZROOT + "/" + environment.getInstanceID() + Constants.ZTABLES
         + "/" + tableId + Constants.ZTABLE_COMPACT_ID;


### PR DESCRIPTION
Added the synchronized modifier to CancelCompactions.mutateZooKeeper which
could be called from concurrent delete table or cancel compaction operations