### PR TITLE
Update Replication Table offline message in Monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
@@ -52,7 +52,7 @@ function refreshReplicationsTable() {
 
   if (data.length === 0) {
     var items = [];
-    items.push(createEmptyRow(5, 'Replication table is offline'));
+    items.push(createEmptyRow(5, 'Replication is disabled by default. Replication table is currently offline.'));
     $('<tr/>', {
       html: items.join('')
     }).appendTo('#replicationStats tbody');


### PR DESCRIPTION
Related to issue #2653
---
Based on discussion in PR #2666, the default message in the Replication page in the Monitor was updated to inform the user that replication is disabled and the table is offline by default.