### PR TITLE
Replace iterator usage

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -131,7 +131,6 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
         setOptions((ScannerOptions) scanner, opts);
 
         return scanner.iterator();
-        // return new FaultyIterator(scanner.iterator());
       }
     }
 

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client.rfile;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -521,10 +522,8 @@ public class RFileClientTest {
 
     random.ints(100, 0, 10_000).forEach(r -> {
       scanner.setRange(new Range(rowStr(r)));
-      Iterator<Entry<Key,Value>> iter = scanner.iterator();
-      assertTrue(iter.hasNext());
-      assertEquals(rowStr(r), iter.next().getKey().getRow().toString());
-      assertFalse(iter.hasNext());
+      String actual = scanner.stream().collect(onlyElement()).getKey().getRow().toString();
+      assertEquals(rowStr(r), actual);
     });
 
     scanner.close();

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloOutputFormatIT.java
@@ -18,16 +18,14 @@
  */
 package org.apache.accumulo.hadoop.its.mapred;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -217,11 +215,9 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int i = scanner.stream().map(entry -> Integer.parseInt(new String(entry.getValue().get())))
+            .collect(onlyElement());
+        assertEquals(100, i);
       }
     }
   }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/TokenFileIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.hadoop.its.mapred;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,8 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Paths;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -170,11 +168,9 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int i = scanner.stream().map(entry -> Integer.parseInt(new String(entry.getValue().get())))
+            .collect(onlyElement());
+        assertEquals(100, i);
       }
     }
   }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloOutputFormatIT.java
@@ -18,15 +18,12 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -144,11 +141,9 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int i = scanner.stream().map(entry -> Integer.parseInt(new String(entry.getValue().get())))
+            .collect(onlyElement());
+        assertEquals(100, i);
       }
     }
   }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,8 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Paths;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -164,11 +162,9 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int i = scanner.stream().map(entry -> Integer.parseInt(new String(entry.getValue().get())))
+            .collect(onlyElement());
+        assertEquals(100, i);
       }
     }
   }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/TokenFileIT.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -144,13 +145,13 @@ public class TokenFileIT extends AccumuloClusterHarness {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
-      BatchWriter bw = c.createBatchWriter(table1);
-      for (int i = 0; i < 100; i++) {
-        Mutation m = new Mutation(new Text(String.format("%09x", i + 1)));
-        m.put("", "", String.format("%09x", i));
-        bw.addMutation(m);
+      try (BatchWriter bw = c.createBatchWriter(table1)) {
+        for (int i = 0; i < 100; i++) {
+          Mutation m = new Mutation(new Text(String.format("%09x", i + 1)));
+          m.put("", "", String.format("%09x", i));
+          bw.addMutation(m);
+        }
       }
-      bw.close();
 
       File tf = new File(tempDir, "client.properties");
       assertTrue(tf.createNewFile(), "Failed to create file: " + tf);
@@ -162,8 +163,8 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        int i = scanner.stream().map(entry -> Integer.parseInt(new String(entry.getValue().get())))
-            .collect(onlyElement());
+        int i = scanner.stream().map(Map.Entry::getValue).map(Value::get).map(String::new)
+            .map(Integer::parseInt).collect(onlyElement());
         assertEquals(100, i);
       }
     }

