### PR TITLE
Add declaration for scansList prior to usage

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -18,6 +18,8 @@
  */
 "use strict";
 
+var scansList;
+
 /**
  * Creates scans initial table
  */


### PR DESCRIPTION
On the `Active Scans` page in the Monitor, the console complains about `scansList` not being defined.
This update was made using `compactions.js` as a reference.