### PR TITLE
Refactor testZookeeperPortSpecific test case to improve readability

### DIFF
--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -42,15 +42,17 @@ public class MiniAccumuloConfigImplTest {
       new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
   @Test
-  public void testZookeeperPort() {
-
-    // set specific zookeeper port
+  public void testZookeeperPortSpecific() {
     MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password")
-        .setZooKeeperPort(5000).initialize();
-    assertEquals(5000, config.getZooKeeperPort());
+            .setZooKeeperPort(5000).initialize();
 
-    // generate zookeeper port
-    config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password").initialize();
+    assertEquals(5000, config.getZooKeeperPort());
+  }
+
+  @Test
+  public void testZookeeperPortGenerate() {
+    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password").initialize();
+
     assertTrue(config.getZooKeeperPort() > 0);
   }
 


### PR DESCRIPTION
## Description

This pull request refactors the test case [testZookeeperPort](https://github.com/Codegass/accumulo/tree/main/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45) in test class PairTest. Currently, this test case combines 2 different test scenarios for the Zookeeper port initialization. This does not follow the best practice of unit testing. The refactoring breaks this test case down into 2 separate test cases, each of which focuses on one scenario. This will make the test cases smaller and simpler---thus easier to understand and maintain with its name. This should also make debugging easier since each test case is more focused.

### Motivation

- Make test cases smaller, simpler, and easier to understand: The original test case is complicated with combined test scenarios. By extracting the test targets to 2 separate unit test cases focusing on specific test scenarios. Each test case is kept small and simple, and given a meaningful name to show its purpose. And each test case now follows the clear A-arrange, A-action, and A-assert structure, which is easy for anyone to quickly pick up and change in the future.

- Debugging will be more straightforward. With the original one big test case, if it fails, it will take time to tell why it fails, due to the cluttered structure. Now, separating into 2 test cases, each test case fails for only one scenario. This makes bugs more difficult to hide and debugging easier.

### Key Changes in this PR

- Replace the [testZookeeperPort](https://github.com/Codegass/accumulo/tree/main/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45) test case with 2 unit test, each unit test case is named based on the test target and its specific action or parameter in the testing:

  - [testHashMethodSameValue](https://github.com/Codegass/accumulo/tree/refactor-ZookeeperPort/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L45-L50)
  - [testHashMethodNullValue](https://github.com/Codegass/accumulo/tree/refactor-ZookeeperPort/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java#L53-L57)

