### PR TITLE
Add VFS type mapping for new jar mime type

### DIFF
--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -285,6 +285,7 @@ public class AccumuloVFSClassLoader {
     vfs.addExtensionMap("tbz2", "tar");
     vfs.addExtensionMap("tgz", "tar");
     vfs.addExtensionMap("bz2", "bz2");
+    vfs.addMimeTypeMap("application/java-archive", "jar");
     vfs.addMimeTypeMap("application/x-tar", "tar");
     vfs.addMimeTypeMap("application/x-gzip", "gz");
     vfs.addMimeTypeMap("application/zip", "zip");
@@ -426,9 +427,7 @@ public class AccumuloVFSClassLoader {
   private static synchronized ContextManager getContextManager() throws IOException {
     if (contextManager == null) {
       getClassLoader();
-      contextManager = new ContextManager(generateVfs(), () -> {
-        return getClassLoader();
-      });
+      contextManager = new ContextManager(generateVfs(), AccumuloVFSClassLoader::getClassLoader);
     }
 
     return contextManager;

--- a/start/src/test/java/org/apache/accumulo/start/test/AccumuloDFSBase.java
+++ b/start/src/test/java/org/apache/accumulo/start/test/AccumuloDFSBase.java
@@ -112,6 +112,7 @@ public class AccumuloDFSBase {
       vfs.addExtensionMap("tbz2", "tar");
       vfs.addExtensionMap("tgz", "tar");
       vfs.addExtensionMap("bz2", "bz2");
+      vfs.addMimeTypeMap("application/java-archive", "jar");
       vfs.addMimeTypeMap("application/x-tar", "tar");
       vfs.addMimeTypeMap("application/x-gzip", "gz");
       vfs.addMimeTypeMap("application/zip", "zip");


### PR DESCRIPTION
Add VFS type mapping for the new jar mime type added in newer versions
of Java 17, application/java-archive, to ensure it is associated with
the "jar" scheme in VFS. This ensures VFS loads jars correctly when run
on a newer version of Java.

This fixes #2682
See related: https://issues.apache.org/jira/browse/VFS-819