### PR TITLE
Bug fix for caption in tservers table in monitor

### DIFF
--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -117,6 +117,9 @@ public class TabletServerResource {
   public TabletServersRecovery getTserverRecovery() {
     TabletServersRecovery recoveryList = new TabletServersRecovery();
 
+    recoveryList
+        .addRecovery(new TabletServerRecoveryInformation("localhost:10000", "log", 5000, 0.34));
+
     ManagerMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return new TabletServersRecovery();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/tservers/TabletServerResource.java
@@ -117,9 +117,6 @@ public class TabletServerResource {
   public TabletServersRecovery getTserverRecovery() {
     TabletServersRecovery recoveryList = new TabletServersRecovery();
 
-    recoveryList
-        .addRecovery(new TabletServerRecoveryInformation("localhost:10000", "log", 5000, 0.34));
-
     ManagerMonitorInfo mmi = monitor.getMmi();
     if (mmi == null) {
       return new TabletServersRecovery();

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -88,7 +88,7 @@ $(document).ready(function() {
         // reset background of each row
         $(row).css('background-color', '');
 
-        // return if the current rows' tserver is not recovering
+        // return if the current row's tserver is not recovering
         if (!recoveryList.includes(data.hostname))
           return;
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -18,29 +18,25 @@
  */
 "use strict";
 
-var tserversList;
+var tserversTable;
 /**
  * Creates tservers initial table
  */
 $(document).ready(function() {
-    
+
+  // hide the note about highlighted rows by default
+  $('#recovery-caption').hide();
+
   const recoveryList = []
   getRecoveryList().then(function () {
     // fill recoveryList
     JSON.parse(sessionStorage.recoveryList).recoveryList.forEach(entry => {
       recoveryList.push(entry.server);
     });
-
-    // only show the note about highlighted rows if there are rows to highlight
-    if (recoveryList.length === 0) {
-      $('#recovery-caption').hide();
-    } else {
-      $('#recovery-caption').show();
-    }
   });
     
     // Create a table for tserver list
-    tserversList = $('#tservers').DataTable({
+    tserversTable = $('#tservers').DataTable({
       "ajax": {
         "url": '/rest/tservers',
         "dataSrc": "servers"
@@ -95,6 +91,9 @@ $(document).ready(function() {
         // return if current rows tserver is not recovering
         if (!recoveryList.includes(data.hostname))
           return;
+
+        // only show the caption if we know there are rows in the tservers table
+        $('#recovery-caption').show();
 
         // highlight current row
         console.log('Highlighting row index:' + index + ' tserver:' + data.hostname);
@@ -193,5 +192,5 @@ function clearDeadTServers(server) {
  * Generates the tserver table
  */
 function refreshTServersTable() {
-  if (tserversList) tserversList.ajax.reload(null, false); // user paging is not reset on reload
+  if (tserversTable) tserversTable.ajax.reload(null, false); // user paging is not reset on reload
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -88,7 +88,7 @@ $(document).ready(function() {
         // reset background of each row
         $(row).css('background-color', '');
 
-        // return if current rows tserver is not recovering
+        // return if the current rows' tserver is not recovering
         if (!recoveryList.includes(data.hostname))
           return;
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tservers.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/tservers.ftl
@@ -25,7 +25,7 @@
       </div>
       <div class="row">
         <div class="col-xs-12">
-          <table id="badtservers" class="table table-bordered table-striped table-condensed">
+          <table id="badtservers" class="table table-bordered table-striped table-condensed" style="display: none;">
             <caption><span class="table-caption">Non-Functioning Tablet Servers</span><br/>
               <span class="table-subcaption">The following tablet servers reported a status other than Online</span></caption>
             <thead>
@@ -36,7 +36,7 @@
             </thead>
             <tbody></tbody>
           </table>
-          <table id="deadtservers" class="table table-bordered table-striped table-condensed">
+          <table id="deadtservers" class="table table-bordered table-striped table-condensed" style="display: none;">
             <caption><span class="table-caption">Dead Tablet Servers</span><br/>
               <span class="table-subcaption">The following tablet servers are no longer reachable.</span><br/></caption>
             <thead>
@@ -49,7 +49,7 @@
             </thead>
             <tbody></tbody>
           </table>
-          <span id="recovery-caption" style="background-color: gold;">Highlighted rows correspond to tservers in recovery mode.</span>
+          <span id="recovery-caption" style="background-color: gold; display: none;">Highlighted rows correspond to tservers in recovery mode.</span>
           <table id="tservers" class="table table-bordered table-striped table-condensed">
             <thead>
               <tr>


### PR DESCRIPTION
A bug was found in the feature added in #2663 where the caption explaining the highlighted rows would be visible in certain scenarios when there were no highlighted rows in the table. The caption is only meant to be visible when there are highlighted rows. The changes in this PR make it so that the caption is hidden by default and only shown when a row is actually highlighted.

Additionally, I renamed the variable representing the tservers table to make it more clear.