### PR TITLE
Improvements to loading of compression configs

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.core.file.rfile;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.accumulo.core.cli.Help;
@@ -59,10 +58,9 @@ public class CreateEmpty implements KeywordExecutable {
   public static class IsSupportedCompressionAlgorithm implements IParameterValidator {
     @Override
     public void validate(String name, String value) throws ParameterException {
-      String[] algorithms = Compression.getSupportedAlgorithms();
-      if (!Arrays.asList(algorithms).contains(value)) {
-        throw new ParameterException(
-            "Compression codec must be one of " + Arrays.toString(algorithms));
+      List<String> algorithms = Compression.getSupportedAlgorithms();
+      if (!algorithms.contains(value)) {
+        throw new ParameterException("Compression codec must be one of " + algorithms);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Bzip2.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Bzip2.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.core.spi.file.rfile.compression;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class Bzip2 implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Gz.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Gz.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.core.spi.file.rfile.compression;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class Gz implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Lz4.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Lz4.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.core.spi.file.rfile.compression;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class Lz4 implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Lzo.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Lzo.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.core.spi.file.rfile.compression;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class Lzo implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/NoCompression.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/NoCompression.java
@@ -20,9 +20,6 @@ package org.apache.accumulo.core.spi.file.rfile.compression;
 
 import org.apache.accumulo.core.file.rfile.bcfile.IdentityCodec;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class NoCompression implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Snappy.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/Snappy.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.core.spi.file.rfile.compression;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class Snappy implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/ZStandard.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/file/rfile/compression/ZStandard.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.core.spi.file.rfile.compression;
 
-import com.google.auto.service.AutoService;
-
-@AutoService(CompressionAlgorithmConfiguration.class)
 public class ZStandard implements CompressionAlgorithmConfiguration {
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
   <properties>
     <!-- used for filtering the java source with the current version -->
     <accumulo.release.version>${project.version}</accumulo.release.version>
+    <auto-service.version>1.0.1</auto-service.version>
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
@@ -130,7 +131,8 @@
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
-    <hadoop.version>3.3.1</hadoop.version>
+    <!-- Version 3.3.1 seems to have issues especially with CountNameNodeOptsBulkIT -->
+    <hadoop.version>3.3.0</hadoop.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <!-- prevent introduction of new compiler warnings -->
@@ -263,7 +265,7 @@
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
-        <version>1.0.1</version>
+        <version>${auto-service.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -805,6 +807,13 @@
               <arg>-Xmaxwarns</arg>
               <arg>5</arg>
             </compilerArgs>
+            <annotationProcessorPaths combine.children="append">
+              <path>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${auto-service.version}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>
@@ -1697,11 +1706,6 @@
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
                   <version>${errorprone.version}</version>
-                </path>
-                <path>
-                  <groupId>com.google.auto.service</groupId>
-                  <artifactId>auto-service</artifactId>
-                  <version>1.0</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>


### PR DESCRIPTION
This follows up from the work done in #2518 to remove the use of the
Java ServiceLoader for built-in known compression configs. Instead of
loading all compression configs through the ServiceLoader, this change
loads the known ones, and combines those with those discovered by the
ServiceLoader. This prevents issues during development where the
integration tests cannot be run inside an IDE, like Eclipse, due to the
auto-service annotation processor not having been executed in that
environment to make the implementing classes known to the ServiceLoader.
Now, they are always available for integration tests.

This also prevents the `@AutoService` annotation from being exposed in
SPI classes, although it's not clear that's necessarily a problem.

Additionally, this cleans up some of the previous code, that
unnecessarily placed the supported algorithm names in a list, then
converted it to an array, only to have it converted to a list again.

For the pom, this change also sets the auto-service version in a
property, so the multiple uses will use the same version, and explicitly
includes the annotation processor in the maven-compiler-plugin
configuration so it is consistent both within the errorprone profile and
outside it.

And finally, revert the version of Hadoop to 3.3.0, because 3.3.1 seems
to be the cause of some flaky testing. In particular, it seems to cause
unexpected EOF errors when trying to talk to data nodes, which is
revealed by regular CountNameNodeOpsBulkIT failures, some so bad they
seem to corrupt the XML output from failsafe, causing failsafe to be
unable to read the result of the test. I was not able to reproduce these
failures using 3.3.0, whereas I was seeing them regularly with 3.3.1.