### PR TITLE
Convert AccumuloUncaughtExceptionHandlerTest to JUnit5

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/util/threads/AccumuloUncaughtExceptionHandlerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/threads/AccumuloUncaughtExceptionHandlerTest.java
@@ -19,13 +19,13 @@
 package org.apache.accumulo.core.util.threads;
 
 import static org.apache.accumulo.core.util.threads.AccumuloUncaughtExceptionHandler.isError;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccumuloUncaughtExceptionHandlerTest {
 


### PR DESCRIPTION
It looks like this test was created/merged before the core module tests were fully converted to JUnit5. 

I'm thinking there should be a check for instances like these where, in modules that have already been fully converted to JUnit5, a checkstyle warning (or something similar) should be thrown to alert that JUnit5 should be used instead.