### PR TITLE
Migrate Minicluster module to JUnit5

### DIFF
--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -143,13 +143,6 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    -->
   </dependencies>
   <build>
     <pluginManagement>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -124,6 +124,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
       <scope>test</scope>
@@ -136,6 +142,11 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -124,12 +124,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-      <version>5.1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
       <scope>test</scope>
@@ -149,11 +143,13 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    -->
   </dependencies>
   <build>
     <pluginManagement>

--- a/minicluster/src/test/java/org/apache/accumulo/WithTestNames.java
+++ b/minicluster/src/test/java/org/apache/accumulo/WithTestNames.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+// This is only for the unit tests and integration tests in this module
+// It must be copied for use in other modules, because tests in one module
+// don't have dependencies on other modules, and we can't put this in a
+// regular, non-test jar, because we don't want to add a dependency on
+// JUnit in a non-test jar
+public class WithTestNames {
+
+  private String testName;
+
+  @BeforeEach
+  public void setTestName(TestInfo info) {
+    testName = info.getTestMethod().get().getName();
+  }
+
+  protected String testName() {
+    return testName;
+  }
+
+}

--- a/minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneAccumuloClusterTest.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.cluster.standalone;
 import org.apache.accumulo.core.manager.thrift.ManagerGoalState;
 import org.apache.accumulo.minicluster.ServerType;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StandaloneAccumuloClusterTest {
 

--- a/minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControlTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/cluster/standalone/StandaloneClusterControlTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.cluster.standalone;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StandaloneClusterControlTest {
 

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.util.Map;
 
-import org.apache.accumulo.WithTestNames;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterExistingZooKeepersTest.java
@@ -18,27 +18,26 @@
  */
 package org.apache.accumulo.minicluster;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Map;
 
+import org.apache.accumulo.WithTestNames;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class MiniAccumuloClusterExistingZooKeepersTest {
+public class MiniAccumuloClusterExistingZooKeepersTest extends WithTestNames {
   private static final File BASE_DIR = new File(System.getProperty("user.dir")
       + "/target/mini-tests/" + MiniAccumuloClusterExistingZooKeepersTest.class.getName());
 
@@ -46,13 +45,10 @@ public class MiniAccumuloClusterExistingZooKeepersTest {
 
   private MiniAccumuloConfig config;
 
-  @Rule
-  public TestName testName = new TestName();
-
-  @Before
+  @BeforeEach
   public void setupTestCluster() {
     assertTrue(BASE_DIR.mkdirs() || BASE_DIR.isDirectory());
-    File testDir = new File(BASE_DIR, testName.getMethodName());
+    File testDir = new File(BASE_DIR, testName());
     FileUtils.deleteQuietly(testDir);
     assertTrue(testDir.mkdir());
 

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.accumulo.WithTestNames;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterStartStopTest.java
@@ -18,43 +18,39 @@
  */
 package org.apache.accumulo.minicluster;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.accumulo.WithTestNames;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class MiniAccumuloClusterStartStopTest {
+public class MiniAccumuloClusterStartStopTest extends WithTestNames {
 
   private static final Logger log = LoggerFactory.getLogger(MiniAccumuloClusterStartStopTest.class);
   private File baseDir =
       new File(System.getProperty("user.dir") + "/target/mini-tests/" + this.getClass().getName());
   private MiniAccumuloCluster accumulo;
 
-  @Rule
-  public TestName testName = new TestName();
-
-  @Before
+  @BeforeEach
   public void setupTestCluster() throws IOException {
     assertTrue(baseDir.mkdirs() || baseDir.isDirectory());
-    File testDir = new File(baseDir, testName.getMethodName());
+    File testDir = new File(baseDir, testName());
     FileUtils.deleteQuietly(testDir);
     assertTrue(testDir.mkdir());
     accumulo = new MiniAccumuloCluster(testDir, "superSecret");
   }
 
-  @After
+  @AfterEach
   public void teardownTestCluster() {
     if (accumulo != null) {
       try {

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.minicluster;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,7 +31,6 @@ import java.io.FileReader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -101,7 +101,7 @@ public class MiniAccumuloClusterTest {
 
   @SuppressWarnings("deprecation")
   @Test
-  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
   public void test() throws Exception {
     org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
 
@@ -177,7 +177,7 @@ public class MiniAccumuloClusterTest {
 
   @SuppressWarnings("deprecation")
   @Test
-  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testPerTableClasspath() throws Exception {
 
     org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
@@ -185,8 +185,7 @@ public class MiniAccumuloClusterTest {
     conn.tableOperations().create("table2");
 
     File jarFile = new File(tempDir, "iterator.jar");
-    FileUtils.copyURLToFile(Objects.requireNonNull(this.getClass().getResource("/FooFilter.jar")),
-        jarFile);
+    FileUtils.copyURLToFile(requireNonNull(getClass().getResource("/FooFilter.jar")), jarFile);
 
     conn.instanceOperations().setProperty(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "cx1",
         jarFile.toURI().toString());
@@ -226,7 +225,7 @@ public class MiniAccumuloClusterTest {
   }
 
   @Test
-  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
   public void testDebugPorts() {
 
     Set<Pair<ServerType,Integer>> debugPorts = accumulo.getDebugPorts();

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
@@ -101,7 +100,7 @@ public class MiniAccumuloClusterTest {
 
   @SuppressWarnings("deprecation")
   @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @Timeout(30)
   public void test() throws Exception {
     org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
 
@@ -177,7 +176,7 @@ public class MiniAccumuloClusterTest {
 
   @SuppressWarnings("deprecation")
   @Test
-  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  @Timeout(60)
   public void testPerTableClasspath() throws Exception {
 
     org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
@@ -225,7 +224,7 @@ public class MiniAccumuloClusterTest {
   }
 
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(10)
   public void testDebugPorts() {
 
     Set<Pair<ServerType,Integer>> debugPorts = accumulo.getDebugPorts();

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/WithTestNames.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/WithTestNames.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo;
+package org.apache.accumulo.minicluster;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/CleanShutdownMacTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/CleanShutdownMacTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.miniclusterImpl;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.concurrent.Callable;
@@ -25,23 +27,23 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import org.easymock.EasyMock;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class CleanShutdownMacTest {
 
-  @Rule
-  public TemporaryFolder tmpDir =
-      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+  @TempDir
+  private static File tmpDir;
 
   @SuppressWarnings("unchecked")
   @Test
   public void testExecutorServiceShutdown() throws Exception {
-    File tmp = tmpDir.newFolder();
+    // File tmp = tmpDir.newFolder();
+    File tmp = new File(tmpDir, "folder1/");
+    assertTrue(tmp.isDirectory() || tmp.mkdir(), "Failed to make a new sub-directory");
     MiniAccumuloClusterImpl cluster = new MiniAccumuloClusterImpl(tmp, "foo");
 
     ExecutorService mockService = EasyMock.createMock(ExecutorService.class);

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/CleanShutdownMacTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/CleanShutdownMacTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.apache.accumulo.minicluster.WithTestNames;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class CleanShutdownMacTest {
+public class CleanShutdownMacTest extends WithTestNames {
 
   @TempDir
   private static File tmpDir;
@@ -41,8 +42,7 @@ public class CleanShutdownMacTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testExecutorServiceShutdown() throws Exception {
-    // File tmp = tmpDir.newFolder();
-    File tmp = new File(tmpDir, "folder1/");
+    File tmp = new File(tmpDir, testName());
     assertTrue(tmp.isDirectory() || tmp.mkdir(), "Failed to make a new sub-directory");
     MiniAccumuloClusterImpl cluster = new MiniAccumuloClusterImpl(tmp, "foo");
 

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -86,7 +86,7 @@ public class MiniAccumuloClusterImplTest {
   }
 
   @Test
-  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
   public void testAccurateProcessListReturned() throws Exception {
     Map<ServerType,Collection<ProcessReference>> procs = accumulo.getProcesses();
 
@@ -105,7 +105,7 @@ public class MiniAccumuloClusterImplTest {
   }
 
   @Test
-  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void saneMonitorInfo() throws Exception {
     ManagerMonitorInfo stats;
     while (true) {

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
@@ -86,7 +85,7 @@ public class MiniAccumuloClusterImplTest {
   }
 
   @Test
-  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  @Timeout(10)
   public void testAccurateProcessListReturned() throws Exception {
     Map<ServerType,Collection<ProcessReference>> procs = accumulo.getProcesses();
 
@@ -105,7 +104,7 @@ public class MiniAccumuloClusterImplTest {
   }
 
   @Test
-  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  @Timeout(60)
   public void saneMonitorInfo() throws Exception {
     ManagerMonitorInfo stats;
     while (true) {

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImplTest.java
@@ -18,15 +18,16 @@
  */
 package org.apache.accumulo.miniclusterImpl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
@@ -40,9 +41,10 @@ import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import com.google.common.collect.Iterators;
 
@@ -59,7 +61,7 @@ public class MiniAccumuloClusterImplTest {
   private static String TEST_TABLE = "test";
   private static String testTableID;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupMiniCluster() throws Exception {
     File baseDir = new File(System.getProperty("user.dir") + "/target/mini-tests");
     assertTrue(baseDir.mkdirs() || baseDir.isDirectory());
@@ -83,7 +85,8 @@ public class MiniAccumuloClusterImplTest {
     Iterators.size(s.iterator());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testAccurateProcessListReturned() throws Exception {
     Map<ServerType,Collection<ProcessReference>> procs = accumulo.getProcesses();
 
@@ -101,7 +104,8 @@ public class MiniAccumuloClusterImplTest {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void saneMonitorInfo() throws Exception {
     ManagerMonitorInfo stats;
     while (true) {
@@ -116,21 +120,21 @@ public class MiniAccumuloClusterImplTest {
     }
     List<ManagerState> validStates = Arrays.asList(ManagerState.values());
     List<ManagerGoalState> validGoals = Arrays.asList(ManagerGoalState.values());
-    assertTrue("manager state should be valid.", validStates.contains(stats.state));
-    assertTrue("manager goal state should be in " + validGoals + ". is " + stats.goalState,
-        validGoals.contains(stats.goalState));
-    assertNotNull("should have a table map.", stats.tableMap);
-    assertTrue("root table should exist in " + stats.tableMap.keySet(),
-        stats.tableMap.containsKey(RootTable.ID.canonical()));
-    assertTrue("meta table should exist in " + stats.tableMap.keySet(),
-        stats.tableMap.containsKey(MetadataTable.ID.canonical()));
-    assertTrue("our test table should exist in " + stats.tableMap.keySet(),
-        stats.tableMap.containsKey(testTableID));
-    assertNotNull("there should be tservers.", stats.tServerInfo);
+    assertTrue(validStates.contains(stats.state), "manager state should be valid.");
+    assertTrue(validGoals.contains(stats.goalState),
+        "manager goal state should be in " + validGoals + ". is " + stats.goalState);
+    assertNotNull(stats.tableMap, "should have a table map.");
+    assertTrue(stats.tableMap.containsKey(RootTable.ID.canonical()),
+        "root table should exist in " + stats.tableMap.keySet());
+    assertTrue(stats.tableMap.containsKey(MetadataTable.ID.canonical()),
+        "meta table should exist in " + stats.tableMap.keySet());
+    assertTrue(stats.tableMap.containsKey(testTableID),
+        "our test table should exist in " + stats.tableMap.keySet());
+    assertNotNull(stats.tServerInfo, "there should be tservers.");
     assertEquals(NUM_TSERVERS, stats.tServerInfo.size());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownMiniCluster() throws Exception {
     accumulo.stop();
   }

--- a/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImplTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.miniclusterImpl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;
@@ -28,29 +28,27 @@ import java.util.Map;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.minicluster.ServerType;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class MiniAccumuloConfigImplTest {
 
-  @Rule
-  public TemporaryFolder tempFolder =
-      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+  @TempDir
+  private static File tempFolder;
 
   @Test
   public void testZookeeperPort() {
 
     // set specific zookeeper port
-    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password")
-        .setZooKeeperPort(5000).initialize();
+    MiniAccumuloConfigImpl config =
+        new MiniAccumuloConfigImpl(tempFolder, "password").setZooKeeperPort(5000).initialize();
     assertEquals(5000, config.getZooKeeperPort());
 
     // generate zookeeper port
-    config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password").initialize();
+    config = new MiniAccumuloConfigImpl(tempFolder, "password").initialize();
     assertTrue(config.getZooKeeperPort() > 0);
   }
 
@@ -58,7 +56,7 @@ public class MiniAccumuloConfigImplTest {
   public void testZooKeeperStartupTime() {
 
     // set specific zookeeper startup time
-    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password")
+    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder, "password")
         .setZooKeeperStartupTime(5000).initialize();
     assertEquals(5000, config.getZooKeeperStartupTime());
   }
@@ -69,16 +67,15 @@ public class MiniAccumuloConfigImplTest {
     // constructor site config overrides default props
     Map<String,String> siteConfig = new HashMap<>();
     siteConfig.put(Property.INSTANCE_VOLUMES.getKey(), "hdfs://");
-    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password")
-        .setSiteConfig(siteConfig).initialize();
+    MiniAccumuloConfigImpl config =
+        new MiniAccumuloConfigImpl(tempFolder, "password").setSiteConfig(siteConfig).initialize();
     assertEquals("hdfs://", config.getSiteConfig().get(Property.INSTANCE_VOLUMES.getKey()));
   }
 
   @Test
   public void testMemoryConfig() {
 
-    MiniAccumuloConfigImpl config =
-        new MiniAccumuloConfigImpl(tempFolder.getRoot(), "password").initialize();
+    MiniAccumuloConfigImpl config = new MiniAccumuloConfigImpl(tempFolder, "password").initialize();
     config.setDefaultMemory(96, MemoryUnit.MEGABYTE);
     assertEquals(96 * 1024 * 1024L, config.getMemory(ServerType.MANAGER));
     assertEquals(96 * 1024 * 1024L, config.getMemory(ServerType.TABLET_SERVER));


### PR DESCRIPTION
Part of issue #2441 This PR contains changes for the conversion from JUnit4 to JUnit5 for the accumulo-minicluster module.