### PR TITLE
Add js strict directive to Monitor javascript

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * Creates bulk import initial table

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactions.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
  var compactionsList;
  /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
  var coordinatorTable;
  var compactorsTable;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 // Suffixes for quantity
 var QUANTITY_SUFFIX = ['', 'K', 'M', 'B', 'T', 'e15', 'e18', 'e21'];

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var gcTable;
  /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/global.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/global.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * List of namespaces in Accumulo

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/listType.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/listType.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var type, minutes;
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * Creates manager initial table

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * Creates the initial sidebar

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * Creates overview initial tables

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var tableID;
 var problemSummaryTable;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * Creates replication initial table

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 /**
  * Creates scans initial table

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var dashCell = "<td>&mdash;</td>";
 var serv;

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/show.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/show.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var id;
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/summary.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/summary.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var minutes;
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var tableID;
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+"use strict";
 
 var tserversList;
 /**


### PR DESCRIPTION
* Add the JS "use strict"; directive to all JS in Monitor
* This will execute scripts in "strict mode" and prevent use of undeclared variables