### PR TITLE
Execute Caffeine tasks in current Thread for tests

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ZooPropLoaderTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ZooPropLoaderTest.java
@@ -147,8 +147,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load into cache
     assertNotNull(cache.get(propCacheKey));
@@ -185,8 +185,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     assertNull(cache.get(propCacheKey));
 
@@ -214,8 +214,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load cache
     assertNotNull(cache.get(propCacheKey));
@@ -266,8 +266,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // prime cache
     assertNotNull(cache.get(propCacheKey));
@@ -284,9 +284,6 @@ public class ZooPropLoaderTest {
 
     assertNotNull(cache.get(propCacheKey));
 
-    // yield so async thread completes.
-    Thread.sleep(250);
-
     assertNull(cache.get(propCacheKey));
   }
 
@@ -295,8 +292,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     assertNull(cache.getWithoutCaching(propCacheKey));
 
@@ -319,8 +316,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load into cache
     assertNotNull(cache.get(sysPropKey));
@@ -351,8 +348,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load into cache
     assertNotNull(cache.get(sysPropKey));
@@ -370,8 +367,8 @@ public class ZooPropLoaderTest {
   public void getWithoutCachingNotPresentTest() {
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load into cache
     assertNull(cache.getWithoutCaching(propCacheKey));
@@ -405,8 +402,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load cache
     log.debug("received: {}", cache.get(propCacheKey));
@@ -419,13 +416,9 @@ public class ZooPropLoaderTest {
 
     assertNotNull(cache.get(propCacheKey));
 
-    Thread.sleep(100);
-
     ticker.advance(REFRESH_MIN + 1, TimeUnit.MINUTES);
 
     assertNotNull(cache.get(propCacheKey));
-
-    Thread.sleep(100);
 
     ticker.advance(1, TimeUnit.MINUTES);
 
@@ -489,11 +482,13 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // prime cache
-    assertNotNull(cache.get(propCacheKey));
+    var origProps = cache.get(propCacheKey);
+    assertNotNull(origProps);
+    assertEquals("7G", origProps.asMap().get(Property.TABLE_SPLIT_THRESHOLD.getKey()));
 
     ticker.advance(REFRESH_MIN + 1, TimeUnit.MINUTES);
     // first call after refresh return original and schedules update
@@ -501,15 +496,11 @@ public class ZooPropLoaderTest {
     assertNotNull(originalProps);
     assertNotNull(originalProps.asMap().get(Property.TABLE_SPLIT_THRESHOLD.getKey()));
 
-    // allow refresh thread to run
-    Thread.sleep(50);
-
     // refresh should have loaded updated value;
     var updatedProps = cache.get(propCacheKey);
     log.debug("Updated props: {}", updatedProps == null ? "null" : updatedProps.print(true));
 
     assertNotNull(updatedProps);
-    Thread.sleep(250);
 
     assertEquals("12G", updatedProps.asMap().get(Property.TABLE_SPLIT_THRESHOLD.getKey()));
   }
@@ -557,8 +548,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics, mockProps);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // prime cache
     cache.get(propCacheKey);
@@ -570,7 +561,6 @@ public class ZooPropLoaderTest {
 
     assertNotNull(vPropsRead);
 
-    Thread.sleep(250);
     cache.get(propCacheKey);
 
     verify(mockProps);
@@ -618,8 +608,8 @@ public class ZooPropLoaderTest {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
-    PropCacheCaffeineImpl cache =
-        new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).withTicker(ticker).build();
+    PropCacheCaffeineImpl cache = new PropCacheCaffeineImpl.Builder(loader, cacheMetrics)
+        .withTicker(ticker).forTests().build();
 
     // load cache
     log.debug("received: {}", cache.get(propCacheKey));
@@ -628,7 +618,6 @@ public class ZooPropLoaderTest {
 
     assertNotNull(cache.get(propCacheKey)); // returns current and queues async refresh
 
-    Thread.sleep(150);
     assertNull(cache.get(propCacheKey)); // on exception, the loader should return null
 
   }


### PR DESCRIPTION
As described at https://github.com/ben-manes/caffeine/wiki/Testing, Caffeine
delegates maintenance tasks (eviction, refreshes, etc.) to background threads
to take advantage of batching. This change implements the suggestion at
https://github.com/ben-manes/caffeine/issues/455#issuecomment-689398669 to
run all of the maintenance tasks in the current Thread for testing. Using
Cache.cleanup as suggested in the wiki page did not appear to work, but this
approach allows us to remove all of the calls to Thread.sleep in the tests.