### PR TITLE
Add two missing override annotations

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -143,6 +143,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
     }
   }
 
+  @Override
   public synchronized void startCoordinator(Class<? extends CompactionCoordinator> coordinator)
       throws IOException {
     if (coordinatorProcess == null) {
@@ -162,6 +163,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
     }
   }
 
+  @Override
   public synchronized void startCompactors(Class<? extends Compactor> compactor, int limit,
       String queueName) throws IOException {
     synchronized (compactorProcesses) {


### PR DESCRIPTION
Add two missing override annotations within the
MiniAccumuloClusterControl class.