### PR TITLE
Improvements to MiniAccumuloClusterTest

### DIFF
--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/MiniAccumuloClusterTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
@@ -62,11 +63,14 @@ import org.junit.jupiter.api.io.TempDir;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "paths not set by user input")
-public class MiniAccumuloClusterTest {
+public class MiniAccumuloClusterTest extends WithTestNames {
 
   @SuppressWarnings("removal")
   private static final Property VFS_CONTEXT_CLASSPATH_PROPERTY =
       Property.VFS_CONTEXT_CLASSPATH_PROPERTY;
+
+  public static final String ROOT_PASSWORD = "superSecret";
+  public static final String ROOT_USER = "root";
 
   public static File testDir;
 
@@ -80,7 +84,7 @@ public class MiniAccumuloClusterTest {
     FileUtils.deleteQuietly(testDir);
     assertTrue(testDir.mkdir());
 
-    MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, "superSecret").setJDWPEnabled(true);
+    MiniAccumuloConfig config = new MiniAccumuloConfig(testDir, ROOT_PASSWORD).setJDWPEnabled(true);
     config.setZooKeeperPort(0);
     HashMap<String,String> site = new HashMap<>();
     site.put(Property.TSERV_WORKQ_THREADS.getKey(), "2");
@@ -102,73 +106,84 @@ public class MiniAccumuloClusterTest {
   @Test
   @Timeout(30)
   public void test() throws Exception {
-    org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
+    org.apache.accumulo.core.client.Connector conn =
+        accumulo.getConnector(ROOT_USER, ROOT_PASSWORD);
 
-    conn.tableOperations().create("table1", new NewTableConfiguration());
-
-    conn.securityOperations().createLocalUser("user1", new PasswordToken("pass1"));
-    conn.securityOperations().changeUserAuthorizations("user1", new Authorizations("A", "B"));
-    conn.securityOperations().grantTablePermission("user1", "table1", TablePermission.WRITE);
-    conn.securityOperations().grantTablePermission("user1", "table1", TablePermission.READ);
+    final String tableName = testName();
 
     IteratorSetting is = new IteratorSetting(10, SummingCombiner.class);
     SummingCombiner.setEncodingType(is, LongCombiner.Type.STRING);
     SummingCombiner.setColumns(is,
         Collections.singletonList(new IteratorSetting.Column("META", "COUNT")));
 
-    conn.tableOperations().attachIterator("table1", is);
+    conn.tableOperations().create(tableName, new NewTableConfiguration().attachIterator(is));
 
-    org.apache.accumulo.core.client.Connector uconn = accumulo.getConnector("user1", "pass1");
+    final String principal = "user1";
+    final String password = "pass1";
+    conn.securityOperations().createLocalUser(principal, new PasswordToken(password));
+    conn.securityOperations().changeUserAuthorizations(principal, new Authorizations("A", "B"));
+    conn.securityOperations().grantTablePermission(principal, tableName, TablePermission.WRITE);
+    conn.securityOperations().grantTablePermission(principal, tableName, TablePermission.READ);
 
-    BatchWriter bw = uconn.createBatchWriter("table1", new BatchWriterConfig());
+    org.apache.accumulo.core.client.Connector uconn = accumulo.getConnector(principal, password);
 
-    UUID uuid = UUID.randomUUID();
+    try (BatchWriter bw = uconn.createBatchWriter(tableName, new BatchWriterConfig())) {
 
-    Mutation m = new Mutation(uuid.toString());
-    m.put("META", "SIZE", new ColumnVisibility("A|B"), "8");
-    m.put("META", "CRC", new ColumnVisibility("A|B"), "456");
-    m.put("META", "COUNT", new ColumnVisibility("A|B"), "1");
-    m.put("DATA", "IMG", new ColumnVisibility("A&B"), "ABCDEFGH");
+      UUID uuid = UUID.randomUUID();
 
-    bw.addMutation(m);
-    bw.flush();
+      ColumnVisibility colVisAorB = new ColumnVisibility("A|B");
+      Mutation m = new Mutation(uuid.toString());
+      m.put("META", "SIZE", colVisAorB, "8");
+      m.put("META", "CRC", colVisAorB, "456");
+      m.put("META", "COUNT", colVisAorB, "1");
+      m.put("DATA", "IMG", new ColumnVisibility("A&B"), "ABCDEFGH");
 
-    m = new Mutation(uuid.toString());
-    m.put("META", "COUNT", new ColumnVisibility("A|B"), "1");
-    m.put("META", "CRC", new ColumnVisibility("A|B"), "123");
-    bw.addMutation(m);
+      bw.addMutation(m);
+      bw.flush();
 
-    bw.close();
+      m = new Mutation(uuid.toString());
+      m.put("META", "COUNT", colVisAorB, "1");
+      m.put("META", "CRC", colVisAorB, "123");
+      bw.addMutation(m);
 
-    int count = 0;
-    Scanner scanner = uconn.createScanner("table1", new Authorizations("A"));
-    for (Entry<Key,Value> entry : scanner) {
-      if (entry.getKey().getColumnQualifierData().toString().equals("COUNT")) {
-        assertEquals("2", entry.getValue().toString());
-      } else if (entry.getKey().getColumnQualifierData().toString().equals("SIZE")) {
-        assertEquals("8", entry.getValue().toString());
-      } else if (entry.getKey().getColumnQualifierData().toString().equals("CRC")) {
-        assertEquals("123", entry.getValue().toString());
-      } else {
-        fail();
-      }
-      count++;
     }
 
+    int count = 0;
+    try (Scanner scanner = uconn.createScanner(tableName, new Authorizations("A"))) {
+      for (Entry<Key,Value> entry : scanner) {
+        final String actualValue = entry.getValue().toString();
+        switch (entry.getKey().getColumnQualifierData().toString()) {
+          case "COUNT":
+            assertEquals("2", actualValue);
+            break;
+          case "SIZE":
+            assertEquals("8", actualValue);
+            break;
+          case "CRC":
+            assertEquals("123", actualValue);
+            break;
+          default:
+            fail();
+            break;
+        }
+        count++;
+      }
+    }
     assertEquals(3, count);
 
     count = 0;
-    scanner = uconn.createScanner("table1", new Authorizations("A", "B"));
-    for (Entry<Key,Value> entry : scanner) {
-      if (entry.getKey().getColumnQualifierData().toString().equals("IMG")) {
-        assertEquals("ABCDEFGH", entry.getValue().toString());
+    try (Scanner scanner = uconn.createScanner(tableName, new Authorizations("A", "B"))) {
+      for (Entry<Key,Value> entry : scanner) {
+        if (entry.getKey().getColumnQualifierData().toString().equals("IMG")) {
+          assertEquals("ABCDEFGH", entry.getValue().toString());
+        }
+        count++;
       }
-      count++;
     }
 
     assertEquals(4, count);
 
-    conn.tableOperations().delete("table1");
+    conn.tableOperations().delete(tableName);
   }
 
   @TempDir
@@ -178,49 +193,51 @@ public class MiniAccumuloClusterTest {
   @Test
   @Timeout(60)
   public void testPerTableClasspath() throws Exception {
+    org.apache.accumulo.core.client.Connector conn =
+        accumulo.getConnector(ROOT_USER, ROOT_PASSWORD);
 
-    org.apache.accumulo.core.client.Connector conn = accumulo.getConnector("root", "superSecret");
-
-    conn.tableOperations().create("table2");
-
+    final String tableName = testName();
     File jarFile = new File(tempDir, "iterator.jar");
+
+    var ntc = new NewTableConfiguration();
+    ntc.setProperties(Map.of(Property.TABLE_CLASSLOADER_CONTEXT.getKey(), "cx1"));
+    ntc.attachIterator(new IteratorSetting(100, "foocensor", "org.apache.accumulo.test.FooFilter"));
+
+    conn.tableOperations().create(tableName, ntc);
+
     FileUtils.copyURLToFile(requireNonNull(getClass().getResource("/FooFilter.jar")), jarFile);
 
     conn.instanceOperations().setProperty(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "cx1",
         jarFile.toURI().toString());
-    conn.tableOperations().setProperty("table2", Property.TABLE_CLASSLOADER_CONTEXT.getKey(),
-        "cx1");
-    conn.tableOperations().attachIterator("table2",
-        new IteratorSetting(100, "foocensor", "org.apache.accumulo.test.FooFilter"));
 
-    BatchWriter bw = conn.createBatchWriter("table2", new BatchWriterConfig());
+    try (BatchWriter bw = conn.createBatchWriter(tableName, new BatchWriterConfig())) {
 
-    Mutation m1 = new Mutation("foo");
-    m1.put("cf1", "cq1", "v2");
-    m1.put("cf1", "cq2", "v3");
+      Mutation m1 = new Mutation("foo");
+      m1.put("cf1", "cq1", "v2");
+      m1.put("cf1", "cq2", "v3");
 
-    bw.addMutation(m1);
+      bw.addMutation(m1);
 
-    Mutation m2 = new Mutation("bar");
-    m2.put("cf1", "cq1", "v6");
-    m2.put("cf1", "cq2", "v7");
+      Mutation m2 = new Mutation("bar");
+      m2.put("cf1", "cq1", "v6");
+      m2.put("cf1", "cq2", "v7");
 
-    bw.addMutation(m2);
+      bw.addMutation(m2);
 
-    bw.close();
-
-    Scanner scanner = conn.createScanner("table2", new Authorizations());
+    }
 
     int count = 0;
-    for (Entry<Key,Value> entry : scanner) {
-      assertFalse(entry.getKey().getRowData().toString().toLowerCase().contains("foo"));
-      count++;
+    try (Scanner scanner = conn.createScanner(tableName, new Authorizations())) {
+      for (Entry<Key,Value> entry : scanner) {
+        assertFalse(entry.getKey().getRowData().toString().toLowerCase().contains("foo"));
+        count++;
+      }
     }
 
     assertEquals(2, count);
 
     conn.instanceOperations().removeProperty(VFS_CONTEXT_CLASSPATH_PROPERTY.getKey() + "cx1");
-    conn.tableOperations().delete("table2");
+    conn.tableOperations().delete(tableName);
   }
 
   @Test
@@ -254,7 +271,7 @@ public class MiniAccumuloClusterTest {
     for (Property randomPortProp : new Property[] {Property.TSERV_CLIENTPORT, Property.MONITOR_PORT,
         Property.MANAGER_CLIENTPORT, Property.GC_PORT}) {
       String value = config.getString(randomPortProp.getKey());
-      assertNotNull("Found no value for " + randomPortProp, value);
+      assertNotNull(value, "Found no value for " + randomPortProp);
       assertEquals("0", value);
     }
   }


### PR DESCRIPTION
I noticed that this test failed after merging in #2685. I'm fairly certain the test failure is unrelated since #2685 only touched JavaScript and FreeMarker files.

Commit: https://github.com/apache/accumulo/commit/19e420da392c3905dbe9f3b020a4a60d03615d55
CI run: https://github.com/apache/accumulo/runs/6393887792?check_suite_focus=true

I'm not too sure why this test failed and have been unable to reproduce the failure but while investigating, I made various changes that seem like improvements to me:
* Use unique names for tables (this may have caused the error if it collided with a table name from another test)
* Refactor into several new constants and variables
* Add resources to try-with-resources blocks
* Use NewTableConfiguration to create tables