### PR TITLE
Add rule to always use static imports for assume

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1103,6 +1103,14 @@
                   <property name="message" value="Use static imports for Assert.* methods for consistency" />
                 </module>
                 <module name="RegexpSinglelineJava">
+                  <property name="format" value="import org[.]junit[.]Assume;" />
+                  <property name="message" value="Use static imports for Assume.* methods for consistency" />
+                </module>
+                <module name="RegexpSinglelineJava">
+                  <property name="format" value="org[.]junit[.]jupiter[.]api[.]Assumptions;" />
+                  <property name="message" value="Use static imports for Assumptions.* methods for consistency" />
+                </module>
+                <module name="RegexpSinglelineJava">
                   <property name="format" value="import java[.]nio[.]charset[.]StandardCharsets;" />
                   <property name="message" value="Use static imports for StandardCharsets.* constants for consistency" />
                 </module>

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/HistoryCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/HistoryCommandTest.java
@@ -23,6 +23,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,7 +39,6 @@ import org.jline.reader.impl.DefaultExpander;
 import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -94,8 +94,7 @@ public class HistoryCommandTest {
     reader.unsetOpt(LineReader.Option.DISABLE_EVENT_EXPANSION);
     Expander expander = new DefaultExpander();
     // Fails github QA since that doesn't have terminal with event expansion. Adding this check
-    Assume
-        .assumeFalse(expander.expandHistory(reader.getHistory(), baos.toString().trim()).isEmpty());
+    assumeFalse(expander.expandHistory(reader.getHistory(), baos.toString().trim()).isEmpty());
 
     assertEquals("foo", expander.expandHistory(reader.getHistory(), baos.toString().trim()));
   }

