### PR TITLE
Use ServerContext.getScheduledExecutor where appropriate

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -455,9 +455,8 @@ public class ServerContext extends ClientContext {
    */
   public synchronized ScheduledThreadPoolExecutor getScheduledExecutor() {
     if (sharedScheduledThreadPool == null) {
-      sharedScheduledThreadPool =
-          (ScheduledThreadPoolExecutor) ThreadPools.getServerThreadPools().createExecutorService(
-              getConfiguration(), Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, true);
+      sharedScheduledThreadPool = ThreadPools.getServerThreadPools()
+          .createGeneralScheduledExecutorService(getConfiguration());
     }
     return sharedScheduledThreadPool;
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
@@ -64,8 +64,6 @@ public class ManagerTime {
       throw new IOException("Error updating manager time", ex);
     }
 
-    // Previous versions of this class did not use a shared thread pool, it created its own
-    // Timer instance.
     ThreadPools.watchCriticalScheduledTask(
         ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf)
             .scheduleWithFixedDelay(Threads.createNamedRunnable("Manager time keeper", () -> run()),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerTime.java
@@ -64,6 +64,8 @@ public class ManagerTime {
       throw new IOException("Error updating manager time", ex);
     }
 
+    // Previous versions of this class did not use a shared thread pool, it created its own
+    // Timer instance.
     ThreadPools.watchCriticalScheduledTask(
         ThreadPools.getServerThreadPools().createGeneralScheduledExecutorService(conf)
             .scheduleWithFixedDelay(Threads.createNamedRunnable("Manager time keeper", () -> run()),

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/session/SessionManager.java
@@ -65,8 +65,10 @@ public class SessionManager {
   private final List<Session> idleSessions = new ArrayList<>();
   private final Long expiredSessionMarker = (long) -1;
   private final AccumuloConfiguration aconf;
+  private final ServerContext ctx;
 
   public SessionManager(ServerContext context) {
+    this.ctx = context;
     this.aconf = context.getConfiguration();
     maxUpdateIdle = aconf.getTimeInMillis(Property.TSERV_UPDATE_SESSION_MAXIDLE);
     maxIdle = aconf.getTimeInMillis(Property.TSERV_SESSION_MAXIDLE);
@@ -279,8 +281,8 @@ public class SessionManager {
         }
       };
 
-      ScheduledFuture<?> future = ThreadPools.getServerThreadPools()
-          .createGeneralScheduledExecutorService(aconf).schedule(r, delay, TimeUnit.MILLISECONDS);
+      ScheduledFuture<?> future =
+          ctx.getScheduledExecutor().schedule(r, delay, TimeUnit.MILLISECONDS);
       ThreadPools.watchNonCriticalScheduledTask(future);
     }
   }


### PR DESCRIPTION
Reviewed the direct usage of ThreadPools.createGeneralScheduledExecutorService
and compared it to the usage of Timer and SimpleTimer in version 2.0.1. Found
and fixed a case in SessionManager where a new SheduledThreadPool was being created
in each SessionManager but a shared instance of SimpleTimer was being used in
the previous version.