### PR TITLE
Add trace and debug log to consistency check

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -656,6 +656,8 @@ public enum Property {
       "1.4.0"),
   TSERV_BULK_TIMEOUT("tserver.bulk.timeout", "5m", PropertyType.TIMEDURATION,
       "The time to wait for a tablet server to process a bulk import request.", "1.4.3"),
+  TSERV_HEALTH_CHECK_FREQ("tserver.health.check.interval", "30m", PropertyType.TIMEDURATION,
+      "The time between tablet server health checks.", "2.1.0"),
   TSERV_MINTHREADS("tserver.server.threads.minimum", "20", PropertyType.COUNT,
       "The minimum number of threads to use to handle incoming requests.", "1.4.0"),
   TSERV_MINTHREADS_TIMEOUT("tserver.server.threads.timeout", "0s", PropertyType.TIMEDURATION,

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -166,6 +166,13 @@ public class ThreadPools {
     CRITICAL_RUNNING_TASKS.add(future);
   }
 
+  public static void watchCriticalFixedDelay(AccumuloConfiguration aconf, long intervalMillis,
+      Runnable runnable) {
+    ScheduledFuture<?> future = getServerThreadPools().createGeneralScheduledExecutorService(aconf)
+        .scheduleWithFixedDelay(runnable, intervalMillis, intervalMillis, TimeUnit.MILLISECONDS);
+    CRITICAL_RUNNING_TASKS.add(future);
+  }
+
   public static void watchNonCriticalScheduledTask(ScheduledFuture<?> future) {
     NON_CRITICAL_RUNNING_TASKS.add(future);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -836,12 +836,13 @@ public class TabletServer extends AbstractServer {
               duration = Duration.between(start, Instant.now());
 
               // for each tablet, compare its metadata to what is held in memory
-              tabletsMetadata.forEach(tabletMetadata -> {
+              for (var tabletMetadata : tabletsMetadata) {
+                tabletCount++;
                 KeyExtent extent = tabletMetadata.getExtent();
                 Tablet tablet = onlineTabletsSnapshot.get(extent);
                 Long counter = updateCounts.get(extent);
                 tablet.compareTabletInfo(counter, tabletMetadata);
-              });
+              }
 
               log.debug("Metadata scan took {}ms for {} tablets read.", duration.toMillis(),
                   tabletCount);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -847,7 +847,7 @@ public class TabletServer extends AbstractServer {
           }
 
           log.debug("Metadata scan took {}ms for {} tablets read.", duration.toMillis(),
-              tabletCount);
+              onlineTabletsSnapshot.keySet().size());
         }
       }
     });


### PR DESCRIPTION
* Closes #2577 
* Add trace span and time measurement around consistency check
so we get an idea of how long metadata scans are taking
* Create new property tserver.health.check.interval to make it configurable
* Create new method watchCriticalFixedDelay() in ThreadPools 