### PR TITLE
Migrate manager module to JUnit5

### DIFF
--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -124,8 +124,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/server/manager/src/test/java/org/apache/accumulo/manager/WithTestNames.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/WithTestNames.java
@@ -16,35 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.manager.metrics.fate;
+package org.apache.accumulo.manager;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
-import org.junit.jupiter.api.Test;
+// This is only for the unit tests and integration tests in this module
+// It must be copied for use in other modules, because tests in one module
+// don't have dependencies on other modules, and we can't put this in a
+// regular, non-test jar, because we don't want to add a dependency on
+// JUnit in a non-test jar
+public class WithTestNames {
 
-public class FateMetricValuesTest {
+  private String testName;
 
-  @Test
-  public void defaultValueTest() {
-
-    FateMetricValues v = FateMetricValues.builder().build();
-
-    assertEquals(0, v.getCurrentFateOps());
-    assertEquals(0, v.getZkFateChildOpsTotal());
-    assertEquals(0, v.getZkConnectionErrors());
+  @BeforeEach
+  public void setTestName(TestInfo info) {
+    testName = info.getTestMethod().get().getName();
   }
 
-  @Test
-  public void valueTest() {
-
-    FateMetricValues.Builder builder = FateMetricValues.builder();
-
-    FateMetricValues v =
-        builder.withCurrentFateOps(1).withZkFateChildOpsTotal(2).withZkConnectionErrors(3).build();
-
-    assertEquals(1, v.getCurrentFateOps());
-    assertEquals(2, v.getZkFateChildOpsTotal());
-    assertEquals(3, v.getZkConnectionErrors());
-
+  protected String testName() {
+    return testName;
   }
+
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/metrics/ReplicationMetricsTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/metrics/ReplicationMetricsTest.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.server.replication.ReplicationUtil;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssignerHelperTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/DistributedWorkQueueWorkAssignerHelperTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.manager.replication;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map.Entry;
 import java.util.UUID;
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.replication.ReplicationTarget;
 import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHelper;
 import org.apache.hadoop.fs.Path;
 import org.apache.zookeeper.common.PathUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class DistributedWorkQueueWorkAssignerHelperTest {

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/ManagerReplicationCoordinatorTest.java
@@ -22,8 +22,8 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.TreeSet;
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.server.ServerContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class ManagerReplicationCoordinatorTest {

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/SequentialWorkAssignerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/SequentialWorkAssignerTest.java
@@ -22,7 +22,7 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -38,8 +38,8 @@ import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHelper;
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class SequentialWorkAssignerTest {
@@ -47,7 +47,7 @@ public class SequentialWorkAssignerTest {
   private AccumuloClient client;
   private SequentialWorkAssigner assigner;
 
-  @Before
+  @BeforeEach
   public void init() {
     AccumuloConfiguration conf = createMock(AccumuloConfiguration.class);
     client = createMock(AccumuloClient.class);

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/UnorderedWorkAssignerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/UnorderedWorkAssignerTest.java
@@ -23,8 +23,8 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -44,18 +44,18 @@ import org.apache.accumulo.fate.zookeeper.ZooCache;
 import org.apache.accumulo.server.replication.DistributedWorkQueueWorkAssignerHelper;
 import org.apache.accumulo.server.zookeeper.DistributedWorkQueue;
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
-@Ignore("Replication Tests are not stable and not currently maintained")
+@Disabled("Replication Tests are not stable and not currently maintained")
 public class UnorderedWorkAssignerTest {
 
   private AccumuloClient client;
   private UnorderedWorkAssigner assigner;
 
-  @Before
+  @BeforeEach
   public void init() {
     AccumuloConfiguration conf = createMock(AccumuloConfiguration.class);
     client = createMock(AccumuloClient.class);
@@ -105,9 +105,9 @@ public class UnorderedWorkAssignerTest {
     verify(workQueue);
 
     Set<String> queuedWork = assigner.getQueuedWork();
-    assertEquals("Expected existing work and queued work to be the same size", existingWork.size(),
-        queuedWork.size());
-    assertTrue("Expected all existing work to be queued", queuedWork.containsAll(existingWork));
+    assertEquals(existingWork.size(), queuedWork.size(),
+        "Expected existing work and queued work to be the same size");
+    assertTrue(queuedWork.containsAll(existingWork), "Expected all existing work to be queued");
   }
 
   @Test
@@ -132,7 +132,7 @@ public class UnorderedWorkAssignerTest {
     assigner.cleanupFinishedWork();
 
     verify(cache, client);
-    assertTrue("Queued work was not emptied", queuedWork.isEmpty());
+    assertTrue(queuedWork.isEmpty(), "Queued work was not emptied");
   }
 
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/replication/WorkMakerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/replication/WorkMakerTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.accumulo.manager.replication;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.accumulo.server.replication.StatusUtil;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @Deprecated
 public class WorkMakerTest {

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/ShutdownTServerTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/ShutdownTServerTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.manager.tableOps;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,7 +34,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tserverOps.ShutdownTServer;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShutdownTServerTest {
 
@@ -64,7 +65,7 @@ public class ShutdownTServerTest {
 
     // FATE op is not ready
     long wait = op.isReady(tid, manager);
-    assertTrue("Expected wait to be greater than 0", wait > 0);
+    assertTrue(wait > 0, "Expected wait to be greater than 0");
 
     EasyMock.verify(tserverCnxn, manager);
 
@@ -86,10 +87,10 @@ public class ShutdownTServerTest {
 
     // FATE op is not ready
     wait = op.isReady(tid, manager);
-    assertTrue("Expected wait to be 0", wait == 0);
+    assertEquals(0, wait, "Expected wait to be 0");
 
     Repo<Manager> op2 = op.call(tid, manager);
-    assertNull("Expected no follow on step", op2);
+    assertNull(op2, "Expected no follow on step");
 
     EasyMock.verify(tserverCnxn, manager);
   }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/bulkVer2/PrepBulkImportTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.bulkVer2;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,7 +46,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.manager.tableOps.bulkVer2.PrepBulkImport.TabletIterFactory;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -150,8 +150,8 @@ public class PrepBulkImportTest {
   public void runExceptionTest(List<KeyExtent> loadRanges, List<KeyExtent> tabletRanges) {
     String message = "expected " + toRangeStrings(loadRanges) + " to fail against "
         + toRangeStrings(tabletRanges);
-    assertThrows(message, AcceptableThriftTableOperationException.class,
-        () -> runTest(loadRanges, tabletRanges));
+    assertThrows(AcceptableThriftTableOperationException.class,
+        () -> runTest(loadRanges, tabletRanges), message);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class PrepBulkImportTest {
   }
 
   @Test
-  public void testException() throws Exception {
+  public void testException() {
     for (List<KeyExtent> loadRanges : powerSet(nke(null, "b"), nke("b", "m"), nke("m", "r"),
         nke("r", "v"), nke("v", null))) {
 
@@ -274,6 +274,6 @@ public class PrepBulkImportTest {
     var exception = assertThrows(ThriftTableOperationException.class,
         () -> runTest(loadRanges, createExtents(tablets), maxTablets));
     String message = exception.toString();
-    assertTrue(expectedMessage + " -- " + message, exception.toString().contains(expectedMessage));
+    assertTrue(exception.toString().contains(expectedMessage), expectedMessage + " -- " + message);
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriverTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.manager.tableOps.compact;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
 
@@ -35,7 +35,7 @@ import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.delete.PreDeleteTable;
 import org.apache.accumulo.server.ServerContext;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompactionDriverTest {
 
@@ -69,10 +69,10 @@ public class CompactionDriverTest {
     var e = assertThrows(AcceptableThriftTableOperationException.class,
         () -> driver.isReady(tableIdLong, manager));
 
-    assertTrue(e.getTableId().equals(tableId.toString()));
-    assertTrue(e.getOp().equals(TableOperation.COMPACT));
-    assertTrue(e.getType().equals(TableOperationExceptionType.OTHER));
-    assertTrue(e.getDescription().equals(TableOperationsImpl.COMPACTION_CANCELED_MSG));
+    assertEquals(e.getTableId(), tableId.toString());
+    assertEquals(e.getOp(), TableOperation.COMPACT);
+    assertEquals(e.getType(), TableOperationExceptionType.OTHER);
+    assertEquals(TableOperationsImpl.COMPACTION_CANCELED_MSG, e.getDescription());
 
     EasyMock.verify(manager, ctx, zrw);
   }
@@ -110,10 +110,10 @@ public class CompactionDriverTest {
     var e = assertThrows(AcceptableThriftTableOperationException.class,
         () -> driver.isReady(tableIdLong, manager));
 
-    assertTrue(e.getTableId().equals(tableId.toString()));
-    assertTrue(e.getOp().equals(TableOperation.COMPACT));
-    assertTrue(e.getType().equals(TableOperationExceptionType.OTHER));
-    assertTrue(e.getDescription().equals(TableOperationsImpl.TABLE_DELETED_MSG));
+    assertEquals(e.getTableId(), tableId.toString());
+    assertEquals(e.getOp(), TableOperation.COMPACT);
+    assertEquals(e.getType(), TableOperationExceptionType.OTHER);
+    assertEquals(TableOperationsImpl.TABLE_DELETED_MSG, e.getDescription());
 
     EasyMock.verify(manager, ctx, zrw);
   }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTableTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/tableOps/tableImport/ImportTableTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.accumulo.manager.tableOps.tableImport;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
 import java.util.List;
@@ -37,7 +37,7 @@ import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
 import org.apache.hadoop.fs.Path;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ImportTableTest {
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/AccumuloTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/AccumuloTest.java
@@ -21,8 +21,8 @@ package org.apache.accumulo.manager.upgrade;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
 
@@ -37,8 +37,8 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
 
@@ -47,7 +47,7 @@ public class AccumuloTest {
   private Path path;
   private ServerDirs serverDirs;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     fs = createMock(FileSystem.class);
     path = createMock(Path.class);

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader9to10Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader9to10Test.java
@@ -24,10 +24,10 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -64,7 +64,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -194,8 +194,8 @@ public class Upgrader9to10Test {
     List<Mutation> results = new ArrayList<>();
 
     setupMocks(c, fs, map, results);
-    assertFalse("Invalid Relative path check",
-        Upgrader9to10.checkForRelativePaths(c, fs, tableName, volumeUpgrade));
+    assertFalse(Upgrader9to10.checkForRelativePaths(c, fs, tableName, volumeUpgrade),
+        "Invalid Relative path check");
     assertTrue(results.isEmpty());
   }
 
@@ -333,7 +333,7 @@ public class Upgrader9to10Test {
       }
     }
 
-    assertEquals("Replacements should have update for every delete", deleteCount, updateCount);
+    assertEquals(deleteCount, updateCount, "Replacements should have update for every delete");
   }
 
   @Test


### PR DESCRIPTION
This PR migrates the tests in server/manager module from JUnit4 to JUnit5.

All tests pass before and after these changes.

Part of #2441 