--- a/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestBase.java
+++ b/iterator-test-harness/src/main/java/org/apache/accumulo/iteratortest/IteratorTestBase.java
@@ -69,8 +69,6 @@ public abstract class IteratorTestBase {
     Set<ClassInfo> classes = cp.getTopLevelClasses(searchPackage);
 
     final List<IteratorTestCase> testCases1 = new ArrayList<>();
-    // final Set<Class<? extends IteratorTestCase>> classes =
-    // reflections.getSubTypesOf(IteratorTestCase.class);
     for (ClassInfo classInfo : classes) {
       Class<?> clz;
       try {

--- a/test/src/main/java/org/apache/accumulo/test/IsolationAndDeepCopyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/IsolationAndDeepCopyIT.java
@@ -18,12 +18,8 @@
  */
 package org.apache.accumulo.test;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -31,9 +27,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.IntersectingIterator;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -71,10 +65,9 @@ public class IsolationAndDeepCopyIT extends AccumuloClusterHarness {
         scanner.addScanIterator(iterCfg);
 
         for (int i = 0; i < 100; i++) {
-          Iterator<Entry<Key,Value>> iter = scanner.iterator();
-          assertTrue(iter.hasNext());
-          assertEquals("000A", iter.next().getKey().getColumnQualifierData().toString());
-          assertFalse(iter.hasNext());
+          String actual =
+              scanner.stream().collect(onlyElement()).getKey().getColumnQualifierData().toString();
+          assertEquals("000A", actual);
         }
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/IsolationAndDeepCopyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/IsolationAndDeepCopyIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -65,8 +64,7 @@ public class IsolationAndDeepCopyIT extends AccumuloClusterHarness {
         scanner.addScanIterator(iterCfg);
 
         for (int i = 0; i < 100; i++) {
-          String actual =
-              scanner.stream().collect(onlyElement()).getKey().getColumnQualifierData().toString();
+          String actual = getOnlyElement(scanner).getKey().getColumnQualifierData().toString();
           assertEquals("000A", actual);
         }
       }

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -47,8 +47,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Iterators;
-
 public class SplitRecoveryIT extends AccumuloClusterHarness {
 
   @Override
@@ -67,7 +65,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
     try (Scanner scanner = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
       scanner.setRange(new Range(new Text(tableId + ";"), new Text(tableId + "<")));
       scanner.fetchColumnFamily(CurrentLocationColumnFamily.NAME);
-      return Iterators.size(scanner.iterator()) == 0;
+      return scanner.stream().findAny().isEmpty();
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
@@ -67,7 +67,7 @@ public class BigRootTabletIT extends AccumuloClusterHarness {
       cluster.stop();
       cluster.start();
       assertTrue(
-          Iterators.size(c.createScanner(RootTable.NAME, Authorizations.EMPTY).iterator()) > 0);
+          c.createScanner(RootTable.NAME, Authorizations.EMPTY).stream().findAny().isPresent());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BigRootTabletIT.java
@@ -34,8 +34,6 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Iterators;
-
 public class BigRootTabletIT extends AccumuloClusterHarness {
   // ACCUMULO-542: A large root tablet will fail to load if it does't fit in the tserver scan
   // buffers

--- a/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -114,7 +113,7 @@ public class ClassLoaderIT extends AccumuloClusterHarness {
 
   private void scanCheck(AccumuloClient c, String tableName, String expected) throws Exception {
     try (Scanner bs = c.createScanner(tableName, Authorizations.EMPTY)) {
-      String actual = bs.stream().collect(onlyElement()).getValue().toString();
+      String actual = getOnlyElement(bs).getValue().toString();
       assertEquals(expected, actual);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ClassLoaderIT.java
@@ -18,11 +18,10 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
@@ -30,8 +29,6 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -39,9 +36,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.security.Authorizations;
@@ -119,11 +114,8 @@ public class ClassLoaderIT extends AccumuloClusterHarness {
 
   private void scanCheck(AccumuloClient c, String tableName, String expected) throws Exception {
     try (Scanner bs = c.createScanner(tableName, Authorizations.EMPTY)) {
-      Iterator<Entry<Key,Value>> iterator = bs.iterator();
-      assertTrue(iterator.hasNext());
-      Entry<Key,Value> next = iterator.next();
-      assertFalse(iterator.hasNext());
-      assertEquals(expected, next.getValue().toString());
+      String actual = bs.stream().collect(onlyElement()).getValue().toString();
+      assertEquals(expected, actual);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
@@ -18,23 +18,18 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.LongCombiner.Type;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.security.Authorizations;
@@ -50,11 +45,8 @@ public class CombinerIT extends AccumuloClusterHarness {
 
   private void checkSum(String tableName, AccumuloClient c) throws Exception {
     try (Scanner s = c.createScanner(tableName, Authorizations.EMPTY)) {
-      Iterator<Entry<Key,Value>> i = s.iterator();
-      assertTrue(i.hasNext());
-      Entry<Key,Value> entry = i.next();
-      assertEquals("45", entry.getValue().toString());
-      assertFalse(i.hasNext());
+      String actual = s.stream().collect(onlyElement()).getValue().toString();
+      assertEquals("45", actual);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CombinerIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
@@ -45,7 +44,7 @@ public class CombinerIT extends AccumuloClusterHarness {
 
   private void checkSum(String tableName, AccumuloClient c) throws Exception {
     try (Scanner s = c.createScanner(tableName, Authorizations.EMPTY)) {
-      String actual = s.stream().collect(onlyElement()).getValue().toString();
+      String actual = getOnlyElement(s).getValue().toString();
       assertEquals("45", actual);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateAndUseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateAndUseIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -133,9 +134,7 @@ public class CreateAndUseIT extends AccumuloClusterHarness {
 
       try (BatchScanner bs = client.createBatchScanner(table3)) {
         bs.setRanges(ranges);
-        Iterator<Entry<Key,Value>> iter = bs.iterator();
-        int count = Iterators.size(iter);
-        assertEquals(0, count, "Did not expect to find any entries");
+        assertTrue(bs.stream().findAny().isEmpty(), "Did not expect to find any entries");
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CreateAndUseIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CreateAndUseIT.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -43,8 +42,6 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Iterators;
 
 public class CreateAndUseIT extends AccumuloClusterHarness {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteEverythingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteEverythingIT.java
@@ -19,7 +19,7 @@
 package org.apache.accumulo.test.functional;
 
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Map;
@@ -41,9 +41,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 
 public class DeleteEverythingIT extends AccumuloClusterHarness {
 
@@ -103,8 +100,8 @@ public class DeleteEverythingIT extends AccumuloClusterHarness {
 
       try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
         scanner.setRange(new Range());
-        int count = Iterators.size(scanner.iterator());
-        assertEquals(0, count, "count == " + count);
+
+        assertTrue(scanner.stream().findAny().isEmpty());
         c.tableOperations().flush(tableName, null, null, true);
 
         c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");
@@ -114,11 +111,8 @@ public class DeleteEverythingIT extends AccumuloClusterHarness {
 
         bw.close();
 
-        count = Iterables.size(scanner);
+        assertTrue(scanner.stream().findAny().isEmpty());
 
-        if (count != 0) {
-          throw new Exception("count == " + count);
-        }
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsIT.java
@@ -43,8 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Iterators;
-
 public class DeleteRowsIT extends AccumuloClusterHarness {
 
   private static final Logger log = LoggerFactory.getLogger(DeleteRowsIT.class);
@@ -75,7 +73,7 @@ public class DeleteRowsIT extends AccumuloClusterHarness {
         c.tableOperations().create(tableName);
         c.tableOperations().deleteRows(tableName, null, null);
         try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
-          assertEquals(0, Iterators.size(scanner.iterator()));
+          assertTrue(scanner.stream().findAny().isEmpty());
         }
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -241,7 +240,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       }
 
       try (Scanner scanner = c.createScanner(table, Authorizations.EMPTY)) {
-        Entry<Key,Value> entry = scanner.stream().collect(onlyElement());
+        Entry<Key,Value> entry = getOnlyElement(scanner);
         assertEquals("r1", entry.getKey().getRow().toString());
         assertEquals("cf1", entry.getKey().getColumnFamily().toString());
         assertEquals("cq1", entry.getKey().getColumnQualifier().toString());

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -18,9 +18,9 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
@@ -242,14 +241,11 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       }
 
       try (Scanner scanner = c.createScanner(table, Authorizations.EMPTY)) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
+        Entry<Key,Value> entry = scanner.stream().collect(onlyElement());
         assertEquals("r1", entry.getKey().getRow().toString());
         assertEquals("cf1", entry.getKey().getColumnFamily().toString());
         assertEquals("cq1", entry.getKey().getColumnQualifier().toString());
         assertEquals("v1", entry.getValue().toString());
-        assertFalse(iter.hasNext());
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,7 +34,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
@@ -379,12 +379,9 @@ public class KerberosIT extends AccumuloITBase {
 
       // Read (and proper authorizations)
       try (Scanner s = client.createScanner(table, new Authorizations(viz))) {
-        Iterator<Entry<Key,Value>> iter = s.iterator();
-        assertTrue(iter.hasNext(), "No results from iterator");
-        Entry<Key,Value> entry = iter.next();
+        Entry<Key,Value> entry = s.stream().collect(onlyElement());
         assertEquals(new Key("a", "b", "c", viz, ts), entry.getKey());
         assertEquals(new Value("d"), entry.getValue());
-        assertFalse(iter.hasNext(), "Had more results from iterator");
         return null;
       }
     });

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -379,7 +378,7 @@ public class KerberosIT extends AccumuloITBase {
 
       // Read (and proper authorizations)
       try (Scanner s = client.createScanner(table, new Authorizations(viz))) {
-        Entry<Key,Value> entry = s.stream().collect(onlyElement());
+        Entry<Key,Value> entry = getOnlyElement(s);
         assertEquals(new Key("a", "b", "c", viz, ts), entry.getKey());
         assertEquals(new Value("d"), entry.getValue());
         return null;

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -144,15 +144,13 @@ public class MetadataIT extends AccumuloClusterHarness {
       // batch scan regular metadata table
       try (BatchScanner s = c.createBatchScanner(MetadataTable.NAME)) {
         s.setRanges(Collections.singleton(new Range()));
-        long count = s.stream().filter(Objects::nonNull).count();
-        assertTrue(count > 0);
+        assertTrue(s.stream().anyMatch(Objects::nonNull));
       }
 
       // batch scan root metadata table
       try (BatchScanner s = c.createBatchScanner(RootTable.NAME)) {
         s.setRanges(Collections.singleton(new Range()));
-        long count = s.stream().filter(Objects::nonNull).count();
-        assertTrue(count > 0);
+        assertTrue(s.stream().anyMatch(Objects::nonNull));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -61,8 +61,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Iterators;
-
 public class MetadataIT extends AccumuloClusterHarness {
 
   @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -143,25 +144,16 @@ public class MetadataIT extends AccumuloClusterHarness {
       c.tableOperations().create(tableName);
 
       // batch scan regular metadata table
-      int count = 0;
       try (BatchScanner s = c.createBatchScanner(MetadataTable.NAME)) {
         s.setRanges(Collections.singleton(new Range()));
-        for (Entry<Key,Value> e : s) {
-          if (e != null)
-            count++;
-        }
+        long count = s.stream().filter(Objects::nonNull).count();
+        assertTrue(count > 0);
       }
-
-      assertTrue(count > 0);
 
       // batch scan root metadata table
       try (BatchScanner s = c.createBatchScanner(RootTable.NAME)) {
         s.setRanges(Collections.singleton(new Range()));
-        count = 0;
-        for (Entry<Key,Value> e : s) {
-          if (e != null)
-            count++;
-        }
+        long count = s.stream().filter(Objects::nonNull).count();
         assertTrue(count > 0);
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -129,7 +129,7 @@ public class MetadataIT extends AccumuloClusterHarness {
       c.tableOperations().merge(MetadataTable.NAME, null, null);
       try (Scanner s = c.createScanner(RootTable.NAME, Authorizations.EMPTY)) {
         s.setRange(DeletesSection.getRange());
-        while (Iterators.size(s.iterator()) == 0) {
+        while (s.stream().findAny().isEmpty()) {
           sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
         }
         assertEquals(0, c.tableOperations().listSplits(MetadataTable.NAME).size());

--- a/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test.functional;
 import static org.apache.accumulo.test.functional.FunctionalTestUtils.checkRFiles;
 import static org.apache.accumulo.test.functional.FunctionalTestUtils.nm;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -105,8 +106,7 @@ public class RowDeleteIT extends AccumuloClusterHarness {
       }
 
       try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
-        count = Iterators.size(scanner.iterator());
-        assertEquals(0, count, "count == " + count);
+        assertTrue(scanner.stream().findAny().isEmpty());
         bw.close();
       }
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RowDeleteIT.java
@@ -24,9 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,6 +33,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.user.RowDeletingIterator;
@@ -64,27 +63,26 @@ public class RowDeleteIT extends AccumuloClusterHarness {
   @Test
   public void run() throws Exception {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
-      String tableName = getUniqueNames(1)[0];
-      c.tableOperations().create(tableName);
-      Map<String,Set<Text>> groups = new HashMap<>();
-      groups.put("lg1", Collections.singleton(new Text("foo")));
-      c.tableOperations().setLocalityGroups(tableName, groups);
+      final String tableName = getUniqueNames(1)[0];
+      NewTableConfiguration ntc = new NewTableConfiguration();
       IteratorSetting setting = new IteratorSetting(30, RowDeletingIterator.class);
-      c.tableOperations().attachIterator(tableName, setting, EnumSet.of(IteratorScope.majc));
-      c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "100");
+      ntc.attachIterator(setting, EnumSet.of(IteratorScope.majc));
+      ntc.setLocalityGroups(Map.of("lg1", Set.of(new Text("foo"))));
+      ntc.setProperties(Map.of(Property.TABLE_MAJC_RATIO.getKey(), "100"));
+      c.tableOperations().create(tableName, ntc);
 
-      BatchWriter bw = c.createBatchWriter(tableName);
+      try (BatchWriter bw = c.createBatchWriter(tableName);
+          Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
 
-      bw.addMutation(nm("r1", "foo", "cf1", "v1"));
-      bw.addMutation(nm("r1", "bar", "cf1", "v2"));
+        bw.addMutation(nm("r1", "foo", "cf1", "v1"));
+        bw.addMutation(nm("r1", "bar", "cf1", "v2"));
 
-      bw.flush();
-      c.tableOperations().flush(tableName, null, null, true);
+        bw.flush();
+        c.tableOperations().flush(tableName, null, null, true);
 
-      checkRFiles(c, tableName, 1, 1, 1, 1);
+        checkRFiles(c, tableName, 1, 1, 1, 1);
 
-      int count;
-      try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
+        int count;
         count = Iterators.size(scanner.iterator());
         assertEquals(2, count, "count == " + count);
 
@@ -94,20 +92,15 @@ public class RowDeleteIT extends AccumuloClusterHarness {
         c.tableOperations().flush(tableName, null, null, true);
 
         checkRFiles(c, tableName, 1, 1, 2, 2);
-      }
 
-      try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
         count = Iterators.size(scanner.iterator());
         assertEquals(3, count, "count == " + count);
 
         c.tableOperations().compact(tableName, null, null, false, true);
 
         checkRFiles(c, tableName, 1, 1, 0, 0);
-      }
 
-      try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {
         assertTrue(scanner.stream().findAny().isEmpty());
-        bw.close();
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -47,8 +47,6 @@ import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Iterators;
-
 @Tag(MINI_CLUSTER_ONLY)
 public class TableIT extends AccumuloClusterHarness {
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TableIT.java
@@ -78,12 +78,12 @@ public class TableIT extends AccumuloClusterHarness {
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
         s.setRange(new KeyExtent(id, null, null).toMetaRange());
         s.fetchColumnFamily(DataFileColumnFamily.NAME);
-        assertTrue(Iterators.size(s.iterator()) > 0);
+        assertTrue(s.stream().findAny().isPresent());
 
         FileSystem fs = getCluster().getFileSystem();
         assertTrue(fs.listStatus(new Path(rootPath + "/accumulo/tables/" + id)).length > 0);
         to.delete(tableName);
-        assertEquals(0, Iterators.size(s.iterator()));
+        assertTrue(s.stream().findAny().isEmpty());
 
         try {
           assertEquals(0, fs.listStatus(new Path(rootPath + "/accumulo/tables/" + id)).length);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZookeeperRestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZookeeperRestartIT.java
@@ -18,16 +18,13 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -36,9 +33,7 @@ import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.conf.ClientProperty;
 import org.apache.accumulo.core.conf.Property;
-import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -83,10 +78,8 @@ public class ZookeeperRestartIT extends ConfigurableMacBase {
 
       // use the tservers
       try (Scanner s = c.createScanner("test_ingest", Authorizations.EMPTY)) {
-        Iterator<Entry<Key,Value>> i = s.iterator();
-        assertTrue(i.hasNext());
-        assertEquals("row", i.next().getKey().getRow().toString());
-        assertFalse(i.hasNext());
+        String actual = s.stream().collect(onlyElement()).getKey().getRow().toString();
+        assertEquals("row", actual);
         // use the manager
         c.tableOperations().delete("test_ingest");
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZookeeperRestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZookeeperRestartIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.apache.accumulo.fate.util.UtilWaitThread.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -78,7 +77,7 @@ public class ZookeeperRestartIT extends ConfigurableMacBase {
 
       // use the tservers
       try (Scanner s = c.createScanner("test_ingest", Authorizations.EMPTY)) {
-        String actual = s.stream().collect(onlyElement()).getKey().getRow().toString();
+        String actual = getOnlyElement(s).getKey().getRow().toString();
         assertEquals("row", actual);
         // use the manager
         c.tableOperations().delete("test_ingest");

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
@@ -234,7 +234,7 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
         int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
             .map(Integer::parseInt).collect(onlyElement());
-        assertEquals(actual, 100);
+        assertEquals(100, actual);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/AccumuloOutputFormatIT.java
@@ -18,15 +18,14 @@
  */
 package org.apache.accumulo.test.mapred;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -233,11 +232,9 @@ public class AccumuloOutputFormatIT extends ConfigurableMacBase {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
+            .map(Integer::parseInt).collect(onlyElement());
+        assertEquals(actual, 100);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
@@ -200,7 +200,7 @@ public class TokenFileIT extends AccumuloClusterHarness {
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
         int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
             .map(Integer::parseInt).collect(onlyElement());
-        assertEquals(actual, 100);
+        assertEquals(100, actual);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapred/TokenFileIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.mapred;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -199,11 +198,9 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
+            .map(Integer::parseInt).collect(onlyElement());
+        assertEquals(actual, 100);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloOutputFormatIT.java
@@ -18,14 +18,12 @@
  */
 package org.apache.accumulo.test.mapreduce;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -164,11 +162,9 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
+            .map(Integer::parseInt).collect(onlyElement());
+        assertEquals(actual, 100);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloOutputFormatIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/AccumuloOutputFormatIT.java
@@ -164,7 +164,7 @@ public class AccumuloOutputFormatIT extends AccumuloClusterHarness {
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
         int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
             .map(Integer::parseInt).collect(onlyElement());
-        assertEquals(actual, 100);
+        assertEquals(100, actual);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.mapreduce;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -204,11 +203,9 @@ public class TokenFileIT extends AccumuloClusterHarness {
       assertNull(e1);
 
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
-        assertTrue(iter.hasNext());
-        Entry<Key,Value> entry = iter.next();
-        assertEquals(Integer.parseInt(new String(entry.getValue().get())), 100);
-        assertFalse(iter.hasNext());
+        int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
+            .map(Integer::parseInt).collect(onlyElement());
+        assertEquals(actual, 100);
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/mapreduce/TokenFileIT.java
@@ -175,13 +175,13 @@ public class TokenFileIT extends AccumuloClusterHarness {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProps()).build()) {
       c.tableOperations().create(table1);
       c.tableOperations().create(table2);
-      BatchWriter bw = c.createBatchWriter(table1);
-      for (int i = 0; i < 100; i++) {
-        Mutation m = new Mutation(new Text(String.format("%09x", i + 1)));
-        m.put("", "", String.format("%09x", i));
-        bw.addMutation(m);
+      try (BatchWriter bw = c.createBatchWriter(table1)) {
+        for (int i = 0; i < 100; i++) {
+          Mutation m = new Mutation(new Text(String.format("%09x", i + 1)));
+          m.put("", "", String.format("%09x", i));
+          bw.addMutation(m);
+        }
       }
-      bw.close();
 
       File tf = new File(tempDir, "root_test.pw");
       assertTrue(tf.createNewFile(), "Failed to create file: " + tf);
@@ -205,7 +205,7 @@ public class TokenFileIT extends AccumuloClusterHarness {
       try (Scanner scanner = c.createScanner(table2, new Authorizations())) {
         int actual = scanner.stream().map(Entry::getValue).map(Value::get).map(String::new)
             .map(Integer::parseInt).collect(onlyElement());
-        assertEquals(actual, 100);
+        assertEquals(100, actual);
       }
     }
   }


### PR DESCRIPTION
I was looking through places where the use of `Scanner.Iterator` might be improved by using the new `Scanner.stream` method and found a few patterns to replace that seemed worth-while. 

* In a lot of places, we create an interator, assert that the iterator `hasNext`, get the next entry, compare that entry to what we expect it to be, then assert that `hasNext` is false. All this to make sure there is just one entry. To simplify I changed these places to `.stream().collect(onlyElement())` and then perform the `assertEquals` on the single returned value.
* Convert `Iterators.size(s.iterator()) == 0` -> `s.stream().findAny().isEmpty()`
* Convert `Iterators.size(s.iterator()) > 0` -> `s.stream().findAny().isPresent()`

I also wanted to see if anyone had an opinion on which of the following equivalent options is better:
1. `scanner.stream().map(Entry::getValue).map(Value::get).map(String::new).map(Integer::parseInt).collect(onlyElement());`
2. `scanner.stream().map(entry -> Integer.parseInt(new String(entry.getValue().get()))).collect(onlyElement());`

I have both in these changes. To me, one does not seem significantly, different/more readable than the other so I thought I would ask.