### PR TITLE
Add missing javadoc for exceptions thrown on invalid arguments

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -340,6 +340,8 @@ public enum ClientProperty {
   /**
    * @throws IllegalArgumentException
    *           if Properties does not contain all required
+   * @throws NullPointerException
+   *           if {@code properties == null}
    */
   public static void validate(Properties properties) {
     validate(properties, true);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataTime.java
@@ -40,6 +40,8 @@ public final class MetadataTime implements Comparable<MetadataTime> {
    * @param timestr
    *          string representation of a metatdata time, ex. "M12345678"
    * @return a MetadataTime object represented by string
+   * @throws IllegalArgumentException
+   *           if {@code timesstr == null} or {@code timestr.length() <= 1)}
    */
 
   public static MetadataTime parse(String timestr) throws IllegalArgumentException {

--- a/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ClientPropertyTest.java
@@ -78,4 +78,9 @@ public class ClientPropertyTest {
     assertThrows(IllegalStateException.class,
         () -> ClientProperty.BATCH_WRITER_LATENCY_MAX.getBytes(props));
   }
+
+  @Test
+  public void validateThrowsNPEOnNullProperties() {
+    assertThrows(NullPointerException.class, () -> ClientProperty.validate(null));
+  }
 }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/MetadataTimeTest.java
@@ -49,6 +49,17 @@ public class MetadataTimeTest {
   }
 
   @Test
+  public void testGetInstance_nullArgument() {
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.parse(null));
+  }
+
+  @Test
+  public void testGetInstance_Invalid_timestr() {
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.parse(""));
+    assertThrows(IllegalArgumentException.class, () -> MetadataTime.parse("X"));
+  }
+
+  @Test
   public void testGetInstance_Millis() {
     assertEquals(1234, m1234.getTime());
     assertEquals(TimeType.MILLIS, m1234.getType());

--- a/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java
+++ b/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java
@@ -161,7 +161,7 @@ public class SerializationUtil {
    *          the object to serialize to bytes, may be null
    * @param outputStream
    *          the stream to write to, must not be null
-   * @throws IllegalArgumentException
+   * @throws NullPointerException
    *           if {@code outputStream} is {@code null}
    */
   public static void serialize(Serializable obj, OutputStream outputStream) {


### PR DESCRIPTION
Hi! I'm working on a tool that identifies exceptions that could be thrown in given methods. It found some missing documentation and I'm submitting some to check if you find them useful.

I added a few `@throws` tags on methods that already had documentation. I also added tests when possible.
I'm assuming adding documentation to an existent javadoc could be more valuable than doing so on methods that don't have any.

In addition to missing javadoc, in `SerializationUtil` the exception was IAE when it should be a NPE. It's likely a problem originated in Commons Lang. Anyways, the class seems to be used only by `BatchWriterIterator`. So I understand if this is not the most useful change.  https://github.com/apache/accumulo/blob/69c31d48058e8fbf121ace69324f186ab56a4e70/test/src/main/java/org/apache/accumulo/test/util/SerializationUtil.java#L164-L168  

I'm happy to submit a few more javadoc additions if you find this kind of contribution valuable.
Thanks!