### PR TITLE
Convert tserver module tests from JUnit4 to JUnit5 

### DIFF
--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -120,8 +120,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/AssignmentWatcherTest.java
@@ -30,8 +30,8 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.tserver.TabletServerResourceManager.AssignmentWatcher;
 import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AssignmentWatcherTest {
 
@@ -40,7 +40,7 @@ public class AssignmentWatcherTest {
   private AccumuloConfiguration conf;
   private AssignmentWatcher watcher;
 
-  @Before
+  @BeforeEach
   public void setup() {
     assignments = new HashMap<>();
     context = EasyMock.createMock(ServerContext.class);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/BusiestTrackerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/BusiestTrackerTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.tserver;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.util.ComparablePair;
 import org.apache.accumulo.tserver.tablet.Tablet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Preconditions;
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CheckTabletMetadataTest.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.tserver;
 
 import static org.apache.accumulo.tserver.AssignmentHandler.checkTabletMetadata;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
 import java.util.TreeMap;
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckTabletMetadataTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/CountingIteratorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/CountingIteratorTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.server.compaction.CountingIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CountingIteratorTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/MemValueTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/MemValueTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.accumulo.tserver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.data.Value;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MemValueTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletResourceManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletResourceManagerTest.java
@@ -19,13 +19,13 @@
 package org.apache.accumulo.tserver;
 
 import static org.easymock.EasyMock.createMock;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.tserver.TabletServerResourceManager.TabletResourceManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TabletResourceManagerTest {
   private TabletServerResourceManager tsrm;
@@ -33,7 +33,7 @@ public class TabletResourceManagerTest {
   private KeyExtent extent;
   private TableConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     tsrm = createMock(TabletServerResourceManager.class);
     extent = createMock(KeyExtent.class);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TabletServerSyncCheckTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.Map;
@@ -36,7 +36,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TabletServerSyncCheckTest {
   private static final String DFS_SUPPORT_APPEND = "dfs.support.append";

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/TservConstraintEnvTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/TservConstraintEnvTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.tserver;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.server.security.SecurityOperation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TservConstraintEnvTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/WalRemovalOrderTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/WalRemovalOrderTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.tserver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -31,7 +31,7 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.tserver.TabletServer.ReferencedRemover;
 import org.apache.accumulo.tserver.log.DfsLogger;
 import org.apache.accumulo.tserver.log.DfsLogger.ServerResources;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/WithTestNames.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/WithTestNames.java
@@ -16,23 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.tserver.log;
+package org.apache.accumulo.tserver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
-import org.apache.accumulo.tserver.logger.LogEvents;
-import org.junit.jupiter.api.Test;
+// This is only for the unit tests and integration tests in this module
+// It must be copied for use in other modules, because tests in one module
+// don't have dependencies on other modules, and we can't put this in a
+// regular, non-test jar, because we don't want to add a dependency on
+// JUnit in a non-test jar
+public class WithTestNames {
 
-public class LogEventsTest {
-  @Test
-  public void testOrdinals() {
-    // Ordinals are used for persistence, so its important they are stable.
+  private String testName;
 
-    LogEvents[] expectedOrder = {LogEvents.OPEN, LogEvents.DEFINE_TABLET, LogEvents.MUTATION,
-        LogEvents.MANY_MUTATIONS, LogEvents.COMPACTION_START, LogEvents.COMPACTION_FINISH};
-
-    for (int i = 0; i < expectedOrder.length; i++) {
-      assertEquals(i, expectedOrder[i].ordinal());
-    }
+  @BeforeEach
+  public void setTestName(TestInfo info) {
+    testName = info.getTestMethod().get().getName();
   }
+
+  protected String testName() {
+    return testName;
+  }
+
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactableUtilsTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactableUtilsTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.tserver.compaction;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.tserver.tablet.CompactableUtils;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompactableUtilsTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactionPlanTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactionPlanTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.tserver.compaction;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Set;
 
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class CompactionPlanTest {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/DefaultCompactionStrategyTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.tserver.compaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.util.ArrayList;
@@ -57,7 +57,7 @@ import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class DefaultCompactionStrategyTest {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeLimitCompactionStrategyTest.java
@@ -19,9 +19,9 @@
 package org.apache.accumulo.tserver.compaction;
 
 import static org.apache.accumulo.tserver.compaction.DefaultCompactionStrategyTest.getServerContext;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class SizeLimitCompactionStrategyTest {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeWindowTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/SizeWindowTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.tserver.compaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.tserver.compaction.DefaultCompactionStrategy.SizeWindow;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SizeWindowTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/BasicCompactionStrategyTest.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.tserver.compaction.strategies;
 
 import static org.apache.accumulo.tserver.compaction.DefaultCompactionStrategyTest.getServerContext;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -41,8 +41,8 @@ import org.apache.accumulo.tserver.InMemoryMapTest;
 import org.apache.accumulo.tserver.compaction.MajorCompactionReason;
 import org.apache.accumulo.tserver.compaction.MajorCompactionRequest;
 import org.apache.accumulo.tserver.compaction.SizeLimitCompactionStrategyTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests org.apache.accumulo.tserver.compaction.BasicCompactionStrategy
@@ -66,7 +66,7 @@ public class BasicCompactionStrategyTest {
     return ret;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     opts.put(BasicCompactionStrategy.LARGE_FILE_COMPRESSION_TYPE, largeCompressionType);
     opts.put(BasicCompactionStrategy.LARGE_FILE_COMPRESSION_THRESHOLD, "500M");

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/strategies/ConfigurableCompactionStrategyTest.java
@@ -19,8 +19,8 @@
 package org.apache.accumulo.tserver.compaction.strategies;
 
 import static org.apache.accumulo.core.conf.ConfigurationTypeHelper.getFixedMemoryAsBytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.client.admin.compaction.CompactionConfigurer.Ove
 import org.apache.accumulo.core.compaction.CompactionSettings;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConfigurableCompactionStrategyTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/constraints/ConstraintCheckerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/constraints/ConstraintCheckerTest.java
@@ -23,8 +23,8 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createMockBuilder;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -37,8 +37,8 @@ import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.constraints.Constraint;
 import org.apache.accumulo.core.data.constraints.Constraint.Environment;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterables;
 
@@ -51,7 +51,7 @@ public class ConstraintCheckerTest {
   private Mutation m;
   private Mutation m2;
 
-  @Before
+  @BeforeEach
   public void setup() throws SecurityException {
     cc = createMockBuilder(ConstraintChecker.class).addMockedMethod("getConstraints").createMock();
     constraints = new ArrayList<>();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/DfsLoggerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.tserver.log;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.client.Durability;
 import org.apache.accumulo.tserver.TabletMutations;
 import org.apache.accumulo.tserver.tablet.CommitSession;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DfsLoggerTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/LogFileKeyTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.tserver.log;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.tserver.logger.LogEvents;
 import org.apache.accumulo.tserver.logger.LogFileKey;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogFileKeyTest {
 
@@ -111,8 +111,8 @@ public class LogFileKeyTest {
     Key k = logFileKey.toKey();
 
     var converted = LogFileKey.fromKey(k);
-    assertEquals("Failed to convert tabletId = " + tabletId + " seq = " + seq, logFileKey,
-        converted);
+    assertEquals(logFileKey, converted,
+        "Failed to convert tabletId = " + tabletId + " seq = " + seq);
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsIteratorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/RecoveryLogsIteratorTest.java
@@ -26,7 +26,6 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -76,12 +75,8 @@ public class RecoveryLogsIteratorTest extends WithTestNames {
     context = createMock(ServerContext.class);
     logSorter = new LogSorter(context, DefaultConfiguration.getInstance());
 
-    File tempFolder = new File(tempDir, testName());
-    assertTrue(tempFolder.isDirectory() || tempFolder.mkdir(),
-        "Failed to create folder: " + tempFolder);
-    workDir = tempFolder;
+    workDir = new File(tempDir, testName());
     String path = workDir.getAbsolutePath();
-    assertTrue(workDir.delete());
     fs = VolumeManagerImpl.getLocalForTesting(path);
     expect(context.getVolumeManager()).andReturn(fs).anyTimes();
     expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/SortedLogRecoveryTest.java
@@ -165,10 +165,7 @@ public class SortedLogRecoveryTest extends WithTestNames {
   private List<Mutation> recover(Map<String,KeyValue[]> logs, Set<String> files, KeyExtent extent,
       int bufferSize) throws IOException {
 
-    File tempFolder = new File(tempDir, testName());
-    assertTrue(tempFolder.isDirectory() || tempFolder.mkdir(),
-        "Failed to create folder: " + tempFolder);
-    final String workdir = tempFolder.getAbsolutePath();
+    final String workdir = new File(tempDir, testName()).getAbsolutePath();
     try (var fs = VolumeManagerImpl.getLocalForTesting(workdir)) {
       expect(context.getVolumeManager()).andReturn(fs).anyTimes();
       expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())
@@ -1096,10 +1093,8 @@ public class SortedLogRecoveryTest extends WithTestNames {
     testConfig.set(prefix + "blocksize", "256B");
     testConfig.set(prefix + "replication", "3");
     LogSorter sorter = new LogSorter(context, testConfig);
-    File tempFolder = new File(tempDir, testName());
-    assertTrue(tempFolder.isDirectory() || tempFolder.mkdir(),
-        "Failed to create folder: " + tempFolder);
-    final String workdir = tempFolder.getAbsolutePath();
+
+    final String workdir = new File(tempDir, testName()).getAbsolutePath();
 
     try (var vm = VolumeManagerImpl.getLocalForTesting(workdir)) {
       expect(context.getVolumeManager()).andReturn(vm).anyTimes();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
@@ -23,9 +23,9 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -39,19 +39,19 @@ import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
+import org.apache.accumulo.tserver.WithTestNames;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "PATH_TRAVERSAL_OUT"},
     justification = "paths not set by user input")
-public class TestUpgradePathForWALogs {
+public class TestUpgradePathForWALogs extends WithTestNames {
 
   // older logs no longer compatible
   private static final String WALOG_FROM_15 = "/walog-from-15.walog";
@@ -63,16 +63,22 @@ public class TestUpgradePathForWALogs {
   private static final AccumuloConfiguration config = DefaultConfiguration.getInstance();
   private ServerContext context;
 
-  @Rule
-  public TemporaryFolder tempFolder =
-      new TemporaryFolder(new File(System.getProperty("user.dir"), "target"));
+  @TempDir
+  private static File tempDir;
 
-  @Before
+  private static File perTestTempSubDir;
+
+  @BeforeEach
   public void setUp() throws Exception {
     context = createMock(ServerContext.class);
-    File workDir = tempFolder.newFolder();
+
+    perTestTempSubDir = new File(tempDir, testName());
+    assertTrue(perTestTempSubDir.isDirectory() || perTestTempSubDir.mkdir(),
+        "Failed to create folder: " + perTestTempSubDir);
+
+    File workDir = new File(perTestTempSubDir, testName());
     String path = workDir.getAbsolutePath();
-    assertTrue(workDir.delete());
+
     VolumeManager fs = VolumeManagerImpl.getLocalForTesting(path);
     expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())
         .anyTimes();
@@ -80,7 +86,7 @@ public class TestUpgradePathForWALogs {
     replay(context);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     verify(context);
   }
@@ -91,7 +97,7 @@ public class TestUpgradePathForWALogs {
   @Test
   public void testUpgradeOf15WALog() throws IOException {
     String walogToTest = WALOG_FROM_15;
-    String testPath = tempFolder.getRoot().getAbsolutePath();
+    String testPath = perTestTempSubDir.getAbsolutePath();
 
     try (InputStream walogStream = getClass().getResourceAsStream(walogToTest);
         OutputStream walogInHDFStream = new FileOutputStream(testPath + walogToTest)) {
@@ -111,7 +117,7 @@ public class TestUpgradePathForWALogs {
   @Test
   public void testBasic16WALogRead() throws IOException {
     String walogToTest = WALOG_FROM_16;
-    String testPath = tempFolder.getRoot().getAbsolutePath();
+    String testPath = perTestTempSubDir.getAbsolutePath();
     String destPath = "file://" + testPath + "/manyMaps";
 
     try (InputStream walogStream = getClass().getResourceAsStream(walogToTest);
@@ -135,7 +141,7 @@ public class TestUpgradePathForWALogs {
   @Test
   public void testBasic20WALogRead() throws IOException {
     String walogToTest = WALOG_FROM_20;
-    String testPath = tempFolder.getRoot().getAbsolutePath();
+    String testPath = perTestTempSubDir.getAbsolutePath();
     String destPath = "file://" + testPath + "/manyMaps";
 
     try (InputStream walogStream = getClass().getResourceAsStream(walogToTest);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/log/TestUpgradePathForWALogs.java
@@ -72,12 +72,12 @@ public class TestUpgradePathForWALogs extends WithTestNames {
   public void setUp() throws Exception {
     context = createMock(ServerContext.class);
 
+    // Create a new subdirectory for each test
     perTestTempSubDir = new File(tempDir, testName());
     assertTrue(perTestTempSubDir.isDirectory() || perTestTempSubDir.mkdir(),
         "Failed to create folder: " + perTestTempSubDir);
 
-    File workDir = new File(perTestTempSubDir, testName());
-    String path = workDir.getAbsolutePath();
+    String path = perTestTempSubDir.getAbsolutePath();
 
     VolumeManager fs = VolumeManagerImpl.getLocalForTesting(path);
     expect(context.getCryptoService()).andReturn(CryptoServiceFactory.newDefaultInstance())

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/logger/LogFileTest.java
@@ -24,8 +24,8 @@ import static org.apache.accumulo.tserver.logger.LogEvents.DEFINE_TABLET;
 import static org.apache.accumulo.tserver.logger.LogEvents.MANY_MUTATIONS;
 import static org.apache.accumulo.tserver.logger.LogEvents.MUTATION;
 import static org.apache.accumulo.tserver.logger.LogEvents.OPEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,7 +39,7 @@ import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogFileTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/memory/LargestFirstMemoryManagerTest.java
@@ -22,7 +22,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,14 +34,12 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(60)
 public class LargestFirstMemoryManagerTest {
-  @Rule
-  public Timeout timeout = Timeout.seconds(60);
 
   private static final long ZERO = LargestFirstMemoryManager.ZERO_TIME;
   private static final long LATER = ZERO + MINUTES.toMillis(20);
@@ -52,7 +50,7 @@ public class LargestFirstMemoryManagerTest {
 
   private ServerContext context;
 
-  @Before
+  @BeforeEach
   public void mockServerInfo() {
     context = createMock(ServerContext.class);
     AccumuloConfiguration conf = createMock(AccumuloConfiguration.class);

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/AccumuloReplicaSystemTest.java
@@ -22,9 +22,9 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -57,7 +57,7 @@ import org.apache.accumulo.tserver.logger.LogFileKey;
 import org.apache.accumulo.tserver.logger.LogFileValue;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class AccumuloReplicaSystemTest {
@@ -321,8 +321,8 @@ public class AccumuloReplicaSystemTest {
 
     assertEquals("row", new String(m.getRow()));
     assertEquals(1, m.getReplicationSources().size());
-    assertTrue("Expected source cluster to be listed in mutation replication source",
-        m.getReplicationSources().contains("source"));
+    assertTrue(m.getReplicationSources().contains("source"),
+        "Expected source cluster to be listed in mutation replication source");
   }
 
   @Test

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/BatchWriterReplicationReplayerTest.java
@@ -39,9 +39,9 @@ import org.apache.accumulo.core.replication.thrift.WalEdits;
 import org.apache.accumulo.server.data.ServerMutation;
 import org.apache.accumulo.tserver.logger.LogEvents;
 import org.apache.accumulo.tserver.logger.LogFileKey;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
 
@@ -52,7 +52,7 @@ public class BatchWriterReplicationReplayerTest {
   private AccumuloConfiguration conf;
   private BatchWriter bw;
 
-  @Before
+  @BeforeEach
   public void setUpContext() {
     conf = createMock(AccumuloConfiguration.class);
     bw = createMock(BatchWriter.class);
@@ -60,7 +60,7 @@ public class BatchWriterReplicationReplayerTest {
     expect(context.getConfiguration()).andReturn(conf).anyTimes();
   }
 
-  @After
+  @AfterEach
   public void verifyMock() {
     verify(context, conf, bw);
   }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/replication/ReplicationProcessorTest.java
@@ -24,8 +24,8 @@ import static org.easymock.EasyMock.createMockBuilder;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
 
@@ -39,7 +39,7 @@ import org.apache.accumulo.server.replication.ReplicaSystem;
 import org.apache.accumulo.server.replication.ReplicaSystemHelper;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class ReplicationProcessorTest {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplFileManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplFileManagerTest.java
@@ -23,10 +23,10 @@ import static org.apache.accumulo.core.spi.compaction.CompactionKind.SELECTOR;
 import static org.apache.accumulo.core.spi.compaction.CompactionKind.SYSTEM;
 import static org.apache.accumulo.core.spi.compaction.CompactionKind.USER;
 import static org.apache.accumulo.tserver.tablet.CompactableImplFileManagerTest.TestFileManager.SELECTION_EXPIRATION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -47,7 +47,7 @@ import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.tserver.tablet.CompactableImpl.ChopSelectionStatus;
 import org.apache.accumulo.tserver.tablet.CompactableImpl.FileManager.ChopSelector;
 import org.apache.accumulo.tserver.tablet.CompactableImpl.FileSelectionStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplTest.java
@@ -20,8 +20,8 @@ package org.apache.accumulo.tserver.tablet;
 
 import static org.apache.accumulo.tserver.tablet.CompactableImplFileManagerTest.newFile;
 import static org.apache.accumulo.tserver.tablet.CompactableImplFileManagerTest.newFiles;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
 import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.util.compaction.CompactionExecutorIdImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompactableImplTest {
   private static ExternalCompactionMetadata newECM(Set<StoredTabletFile> jobFiles,

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletMutationPrepAttemptTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletMutationPrepAttemptTest.java
@@ -19,10 +19,10 @@
 package org.apache.accumulo.tserver.tablet;
 
 import static org.easymock.EasyMock.mock;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.constraints.Violations;
 import org.apache.accumulo.core.data.Mutation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TabletMutationPrepAttemptTest {
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/TabletTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.tserver.tablet;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 
@@ -26,7 +26,7 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.tserver.compaction.CompactionPlan;
 import org.apache.accumulo.tserver.compaction.WriteParameters;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TabletTest {


### PR DESCRIPTION
This PR converts all tests in the `tserver` module from JUnit4 to JUnit5 Jupiter tests.

All tests in the module pass before and after these changes.