### PR TITLE
Allow UncaughtExceptionHandler to be overridden in client

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/classloader/DefaultContextClassLoaderFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/DefaultContextClassLoaderFactory.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.core.classloader;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
@@ -64,11 +63,8 @@ public class DefaultContextClassLoaderFactory implements ContextClassLoaderFacto
 
   private static void startCleanupThread(final AccumuloConfiguration conf,
       final Supplier<Map<String,String>> contextConfigSupplier) {
-    ScheduledFuture<?> future = ThreadPools.getClientThreadPools(new UncaughtExceptionHandler() {
-      @Override
-      public void uncaughtException(Thread arg0, Throwable arg1) {
-        LOG.error("context classloader cleanup thread has failed.", arg1);
-      }
+    ScheduledFuture<?> future = ThreadPools.getClientThreadPools((t, e) -> {
+      LOG.error("context classloader cleanup thread has failed.", e);
     }).createGeneralScheduledExecutorService(conf)
         .scheduleWithFixedDelay(Threads.createNamedRunnable(className + "-cleanup", () -> {
           LOG.trace("{}-cleanup thread, properties: {}", className, conf);

--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
@@ -350,8 +350,8 @@ public interface AccumuloClient extends AutoCloseable {
     /**
      * Override default handling of uncaught exceptions in client threads
      *
-     * @param UncaughtExceptionHandler
-     *          implementation
+     * @param ueh
+     *          UncaughtExceptionHandler implementation
      * @return AccumuloClient or Properties
      * @since 2.1.0
      */

--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client;
 
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -345,6 +346,16 @@ public interface AccumuloClient extends AutoCloseable {
    * @since 2.0.0
    */
   interface ClientFactory<T> {
+
+    /**
+     * Override default handling of uncaught exceptions in client threads
+     *
+     * @param UncaughtExceptionHandler
+     *          implementation
+     * @return AccumuloClient or Properties
+     * @since 2.1.0
+     */
+    ClientFactory<T> withUncaughtExceptionHandler(Class<? extends UncaughtExceptionHandler> ueh);
 
     /**
      * Builds AccumuloClient or client Properties

--- a/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/AccumuloClient.java
@@ -355,7 +355,7 @@ public interface AccumuloClient extends AutoCloseable {
      * @return AccumuloClient or Properties
      * @since 2.1.0
      */
-    ClientFactory<T> withUncaughtExceptionHandler(Class<? extends UncaughtExceptionHandler> ueh);
+    ClientFactory<T> withUncaughtExceptionHandler(UncaughtExceptionHandler ueh);
 
     /**
      * Builds AccumuloClient or client Properties

--- a/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ZooKeeperInstance.java
@@ -192,7 +192,7 @@ public class ZooKeeperInstance implements Instance {
     ClientInfo info = new ClientInfoImpl(properties, token);
     AccumuloConfiguration serverConf = ClientConfConverter.toAccumuloConf(properties);
     return new org.apache.accumulo.core.clientImpl.ConnectorImpl(
-        new ClientContext(SingletonReservation.noop(), info, serverConf));
+        new ClientContext(SingletonReservation.noop(), info, serverConf, null));
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -129,7 +129,7 @@ public class ClientContext implements AccumuloClient {
   private TCredentials rpcCreds;
   private ThriftTransportPool thriftTransportPool;
 
-  private boolean closed = false;
+  private volatile boolean closed = false;
 
   private SecurityOperations secops = null;
   private final TableOperationsImpl tableops;
@@ -783,7 +783,7 @@ public class ClientContext implements AccumuloClient {
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     closed = true;
     if (thriftTransportPool != null) {
       thriftTransportPool.shutdown();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 
-import java.lang.ref.Cleaner.Cleanable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,9 +40,7 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -78,7 +75,6 @@ import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.accumulo.core.util.ByteBufferUtil;
 import org.apache.accumulo.core.util.HostAndPort;
-import org.apache.accumulo.core.util.cleaner.CleanerUtil;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.fate.zookeeper.ServiceLock;
@@ -90,7 +86,6 @@ import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.transport.TTransportException;
-import org.slf4j.LoggerFactory;
 
 class ConditionalWriterImpl implements ConditionalWriter {
 
@@ -116,9 +111,6 @@ class ConditionalWriterImpl implements ConditionalWriter {
   private DelayQueue<QCMutation> failedMutations = new DelayQueue<>();
   private ScheduledThreadPoolExecutor threadPool;
   private final ScheduledFuture<?> failureTaskFuture;
-  private final ThreadPoolExecutor cleanupThreadPool;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
-  private final Cleanable cleaner;
 
   private class RQIterator implements Iterator<Result> {
 
@@ -246,8 +238,6 @@ class ConditionalWriterImpl implements ConditionalWriter {
         }
 
       }
-      closed.set(true);
-      cleaner.clean();
     }
   }
 
@@ -371,12 +361,8 @@ class ConditionalWriterImpl implements ConditionalWriter {
     this.context = context;
     this.auths = config.getAuthorizations();
     this.ve = new VisibilityEvaluator(config.getAuthorizations());
-    this.threadPool = context.getClientThreadPools().createScheduledExecutorService(
+    this.threadPool = context.threadPools().createScheduledExecutorService(
         config.getMaxWriteThreads(), this.getClass().getSimpleName(), false);
-    this.cleanupThreadPool = context.getClientThreadPools().createFixedThreadPool(1, 3, SECONDS,
-        "Conditional Writer Cleanup Thread", true);
-    this.cleaner = CleanerUtil.shutdownThreadPoolExecutor(cleanupThreadPool, closed,
-        LoggerFactory.getLogger(ConditionalWriterImpl.class));
     this.locator = new SyncingTabletLocator(context, tableId);
     this.serverQueues = new HashMap<>();
     this.tableId = tableId;
@@ -813,7 +799,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
   @Override
   public void close() {
     threadPool.shutdownNow();
-    cleanupThreadPool.execute(Threads.createNamedRunnable("ConditionalWriterCleanupTask",
+    context.executeCleanupTask(Threads.createNamedRunnable("ConditionalWriterCleanupTask",
         new CleanupTask(getActiveSessions())));
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -53,7 +53,6 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
 import org.apache.accumulo.core.util.compaction.ExternalCompactionUtil;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
@@ -219,8 +218,8 @@ public class InstanceOperationsImpl implements InstanceOperations {
     List<String> tservers = getTabletServers();
 
     int numThreads = Math.max(4, Math.min((tservers.size() + compactors.size()) / 10, 256));
-    var executorService =
-        ThreadPools.createFixedThreadPool(numThreads, "getactivecompactions", false);
+    var executorService = context.getClientThreadPools().createFixedThreadPool(numThreads,
+        "getactivecompactions", false);
     try {
       List<Future<List<ActiveCompaction>>> futures = new ArrayList<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -218,8 +218,8 @@ public class InstanceOperationsImpl implements InstanceOperations {
     List<String> tservers = getTabletServers();
 
     int numThreads = Math.max(4, Math.min((tservers.size() + compactors.size()) / 10, 256));
-    var executorService = context.getClientThreadPools().createFixedThreadPool(numThreads,
-        "getactivecompactions", false);
+    var executorService =
+        context.threadPools().createFixedThreadPool(numThreads, "getactivecompactions", false);
     try {
       List<Future<List<ActiveCompaction>>> futures = new ArrayList<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -486,8 +486,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
     CountDownLatch latch = new CountDownLatch(splits.size());
     AtomicReference<Exception> exception = new AtomicReference<>(null);
 
-    ExecutorService executor =
-        context.getClientThreadPools().createFixedThreadPool(16, "addSplits", false);
+    ExecutorService executor = context.threadPools().createFixedThreadPool(16, "addSplits", false);
     try {
       executor.execute(
           new SplitTask(new SplitEnv(tableName, tableId, executor, latch, exception), splits));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -136,7 +136,6 @@ import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.OpTimer;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.TextUtil;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.hadoop.fs.FileStatus;
@@ -487,7 +486,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
     CountDownLatch latch = new CountDownLatch(splits.size());
     AtomicReference<Exception> exception = new AtomicReference<>(null);
 
-    ExecutorService executor = ThreadPools.createFixedThreadPool(16, "addSplits", false);
+    ExecutorService executor =
+        context.getClientThreadPools().createFixedThreadPool(16, "addSplits", false);
     try {
       executor.execute(
           new SplitTask(new SplitEnv(tableName, tableId, executor, latch, exception), splits));

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -71,7 +71,7 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
     this.tableName = tableName;
     this.numThreads = numQueryThreads;
 
-    queryThreadPool = context.getClientThreadPools().createFixedThreadPool(numQueryThreads,
+    queryThreadPool = context.threadPools().createFixedThreadPool(numQueryThreads,
         "batch scanner " + batchReaderInstance + "-", false);
     // Call shutdown on this thread pool in case the caller does not call close().
     cleanable = CleanerUtil.shutdownThreadPoolExecutor(queryThreadPool, closed, log);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.cleaner.CleanerUtil;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +71,7 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
     this.tableName = tableName;
     this.numThreads = numQueryThreads;
 
-    queryThreadPool = ThreadPools.createFixedThreadPool(numQueryThreads,
+    queryThreadPool = context.getClientThreadPools().createFixedThreadPool(numQueryThreads,
         "batch scanner " + batchReaderInstance + "-", false);
     // Call shutdown on this thread pool in case the caller does not call close().
     cleanable = CleanerUtil.shutdownThreadPoolExecutor(queryThreadPool, closed, log);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -202,7 +202,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
   public TabletServerBatchWriter(ClientContext context, BatchWriterConfig config) {
     this.context = context;
-    this.executor = context.getClientThreadPools()
+    this.executor = context.threadPools()
         .createGeneralScheduledExecutorService(this.context.getConfiguration());
     this.failedMutations = new FailedMutations();
     this.maxMem = config.getMaxMemory();
@@ -655,10 +655,10 @@ public class TabletServerBatchWriter implements AutoCloseable {
     public MutationWriter(int numSendThreads) {
       serversMutations = new HashMap<>();
       queued = new HashSet<>();
-      sendThreadPool = context.getClientThreadPools().createFixedThreadPool(numSendThreads,
+      sendThreadPool = context.threadPools().createFixedThreadPool(numSendThreads,
           this.getClass().getName(), false);
       locators = new HashMap<>();
-      binningThreadPool = context.getClientThreadPools().createFixedThreadPool(1, "BinMutations",
+      binningThreadPool = context.threadPools().createFixedThreadPool(1, "BinMutations",
           new SynchronousQueue<>(), false);
       binningThreadPool.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -202,8 +202,8 @@ public class TabletServerBatchWriter implements AutoCloseable {
 
   public TabletServerBatchWriter(ClientContext context, BatchWriterConfig config) {
     this.context = context;
-    this.executor =
-        ThreadPools.createGeneralScheduledExecutorService(this.context.getConfiguration());
+    this.executor = context.getClientThreadPools()
+        .createGeneralScheduledExecutorService(this.context.getConfiguration());
     this.failedMutations = new FailedMutations();
     this.maxMem = config.getMaxMemory();
     this.maxLatency = config.getMaxLatency(MILLISECONDS) <= 0 ? Long.MAX_VALUE
@@ -655,11 +655,11 @@ public class TabletServerBatchWriter implements AutoCloseable {
     public MutationWriter(int numSendThreads) {
       serversMutations = new HashMap<>();
       queued = new HashSet<>();
-      sendThreadPool =
-          ThreadPools.createFixedThreadPool(numSendThreads, this.getClass().getName(), false);
+      sendThreadPool = context.getClientThreadPools().createFixedThreadPool(numSendThreads,
+          this.getClass().getName(), false);
       locators = new HashMap<>();
-      binningThreadPool =
-          ThreadPools.createFixedThreadPool(1, "BinMutations", new SynchronousQueue<>(), false);
+      binningThreadPool = context.getClientThreadPools().createFixedThreadPool(1, "BinMutations",
+          new SynchronousQueue<>(), false);
       binningThreadPool.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -475,11 +475,11 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
     if (this.executor != null) {
       executor = this.executor;
     } else if (numThreads > 0) {
-      executor = service = context.getClientThreadPools().createFixedThreadPool(numThreads,
-          "BulkImportThread", false);
+      executor = service =
+          context.threadPools().createFixedThreadPool(numThreads, "BulkImportThread", false);
     } else {
       String threads = context.getConfiguration().get(ClientProperty.BULK_LOAD_THREADS.getKey());
-      executor = service = context.getClientThreadPools().createFixedThreadPool(
+      executor = service = context.threadPools().createFixedThreadPool(
           ConfigurationTypeHelper.getNumThreads(threads), "BulkImportThread", false);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -75,7 +75,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
-import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
 import org.apache.accumulo.fate.util.Retry;
 import org.apache.commons.io.FilenameUtils;
@@ -476,10 +475,11 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
     if (this.executor != null) {
       executor = this.executor;
     } else if (numThreads > 0) {
-      executor = service = ThreadPools.createFixedThreadPool(numThreads, "BulkImportThread", false);
+      executor = service = context.getClientThreadPools().createFixedThreadPool(numThreads,
+          "BulkImportThread", false);
     } else {
       String threads = context.getConfiguration().get(ClientProperty.BULK_LOAD_THREADS.getKey());
-      executor = service = ThreadPools.createFixedThreadPool(
+      executor = service = context.getClientThreadPools().createFixedThreadPool(
           ConfigurationTypeHelper.getNumThreads(threads), "BulkImportThread", false);
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -128,7 +128,10 @@ public enum ClientProperty {
       "A list of span receiver classes to send trace spans"),
   @Deprecated(since = "2.1.0", forRemoval = true)
   TRACE_ZOOKEEPER_PATH("trace.zookeeper.path", Constants.ZTRACERS, PropertyType.PATH,
-      "The zookeeper node where tracers are registered", "2.0.0", false);
+      "The zookeeper node where tracers are registered", "2.0.0", false),
+  UNCAUGHT_EXCEPTION_HANDLER("client.uncaught.exception.handler", "", PropertyType.CLASSNAME,
+      "The name of the uncaught exception handler implementation for the client VM", "2.1.0",
+      false);
 
   @Deprecated(since = "2.1.0", forRemoval = true)
   public static final String TRACE_SPAN_RECEIVER_PREFIX = "trace.span.receiver";

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -128,10 +128,7 @@ public enum ClientProperty {
       "A list of span receiver classes to send trace spans"),
   @Deprecated(since = "2.1.0", forRemoval = true)
   TRACE_ZOOKEEPER_PATH("trace.zookeeper.path", Constants.ZTRACERS, PropertyType.PATH,
-      "The zookeeper node where tracers are registered", "2.0.0", false),
-  UNCAUGHT_EXCEPTION_HANDLER("client.uncaught.exception.handler", "", PropertyType.CLASSNAME,
-      "The name of the uncaught exception handler implementation for the client VM", "2.1.0",
-      false);
+      "The zookeeper node where tracers are registered", "2.0.0", false);
 
   @Deprecated(since = "2.1.0", forRemoval = true)
   public static final String TRACE_SPAN_RECEIVER_PREFIX = "trace.span.receiver";

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -79,8 +79,8 @@ public class BloomFilterLayer {
     }
 
     if (maxLoadThreads > 0) {
-      loadThreadPool =
-          ThreadPools.createThreadPool(0, maxLoadThreads, 60, SECONDS, "bloom-loader", false);
+      loadThreadPool = ThreadPools.getServerThreadPools().createThreadPool(0, maxLoadThreads, 60,
+          SECONDS, "bloom-loader", false);
     }
 
     return loadThreadPool;

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
@@ -102,8 +102,8 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
   private final EvictionThread evictionThread;
 
   /** Statistics thread schedule pool (for heavy debugging, could remove) */
-  private final ScheduledExecutorService scheduleThreadPool =
-      ThreadPools.createScheduledExecutorService(1, "LRUBlockCacheStats", true);
+  private final ScheduledExecutorService scheduleThreadPool = ThreadPools.getServerThreadPools()
+      .createScheduledExecutorService(1, "LRUBlockCacheStats", true);
 
   /** Current size of cache */
   private final AtomicLong size;

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
@@ -60,8 +60,8 @@ public final class TinyLfuBlockCache implements BlockCache {
   private final Cache<String,Block> cache;
   private final Policy.Eviction<String,Block> policy;
   private final int maxSize;
-  private final ScheduledExecutorService statsExecutor =
-      ThreadPools.createScheduledExecutorService(1, "TinyLfuBlockCacheStatsExecutor", true);
+  private final ScheduledExecutorService statsExecutor = ThreadPools.getServerThreadPools()
+      .createScheduledExecutorService(1, "TinyLfuBlockCacheStatsExecutor", true);
 
   public TinyLfuBlockCache(Configuration conf, CacheType type) {
     cache = Caffeine.newBuilder()

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
@@ -231,8 +231,8 @@ public class ExternalCompactionUtil {
    */
   public static List<RunningCompaction> getCompactionsRunningOnCompactors(ClientContext context) {
     final List<RunningCompactionFuture> rcFutures = new ArrayList<>();
-    final ExecutorService executor =
-        ThreadPools.createFixedThreadPool(16, "CompactorRunningCompactions", false);
+    final ExecutorService executor = ThreadPools.getServerThreadPools().createFixedThreadPool(16,
+        "CompactorRunningCompactions", false);
 
     getCompactorAddrs(context).forEach((q, hp) -> {
       hp.forEach(hostAndPort -> {
@@ -259,8 +259,8 @@ public class ExternalCompactionUtil {
 
   public static Collection<ExternalCompactionId>
       getCompactionIdsRunningOnCompactors(ClientContext context) {
-    final ExecutorService executor =
-        ThreadPools.createFixedThreadPool(16, "CompactorRunningCompactions", false);
+    final ExecutorService executor = ThreadPools.getServerThreadPools().createFixedThreadPool(16,
+        "CompactorRunningCompactions", false);
 
     List<Future<ExternalCompactionId>> futures = new ArrayList<>();
 

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
@@ -56,7 +56,8 @@ public class SharedRateLimiterFactory {
     if (instance == null) {
       instance = new SharedRateLimiterFactory();
 
-      ScheduledThreadPoolExecutor svc = ThreadPools.createGeneralScheduledExecutorService(conf);
+      ScheduledThreadPoolExecutor svc =
+          ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf);
       updateTaskFuture = svc.scheduleWithFixedDelay(Threads
           .createNamedRunnable("SharedRateLimiterFactory update polling", instance::updateAll),
           UPDATE_RATE, UPDATE_RATE, MILLISECONDS);

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/NamedThreadFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/NamedThreadFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.util.threads;
 
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.OptionalInt;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,17 +30,19 @@ class NamedThreadFactory implements ThreadFactory {
 
   private static final String FORMAT = "%s-%s-%d";
 
-  private AtomicInteger threadNum = new AtomicInteger(1);
-  private String name;
-  private OptionalInt priority;
+  private final AtomicInteger threadNum = new AtomicInteger(1);
+  private final String name;
+  private final OptionalInt priority;
+  private final UncaughtExceptionHandler handler;
 
-  NamedThreadFactory(String name) {
-    this(name, OptionalInt.empty());
+  NamedThreadFactory(String name, UncaughtExceptionHandler ueh) {
+    this(name, OptionalInt.empty(), ueh);
   }
 
-  NamedThreadFactory(String name, OptionalInt priority) {
+  NamedThreadFactory(String name, OptionalInt priority, UncaughtExceptionHandler ueh) {
     this.name = name;
     this.priority = priority;
+    this.handler = ueh;
   }
 
   @Override
@@ -52,6 +55,6 @@ class NamedThreadFactory implements ThreadFactory {
       threadName =
           String.format(FORMAT, name, r.getClass().getSimpleName(), threadNum.getAndIncrement());
     }
-    return Threads.createThread(threadName, priority, r);
+    return Threads.createThread(threadName, priority, r, handler);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.util.threads;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Iterator;
 import java.util.List;
 import java.util.OptionalInt;
@@ -65,8 +66,18 @@ public class ThreadPools {
   // the number of seconds before we allow a thread to terminate with non-use.
   public static final long DEFAULT_TIMEOUT_MILLISECS = 180000L;
 
+  private static final ThreadPools SERVER_INSTANCE = new ThreadPools(Threads.UEH);
+
+  public static final ThreadPools getServerThreadPools() {
+    return SERVER_INSTANCE;
+  }
+
+  public static final ThreadPools getClientThreadPools(UncaughtExceptionHandler ueh) {
+    return new ThreadPools(ueh);
+  }
+
   private static final ThreadPoolExecutor SCHEDULED_FUTURE_CHECKER_POOL =
-      createFixedThreadPool(1, "Scheduled Future Checker", false);
+      getServerThreadPools().createFixedThreadPool(1, "Scheduled Future Checker", false);
 
   private static final ConcurrentLinkedQueue<ScheduledFuture<?>> CRITICAL_RUNNING_TASKS =
       new ConcurrentLinkedQueue<>();
@@ -216,6 +227,12 @@ public class ThreadPools {
     resizePool(pool, () -> conf.getCount(p), p.getKey());
   }
 
+  private final UncaughtExceptionHandler handler;
+
+  private ThreadPools(UncaughtExceptionHandler ueh) {
+    handler = ueh;
+  }
+
   /**
    * Create a thread pool based on a thread pool related property
    *
@@ -235,7 +252,7 @@ public class ThreadPools {
    *           if property is not handled
    */
   @SuppressWarnings("deprecation")
-  public static ThreadPoolExecutor createExecutorService(final AccumuloConfiguration conf,
+  public ThreadPoolExecutor createExecutorService(final AccumuloConfiguration conf,
       final Property p, boolean emitThreadPoolMetrics) {
 
     switch (p) {
@@ -304,7 +321,7 @@ public class ThreadPools {
    *          over long time periods.
    * @return ThreadPoolExecutor
    */
-  public static ThreadPoolExecutor createFixedThreadPool(int numThreads, final String name,
+  public ThreadPoolExecutor createFixedThreadPool(int numThreads, final String name,
       boolean emitThreadPoolMetrics) {
     return createFixedThreadPool(numThreads, DEFAULT_TIMEOUT_MILLISECS, MILLISECONDS, name,
         emitThreadPoolMetrics);
@@ -328,7 +345,7 @@ public class ThreadPools {
    *          over long time periods.
    * @return ThreadPoolExecutor
    */
-  public static ThreadPoolExecutor createFixedThreadPool(int numThreads, final String name,
+  public ThreadPoolExecutor createFixedThreadPool(int numThreads, final String name,
       BlockingQueue<Runnable> queue, boolean emitThreadPoolMetrics) {
     return createThreadPool(numThreads, numThreads, DEFAULT_TIMEOUT_MILLISECS, MILLISECONDS, name,
         queue, emitThreadPoolMetrics);
@@ -354,8 +371,8 @@ public class ThreadPools {
    *          over long time periods.
    * @return ThreadPoolExecutor
    */
-  public static ThreadPoolExecutor createFixedThreadPool(int numThreads, long timeOut,
-      TimeUnit units, final String name, boolean emitThreadPoolMetrics) {
+  public ThreadPoolExecutor createFixedThreadPool(int numThreads, long timeOut, TimeUnit units,
+      final String name, boolean emitThreadPoolMetrics) {
     return createThreadPool(numThreads, numThreads, timeOut, units, name, emitThreadPoolMetrics);
   }
 
@@ -381,7 +398,7 @@ public class ThreadPools {
    *          over long time periods.
    * @return ThreadPoolExecutor
    */
-  public static ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
+  public ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
       TimeUnit units, final String name, boolean emitThreadPoolMetrics) {
     return createThreadPool(coreThreads, maxThreads, timeOut, units, name,
         new LinkedBlockingQueue<>(), emitThreadPoolMetrics);
@@ -411,7 +428,7 @@ public class ThreadPools {
    *          over long time periods.
    * @return ThreadPoolExecutor
    */
-  public static ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
+  public ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
       TimeUnit units, final String name, BlockingQueue<Runnable> queue,
       boolean emitThreadPoolMetrics) {
     return createThreadPool(coreThreads, maxThreads, timeOut, units, name, queue,
@@ -444,11 +461,11 @@ public class ThreadPools {
    *          over long time periods.
    * @return ThreadPoolExecutor
    */
-  public static ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
+  public ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
       TimeUnit units, final String name, BlockingQueue<Runnable> queue, OptionalInt priority,
       boolean emitThreadPoolMetrics) {
     var result = new ThreadPoolExecutor(coreThreads, maxThreads, timeOut, units, queue,
-        new NamedThreadFactory(name, priority)) {
+        new NamedThreadFactory(name, priority, handler)) {
 
       @Override
       public void execute(Runnable arg0) {
@@ -488,7 +505,7 @@ public class ThreadPools {
    * If you need the server-side shared ScheduledThreadPoolExecutor, then use
    * ServerContext.getScheduledExecutor()
    */
-  public static ScheduledThreadPoolExecutor
+  public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     return (ScheduledThreadPoolExecutor) createExecutorService(conf,
         Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, true);
@@ -510,58 +527,59 @@ public class ThreadPools {
    *          over long time periods.
    * @return ScheduledThreadPoolExecutor
    */
-  public static ScheduledThreadPoolExecutor createScheduledExecutorService(int numThreads,
+  public ScheduledThreadPoolExecutor createScheduledExecutorService(int numThreads,
       final String name, boolean emitThreadPoolMetrics) {
-    var result = new ScheduledThreadPoolExecutor(numThreads, new NamedThreadFactory(name)) {
+    var result =
+        new ScheduledThreadPoolExecutor(numThreads, new NamedThreadFactory(name, handler)) {
 
-      @Override
-      public void execute(Runnable command) {
-        super.execute(TraceUtil.wrap(command));
-      }
+          @Override
+          public void execute(Runnable command) {
+            super.execute(TraceUtil.wrap(command));
+          }
 
-      @Override
-      public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        return super.schedule(TraceUtil.wrap(callable), delay, unit);
-      }
+          @Override
+          public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            return super.schedule(TraceUtil.wrap(callable), delay, unit);
+          }
 
-      @Override
-      public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        return super.schedule(TraceUtil.wrap(command), delay, unit);
-      }
+          @Override
+          public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            return super.schedule(TraceUtil.wrap(command), delay, unit);
+          }
 
-      @Override
-      public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
-          long period, TimeUnit unit) {
-        return super.scheduleAtFixedRate(TraceUtil.wrap(command), initialDelay, period, unit);
-      }
+          @Override
+          public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
+              long period, TimeUnit unit) {
+            return super.scheduleAtFixedRate(TraceUtil.wrap(command), initialDelay, period, unit);
+          }
 
-      @Override
-      public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
-          long delay, TimeUnit unit) {
-        return super.scheduleWithFixedDelay(TraceUtil.wrap(command), initialDelay, delay, unit);
-      }
+          @Override
+          public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
+              long delay, TimeUnit unit) {
+            return super.scheduleWithFixedDelay(TraceUtil.wrap(command), initialDelay, delay, unit);
+          }
 
-      @Override
-      public <T> Future<T> submit(Callable<T> task) {
-        return super.submit(TraceUtil.wrap(task));
-      }
+          @Override
+          public <T> Future<T> submit(Callable<T> task) {
+            return super.submit(TraceUtil.wrap(task));
+          }
 
-      @Override
-      public <T> Future<T> submit(Runnable task, T result) {
-        return super.submit(TraceUtil.wrap(task), result);
-      }
+          @Override
+          public <T> Future<T> submit(Runnable task, T result) {
+            return super.submit(TraceUtil.wrap(task), result);
+          }
 
-      @Override
-      public Future<?> submit(Runnable task) {
-        return super.submit(TraceUtil.wrap(task));
-      }
+          @Override
+          public Future<?> submit(Runnable task) {
+            return super.submit(TraceUtil.wrap(task));
+          }
 
-      @Override
-      public boolean remove(Runnable task) {
-        return super.remove(TraceUtil.wrap(task));
-      }
+          @Override
+          public boolean remove(Runnable task) {
+            return super.remove(TraceUtil.wrap(task));
+          }
 
-    };
+        };
     if (emitThreadPoolMetrics) {
       MetricsUtil.addExecutorServiceMetrics(result, name);
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.trace.TraceUtil;
 
 public class Threads {
 
-  static final UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
+  public static final UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
 
   public static class AccumuloDaemonThread extends Thread {
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -25,23 +25,26 @@ import org.apache.accumulo.core.trace.TraceUtil;
 
 public class Threads {
 
-  private static UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
+  static final UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
 
   public static class AccumuloDaemonThread extends Thread {
 
-    public AccumuloDaemonThread(Runnable target, String name) {
+    public AccumuloDaemonThread(Runnable target, String name, UncaughtExceptionHandler ueh) {
       super(target, name);
-      configureThread(this, name);
+      setDaemon(true);
+      setUncaughtExceptionHandler(ueh);
     }
 
     public AccumuloDaemonThread(String name) {
-      super(name);
-      configureThread(this, name);
+      this(name, UEH);
     }
-  }
 
-  public static void setUncaughtExceptionHandler(UncaughtExceptionHandler ueh) {
-    UEH = ueh;
+    private AccumuloDaemonThread(String name, UncaughtExceptionHandler ueh) {
+      super(name);
+      setDaemon(true);
+      setUncaughtExceptionHandler(ueh);
+    }
+
   }
 
   public static Runnable createNamedRunnable(String name, Runnable r) {
@@ -49,18 +52,18 @@ public class Threads {
   }
 
   public static Thread createThread(String name, Runnable r) {
-    return createThread(name, OptionalInt.empty(), r);
+    return createThread(name, OptionalInt.empty(), r, UEH);
   }
 
   public static Thread createThread(String name, OptionalInt priority, Runnable r) {
-    Thread thread = new AccumuloDaemonThread(TraceUtil.wrap(r), name);
+    return createThread(name, priority, r, UEH);
+  }
+
+  public static Thread createThread(String name, OptionalInt priority, Runnable r,
+      UncaughtExceptionHandler ueh) {
+    Thread thread = new AccumuloDaemonThread(TraceUtil.wrap(r), name, ueh);
     priority.ifPresent(thread::setPriority);
     return thread;
   }
 
-  private static void configureThread(Thread thread, String name) {
-    thread.setName(name);
-    thread.setDaemon(true);
-    thread.setUncaughtExceptionHandler(UEH);
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/Threads.java
@@ -25,6 +25,8 @@ import org.apache.accumulo.core.trace.TraceUtil;
 
 public class Threads {
 
+  private static UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
+
   public static class AccumuloDaemonThread extends Thread {
 
     public AccumuloDaemonThread(Runnable target, String name) {
@@ -38,11 +40,13 @@ public class Threads {
     }
   }
 
+  public static void setUncaughtExceptionHandler(UncaughtExceptionHandler ueh) {
+    UEH = ueh;
+  }
+
   public static Runnable createNamedRunnable(String name, Runnable r) {
     return new NamedRunnable(name, r);
   }
-
-  private static final UncaughtExceptionHandler UEH = new AccumuloUncaughtExceptionHandler();
 
   public static Thread createThread(String name, Runnable r) {
     return createThread(name, OptionalInt.empty(), r);

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -237,9 +237,10 @@ public class Fate<T> {
    * Launches the specified number of worker threads.
    */
   public void startTransactionRunners(AccumuloConfiguration conf) {
-    final ThreadPoolExecutor pool =
-        ThreadPools.createExecutorService(conf, Property.MANAGER_FATE_THREADPOOL_SIZE, true);
-    fatePoolWatcher = ThreadPools.createGeneralScheduledExecutorService(conf);
+    final ThreadPoolExecutor pool = ThreadPools.getServerThreadPools().createExecutorService(conf,
+        Property.MANAGER_FATE_THREADPOOL_SIZE, true);
+    fatePoolWatcher =
+        ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf);
     ThreadPools.watchCriticalScheduledTask(fatePoolWatcher.schedule(() -> {
       // resize the pool if the property changed
       ThreadPools.resizePool(pool, conf, Property.MANAGER_FATE_THREADPOOL_SIZE);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderTest.java
@@ -36,7 +36,7 @@ public class TabletServerBatchReaderTest {
   @BeforeEach
   public void setup() {
     context = EasyMock.createMock(ClientContext.class);
-    EasyMock.expect(context.getClientThreadPools()).andReturn(ThreadPools.getServerThreadPools());
+    EasyMock.expect(context.threadPools()).andReturn(ThreadPools.getServerThreadPools());
     EasyMock.replay(context);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,8 @@ public class TabletServerBatchReaderTest {
   @BeforeEach
   public void setup() {
     context = EasyMock.createMock(ClientContext.class);
+    EasyMock.expect(context.getClientThreadPools()).andReturn(ThreadPools.getServerThreadPools());
+    EasyMock.replay(context);
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -233,8 +233,8 @@ public class MultiThreadedRFileTest {
       // now start up multiple RFile deepcopies
       int maxThreads = 10;
       String name = "MultiThreadedRFileTestThread";
-      ThreadPoolExecutor pool = ThreadPools.createThreadPool(maxThreads + 1, maxThreads + 1, 5 * 60,
-          SECONDS, name, false);
+      ThreadPoolExecutor pool = ThreadPools.getServerThreadPools().createThreadPool(maxThreads + 1,
+          maxThreads + 1, 5 * 60, SECONDS, name, false);
       try {
         Runnable runnable = () -> {
           try {

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.AddressUtil;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.threads.ThreadPools;
+import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
@@ -102,7 +103,7 @@ public class ServerContext extends ClientContext {
   }
 
   private ServerContext(ServerInfo info) {
-    super(SingletonReservation.noop(), info, info.getSiteConfiguration());
+    super(SingletonReservation.noop(), info, info.getSiteConfiguration(), Threads.UEH);
     this.info = info;
     zooReaderWriter = new ZooReaderWriter(info.getSiteConfiguration());
     serverDirs = info.getServerDirs();

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -455,8 +455,8 @@ public class ServerContext extends ClientContext {
   public synchronized ScheduledThreadPoolExecutor getScheduledExecutor() {
     if (sharedScheduledThreadPool == null) {
       sharedScheduledThreadPool =
-          (ScheduledThreadPoolExecutor) ThreadPools.createExecutorService(getConfiguration(),
-              Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, true);
+          (ScheduledThreadPoolExecutor) ThreadPools.getServerThreadPools().createExecutorService(
+              getConfiguration(), Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, true);
     }
     return sharedScheduledThreadPool;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -130,8 +130,8 @@ public class BulkImporter {
           Collections.synchronizedSortedMap(new TreeMap<>());
 
       timer.start(Timers.EXAMINE_MAP_FILES);
-      ExecutorService threadPool =
-          ThreadPools.createFixedThreadPool(numThreads, "findOverlapping", false);
+      ExecutorService threadPool = ThreadPools.getServerThreadPools()
+          .createFixedThreadPool(numThreads, "findOverlapping", false);
 
       for (Path path : paths) {
         final Path mapFile = path;
@@ -351,8 +351,8 @@ public class BulkImporter {
 
     final Map<Path,List<AssignmentInfo>> ais = Collections.synchronizedMap(new TreeMap<>());
 
-    ExecutorService threadPool =
-        ThreadPools.createFixedThreadPool(numThreads, "estimateSizes", false);
+    ExecutorService threadPool = ThreadPools.getServerThreadPools()
+        .createFixedThreadPool(numThreads, "estimateSizes", false);
 
     for (final Entry<Path,List<TabletLocation>> entry : assignments.entrySet()) {
       if (entry.getValue().size() == 1) {
@@ -536,7 +536,8 @@ public class BulkImporter {
       }
     });
 
-    ExecutorService threadPool = ThreadPools.createFixedThreadPool(numThreads, "submit", false);
+    ExecutorService threadPool =
+        ThreadPools.getServerThreadPools().createFixedThreadPool(numThreads, "submit", false);
 
     for (Entry<String,Map<KeyExtent,List<PathSize>>> entry : assignmentsPerTabletServer
         .entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -304,7 +304,8 @@ public class VolumeManagerImpl implements VolumeManager {
   public void bulkRename(Map<Path,Path> oldToNewPathMap, int poolSize, String poolName,
       String transactionId) throws IOException {
     List<Future<Void>> results = new ArrayList<>();
-    ExecutorService workerPool = ThreadPools.createFixedThreadPool(poolSize, poolName, false);
+    ExecutorService workerPool =
+        ThreadPools.getServerThreadPools().createFixedThreadPool(poolSize, poolName, false);
     oldToNewPathMap.forEach((oldPath, newPath) -> results.add(workerPool.submit(() -> {
       boolean success;
       try {

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -66,8 +66,8 @@ public class ProblemReports implements Iterable<ProblemReport> {
    * processed because the whole system is in a really bad state (like HDFS is down) and everything
    * is reporting lots of problems, but problem reports can not be processed
    */
-  private ExecutorService reportExecutor = ThreadPools.createThreadPool(0, 1, 60, TimeUnit.SECONDS,
-      "acu-problem-reporter", new LinkedBlockingQueue<>(500), false);
+  private ExecutorService reportExecutor = ThreadPools.getServerThreadPools().createThreadPool(0, 1,
+      60, TimeUnit.SECONDS, "acu-problem-reporter", new LinkedBlockingQueue<>(500), false);
 
   private final ServerContext context;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -311,11 +311,11 @@ public class TServerUtils {
   public static ThreadPoolExecutor createSelfResizingThreadPool(final String serverName,
       final int executorThreads, long threadTimeOut, final AccumuloConfiguration conf,
       long timeBetweenThreadChecks) {
-    final ThreadPoolExecutor pool = ThreadPools.createFixedThreadPool(executorThreads,
-        threadTimeOut, TimeUnit.MILLISECONDS, serverName + "-ClientPool", true);
+    final ThreadPoolExecutor pool = ThreadPools.getServerThreadPools().createFixedThreadPool(
+        executorThreads, threadTimeOut, TimeUnit.MILLISECONDS, serverName + "-ClientPool", true);
     // periodically adjust the number of threads we need by checking how busy our threads are
-    ThreadPools.watchCriticalScheduledTask(
-        ThreadPools.createGeneralScheduledExecutorService(conf).scheduleWithFixedDelay(() -> {
+    ThreadPools.watchCriticalScheduledTask(ThreadPools.getServerThreadPools()
+        .createGeneralScheduledExecutorService(conf).scheduleWithFixedDelay(() -> {
           // there is a minor race condition between sampling the current state of the thread pool
           // and
           // adjusting it

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileSystemMonitor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileSystemMonitor.java
@@ -117,8 +117,8 @@ public class FileSystemMonitor {
 
     // Create a task to check each mount periodically to see if its state has changed.
     for (Mount mount : mounts) {
-      ThreadPools.watchCriticalScheduledTask(
-          ThreadPools.createGeneralScheduledExecutorService(conf).scheduleWithFixedDelay(
+      ThreadPools.watchCriticalScheduledTask(ThreadPools.getServerThreadPools()
+          .createGeneralScheduledExecutorService(conf).scheduleWithFixedDelay(
               Threads.createNamedRunnable(mount.mountPoint + "filesystem monitor", () -> {
                 try {
                   checkMount(mount);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RemoveEntriesForMissingFiles.java
@@ -121,7 +121,8 @@ public class RemoveEntriesForMissingFiles {
 
     Map<Path,Path> cache = new LRUMap<>(100000);
     Set<Path> processing = new HashSet<>();
-    ExecutorService threadPool = ThreadPools.createFixedThreadPool(16, "CheckFileTasks", false);
+    ExecutorService threadPool =
+        ThreadPools.getServerThreadPools().createFixedThreadPool(16, "CheckFileTasks", false);
 
     System.out.printf("Scanning : %s %s\n", tableName, range);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -124,7 +124,8 @@ public class VerifyTabletAssignments {
       }
     }
 
-    ExecutorService tp = ThreadPools.createFixedThreadPool(20, "CheckTabletServer", false);
+    ExecutorService tp =
+        ThreadPools.getServerThreadPools().createFixedThreadPool(20, "CheckTabletServer", false);
     for (final Entry<HostAndPort,List<KeyExtent>> entry : extentsPerServer.entrySet()) {
       Runnable r = () -> {
         try {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -127,7 +127,7 @@ public class CompactionCoordinator extends AbstractServer
   protected CompactionCoordinator(ServerOpts opts, String[] args) {
     super("compaction-coordinator", opts, args);
     aconf = getConfiguration();
-    schedExecutor = ThreadPools.createGeneralScheduledExecutorService(aconf);
+    schedExecutor = ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(aconf);
     compactionFinalizer = createCompactionFinalizer(schedExecutor);
     tserverSet = createLiveTServerSet();
     setupSecurity();
@@ -139,7 +139,7 @@ public class CompactionCoordinator extends AbstractServer
   protected CompactionCoordinator(ServerOpts opts, String[] args, AccumuloConfiguration conf) {
     super("compaction-coordinator", opts, args);
     aconf = conf;
-    schedExecutor = ThreadPools.createGeneralScheduledExecutorService(aconf);
+    schedExecutor = ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(aconf);
     compactionFinalizer = createCompactionFinalizer(schedExecutor);
     tserverSet = createLiveTServerSet();
     setupSecurity();
@@ -319,8 +319,8 @@ public class CompactionCoordinator extends AbstractServer
   }
 
   private void updateSummaries() {
-    ExecutorService executor =
-        ThreadPools.createFixedThreadPool(10, "Compaction Summary Gatherer", false);
+    ExecutorService executor = ThreadPools.getServerThreadPools().createFixedThreadPool(10,
+        "Compaction Summary Gatherer", false);
     try {
       Set<String> queuesSeen = new ConcurrentSkipListSet<>();
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
@@ -73,11 +73,11 @@ public class CompactionFinalizer {
     int max = this.context.getConfiguration()
         .getCount(Property.COMPACTION_COORDINATOR_FINALIZER_TSERVER_NOTIFIER_MAXTHREADS);
 
-    this.ntfyExecutor = ThreadPools.createThreadPool(3, max, 1, TimeUnit.MINUTES,
-        "Compaction Finalizer Notifier", true);
+    this.ntfyExecutor = ThreadPools.getServerThreadPools().createThreadPool(3, max, 1,
+        TimeUnit.MINUTES, "Compaction Finalizer Notifier", true);
 
-    this.backgroundExecutor =
-        ThreadPools.createFixedThreadPool(1, "Compaction Finalizer Background Task", true);
+    this.backgroundExecutor = ThreadPools.getServerThreadPools().createFixedThreadPool(1,
+        "Compaction Finalizer Background Task", true);
 
     backgroundExecutor.execute(() -> {
       processPending();

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -166,7 +166,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     aconf = getConfiguration();
     setupSecurity();
     watcher = new CompactionWatcher(aconf);
-    var schedExecutor = ThreadPools.createGeneralScheduledExecutorService(aconf);
+    var schedExecutor =
+        ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(aconf);
     startGCLogger(schedExecutor);
     startCancelChecker(schedExecutor, TIME_BETWEEN_CANCEL_CHECKS);
     printStartupMsg();
@@ -178,7 +179,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     aconf = conf;
     setupSecurity();
     watcher = new CompactionWatcher(aconf);
-    var schedExecutor = ThreadPools.createGeneralScheduledExecutorService(aconf);
+    var schedExecutor =
+        ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(aconf);
     startGCLogger(schedExecutor);
     startCancelChecker(schedExecutor, TIME_BETWEEN_CANCEL_CHECKS);
     printStartupMsg();

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -286,8 +286,8 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
 
       minimizeDeletes(confirmedDeletes, processedDeletes, fs);
 
-      ExecutorService deleteThreadPool =
-          ThreadPools.createExecutorService(getConfiguration(), Property.GC_DELETE_THREADS, false);
+      ExecutorService deleteThreadPool = ThreadPools.getServerThreadPools()
+          .createExecutorService(getConfiguration(), Property.GC_DELETE_THREADS, false);
 
       final List<Pair<Path,Path>> replacements = getContext().getVolumeReplacements();
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -919,8 +919,8 @@ public class Manager extends AbstractServer
       Set<TServerInstance> currentServers, SortedMap<TabletServerId,TServerStatus> balancerMap) {
     final long rpcTimeout = getConfiguration().getTimeInMillis(Property.GENERAL_RPC_TIMEOUT);
     int threads = getConfiguration().getCount(Property.MANAGER_STATUS_THREAD_POOL_SIZE);
-    ExecutorService tp = ThreadPools.createExecutorService(getConfiguration(),
-        Property.MANAGER_STATUS_THREAD_POOL_SIZE, false);
+    ExecutorService tp = ThreadPools.getServerThreadPools()
+        .createExecutorService(getConfiguration(), Property.MANAGER_STATUS_THREAD_POOL_SIZE, false);
     long start = System.currentTimeMillis();
     final SortedMap<TServerInstance,TabletServerStatus> result = new ConcurrentSkipListMap<>();
     final RateLimiter shutdownServerRateLimiter = RateLimiter.create(MAX_SHUTDOWNS_PER_SEC);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
@@ -64,9 +64,10 @@ public class ManagerTime {
       throw new IOException("Error updating manager time", ex);
     }
 
-    ThreadPools.watchCriticalScheduledTask(ThreadPools.createGeneralScheduledExecutorService(conf)
-        .scheduleWithFixedDelay(Threads.createNamedRunnable("Manager time keeper", () -> run()), 0,
-            SECONDS.toMillis(10), MILLISECONDS));
+    ThreadPools.watchCriticalScheduledTask(
+        ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf)
+            .scheduleWithFixedDelay(Threads.createNamedRunnable("Manager time keeper", () -> run()),
+                0, SECONDS.toMillis(10), MILLISECONDS));
   }
 
   /**

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/ReplicationMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/ReplicationMetrics.java
@@ -162,8 +162,8 @@ public class ReplicationMetrics implements MetricsProducer {
     maxReplicationThreads = registry.gauge(METRICS_REPLICATION_THREADS, MetricsUtil.getCommonTags(),
         new AtomicInteger(0));
 
-    ScheduledExecutorService scheduler =
-        ThreadPools.createScheduledExecutorService(1, "replicationMetricsPoller", false);
+    ScheduledExecutorService scheduler = ThreadPools.getServerThreadPools()
+        .createScheduledExecutorService(1, "replicationMetricsPoller", false);
     Runtime.getRuntime().addShutdownHook(new Thread(scheduler::shutdownNow));
     long minimumRefreshDelay = TimeUnit.SECONDS.toMillis(5);
     ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(this::update, minimumRefreshDelay,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -152,8 +152,8 @@ public class FateMetrics implements MetricsProducer {
     update();
 
     // get fate status is read only operation - no reason to be nice on shutdown.
-    ScheduledExecutorService scheduler =
-        ThreadPools.createScheduledExecutorService(1, "fateMetricsPoller", false);
+    ScheduledExecutorService scheduler = ThreadPools.getServerThreadPools()
+        .createScheduledExecutorService(1, "fateMetricsPoller", false);
     Runtime.getRuntime().addShutdownHook(new Thread(scheduler::shutdownNow));
 
     ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(() -> {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -73,7 +73,8 @@ public class RecoveryManager {
         CacheBuilder.newBuilder().expireAfterWrite(timeToCacheExistsInMillis, TimeUnit.MILLISECONDS)
             .maximumWeight(10_000_000).weigher((path, exist) -> path.toString().length()).build();
 
-    executor = ThreadPools.createScheduledExecutorService(4, "Walog sort starter", false);
+    executor = ThreadPools.getServerThreadPools().createScheduledExecutorService(4,
+        "Walog sort starter", false);
     zooCache = new ZooCache(manager.getContext().getZooReader(), null);
     try {
       List<String> workIDs =

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
@@ -200,7 +200,7 @@ public class BulkImport extends ManagerRepo {
 
     AccumuloConfiguration serverConfig = manager.getConfiguration();
     @SuppressWarnings("deprecation")
-    ExecutorService workers = ThreadPools.createExecutorService(serverConfig,
+    ExecutorService workers = ThreadPools.getServerThreadPools().createExecutorService(serverConfig,
         serverConfig.resolve(Property.MANAGER_RENAME_THREADS, Property.MANAGER_BULK_RENAME_THREADS),
         false);
     List<Future<Exception>> results = new ArrayList<>();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
@@ -91,8 +91,8 @@ class LoadFiles extends ManagerRepo {
 
   private static synchronized ExecutorService getThreadPool(Manager manager) {
     if (threadPool == null) {
-      threadPool = ThreadPools.createExecutorService(manager.getConfiguration(),
-          Property.MANAGER_BULK_THREADPOOL_SIZE, true);
+      threadPool = ThreadPools.getServerThreadPools().createExecutorService(
+          manager.getConfiguration(), Property.MANAGER_BULK_THREADPOOL_SIZE, true);
     }
     return threadPool;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -174,8 +174,9 @@ public class UpgradeCoordinator {
         "Not currently in a suitable state to do metadata upgrade %s", status);
 
     if (currentVersion < AccumuloDataVersion.get()) {
-      return ThreadPools.createThreadPool(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
-          "UpgradeMetadataThreads", new SynchronousQueue<>(), false).submit(() -> {
+      return ThreadPools.getServerThreadPools().createThreadPool(0, Integer.MAX_VALUE, 60L,
+          TimeUnit.SECONDS, "UpgradeMetadataThreads", new SynchronousQueue<>(), false)
+          .submit(() -> {
             try {
               for (int v = currentVersion; v < AccumuloDataVersion.get(); v++) {
                 log.info("Upgrading Root from data version {}", v);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -771,8 +771,8 @@ public class TabletServer extends AbstractServer {
       throw new RuntimeException(e);
     }
 
-    ThreadPoolExecutor distWorkQThreadPool =
-        ThreadPools.createExecutorService(getConfiguration(), Property.TSERV_WORKQ_THREADS, true);
+    ThreadPoolExecutor distWorkQThreadPool = ThreadPools.getServerThreadPools()
+        .createExecutorService(getConfiguration(), Property.TSERV_WORKQ_THREADS, true);
 
     bulkFailedCopyQ =
         new DistributedWorkQueue(getContext().getZooKeeperRoot() + Constants.ZBULK_FAILED_COPYQ,
@@ -806,8 +806,8 @@ public class TabletServer extends AbstractServer {
 
     int tabletCheckFrequency = 30 + random.nextInt(31); // random 30-60 minute delay
     // Periodically check that metadata of tablets matches what is held in memory
-    ThreadPools.watchCriticalScheduledTask(
-        ThreadPools.createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(() -> {
+    ThreadPools.watchCriticalScheduledTask(ThreadPools.getServerThreadPools()
+        .createGeneralScheduledExecutorService(aconf).scheduleWithFixedDelay(() -> {
           final SortedMap<KeyExtent,Tablet> onlineTabletsSnapshot = onlineTablets.snapshot();
 
           Map<KeyExtent,Long> updateCounts = new HashMap<>();
@@ -951,7 +951,7 @@ public class TabletServer extends AbstractServer {
     }
 
     // Start the pool to handle outgoing replications
-    final ThreadPoolExecutor replicationThreadPool = ThreadPools
+    final ThreadPoolExecutor replicationThreadPool = ThreadPools.getServerThreadPools()
         .createExecutorService(getConfiguration(), Property.REPLICATION_WORKER_THREADS, false);
     replWorker.setExecutor(replicationThreadPool);
     replWorker.run();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -187,9 +187,9 @@ public class TabletServerResourceManager {
 
     scanExecQueues.put(sec.name, queue);
 
-    ThreadPoolExecutor es =
-        ThreadPools.createThreadPool(sec.getCurrentMaxThreads(), sec.getCurrentMaxThreads(), 0L,
-            TimeUnit.MILLISECONDS, "scan-" + sec.name, queue, sec.priority, true);
+    ThreadPoolExecutor es = ThreadPools.getServerThreadPools().createThreadPool(
+        sec.getCurrentMaxThreads(), sec.getCurrentMaxThreads(), 0L, TimeUnit.MILLISECONDS,
+        "scan-" + sec.name, queue, sec.priority, true);
     modifyThreadPoolSizesAtRuntime(sec::getCurrentMaxThreads, "scan-" + sec.name, es);
     return es;
 
@@ -303,22 +303,23 @@ public class TabletServerResourceManager {
       log.warn("In-memory map may not fit into local memory space.");
     }
 
-    minorCompactionThreadPool =
-        ThreadPools.createExecutorService(acuConf, Property.TSERV_MINC_MAXCONCURRENT, true);
+    minorCompactionThreadPool = ThreadPools.getServerThreadPools().createExecutorService(acuConf,
+        Property.TSERV_MINC_MAXCONCURRENT, true);
     modifyThreadPoolSizesAtRuntime(
         () -> context.getConfiguration().getCount(Property.TSERV_MINC_MAXCONCURRENT),
         "minor compactor", minorCompactionThreadPool);
 
-    splitThreadPool = ThreadPools.createThreadPool(0, 1, 1, TimeUnit.SECONDS, "splitter", true);
+    splitThreadPool = ThreadPools.getServerThreadPools().createThreadPool(0, 1, 1, TimeUnit.SECONDS,
+        "splitter", true);
 
-    defaultSplitThreadPool =
-        ThreadPools.createThreadPool(0, 1, 60, TimeUnit.SECONDS, "md splitter", true);
+    defaultSplitThreadPool = ThreadPools.getServerThreadPools().createThreadPool(0, 1, 60,
+        TimeUnit.SECONDS, "md splitter", true);
 
-    defaultMigrationPool =
-        ThreadPools.createThreadPool(0, 1, 60, TimeUnit.SECONDS, "metadata tablet migration", true);
+    defaultMigrationPool = ThreadPools.getServerThreadPools().createThreadPool(0, 1, 60,
+        TimeUnit.SECONDS, "metadata tablet migration", true);
 
-    migrationPool =
-        ThreadPools.createExecutorService(acuConf, Property.TSERV_MIGRATE_MAXCONCURRENT, true);
+    migrationPool = ThreadPools.getServerThreadPools().createExecutorService(acuConf,
+        Property.TSERV_MIGRATE_MAXCONCURRENT, true);
     modifyThreadPoolSizesAtRuntime(
         () -> context.getConfiguration().getCount(Property.TSERV_MIGRATE_MAXCONCURRENT),
         "tablet migration", migrationPool);
@@ -328,31 +329,31 @@ public class TabletServerResourceManager {
     // individual tablet servers are already running assignments concurrently... having each
     // individual tablet server run
     // concurrent assignments would put more load on the metadata table at startup
-    assignmentPool =
-        ThreadPools.createExecutorService(acuConf, Property.TSERV_ASSIGNMENT_MAXCONCURRENT, true);
+    assignmentPool = ThreadPools.getServerThreadPools().createExecutorService(acuConf,
+        Property.TSERV_ASSIGNMENT_MAXCONCURRENT, true);
     modifyThreadPoolSizesAtRuntime(
         () -> context.getConfiguration().getCount(Property.TSERV_ASSIGNMENT_MAXCONCURRENT),
         "tablet assignment", assignmentPool);
 
-    assignMetaDataPool = ThreadPools.createThreadPool(0, 1, 60, TimeUnit.SECONDS,
-        "metadata tablet assignment", true);
+    assignMetaDataPool = ThreadPools.getServerThreadPools().createThreadPool(0, 1, 60,
+        TimeUnit.SECONDS, "metadata tablet assignment", true);
 
     activeAssignments = new ConcurrentHashMap<>();
 
-    summaryRetrievalPool =
-        ThreadPools.createExecutorService(acuConf, Property.TSERV_SUMMARY_RETRIEVAL_THREADS, true);
+    summaryRetrievalPool = ThreadPools.getServerThreadPools().createExecutorService(acuConf,
+        Property.TSERV_SUMMARY_RETRIEVAL_THREADS, true);
     modifyThreadPoolSizesAtRuntime(
         () -> context.getConfiguration().getCount(Property.TSERV_SUMMARY_RETRIEVAL_THREADS),
         "summary file retriever", summaryRetrievalPool);
 
-    summaryRemotePool =
-        ThreadPools.createExecutorService(acuConf, Property.TSERV_SUMMARY_REMOTE_THREADS, true);
+    summaryRemotePool = ThreadPools.getServerThreadPools().createExecutorService(acuConf,
+        Property.TSERV_SUMMARY_REMOTE_THREADS, true);
     modifyThreadPoolSizesAtRuntime(
         () -> context.getConfiguration().getCount(Property.TSERV_SUMMARY_REMOTE_THREADS),
         "summary remote", summaryRemotePool);
 
-    summaryPartitionPool =
-        ThreadPools.createExecutorService(acuConf, Property.TSERV_SUMMARY_PARTITION_THREADS, true);
+    summaryPartitionPool = ThreadPools.getServerThreadPools().createExecutorService(acuConf,
+        Property.TSERV_SUMMARY_PARTITION_THREADS, true);
     modifyThreadPoolSizesAtRuntime(
         () -> context.getConfiguration().getCount(Property.TSERV_SUMMARY_PARTITION_THREADS),
         "summary partition", summaryPartitionPool);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -126,8 +126,8 @@ public class CompactionService {
 
     this.executors = Map.copyOf(tmpExecutors);
 
-    this.planningExecutor =
-        ThreadPools.createThreadPool(1, 1, 0L, TimeUnit.MILLISECONDS, "CompactionPlanner", false);
+    this.planningExecutor = ThreadPools.getServerThreadPools().createThreadPool(1, 1, 0L,
+        TimeUnit.MILLISECONDS, "CompactionPlanner", false);
 
     this.queuedForPlanning = new EnumMap<>(CompactionKind.class);
     for (CompactionKind kind : CompactionKind.values()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/InternalCompactionExecutor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/InternalCompactionExecutor.java
@@ -162,8 +162,8 @@ public class InternalCompactionExecutor implements CompactionExecutor {
 
     queue = new PriorityBlockingQueue<>(100, comparator);
 
-    threadPool = ThreadPools.createThreadPool(threads, threads, 60, TimeUnit.SECONDS,
-        "compaction." + ceid, queue, false);
+    threadPool = ThreadPools.getServerThreadPools().createThreadPool(threads, threads, 60,
+        TimeUnit.SECONDS, "compaction." + ceid, queue, false);
 
     metricCloser =
         ceMetrics.addExecutor(ceid, () -> threadPool.getActiveCount(), () -> queuedJob.size());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -214,8 +214,8 @@ public class LogSorter {
     @SuppressWarnings("deprecation")
     int threadPoolSize = conf.getCount(conf.resolve(Property.TSERV_WAL_SORT_MAX_CONCURRENT,
         Property.TSERV_RECOVERY_MAX_CONCURRENT));
-    this.threadPool =
-        ThreadPools.createFixedThreadPool(threadPoolSize, this.getClass().getName(), true);
+    this.threadPool = ThreadPools.getServerThreadPools().createFixedThreadPool(threadPoolSize,
+        this.getClass().getName(), true);
     this.walBlockSize = DfsLogger.getWalBlockSize(conf);
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/TabletServerLogger.java
@@ -262,7 +262,8 @@ public class TabletServerLogger {
     if (nextLogMaker != null) {
       return;
     }
-    nextLogMaker = ThreadPools.createFixedThreadPool(1, "WALog creator", true);
+    nextLogMaker =
+        ThreadPools.getServerThreadPools().createFixedThreadPool(1, "WALog creator", true);
     nextLogMaker.execute(new Runnable() {
       @Override
       public void run() {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/metrics/CompactionExecutorsMetrics.java
@@ -65,8 +65,8 @@ public class CompactionExecutorsMetrics implements MetricsProducer {
 
   public CompactionExecutorsMetrics() {
 
-    ScheduledExecutorService scheduler =
-        ThreadPools.createScheduledExecutorService(1, "compactionExecutorsMetricsPoller", false);
+    ScheduledExecutorService scheduler = ThreadPools.getServerThreadPools()
+        .createScheduledExecutorService(1, "compactionExecutorsMetricsPoller", false);
     Runtime.getRuntime().addShutdownHook(new Thread(scheduler::shutdownNow));
     long minimumRefreshDelay = TimeUnit.SECONDS.toMillis(5);
     ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(this::update, minimumRefreshDelay,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystem.java
@@ -61,6 +61,7 @@ import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.singletons.SingletonReservation;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.replication.ReplicaSystem;
 import org.apache.accumulo.server.replication.ReplicaSystemHelper;
@@ -571,7 +572,7 @@ public class AccumuloReplicaSystem implements ReplicaSystem {
     ClientProperty.setAuthenticationToken(properties, token);
 
     return new ClientContext(SingletonReservation.noop(), ClientInfo.from(properties, token),
-        localConf);
+        localConf, Threads.UEH);
   }
 
   protected Set<Integer> consumeWalPrefix(ReplicationTarget target, DataInputStream wal,

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -279,8 +279,8 @@ public class SessionManager {
         }
       };
 
-      ScheduledFuture<?> future = ThreadPools.createGeneralScheduledExecutorService(aconf)
-          .schedule(r, delay, TimeUnit.MILLISECONDS);
+      ScheduledFuture<?> future = ThreadPools.getServerThreadPools()
+          .createGeneralScheduledExecutorService(aconf).schedule(r, delay, TimeUnit.MILLISECONDS);
       ThreadPools.watchNonCriticalScheduledTask(future);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/BalanceWithOfflineTableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BalanceWithOfflineTableIT.java
@@ -77,7 +77,8 @@ public class BalanceWithOfflineTableIT extends ConfigurableMacBase {
 
       log.info("Waiting for balance");
 
-      ExecutorService pool = ThreadPools.createFixedThreadPool(1, "waitForBalance", false);
+      ExecutorService pool =
+          ThreadPools.getServerThreadPools().createFixedThreadPool(1, "waitForBalance", false);
       Future<Boolean> wait = pool.submit(() -> {
         c.instanceOperations().waitForBalance();
         return true;

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchWriterFlushIT.java
@@ -207,8 +207,8 @@ public class BatchWriterFlushIT extends AccumuloClusterHarness {
         allMuts.add(muts);
       }
 
-      ThreadPoolExecutor threads =
-          ThreadPools.createFixedThreadPool(NUM_THREADS, "ClientThreads", false);
+      ThreadPoolExecutor threads = ThreadPools.getServerThreadPools()
+          .createFixedThreadPool(NUM_THREADS, "ClientThreads", false);
       threads.allowCoreThreadTimeOut(false);
       threads.prestartAllCoreThreads();
 


### PR DESCRIPTION
When an ExecutorService's task or Thread in Accumulo encounter an
unhandled exception the default UncaughtExceptionHandler will be
invoked. An Exception is logged, while an Error is logged and then
the VM is terminated. This change allows clients to override the
default uncaught exception handling logic so that the client VM is
not terminated when an Error happens in a background thread of a
client object.

Closes #2331 and supersedes #2346