### PR TITLE
Bump dependencies

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -57,21 +57,18 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-base</artifactId>
-      <classifier>jakarta</classifier>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-base</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <classifier>jakarta</classifier>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <classifier>jakarta</classifier>
+      <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/assemble/src/main/assemblies/component.xml
+++ b/assemble/src/main/assemblies/component.xml
@@ -35,9 +35,9 @@
         <include>com.fasterxml.jackson.core:jackson-annotations</include>
         <include>com.fasterxml.jackson.core:jackson-core</include>
         <include>com.fasterxml.jackson.core:jackson-databind</include>
-        <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:jakarta</include>
-        <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:jakarta</include>
-        <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:jakarta</include>
+        <include>com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base</include>
+        <include>com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider</include>
+        <include>com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations</include>
         <include>com.github.ben-manes.caffeine:caffeine</include>
         <include>com.google.code.gson:gson</include>
         <include>com.google.guava:failureaccess</include>

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/AbstractHashSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/AbstractHashSampler.java
@@ -105,7 +105,7 @@ public abstract class AbstractHashSampler implements Sampler {
 
     switch (hasherOpt) {
       case "murmur3_32":
-        hashFunction = Hashing.murmur3_32();
+        hashFunction = Hashing.murmur3_32_fixed();
         break;
       case "md5":
         @SuppressWarnings("deprecation")

--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -56,7 +56,7 @@ public class SummarizerConfiguration {
     if (configId == null) {
       ArrayList<String> keys = new ArrayList<>(this.options.keySet());
       Collections.sort(keys);
-      Hasher hasher = Hashing.murmur3_32().newHasher();
+      Hasher hasher = Hashing.murmur3_32_fixed().newHasher();
       hasher.putString(className, UTF_8);
       for (String key : keys) {
         hasher.putString(key, UTF_8);
@@ -84,7 +84,7 @@ public class SummarizerConfiguration {
   }
 
   /**
-   * The propertyId is used to when creating table properties for a summarizer. Its not used for
+   * The propertyId is used when creating table properties for a summarizer. It's not used for
    * equality or hashCode for this class.
    */
   public String getPropertyId() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/SortSkew.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/SortSkew.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.core.metadata.schema;
 
-import static com.google.common.hash.Hashing.murmur3_32;
+import static com.google.common.hash.Hashing.murmur3_32_fixed;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Strings;
@@ -43,7 +43,7 @@ public class SortSkew {
    * @return coded value of keypart
    */
   public static String getCode(String keypart) {
-    int hashCode = murmur3_32().hashString(keypart, UTF_8).asInt();
+    int hashCode = murmur3_32_fixed().hashString(keypart, UTF_8).asInt();
     return Strings.padStart(Integer.toHexString(hashCode), SORTSKEW_LENGTH, '0');
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -213,9 +213,9 @@ public class Gatherer {
 
         // When no location, the approach below will consistently choose the same tserver for the
         // same file (as long as the set of tservers is stable).
-        int idx =
-            Math.abs(Hashing.murmur3_32().hashString(entry.getKey().getPathStr(), UTF_8).asInt())
-                % tservers.size();
+        int idx = Math
+            .abs(Hashing.murmur3_32_fixed().hashString(entry.getKey().getPathStr(), UTF_8).asInt())
+            % tservers.size();
         location = tservers.get(idx);
       }
 
@@ -368,9 +368,9 @@ public class Gatherer {
 
     private synchronized void initiateProcessing(ProcessedFiles previousWork) {
       try {
-        Predicate<TabletFile> fileSelector =
-            file -> Math.abs(Hashing.murmur3_32().hashString(file.getPathStr(), UTF_8).asInt())
-                % modulus == remainder;
+        Predicate<TabletFile> fileSelector = file -> Math
+            .abs(Hashing.murmur3_32_fixed().hashString(file.getPathStr(), UTF_8).asInt()) % modulus
+            == remainder;
         if (previousWork != null) {
           fileSelector = fileSelector.and(previousWork.failedFiles::contains);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
-    <curator.version>5.1.0</curator.version>
+    <curator.version>5.2.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <errorprone.version>2.11.0</errorprone.version>
@@ -166,70 +166,70 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.12.3</version>
+        <version>2.13.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.7.5</version>
+        <version>1.8.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.7.1</version>
+        <version>1.11.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom-alpha</artifactId>
-        <version>1.7.1-alpha</version>
+        <version>1.11.0-alpha</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>9.1.0-RC1</version>
+        <version>9.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.1</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>11.0.2</version>
+        <version>11.0.8</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-bom</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-bom</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey</groupId>
         <artifactId>jersey-bom</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -253,7 +253,7 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.5</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
@@ -263,7 +263,7 @@
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
-        <version>1.0</version>
+        <version>1.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -273,13 +273,13 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.9</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <!-- converge transitive dependency version between guava and caffeine -->
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.6.0</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <!-- this is a runtime dependency of guava, no longer included with guava as of 27.1 -->
@@ -290,7 +290,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1.1-jre</version>
+        <version>31.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -321,6 +321,12 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.2</version>
+      </dependency>
+      <dependency>
+        <!-- legacy junit version specified here for dependency convergence -->
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.accumulo</groupId>
@@ -441,7 +447,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
-        <version>2.8.0</version>
+        <version>2.9.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
@@ -572,7 +578,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.13.0</version>
+        <version>3.21.2</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
@@ -587,7 +593,7 @@
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.el</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.hdrhistogram</groupId>
@@ -597,7 +603,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>7.0.1.Final</version>
+        <version>7.0.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
@@ -607,12 +613,12 @@
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
-        <version>3.4.1.Final</version>
+        <version>3.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
-        <version>3.20.0</version>
+        <version>3.21.0</version>
       </dependency>
       <dependency>
         <groupId>org.latencyutils</groupId>
@@ -659,7 +665,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.29</version>
+        <version>1.30</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -891,11 +897,8 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.17.1</version>
+          <version>2.18.0</version>
           <configuration>
-            <compilerCompliance>${maven.compiler.source}</compilerCompliance>
-            <compilerSource>${maven.compiler.source}</compilerSource>
-            <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
             <configFile>${eclipseFormatterStyle}</configFile>
             <excludes>
               <exclude>**/thrift/*.java</exclude>
@@ -903,7 +906,6 @@
             </excludes>
             <lineEnding>LF</lineEnding>
             <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
-            <removeTrailingWhitespace>true</removeTrailingWhitespace>
             <skipCssFormatting>true</skipCssFormatting>
             <skipHtmlFormatting>true</skipHtmlFormatting>
             <skipJsFormatting>true</skipJsFormatting>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.4.2</version>
+        <version>4.5.3</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -722,7 +722,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.4.2.2</version>
+          <version>4.5.3.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -65,19 +65,17 @@ public class RemoveEntriesForMissingFiles {
   }
 
   private static class CheckFileTask implements Runnable {
-    @SuppressWarnings("rawtypes")
-    private Map cache;
-    private VolumeManager fs;
-    private AtomicInteger missing;
-    private BatchWriter writer;
-    private Key key;
-    private Path path;
-    private Set<Path> processing;
-    private AtomicReference<Exception> exceptionRef;
+    private final Map<Path,Path> cache;
+    private final VolumeManager fs;
+    private final AtomicInteger missing;
+    private final BatchWriter writer;
+    private final Key key;
+    private final Path path;
+    private final Set<Path> processing;
+    private final AtomicReference<Exception> exceptionRef;
 
-    @SuppressWarnings({"rawtypes"})
-    CheckFileTask(Map cache, VolumeManager fs, AtomicInteger missing, BatchWriter writer, Key key,
-        Path map, Set<Path> processing, AtomicReference<Exception> exceptionRef) {
+    CheckFileTask(Map<Path,Path> cache, VolumeManager fs, AtomicInteger missing, BatchWriter writer,
+        Key key, Path map, Set<Path> processing, AtomicReference<Exception> exceptionRef) {
       this.cache = cache;
       this.fs = fs;
       this.missing = missing;
@@ -89,7 +87,6 @@ public class RemoveEntriesForMissingFiles {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void run() {
       try {
         if (fs.exists(path)) {
@@ -122,8 +119,7 @@ public class RemoveEntriesForMissingFiles {
   private static int checkTable(ServerContext context, String tableName, Range range, boolean fix)
       throws Exception {
 
-    @SuppressWarnings({"rawtypes"})
-    Map cache = new LRUMap(100000);
+    Map<Path,Path> cache = new LRUMap<>(100000);
     Set<Path> processing = new HashSet<>();
     ExecutorService threadPool = ThreadPools.createFixedThreadPool(16, "CheckFileTasks", false);
 


### PR DESCRIPTION
* Bump jackson and use newer jakarta artifact names instead of jakarta
  classifiers
* Bump guava and use newer murmur3_32 method that fixes the previous
  broken implementation
* Bump other deps: curator, micrometer, opentelemetry, jakartaee,
  log4j2, jetty, hk2, jaxb, jersey, caffeine, auto-service, gson,
  error_prone_annotations, commons-vfs2, checker-qual, jakarta.el,
  hibernate-validator, jboss-logging, jline, snakeyaml
* Ensure the legacy junit version is explicitly managed, in case it gets
  brought in transitively and conflicts with other dependencies
* Bump formatter-maven-plugin to recently released, and remove redundant
  default configs