### PR TITLE
Add compareTo method to HostAndPort class

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -59,7 +59,7 @@ import java.util.Objects;
  * colons, and port numbers. Full validation of the host field (if desired) is the caller's
  * responsibility.
  */
-public final class HostAndPort implements Serializable {
+public final class HostAndPort implements Serializable, Comparable<HostAndPort> {
   /** Magic value indicating the absence of a port number. */
   private static final int NO_PORT = -1;
 
@@ -279,6 +279,20 @@ public final class HostAndPort implements Serializable {
    */
   public int getPortOrDefault(int defaultPort) {
     return hasPort() ? port : defaultPort;
+  }
+
+  /**
+   * HostAndPort must implement compareTo. As this is a seldom used utiltiy, compareTo simply orders
+   * HostAndPort values using a String compare on the Host value with a secondary integer compare on
+   * the Port if Host values are identical.
+   */
+  @Override
+  public int compareTo(HostAndPort other) {
+    if (this == other) {
+      return 0;
+    }
+    int hostCompareValue = this.getHost().compareTo(other.getHost());
+    return hostCompareValue < 0 ? -1 : hostCompareValue > 0 ? 1 : this.port - other.port;
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Objects;
 
 /**
@@ -282,17 +283,12 @@ public final class HostAndPort implements Serializable, Comparable<HostAndPort> 
   }
 
   /**
-   * HostAndPort must implement compareTo. As this is a seldom used utiltiy, compareTo simply orders
-   * HostAndPort values using a String compare on the Host value with a secondary integer compare on
-   * the Port if Host values are identical.
+   * HostAndPort must implement compareTo. As this is a seldom used utiltiy, compareTo simply treats
+   * HostAndPort values as Strings.
    */
   @Override
   public int compareTo(HostAndPort other) {
-    if (this == other) {
-      return 0;
-    }
-    int hostCompareValue = this.getHost().compareTo(other.getHost());
-    return hostCompareValue < 0 ? -1 : hostCompareValue > 0 ? 1 : this.port - other.port;
+    return Comparator.nullsFirst(Comparator.comparing(HostAndPort::toString)).compare(this, other);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -283,8 +283,8 @@ public final class HostAndPort implements Serializable, Comparable<HostAndPort> 
   }
 
   /**
-   * HostAndPort must implement compareTo. As this is a seldom used utility, compareTo simply treats
-   * HostAndPort values as Strings.
+   * HostAndPort must implement compareTo. This method orders HostAndPort values using a String
+   * compare on the Host value with a secondary integer compare on the Port value.
    */
   @Override
   public int compareTo(HostAndPort other) {

--- a/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/HostAndPort.java
@@ -288,7 +288,10 @@ public final class HostAndPort implements Serializable, Comparable<HostAndPort> 
    */
   @Override
   public int compareTo(HostAndPort other) {
-    return Comparator.nullsFirst(Comparator.comparing(HostAndPort::toString)).compare(this, other);
+    return Comparator
+        .nullsFirst(
+            Comparator.comparing(HostAndPort::getHost).thenComparingInt(h -> h.getPortOrDefault(0)))
+        .compare(this, other);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
@@ -74,6 +74,10 @@ class HostAndPortTest {
     hostAndPort2 = HostAndPort.fromString("2001:db9::1");
     assertTrue(hostAndPort1.compareTo(hostAndPort2) < 0);
     assertTrue(hostAndPort2.compareTo(hostAndPort1) > 0);
+
+    hostAndPort1 = HostAndPort.fromString("2001:db8::1");
+    hostAndPort2 = null;
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) > 0);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+class HostAndPortTest {
+
+  @Test
+  void testCompareTo() {
+    HostAndPort hostAndPort1 = HostAndPort.fromString("example.info");
+    HostAndPort hostAndPort2 = HostAndPort.fromString("example.com");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) > 0);
+
+    HostAndPort hostPortSame = HostAndPort.fromString("www.test.com");
+    assertTrue(hostAndPort1.compareTo(hostAndPort1) == 0);
+
+    hostAndPort1 = HostAndPort.fromString("www.example.com");
+    hostAndPort2 = HostAndPort.fromString("www.example.com");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) == 0);
+
+    hostAndPort1 = HostAndPort.fromString("192.0.2.1:80");
+    hostAndPort2 = HostAndPort.fromString("192.0.2.1");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) > 0);
+
+    hostAndPort1 = HostAndPort.fromString("[2001:db8::1]");
+    hostAndPort2 = HostAndPort.fromString("[2001:db9::1]");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) < 0);
+
+    hostAndPort1 = HostAndPort.fromString("2001:db8:3333:4444:5555:6676:7777:8888");
+    hostAndPort2 = HostAndPort.fromString("2001:db8:3333:4444:5555:6666:7777:8888");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) > 0);
+
+    hostAndPort1 = HostAndPort.fromString("192.0.2.1:80");
+    hostAndPort2 = HostAndPort.fromString("192.1.2.1");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) < 0);
+
+    hostAndPort1 = HostAndPort.fromString("12.1.2.1");
+    hostAndPort2 = HostAndPort.fromString("192.1.2.1");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) < 0);
+
+    hostAndPort1 = HostAndPort.fromString("wwww.example.com");
+    hostAndPort2 = HostAndPort.fromString("192.1.2.1");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) > 0);
+
+    hostAndPort1 = HostAndPort.fromString("2001:db8::1");
+    hostAndPort2 = HostAndPort.fromString("2001:db9::1");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) < 0);
+
+    hostAndPort1 = HostAndPort.fromString("");
+    hostAndPort2 = HostAndPort.fromString("2001:db9::1");
+    assertTrue(hostAndPort1.compareTo(hostAndPort2) < 0);
+    assertTrue(hostAndPort2.compareTo(hostAndPort1) > 0);
+  }
+
+  @Test
+  void testOrder() {
+    Set<HostAndPort> hostPortSet = new TreeSet<>();
+    hostPortSet.add(HostAndPort.fromString("example.info"));
+    hostPortSet.add(HostAndPort.fromString("192.12.2.1:80"));
+    hostPortSet.add(HostAndPort.fromString("example.com:80"));
+    hostPortSet.add(HostAndPort.fromString("a.bb.c.d"));
+    hostPortSet.add(HostAndPort.fromString("12.1.2.1"));
+    hostPortSet.add(HostAndPort.fromString("example.com"));
+    hostPortSet.add(HostAndPort.fromString("100.100.100.100"));
+    hostPortSet.add(HostAndPort.fromString("www.example.com"));
+    hostPortSet.add(HostAndPort.fromString("[2001:eb8::1]"));
+    hostPortSet.add(HostAndPort.fromString("[2001:eb8::1]:80"));
+    hostPortSet.add(HostAndPort.fromString("2001:db8::1"));
+    hostPortSet.add(HostAndPort.fromString("100.100.101.100"));
+    hostPortSet.add(HostAndPort.fromString("2001:::1"));
+    hostPortSet.add(HostAndPort.fromString("192.12.2.1"));
+    hostPortSet.add(HostAndPort.fromString("192.12.2.1:81"));
+    hostPortSet.add(HostAndPort.fromString("199.10.1.1:14"));
+    hostPortSet.add(HostAndPort.fromString("10.100.100.100"));
+    hostPortSet.add(HostAndPort.fromString("192.12.2.1:79"));
+    hostPortSet.add(HostAndPort.fromString("1.1.1.1:24"));
+    hostPortSet.add(HostAndPort.fromString("1.1.1.1"));
+    hostPortSet.add(HostAndPort.fromString("192.12.2.1:79"));
+    hostPortSet.add(HostAndPort.fromString("a.b.c.d"));
+    hostPortSet.add(HostAndPort.fromString("1.100.100.100"));
+    hostPortSet.add(HostAndPort.fromString("a.b.b.d"));
+    hostPortSet.add(HostAndPort.fromString("www.example.com"));
+    hostPortSet.add(HostAndPort.fromString("www.alpha.org"));
+    hostPortSet.add(HostAndPort.fromString("a.b.c.d:10"));
+    hostPortSet.add(HostAndPort.fromString("a.b.b.d:10"));
+    hostPortSet.add(HostAndPort.fromString("a.b.b.d:11"));
+
+    List<HostAndPort> expected = List.of(HostAndPort.fromString("1.1.1.1"),
+        HostAndPort.fromString("1.1.1.1:24"), HostAndPort.fromString("1.100.100.100"),
+        HostAndPort.fromString("10.100.100.100"), HostAndPort.fromString("100.100.100.100"),
+        HostAndPort.fromString("100.100.101.100"), HostAndPort.fromString("12.1.2.1"),
+        HostAndPort.fromString("192.12.2.1"), HostAndPort.fromString("192.12.2.1:79"),
+        HostAndPort.fromString("192.12.2.1:80"), HostAndPort.fromString("192.12.2.1:81"),
+        HostAndPort.fromString("199.10.1.1:14"), HostAndPort.fromString("[2001:::1]"),
+        HostAndPort.fromString("[2001:db8::1]"), HostAndPort.fromString("[2001:eb8::1]"),
+        HostAndPort.fromString("[2001:eb8::1]:80"), HostAndPort.fromString("a.b.b.d"),
+        HostAndPort.fromString("a.b.b.d:10"), HostAndPort.fromString("a.b.b.d:11"),
+        HostAndPort.fromString("a.b.c.d"), HostAndPort.fromString("a.b.c.d:10"),
+        HostAndPort.fromString("a.bb.c.d"), HostAndPort.fromString("example.com"),
+        HostAndPort.fromString("example.com:80"), HostAndPort.fromString("example.info"),
+        HostAndPort.fromString("www.alpha.org"), HostAndPort.fromString("www.example.com"));
+
+    Object[] expectedArray = expected.toArray();
+    Object[] hostPortArray = hostPortSet.toArray();
+
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expectedArray[i].toString(), hostPortArray[i].toString());
+    }
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
@@ -88,10 +88,12 @@ class HostAndPortTest {
     hostPortSet.add(HostAndPort.fromString("example.com:80"));
     hostPortSet.add(HostAndPort.fromString("a.bb.c.d"));
     hostPortSet.add(HostAndPort.fromString("12.1.2.1"));
+    hostPortSet.add(HostAndPort.fromString("localhost:0000090"));
     hostPortSet.add(HostAndPort.fromString("example.com"));
     hostPortSet.add(HostAndPort.fromString("100.100.100.100"));
     hostPortSet.add(HostAndPort.fromString("www.example.com"));
     hostPortSet.add(HostAndPort.fromString("[2001:eb8::1]"));
+    hostPortSet.add(HostAndPort.fromString("localhost:90"));
     hostPortSet.add(HostAndPort.fromString("[2001:eb8::1]:80"));
     hostPortSet.add(HostAndPort.fromString("2001:db8::1"));
     hostPortSet.add(HostAndPort.fromString("100.100.101.100"));
@@ -102,10 +104,12 @@ class HostAndPortTest {
     hostPortSet.add(HostAndPort.fromString("10.100.100.100"));
     hostPortSet.add(HostAndPort.fromString("192.12.2.1:79"));
     hostPortSet.add(HostAndPort.fromString("1.1.1.1:24"));
+    hostPortSet.add(HostAndPort.fromParts("localhost", 000001));
     hostPortSet.add(HostAndPort.fromString("1.1.1.1"));
     hostPortSet.add(HostAndPort.fromString("192.12.2.1:79"));
     hostPortSet.add(HostAndPort.fromString("a.b.c.d"));
     hostPortSet.add(HostAndPort.fromString("1.100.100.100"));
+    hostPortSet.add(HostAndPort.fromParts("localhost", 1));
     hostPortSet.add(HostAndPort.fromString("a.b.b.d"));
     hostPortSet.add(HostAndPort.fromString("www.example.com"));
     hostPortSet.add(HostAndPort.fromString("www.alpha.org"));
@@ -126,7 +130,11 @@ class HostAndPortTest {
         HostAndPort.fromString("a.b.c.d"), HostAndPort.fromString("a.b.c.d:10"),
         HostAndPort.fromString("a.bb.c.d"), HostAndPort.fromString("example.com"),
         HostAndPort.fromString("example.com:80"), HostAndPort.fromString("example.info"),
+        HostAndPort.fromString("localhost:1"), HostAndPort.fromString("localhost:90"),
         HostAndPort.fromString("www.alpha.org"), HostAndPort.fromString("www.example.com"));
+
+    System.err.println("hostPort: " + hostPortSet);
+    System.err.println("expected: " + expected);
 
     Object[] expectedArray = expected.toArray();
     Object[] hostPortArray = hostPortSet.toArray();

--- a/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/HostAndPortTest.java
@@ -102,6 +102,7 @@ class HostAndPortTest {
     hostPortSet.add(HostAndPort.fromString("192.12.2.1:81"));
     hostPortSet.add(HostAndPort.fromString("199.10.1.1:14"));
     hostPortSet.add(HostAndPort.fromString("10.100.100.100"));
+    hostPortSet.add(HostAndPort.fromString("2.2.2.2:10000"));
     hostPortSet.add(HostAndPort.fromString("192.12.2.1:79"));
     hostPortSet.add(HostAndPort.fromString("1.1.1.1:24"));
     hostPortSet.add(HostAndPort.fromParts("localhost", 000001));
@@ -109,6 +110,7 @@ class HostAndPortTest {
     hostPortSet.add(HostAndPort.fromString("192.12.2.1:79"));
     hostPortSet.add(HostAndPort.fromString("a.b.c.d"));
     hostPortSet.add(HostAndPort.fromString("1.100.100.100"));
+    hostPortSet.add(HostAndPort.fromString("2.2.2.2:9999"));
     hostPortSet.add(HostAndPort.fromParts("localhost", 1));
     hostPortSet.add(HostAndPort.fromString("a.b.b.d"));
     hostPortSet.add(HostAndPort.fromString("www.example.com"));
@@ -123,7 +125,8 @@ class HostAndPortTest {
         HostAndPort.fromString("100.100.101.100"), HostAndPort.fromString("12.1.2.1"),
         HostAndPort.fromString("192.12.2.1"), HostAndPort.fromString("192.12.2.1:79"),
         HostAndPort.fromString("192.12.2.1:80"), HostAndPort.fromString("192.12.2.1:81"),
-        HostAndPort.fromString("199.10.1.1:14"), HostAndPort.fromString("[2001:::1]"),
+        HostAndPort.fromString("199.10.1.1:14"), HostAndPort.fromString("2.2.2.2:9999"),
+        HostAndPort.fromString("2.2.2.2:10000"), HostAndPort.fromString("[2001:::1]"),
         HostAndPort.fromString("[2001:db8::1]"), HostAndPort.fromString("[2001:eb8::1]"),
         HostAndPort.fromString("[2001:eb8::1]:80"), HostAndPort.fromString("a.b.b.d"),
         HostAndPort.fromString("a.b.b.d:10"), HostAndPort.fromString("a.b.b.d:11"),
@@ -132,9 +135,6 @@ class HostAndPortTest {
         HostAndPort.fromString("example.com:80"), HostAndPort.fromString("example.info"),
         HostAndPort.fromString("localhost:1"), HostAndPort.fromString("localhost:90"),
         HostAndPort.fromString("www.alpha.org"), HostAndPort.fromString("www.example.com"));
-
-    System.err.println("hostPort: " + hostPortSet);
-    System.err.println("expected: " + expected);
 
     Object[] expectedArray = expected.toArray();
     Object[] hostPortArray = hostPortSet.toArray();

--- a/pom.xml
+++ b/pom.xml
@@ -1677,14 +1677,13 @@
                   -XepExcludedPaths:.*/(proto|thrift|generated-sources|src/test)/.* \
                   -XepDisableWarningsInGeneratedCode \
                   -XepDisableAllWarnings \
-                  <!-- error/warning patterns to ignore -->
-                  -Xep:Incomparable:OFF \
+                  <!-- error patterns to ignore -->
                   -Xep:CheckReturnValue:OFF \
                   -Xep:MustBeClosedChecker:OFF \
                   -Xep:ReturnValueIgnored:OFF \
                   -Xep:FutureReturnValueIgnored:ERROR \
                   -Xep:UnicodeInCode:OFF \
-                  <!-- error/warning patterns to specifically check -->
+                  <!-- warning patterns to specifically check -->
                   -Xep:ExpectedExceptionChecker \
                   -Xep:MissingOverride \
                   <!-- Items containing 'OFF' are currently flagged by ErrorProne. The 'OFF'


### PR DESCRIPTION
The utility class, VerifyTabletAssignements, uses a TreeMap collection
to hold HostAndPort values. This requires the HostAndPort class to
implement the Comparable interface. This ticket adds the compareTo
method to HostAndPort. Given that the utility is seldom used, the
compareTo uses a simple compare on the Host portion and an integer
compare on the Port if required.

A HostAndPortTest class was added to verify changes.

This was first found when running ErrorProne. The ErrorProne check for
this condition had been disabled due to this issue. The check has now
been re-enabled in the ErrorProne configuration within the POM file.