### PR TITLE
MiniAccumuloCluster improvements

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloCluster.java
+++ b/minicluster/src/main/java/org/apache/accumulo/minicluster/MiniAccumuloCluster.java
@@ -162,7 +162,7 @@ public class MiniAccumuloCluster implements AutoCloseable {
   }
 
   /**
-   * @return Connection properties for cluster
+   * @return A copy of the connection properties for the cluster
    * @since 2.0.0
    */
   public Properties getClientProperties() {


### PR DESCRIPTION
* Use a memoized Supplier to lazily load client properties and server
  context and remove now unnecessary synchronization for these
* Make a protective copy of the client properties when returning in the
  public API method, getClientProperties(), and update javadoc
* Make fields final where possible
* Relocate constructors to just under the fields, prior to other
  methods, for easier class navigation

This fixes #2619