### PR TITLE
Mark BulkImport v1 server side code as deprecated

### DIFF
--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateOperation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateOperation.java
@@ -34,6 +34,7 @@ public enum FateOperation implements org.apache.thrift.TEnum {
   TABLE_OFFLINE(5),
   TABLE_MERGE(6),
   TABLE_DELETE_RANGE(7),
+  @Deprecated
   TABLE_BULK_IMPORT(8),
   TABLE_COMPACT(9),
   TABLE_IMPORT(10),

--- a/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/BulkImporter.java
@@ -70,6 +70,7 @@ import org.apache.thrift.TServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
 public class BulkImporter {
 
   private static final Logger log = LoggerFactory.getLogger(BulkImporter.class);

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -324,6 +324,7 @@ public class ClientServiceHandler implements ClientService.Iface {
   }
 
   @Override
+  @Deprecated
   public List<String> bulkImportFiles(TInfo tinfo, final TCredentials credentials, final long tid,
       final String tableId, final List<String> files, final String errorDir, final boolean setTime)
       throws ThriftSecurityException, ThriftTableOperationException, TException {

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
+@Deprecated
 public class BulkImporterTest {
 
   static final SortedSet<KeyExtent> fakeMetaData = new TreeSet<>();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -110,6 +110,7 @@ class FateServiceHandler implements FateService.Iface {
     return manager.fate.startTransaction();
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void executeFateOperation(TInfo tinfo, TCredentials c, long opid, FateOperation op,
       List<ByteBuffer> arguments, Map<String,String> options, boolean autoCleanup)

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
@@ -72,6 +72,7 @@ import com.google.common.annotations.VisibleForTesting;
  * about the request. To prevent problems like this, an Arbitrator is used. Before starting any new
  * request, the tablet server checks the Arbitrator to see if the request is still valid.
  */
+@Deprecated
 public class BulkImport extends ManagerRepo {
   public static final String FAILURES_TXT = "failures.txt";
 
@@ -199,7 +200,6 @@ public class BulkImport extends ManagerRepo {
     final UniqueNameAllocator namer = manager.getUniqueNameAllocator();
 
     AccumuloConfiguration serverConfig = manager.getConfiguration();
-    @SuppressWarnings("deprecation")
     ExecutorService workers = ThreadPools.getServerThreadPools().createExecutorService(serverConfig,
         serverConfig.resolve(Property.MANAGER_RENAME_THREADS, Property.MANAGER_BULK_RENAME_THREADS),
         false);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
 public class CleanUpBulkImport extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CompleteBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CompleteBulkImport.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 
+@Deprecated
 public class CompleteBulkImport extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CopyFailed.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CopyFailed.java
@@ -52,6 +52,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
 class CopyFailed extends ManagerRepo {
   private static final Logger log = LoggerFactory.getLogger(CopyFailed.class);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/LoadFiles.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
 class LoadFiles extends ManagerRepo {
 
   private static final long serialVersionUID = 1L;

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkFailureIT.java
@@ -77,6 +77,7 @@ import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class BulkFailureIT extends AccumuloClusterHarness {
 
   interface Loader {


### PR DESCRIPTION
Marked BulkImport v1 server side components as deprecated for easy identification and removal in 3.0