### PR TITLE
Use memoized suppliers to lazy load resources

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
@@ -18,9 +18,12 @@
  */
 package org.apache.accumulo.core.conf;
 
+import static com.google.common.base.Suppliers.memoize;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -29,7 +32,9 @@ import java.util.stream.Collectors;
  */
 public class DefaultConfiguration extends AccumuloConfiguration {
 
-  private static final Map<String,String> resolvedProps =
+  private static final Supplier<DefaultConfiguration> instance = memoize(DefaultConfiguration::new);
+
+  private final Map<String,String> resolvedProps =
       Arrays.stream(Property.values()).filter(p -> p.getType() != PropertyType.PREFIX)
           .collect(Collectors.toMap(Property::getKey, Property::getDefaultValue));
 
@@ -41,7 +46,7 @@ public class DefaultConfiguration extends AccumuloConfiguration {
    * @return default configuration
    */
   public static DefaultConfiguration getInstance() {
-    return new DefaultConfiguration();
+    return instance.get();
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -77,8 +77,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
     // visible to package-private for testing only
     Builder() {}
 
-    // exists for testing only
-    OverridesOption noFile() {
+    private OverridesOption noFile() {
       return this;
     }
 
@@ -194,6 +193,13 @@ public class SiteConfiguration extends AccumuloConfiguration {
    */
   public static SiteConfiguration.OverridesOption fromFile(File propertiesFileLocation) {
     return new SiteConfiguration.Builder().fromFile(propertiesFileLocation);
+  }
+
+  /**
+   * Build a SiteConfiguration that is initially empty with the option to override.
+   */
+  public static SiteConfiguration.OverridesOption empty() {
+    return new SiteConfiguration.Builder().noFile();
   }
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/SiteConfigurationTest.java
@@ -46,7 +46,7 @@ public class SiteConfigurationTest {
 
     var overrides =
         Map.of(Property.GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS.getKey(), credProvPath);
-    var config = new SiteConfiguration.Builder().noFile().withOverrides(overrides).build();
+    var config = SiteConfiguration.empty().withOverrides(overrides).build();
 
     assertEquals("mysecret", config.get(Property.INSTANCE_SECRET));
     assertNull(config.get("ignored.property"));
@@ -56,7 +56,7 @@ public class SiteConfigurationTest {
 
   @Test
   public void testDefault() {
-    var conf = SiteConfiguration.auto();
+    var conf = SiteConfiguration.empty().build();
     assertEquals("localhost:2181", conf.get(Property.INSTANCE_ZK_HOST));
     assertEquals("DEFAULT", conf.get(Property.INSTANCE_SECRET));
     assertEquals("", conf.get(Property.INSTANCE_VOLUMES));
@@ -84,10 +84,10 @@ public class SiteConfigurationTest {
 
   @Test
   public void testConfigOverrides() {
-    var conf = SiteConfiguration.auto();
+    var conf = SiteConfiguration.empty().build();
     assertEquals("localhost:2181", conf.get(Property.INSTANCE_ZK_HOST));
 
-    conf = new SiteConfiguration.Builder().noFile()
+    conf = SiteConfiguration.empty()
         .withOverrides(Map.of(Property.INSTANCE_ZK_HOST.getKey(), "myhost:2181")).build();
     assertEquals("myhost:2181", conf.get(Property.INSTANCE_ZK_HOST));
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerReconfigurationTest.java
@@ -63,7 +63,7 @@ public class HostRegexTableLoadBalancerReconfigurationTest
     tables.put(BAR.getTableName(), BAR.getId());
     tables.put(BAZ.getTableName(), BAZ.getId());
 
-    ConfigurationCopy config = new ConfigurationCopy(SiteConfiguration.auto());
+    ConfigurationCopy config = new ConfigurationCopy(SiteConfiguration.empty().build());
     DEFAULT_TABLE_PROPERTIES.forEach(config::set);
     ConfigurationImpl configImpl = new ConfigurationImpl(config);
     BalancerEnvironment environment = createMock(BalancerEnvironment.class);

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/HostRegexTableLoadBalancerTest.java
@@ -65,7 +65,7 @@ public class HostRegexTableLoadBalancerTest extends BaseHostRegexTableLoadBalanc
     tables.put(BAR.getTableName(), BAR.getId());
     tables.put(BAZ.getTableName(), BAZ.getId());
 
-    ConfigurationCopy config = new ConfigurationCopy(SiteConfiguration.auto());
+    ConfigurationCopy config = new ConfigurationCopy(SiteConfiguration.empty().build());
     tableProperties.forEach(config::set);
     ConfigurationImpl configImpl = new ConfigurationImpl(config);
     BalancerEnvironment environment = createMock(BalancerEnvironment.class);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Suppliers.memoize;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -37,6 +38,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.ClientContext;
@@ -91,15 +93,15 @@ public class ServerContext extends ClientContext {
   private final ZooReaderWriter zooReaderWriter;
   private final ServerDirs serverDirs;
 
-  private TableManager tableManager;
-  private UniqueNameAllocator nameAllocator;
-  private ServerConfigurationFactory serverConfFactory = null;
-  private DefaultConfiguration defaultConfig = null;
-  private AccumuloConfiguration systemConfig = null;
-  private AuthenticationTokenSecretManager secretManager;
-  private CryptoService cryptoService = null;
-  private ScheduledThreadPoolExecutor sharedScheduledThreadPool = null;
-  private AuditedSecurityOperation securityOperation = null;
+  // lazily loaded resources, only loaded when needed
+  private final Supplier<TableManager> tableManager;
+  private final Supplier<UniqueNameAllocator> nameAllocator;
+  private final Supplier<ServerConfigurationFactory> serverConfFactory;
+  private final Supplier<AccumuloConfiguration> systemConfig;
+  private final Supplier<AuthenticationTokenSecretManager> secretManager;
+  private final Supplier<CryptoService> cryptoService;
+  private final Supplier<ScheduledThreadPoolExecutor> sharedScheduledThreadPool;
+  private final Supplier<AuditedSecurityOperation> securityOperation;
 
   public ServerContext(SiteConfiguration siteConfig) {
     this(new ServerInfo(siteConfig));
@@ -110,6 +112,23 @@ public class ServerContext extends ClientContext {
     this.info = info;
     zooReaderWriter = new ZooReaderWriter(info.getSiteConfiguration());
     serverDirs = info.getServerDirs();
+
+    tableManager = memoize(() -> new TableManager(this));
+    nameAllocator = memoize(() -> new UniqueNameAllocator(this));
+    serverConfFactory = memoize(() -> new ServerConfigurationFactory(this, getSiteConfiguration()));
+    // system configuration uses its own instance of ZooCache
+    // this could be useful to keep its update counter independent
+    systemConfig = memoize(() -> new ZooConfiguration(this, new ZooCache(getZooReader(), null),
+        getSiteConfiguration()));
+    secretManager = memoize(() -> new AuthenticationTokenSecretManager(getInstanceID(),
+        getConfiguration().getTimeInMillis(Property.GENERAL_DELEGATION_TOKEN_LIFETIME)));
+    cryptoService = memoize(
+        () -> CryptoServiceFactory.newInstance(getConfiguration(), ClassloaderType.ACCUMULO));
+    sharedScheduledThreadPool = memoize(() -> ThreadPools.getServerThreadPools()
+        .createGeneralScheduledExecutorService(getConfiguration()));
+    securityOperation =
+        memoize(() -> new AuditedSecurityOperation(this, SecurityOperation.getAuthorizor(this),
+            SecurityOperation.getAuthenticator(this), SecurityOperation.getPermHandler(this)));
   }
 
   /**
@@ -134,54 +153,25 @@ public class ServerContext extends ClientContext {
     return info.getInstanceID();
   }
 
-  /**
-   * Should only be called by the Tablet server
-   */
-  public synchronized void setupCrypto() throws CryptoService.CryptoException {
-    if (cryptoService != null) {
-      throw new CryptoService.CryptoException("Crypto Service " + cryptoService.getClass().getName()
-          + " already exists and cannot be setup again");
-    }
-
-    AccumuloConfiguration acuConf = getConfiguration();
-    cryptoService = CryptoServiceFactory.newInstance(acuConf, ClassloaderType.ACCUMULO);
-  }
-
   public SiteConfiguration getSiteConfiguration() {
     return info.getSiteConfiguration();
   }
 
-  public synchronized ServerConfigurationFactory getServerConfFactory() {
-    if (serverConfFactory == null) {
-      serverConfFactory = new ServerConfigurationFactory(this, info.getSiteConfiguration());
-    }
-    return serverConfFactory;
-  }
-
   @Override
   public AccumuloConfiguration getConfiguration() {
-    if (systemConfig == null) {
-      // system configuration uses its own instance of ZooCache
-      // this could be useful to keep its update counter independent
-      ZooCache propCache = new ZooCache(getZooReader(), null);
-      systemConfig = new ZooConfiguration(this, propCache, getSiteConfiguration());
-    }
-    return systemConfig;
+    return systemConfig.get();
   }
 
   public TableConfiguration getTableConfiguration(TableId id) {
-    return getServerConfFactory().getTableConfiguration(id);
+    return serverConfFactory.get().getTableConfiguration(id);
   }
 
   public NamespaceConfiguration getNamespaceConfiguration(NamespaceId namespaceId) {
-    return getServerConfFactory().getNamespaceConfiguration(namespaceId);
+    return serverConfFactory.get().getNamespaceConfiguration(namespaceId);
   }
 
   public DefaultConfiguration getDefaultConfiguration() {
-    if (defaultConfig == null) {
-      defaultConfig = DefaultConfiguration.getInstance();
-    }
-    return defaultConfig;
+    return DefaultConfiguration.getInstance();
   }
 
   public ServerDirs getServerDirs() {
@@ -194,7 +184,7 @@ public class ServerContext extends ClientContext {
    */
   // Should be private, but package-protected so EasyMock will work
   void enforceKerberosLogin() {
-    final AccumuloConfiguration conf = getServerConfFactory().getSiteConfiguration();
+    final AccumuloConfiguration conf = getSiteConfiguration();
     // Unwrap _HOST into the FQDN to make the kerberos principal we'll compare against
     final String kerberosPrincipal =
         SecurityUtil.getServerPrincipal(conf.get(Property.GENERAL_KERBEROS_PRINCIPAL));
@@ -234,11 +224,11 @@ public class ServerContext extends ClientContext {
 
   @Override
   public SaslServerConnectionParams getSaslParams() {
-    AccumuloConfiguration conf = getServerConfFactory().getSiteConfiguration();
+    AccumuloConfiguration conf = getSiteConfiguration();
     if (!conf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
       return null;
     }
-    return new SaslServerConnectionParams(conf, getCredentials().getToken(), secretManager);
+    return new SaslServerConnectionParams(conf, getCredentials().getToken(), getSecretManager());
   }
 
   /**
@@ -269,33 +259,20 @@ public class ServerContext extends ClientContext {
     }
   }
 
-  public void setSecretManager(AuthenticationTokenSecretManager secretManager) {
-    this.secretManager = secretManager;
-  }
-
   public AuthenticationTokenSecretManager getSecretManager() {
-    return secretManager;
+    return secretManager.get();
   }
 
-  public synchronized TableManager getTableManager() {
-    if (tableManager == null) {
-      tableManager = new TableManager(this);
-    }
-    return tableManager;
+  public TableManager getTableManager() {
+    return tableManager.get();
   }
 
-  public synchronized UniqueNameAllocator getUniqueNameAllocator() {
-    if (nameAllocator == null) {
-      nameAllocator = new UniqueNameAllocator(this);
-    }
-    return nameAllocator;
+  public UniqueNameAllocator getUniqueNameAllocator() {
+    return nameAllocator.get();
   }
 
   public CryptoService getCryptoService() {
-    if (cryptoService == null) {
-      throw new CryptoService.CryptoException("Crypto service not initialized.");
-    }
-    return cryptoService;
+    return cryptoService.get();
   }
 
   @Override
@@ -453,15 +430,8 @@ public class ServerContext extends ClientContext {
     ThreadPools.watchNonCriticalScheduledTask(future);
   }
 
-  /**
-   * return a shared scheduled executor
-   */
-  public synchronized ScheduledThreadPoolExecutor getScheduledExecutor() {
-    if (sharedScheduledThreadPool == null) {
-      sharedScheduledThreadPool = ThreadPools.getServerThreadPools()
-          .createGeneralScheduledExecutorService(getConfiguration());
-    }
-    return sharedScheduledThreadPool;
+  public ScheduledThreadPoolExecutor getScheduledExecutor() {
+    return sharedScheduledThreadPool.get();
   }
 
   @Override
@@ -470,11 +440,7 @@ public class ServerContext extends ClientContext {
   }
 
   public AuditedSecurityOperation getSecurityOperation() {
-    if (securityOperation == null) {
-      securityOperation = new AuditedSecurityOperation(this, SecurityOperation.getAuthorizor(this),
-          SecurityOperation.getAuthenticator(this), SecurityOperation.getPermHandler(this));
-    }
-    return securityOperation;
+    return securityOperation.get();
   }
 
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -92,7 +92,7 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
         TestDefaultBalancer.class.getName());
   }
 
-  private static SiteConfiguration siteConfg = SiteConfiguration.auto();
+  private static SiteConfiguration siteConfg = SiteConfiguration.empty().build();
 
   protected static class TestServerConfigurationFactory extends ServerConfigurationFactory {
 

--- a/server/base/src/test/java/org/apache/accumulo/server/security/SystemCredentialsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/SystemCredentialsTest.java
@@ -39,7 +39,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class SystemCredentialsTest {
 
-  private static SiteConfiguration siteConfig = SiteConfiguration.auto();
+  private static SiteConfiguration siteConfig = SiteConfiguration.empty().build();
   private InstanceId instanceId =
       InstanceId.of(UUID.nameUUIDFromBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0}));
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -157,7 +157,6 @@ public class CompactionCoordinator extends AbstractServer
   }
 
   protected void setupSecurity() {
-    getContext().setupCrypto();
     security = getContext().getSecurityOperation();
   }
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -191,7 +191,6 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
   }
 
   protected void setupSecurity() {
-    getContext().setupCrypto();
     security = getContext().getSecurityOperation();
   }
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -60,7 +60,7 @@ public class SimpleGarbageCollectorTest {
   private Credentials credentials;
   private SimpleGarbageCollector gc;
   private ConfigurationCopy systemConfig;
-  private static SiteConfiguration siteConfig = SiteConfiguration.auto();
+  private static SiteConfiguration siteConfig = SiteConfiguration.empty().build();
 
   @BeforeEach
   public void setUp() {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -130,7 +130,6 @@ import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftProcessorTypes;
 import org.apache.accumulo.server.security.SecurityOperation;
 import org.apache.accumulo.server.security.delegation.AuthenticationTokenKeyManager;
-import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
 import org.apache.accumulo.server.security.delegation.ZooAuthenticationKeyDistributor;
 import org.apache.accumulo.server.tables.TableManager;
 import org.apache.accumulo.server.tables.TableObserver;
@@ -386,9 +385,7 @@ public class Manager extends AbstractServer
 
     this.security = context.getSecurityOperation();
 
-    // Create the secret manager (can generate and verify delegation tokens)
     final long tokenLifetime = aconf.getTimeInMillis(Property.GENERAL_DELEGATION_TOKEN_LIFETIME);
-    context.setSecretManager(new AuthenticationTokenSecretManager(getInstanceID(), tokenLifetime));
 
     authenticationTokenKeyManager = null;
     keyDistributor = null;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -376,8 +376,6 @@ public class Upgrader9to10 implements Upgrader {
   MetadataTime computeRootTabletTime(ServerContext context, Collection<String> goodPaths) {
 
     try {
-      context.setupCrypto();
-
       long rtime = Long.MIN_VALUE;
       for (String good : goodPaths) {
         Path path = new Path(good);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -124,7 +124,6 @@ import org.apache.accumulo.server.rpc.TServerUtils;
 import org.apache.accumulo.server.rpc.ThriftProcessorTypes;
 import org.apache.accumulo.server.security.SecurityOperation;
 import org.apache.accumulo.server.security.SecurityUtil;
-import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
 import org.apache.accumulo.server.security.delegation.ZooAuthenticationKeyWatcher;
 import org.apache.accumulo.server.util.FileSystemMonitor;
 import org.apache.accumulo.server.util.ServerBulkImportStatus;
@@ -247,7 +246,6 @@ public class TabletServer extends AbstractServer {
   protected TabletServer(ServerOpts opts, String[] args) {
     super("tserver", opts, args);
     context = super.getContext();
-    context.setupCrypto();
     this.managerLockCache = new ZooCache(context.getZooReader(), null);
     final AccumuloConfiguration aconf = getConfiguration();
     log.info("Version " + Constants.VERSION);
@@ -363,9 +361,6 @@ public class TabletServer extends AbstractServer {
         TabletLocator::clearLocators, jitter(), jitter(), TimeUnit.MILLISECONDS));
     walMarker = new WalStateManager(context);
 
-    // Create the secret manager
-    context.setSecretManager(new AuthenticationTokenSecretManager(context.getInstanceID(),
-        aconf.getTimeInMillis(Property.GENERAL_DELEGATION_TOKEN_LIFETIME)));
     if (aconf.getBoolean(Property.INSTANCE_RPC_SASL_ENABLED)) {
       log.info("SASL is enabled, creating ZooKeeper watcher for AuthenticationKeys");
       // Watcher to notice new AuthenticationKeys which enable delegation tokens


### PR DESCRIPTION
* Remove the need to synchronize on reads for lazily initialized
  singleton resources, particularly in the configuration and context
  utilities, using Suppliers.memoize
* Apply to DefaultConfiguration.getInstance() to avoid unnecessary
  object creation whenever that is called
* Make all ServerContext fields final, and use memoize to lazily load
  anything that was previously checking if it was set in a synchronized
  getter method
* Use computeIfAbsent in ServerConfigurationFactory, and make its caches
  of configuration objects non-static, so they only live as long as the
  ServerContext that created it lives; this, along with using
  ConcurrentHashMaps, dramatically simplifies this code
* Reduce ServerContext reliance on ServerConfigurationFactory when it
  already has the information (notably, it has the instance of
  SiteConfiguration it used to construct the ServerConfigurationFactory)
* Add a builder option for SiteConfiguration.empty() for use with tests
* Update related tests, and make ServerContextTest.testCanRun more
  robust