--- a/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
+++ b/test/src/main/java/org/apache/accumulo/harness/AccumuloClusterHarness.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.harness;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -47,7 +48,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
@@ -114,7 +114,7 @@ public abstract class AccumuloClusterHarness extends AccumuloITBase
   public void setupCluster() throws Exception {
     // Before we try to instantiate the cluster, check to see if the test even wants to run against
     // this type of cluster
-    Assume.assumeTrue(canRunTest(type));
+    assumeTrue(canRunTest(type));
 
     switch (type) {
       case MINI:

--- a/test/src/main/java/org/apache/accumulo/test/compaction/UserCompactionStrategyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/UserCompactionStrategyIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.util.Arrays;
@@ -55,7 +56,6 @@ import org.apache.accumulo.test.functional.FunctionalTestUtils;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.apache.hadoop.io.Text;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Test;
 
 @SuppressWarnings("removal")
@@ -148,7 +148,7 @@ public class UserCompactionStrategyIT extends AccumuloClusterHarness {
   @Test
   public void testPerTableClasspath() throws Exception {
     // Can't assume that a test-resource will be on the server's classpath
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
+    assumeTrue(getClusterType() == ClusterType.MINI);
 
     // test per-table classpath + user specified compaction strategy
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BalanceInPresenceOfOfflineTableIT.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.test.functional;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -54,7 +55,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -101,7 +101,7 @@ public class BalanceInPresenceOfOfflineTableIT extends AccumuloClusterHarness {
         break;
       UtilWaitThread.sleep(TimeUnit.SECONDS.toMillis(2));
     }
-    Assume.assumeTrue("Not enough tservers to run test",
+    assumeTrue("Not enough tservers to run test",
         accumuloClient.instanceOperations().getTabletServers().size() >= 2);
 
     // set up splits

--- a/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
@@ -22,6 +22,7 @@ import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,7 +49,6 @@ import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -67,7 +67,7 @@ public class ClassLoaderIT extends AccumuloClusterHarness {
 
   @Before
   public void checkCluster() {
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
+    assumeTrue(getClusterType() == ClusterType.MINI);
     MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) getCluster();
     rootPath = mac.getConfig().getDir().getAbsolutePath();
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,7 +66,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.junit.Assume;
 import org.junit.Test;
 
 public class CloneTestIT extends AccumuloClusterHarness {
@@ -221,7 +221,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
 
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       AccumuloCluster cluster = getCluster();
-      Assume.assumeTrue(cluster instanceof MiniAccumuloClusterImpl);
+      assumeTrue(cluster instanceof MiniAccumuloClusterImpl);
       MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;
       String rootPath = mac.getConfig().getDir().getAbsolutePath();
 
@@ -272,7 +272,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
 
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       AccumuloCluster cluster = getCluster();
-      Assume.assumeTrue(cluster instanceof MiniAccumuloClusterImpl);
+      assumeTrue(cluster instanceof MiniAccumuloClusterImpl);
 
       c.tableOperations().create(table1);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PermissionsIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -55,7 +56,6 @@ import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.io.Text;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -77,7 +77,7 @@ public class PermissionsIT extends AccumuloClusterHarness {
 
   @Before
   public void limitToMini() throws Exception {
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
+    assumeTrue(getClusterType() == ClusterType.MINI);
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       Set<String> users = c.securityOperations().listLocalUsers();
       ClusterUser user = getUser(0);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScannerContextIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -45,7 +46,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -70,7 +70,7 @@ public class ScannerContextIT extends AccumuloClusterHarness {
 
   @Before
   public void checkCluster() throws Exception {
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
+    assumeTrue(getClusterType() == ClusterType.MINI);
     MiniAccumuloClusterImpl.class.cast(getCluster());
     fs = FileSystem.get(cluster.getServerContext().getHadoopConf());
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonMap;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +52,6 @@ import org.apache.accumulo.test.VerifyIngest;
 import org.apache.accumulo.test.VerifyIngest.VerifyParams;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -75,7 +75,7 @@ public class SplitIT extends AccumuloClusterHarness {
 
   @Before
   public void alterConfig() throws Exception {
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
+    assumeTrue(getClusterType() == ClusterType.MINI);
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       InstanceOperations iops = client.instanceOperations();
       Map<String,String> config = iops.getSystemConfiguration();

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.FileNotFoundException;
 
@@ -42,7 +43,6 @@ import org.apache.accumulo.test.VerifyIngest.VerifyParams;
 import org.apache.accumulo.test.categories.MiniClusterOnlyTests;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -58,7 +58,7 @@ public class TableIT extends AccumuloClusterHarness {
 
   @Test
   public void test() throws Exception {
-    Assume.assumeTrue(getClusterType() == ClusterType.MINI);
+    assumeTrue(getClusterType() == ClusterType.MINI);
 
     AccumuloCluster cluster = getCluster();
     MiniAccumuloClusterImpl mac = (MiniAccumuloClusterImpl) cluster;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -84,7 +86,6 @@ import org.apache.hadoop.tools.DistCp;
 import org.jline.terminal.Terminal;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -580,7 +581,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
   @Test
   public void getAuths() throws Exception {
-    Assume.assumeFalse("test skipped for kerberos", getToken() instanceof KerberosToken);
+    assumeFalse("test skipped for kerberos", getToken() instanceof KerberosToken);
 
     // create two users with different auths
     for (int i = 1; i <= 2; i++) {
@@ -1564,7 +1565,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
   @Test
   public void badLogin() throws Exception {
     // Can't run with Kerberos, can't switch identity in shell presently
-    Assume.assumeTrue(getToken() instanceof PasswordToken);
+    assumeTrue(getToken() instanceof PasswordToken);
     ts.input.set(getRootPassword() + "\n");
     String err = ts.exec("user NoSuchUser", false);
     assertTrue(err.contains("BAD_CREDENTIALS for user NoSuchUser"));


### PR DESCRIPTION
This PR adds a rule to ensure assume statements are statically imported and corrects the offending cases of that rule.

We have a rule to ensure assert statements are always statically imported. We don't have nearly as many assume statements but it would be nice if all of those were consistent as well.