### PR TITLE
Remove explicit FutureReturnValueIgnored from ErrorProne

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1684,7 +1684,6 @@
                   -Xep:CheckReturnValue:OFF \
                   -Xep:MustBeClosedChecker:OFF \
                   -Xep:ReturnValueIgnored:OFF \
-                  -Xep:FutureReturnValueIgnored:ERROR \
                   -Xep:UnicodeInCode:OFF \
                   <!-- warning patterns to specifically check -->
                   -Xep:ExpectedExceptionChecker \


### PR DESCRIPTION
By default, all ErrorProne Error patterns are checked. There is no
need to explicitly list FutureReturnValueIgnored as an error pattern.
Only error conditions that you do not wish to check for should be
explicitly listed (with the OFF setting).

Note that it is the opposite for Warning patterns. With the current
configuration you must list any warning patterns you wish to check.