### PR TITLE
Bump ZooKeeper and Hadoop dependencies

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -64,7 +64,7 @@ jobs:
         profile:
           - {name: 'unit-tests',    javaver: 11, args: 'verify -PskipQA -DskipTests=false'}
           - {name: 'qa-checks',     javaver: 11, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'hadoop-compat', javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3'}
+          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.5.9'}
           - {name: 'jdk17',         javaver: 17, args: 'verify -DskipITs'}
       fail-fast: false
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.1</hadoop.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <!-- prevent introduction of new compiler warnings -->
@@ -159,7 +159,7 @@
     <thrift.version>0.15.0</thrift.version>
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
     <!-- ZooKeeper version -->
-    <zookeeper.version>3.5.9</zookeeper.version>
+    <zookeeper.version>3.7.0</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/zookeeper/DistributedWorkQueue.java
@@ -210,12 +210,7 @@ public class DistributedWorkQueue {
             else
               log.info("Unexpected path for NodeChildrenChanged event {}", event.getPath());
             break;
-          case NodeCreated:
-          case NodeDataChanged:
-          case NodeDeleted:
-          case ChildWatchRemoved:
-          case DataWatchRemoved:
-          case None:
+          default:
             log.info("Got unexpected zookeeper event: {} for {}", event.getType(), path);
             break;
         }
@@ -274,12 +269,7 @@ public class DistributedWorkQueue {
               condVar.notify();
             }
             break;
-          case NodeCreated:
-          case NodeDataChanged:
-          case NodeDeleted:
-          case ChildWatchRemoved:
-          case DataWatchRemoved:
-          case None:
+          default:
             log.info("Got unexpected zookeeper event: {} for {}", event.getType(), path);
             break;
         }


### PR DESCRIPTION
Bump Hadoop to latest bugfix release (3.3.0 to 3.3.1)

Bump ZooKeeper from 3.5 to 3.7

Recent conversations on the ZooKeeper mailing lists suggest that
community will soon mark 3.5 as EOL, and may also move to make 3.6 EOL
after 3.8 is released.

This change updates the default ZooKeeper used to build Accumulo to
3.7.0, but updates the GitHub Actions to test that 3.5 still works.

Additionally, since a new event type (PersistentWatchRemoved) was added
after 3.5, all unhandled event types in switch statements in
DistributedWorkQueue are collapsed into a single default case to ensure
it includes the new event type without directly referencing it, which
would cause a compile failure against 3.5.