### PR TITLE
Fix ThriftTransportPool client idle timeout default

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -1014,10 +1014,15 @@ public class ClientContext implements AccumuloClient {
     return zooReader;
   }
 
+  protected long getTransportPoolMaxAgeMillis() {
+    ensureOpen();
+    return ClientProperty.RPC_TRANSPORT_IDLE_TIMEOUT.getTimeInMillis(getProperties());
+  }
+
   public synchronized ThriftTransportPool getTransportPool() {
     ensureOpen();
     if (thriftTransportPool == null) {
-      thriftTransportPool = ThriftTransportPool.startNew(this::getClientTimeoutInMillis);
+      thriftTransportPool = ThriftTransportPool.startNew(this::getTransportPoolMaxAgeMillis);
     }
     return thriftTransportPool;
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -106,7 +106,7 @@ public class ThriftTransportPool {
    */
   static ThriftTransportPool startNew(LongSupplier maxAgeMillis) {
     var pool = new ThriftTransportPool(maxAgeMillis);
-    log.debug("Set thrift transport pool idle time to {}", maxAgeMillis);
+    log.debug("Set thrift transport pool idle time to {}ms", maxAgeMillis.getAsLong());
     pool.checkThread.start();
     return pool;
   }

--- a/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ClientProperty.java
@@ -122,6 +122,11 @@ public enum ClientProperty {
   SASL_KERBEROS_SERVER_PRIMARY("sasl.kerberos.server.primary", "accumulo",
       "Kerberos principal/primary that Accumulo servers use to login"),
 
+  // RPC
+  RPC_TRANSPORT_IDLE_TIMEOUT("rpc.transport.idle.timeout", "3s", PropertyType.TIMEDURATION,
+      "The maximum duration to leave idle transports open in the client's transport pool", "2.1.0",
+      false),
+
   // Trace
   @Deprecated(since = "2.1.0", forRemoval = true)
   TRACE_SPAN_RECEIVERS("trace.span.receivers", "org.apache.accumulo.tracer.ZooTraceClient",

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -461,4 +461,9 @@ public class ServerContext extends ClientContext {
     return sharedScheduledThreadPool;
   }
 
+  @Override
+  protected long getTransportPoolMaxAgeMillis() {
+    return getClientTimeoutInMillis();
+  }
+
 }


### PR DESCRIPTION
* Create new client-side property for ThriftTransportPool's idle
  transport timeout. This allows the default value for clients to be
  configured independently of the default value for servers.
* Set default value for clients back to 3 seconds, like it was
  hard-coded prior to the changes in #2612
* Fix debug logging of the transport pool idle time value

This fixes #2626