### PR TITLE
Remove json prettyPrint from RootGcCandidates

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootGcCandidates.java
@@ -36,7 +36,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 public class RootGcCandidates {
-  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final Gson GSON = new GsonBuilder().create();
 
   // This class is used to serialize and deserialize root tablet metadata using GSon. Any changes to
   // this class must consider persisted data.


### PR DESCRIPTION
  - removes multi-line json output from logs

With this change, the log looks like:

```
2022-05-06T13:53:04,574 [metadata.ServerAmpleImpl] DEBUG: Root GC candidates before change : {"version":1,"candidates":{}}
2022-05-06T13:53:04,576 [metadata.ServerAmpleImpl] DEBUG: Root GC candidates after change  : {"version":1,"candidates":{"hdfs://localhost:8020/accumulo/tables/+r/root_tablet":["00000_00000.rf","F0000000.rf","F0000004.rf"]}}
```

Before, the logs looked like:

```
2022-05-05T22:02:10,056 [metadata.ServerAmpleImpl] DEBUG: Root GC candidates before change : {
  "version": 1,
  "candidates": {}
}
2022-05-05T22:02:10,056 [metadata.ServerAmpleImpl] DEBUG: Root GC candidates after change  : {
  "version": 1,
  "candidates": {
    "hdfs://localhost:8020/accumulo/tables/+r/root_tablet": [
      "A00000ax.rf",
      "F00000ay.rf"
    ]
  }
}

```
