### PR TITLE
Fix CleanUpIT failure

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -104,7 +104,7 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
 
   private synchronized void ensureOpen() {
     if (closed)
-      throw new IllegalArgumentException("Scanner is closed");
+      throw new IllegalStateException("Scanner is closed");
   }
 
   public ScannerImpl(ClientContext context, TableId tableId, Authorizations authorizations) {


### PR DESCRIPTION
* Throw correct runtime exception when accessing a closed scanner
  (should be an illegal state, not an illegal argument)
* Close the scanner before closing the client in CleanUpIT because
  closing the scanner requires the client to not be closed in order to
  execute cleanup tasks without blocking