### PR TITLE
Simplify creation of `@Testdir`

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/classloader/ContextClassLoaderFactoryTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/classloader/ContextClassLoaderFactoryTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.net.URLClassLoader;
 import java.util.Objects;
 
+import org.apache.accumulo.core.WithTestNames;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.commons.io.FileUtils;
@@ -35,11 +36,10 @@ import org.junit.jupiter.api.io.TempDir;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class ContextClassLoaderFactoryTest {
+public class ContextClassLoaderFactoryTest extends WithTestNames {
 
   @TempDir
-  private final File tempFolder = new File(System.getProperty("user.dir") + "/target",
-      ContextClassLoaderFactoryTest.class.getSimpleName() + "/");
+  private static File tempFolder;
 
   private String uri1;
   private String uri2;
@@ -47,14 +47,14 @@ public class ContextClassLoaderFactoryTest {
   @BeforeEach
   public void setup() throws Exception {
 
-    File folder1 = new File(tempFolder, "folder1/");
+    File folder1 = new File(tempFolder, testName() + "_1");
     assertTrue(folder1.isDirectory() || folder1.mkdir(), "Failed to make a new sub-directory");
     FileUtils.copyURLToFile(
         Objects.requireNonNull(this.getClass().getResource("/accumulo.properties")),
         new File(folder1, "accumulo.properties"));
     uri1 = new File(folder1, "accumulo.properties").toURI().toString();
 
-    File folder2 = new File(tempFolder, "folder2/");
+    File folder2 = new File(tempFolder, testName() + "_2");
     assertTrue(folder2.isDirectory() || folder2.mkdir(), "Failed to make a new sub-directory");
     FileUtils.copyURLToFile(
         Objects.requireNonNull(this.getClass().getResource("/accumulo2.properties")),
@@ -64,7 +64,7 @@ public class ContextClassLoaderFactoryTest {
   }
 
   @Test
-  public void differentContexts() throws Exception {
+  public void differentContexts() {
 
     ConfigurationCopy cc = new ConfigurationCopy();
     cc.set(Property.GENERAL_CONTEXT_CLASSLOADER_FACTORY.getKey(),

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -55,8 +55,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
   private static final SecureRandom random = new SecureRandom();
 
   @TempDir
-  private final File tempDir = new File(System.getProperty("user.dir") + "/target",
-      BloomFilterLayerLookupTest.class.getSimpleName() + "/");
+  private static File tempDir;
 
   @Test
   public void test() throws IOException {

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/GenerateSplitsTest.java
@@ -51,8 +51,7 @@ public class GenerateSplitsTest {
   private static final Logger log = LoggerFactory.getLogger(GenerateSplitsTest.class);
 
   @TempDir
-  private static File tempFolder = new File(System.getProperty("user.dir") + "/target",
-      GenerateSplitsTest.class.getSimpleName() + "/");
+  private static File tempDir;
 
   private static final RFileTest.TestRFile trf = new RFileTest.TestRFile(null);
   private static String rfilePath;
@@ -74,7 +73,7 @@ public class GenerateSplitsTest {
     trf.writer.append(newKey("r6", "cf4", "cq1", "L1", 55), newValue("foo6"));
     trf.closeWriter();
 
-    File file = new File(tempFolder, "testGenerateSplits.rf");
+    File file = new File(tempDir, "testGenerateSplits.rf");
     assertTrue(file.createNewFile(), "Failed to create file: " + file);
     try (var fileOutputStream = new FileOutputStream(file)) {
       fileOutputStream.write(trf.baos.toByteArray());
@@ -82,7 +81,7 @@ public class GenerateSplitsTest {
     rfilePath = "file:" + file.getAbsolutePath();
     log.info("Wrote to file {}", rfilePath);
 
-    File splitsFile = new File(tempFolder, "testSplitsFile");
+    File splitsFile = new File(tempDir, "testSplitsFile");
     assertTrue(splitsFile.createNewFile(), "Failed to create file: " + splitsFile);
     splitsFilePath = splitsFile.getAbsolutePath();
   }
@@ -132,8 +131,8 @@ public class GenerateSplitsTest {
     e = assertThrows(IllegalArgumentException.class, () -> main(args3.toArray(new String[0])));
     assertTrue(e.getMessage().contains("Requested number of splits and"), e.getMessage());
 
-    File dir1 = new File(tempFolder, "dir1/");
-    File dir2 = new File(tempFolder, "dir2/");
+    File dir1 = new File(tempDir, "dir1/");
+    File dir2 = new File(tempDir, "dir2/");
     assertTrue(dir1.mkdir() && dir2.mkdir(), "Failed to make new sub-directories");
 
     List<String> args4 = List.of(dir1.getAbsolutePath(), dir2.getAbsolutePath(), "-n", "2");

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -129,8 +129,7 @@ public class RFileTest {
   private static final Configuration hadoopConf = new Configuration();
 
   @TempDir
-  private final File tempFolder =
-      new File(System.getProperty("user.dir") + "/target", RFileTest.class.getSimpleName() + "/");
+  private static File tempDir;
 
   @BeforeAll
   public static void setupCryptoKeyFile() throws Exception {
@@ -2321,7 +2320,7 @@ public class RFileTest {
 
     if (true) {
       FileOutputStream fileOutputStream =
-          new FileOutputStream(new File(tempFolder, "testEncryptedRootFile.rf"));
+          new FileOutputStream(new File(tempDir, "testEncryptedRootFile.rf"));
       fileOutputStream.write(testRfile.baos.toByteArray());
       fileOutputStream.flush();
       fileOutputStream.close();


### PR DESCRIPTION
It looks like the new JUnit 5 `@Tempdir` does not behave quite how I thought it did. In the tests that we use `@Tempdir`, we specify a parent directory where we want the new directory to be created as well as a name for the new directory. However after some testing it looks like these parameters don't make a difference in where the directory is actually created or what it is named.

Here is a quick example to illustrate this point:
```java
  @TempDir
  private static File tempdir = new File(System.getProperty("user.dir") + "/target", "FooBarClassname/");

  @TempDir
  private static File tempdir1 = new File(System.getProperty("user.dir") + "/target");

  @TempDir
  private static File tempdir2 = new File("");

  @TempDir
  private static File tempdir3;

  @BeforeAll
  public static void setup() throws Exception {
    log.debug("Tempdir : {}", tempdir.getAbsolutePath());
    log.debug("Tempdir1: {}", tempdir1.getAbsolutePath());
    log.debug("Tempdir2: {}", tempdir2.getAbsolutePath());
    log.debug("Tempdir3: {}", tempdir3.getAbsolutePath());
  }
```
this yields:
```
DEBUG: Tempdir : /home/dgarguilo/github/accumulo/test/target/junit13744458181439768791
DEBUG: Tempdir1: /home/dgarguilo/github/accumulo/test/target/junit3179925728963842725
DEBUG: Tempdir2: /home/dgarguilo/github/accumulo/test/target/junit4772587255279214508
DEBUG: Tempdir3: /home/dgarguilo/github/accumulo/test/target/junit2922176067888214114
```

I don't think this should affect the functionality of the tests but since all of the examples produce the same result, it might be best if we replace all instances of `@Tempdir` with the shortest code that still produces the same result (which would be `tempdir3` in the example).

The tests pass before and after these changes.