### PR TITLE
Update ChangeSecret to work as documentation states

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -64,8 +64,8 @@ public class ChangeSecret {
       ServerDirs serverDirs = new ServerDirs(siteConfig, hadoopConf);
       verifyHdfsWritePermission(serverDirs, fs);
 
-      String oldPass = String.valueOf(System.console().readPassword("Old password: "));
-      String newPass = String.valueOf(System.console().readPassword("New password: "));
+      String oldPass = String.valueOf(System.console().readPassword("Old secret: "));
+      String newPass = String.valueOf(System.console().readPassword("New secret: "));
       Span span = TraceUtil.startSpan(ChangeSecret.class, "main");
       try (Scope scope = span.makeCurrent()) {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -38,6 +38,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -45,7 +46,6 @@ import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.zookeeper.ZooDefs.Ids;
-import org.apache.zookeeper.common.StringUtils;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -79,7 +79,7 @@ public class ChangeSecret {
       argsList.add("--new");
       argsList.addAll(Arrays.asList(args));
 
-      opts.parseArgs(ChangeSecret.class.getName(), args);
+      opts.parseArgs(ChangeSecret.class.getName(), argsList.toArray(new String[0]));
       Span span = TraceUtil.startSpan(ChangeSecret.class, "main");
       try (Scope scope = span.makeCurrent()) {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -79,7 +79,9 @@ public class ChangeSecret {
       argsList.add("--new");
       argsList.addAll(Arrays.asList(args));
 
-      opts.parseArgs(ChangeSecret.class.getName(), argsList.toArray(new String[0]));
+      opts.parseArgs(ChangeSecret.class.getName(), args);
+      String oldPass = String.valueOf(System.console().readPassword("Old password: "));
+      String newPass = String.valueOf(System.console().readPassword("New password: "));
       Span span = TraceUtil.startSpan(ChangeSecret.class, "main");
       try (Scope scope = span.makeCurrent()) {
 

--- a/server/manager/src/test/resources/conf/accumulo-site.xml
+++ b/server/manager/src/test/resources/conf/accumulo-site.xml
@@ -41,10 +41,9 @@
   <property>
     <name>instance.secret</name>
     <value>DEFAULT</value>
-    <description>A secret unique to a given instance that all servers must know in order to communicate with one another.
-      Change it before initialization. To
-      change it later use ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret [oldpasswd] [newpasswd],
-      and then update this file.
+    <description>A secret unique to a given instance that all servers must know in order to
+      communicate with one another. Change it before initialization. To change it later use
+      ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret, and then update this file.
     </description>
   </property>
 


### PR DESCRIPTION
There are inconsistencies in how ChangeSecret should be run, as well as
exceptions thrown when attempting to execute ChangeSecret.

In two locations, instructions for executing ChangeSecret indicate

     ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret

But within accumulo-site.xml, instructions indicate

     ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret [oldpasswd] [newpasswd]

Neither one of the two methods work properly.

Running with no parameters throws a NullPointerException. Running with
the indicated parameters presents a usage message with an error
message provided. Additionally, the usage message makes no mention of
the old and new password parameters.

This PR updates site.xml to match the instructions within the rest of
the code, i.e., execute the command with no parameters.

It also updates the parseArgs method within ChangeSecret to parse
the argsList variable as it did previously, thereby prompting the user for
the old and new password as appears to be the original intention.