### PR TITLE
Move ZooKeeperTestingServer

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.manager.tableOps.TraceRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
-import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.apache.zookeeper.KeeperException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ServiceLockIT.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooSession;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
-import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooKeeperTestingServer.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.test.zookeeper;
+package org.apache.accumulo.test.fate.zookeeper;
 
 import java.io.File;
 import java.io.IOException;

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/ZooMutatorIT.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Future;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.test.categories.ZooKeeperTestingServerTests;
-import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;


### PR DESCRIPTION
* ZooKeeperTestingServer is only used by the tests in fate.zookeeper pkg