### PR TITLE
Start spans when inside a valid span

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/trace/TraceUtil.java
@@ -110,7 +110,7 @@ public class TraceUtil {
 
   private static Span startSpan(Class<?> caller, String spanName, SpanKind kind,
       Map<String,String> attributes, TInfo tinfo) {
-    if (!enabled) {
+    if (!enabled && !Span.current().getSpanContext().isValid()) {
       return Span.getInvalid();
     }
     final String name = String.format(SPAN_FORMAT, caller.getSimpleName(), spanName);
@@ -153,8 +153,7 @@ public class TraceUtil {
    */
   public static TInfo traceInfo() {
     TInfo tinfo = new TInfo();
-    W3CTraceContextPropagator.getInstance().inject(Context.current(), tinfo,
-        (carrier, key, value) -> carrier.putToHeaders(key, value));
+    W3CTraceContextPropagator.getInstance().inject(Context.current(), tinfo, TInfo::putToHeaders);
     return tinfo;
   }
 


### PR DESCRIPTION
Start a span, even if tracing is disabled on our end, if we find our
code inside a valid span. This implies that we're running inside a
user's span, started in user code.

This prevents us from needing to expose Accumulo internal
enabling/disabling utilities to client code. Users can enable
client-side tracing merely by wrapping our code with their own valid
spans.