### PR TITLE
 Rename property GENERAL_SIMPLETIMER_THREADPOOL_SIZE

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -244,12 +244,13 @@ public enum Property {
   GENERAL_OPENTELEMETRY_ENABLED("general.opentelemetry.enabled", "false", PropertyType.BOOLEAN,
       "Enables tracing functionality using OpenTelemetry (assuming OpenTelemetry is configured).",
       "2.1.0"),
-  @Deprecated
+  GENERAL_THREADPOOL_SIZE("general.server.threadpool.size", "1", PropertyType.COUNT,
+      "The number of threads to use for server-internal scheduled tasks", "2.1.0"),
+  @Deprecated(since = "2.1.0")
+  @ReplacedBy(property = GENERAL_THREADPOOL_SIZE)
   GENERAL_SIMPLETIMER_THREADPOOL_SIZE("general.server.simpletimer.threadpool.size", "1",
       PropertyType.COUNT, "The number of threads to use for server-internal scheduled tasks",
       "1.7.0"),
-  GENERAL_THREADPOOL_SIZE("general.server.threadpool.size", "1", PropertyType.COUNT,
-      "The number of threads to use for server-internal scheduled tasks", "3.0.0"),
   // If you update the default type, be sure to update the default used for initialization failures
   // in VolumeManagerImpl
   @Experimental

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -244,9 +244,12 @@ public enum Property {
   GENERAL_OPENTELEMETRY_ENABLED("general.opentelemetry.enabled", "false", PropertyType.BOOLEAN,
       "Enables tracing functionality using OpenTelemetry (assuming OpenTelemetry is configured).",
       "2.1.0"),
+  @Deprecated
   GENERAL_SIMPLETIMER_THREADPOOL_SIZE("general.server.simpletimer.threadpool.size", "1",
       PropertyType.COUNT, "The number of threads to use for server-internal scheduled tasks",
       "1.7.0"),
+  GENERAL_THREADPOOL_SIZE("general.server.threadpool.size", "1", PropertyType.COUNT,
+      "The number of threads to use for server-internal scheduled tasks", "3.0.0"),
   // If you update the default type, be sure to update the default used for initialization failures
   // in VolumeManagerImpl
   @Experimental

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -518,9 +518,9 @@ public class ThreadPools {
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     @SuppressWarnings("deprecation")
-    var oldProp = Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE;
-    return (ScheduledThreadPoolExecutor) createExecutorService(conf,
-        conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp), true);
+    Property prop = conf.resolve(Property.GENERAL_THREADPOOL_SIZE,
+        Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE);
+    return (ScheduledThreadPoolExecutor) createExecutorService(conf, prop, true);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -519,8 +519,13 @@ public class ThreadPools {
   @SuppressWarnings("deprecation")
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
-    return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
-        Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
+    try {
+      return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
+          Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
+    } catch (NullPointerException e) {
+      return (ScheduledThreadPoolExecutor) createExecutorService(conf,
+          Property.GENERAL_THREADPOOL_SIZE, true);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -519,8 +519,13 @@ public class ThreadPools {
   @SuppressWarnings("deprecation")
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
-    return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
-        Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
+    if (conf != null) {
+      return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
+          Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
+    } else {
+      return (ScheduledThreadPoolExecutor) createExecutorService(conf,
+          Property.GENERAL_THREADPOOL_SIZE, true);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -266,6 +266,10 @@ public class ThreadPools {
       case GENERAL_SIMPLETIMER_THREADPOOL_SIZE:
         return createScheduledExecutorService(conf.getCount(p), "SimpleTimer",
             emitThreadPoolMetrics);
+      case GENERAL_THREADPOOL_SIZE:
+        return createScheduledExecutorService(conf.getCount(p), "General", // TODO ask if name
+                                                                           // should be changed
+            emitThreadPoolMetrics);
       case MANAGER_BULK_THREADPOOL_SIZE:
         return createFixedThreadPool(conf.getCount(p),
             conf.getTimeInMillis(Property.MANAGER_BULK_THREADPOOL_TIMEOUT), MILLISECONDS,
@@ -515,7 +519,7 @@ public class ThreadPools {
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     return (ScheduledThreadPoolExecutor) createExecutorService(conf,
-        Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, true);
+        Property.GENERAL_THREADPOOL_SIZE, true);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -516,10 +516,11 @@ public class ThreadPools {
    * If you need the server-side shared ScheduledThreadPoolExecutor, then use
    * ServerContext.getScheduledExecutor()
    */
+  @SuppressWarnings("deprecation")
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
-    return (ScheduledThreadPoolExecutor) createExecutorService(conf,
-        Property.GENERAL_THREADPOOL_SIZE, true);
+    return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
+        Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -519,8 +519,8 @@ public class ThreadPools {
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     @SuppressWarnings("deprecation")
     var oldProp = Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE;
-    return (ScheduledThreadPoolExecutor) createExecutorService(conf,
-        conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp), true);
+    var prop = conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp);
+    return (ScheduledThreadPoolExecutor) createExecutorService(conf, prop, true);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -518,8 +518,8 @@ public class ThreadPools {
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     @SuppressWarnings("deprecation")
-    var oldProp = Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE;
-    var prop = conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp);
+    Property oldProp = Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE;
+    Property prop = conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp);
     return (ScheduledThreadPoolExecutor) createExecutorService(conf, prop, true);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -268,7 +268,7 @@ public class ThreadPools {
             emitThreadPoolMetrics);
       case GENERAL_THREADPOOL_SIZE:
         return createScheduledExecutorService(conf.getCount(p), "General", // TODO ask if name
-                                                                           // should be changed
+            // should be changed
             emitThreadPoolMetrics);
       case MANAGER_BULK_THREADPOOL_SIZE:
         return createFixedThreadPool(conf.getCount(p),
@@ -522,7 +522,7 @@ public class ThreadPools {
     try {
       return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
           Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
-    } catch (NullPointerException e) {
+    } catch (Exception e) {
       return (ScheduledThreadPoolExecutor) createExecutorService(conf,
           Property.GENERAL_THREADPOOL_SIZE, true);
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -267,8 +267,7 @@ public class ThreadPools {
         return createScheduledExecutorService(conf.getCount(p), "SimpleTimer",
             emitThreadPoolMetrics);
       case GENERAL_THREADPOOL_SIZE:
-        return createScheduledExecutorService(conf.getCount(p), "General", // TODO ask if name
-            // should be changed
+        return createScheduledExecutorService(conf.getCount(p), "GeneralExecutor",
             emitThreadPoolMetrics);
       case MANAGER_BULK_THREADPOOL_SIZE:
         return createFixedThreadPool(conf.getCount(p),
@@ -516,16 +515,12 @@ public class ThreadPools {
    * If you need the server-side shared ScheduledThreadPoolExecutor, then use
    * ServerContext.getScheduledExecutor()
    */
-  @SuppressWarnings("deprecation")
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
-    try {
-      return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
-          Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
-    } catch (Exception e) {
-      return (ScheduledThreadPoolExecutor) createExecutorService(conf,
-          Property.GENERAL_THREADPOOL_SIZE, true);
-    }
+    @SuppressWarnings("deprecation")
+    var oldProp = Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE;
+    return (ScheduledThreadPoolExecutor) createExecutorService(conf,
+        conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp), true);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -518,9 +518,9 @@ public class ThreadPools {
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
     @SuppressWarnings("deprecation")
-    Property prop = conf.resolve(Property.GENERAL_THREADPOOL_SIZE,
-        Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE);
-    return (ScheduledThreadPoolExecutor) createExecutorService(conf, prop, true);
+    var oldProp = Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE;
+    return (ScheduledThreadPoolExecutor) createExecutorService(conf,
+        conf.resolve(Property.GENERAL_THREADPOOL_SIZE, oldProp), true);
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -519,13 +519,8 @@ public class ThreadPools {
   @SuppressWarnings("deprecation")
   public ScheduledThreadPoolExecutor
       createGeneralScheduledExecutorService(AccumuloConfiguration conf) {
-    if (conf != null) {
-      return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
-          Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
-    } else {
-      return (ScheduledThreadPoolExecutor) createExecutorService(conf,
-          Property.GENERAL_THREADPOOL_SIZE, true);
-    }
+    return (ScheduledThreadPoolExecutor) createExecutorService(conf, conf.resolve(
+        Property.GENERAL_THREADPOOL_SIZE, Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE), true);
   }
 
   /**

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -233,7 +233,7 @@ public class ExternalCompactionTestUtils {
     cfg.setProperty(Property.COMPACTION_COORDINATOR_TSERVER_COMPACTION_CHECK_INTERVAL, "3s");
     cfg.setProperty(Property.COMPACTION_COORDINATOR_THRIFTCLIENT_PORTSEARCH, "true");
     cfg.setProperty(Property.COMPACTOR_PORTSEARCH, "true");
-    cfg.setProperty(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "10");
+    cfg.setProperty(Property.GENERAL_THREADPOOL_SIZE, "10");
     cfg.setProperty(Property.MANAGER_FATE_THREADPOOL_SIZE, "10");
     // use raw local file system so walogs sync and flush will work
     coreSite.set("fs.file.impl", RawLocalFileSystem.class.getName());

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -160,7 +160,7 @@ public class FateIT {
     Fate<Manager> fate = new Fate<Manager>(manager, store, TraceRepo::toLogString);
     try {
       ConfigurationCopy config = new ConfigurationCopy();
-      config.set(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "2");
+      config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
       config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, "1");
       fate.startTransactionRunners(config);
 
@@ -221,7 +221,7 @@ public class FateIT {
     Fate<Manager> fate = new Fate<Manager>(manager, store, TraceRepo::toLogString);
     try {
       ConfigurationCopy config = new ConfigurationCopy();
-      config.set(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "2");
+      config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
       config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, "1");
       fate.startTransactionRunners(config);
 
@@ -260,7 +260,7 @@ public class FateIT {
 
     Fate<Manager> fate = new Fate<Manager>(manager, store, TraceRepo::toLogString);
     ConfigurationCopy config = new ConfigurationCopy();
-    config.set(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "2");
+    config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
 
     // Notice that we did not start the transaction runners
 
@@ -294,7 +294,7 @@ public class FateIT {
     Fate<Manager> fate = new Fate<Manager>(manager, store, TraceRepo::toLogString);
     try {
       ConfigurationCopy config = new ConfigurationCopy();
-      config.set(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "2");
+      config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
       config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, "1");
       fate.startTransactionRunners(config);
 
@@ -336,7 +336,7 @@ public class FateIT {
     Fate<Manager> fate = new Fate<Manager>(manager, store, TraceRepo::toLogString);
     try {
       ConfigurationCopy config = new ConfigurationCopy();
-      config.set(Property.GENERAL_SIMPLETIMER_THREADPOOL_SIZE, "2");
+      config.set(Property.GENERAL_THREADPOOL_SIZE, "2");
       config.set(Property.MANAGER_FATE_THREADPOOL_SIZE, "1");
       fate.startTransactionRunners(config);
 


### PR DESCRIPTION
- Added property with new name
- Marked old property as Deprecated
- Updated usages

Fixes #2618 