### PR TITLE
Add exception to catch class loading error

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/IterConfigUtil.java
@@ -233,6 +233,9 @@ public class IterConfigUtil {
       String context, IterInfo iterInfo) throws ClassNotFoundException, IOException {
     Class<SortedKeyValueIterator<Key,Value>> clazz = null;
     if (useAccumuloClassLoader) {
+      if (context == null) {
+        throw new IllegalStateException("Null context when using Accumulo class loader");
+      }
       clazz = (Class<SortedKeyValueIterator<Key,Value>>) ClassLoaderUtil.loadClass(context,
           iterInfo.className, SortedKeyValueIterator.class);
       log.trace("Iterator class {} loaded from context {}, classloader: {}", iterInfo.className,


### PR DESCRIPTION
I am not sure if this is a bug or not. I found a place in the code where `context` is null but we are trying to use the Accumulo Class Loader.