### PR TITLE
Change timeouts to correct unit in accumulo-core module

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/data/NamespaceIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/NamespaceIdTest.java
@@ -69,7 +69,7 @@ public class NamespaceIdTest extends WithTestNames {
   }
 
   @Test
-  @Timeout(30_000)
+  @Timeout(30)
   public void testCacheIncreasesAndDecreasesAfterGC() {
     long initialSize = cacheCount();
     assertTrue(initialSize < 20); // verify initial amount is reasonably low

--- a/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/TableIdTest.java
@@ -81,7 +81,7 @@ public class TableIdTest extends WithTestNames {
   }
 
   @Test
-  @Timeout(30_000)
+  @Timeout(30)
   public void testCacheIncreasesAndDecreasesAfterGC() {
     long initialSize = cacheCount();
     assertTrue(initialSize < 20); // verify initial amount is reasonably low

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionTest.java
@@ -159,7 +159,7 @@ public class CompressionTest {
   }
 
   @Test
-  @Timeout(60_000)
+  @Timeout(60)
   public void testManyStartNotNull() throws InterruptedException, ExecutionException {
 
     for (final Algorithm al : Algorithm.values()) {
@@ -202,7 +202,7 @@ public class CompressionTest {
 
   // don't start until we have created the codec
   @Test
-  @Timeout(60_000)
+  @Timeout(60)
   public void testManyDontStartUntilThread() throws InterruptedException, ExecutionException {
 
     for (final Algorithm al : Algorithm.values()) {
@@ -239,7 +239,7 @@ public class CompressionTest {
   }
 
   @Test
-  @Timeout(60_000)
+  @Timeout(60)
   public void testThereCanBeOnlyOne() throws InterruptedException, ExecutionException {
 
     for (final Algorithm al : Algorithm.values()) {

--- a/core/src/test/java/org/apache/accumulo/core/util/InternerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/InternerTest.java
@@ -81,7 +81,7 @@ public class InternerTest {
   }
 
   @Test
-  @Timeout(20_000)
+  @Timeout(20)
   public void testInternsGetGarbageCollected() {
     var interner = new Interner<TestObj>();
     assertEquals(0, interner.size()); // ensure empty

--- a/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooSessionTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/zookeeper/ZooSessionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.fate.zookeeper;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.zookeeper.ZooKeeper;
@@ -26,14 +27,15 @@ import org.junit.jupiter.api.Timeout;
 
 public class ZooSessionTest {
 
-  private static final int MINIMUM_TIMEOUT = 10000;
+  private static final int TIMEOUT_SECONDS = 10;
   private static final String UNKNOWN_HOST = "hostname.that.should.not.exist.example.com:2181";
 
   @Test
-  @Timeout(MINIMUM_TIMEOUT * 4)
+  @Timeout(TIMEOUT_SECONDS * 4)
   public void testUnknownHost() {
     assertThrows(RuntimeException.class, () -> {
-      ZooKeeper session = ZooSession.connect(UNKNOWN_HOST, MINIMUM_TIMEOUT, null, null, null);
+      ZooKeeper session = ZooSession.connect(UNKNOWN_HOST, (int) SECONDS.toMillis(TIMEOUT_SECONDS),
+          null, null, null);
       session.close();
     });
   }


### PR DESCRIPTION
In #2427 I converted to the new syntax for timeouts but overlooked the fact that the default units have changed from milliseconds to seconds. This PR changes the timeouts back to their intended duration.