### PR TITLE
Fix usage of `@Tempdir` in accumulo-core module

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/classloader/ContextClassLoaderFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/classloader/ContextClassLoaderFactoryTest.java
@@ -38,7 +38,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class ContextClassLoaderFactoryTest {
 
   @TempDir
-  private static final File tempFolder = new File(System.getProperty("user.dir") + "/target",
+  private final File tempFolder = new File(System.getProperty("user.dir") + "/target",
       ContextClassLoaderFactoryTest.class.getSimpleName() + "/");
 
   private String uri1;

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -55,7 +55,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
   private static final SecureRandom random = new SecureRandom();
 
   @TempDir
-  private static final File tempDir = new File(System.getProperty("user.dir") + "/target",
+  private final File tempDir = new File(System.getProperty("user.dir") + "/target",
       BloomFilterLayerLookupTest.class.getSimpleName() + "/");
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
@@ -51,7 +51,7 @@ public class GenerateSplitsTest {
   private static final Logger log = LoggerFactory.getLogger(GenerateSplitsTest.class);
 
   @TempDir
-  public static final File tempFolder = new File(System.getProperty("user.dir") + "/target",
+  private static File tempFolder = new File(System.getProperty("user.dir") + "/target",
       GenerateSplitsTest.class.getSimpleName() + "/");
 
   private static final RFileTest.TestRFile trf = new RFileTest.TestRFile(null);
@@ -75,6 +75,7 @@ public class GenerateSplitsTest {
     trf.closeWriter();
 
     File file = new File(tempFolder, "testGenerateSplits.rf");
+    assertTrue(file.createNewFile(), "Failed to create file: " + file);
     try (var fileOutputStream = new FileOutputStream(file)) {
       fileOutputStream.write(trf.baos.toByteArray());
     }
@@ -82,6 +83,7 @@ public class GenerateSplitsTest {
     log.info("Wrote to file {}", rfilePath);
 
     File splitsFile = new File(tempFolder, "testSplitsFile");
+    assertTrue(splitsFile.createNewFile(), "Failed to create file: " + splitsFile);
     splitsFilePath = splitsFile.getAbsolutePath();
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -129,7 +129,7 @@ public class RFileTest {
   private static final Configuration hadoopConf = new Configuration();
 
   @TempDir
-  private static final File tempFolder =
+  private final File tempFolder =
       new File(System.getProperty("user.dir") + "/target", RFileTest.class.getSimpleName() + "/");
 
   @BeforeAll


### PR DESCRIPTION
It looks like these tests were being ignored because the `@Tempdir` files were either `final` or `static` which appears to cause issues in certain cases.

When the `File` is used in a `@BeforeAll` method it cannot be final, and otherwise cannot be static. I reran these tests and they all pass and look to be running as intended.