### PR TITLE
Minor cleanup of ThriftTransportPool

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -1014,11 +1014,14 @@ public class ClientContext implements AccumuloClient {
     return zooReader;
   }
 
+  protected long getTransportPoolMaxAgeMillis() {
+    return 3000; // 3 seconds for clients
+  }
+
   public synchronized ThriftTransportPool getTransportPool() {
     ensureOpen();
     if (thriftTransportPool == null) {
-      thriftTransportPool = new ThriftTransportPool();
-      thriftTransportPool.startCheckerThread();
+      thriftTransportPool = ThriftTransportPool.startNew(getTransportPoolMaxAgeMillis());
     }
     return thriftTransportPool;
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -1014,14 +1014,10 @@ public class ClientContext implements AccumuloClient {
     return zooReader;
   }
 
-  protected long getTransportPoolMaxAgeMillis() {
-    return 3000; // 3 seconds for clients
-  }
-
   public synchronized ThriftTransportPool getTransportPool() {
     ensureOpen();
     if (thriftTransportPool == null) {
-      thriftTransportPool = ThriftTransportPool.startNew(getTransportPoolMaxAgeMillis());
+      thriftTransportPool = ThriftTransportPool.startNew(this::getClientTimeoutInMillis);
     }
     return thriftTransportPool;
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientConfConverterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientConfConverterTest.java
@@ -18,11 +18,16 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Properties;
 
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ClientProperty;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.conf.Property;
 import org.junit.jupiter.api.Test;
 
 public class ClientConfConverterTest {
@@ -43,5 +48,20 @@ public class ClientConfConverterTest {
 
     Properties after = ClientConfConverter.toProperties(ClientConfConverter.toClientConf(before));
     assertEquals(before, after);
+  }
+
+  // this test ensures a general property can be set and used by a client
+  @Test
+  public void testGeneralPropsWorkAsClientProperties() {
+    Property prop = Property.GENERAL_RPC_TIMEOUT;
+    Properties fromUser = new Properties();
+    fromUser.setProperty(prop.getKey(), "5s");
+    AccumuloConfiguration converted = ClientConfConverter.toAccumuloConf(fromUser);
+
+    // verify that converting client props actually picked up and overrode the default
+    assertNotEquals(converted.getTimeInMillis(prop),
+        DefaultConfiguration.getInstance().getTimeInMillis(prop));
+    // verify that it was set to the expected value set in the client props
+    assertEquals(SECONDS.toMillis(5), converted.getTimeInMillis(prop));
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -461,9 +461,4 @@ public class ServerContext extends ClientContext {
     return sharedScheduledThreadPool;
   }
 
-  @Override
-  protected long getTransportPoolMaxAgeMillis() {
-    return getConfiguration().getTimeInMillis(Property.GENERAL_RPC_TIMEOUT);
-  }
-
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -461,4 +461,9 @@ public class ServerContext extends ClientContext {
     return sharedScheduledThreadPool;
   }
 
+  @Override
+  protected long getTransportPoolMaxAgeMillis() {
+    return getConfiguration().getTimeInMillis(Property.GENERAL_RPC_TIMEOUT);
+  }
+
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -382,7 +382,6 @@ public class Manager extends AbstractServer
     log.info("Version {}", Constants.VERSION);
     log.info("Instance {}", getInstanceID());
     timeKeeper = new ManagerTime(this, aconf);
-    context.getTransportPool().setIdleTime(aconf.getTimeInMillis(Property.GENERAL_RPC_TIMEOUT));
     tserverSet = new LiveTServerSet(context, this);
     initializeBalancer();
 


### PR DESCRIPTION
* Remove unnecessary memoization of the checker thread
* Inline the Closer Runnable type and make it a lambda
* Use primitive long for `ERROR_THRESHOLD`
* Reorder all the class members before all the inner-classes, and place
  the fields above the methods to make it easier to navigate the class
* Make constructor private and use a static method to construct and
  start the checker thread after construction, then return the instance
* Make ThriftTransportPool immutable by passing in the maximum age of
  idle transports, rather than setting it after it is constructed; this
  also changes the default to the general purpose RPC timeout config
  value for all servers, rather than just the manager; clients continue
  to use the hard-coded 3 seconds, just as before this change