### PR TITLE
Sync FateIT.getTxStatus

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -196,6 +196,7 @@ public class FateIT {
    */
   private static TStatus getTxStatus(ZooReaderWriter zrw, long txid)
       throws KeeperException, InterruptedException {
+    zrw.sync(ZK_ROOT);
     String txdir = String.format("%s%s/tx_%016x", ZK_ROOT, Constants.ZFATE, txid);
     return TStatus.valueOf(new String(zrw.getData(txdir), UTF_8));
   }


### PR DESCRIPTION
Fix FateIT stability issues by ensuring the ZooKeeper client is sync'd
to the quorum state when verifying the transaction status.

This fixes #2474 and supersedes #2546