### PR TITLE
Utility to print metadata table

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -471,4 +471,9 @@ public class TabletMetadata {
     }
     return server;
   }
+
+  @Override
+  public String toString() {
+    return getExtent() + " " + getDirName() + " " + getLocation();
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
@@ -70,8 +70,9 @@ public class PrintMetadata implements KeywordExecutable {
     if (this.context == null) {
       this.context = opts.getServerContext();
     }
-    var ample = context.getAmple();
     var tableNameToIdMap = context.tableOperations().tableIdMap();
+
+    var ample = context.getAmple();
 
     opts.tables.forEach(tableName -> {
       String tableId = tableNameToIdMap.get(tableName);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.server.util;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,6 +39,7 @@ public class PrintMetadata implements KeywordExecutable {
   public PrintMetadata(ServerContext context) {
     this.context = context;
   }
+
   public PrintMetadata() {
     this.context = null;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PrintMetadata.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.server.cli.ServerUtilOpts;
+import org.apache.accumulo.start.spi.KeywordExecutable;
+
+import com.beust.jcommander.Parameter;
+import com.google.auto.service.AutoService;
+
+@AutoService(KeywordExecutable.class)
+public class PrintMetadata implements KeywordExecutable {
+  static class Opts extends ServerUtilOpts {
+    @Parameter(description = " <table> { <table> ... } ")
+    List<String> tables = new ArrayList<>();
+  }
+
+  @Override
+  public String keyword() {
+    return "print-md";
+  }
+
+  @Override
+  public String description() {
+    return "Prints the Accumulo metadata table to the command line.";
+  }
+
+  public static void main(String[] args) throws Exception {
+    new PrintMetadata().execute(args);
+  }
+
+  @Override
+  public void execute(String[] args) throws Exception {
+    Opts opts = new Opts();
+    opts.parseArgs(keyword(), args);
+    var serverContext = opts.getServerContext();
+    var ample = serverContext.getAmple();
+    var tableNameToIdMap = serverContext.tableOperations().tableIdMap();
+
+    opts.tables.forEach(tableName -> {
+      String tableId = tableNameToIdMap.get(tableName);
+      var tm = ample.readTablets().forTable(TableId.of(tableId)).build();
+      for (var tablet : tm) {
+        System.out.println(tablet);
+      }
+    });
+  }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/MockAmple.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockAmple.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/server/base/src/test/java/org/apache/accumulo/server/MockAmple.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockAmple.java
@@ -1,0 +1,14 @@
+package org.apache.accumulo.server;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+
+import org.apache.accumulo.core.metadata.schema.Ample;
+
+public class MockAmple {
+
+    public static Ample get() {
+        Ample ample = createMock(Ample.class);
+        return ample;
+    }
+}

--- a/server/base/src/test/java/org/apache/accumulo/server/MockAmple.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockAmple.java
@@ -1,14 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.accumulo.server;
 
 import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
 
 import org.apache.accumulo.core.metadata.schema.Ample;
 
 public class MockAmple {
 
-    public static Ample get() {
-        Ample ample = createMock(Ample.class);
-        return ample;
-    }
+  public static Ample get() {
+    Ample ample = createMock(Ample.class);
+    return ample;
+  }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
@@ -28,9 +28,9 @@ import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.crypto.CryptoServiceFactory;
 import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.conf.store.PropStore;
-import org.easymock.EasyMock;
 
 /**
  * Get a generic mocked ServerContext with junk for testing.
@@ -38,7 +38,7 @@ import org.easymock.EasyMock;
 public class MockServerContext {
 
   public static ServerContext get() {
-    ServerContext context = EasyMock.createMock(ServerContext.class);
+    ServerContext context = createMock(ServerContext.class);
     ConfigurationCopy conf = new ConfigurationCopy(DefaultConfiguration.getInstance());
     conf.set(Property.INSTANCE_VOLUMES, "file:///");
     expect(context.getConfiguration()).andReturn(conf).anyTimes();
@@ -65,6 +65,13 @@ public class MockServerContext {
     expect(sc.getZooReaderWriter()).andReturn(zrw).anyTimes();
     expect(sc.getZooKeeperRoot()).andReturn("/accumulo/" + instanceID).anyTimes();
     expect(sc.getPropStore()).andReturn(propStore).anyTimes();
+    return sc;
+  }
+
+  public static ServerContext getWithAmple() {
+    ServerContext sc = get();
+    Ample ample = MockAmple.get();
+    expect(sc.getAmple()).andReturn(ample).anyTimes();
     return sc;
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/MockServerContext.java
@@ -18,11 +18,20 @@
  */
 package org.apache.accumulo.server;
 
+import static java.util.Arrays.stream;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
+import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -31,12 +40,22 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.server.conf.store.PropStore;
+import org.easymock.EasyMock;
 
 /**
- * Get a generic mocked ServerContext with junk for testing.
+ * A mocked ServerContext. Can be used with static methods, which use {@link #get()} or constructed
+ * builder style, which requires a call to {@link #done()}.
  */
 public class MockServerContext {
+  ServerContext sc;
 
+  public MockServerContext() {
+    sc = get();
+  }
+
+  /**
+   * Get a generic mocked ServerContext with junk for testing.
+   */
   public static ServerContext get() {
     ServerContext context = createMock(ServerContext.class);
     ConfigurationCopy conf = new ConfigurationCopy(DefaultConfiguration.getInstance());
@@ -68,10 +87,64 @@ public class MockServerContext {
     return sc;
   }
 
-  public static ServerContext getWithAmple() {
-    ServerContext sc = get();
+  public static void verify(ServerContext context, Object... objects) {
+    EasyMock.verify(context, objects);
+  }
+
+  public MockServerContext withAmple() {
     Ample ample = MockAmple.get();
     expect(sc.getAmple()).andReturn(ample).anyTimes();
+    return this;
+  }
+
+  /**
+   * Mock {@link TableOperations} with the given tableNames. Mocks a single call to create table.
+   * Allows any number of calls to exist, list, and flush.
+   */
+  // public MockServerContext withTables(String name) throws Exception {
+  public MockServerContext withTables(String... tableNames) throws Exception {
+    TableOperations tableOps = createMock(TableOperations.class);
+
+    // mock tables are created once and exist always
+    stream(tableNames).forEach(name -> {
+      try {
+        tableOps.create(name);
+        expectLastCall().once();
+        tableOps.flush(name);
+        expectLastCall().anyTimes();
+        expect(tableOps.isOnline(name)).andReturn(true).anyTimes();
+
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      expect(tableOps.exists(name)).andReturn(true).anyTimes();
+    });
+    expect(tableOps.list()).andReturn(new TreeSet<>(Set.of(tableNames))).anyTimes();
+    // expect(tableOps.list()).andReturn(new TreeSet<>(Set.of(name))).anyTimes();
+    expect(tableOps.tableIdMap()).andReturn(tableIdMap(tableNames)).anyTimes();
+    // expect(tableOps.tableIdMap()).andReturn(tableIdMap(name)).anyTimes();
+    expect(sc.tableOperations()).andReturn(tableOps).anyTimes();
+
+    return this;
+  }
+
+  /**
+   * Get a mapping of table name to internal fake Table Ids for the given tableNames.
+   */
+  private Map<String,String> tableIdMap(String... tableNames) {
+    Map<String,String> tableIdMap = new TreeMap<>();
+    int i = 1;
+    for (String name : tableNames) {
+      tableIdMap.put(name, "" + i++);
+    }
+    return tableIdMap;
+  }
+
+  /**
+   * Call replay and return the Mocked ServerContext.
+   */
+  public ServerContext done() {
+    replay(sc);
     return sc;
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
@@ -22,15 +22,11 @@ import org.apache.accumulo.server.MockServerContext;
 import org.apache.accumulo.server.ServerContext;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 public class PrintMetadataTest {
   @Test
   public void test() throws Exception {
     ServerContext serverContext = MockServerContext.getWithAmple();
     PrintMetadata printMetadata = new PrintMetadata(serverContext);
-    printMetadata.execute(new String[]{});
+    printMetadata.execute(new String[] {});
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 public class PrintMetadataTest {
   @Test
   public void test() throws Exception {
-    ServerContext serverContext = MockServerContext.getWithAmple();
+    ServerContext serverContext = new MockServerContext().withTables("table1").withAmple().done();
+
     PrintMetadata printMetadata = new PrintMetadata(serverContext);
     printMetadata.execute(new String[] {});
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/PrintMetadataTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.server.util;
+
+import org.apache.accumulo.server.MockServerContext;
+import org.apache.accumulo.server.ServerContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class PrintMetadataTest {
+  @Test
+  public void test() throws Exception {
+    ServerContext serverContext = MockServerContext.getWithAmple();
+    PrintMetadata printMetadata = new PrintMetadata(serverContext);
+    printMetadata.execute(new String[]{});
+  }
+}


### PR DESCRIPTION
I thought that a utility to easily print different things from the new Ample classes would be useful. I am not sure what to print though. Most of the tablet stuff is available through other utilities like `listtablets` and could just be obtained through a scan of the metadata table. My thinking was something more user friendly than having to scan the metadata table, and deciphering the schema.