### PR TITLE
Fate op defer time is not used

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -81,6 +81,11 @@ public class Fate<T> {
             try {
               deferTime = op.isReady(tid, environment);
 
+              // For this if/else statenebt, the deferTime value is treated as an exit code, where
+              // 0 indicates success and processing continues. A non-zero value indicates that
+              // processing should not immediately proceed and another loop of the while occurs.
+              // The actual deferTime value is utilized as a wait time within the ZooStore
+              // class.
               if (deferTime == 0) {
                 prevOp = op;
                 if (status == TStatus.SUBMITTED) {

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -81,11 +81,9 @@ public class Fate<T> {
             try {
               deferTime = op.isReady(tid, environment);
 
-              // For this if/else statenebt, the deferTime value is treated as an exit code, where
-              // 0 indicates success and processing continues. A non-zero value indicates that
-              // processing should not immediately proceed and another loop of the while occurs.
-              // The actual deferTime value is utilized as a wait time within the ZooStore
-              // class.
+              // Here, deferTime is only used to determine success (zero) or failure (non-zero),
+              // proceeding on success and returning to the while loop on failure.
+              // The value of deferTime is only used as a wait time in ZooStore.unreserve
               if (deferTime == 0) {
                 prevOp = op;
                 if (status == TStatus.SUBMITTED) {


### PR DESCRIPTION
A comment was added to Fate.java to indicate how the deferTime variable
is being used. It clarifies that the value is used in the manner of an
exit code for the particular if/else loop after the comment.

But it also makes clear that the value of deferTime is used as a wait
value later on within the ZooStore class.

No code was modified with this ticket.