### PR TITLE
Resolve unused format arguments

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
@@ -272,7 +272,7 @@ public class AuditedSecurityOperation extends SecurityOperation {
   }
 
   public static final String CAN_DELETE_TABLE_AUDIT_TEMPLATE =
-      "action: deleteTable; targetTable: %s;";
+      "action: deleteTable; targetTable: %s:%s";
 
   @Override
   public boolean canDeleteTable(TCredentials c, TableId tableId, NamespaceId namespaceId)
@@ -690,7 +690,7 @@ public class AuditedSecurityOperation extends SecurityOperation {
   }
 
   public static final String CAN_ONLINE_OFFLINE_TABLE_AUDIT_TEMPLATE =
-      "action: %s; targetTable: %s;";
+      "action: %s; targetTable: %s:%s";
 
   @Override
   public boolean canOnlineOfflineTable(TCredentials credentials, TableId tableId, FateOperation op,

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -449,7 +449,7 @@ public class CompactionCoordinator extends AbstractServer
                 prioTserver.prio, compactorAddress, externalCompactionId);
         if (null == job.getExternalCompactionId()) {
           LOG.trace("No compactions found for queue {} on tserver {}, trying next tserver", queue,
-              tserver.getHostAndPort(), compactorAddress);
+              tserver.getHostAndPort());
 
           QUEUE_SUMMARIES.removeSummary(tserver, queue, prioTserver.prio);
           prioTserver = QUEUE_SUMMARIES.getNextTserver(queue);

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -78,6 +78,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
   private static final String AUDIT_USER_2 = "AuditUser2";
   private static final String PASSWORD = "password";
   private static final String OLD_TEST_TABLE_NAME = "apples";
+  private static final String OLD_TEST_TABLE_NAME_ID = "1";
   private static final String NEW_TEST_TABLE_NAME = "oranges";
   private static final String THIRD_TEST_TABLE_NAME = "pears";
   private static final Authorizations auths = new Authorizations("private", "public");
@@ -361,7 +362,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
     assertEquals(1,
         findAuditMessage(auditMessages,
             String.format(AuditedSecurityOperation.CAN_ONLINE_OFFLINE_TABLE_AUDIT_TEMPLATE,
-                "offlineTable", OLD_TEST_TABLE_NAME)));
+                "offlineTable", OLD_TEST_TABLE_NAME, OLD_TEST_TABLE_NAME_ID)));
     assertEquals(1, findAuditMessage(auditMessages, String.format(
         AuditedSecurityOperation.CAN_EXPORT_AUDIT_TEMPLATE, OLD_TEST_TABLE_NAME, exportDir)));
     assertEquals(1,
@@ -377,7 +378,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
     assertEquals(1,
         findAuditMessage(auditMessages,
             String.format(AuditedSecurityOperation.CAN_ONLINE_OFFLINE_TABLE_AUDIT_TEMPLATE,
-                "onlineTable", OLD_TEST_TABLE_NAME)));
+                "onlineTable", OLD_TEST_TABLE_NAME, OLD_TEST_TABLE_NAME_ID)));
 
   }
 
@@ -494,13 +495,16 @@ public class AuditMessageIT extends ConfigurableMacBase {
             "operation: denied;.*"
                 + String.format(AuditedSecurityOperation.CAN_CLONE_TABLE_AUDIT_TEMPLATE,
                     OLD_TEST_TABLE_NAME, NEW_TEST_TABLE_NAME)));
-    assertEquals(1, findAuditMessage(auditMessages, "operation: denied;.*" + String
-        .format(AuditedSecurityOperation.CAN_DELETE_TABLE_AUDIT_TEMPLATE, OLD_TEST_TABLE_NAME)));
+    assertEquals(1,
+        findAuditMessage(auditMessages,
+            "operation: denied;.*"
+                + String.format(AuditedSecurityOperation.CAN_DELETE_TABLE_AUDIT_TEMPLATE,
+                    OLD_TEST_TABLE_NAME, OLD_TEST_TABLE_NAME_ID)));
     assertEquals(1,
         findAuditMessage(auditMessages,
             "operation: denied;.*"
                 + String.format(AuditedSecurityOperation.CAN_ONLINE_OFFLINE_TABLE_AUDIT_TEMPLATE,
-                    "offlineTable", OLD_TEST_TABLE_NAME)));
+                    "offlineTable", OLD_TEST_TABLE_NAME, OLD_TEST_TABLE_NAME_ID)));
     assertEquals(1, findAuditMessage(auditMessages,
         "operation: denied;.*action: scan; targetTable: " + OLD_TEST_TABLE_NAME));
     assertEquals(1,


### PR DESCRIPTION
Updated three instances where the number of format arguments did not
match number of arguments.

In CompactionCoordinator the compactorAddress was a third argument for
a statement containing only two format arguments. The compactorAddress
was dropped as it did not seem to be necessary.

In AuditedSecurityOperation there were two occasions of mismatched
formats and arguments. In both cases, an additional format argument was
added to allow both the tableName and tableId to be displayed in the
audit log.