### PR TITLE
Convert server-base module to junit 5

### DIFF
--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -120,8 +120,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerContextTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,15 +43,15 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServerContextTest {
 
   private UserGroupInformation testUser;
   private String username;
 
-  @Before
+  @BeforeEach
   public void setup() {
     System.setProperty("java.security.krb5.realm", "accumulo");
     System.setProperty("java.security.krb5.kdc", "fake");

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerDirsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerDirsTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,30 +35,32 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.minicluster.WithTestNames;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class ServerDirsTest {
+public class ServerDirsTest extends WithTestNames {
 
   AccumuloConfiguration conf;
   Configuration hadoopConf = new Configuration();
   ServerDirs constants;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     String uuid = UUID.randomUUID().toString();
 
-    var vols =
-        init(folder.newFolder(), Arrays.asList(uuid), Arrays.asList(AccumuloDataVersion.get()));
+    File folder = new File(tempDir, testName());
+    assertTrue(folder.isDirectory() || folder.mkdir(), "Failed to create folder");
+
+    var vols = init(folder, List.of(uuid), List.of(AccumuloDataVersion.get()));
 
     ConfigurationCopy copy = new ConfigurationCopy();
     copy.set(Property.INSTANCE_VOLUMES.getKey(), String.join(",", vols));
@@ -65,32 +68,36 @@ public class ServerDirsTest {
     constants = new ServerDirs(conf, hadoopConf);
   }
 
-  @Rule
-  public TemporaryFolder folder =
-      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+  @TempDir
+  private static File tempDir;
 
   @Test
   public void testCheckBaseDirs() throws IOException {
     String uuid1 = UUID.randomUUID().toString();
     String uuid2 = UUID.randomUUID().toString();
 
-    verifyAllPass(
-        init(folder.newFolder(), Arrays.asList(uuid1), Arrays.asList(AccumuloDataVersion.get())));
-    verifyAllPass(init(folder.newFolder(), Arrays.asList(uuid1, uuid1),
+    File[] folders = new File[8];
+    for (int i = 0; i < folders.length; i++) {
+      File newFolder = new File(tempDir, testName() + i);
+      assertTrue(newFolder.isDirectory() || newFolder.mkdir(), "Failed to create folder");
+      folders[i] = newFolder;
+    }
+
+    verifyAllPass(init(folders[0], List.of(uuid1), List.of(AccumuloDataVersion.get())));
+    verifyAllPass(init(folders[1], Arrays.asList(uuid1, uuid1),
         Arrays.asList(AccumuloDataVersion.get(), AccumuloDataVersion.get())));
 
-    verifyError(
-        init(folder.newFolder(), Arrays.asList((String) null), Arrays.asList((Integer) null)));
-    verifyError(init(folder.newFolder(), Arrays.asList(uuid1, uuid2),
+    verifyError(init(folders[2], Arrays.asList((String) null), Arrays.asList((Integer) null)));
+    verifyError(init(folders[3], Arrays.asList(uuid1, uuid2),
         Arrays.asList(AccumuloDataVersion.get(), AccumuloDataVersion.get())));
-    verifyError(init(folder.newFolder(), Arrays.asList(uuid1, uuid1),
+    verifyError(init(folders[4], Arrays.asList(uuid1, uuid1),
         Arrays.asList(AccumuloDataVersion.get(), AccumuloDataVersion.get() - 1)));
-    verifyError(init(folder.newFolder(), Arrays.asList(uuid1, uuid2),
+    verifyError(init(folders[5], Arrays.asList(uuid1, uuid2),
         Arrays.asList(AccumuloDataVersion.get(), AccumuloDataVersion.get() - 1)));
-    verifyError(init(folder.newFolder(), Arrays.asList(uuid1, uuid2, null), Arrays
+    verifyError(init(folders[6], Arrays.asList(uuid1, uuid2, null), Arrays
         .asList(AccumuloDataVersion.get(), AccumuloDataVersion.get(), AccumuloDataVersion.get())));
 
-    verifySomePass(init(folder.newFolder(), Arrays.asList(uuid1, uuid1, null),
+    verifySomePass(init(folders[7], Arrays.asList(uuid1, uuid1, null),
         Arrays.asList(AccumuloDataVersion.get(), AccumuloDataVersion.get(), null)));
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/ServerOptsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServerOptsTest.java
@@ -18,18 +18,18 @@
  */
 package org.apache.accumulo.server;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServerOptsTest {
   private ServerOpts opts;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     opts = new ServerOpts();
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/ServiceEnvironmentImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/ServiceEnvironmentImplTest.java
@@ -22,22 +22,22 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServiceEnvironmentImplTest {
   private ServerContext context;
   private AccumuloConfiguration acfg;
   private ServiceEnvironmentImpl serviceEnvironment;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     context = createMock(ServerContext.class);
     acfg = createMock(AccumuloConfiguration.class);
@@ -46,7 +46,7 @@ public class ServiceEnvironmentImplTest {
     serviceEnvironment = new ServiceEnvironmentImpl(context);
   }
 
-  @After
+  @AfterEach
   public void verifyMocks() {
     verify(context, acfg);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/WithTestNames.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/WithTestNames.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.minicluster;
+package org.apache.accumulo.server;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;

--- a/server/base/src/test/java/org/apache/accumulo/server/WithTestNames.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/WithTestNames.java
@@ -16,24 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.server.replication.proto;
+package org.apache.accumulo.minicluster;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
-import org.apache.accumulo.server.replication.proto.Replication.Status;
-import org.junit.jupiter.api.Test;
+// This is only for the unit tests and integration tests in this module
+// It must be copied for use in other modules, because tests in one module
+// don't have dependencies on other modules, and we can't put this in a
+// regular, non-test jar, because we don't want to add a dependency on
+// JUnit in a non-test jar
+public class WithTestNames {
 
-@Deprecated
-public class StatusTest {
+  private String testName;
 
-  @Test
-  public void equality() {
-    Status replicated = Status.newBuilder().setBegin(Long.MAX_VALUE).setEnd(0).setInfiniteEnd(true)
-        .setClosed(false).build();
-    Status unreplicated = Status.newBuilder().setBegin(0).setEnd(0).setInfiniteEnd(true)
-        .setClosed(false).build();
+  @BeforeEach
+  public void setTestName(TestInfo info) {
+    testName = info.getTestMethod().get().getName();
+  }
 
-    assertNotEquals(replicated, unreplicated);
+  protected String testName() {
+    return testName;
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -48,7 +48,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BulkImporterTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/CheckCompactionConfigTest.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.server.conf;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -29,27 +29,21 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
+import org.apache.accumulo.minicluster.WithTestNames;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path not set by user input")
-public class CheckCompactionConfigTest {
+public class CheckCompactionConfigTest extends WithTestNames {
 
   private final static Logger log = LoggerFactory.getLogger(CheckCompactionConfigTest.class);
 
-  @Rule
-  public TestName testName = new TestName();
-
-  @ClassRule
-  public static final TemporaryFolder folder =
-      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
+  @TempDir
+  private static File tempDir;
 
   @Test
   public void testValidInput1() throws Exception {
@@ -143,7 +137,8 @@ public class CheckCompactionConfigTest {
   }
 
   private String writeToFileAndReturnPath(String inputString) throws IOException {
-    File file = folder.newFile(testName.getMethodName() + ".properties");
+    File file = new File(tempDir, testName() + ".properties");
+    assertTrue(file.isFile() || file.createNewFile());
     try (FileWriter fileWriter = new FileWriter(file, UTF_8);
         BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
       bufferedWriter.write(inputString);

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/NamespaceConfigurationTest.java
@@ -24,8 +24,8 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import java.util.Map;
@@ -43,8 +43,8 @@ import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.MockServerContext;
 import org.apache.accumulo.server.ServerContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NamespaceConfigurationTest {
   private static final NamespaceId NSID = NamespaceId.of("namespace");
@@ -58,7 +58,7 @@ public class NamespaceConfigurationTest {
   private ZooCache zc;
   private NamespaceConfiguration c;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     iid = InstanceId.of(UUID.randomUUID());
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -25,9 +25,9 @@ import static org.easymock.EasyMock.endsWith;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
@@ -38,10 +38,10 @@ import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.server.MockServerContext;
 import org.apache.accumulo.server.ServerContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServerConfigurationFactoryTest {
   private static final String ZK_HOST = "localhost";
@@ -53,7 +53,7 @@ public class ServerConfigurationFactoryTest {
   private static ZooCache zc;
   private static SiteConfiguration siteConfig = SiteConfiguration.auto();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() {
     zcf = createMock(ZooCacheFactory.class);
     zc = createMock(ZooCache.class);
@@ -70,12 +70,12 @@ public class ServerConfigurationFactoryTest {
   private ServerContext context;
   private ServerConfigurationFactory scf;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     context = MockServerContext.getWithZK(IID, ZK_HOST, ZK_TIMEOUT);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ServerConfigurationFactory.clearCachedConfigurations();
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/TableConfigurationTest.java
@@ -24,7 +24,7 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Map;
@@ -40,8 +40,8 @@ import org.apache.accumulo.fate.zookeeper.ZooCacheFactory;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.MockServerContext;
 import org.apache.accumulo.server.ServerContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TableConfigurationTest {
   private static final TableId TID = TableId.of("table");
@@ -55,7 +55,7 @@ public class TableConfigurationTest {
   private ZooCache zc;
   private TableConfiguration c;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     iid = InstanceId.of(UUID.randomUUID());
     context = MockServerContext.getWithZK(iid, ZOOKEEPERS, ZK_SESSION_TIMEOUT);

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ZooCachePropertyAccessorTest.java
@@ -23,9 +23,9 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
 import java.util.Map;
@@ -34,8 +34,8 @@ import java.util.function.Predicate;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ZooCachePropertyAccessorTest {
   private static final String PATH = "/root/path/to/props";
@@ -48,7 +48,7 @@ public class ZooCachePropertyAccessorTest {
   private ZooCache zc;
   private ZooCachePropertyAccessor a;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     zc = createMock(ZooCache.class);
     a = new ZooCachePropertyAccessor(zc);

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropCodecTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropCodecTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.accumulo.server.conf.codec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Exercise the base class specific methods - most testing will occur in subclasses

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodecTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropEncryptCodecTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.server.conf.codec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,7 +33,7 @@ import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,14 +124,14 @@ public class VersionedPropEncryptCodecTest {
     // validate encoded version incremented.
     assertEquals(aVersion + 1, decodedProps.getDataVersion());
 
-    assertEquals("encoded version should be 1 up", aVersion + 1, decodedProps.getDataVersion());
-    assertEquals("version written should be the source next version", vProps.getNextVersion(),
-        decodedProps.getDataVersion());
-    assertEquals("the next version in decoded should be +2", aVersion + 2,
-        decodedProps.getNextVersion());
+    assertEquals(aVersion + 1, decodedProps.getDataVersion(), "encoded version should be 1 up");
+    assertEquals(vProps.getNextVersion(), decodedProps.getDataVersion(),
+        "version written should be the source next version");
+    assertEquals(aVersion + 2, decodedProps.getNextVersion(),
+        "the next version in decoded should be +2");
 
-    assertTrue("timestamp should be now or earlier",
-        vProps.getTimestamp().compareTo(Instant.now()) <= 0);
+    assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
+        "timestamp should be now or earlier");
 
   }
 
@@ -175,14 +175,14 @@ public class VersionedPropEncryptCodecTest {
     // validate encoded version incremented.
     assertEquals(aVersion + 1, decodedProps.getDataVersion());
 
-    assertEquals("encoded version should be 1 up", aVersion + 1, decodedProps.getDataVersion());
-    assertEquals("version written should be the source next version", vProps.getNextVersion(),
-        decodedProps.getDataVersion());
-    assertEquals("the next version in decoded should be +2", aVersion + 2,
-        decodedProps.getNextVersion());
+    assertEquals(aVersion + 1, decodedProps.getDataVersion(), "encoded version should be 1 up");
+    assertEquals(vProps.getNextVersion(), decodedProps.getDataVersion(),
+        "version written should be the source next version");
+    assertEquals(aVersion + 2, decodedProps.getNextVersion(),
+        "the next version in decoded should be +2");
 
-    assertTrue("timestamp should be now or earlier",
-        vProps.getTimestamp().compareTo(Instant.now()) <= 0);
+    assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
+        "timestamp should be now or earlier");
 
   }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropGzipCodecTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropGzipCodecTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.accumulo.server.conf.codec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,11 +49,11 @@ public class VersionedPropGzipCodecTest {
     log.debug("Decoded: {}", decodedProps.getProperties());
 
     // default - first write version should be 0
-    assertEquals("default - first write version should be 0", 0, decodedProps.getDataVersion());
-    assertEquals("default - first write next version should be 1", 1,
-        decodedProps.getNextVersion());
-    assertTrue("timestamp should be now or earlier",
-        vProps.getTimestamp().compareTo(Instant.now()) <= 0);
+    assertEquals(0, decodedProps.getDataVersion(), "default - first write version should be 0");
+    assertEquals(1, decodedProps.getNextVersion(),
+        "default - first write next version should be 1");
+    assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
+        "timestamp should be now or earlier");
     assertEquals(vProps.getProperties(), decodedProps.getProperties());
   }
 
@@ -69,11 +69,11 @@ public class VersionedPropGzipCodecTest {
 
     log.debug("Decoded: {}", decodedProps.getProperties());
 
-    assertEquals("default - first write version should be 0", 0, decodedProps.getDataVersion());
-    assertEquals("default - first write next version should be 1", 1,
-        decodedProps.getNextVersion());
-    assertTrue("timestamp should be now or earlier",
-        vProps.getTimestamp().compareTo(Instant.now()) <= 0);
+    assertEquals(0, decodedProps.getDataVersion(), "default - first write version should be 0");
+    assertEquals(1, decodedProps.getNextVersion(),
+        "default - first write next version should be 1");
+    assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
+        "timestamp should be now or earlier");
     assertEquals(vProps.getProperties(), decodedProps.getProperties());
   }
 
@@ -102,14 +102,14 @@ public class VersionedPropGzipCodecTest {
     // validate encoded version incremented.
     assertEquals(aVersion + 1, decodedProps.getDataVersion());
 
-    assertEquals("encoded version should be 1 up", aVersion + 1, decodedProps.getDataVersion());
-    assertEquals("version written should be the source next version", vProps.getNextVersion(),
-        decodedProps.getDataVersion());
-    assertEquals("the next version in decoded should be +2", aVersion + 2,
-        decodedProps.getNextVersion());
+    assertEquals(aVersion + 1, decodedProps.getDataVersion(), "encoded version should be 1 up");
+    assertEquals(vProps.getNextVersion(), decodedProps.getDataVersion(),
+        "version written should be the source next version");
+    assertEquals(aVersion + 2, decodedProps.getNextVersion(),
+        "the next version in decoded should be +2");
 
-    assertTrue("timestamp should be now or earlier",
-        vProps.getTimestamp().compareTo(Instant.now()) <= 0);
+    assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
+        "timestamp should be now or earlier");
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/codec/VersionedPropertiesTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.server.conf.codec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,9 +157,9 @@ public class VersionedPropertiesTest {
     assertEquals(0, vProps.getDataVersion());
 
     // the initial version for write should be 0
-    assertEquals("Initial expected version should be 0", 0, vProps.getNextVersion());
-    assertTrue("timestamp should be now or earlier",
-        vProps.getTimestamp().compareTo(Instant.now()) <= 0);
+    assertEquals(0, vProps.getNextVersion(), "Initial expected version should be 0");
+    assertTrue(vProps.getTimestamp().compareTo(Instant.now()) <= 0,
+        "timestamp should be now or earlier");
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.server.constraints;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
@@ -36,7 +36,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MetadataConstraintsTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/data/ServerMutationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/data/ServerMutationTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.server.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServerMutationTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/FileTypeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/FileTypeTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.server.fs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FileTypeTest {
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.fs;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +33,7 @@ import org.apache.accumulo.core.spi.fs.VolumeChooser;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VolumeManagerImplTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeUtilTest.java
@@ -18,28 +18,21 @@
  */
 package org.apache.accumulo.server.fs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
 public class VolumeUtilTest {
-
-  @Rule
-  public TemporaryFolder tempFolder =
-      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
 
   @Test
   public void testSwitchVolume() {

--- a/server/base/src/test/java/org/apache/accumulo/server/init/InitializeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/init/InitializeTest.java
@@ -23,8 +23,8 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -34,9 +34,9 @@ import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test is not thread-safe.
@@ -48,7 +48,7 @@ public class InitializeTest {
   private ZooReaderWriter zoo;
   private InitialConfiguration initConfig;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new Configuration(false);
     fs = createMock(VolumeManager.class);
@@ -62,7 +62,7 @@ public class InitializeTest {
     zoo = createMock(ZooReaderWriter.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     verify(sconf, zoo, fs);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilterTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.iterators;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.Arbitrator;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MetadataBulkLoadFilterTest {
   static class TestArbitrator implements Arbitrator {

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/LiveTServerSetTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/LiveTServerSetTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.manager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +31,7 @@ import org.apache.accumulo.server.manager.LiveTServerSet.Listener;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerInfo;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LiveTServerSetTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/MergeInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/MergeInfoTest.java
@@ -22,11 +22,11 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,15 +38,15 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MergeInfoTest {
 
   private KeyExtent keyExtent;
   private MergeInfo mi;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     keyExtent = createMock(KeyExtent.class);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.server.manager.state;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +41,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.metadata.TabletMutatorBase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Preconditions;
 

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
@@ -21,12 +21,12 @@ package org.apache.accumulo.server.manager.state;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Set;
@@ -36,15 +36,15 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TabletLocationStateTest {
   private static final Collection<String> innerWalogs = new java.util.HashSet<>();
   private static final Collection<Collection<String>> walogs = new java.util.HashSet<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() {
     walogs.add(innerWalogs);
     innerWalogs.add("somelog");
@@ -56,7 +56,7 @@ public class TabletLocationStateTest {
   private TServerInstance last;
   private TabletLocationState tls;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     keyExtent = createMock(KeyExtent.class);
     future = createMock(TServerInstance.class);

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/DefaultLoadBalancerTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.server.master.balancer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,8 +42,8 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @Deprecated(since = "2.1.0")
 public class DefaultLoadBalancerTest {
@@ -85,7 +85,7 @@ public class DefaultLoadBalancerTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     last.clear();
     servers.clear();

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/GroupBalancerTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.master.balancer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated(since = "2.1.0")
 public class GroupBalancerTest {
@@ -121,8 +121,8 @@ public class GroupBalancerTest {
 
         balancer.balance(current, migrations, migrationsOut);
 
-        assertTrue("Max Migration exceeded " + maxMigrations + " " + migrationsOut.size(),
-            migrationsOut.size() <= (maxMigrations + 5));
+        assertTrue(migrationsOut.size() <= (maxMigrations + 5),
+            "Max Migration exceeded " + maxMigrations + " " + migrationsOut.size());
 
         for (TabletMigration tabletMigration : migrationsOut) {
           assertEquals(tabletLocs.get(tabletMigration.tablet), tabletMigration.oldServer);
@@ -175,10 +175,9 @@ public class GroupBalancerTest {
         int tserverExtra = 0;
         for (String group : groupCounts.keySet()) {
           assertTrue(tgc.get(group) >= expectedCounts.get(group));
-          assertTrue(
+          assertTrue(tgc.get(group) <= expectedCounts.get(group) + 1,
               "Group counts not as expected group:" + group + " actual:" + tgc.get(group)
-                  + " expected:" + (expectedCounts.get(group) + 1) + " tserver:" + entry.getKey(),
-              tgc.get(group) <= expectedCounts.get(group) + 1);
+                  + " expected:" + (expectedCounts.get(group) + 1) + " tserver:" + entry.getKey());
           tserverExtra += tgc.get(group) - expectedCounts.get(group);
         }
 

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -20,9 +20,9 @@ package org.apache.accumulo.server.master.balancer;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,7 +41,7 @@ import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
 import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.master.state.TabletMigration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated(since = "2.1.0")
 public class HostRegexTableLoadBalancerReconfigurationTest

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/HostRegexTableLoadBalancerTest.java
@@ -21,10 +21,10 @@ package org.apache.accumulo.server.master.balancer;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +49,7 @@ import org.apache.accumulo.fate.util.UtilWaitThread;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.master.state.TabletMigration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated(since = "2.1.0")
 public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalancerTest {
@@ -77,9 +77,9 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
   @Test
   public void testInit() {
     init();
-    assertEquals("OOB check interval value is incorrect", 7000, this.getOobCheckMillis());
-    assertEquals("Max migrations is incorrect", 4, this.getMaxMigrations());
-    assertEquals("Max outstanding migrations is incorrect", 10, this.getMaxOutstandingMigrations());
+    assertEquals(7000, this.getOobCheckMillis(), "OOB check interval value is incorrect");
+    assertEquals(4, this.getMaxMigrations(), "Max migrations is incorrect");
+    assertEquals(10, this.getMaxOutstandingMigrations(), "Max outstanding migrations is incorrect");
     assertFalse(isIpBasedRegex());
     Map<String,Pattern> patterns = this.getPoolNameToRegexPattern();
     assertEquals(2, patterns.size());

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/TableLoadBalancerTest.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.server.master.balancer;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +49,7 @@ import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.master.state.TabletMigration;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated(since = "2.1.0")
 public class TableLoadBalancerTest {

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
@@ -24,11 +24,11 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -45,8 +45,8 @@ import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.server.MockServerContext;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ProblemReportTest {
   private static final TableId TABLE_ID = TableId.of("table");
@@ -57,7 +57,7 @@ public class ProblemReportTest {
   private ZooReaderWriter zoorw;
   private ProblemReport r;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     context = MockServerContext.getWithZK(InstanceId.of("instance"), "", 30_000);
     zoorw = createMock(ZooReaderWriter.class);

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportingIteratorTest.java
@@ -21,11 +21,11 @@ package org.apache.accumulo.server.problems;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,8 +37,8 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ProblemReportingIteratorTest {
   private static final TableId TABLE_ID = TableId.of("table");
@@ -47,7 +47,7 @@ public class ProblemReportingIteratorTest {
   private InterruptibleIterator ii;
   private ProblemReportingIterator pri;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     ii = EasyMock.createMock(InterruptibleIterator.class);
     pri = new ProblemReportingIterator(null, TABLE_ID, RESOURCE, false, ii);

--- a/server/base/src/test/java/org/apache/accumulo/server/replication/ReplicationUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/replication/ReplicationUtilTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.replication;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,8 +28,8 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.ServerContext;
 import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class ReplicationUtilTest {
@@ -40,7 +40,7 @@ public class ReplicationUtilTest {
   ReplicaSystemFactory factory;
   ReplicationUtil util;
 
-  @Before
+  @BeforeEach
   public void setup() {
     context = EasyMock.createMock(ServerContext.class);
     conf = EasyMock.createMock(AccumuloConfiguration.class);

--- a/server/base/src/test/java/org/apache/accumulo/server/replication/StatusCombinerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/replication/StatusCombinerTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.server.replication;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,8 +38,8 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.replication.ReplicationSchema.StatusSection;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class StatusCombinerTest {
@@ -55,7 +55,7 @@ public class StatusCombinerTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void initCombiner() throws IOException {
     key = new Key();
     combiner = new StatusCombiner();

--- a/server/base/src/test/java/org/apache/accumulo/server/replication/StatusUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/replication/StatusUtilTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.server.replication;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.accumulo.server.replication.proto.Replication.Status;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class StatusUtilTest {

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslDigestCallbackHandlerTest.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.server.rpc;
 
 import static org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier.createTAuthIdentifier;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -35,9 +35,9 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.rpc.SaslDigestCallbackHandler;
 import org.apache.accumulo.server.security.delegation.AuthenticationKey;
 import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SaslDigestCallbackHandlerTest {
 
@@ -56,7 +56,7 @@ public class SaslDigestCallbackHandlerTest {
   private static final int KEY_LENGTH = 64;
   private static KeyGenerator keyGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupKeyGenerator() throws Exception {
     // From org.apache.hadoop.security.token.SecretManager
     keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);
@@ -66,7 +66,7 @@ public class SaslDigestCallbackHandlerTest {
   private SaslTestDigestCallbackHandler handler;
   private DelegationTokenConfig cfg;
 
-  @Before
+  @BeforeEach
   public void setup() {
     handler = new SaslTestDigestCallbackHandler();
     cfg = new DelegationTokenConfig();

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslServerConnectionParamsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/SaslServerConnectionParamsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.rpc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,15 +43,15 @@ import org.apache.accumulo.server.security.SystemCredentials.SystemToken;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SaslServerConnectionParamsTest {
 
   private UserGroupInformation testUser;
   private String username;
 
-  @Before
+  @BeforeEach
   public void setup() {
     System.setProperty("java.security.krb5.realm", "accumulo");
     System.setProperty("java.security.krb5.kdc", "fake");

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandlerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandlerTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.rpc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -36,9 +36,9 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TCredentialsUpdatingInvocationHandlerTest {
   private static final DefaultConfiguration DEFAULT_CONFIG = DefaultConfiguration.getInstance();
@@ -47,7 +47,7 @@ public class TCredentialsUpdatingInvocationHandlerTest {
   ConfigurationCopy cc;
   AccumuloConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     cc = new ConfigurationCopy();
     conf = new AccumuloConfiguration() {
@@ -74,7 +74,7 @@ public class TCredentialsUpdatingInvocationHandlerTest {
     proxy = new TCredentialsUpdatingInvocationHandler<>(new Object(), conf);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     UGIAssumingProcessor.rpcPrincipal.set(null);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/ThriftServerTypeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/ThriftServerTypeTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.server.rpc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.conf.Property;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThriftServerTypeTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/security/SystemCredentialsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/SystemCredentialsTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,24 +32,19 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.server.AccumuloDataVersion;
 import org.apache.accumulo.server.security.SystemCredentials.SystemToken;
 import org.apache.commons.codec.digest.Crypt;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class SystemCredentialsTest {
-
-  @Rule
-  public TestName test = new TestName();
 
   private static SiteConfiguration siteConfig = SiteConfiguration.auto();
   private InstanceId instanceId =
       InstanceId.of(UUID.nameUUIDFromBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
 
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "input not from a user")
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws IOException {
     File testInstanceId =
         new File(new File(new File(new File("target"), "instanceTest"), Constants.INSTANCE_ID_DIR),

--- a/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.server.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +35,8 @@ import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.security.UserImpersonation.AlwaysTrueSet;
 import org.apache.accumulo.server.security.UserImpersonation.UsersWithHosts;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Joiner;
 
@@ -45,7 +45,7 @@ public class UserImpersonationTest {
   private ConfigurationCopy cc;
   private AccumuloConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     cc = new ConfigurationCopy(new HashMap<>());
     conf = new AccumuloConfiguration() {
@@ -126,7 +126,7 @@ public class UserImpersonationTest {
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);
-    assertNull("Impersonation config should be drive by user element, not host", uwh);
+    assertNull(uwh, "Impersonation config should be drive by user element, not host");
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationKeyTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationKeyTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.server.security.delegation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -31,8 +31,8 @@ import java.io.IOException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AuthenticationKeyTest {
   // From org.apache.hadoop.security.token.SecretManager
@@ -40,7 +40,7 @@ public class AuthenticationKeyTest {
   private static final int KEY_LENGTH = 64;
   private static KeyGenerator keyGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupKeyGenerator() throws Exception {
     // From org.apache.hadoop.security.token.SecretManager
     keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManagerTest.java
@@ -23,7 +23,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
@@ -32,9 +32,10 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
 import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ public class AuthenticationTokenKeyManagerTest {
   private static final int KEY_LENGTH = 64;
   private static KeyGenerator keyGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupKeyGenerator() throws Exception {
     // From org.apache.hadoop.security.token.SecretManager
     keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);
@@ -57,7 +58,7 @@ public class AuthenticationTokenKeyManagerTest {
   private AuthenticationTokenSecretManager secretManager;
   private ZooAuthenticationKeyDistributor zooDistributor;
 
-  @Before
+  @BeforeEach
   public void setupMocks() {
     secretManager = createMock(AuthenticationTokenSecretManager.class);
     zooDistributor = createMock(ZooAuthenticationKeyDistributor.class);
@@ -138,7 +139,8 @@ public class AuthenticationTokenKeyManagerTest {
 
   }
 
-  @Test(timeout = 30_000)
+  @Test
+  @Timeout(30)
   public void testStopLoop() throws InterruptedException {
     final MockManager keyManager = EasyMock.createMockBuilder(MockManager.class)
         .addMockedMethod("_run").addMockedMethod("updateStateFromCurrentKeys").createMock();

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -24,12 +24,12 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -45,17 +45,19 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
 import org.apache.accumulo.core.clientImpl.AuthenticationTokenIdentifier;
 import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.minicluster.WithTestNames;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.Token;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 
-public class AuthenticationTokenSecretManagerTest {
+public class AuthenticationTokenSecretManagerTest extends WithTestNames {
   private static final Logger log =
       LoggerFactory.getLogger(AuthenticationTokenSecretManagerTest.class);
 
@@ -64,7 +66,7 @@ public class AuthenticationTokenSecretManagerTest {
   private static final int KEY_LENGTH = 64;
   private static KeyGenerator keyGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupKeyGenerator() throws Exception {
     // From org.apache.hadoop.security.token.SecretManager
     keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);
@@ -74,7 +76,7 @@ public class AuthenticationTokenSecretManagerTest {
   private InstanceId instanceId;
   private DelegationTokenConfig cfg;
 
-  @Before
+  @BeforeEach
   public void setup() {
     instanceId = InstanceId.of(UUID.randomUUID());
     cfg = new DelegationTokenConfig();
@@ -157,10 +159,12 @@ public class AuthenticationTokenSecretManagerTest {
     long now = System.currentTimeMillis();
 
     // Issue date should be after the test started, but before we deserialized the token
-    assertTrue("Issue date did not fall within the expected upper bound. Expected less than " + now
-        + ", but was " + id.getIssueDate(), id.getIssueDate() <= now);
-    assertTrue("Issue date did not fall within the expected lower bound. Expected greater than "
-        + then + ", but was " + id.getIssueDate(), id.getIssueDate() >= then);
+    assertTrue(id.getIssueDate() <= now,
+        "Issue date did not fall within the expected upper bound. Expected less than " + now
+            + ", but was " + id.getIssueDate());
+    assertTrue(id.getIssueDate() >= then,
+        "Issue date did not fall within the expected lower bound. Expected greater than " + then
+            + ", but was " + id.getIssueDate());
 
     // Expiration is the token lifetime plus the issue date
     assertEquals(id.getIssueDate() + tokenLifetime, id.getExpirationDate());
@@ -211,8 +215,8 @@ public class AuthenticationTokenSecretManagerTest {
     byte[] password2 = secretManager.retrievePassword(id2);
 
     // It should be different than the password for the first user.
-    assertFalse("Different tokens for the same user shouldn't have the same password",
-        Arrays.equals(password, password2));
+    assertFalse(Arrays.equals(password, password2),
+        "Different tokens for the same user shouldn't have the same password");
   }
 
   @Test
@@ -307,7 +311,8 @@ public class AuthenticationTokenSecretManagerTest {
     assertThrows(InvalidToken.class, () -> secretManager.retrievePassword(id));
   }
 
-  @Test(timeout = 20_000)
+  @Test
+  @Timeout(20)
   public void testManagerKeyExpiration() throws Exception {
     ZooAuthenticationKeyDistributor keyDistributor =
         createMock(ZooAuthenticationKeyDistributor.class);
@@ -389,10 +394,9 @@ public class AuthenticationTokenSecretManagerTest {
     log.info("actualExpiration={}, approximateLifetime={}", actualExpiration, approximateLifetime);
 
     // We don't know the exact lifetime, but we know that it can be no more than what was requested
-    assertTrue(
+    assertTrue(approximateLifetime <= cfg.getTokenLifetime(TimeUnit.MILLISECONDS),
         "Expected lifetime to be on thet order of the token lifetime, but was "
-            + approximateLifetime,
-        approximateLifetime <= cfg.getTokenLifetime(TimeUnit.MILLISECONDS));
+            + approximateLifetime);
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyDistributorTest.java
@@ -26,8 +26,8 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -44,9 +44,9 @@ import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.zookeeper.KeeperException.AuthFailedException;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Id;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ZooAuthenticationKeyDistributorTest {
 
@@ -55,7 +55,7 @@ public class ZooAuthenticationKeyDistributorTest {
   private static final int KEY_LENGTH = 64;
   private static KeyGenerator keyGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupKeyGenerator() throws Exception {
     // From org.apache.hadoop.security.token.SecretManager
     keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);
@@ -65,7 +65,7 @@ public class ZooAuthenticationKeyDistributorTest {
   private ZooReaderWriter zrw;
   private String baseNode = Constants.ZDELEGATION_TOKEN_KEYS;
 
-  @Before
+  @BeforeEach
   public void setupMocks() {
     zrw = createMock(ZooReaderWriter.class);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcherTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/ZooAuthenticationKeyWatcherTest.java
@@ -24,10 +24,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -46,9 +46,9 @@ import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ZooAuthenticationKeyWatcherTest {
 
@@ -57,7 +57,7 @@ public class ZooAuthenticationKeyWatcherTest {
   private static final int KEY_LENGTH = 64;
   private static KeyGenerator keyGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupKeyGenerator() throws Exception {
     // From org.apache.hadoop.security.token.SecretManager
     keyGen = KeyGenerator.getInstance(DEFAULT_HMAC_ALGORITHM);
@@ -71,7 +71,7 @@ public class ZooAuthenticationKeyWatcherTest {
   private AuthenticationTokenSecretManager secretManager;
   private ZooAuthenticationKeyWatcher keyWatcher;
 
-  @Before
+  @BeforeEach
   public void setupMocks() {
     zk = createMock(ZooReader.class);
     instanceId = InstanceId.of(UUID.randomUUID());
@@ -296,9 +296,9 @@ public class ZooAuthenticationKeyWatcherTest {
     verify(zk);
 
     // We should have no auth keys when we're disconnected
-    assertEquals("Secret manager should be empty after a disconnect", 0,
-        secretManager.getKeys().size());
-    assertNull("Current key should be null", secretManager.getCurrentKey());
+    assertEquals(0, secretManager.getKeys().size(),
+        "Secret manager should be empty after a disconnect");
+    assertNull(secretManager.getCurrentKey(), "Current key should be null");
 
     reset(zk);
 
@@ -340,9 +340,9 @@ public class ZooAuthenticationKeyWatcherTest {
     verify(zk);
 
     // We should have no auth keys after initializing things
-    assertEquals("Secret manager should be empty after a disconnect", 0,
-        secretManager.getKeys().size());
-    assertNull("Current key should be null", secretManager.getCurrentKey());
+    assertEquals(0, secretManager.getKeys().size(),
+        "Secret manager should be empty after a disconnect");
+    assertNull(secretManager.getCurrentKey(), "Current key should be null");
   }
 
   private byte[] serialize(AuthenticationKey key) throws IOException {

--- a/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/handler/ZKAuthenticatorTest.java
@@ -25,9 +25,9 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.matches;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +47,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ZKAuthenticatorTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/tables/IllegalTableTransitionExceptionTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tables/IllegalTableTransitionExceptionTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.server.tables;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IllegalTableTransitionExceptionTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/LogicalTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/LogicalTimeTest.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.server.tablets;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -29,14 +29,14 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.server.tablets.TabletTime.LogicalTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LogicalTimeTest {
   private static final long TIME = 1234L;
   private LogicalTime ltime;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     MetadataTime mTime = MetadataTime.parse("L1234");
     ltime = (LogicalTime) TabletTime.getInstance(mTime);

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/MillisTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/MillisTimeTest.java
@@ -22,22 +22,22 @@ import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.server.tablets.TabletTime.MillisTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MillisTimeTest {
   private static final long TIME = 1234L;
   private MillisTime mtime;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mtime = new MillisTime(TIME);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/tablets/TabletTimeTest.java
@@ -21,17 +21,17 @@ package org.apache.accumulo.server.tablets;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.accumulo.core.client.admin.TimeType;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.server.tablets.TabletTime.LogicalTime;
 import org.apache.accumulo.server.tablets.TabletTime.MillisTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TabletTimeTest {
   private static final long TIME = 1234L;
@@ -41,7 +41,7 @@ public class TabletTimeTest {
   private static final MetadataTime l1234 = new MetadataTime(1234, TimeType.LOGICAL);
   private static final MetadataTime l5678 = new MetadataTime(5678, TimeType.LOGICAL);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mtime = new MillisTime(TIME);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/AdminCommandsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/AdminCommandsTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.server.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AdminCommandsTest {
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/util/AdminTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/AdminTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.server.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.UUID;
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooCache.ZcStat;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AdminTest {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/util/FileInfoTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/FileInfoTest.java
@@ -18,19 +18,19 @@
  */
 package org.apache.accumulo.server.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.server.util.FileUtil.FileInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FileInfoTest {
   private Key key1;
   private Key key2;
   private FileInfo info;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     key1 = new Key("row1");
     key2 = new Key("row2");

--- a/server/base/src/test/java/org/apache/accumulo/server/util/FileSystemMonitorTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/FileSystemMonitorTest.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.server.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.accumulo.server.util.FileSystemMonitor.Mount;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,11 +91,11 @@ public class FileSystemMonitorTest {
     expectedCheckedMountPoints.add("/");
     expectedCheckedMountPoints.add("/grid/0");
     for (Mount mount : mounts) {
-      assertTrue("Did not expect to find " + mount,
-          expectedCheckedMountPoints.remove(mount.mountPoint));
+      assertTrue(expectedCheckedMountPoints.remove(mount.mountPoint),
+          "Did not expect to find " + mount);
     }
-    assertEquals("Should not have any extra mount points: " + expectedCheckedMountPoints, 0,
-        expectedCheckedMountPoints.size());
+    assertEquals(0, expectedCheckedMountPoints.size(),
+        "Should not have any extra mount points: " + expectedCheckedMountPoints);
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/FileUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/FileUtilTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.server.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,31 +27,26 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.minicluster.WithTestNames;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class FileUtilTest {
+public class FileUtilTest extends WithTestNames {
 
-  @Rule
-  public TemporaryFolder tmpDir =
-      new TemporaryFolder(new File(System.getProperty("user.dir") + "/target"));
-
-  @Rule
-  public TestName testName = new TestName();
-
+  @TempDir
+  private static File tempDir;
   private File accumuloDir;
 
-  @Before
-  public void createTmpDir() throws IOException {
-    accumuloDir = tmpDir.newFolder(testName.getMethodName());
+  @BeforeEach
+  public void createTmpDir() {
+    accumuloDir = new File(tempDir, testName());
+    assertTrue(accumuloDir.isDirectory() || accumuloDir.mkdir());
   }
 
   @Test
@@ -68,7 +63,7 @@ public class FileUtilTest {
       FileUtil.cleanupIndexOp(tmpPath1, fs, new ArrayList<>());
     }
 
-    assertFalse("Expected " + tmp1 + " to be cleaned up but it wasn't", tmp1.exists());
+    assertFalse(tmp1.exists(), "Expected " + tmp1 + " to be cleaned up but it wasn't");
   }
 
   @Test
@@ -92,9 +87,9 @@ public class FileUtilTest {
 
     try (var fs = VolumeManagerImpl.getLocalForTesting(accumuloDir.getAbsolutePath())) {
       FileUtil.cleanupIndexOp(tmpPath1, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp1 + " to be cleaned up but it wasn't", tmp1.exists());
+      assertFalse(tmp1.exists(), "Expected " + tmp1 + " to be cleaned up but it wasn't");
       FileUtil.cleanupIndexOp(tmpPath2, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp2 + " to be cleaned up but it wasn't", tmp2.exists());
+      assertFalse(tmp2.exists(), "Expected " + tmp2 + " to be cleaned up but it wasn't");
     }
   }
 
@@ -122,9 +117,9 @@ public class FileUtilTest {
 
     try (var fs = VolumeManagerImpl.getLocalForTesting(accumuloDir.getAbsolutePath())) {
       FileUtil.cleanupIndexOp(tmpPath1, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp1 + " to be cleaned up but it wasn't", tmp1.exists());
+      assertFalse(tmp1.exists(), "Expected " + tmp1 + " to be cleaned up but it wasn't");
       FileUtil.cleanupIndexOp(tmpPath2, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp2 + " to be cleaned up but it wasn't", tmp2.exists());
+      assertFalse(tmp2.exists(), "Expected " + tmp2 + " to be cleaned up but it wasn't");
     }
   }
 
@@ -146,9 +141,9 @@ public class FileUtilTest {
 
     try (var fs = VolumeManagerImpl.getLocalForTesting(accumuloDir.getAbsolutePath())) {
       FileUtil.cleanupIndexOp(tmpPath1, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp1 + " to be cleaned up but it wasn't", tmp1.exists());
+      assertFalse(tmp1.exists(), "Expected " + tmp1 + " to be cleaned up but it wasn't");
       FileUtil.cleanupIndexOp(tmpPath2, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp2 + " to be cleaned up but it wasn't", tmp2.exists());
+      assertFalse(tmp2.exists(), "Expected " + tmp2 + " to be cleaned up but it wasn't");
     }
   }
 
@@ -173,9 +168,9 @@ public class FileUtilTest {
 
     try (var fs = VolumeManagerImpl.getLocalForTesting(accumuloDir.getAbsolutePath())) {
       FileUtil.cleanupIndexOp(tmpPath1, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp1 + " to be cleaned up but it wasn't", tmp1.exists());
+      assertFalse(tmp1.exists(), "Expected " + tmp1 + " to be cleaned up but it wasn't");
       FileUtil.cleanupIndexOp(tmpPath2, fs, new ArrayList<>());
-      assertFalse("Expected " + tmp2 + " to be cleaned up but it wasn't", tmp2.exists());
+      assertFalse(tmp2.exists(), "Expected " + tmp2 + " to be cleaned up but it wasn't");
     }
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/ReplicationTableUtilTest.java
@@ -23,8 +23,8 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,7 +58,7 @@ import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class ReplicationTableUtilTest {

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TServerUtilsTest.java
@@ -22,11 +22,11 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -48,9 +48,9 @@ import org.apache.accumulo.server.rpc.ServerAddress;
 import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftServerType;
 import org.apache.thrift.server.TServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -59,7 +59,7 @@ public class TServerUtilsTest {
   private ServerContext context;
   private final ConfigurationCopy conf = new ConfigurationCopy(DefaultConfiguration.getInstance());
 
-  @Before
+  @BeforeEach
   public void createMockServerContext() {
     context = createMock(ServerContext.class);
     expect(context.getZooReader()).andReturn(null).anyTimes();
@@ -77,7 +77,7 @@ public class TServerUtilsTest {
     replay(context);
   }
 
-  @After
+  @AfterEach
   public void verifyMockServerContext() {
     verify(context);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/time/BaseRelativeTimeTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.server.util.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BaseRelativeTimeTest {
 
@@ -66,8 +66,8 @@ public class BaseRelativeTimeTest {
     }
     long many = brt.currentTime();
     assertTrue(many > once);
-    assertTrue("after much advice, relative time is still closer to local time",
-        (advice.value - many) < (once - local.value));
+    assertTrue((advice.value - many) < (once - local.value),
+        "after much advice, relative time is still closer to local time");
   }
 
   @Test
@@ -84,9 +84,9 @@ public class BaseRelativeTimeTest {
     assertTrue(once < local.value);
     brt.updateTime(advice.value);
     long twice = brt.currentTime();
-    assertTrue("Time cannot go backwards", once <= twice);
+    assertTrue(once <= twice, "Time cannot go backwards");
     brt.updateTime(advice.value - 10000);
-    assertTrue("Time cannot go backwards", once <= twice);
+    assertTrue(once <= twice, "Time cannot go backwards");
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/zookeeper/TransactionWatcherTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/zookeeper/TransactionWatcherTest.java
@@ -18,16 +18,16 @@
  */
 package org.apache.accumulo.server.zookeeper;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransactionWatcherTest {
 
@@ -96,8 +96,8 @@ public class TransactionWatcherTest {
     final SimpleArbitrator sa = new SimpleArbitrator();
     final TransactionWatcher txw = new TransactionWatcher(sa);
     sa.start(txType, txid);
-    assertThrows("simple arbitrator did not throw an exception", Exception.class,
-        () -> sa.start(txType, txid));
+    assertThrows(Exception.class, () -> sa.start(txType, txid),
+        "simple arbitrator did not throw an exception");
     txw.isActive(txid);
     assertFalse(txw.isActive(txid));
     txw.run(txType, txid, () -> {
@@ -111,15 +111,15 @@ public class TransactionWatcherTest {
     assertFalse(sa.transactionComplete(txType, txid));
     sa.cleanup(txType, txid);
     assertTrue(sa.transactionComplete(txType, txid));
-    assertThrows("Should not be able to start a new work on a discontinued transaction",
-        Exception.class, () -> txw.run(txType, txid, () -> null));
+    assertThrows(Exception.class, () -> txw.run(txType, txid, () -> null),
+        "Should not be able to start a new work on a discontinued transaction");
     final long txid2 = 9;
     sa.start(txType, txid2);
     txw.run(txType, txid2, () -> {
       assertTrue(txw.isActive(txid2));
       sa.stop(txType, txid2);
-      assertThrows("Should not be able to start a new work on a discontinued transaction",
-          Exception.class, () -> txw.run(txType, txid2, () -> null));
+      assertThrows(Exception.class, () -> txw.run(txType, txid2, () -> null),
+          "Should not be able to start a new work on a discontinued transaction");
       assertTrue(txw.isActive(txid2));
       return null;
     });


### PR DESCRIPTION
This PR converts the `server-base` module from JUnit4 to JUnit5 Jupiter. This module was fairly straight forward to convert and was mostly just syntax changes. All tests that were changed, still pass.

Part of #2441 

Notes for reviewers:

> 
> Here are some quick notes that might help to reference for those who work on the migration or for reviewers.
> 
> | JUnit4  | JUnit5  |
> | ----------- | ----------- |
> | `@Test` | `@Test` |
> | `@Before` | `@BeforeEach` |
> | `@After` | `@AfterEach` |
> | `@BeforeClass` | `@BeforeAll` |
> | `@AfterClass` | `AfterAll` |
> | `@Ignore` | `@Disable` |
> | `@Category` | `@Tag` |
> 
> | | JUnit4  | JUnit5  |
> | ----------- | ----------- | ----------- |
> | Testing class package | `org.junit` | `org.junit.jupiter.api` |
> | Assertions class | `Assert` | `Assertions` |
> 
> `TemporaryFolder` was removed and instead a `File` or `Path` is used in JUnit5 with the `@TempDir` annotation.
> 
> Additionally, the order of parameters in assert statements has changed. The optional message is now the last parameter rather than the first parameter. e.g. `assertTrue("should be equal", 1==3)` becomes `assertTrue(1==3, "should be equal")`

_Originally posted by @DomGarguilo in https://github.com/apache/accumulo/issues/2441#issuecomment-1041908425_
