### PR TITLE
Create child ITs to SslIT

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/SslIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SslIT.java
@@ -37,7 +37,7 @@ public class SslIT extends ConfigurableMacBase {
 
   @Override
   protected Duration defaultTimeout() {
-    return Duration.ofMinutes(6);
+    return Duration.ofMinutes(2);
   }
 
   @Override
@@ -47,8 +47,10 @@ public class SslIT extends ConfigurableMacBase {
         getSslDir(createTestDir(this.getClass().getName() + "_" + this.testName())));
   }
 
-  @Test
-  public void binary() throws Exception {
+  /**
+   * Test run in SslWithBinaryIT and SslWithClientAuthIT
+   */
+  protected void binary() throws Exception {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = getUniqueNames(1)[0];
       client.tableOperations().create(tableName);
@@ -70,8 +72,10 @@ public class SslIT extends ConfigurableMacBase {
     }
   }
 
-  @Test
-  public void bulk() throws Exception {
+  /**
+   * Test run in SslWithBulkIT and SslWithClientAuthIT
+   */
+  protected void bulk() throws Exception {
     Properties props = getClientProperties();
     try (AccumuloClient client = Accumulo.newClient().from(props).build()) {
       BulkIT.runTest(client, cluster.getFileSystem(),

--- a/test/src/main/java/org/apache/accumulo/test/functional/SslWithBinaryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SslWithBinaryIT.java
@@ -19,19 +19,14 @@
 package org.apache.accumulo.test.functional;
 
 import java.time.Duration;
-import java.util.Map;
 
-import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
-/**
- * Run all the same tests as SslIT, but with client auth turned on.
- *
- * All the methods are overridden just to make it easier to run individual tests from an IDE.
- */
-public class SslWithClientAuthIT extends SslIT {
+public class SslWithBinaryIT extends SslWithClientAuthIT {
 
   @Override
   protected Duration defaultTimeout() {
@@ -41,37 +36,17 @@ public class SslWithClientAuthIT extends SslIT {
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
     super.configure(cfg, hadoopCoreSite);
-    Map<String,String> site = cfg.getSiteConfig();
-    site.put(Property.INSTANCE_RPC_SSL_CLIENT_AUTH.getKey(), "true");
-    cfg.setSiteConfig(site);
+    configureForSsl(cfg,
+        getSslDir(createTestDir(this.getClass().getName() + "_" + this.testName())));
   }
 
-  @Override
   @Test
   public void binary() throws Exception {
-    super.binary();
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+      String tableName = getUniqueNames(1)[0];
+      client.tableOperations().create(tableName);
+      BinaryIT.runTest(client, tableName);
+    }
   }
 
-  @Override
-  @Test
-  public void concurrency() throws Exception {
-    super.concurrency();
-  }
-
-  @Override
-  @Test
-  public void adminStop() throws Exception {
-    super.adminStop();
-  }
-
-  @Test
-  public void bulk() throws Exception {
-    super.bulk();
-  }
-
-  @Override
-  @Test
-  public void mapReduce() throws Exception {
-    super.mapReduce();
-  }
 }


### PR DESCRIPTION
* Closes #2626
* Create 2 new ITs that extend SslWithClientAuthIT.
* Make SslWithBinaryIT and SslWithBulkIT children of the other ssl related ITs so we can better
control the timeouts between the tests