### PR TITLE
Configure opportunistic formatting of JavaScript

### DIFF
--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -244,4 +244,35 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <!-- on by default, but disable with '-P !autoformat' or '-DskipFormat' -->
+      <id>autoformat</id>
+      <activation>
+        <property>
+          <name>!skipFormat</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>format-javascript</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <executable>${basedir}/src/main/scripts/format-js.sh</executable>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -26,78 +26,76 @@
  * Generates the manager bulk import status table
  */
 function refreshBulkImportTable() {
-    $("#bulkListTable tbody").html(EMPTY_ROW_THREE_CELLS);
+  $("#bulkListTable tbody").html(EMPTY_ROW_THREE_CELLS);
 
-    // Get the bulk import data from the session
-    var data = sessionStorage.bulkImports === undefined ?
-                [] : JSON.parse(sessionStorage.bulkImports);
+  // Get the bulk import data from the session
+  var data = sessionStorage.bulkImports === undefined ? [] : JSON.parse(sessionStorage.bulkImports);
 
-    // If the data is empty, clear table, otherwise populate
-    if (data.length === 0 || data.bulkImport.length === 0) {
-        return;
-    }
-    console.log("Populate bulkListTable with " + sessionStorage.bulkImports);
-    var tableBodyHtml = "";
-    $.each(data.bulkImport, function (key, val) {
-        console.log("Append row " + key + " " + JSON.stringify(val) + " to bulkListTable");
-        tableBodyHtml += "<tr><td class='firstcell'>" + val.filename + "</td>";
-        tableBodyHtml += "<td class='center'>" + new Date(val.age) + "</td>";
-        tableBodyHtml += "<td class='center'>" + val.state + "</td></tr>";
-    });
+  // If the data is empty, clear table, otherwise populate
+  if (data.length === 0 || data.bulkImport.length === 0) {
+    return;
+  }
+  console.log("Populate bulkListTable with " + sessionStorage.bulkImports);
+  var tableBodyHtml = "";
+  $.each(data.bulkImport, function (key, val) {
+    console.log("Append row " + key + " " + JSON.stringify(val) + " to bulkListTable");
+    tableBodyHtml += "<tr><td class='firstcell'>" + val.filename + "</td>";
+    tableBodyHtml += "<td class='center'>" + new Date(val.age) + "</td>";
+    tableBodyHtml += "<td class='center'>" + val.state + "</td></tr>";
+  });
 
-    $("#bulkListTable tbody").html(tableBodyHtml);
+  $("#bulkListTable tbody").html(tableBodyHtml);
 }
 
 /**
  * Generates the bulkPerServerTable table
  */
 function refreshServerBulkTable() {
-    $("#bulkPerServerTable tbody").html(EMPTY_ROW_THREE_CELLS);
+  $("#bulkPerServerTable tbody").html(EMPTY_ROW_THREE_CELLS);
 
-    // get the bulkImport data from sessionStorage
-    var data = sessionStorage.bulkImports === undefined ?
-                [] : JSON.parse(sessionStorage.bulkImports);
+  // get the bulkImport data from sessionStorage
+  var data = sessionStorage.bulkImports === undefined ? [] : JSON.parse(sessionStorage.bulkImports);
 
-    // if data is empty, log an error because that means no tablet servers were found
-    if (data.length === 0 || data.tabletServerBulkImport.length === 0) {
-        console.error("No tablet servers.");
-        return;
+  // if data is empty, log an error because that means no tablet servers were found
+  if (data.length === 0 || data.tabletServerBulkImport.length === 0) {
+    console.error("No tablet servers.");
+    return;
+  }
+  var tableBodyHtml = "";
+  $.each(data.tabletServerBulkImport, function (key, val) {
+    console.log("Append " + key + " " + JSON.stringify(val) + " to bulkPerServerTable");
+    var ageCell = EMPTY_CELL;
+    if (val.oldestAge > 0) {
+      ageCell = "<td>" + new Date(val.oldestAge) + "</td>";
     }
-    var tableBodyHtml = "";
-    $.each(data.tabletServerBulkImport, function (key, val) {
-        console.log("Append " + key + " " + JSON.stringify(val) + " to bulkPerServerTable");
-        var ageCell = EMPTY_CELL;
-        if (val.oldestAge > 0) {
-            ageCell = "<td>" + new Date(val.oldestAge) + "</td>";
-        }
-        tableBodyHtml += "<tr><td><a href='/tservers?s=" + val.server + "'>" + val.server + "</a></td>";
-        tableBodyHtml += "<td>" + val.importSize + "</td>";
-        tableBodyHtml += ageCell + "</tr>";
-    });
+    tableBodyHtml += "<tr><td><a href='/tservers?s=" + val.server + "'>" + val.server + "</a></td>";
+    tableBodyHtml += "<td>" + val.importSize + "</td>";
+    tableBodyHtml += ageCell + "</tr>";
+  });
 
-    $("#bulkPerServerTable tbody").html(tableBodyHtml);
+  $("#bulkPerServerTable tbody").html(tableBodyHtml);
 }
 
 /**
-* Makes the REST calls, generates the tables with the new information
-*/
+ * Makes the REST calls, generates the tables with the new information
+ */
 function refreshBulkImport() {
-    getBulkImports().then(function () {
-        refreshBulkImportTable();
-        refreshServerBulkTable();
-    });
+  getBulkImports().then(function () {
+    refreshBulkImportTable();
+    refreshServerBulkTable();
+  });
 }
 
 /**
-* Creates bulk import initial table
-*/
+ * Creates bulk import initial table
+ */
 $(document).ready(function () {
-    refreshBulkImport();
+  refreshBulkImport();
 });
 
 /**
-* Used to redraw the page
-*/
+ * Used to redraw the page
+ */
 function refresh() {
-    refreshBulkImport();
+  refreshBulkImport();
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/compactions.js
@@ -18,60 +18,67 @@
  */
 "use strict";
 
- var compactionsList;
- /**
-  * Creates active compactions table
-  */
- $(document).ready(function() {
-     // Create a table for compactions list
-     compactionsList = $('#compactionsList').DataTable({
-       "ajax": {
-         "url": '/rest/compactions',
-         "dataSrc": "compactions"
-       },
-       "stateSave": true,
-       "dom": 't<"align-left"l>p',
-       "columnDefs": [
-           { "targets": "duration",
-             "render": function ( data, type, row ) {
-               if(type === 'display') data = timeDuration(data);
-               return data;
-             }
-           },
-           { "targets": "date",
-               "render": function ( data, type, row ) {
-                 if(type === 'display') data = dateFormat(data);
-                 return data;
-               }
-             }
-         ],
-       "columns": [
-         { "data": "server",
-           "type": "html",
-           "render": function ( data, type, row, meta ) {
-             if(type === 'display') {
-                data = '<a href="/tservers?s=' + row.server + '">' + row.server + '</a>';
-             }
-             return data;
-           }
-         },
-         { "data": "count" },
-         { "data": "oldest" },
-         { "data": "fetched" },
-       ]
-     });
- });
+var compactionsList;
+/**
+ * Creates active compactions table
+ */
+$(document).ready(function () {
+  // Create a table for compactions list
+  compactionsList = $('#compactionsList').DataTable({
+    "ajax": {
+      "url": '/rest/compactions',
+      "dataSrc": "compactions"
+    },
+    "stateSave": true,
+    "dom": 't<"align-left"l>p',
+    "columnDefs": [{
+        "targets": "duration",
+        "render": function (data, type, row) {
+          if (type === 'display') data = timeDuration(data);
+          return data;
+        }
+      },
+      {
+        "targets": "date",
+        "render": function (data, type, row) {
+          if (type === 'display') data = dateFormat(data);
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "server",
+        "type": "html",
+        "render": function (data, type, row, meta) {
+          if (type === 'display') {
+            data = '<a href="/tservers?s=' + row.server + '">' + row.server + '</a>';
+          }
+          return data;
+        }
+      },
+      {
+        "data": "count"
+      },
+      {
+        "data": "oldest"
+      },
+      {
+        "data": "fetched"
+      },
+    ]
+  });
+});
 
- /**
-  * Generates the compactions table
-  */
- function refreshCompactionsTable() {
-   if(compactionsList) compactionsList.ajax.reload(null, false ); // user paging is not reset on reload
- }
+/**
+ * Generates the compactions table
+ */
+function refreshCompactionsTable() {
+  if (compactionsList) compactionsList.ajax.reload(null, false); // user paging is not reset on reload
+}
 
- /**
-  * Used to redraw the page
-  */
- function refresh() {
-   refreshCompactionsTable();
- }
+/**
+ * Used to redraw the page
+ */
+function refresh() {
+  refreshCompactionsTable();
+}

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -18,250 +18,276 @@
  */
 "use strict";
 
- var coordinatorTable;
- var compactorsTable;
- var compactorsTableData;
- var runningTable;
- var runningTableData;
+var coordinatorTable;
+var compactorsTable;
+var compactorsTableData;
+var runningTable;
+var runningTableData;
 
- /**
-  * Creates active compactions table
-  */
- $(document).ready(function() {
-    if (sessionStorage.ecDetailsJSON === undefined) {
-       sessionStorage.ecDetailsJSON = JSON.stringify([]);
-    }
-    compactorsTable = $('#compactorsTable').DataTable({
-           "ajax": {
-               "url": '/rest/ec/compactors',
-               "dataSrc": "compactors"
-           },
-           "stateSave": true,
-           "dom": 't<"align-left"l>p',
-           "columnDefs": [
-              { "targets": "duration",
-                "render": function ( data, type, row ) {
-                  if(type === 'display') data = timeDuration(data);
-                  return data;
-                }
-              },
-              { "targets": "date",
-                  "render": function ( data, type, row ) {
-                    if(type === 'display') data = dateFormat(data);
-                    return data;
-                  }
-                }
-            ],
-           "columns": [
-             { "data": "server" },
-             { "data": "queueName"},
-             { "data": "lastContact"}
-           ]
-         });
-
-     // Create a table for compactors
-     runningTable = $('#runningTable').DataTable({
-       "ajax": {
-            "url": '/rest/ec/running',
-            "dataSrc": "running"
-       },
-       "stateSave": true,
-       "dom": 't<"align-left"l>p',
-       "columnDefs": [
-           { "targets": "duration",
-             "render": function ( data, type, row ) {
-               if(type === 'display') data = timeDuration(data);
-               return data;
-             }
-           },
-           { "targets": "date",
-               "render": function ( data, type, row ) {
-                 if(type === 'display') data = dateFormat(data);
-                 return data;
-               }
-             }
-         ],
-       "columns": [
-         { "data": "server" },
-         { "data": "kind" },
-         { "data": "status" },
-         { "data": "queueName" },
-         { "data": "tableId" },
-         { "data": "numFiles" },
-         { "data": "progress",
-           "type": "html",
-           "render": function ( data, type, row, meta ) {
-              if(type === 'display') {
-                  if (row.progress < 0) {
-                    data = '--';
-                  } else {
-                    var p = Math.round(Number(row.progress));
-                    console.log("Compaction progress = %" + p);
-                    data = '<div class="progress"><div class="progress-bar" role="progressbar" style="min-width: 2em; width:' +
-                         p + '%;">' + p + '%</div></div>';
-                  }
-              }
-              return data;
-            }
-         },
-         { "data": "lastUpdate"},
-         { "data": "duration"},
-         { // more column settings
-            "class":          "details-control",
-            "orderable":      false,
-            "data":           null,
-            "defaultContent": ""
-         }
-       ]
-     });
-
-     // Array to track the ids of the details displayed rows
-       var detailRows = [];
-       $("#runningTable tbody").on( 'click', 'tr td.details-control', function () {
-         var tr = $(this).closest('tr');
-         var row = runningTable.row( tr );
-         var idx = $.inArray( tr.attr('id'), detailRows );
-
-         if ( row.child.isShown() ) {
-             tr.removeClass( 'details' );
-             row.child.hide();
-
-             // Remove from the 'open' array
-             detailRows.splice( idx, 1 );
-         } else {
-             var rci = row.data();
-             var ecid = rci.ecid;
-             var idSuffix = ecid.substring(ecid.length-5, ecid.length);
-             tr.addClass( 'details' );
-             // put all the information into html for a single row
-             var htmlRow = "<table class='table table-bordered table-striped table-condensed' id='table"+idSuffix+"'>"
-             htmlRow += "<thead><tr><th>#</th><th>Input Files</th><th>Size</th><th>Entries</th></tr></thead>";
-             htmlRow += "<tbody></tbody></table>";
-             htmlRow += "Output File: <span id='outputFile" + idSuffix + "'></span><br>";
-             htmlRow += ecid;
-             row.child(htmlRow).show();
-             // show the row then populate the table
-             var ecDetails = getDetailsFromStorage(idSuffix);
-             if (ecDetails.length === 0) {
-                getRunningDetails(ecid, idSuffix);
-             } else {
-                console.log("Got cached details for " + idSuffix);
-                populateDetails(ecDetails, idSuffix);
-             }
-
-             // Add to the 'open' array
-             if ( idx === -1 ) {
-                 detailRows.push( tr.attr('id') );
-             }
-         }
-       });
-     refreshECTables();
- });
-
- /**
-  * Used to redraw the page
-  */
- function refresh() {
-   refreshECTables();
- }
-
- /**
-  * Generates the compactions table
-  */
- function refreshECTables() {
-   getCompactionCoordinator();
-   var ecInfo = sessionStorage.ecInfo === undefined ? [] :
-      JSON.parse(sessionStorage.ecInfo);
-   if (ecInfo.length === 0) {
-      return;
-   }
-   var ccAddress = ecInfo.server;
-   var numCompactors = ecInfo.numCompactors;
-   var lastContactTime = timeDuration(ecInfo.lastContact);
-   console.log("compaction coordinator = " + ccAddress);
-   console.log("numCompactors = " + numCompactors);
-   $('#ccHostname').text(ccAddress);
-   $('#ccNumQueues').text(ecInfo.numQueues);
-   $('#ccNumCompactors').text(numCompactors);
-   $('#ccLastContact').html(lastContactTime);
-
-   // user paging is not reset on reload
-   if(compactorsTable) compactorsTable.ajax.reload(null, false );
-   if(runningTable) runningTable.ajax.reload(null, false );
- }
-
- /**
-  * Get address of the compaction coordinator info
-  */
- function getCompactionCoordinator() {
-   $.getJSON('/rest/ec', function(data) {
-        sessionStorage.ecInfo = JSON.stringify(data);
-   });
- }
-
- function getRunningDetails(ecid, idSuffix) {
-    var ajaxUrl = '/rest/ec/details?ecid=' + ecid;
-    console.log("Ajax call to " + ajaxUrl);
-    $.getJSON(ajaxUrl, function(data) {
-       populateDetails(data, idSuffix);
-       var detailsJSON = JSON.parse(sessionStorage.ecDetailsJSON);
-       if (detailsJSON === undefined) {
-          detailsJSON = [];
-       } else if (detailsJSON.length >= 50) {
-          // drop the oldest 25 from the sessionStorage to limit size of the cache
-          var newDetailsJSON = [];
-          $.each( detailsJSON, function( num, val ) {
-             if (num > 24) {
-                newDetailsJSON.push(val);
-             }
-          });
-          detailsJSON = newDetailsJSON;
-       }
-       detailsJSON.push({ key : idSuffix, value : data });
-       sessionStorage.ecDetailsJSON = JSON.stringify(detailsJSON);
-    });
+/**
+ * Creates active compactions table
+ */
+$(document).ready(function () {
+  if (sessionStorage.ecDetailsJSON === undefined) {
+    sessionStorage.ecDetailsJSON = JSON.stringify([]);
   }
+  compactorsTable = $('#compactorsTable').DataTable({
+    "ajax": {
+      "url": '/rest/ec/compactors',
+      "dataSrc": "compactors"
+    },
+    "stateSave": true,
+    "dom": 't<"align-left"l>p',
+    "columnDefs": [{
+        "targets": "duration",
+        "render": function (data, type, row) {
+          if (type === 'display') data = timeDuration(data);
+          return data;
+        }
+      },
+      {
+        "targets": "date",
+        "render": function (data, type, row) {
+          if (type === 'display') data = dateFormat(data);
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "server"
+      },
+      {
+        "data": "queueName"
+      },
+      {
+        "data": "lastContact"
+      }
+    ]
+  });
 
- function getDetailsFromStorage(idSuffix) {
-    var details = [];
-    var detailsJSON = JSON.parse(sessionStorage.ecDetailsJSON);
-    if (detailsJSON.length === 0) {
-       return details;
-    } else {
-       // details are stored as key value pairs in the JSON val
-       $.each( detailsJSON, function( num, val ) {
-          if (val.key === idSuffix) {
-             details = val.value;
+  // Create a table for compactors
+  runningTable = $('#runningTable').DataTable({
+    "ajax": {
+      "url": '/rest/ec/running',
+      "dataSrc": "running"
+    },
+    "stateSave": true,
+    "dom": 't<"align-left"l>p',
+    "columnDefs": [{
+        "targets": "duration",
+        "render": function (data, type, row) {
+          if (type === 'display') data = timeDuration(data);
+          return data;
+        }
+      },
+      {
+        "targets": "date",
+        "render": function (data, type, row) {
+          if (type === 'display') data = dateFormat(data);
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "server"
+      },
+      {
+        "data": "kind"
+      },
+      {
+        "data": "status"
+      },
+      {
+        "data": "queueName"
+      },
+      {
+        "data": "tableId"
+      },
+      {
+        "data": "numFiles"
+      },
+      {
+        "data": "progress",
+        "type": "html",
+        "render": function (data, type, row, meta) {
+          if (type === 'display') {
+            if (row.progress < 0) {
+              data = '--';
+            } else {
+              var p = Math.round(Number(row.progress));
+              console.log("Compaction progress = %" + p);
+              data = '<div class="progress"><div class="progress-bar" role="progressbar" style="min-width: 2em; width:' +
+                p + '%;">' + p + '%</div></div>';
+            }
           }
-       });
-       return details;
+          return data;
+        }
+      },
+      {
+        "data": "lastUpdate"
+      },
+      {
+        "data": "duration"
+      },
+      { // more column settings
+        "class": "details-control",
+        "orderable": false,
+        "data": null,
+        "defaultContent": ""
+      }
+    ]
+  });
+
+  // Array to track the ids of the details displayed rows
+  var detailRows = [];
+  $("#runningTable tbody").on('click', 'tr td.details-control', function () {
+    var tr = $(this).closest('tr');
+    var row = runningTable.row(tr);
+    var idx = $.inArray(tr.attr('id'), detailRows);
+
+    if (row.child.isShown()) {
+      tr.removeClass('details');
+      row.child.hide();
+
+      // Remove from the 'open' array
+      detailRows.splice(idx, 1);
+    } else {
+      var rci = row.data();
+      var ecid = rci.ecid;
+      var idSuffix = ecid.substring(ecid.length - 5, ecid.length);
+      tr.addClass('details');
+      // put all the information into html for a single row
+      var htmlRow = "<table class='table table-bordered table-striped table-condensed' id='table" + idSuffix + "'>"
+      htmlRow += "<thead><tr><th>#</th><th>Input Files</th><th>Size</th><th>Entries</th></tr></thead>";
+      htmlRow += "<tbody></tbody></table>";
+      htmlRow += "Output File: <span id='outputFile" + idSuffix + "'></span><br>";
+      htmlRow += ecid;
+      row.child(htmlRow).show();
+      // show the row then populate the table
+      var ecDetails = getDetailsFromStorage(idSuffix);
+      if (ecDetails.length === 0) {
+        getRunningDetails(ecid, idSuffix);
+      } else {
+        console.log("Got cached details for " + idSuffix);
+        populateDetails(ecDetails, idSuffix);
+      }
+
+      // Add to the 'open' array
+      if (idx === -1) {
+        detailRows.push(tr.attr('id'));
+      }
     }
- }
+  });
+  refreshECTables();
+});
 
- function populateDetails(data, idSuffix) {
-     var tableId = 'table' + idSuffix;
-     clearTableBody(tableId);
-    $.each( data.inputFiles, function( key, value ) {
-       var items = [];
-       items.push(createCenterCell(key, key));
-       items.push(createCenterCell(value.metadataFileEntry, value.metadataFileEntry));
-       items.push(createCenterCell(value.size, bigNumberForSize(value.size)));
-       items.push(createCenterCell(value.entries, bigNumberForQuantity(value.entries)));
-       $('<tr/>', {
-           html: items.join('')
-         }).appendTo('#' + tableId + ' tbody');
+/**
+ * Used to redraw the page
+ */
+function refresh() {
+  refreshECTables();
+}
+
+/**
+ * Generates the compactions table
+ */
+function refreshECTables() {
+  getCompactionCoordinator();
+  var ecInfo = sessionStorage.ecInfo === undefined ? [] :
+    JSON.parse(sessionStorage.ecInfo);
+  if (ecInfo.length === 0) {
+    return;
+  }
+  var ccAddress = ecInfo.server;
+  var numCompactors = ecInfo.numCompactors;
+  var lastContactTime = timeDuration(ecInfo.lastContact);
+  console.log("compaction coordinator = " + ccAddress);
+  console.log("numCompactors = " + numCompactors);
+  $('#ccHostname').text(ccAddress);
+  $('#ccNumQueues').text(ecInfo.numQueues);
+  $('#ccNumCompactors').text(numCompactors);
+  $('#ccLastContact').html(lastContactTime);
+
+  // user paging is not reset on reload
+  if (compactorsTable) compactorsTable.ajax.reload(null, false);
+  if (runningTable) runningTable.ajax.reload(null, false);
+}
+
+/**
+ * Get address of the compaction coordinator info
+ */
+function getCompactionCoordinator() {
+  $.getJSON('/rest/ec', function (data) {
+    sessionStorage.ecInfo = JSON.stringify(data);
+  });
+}
+
+function getRunningDetails(ecid, idSuffix) {
+  var ajaxUrl = '/rest/ec/details?ecid=' + ecid;
+  console.log("Ajax call to " + ajaxUrl);
+  $.getJSON(ajaxUrl, function (data) {
+    populateDetails(data, idSuffix);
+    var detailsJSON = JSON.parse(sessionStorage.ecDetailsJSON);
+    if (detailsJSON === undefined) {
+      detailsJSON = [];
+    } else if (detailsJSON.length >= 50) {
+      // drop the oldest 25 from the sessionStorage to limit size of the cache
+      var newDetailsJSON = [];
+      $.each(detailsJSON, function (num, val) {
+        if (num > 24) {
+          newDetailsJSON.push(val);
+        }
+      });
+      detailsJSON = newDetailsJSON;
+    }
+    detailsJSON.push({
+      key: idSuffix,
+      value: data
     });
-    $('#outputFile' + idSuffix).text(data.outputFile);
- }
+    sessionStorage.ecDetailsJSON = JSON.stringify(detailsJSON);
+  });
+}
 
- function refreshCompactors() {
-   console.log("Refresh compactors table.");
-   // user paging is not reset on reload
-   if(compactorsTable) compactorsTable.ajax.reload(null, false );
- }
+function getDetailsFromStorage(idSuffix) {
+  var details = [];
+  var detailsJSON = JSON.parse(sessionStorage.ecDetailsJSON);
+  if (detailsJSON.length === 0) {
+    return details;
+  } else {
+    // details are stored as key value pairs in the JSON val
+    $.each(detailsJSON, function (num, val) {
+      if (val.key === idSuffix) {
+        details = val.value;
+      }
+    });
+    return details;
+  }
+}
 
- function refreshRunning() {
-   console.log("Refresh running compactions table.");
-   // user paging is not reset on reload
-   if(runningTable) runningTable.ajax.reload(null, false );
- }
+function populateDetails(data, idSuffix) {
+  var tableId = 'table' + idSuffix;
+  clearTableBody(tableId);
+  $.each(data.inputFiles, function (key, value) {
+    var items = [];
+    items.push(createCenterCell(key, key));
+    items.push(createCenterCell(value.metadataFileEntry, value.metadataFileEntry));
+    items.push(createCenterCell(value.size, bigNumberForSize(value.size)));
+    items.push(createCenterCell(value.entries, bigNumberForQuantity(value.entries)));
+    $('<tr/>', {
+      html: items.join('')
+    }).appendTo('#' + tableId + ' tbody');
+  });
+  $('#outputFile' + idSuffix).text(data.outputFile);
+}
+
+function refreshCompactors() {
+  console.log("Refresh compactors table.");
+  // user paging is not reset on reload
+  if (compactorsTable) compactorsTable.ajax.reload(null, false);
+}
+
+function refreshRunning() {
+  console.log("Refresh running compactions table.");
+  // user paging is not reset on reload
+  if (runningTable) runningTable.ajax.reload(null, false);
+}

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/gc.js
@@ -19,50 +19,65 @@
 "use strict";
 
 var gcTable;
- /**
-  * Creates active compactions table
-  */
- $(document).ready(function() {
-     // Create a table for compactions list
-     gcTable = $('#gcActivity').DataTable({
-       "ajax": {
-         "url": '/rest/gc',
-         "dataSrc": "stats"
-       },
-       "stateSave": true,
-       "dom": 't<"align-left"l>p',
-       "columnDefs": [
-           { "targets": "date",
-               "render": function ( data, type, row ) {
-                 if(type === 'display' && data > 0) data = dateFormat(data);
-                 return data;
-               }
-           },
-           { "targets": "duration",
-             "render": function ( data, type, row ) {
-               if(type === 'display') data = timeDuration(data);
-               return data;
-             }
-           },
-           { "targets": "big-num",
-               "render": function ( data, type, row ) {
-                 if(type === 'display') data = bigNumberForQuantity(data);
-                 return data;
-               }
-           }
-         ],
-       "columns": [
-         { "data": "type" },
-         { "data": "finished" },
-         { "data": "candidates" },
-         { "data": "deleted" },
-         { "data": "inUse" },
-         { "data": "errors" },
-         { "data": "duration" },
-       ]
-     });
-     refreshGCTable();
- });
+/**
+ * Creates active compactions table
+ */
+$(document).ready(function () {
+  // Create a table for compactions list
+  gcTable = $('#gcActivity').DataTable({
+    "ajax": {
+      "url": '/rest/gc',
+      "dataSrc": "stats"
+    },
+    "stateSave": true,
+    "dom": 't<"align-left"l>p',
+    "columnDefs": [{
+        "targets": "date",
+        "render": function (data, type, row) {
+          if (type === 'display' && data > 0) data = dateFormat(data);
+          return data;
+        }
+      },
+      {
+        "targets": "duration",
+        "render": function (data, type, row) {
+          if (type === 'display') data = timeDuration(data);
+          return data;
+        }
+      },
+      {
+        "targets": "big-num",
+        "render": function (data, type, row) {
+          if (type === 'display') data = bigNumberForQuantity(data);
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "type"
+      },
+      {
+        "data": "finished"
+      },
+      {
+        "data": "candidates"
+      },
+      {
+        "data": "deleted"
+      },
+      {
+        "data": "inUse"
+      },
+      {
+        "data": "errors"
+      },
+      {
+        "data": "duration"
+      },
+    ]
+  });
+  refreshGCTable();
+});
 
 /**
  * Used to redraw the page
@@ -77,14 +92,14 @@ function refresh() {
 function refreshGCTable() {
   var status = JSON.parse(sessionStorage.status).gcStatus;
 
-    if (status === 'ERROR') {
-      $('#gcBanner').show();
-      $('#gcActivity').hide();
-    } else {
-      $('#gcBanner').hide();
-      $('#gcActivity').show();
-      if(gcTable) gcTable.ajax.reload(null, false ); // user paging is not reset on reload
-    }
+  if (status === 'ERROR') {
+    $('#gcBanner').show();
+    $('#gcActivity').hide();
+  } else {
+    $('#gcBanner').hide();
+    $('#gcActivity').show();
+    if (gcTable) gcTable.ajax.reload(null, false); // user paging is not reset on reload
+  }
 
 }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/listType.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/listType.js
@@ -24,7 +24,7 @@ var type, minutes;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshListType() {
-  getTraceOfType(type, minutes).then(function() {
+  getTraceOfType(type, minutes).then(function () {
     refreshTypeTraceTable(minutes);
   });
 }
@@ -48,8 +48,7 @@ function refreshTypeTraceTable(minutes) {
    * Get the trace type value obtained earlier,
    * if it doesn't exists, create an empty array
    */
-  var data = sessionStorage.traceType === undefined ?
-      [] : JSON.parse(sessionStorage.traceType);
+  var data = sessionStorage.traceType === undefined ? [] : JSON.parse(sessionStorage.traceType);
   /*
    * If the data is empty, create an empty row, otherwise,
    * create the rows for the table
@@ -57,18 +56,18 @@ function refreshTypeTraceTable(minutes) {
   if (data.length === 0 || data.traces.length === 0) {
     var items = [];
     items.push(createEmptyRow(3, 'No traces for the last ' +
-        minutes + ' minute(s)'));
+      minutes + ' minute(s)'));
     $('<tr/>', {
       html: items.join('')
     }).appendTo('#trace tbody');
   } else {
-    $.each(data.traces, function(key, val) {
+    $.each(data.traces, function (key, val) {
       var items = [];
 
       // Convert start value to a date
       var date = new Date(val.start);
       items.push(createFirstCell('', '<a href="/trace/show?id=' +
-          val.id + '">' + date.toLocaleString() + '</a>'));
+        val.id + '">' + date.toLocaleString() + '</a>'));
       items.push(createRightCell('', timeDuration(val.ms)));
       items.push(createLeftCell('', val.source));
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -81,8 +81,7 @@ $(document).ready(function () {
     "searching": false,
     "paging": false,
     "info": false,
-    "columnDefs": [
-      {
+    "columnDefs": [{
         "targets": "big-num",
         "render": function (data, type) {
           if (type === 'display') {
@@ -110,10 +109,15 @@ $(document).ready(function () {
         }
       }
     ],
-    "columns": [
-      { "data": "manager" },
-      { "data": "onlineTabletServers" },
-      { "data": "totalTabletServers" },
+    "columns": [{
+        "data": "manager"
+      },
+      {
+        "data": "onlineTabletServers"
+      },
+      {
+        "data": "totalTabletServers"
+      },
       {
         "data": "lastGC",
         "type": "html",
@@ -127,14 +131,30 @@ $(document).ready(function () {
           return data;
         }
       },
-      { "data": "tablets" },
-      { "data": "unassignedTablets" },
-      { "data": "numentries" },
-      { "data": "ingestrate" },
-      { "data": "entriesRead" },
-      { "data": "queryrate" },
-      { "data": "holdTime" },
-      { "data": "osload" },
+      {
+        "data": "tablets"
+      },
+      {
+        "data": "unassignedTablets"
+      },
+      {
+        "data": "numentries"
+      },
+      {
+        "data": "ingestrate"
+      },
+      {
+        "data": "entriesRead"
+      },
+      {
+        "data": "queryrate"
+      },
+      {
+        "data": "holdTime"
+      },
+      {
+        "data": "osload"
+      },
     ]
   });
 
@@ -153,8 +173,7 @@ $(document).ready(function () {
         return data;
       }
     },
-    "columnDefs": [
-      {
+    "columnDefs": [{
         "targets": "duration",
         "render": function (data, type) {
           if (type === 'display') {
@@ -174,11 +193,18 @@ $(document).ready(function () {
       }
     ],
     "stateSave": true,
-    "columns": [
-      { "data": "server" },
-      { "data": "log" },
-      { "data": "time" },
-      { "data": "progress" }
+    "columns": [{
+        "data": "server"
+      },
+      {
+        "data": "log"
+      },
+      {
+        "data": "time"
+      },
+      {
+        "data": "progress"
+      }
     ]
   });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/navbar.js
@@ -21,7 +21,7 @@
 /**
  * Creates the initial sidebar
  */
-$(document).ready(function() {
+$(document).ready(function () {
   refreshSidebar();
 });
 
@@ -29,7 +29,7 @@ $(document).ready(function() {
  * Makes the REST calls, generates the sidebar with the new information
  */
 function refreshSidebar() {
-  getStatus().then(function() {
+  getStatus().then(function () {
     refreshSideBarNotifications();
   });
 }
@@ -47,7 +47,7 @@ function refreshNavBar() {
 function refreshSideBarNotifications() {
 
   var data = sessionStorage.status === undefined ?
-      undefined : JSON.parse(sessionStorage.status);
+    undefined : JSON.parse(sessionStorage.status);
 
   // Setting individual status notification
   if (data.managerStatus === 'OK') {
@@ -57,13 +57,13 @@ function refreshSideBarNotifications() {
   }
   if (data.tServerStatus === 'OK') {
     $('#serverStatusNotification').removeClass('error').removeClass('warning').
-        addClass('normal');
+    addClass('normal');
   } else if (data.tServerStatus === 'WARN') {
     $('#serverStatusNotification').removeClass('error').removeClass('normal').
-        addClass('warning');
+    addClass('warning');
   } else {
     $('#serverStatusNotification').removeClass('normal').removeClass('warning').
-        addClass('error');
+    addClass('error');
   }
   if (data.gcStatus === 'OK') {
     $('#gcStatusNotification').removeClass('error').addClass('normal');
@@ -73,18 +73,18 @@ function refreshSideBarNotifications() {
 
   // Setting overall status notification
   if (data.managerStatus === 'OK' &&
-      data.tServerStatus === 'OK' &&
-      data.gcStatus === 'OK') {
+    data.tServerStatus === 'OK' &&
+    data.gcStatus === 'OK') {
     $('#statusNotification').removeClass('error').removeClass('warning').
-        addClass('normal');
+    addClass('normal');
   } else if (data.managerStatus === 'ERROR' ||
-      data.tServerStatus === 'ERROR' ||
-      data.gcStatus === 'ERROR') {
+    data.tServerStatus === 'ERROR' ||
+    data.gcStatus === 'ERROR') {
     $('#statusNotification').removeClass('normal').removeClass('warning').
-        addClass('error');
+    addClass('error');
   } else if (data.tServerStatus === 'WARN') {
     $('#statusNotification').removeClass('normal').removeClass('error').
-        addClass('warning');
+    addClass('warning');
   }
 
   // Setting individual logs notifications
@@ -124,6 +124,6 @@ function refreshSideBarNotifications() {
 
   // Number
   var totalNumber = data.logNumber + data.problemNumber > 99 ?
-      '99+' : data.logNumber + data.problemNumber;
+    '99+' : data.logNumber + data.problemNumber;
   $('#errorsNotification').html(totalNumber);
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/overview.js
@@ -21,7 +21,7 @@
 /**
  * Creates overview initial tables
  */
-$(document).ready(function() {
+$(document).ready(function () {
   refreshOverview();
 });
 
@@ -29,7 +29,7 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshOverview() {
-  getManager().then(function() {
+  getManager().then(function () {
     refreshManagerTable();
   });
   var requests = [
@@ -44,7 +44,7 @@ function refreshOverview() {
     getIndexCacheHitRate(),
     getDataCacheHitRate()
   ];
-  $.when(...requests).always(function() {
+  $.when(...requests).always(function () {
     makePlots();
   });
 }
@@ -60,8 +60,7 @@ function refresh() {
  * Refreshes the manager table
  */
 function refreshManagerTable() {
-  var data = sessionStorage.manager === undefined ?
-      [] : JSON.parse(sessionStorage.manager);
+  var data = sessionStorage.manager === undefined ? [] : JSON.parse(sessionStorage.manager);
 
   $('#manager tr td:first').hide();
   $('#manager tr td').hide();
@@ -91,7 +90,9 @@ function refreshManagerTable() {
 var plotOptions = {
   colors: ['#d9534f', '#337ab7'],
   grid: {
-    backgroundColor: {colors: ['#fff', '#eee']}
+    backgroundColor: {
+      colors: ['#fff', '#eee']
+    }
   },
   series: {
     lines: {
@@ -124,8 +125,12 @@ var plotWithLegendOptions = $.extend(true, {}, plotOptions, {
 
 var cachePlotOptions = $.extend(true, {}, plotOptions, {
   series: {
-    lines: { show: false },
-    points: { show: true }
+    lines: {
+      show: false
+    },
+    points: {
+      show: true
+    }
   },
   yaxis: {
     autoScale: "none",
@@ -141,97 +146,110 @@ function makePlots() {
   var n = d.getTimezoneOffset() * 60000; // Converts offset to milliseconds
 
   // Create Ingest Rate plot
-  var ingestRate = [{data:[]}];
-  var data = sessionStorage.ingestRate === undefined ?
-      [] : JSON.parse(sessionStorage.ingestRate);
-  $.each(data, function(key, val) {
+  var ingestRate = [{
+    data: []
+  }];
+  var data = sessionStorage.ingestRate === undefined ? [] : JSON.parse(sessionStorage.ingestRate);
+  $.each(data, function (key, val) {
     ingestRate[0].data.push([val.first - n, val.second]);
   });
   $.plot('#ingest_entries', ingestRate, plotOptions);
 
   // Create Scan Entries plot
-  var scanEntries = [
-    {label: 'Read', data: []},
-    {label: 'Returned', data: []}
+  var scanEntries = [{
+      label: 'Read',
+      data: []
+    },
+    {
+      label: 'Returned',
+      data: []
+    }
   ];
-  data = sessionStorage.scanEntries === undefined ?
-      [] : JSON.parse(sessionStorage.scanEntries);
-  $.each(data[0].second, function(key, val) {
+  data = sessionStorage.scanEntries === undefined ? [] : JSON.parse(sessionStorage.scanEntries);
+  $.each(data[0].second, function (key, val) {
     scanEntries[0].data.push([val.first - n, val.second]);
   });
-  $.each(data[1].second, function(key, val) {
+  $.each(data[1].second, function (key, val) {
     scanEntries[1].data.push([val.first - n, val.second]);
   });
   $.plot('#scan_entries', scanEntries, plotWithLegendOptions);
 
   // Create Ingest MB plot
-  var ingestMB = [{data:[]}];
-  data = sessionStorage.ingestMB === undefined ?
-      [] : JSON.parse(sessionStorage.ingestMB);
-  $.each(data, function(key, val) {
+  var ingestMB = [{
+    data: []
+  }];
+  data = sessionStorage.ingestMB === undefined ? [] : JSON.parse(sessionStorage.ingestMB);
+  $.each(data, function (key, val) {
     ingestMB[0].data.push([val.first - n, val.second]);
   });
   $.plot('#ingest_mb', ingestMB, plotOptions);
 
   // Create Query MB plot
-  var queryMB = [{data:[]}];
-  data = sessionStorage.queryMB === undefined ?
-      [] : JSON.parse(sessionStorage.queryMB);
-  $.each(data, function(key, val) {
+  var queryMB = [{
+    data: []
+  }];
+  data = sessionStorage.queryMB === undefined ? [] : JSON.parse(sessionStorage.queryMB);
+  $.each(data, function (key, val) {
     queryMB[0].data.push([val.first - n, val.second]);
   });
   $.plot('#scan_mb', queryMB, plotOptions);
 
   // Create Load Average plot
-  var loadAvg = [{data:[]}];
-  data = sessionStorage.loadAvg === undefined ?
-      [] : JSON.parse(sessionStorage.loadAvg);
-  $.each(data, function(key, val) {
+  var loadAvg = [{
+    data: []
+  }];
+  data = sessionStorage.loadAvg === undefined ? [] : JSON.parse(sessionStorage.loadAvg);
+  $.each(data, function (key, val) {
     loadAvg[0].data.push([val.first - n, val.second]);
   });
   $.plot('#load_avg', loadAvg, plotOptions);
 
   // Create Seeks plot
-  var lookups = [{data:[]}];
-  data = sessionStorage.lookups === undefined ?
-      [] : JSON.parse(sessionStorage.lookups);
-  $.each(data, function(key, val) {
+  var lookups = [{
+    data: []
+  }];
+  data = sessionStorage.lookups === undefined ? [] : JSON.parse(sessionStorage.lookups);
+  $.each(data, function (key, val) {
     lookups[0].data.push([val.first - n, val.second]);
   });
   $.plot('#seeks', lookups, plotOptions);
 
   // Create Minor Compactions plot
-  var minor = [{data:[]}];
-  data = sessionStorage.minorCompactions === undefined ?
-      [] : JSON.parse(sessionStorage.minorCompactions);
-  $.each(data, function(key, val) {
+  var minor = [{
+    data: []
+  }];
+  data = sessionStorage.minorCompactions === undefined ? [] : JSON.parse(sessionStorage.minorCompactions);
+  $.each(data, function (key, val) {
     minor[0].data.push([val.first - n, val.second]);
   });
   $.plot('#minor', minor, plotOptions);
 
   // Create Major Compaction plot
-  var major = [{data:[]}];
-  data = sessionStorage.majorCompactions === undefined ?
-      [] : JSON.parse(sessionStorage.majorCompactions);
-  $.each(data, function(key, val) {
+  var major = [{
+    data: []
+  }];
+  data = sessionStorage.majorCompactions === undefined ? [] : JSON.parse(sessionStorage.majorCompactions);
+  $.each(data, function (key, val) {
     major[0].data.push([val.first - n, val.second]);
   });
   $.plot('#major', major, plotOptions);
 
   // Create Index Cache plot
-  var indexCache = [{data:[]}];
-  data = sessionStorage.indexCache === undefined ?
-      [] : JSON.parse(sessionStorage.indexCache);
-  $.each(data, function(key, val) {
+  var indexCache = [{
+    data: []
+  }];
+  data = sessionStorage.indexCache === undefined ? [] : JSON.parse(sessionStorage.indexCache);
+  $.each(data, function (key, val) {
     indexCache[0].data.push([val.first - n, val.second]);
   });
   $.plot('#index_cache', indexCache, cachePlotOptions);
 
   // Create Data Cache plot
-  var dataCache = [{data:[]}];
-  data = sessionStorage.dataCache === undefined ?
-      [] : JSON.parse(sessionStorage.dataCache);
-  $.each(data, function(key, val) {
+  var dataCache = [{
+    data: []
+  }];
+  data = sessionStorage.dataCache === undefined ? [] : JSON.parse(sessionStorage.dataCache);
+  $.each(data, function (key, val) {
     dataCache[0].data.push([val.first - n, val.second]);
   });
   $.plot('#data_cache', dataCache, cachePlotOptions);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
@@ -21,7 +21,7 @@
 var tableID;
 var problemSummaryTable;
 var problemDetailTable;
-$(document).ready(function() {
+$(document).ready(function () {
   // Create a table for summary. See datatables doc for more info on the dom property
   problemSummaryTable = $('#problemSummary').DataTable({
     "ajax": {
@@ -30,30 +30,36 @@ $(document).ready(function() {
     },
     "stateSave": true,
     "dom": 't<"align-left"l>p',
-    "columnDefs": [
-      { "targets": "big-num",
-        "render": function ( data, type, row ) {
-          if(type === 'display') data = bigNumberForQuantity(data);
-          return data;
-        }
+    "columnDefs": [{
+      "targets": "big-num",
+      "render": function (data, type, row) {
+        if (type === 'display') data = bigNumberForQuantity(data);
+        return data;
       }
-    ],
-    "columns": [
-      { "data": "tableName",
+    }],
+    "columns": [{
+        "data": "tableName",
         "type": "html",
-        "render": function ( data, type, row, meta ) {
-          if(type === 'display') data = '<a href="/tables/' + row.tableID + '">' + row.tableName + '</a>';
+        "render": function (data, type, row, meta) {
+          if (type === 'display') data = '<a href="/tables/' + row.tableID + '">' + row.tableName + '</a>';
           return data;
         }
       },
-      { "data": "fileRead" },
-      { "data": "fileWrite" },
-      { "data": "tableLoad" },
-      { "data": "tableID",
+      {
+        "data": "fileRead"
+      },
+      {
+        "data": "fileWrite"
+      },
+      {
+        "data": "tableLoad"
+      },
+      {
+        "data": "tableID",
         "type": "html",
         "render": function (data, type, row, meta) {
           if (type === 'display') data = '<a href="javascript:clearTableProblemsTable(\'' +
-              row.tableID + '\');">clear ALL ' + row.tableName + ' problems</a>';
+            row.tableID + '\');">clear ALL ' + row.tableName + ' problems</a>';
           return data;
         }
       }
@@ -67,32 +73,42 @@ $(document).ready(function() {
     },
     "stateSave": true,
     "dom": 't<"align-left"l>p',
-    "columnDefs": [
-      { "targets": "date",
-        "render": function ( data, type, row ) {
-          if(type === 'display') data = dateFormat(data);
-          return data;
-        }
+    "columnDefs": [{
+      "targets": "date",
+      "render": function (data, type, row) {
+        if (type === 'display') data = dateFormat(data);
+        return data;
       }
-    ],
-    "columns": [
-      { "data": "tableName",
+    }],
+    "columns": [{
+        "data": "tableName",
         "type": "html",
-        "render": function ( data, type, row, meta ) {
-          if(type === 'display') data = '<a href="/tables/' + row.tableID + '">' + row.tableName + '</a>';
+        "render": function (data, type, row, meta) {
+          if (type === 'display') data = '<a href="/tables/' + row.tableID + '">' + row.tableName + '</a>';
           return data;
         }
       },
-      { "data": "type" },
-      { "data": "server" },
-      { "data": "time" },
-      { "data": "resource" },
-      { "data": "exception" },
-      { "data": "tableID",
+      {
+        "data": "type"
+      },
+      {
+        "data": "server"
+      },
+      {
+        "data": "time"
+      },
+      {
+        "data": "resource"
+      },
+      {
+        "data": "exception"
+      },
+      {
+        "data": "tableID",
         "type": "html",
         "render": function (data, type, row, meta) {
           if (type === 'display') data = '<a href="javascript:clearDetailsProblemsTable(\'' +
-              row.tableID + '\',\'' + row.resource + '\',\'' + row.type + '\')">clear this problem</a>';
+            row.tableID + '\',\'' + row.resource + '\',\'' + row.type + '\')">clear this problem</a>';
           return data;
         }
       }
@@ -140,12 +156,12 @@ function clearDetailsProblemsTable(table, resource, type) {
  * Generates the problem summary table
  */
 function refreshProblemSummaryTable() {
-  if(problemSummaryTable) problemSummaryTable.ajax.reload(null, false ); // user paging is not reset on reload
+  if (problemSummaryTable) problemSummaryTable.ajax.reload(null, false); // user paging is not reset on reload
 }
 
 /**
  * Generates the problem details table
  */
 function refreshProblemDetailsTable() {
-  if(problemDetailTable) problemDetailTable.ajax.reload(null, false ); // user paging is not reset on reload
+  if (problemDetailTable) problemDetailTable.ajax.reload(null, false); // user paging is not reset on reload
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
@@ -21,7 +21,7 @@
 /**
  * Creates replication initial table
  */
-$(document).ready(function() {
+$(document).ready(function () {
   refreshReplication();
 });
 
@@ -29,7 +29,7 @@ $(document).ready(function() {
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshReplication() {
-  getReplication().then(function() {
+  getReplication().then(function () {
     refreshReplicationsTable();
   });
 }
@@ -47,8 +47,7 @@ function refresh() {
 function refreshReplicationsTable() {
   clearTableBody('replicationStats');
 
-  var data = sessionStorage.replication === undefined ?
-      [] : JSON.parse(sessionStorage.replication);
+  var data = sessionStorage.replication === undefined ? [] : JSON.parse(sessionStorage.replication);
 
   if (data.length === 0) {
     var items = [];
@@ -57,7 +56,7 @@ function refreshReplicationsTable() {
       html: items.join('')
     }).appendTo('#replicationStats tbody');
   } else {
-    $.each(data, function(key, val) {
+    $.each(data, function (key, val) {
       var items = [];
       items.push(createFirstCell(val.tableName, val.tableName));
 
@@ -68,7 +67,7 @@ function refreshReplicationsTable() {
       items.push(createRightCell(val.replicaSystemType, val.replicaSystemType));
 
       items.push(createRightCell(val.filesNeedingReplication,
-          bigNumberForQuantity(val.filesNeedingReplication)));
+        bigNumberForQuantity(val.filesNeedingReplication)));
 
       $('<tr/>', {
         html: items.join('')

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/scans.js
@@ -23,44 +23,51 @@ var scansList;
 /**
  * Creates scans initial table
  */
-$(document).ready(function() {
-// Create a table for scans list
-     scansList = $('#scansList').DataTable({
-       "ajax": {
-         "url": '/rest/scans',
-         "dataSrc": "scans"
-       },
-       "stateSave": true,
-       "dom": 't<"align-left"l>p',
-       "columnDefs": [
-           { "targets": "duration",
-             "render": function ( data, type, row ) {
-               if(type === 'display') data = timeDuration(data);
-               return data;
-             }
-           },
-           { "targets": "date",
-               "render": function ( data, type, row ) {
-                 if(type === 'display') data = dateFormat(data);
-                 return data;
-               }
-             }
-         ],
-       "columns": [
-         { "data": "server",
-           "type": "html",
-           "render": function ( data, type, row, meta ) {
-             if(type === 'display') {
-                data = '<a href="/tservers?s=' + row.server + '">' + row.server + '</a>';
-             }
-             return data;
-           }
-         },
-         { "data": "scanCount" },
-         { "data": "oldestScan" },
-         { "data": "fetched" },
-       ]
-     });
+$(document).ready(function () {
+  // Create a table for scans list
+  scansList = $('#scansList').DataTable({
+    "ajax": {
+      "url": '/rest/scans',
+      "dataSrc": "scans"
+    },
+    "stateSave": true,
+    "dom": 't<"align-left"l>p',
+    "columnDefs": [{
+        "targets": "duration",
+        "render": function (data, type, row) {
+          if (type === 'display') data = timeDuration(data);
+          return data;
+        }
+      },
+      {
+        "targets": "date",
+        "render": function (data, type, row) {
+          if (type === 'display') data = dateFormat(data);
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "server",
+        "type": "html",
+        "render": function (data, type, row, meta) {
+          if (type === 'display') {
+            data = '<a href="/tservers?s=' + row.server + '">' + row.server + '</a>';
+          }
+          return data;
+        }
+      },
+      {
+        "data": "scanCount"
+      },
+      {
+        "data": "oldestScan"
+      },
+      {
+        "data": "fetched"
+      },
+    ]
+  });
 });
 
 
@@ -75,5 +82,5 @@ function refresh() {
  * Generates the scans table
  */
 function refreshScansTable() {
-   if(scansList) scansList.ajax.reload(null, false ); // user paging is not reset on reload
+  if (scansList) scansList.ajax.reload(null, false); // user paging is not reset on reload
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/server.js
@@ -24,7 +24,7 @@ var tabletResults;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshServer() {
-  getTServer(serv).then(function() {
+  getTServer(serv).then(function () {
     refreshDetailTable();
     refreshHistoryTable();
     refreshCurrentTable();
@@ -43,35 +43,33 @@ function refresh() {
  * Populates the server details table
  */
 function refreshDetailTable() {
-    var data = sessionStorage.server === undefined ?
-        [] : JSON.parse(sessionStorage.server);
-    if (data.length === 0 || data.details === undefined) {
-        clearAllTableCells("tServerDetail");
-    } else {
-        $("#hostedTablets").text(bigNumberForQuantity(data.details.hostedTablets));
-        $("#entries").text(bigNumberForQuantity(data.details.entries));
-        $("#minors").text(bigNumberForQuantity(data.details.minors));
-        $("#majors").text(bigNumberForQuantity(data.details.majors));
-        $("#splits").text(bigNumberForQuantity(data.details.splits));
-    }
+  var data = sessionStorage.server === undefined ? [] : JSON.parse(sessionStorage.server);
+  if (data.length === 0 || data.details === undefined) {
+    clearAllTableCells("tServerDetail");
+  } else {
+    $("#hostedTablets").text(bigNumberForQuantity(data.details.hostedTablets));
+    $("#entries").text(bigNumberForQuantity(data.details.entries));
+    $("#minors").text(bigNumberForQuantity(data.details.minors));
+    $("#majors").text(bigNumberForQuantity(data.details.majors));
+    $("#splits").text(bigNumberForQuantity(data.details.splits));
+  }
 }
 
 /**
  * Populates the All Time Tablet Operations table
  */
 function refreshHistoryTable() {
-  var data = sessionStorage.server === undefined ?
-      [] : JSON.parse(sessionStorage.server);
+  var data = sessionStorage.server === undefined ? [] : JSON.parse(sessionStorage.server);
 
   if (data.length === 0 || data.allTimeTabletResults === undefined) {
     clearAllTableCells("opHistoryDetails");
   } else {
     var totalTimeSpent = 0;
-    $.each(data.allTimeTabletResults, function(key, val) {
+    $.each(data.allTimeTabletResults, function (key, val) {
       totalTimeSpent += val.timeSpent;
     });
 
-    $.each(data.allTimeTabletResults, function(key, val) {
+    $.each(data.allTimeTabletResults, function (key, val) {
       // use the first 5 characters of the operation for the jquery selector
       var rowId = "#" + val.operation.slice(0, 5) + "Row";
       console.log("Populating rowId " + rowId + " with " + val.operation + " data");
@@ -87,8 +85,8 @@ function refreshHistoryTable() {
 
       var percent = Math.floor((val.timeSpent / totalTimeSpent) * 100);
       var progressBarCell = '<td><div class="progress"><div class="progress-bar"' +
-         ' role="progressbar" style="min-width: 2em; width:' + percent + '%;">' +
-         percent + '%</div></div></td>';
+        ' role="progressbar" style="min-width: 2em; width:' + percent + '%;">' +
+        percent + '%</div></div></td>';
       console.log("Time spent percent = " + val.timeSpent + "/" + totalTimeSpent + " " + percent);
 
       $(rowId).append(progressBarCell);
@@ -100,11 +98,10 @@ function refreshHistoryTable() {
  * Populates the current tablet operations results table
  */
 function refreshCurrentTable() {
-  var data = sessionStorage.server === undefined ?
-      [] : JSON.parse(sessionStorage.server);
+  var data = sessionStorage.server === undefined ? [] : JSON.parse(sessionStorage.server);
 
   if (data.length === 0 || data.currentTabletOperationResults === undefined) {
-      clearAllTableCells("currentTabletOps");
+    clearAllTableCells("currentTabletOps");
   } else {
     var current = data.currentTabletOperationResults;
     $("#currentMinorAvg").html(timeDuration(current.currentMinorAvg * 1000.0));
@@ -118,7 +115,7 @@ function refreshCurrentTable() {
  * Generates the server results table
  */
 function refreshResultsTable() {
-  tabletResults.ajax.reload(null, false ); // user paging is not reset on reload
+  tabletResults.ajax.reload(null, false); // user paging is not reset on reload
 }
 
 /*

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/show.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/show.js
@@ -23,7 +23,7 @@ var id;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTraceShow() {
-  getTraceShow(id).then(function() {
+  getTraceShow(id).then(function () {
     refreshTraceShowTable();
   });
 }
@@ -41,14 +41,13 @@ function refresh() {
 function refreshTraceShowTable() {
   clearTableBody('trace');
   $('#trace caption span span').remove();
-  var data = sessionStorage.traceShow === undefined ?
-      [] : JSON.parse(sessionStorage.traceShow);
+  var data = sessionStorage.traceShow === undefined ? [] : JSON.parse(sessionStorage.traceShow);
 
   if (data.traces.length !== 0) {
     var date = new Date(data.start);
     $('#caption').append('<span>' + date.toLocaleString() + '</span>');
 
-    $.each(data.traces, function(key, val) {
+    $.each(data.traces, function (key, val) {
       var id = val.spanID.toString(16);
       var items = [];
 
@@ -56,35 +55,35 @@ function refreshTraceShowTable() {
       items.push(createRightCell('', val.time + '+'));
       items.push(createLeftCell('', val.start));
       items.push('<td style="text-indent: ' + val.level + '0px">' +
-          val.location + '</td>');
+        val.location + '</td>');
       items.push(createLeftCell('', val.name));
 
       if (val.addlData.data.length !== 0 ||
-          val.addlData.annotations.length !== 0) {
+        val.addlData.annotations.length !== 0) {
 
         items.push('<td><input type="checkbox" id="' + id +
-            '_checkbox" onclick="toggle(\'' + id + '\')"></td>');
+          '_checkbox" onclick="toggle(\'' + id + '\')"></td>');
         items.push('</tr>');
         items.push('<tr id="' + id + '" style="display:none">');
         items.push('<td colspan="5">');
         items.push('<table class="table table-bordered table-striped' +
-            ' table-condensed">');
+          ' table-condensed">');
 
         if (val.addlData.data.length !== 0) {
           items.push('<tr><th>Key</th><th>Value</th></tr>');
 
-          $.each(val.addlData.data, function(key2, val2) {
+          $.each(val.addlData.data, function (key2, val2) {
             items.push('<tr><td>' + val2.key + '</td><td>' + val2.value +
-                '</td></tr>');
+              '</td></tr>');
           });
         }
 
         if (val.addlData.annotations.length !== 0) {
           items.push('<tr><th>Annotation</th><th>Time Offset</th></tr>');
 
-          $.each(val.addlData.annotations, function(key2, val2) {
+          $.each(val.addlData.annotations, function (key2, val2) {
             items.push('<tr><td>' + val2.annotation + '</td><td>' + val2.time +
-                '</td></tr>');
+              '</td></tr>');
           });
         }
 
@@ -99,11 +98,11 @@ function refreshTraceShowTable() {
       $('#trace tbody').append(items.join(''));
     });
   } else {
-      var items = [];
-      items.push('<tr>');
-      items.push(createEmptyRow(5, 'No trace information for ID ' + id));
-      items.push('</tr>');
-      $('#trace tbody').append(items.join(''));
+    var items = [];
+    items.push('<tr>');
+    items.push(createEmptyRow(5, 'No trace information for ID ' + id));
+    items.push('</tr>');
+    $('#trace tbody').append(items.join(''));
   }
 
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/summary.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/summary.js
@@ -23,7 +23,7 @@ var minutes;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshSummary() {
-  getTraceSummary(minutes).then(function() {
+  getTraceSummary(minutes).then(function () {
     refreshTraceSummaryTable(minutes);
   });
 }
@@ -43,23 +43,22 @@ function refresh() {
 function refreshTraceSummaryTable(minutes) {
   clearTableBody('traceSummary');
 
-  var data = sessionStorage.traceSummary === undefined ?
-      [] : JSON.parse(sessionStorage.traceSummary);
+  var data = sessionStorage.traceSummary === undefined ? [] : JSON.parse(sessionStorage.traceSummary);
 
   if (data.length === 0 || data.recentTraces.length === 0) {
     var items = [];
     items.push(createEmptyRow(6, 'No traces available for the last ' +
-        minutes + ' minute(s)'));
+      minutes + ' minute(s)'));
     $('<tr/>', {
       html: items.join('')
     }).appendTo('#traceSummary tbody');
   } else {
-    $.each(data.recentTraces, function(key, val) {
+    $.each(data.recentTraces, function (key, val) {
 
       var items = [];
 
       items.push(createFirstCell('', '<a href="/trace/listType?type=' +
-          val.type + '&minutes=' + minutes + '">' + val.type + '</a>'));
+        val.type + '&minutes=' + minutes + '">' + val.type + '</a>'));
       items.push(createRightCell('', bigNumberForQuantity(val.total)));
       items.push(createRightCell('', timeDuration(val.min)));
       items.push(createRightCell('', timeDuration(val.max)));
@@ -68,9 +67,9 @@ function refreshTraceSummaryTable(minutes) {
       items.push('<table style="width: 100%;">');
       items.push('<tr>');
 
-      $.each(val.histogram, function(key2, val2) {
+      $.each(val.histogram, function (key2, val2) {
         items.push('<td style="width:5em">' + (val2 == 0 ? '-' : val2) +
-            '</td>');
+          '</td>');
       });
       items.push('</tr>');
       items.push('</table>');

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -23,7 +23,7 @@ var tableID;
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTable() {
-  getTableServers(tableID).then(function() {
+  getTableServers(tableID).then(function () {
     refreshTableServersTable();
   });
 }
@@ -41,8 +41,7 @@ function refresh() {
 function refreshTableServersTable() {
   clearTableBody('participatingTServers');
 
-  var data = sessionStorage.tableServers === undefined ?
-      [] : JSON.parse(sessionStorage.tableServers);
+  var data = sessionStorage.tableServers === undefined ? [] : JSON.parse(sessionStorage.tableServers);
 
   if (data.length === 0 || data.servers.length === 0) {
     var items = [];
@@ -52,55 +51,55 @@ function refreshTableServersTable() {
     }).appendTo('#participatingTServers tbody');
   } else {
 
-    $.each(data.servers, function(key, val) {
+    $.each(data.servers, function (key, val) {
       var items = [];
       items.push(createFirstCell(val.hostname, '<a href="/tservers?s=' +
-          val.id + '">' + val.hostname + '</a>'));
+        val.id + '">' + val.hostname + '</a>'));
 
       items.push(createRightCell(val.tablets,
-          bigNumberForQuantity(val.tablets)));
+        bigNumberForQuantity(val.tablets)));
 
       items.push(createRightCell(val.lastContact,
-          timeDuration(val.lastContact)));
+        timeDuration(val.lastContact)));
 
       items.push(createRightCell(val.entries,
-          bigNumberForQuantity(val.entries)));
+        bigNumberForQuantity(val.entries)));
 
       items.push(createRightCell(val.ingest,
-          bigNumberForQuantity(Math.floor(val.ingest))));
+        bigNumberForQuantity(Math.floor(val.ingest))));
 
       items.push(createRightCell(val.query,
-          bigNumberForQuantity(Math.floor(val.query))));
+        bigNumberForQuantity(Math.floor(val.query))));
 
       items.push(createRightCell(val.holdtime,
-          timeDuration(val.holdtime)));
+        timeDuration(val.holdtime)));
 
       items.push(createRightCell((val.compactions.scans.running +
           val.compactions.scans.queued),
-          bigNumberForQuantity(val.compactions.scans.running) +
-          '&nbsp;(' + bigNumberForQuantity(val.compactions.scans.queued) +
-          ')'));
+        bigNumberForQuantity(val.compactions.scans.running) +
+        '&nbsp;(' + bigNumberForQuantity(val.compactions.scans.queued) +
+        ')'));
 
       items.push(createRightCell((val.compactions.minor.running +
           val.compactions.minor.queued),
-          bigNumberForQuantity(val.compactions.minor.running) +
-          '&nbsp;(' + bigNumberForQuantity(val.compactions.minor.queued) +
-          ')'));
+        bigNumberForQuantity(val.compactions.minor.running) +
+        '&nbsp;(' + bigNumberForQuantity(val.compactions.minor.queued) +
+        ')'));
 
       items.push(createRightCell((val.compactions.major.running +
           val.compactions.major.queued),
-          bigNumberForQuantity(val.compactions.major.running) +
-          '&nbsp;(' + bigNumberForQuantity(val.compactions.major.queued) +
-          ')'));
+        bigNumberForQuantity(val.compactions.major.running) +
+        '&nbsp;(' + bigNumberForQuantity(val.compactions.major.queued) +
+        ')'));
 
       items.push(createRightCell(val.indexCacheHitRate * 100,
-          Math.round(val.indexCacheHitRate * 100) + '%'));
+        Math.round(val.indexCacheHitRate * 100) + '%'));
 
       items.push(createRightCell(val.dataCacheHitRate * 100,
-          Math.round(val.dataCacheHitRate * 100) + '%'));
+        Math.round(val.dataCacheHitRate * 100) + '%'));
 
       items.push(createRightCell(val.osload,
-          bigNumberForQuantity(val.osload)));
+        bigNumberForQuantity(val.osload)));
 
       $('<tr/>', {
         html: items.join('')

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/tservers.js
@@ -33,88 +33,86 @@ var recoveryList = [];
  * @returns true if the server is in the recoveryList, else false
  */
 function serverIsInRecoveryList(server) {
-    return recoveryList.includes(server.hostname);
+  return recoveryList.includes(server.hostname);
 }
 
 /**
  * Refreshes the list of recovering tservers and shows/hides the recovery caption
  */
 function refreshRecoveryList() {
-    getRecoveryList().then(function () {
-        var sessionStorageRecoveryList, sessionStorageTserversList;
+  getRecoveryList().then(function () {
+    var sessionStorageRecoveryList, sessionStorageTserversList;
 
-        // get list of recovering servers and online servers from sessionStorage
-        sessionStorageRecoveryList = sessionStorage.recoveryList === undefined ?
-                    [] : JSON.parse(sessionStorage.recoveryList).recoveryList;
-        sessionStorageTserversList = sessionStorage.tservers === undefined ?
-                    [] : JSON.parse(sessionStorage.tservers).servers;
+    // get list of recovering servers and online servers from sessionStorage
+    sessionStorageRecoveryList = sessionStorage.recoveryList === undefined ? [] : JSON.parse(sessionStorage.recoveryList).recoveryList;
+    sessionStorageTserversList = sessionStorage.tservers === undefined ? [] : JSON.parse(sessionStorage.tservers).servers;
 
-        // update global recovery list variable
-        recoveryList = sessionStorageRecoveryList.map(function (entry) {
-            return entry.server;
-        });
-
-        // show the recovery caption if any online servers are in the recovery list
-        if (sessionStorageTserversList.some(serverIsInRecoveryList)) {
-            $('#recovery-caption').show();
-        } else {
-            $('#recovery-caption').hide();
-        }
+    // update global recovery list variable
+    recoveryList = sessionStorageRecoveryList.map(function (entry) {
+      return entry.server;
     });
+
+    // show the recovery caption if any online servers are in the recovery list
+    if (sessionStorageTserversList.some(serverIsInRecoveryList)) {
+      $('#recovery-caption').show();
+    } else {
+      $('#recovery-caption').hide();
+    }
+  });
 }
 
 /**
  * Refreshes data in the tserver table
  */
 function refreshTServersTable() {
-    refreshRecoveryList();
-    ajaxReloadTable(tserversTable);
+  refreshRecoveryList();
+  ajaxReloadTable(tserversTable);
 }
 
 /**
  * Refreshes data in the deadtservers table
  */
 function refreshDeadTServersTable() {
-    ajaxReloadTable(deadTServersTable);
+  ajaxReloadTable(deadTServersTable);
 
-    // Only show the table if there are non-empty rows
-    if ($('#deadtservers tbody .dataTables_empty').length) {
-        $('#deadtservers_wrapper').hide();
-    } else {
-        $('#deadtservers_wrapper').show();
-    }
+  // Only show the table if there are non-empty rows
+  if ($('#deadtservers tbody .dataTables_empty').length) {
+    $('#deadtservers_wrapper').hide();
+  } else {
+    $('#deadtservers_wrapper').show();
+  }
 }
 
 /**
  * Refreshes data in the badtservers table
  */
 function refreshBadTServersTable() {
-    ajaxReloadTable(badTServersTable);
+  ajaxReloadTable(badTServersTable);
 
-    // Only show the table if there are non-empty rows
-    if ($('#badtservers tbody .dataTables_empty').length) {
-        $('#badtservers_wrapper').hide();
-    } else {
-        $('#badtservers_wrapper').show();
-    }
+  // Only show the table if there are non-empty rows
+  if ($('#badtservers tbody .dataTables_empty').length) {
+    $('#badtservers_wrapper').hide();
+  } else {
+    $('#badtservers_wrapper').show();
+  }
 }
 
 /**
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTServers() {
-    getTServers().then(function () {
-        refreshBadTServersTable();
-        refreshDeadTServersTable();
-        refreshTServersTable();
-    });
+  getTServers().then(function () {
+    refreshBadTServersTable();
+    refreshDeadTServersTable();
+    refreshTServersTable();
+  });
 }
 
 /**
  * Used to redraw the page
  */
 function refresh() {
-    refreshTServers();
+  refreshTServers();
 }
 
 /**
@@ -123,9 +121,9 @@ function refresh() {
  * @param {string} server Dead TServer to clear
  */
 function clearDeadTServers(server) {
-    clearDeadServers(server);
-    refreshTServers();
-    refreshNavBar();
+  clearDeadServers(server);
+  refreshTServers();
+  refreshNavBar();
 }
 
 /**
@@ -133,140 +131,168 @@ function clearDeadTServers(server) {
  */
 $(document).ready(function () {
 
-    refreshRecoveryList();
+  refreshRecoveryList();
 
-    // Create a table for tserver list
-    tserversTable = $('#tservers').DataTable({
-        "ajax": {
-            "url": '/rest/tservers',
-            "dataSrc": "servers"
-        },
-        "stateSave": true,
-        "columnDefs": [
-            {
-                "targets": "big-num",
-                "render": function (data, type) {
-                    if (type === 'display') {
-                        data = bigNumberForQuantity(data);
-                    }
-                    return data;
-                }
-            },
-            {
-                "targets": "duration",
-                "render": function (data, type) {
-                    if (type === 'display') {
-                        data = timeDuration(data);
-                    }
-                    return data;
-                }
-            },
-            {
-                "targets": "percent",
-                "render": function (data, type) {
-                    if (type === 'display') {
-                        data = Math.round(data * 100) + '%';
-                    }
-                    return data;
-                }
-            }
-        ],
-        "columns": [
-            {
-                "data": "hostname",
-                "type": "html",
-                "render": function (data, type, row) {
-                    if (type === 'display') {
-                        data = '<a href="/tservers?s=' + row.id + '">' + row.hostname + '</a>';
-                    }
-                    return data;
-                }
-            },
-            { "data": "tablets" },
-            { "data": "lastContact" },
-            { "data": "responseTime" },
-            { "data": "entries" },
-            { "data": "ingest" },
-            { "data": "query" },
-            { "data": "holdtime" },
-            { "data": "scansCombo" },
-            { "data": "minorCombo" },
-            { "data": "majorCombo" },
-            { "data": "indexCacheHitRate" },
-            { "data": "dataCacheHitRate" },
-            { "data": "osload" }
-        ],
-        "rowCallback": function (row, data, index) {
-            // reset background of each row
-            $(row).css('background-color', '');
-
-            // if the curent hostname is in the reovery list
-            if (serverIsInRecoveryList(data)) {
-                // highlight the current row
-                console.log('Highlighting row index:' + index + ' tserver:' + data.hostname);
-                $(row).css('background-color', 'gold');
-            }
+  // Create a table for tserver list
+  tserversTable = $('#tservers').DataTable({
+    "ajax": {
+      "url": '/rest/tservers',
+      "dataSrc": "servers"
+    },
+    "stateSave": true,
+    "columnDefs": [{
+        "targets": "big-num",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(data);
+          }
+          return data;
         }
-    });
+      },
+      {
+        "targets": "duration",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = timeDuration(data);
+          }
+          return data;
+        }
+      },
+      {
+        "targets": "percent",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = Math.round(data * 100) + '%';
+          }
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "hostname",
+        "type": "html",
+        "render": function (data, type, row) {
+          if (type === 'display') {
+            data = '<a href="/tservers?s=' + row.id + '">' + row.hostname + '</a>';
+          }
+          return data;
+        }
+      },
+      {
+        "data": "tablets"
+      },
+      {
+        "data": "lastContact"
+      },
+      {
+        "data": "responseTime"
+      },
+      {
+        "data": "entries"
+      },
+      {
+        "data": "ingest"
+      },
+      {
+        "data": "query"
+      },
+      {
+        "data": "holdtime"
+      },
+      {
+        "data": "scansCombo"
+      },
+      {
+        "data": "minorCombo"
+      },
+      {
+        "data": "majorCombo"
+      },
+      {
+        "data": "indexCacheHitRate"
+      },
+      {
+        "data": "dataCacheHitRate"
+      },
+      {
+        "data": "osload"
+      }
+    ],
+    "rowCallback": function (row, data, index) {
+      // reset background of each row
+      $(row).css('background-color', '');
 
-    // Create a table for deadServers list
-    deadTServersTable = $('#deadtservers').DataTable({
-        "ajax": {
-            "url": '/rest/tservers',
-            "dataSrc": "deadServers"
-        },
-        "stateSave": true,
-        "columnDefs": [
-            {
-                "targets": "date",
-                "render": function (data, type) {
-                    if (type === 'display' && data > 0) {
-                        data = dateFormat(data);
-                    }
-                    return data;
-                }
-            }
-        ],
-        "columns": [
-            { "data": "server" },
-            { "data": "lastStatus" },
-            { "data": "status" },
-            {
-                "data": "server",
-                "type": "html",
-                "render": function (data, type) {
-                    if (type === 'display') {
-                        data = '<a href="javascript:clearDeadTServers(\'' + data + '\');">clear</a>';
-                    }
-                    return data;
-                }
-            }
-        ]
-    });
+      // if the curent hostname is in the reovery list
+      if (serverIsInRecoveryList(data)) {
+        // highlight the current row
+        console.log('Highlighting row index:' + index + ' tserver:' + data.hostname);
+        $(row).css('background-color', 'gold');
+      }
+    }
+  });
 
-    // Create a table for badServers list
-    badTServersTable = $('#badtservers').DataTable({
-        "ajax": {
-            "url": '/rest/tservers',
-            "dataSrc": "badServers"
-        },
-        "stateSave": true,
-        "columnDefs": [
-            {
-                "targets": "date",
-                "render": function (data, type) {
-                    if (type === 'display' && data > 0) {
-                        data = dateFormat(data);
-                    }
-                    return data;
-                }
-            }
-        ],
-        "columns": [
-            { "data": "id" },
-            { "data": "status" }
-        ]
-    });
+  // Create a table for deadServers list
+  deadTServersTable = $('#deadtservers').DataTable({
+    "ajax": {
+      "url": '/rest/tservers',
+      "dataSrc": "deadServers"
+    },
+    "stateSave": true,
+    "columnDefs": [{
+      "targets": "date",
+      "render": function (data, type) {
+        if (type === 'display' && data > 0) {
+          data = dateFormat(data);
+        }
+        return data;
+      }
+    }],
+    "columns": [{
+        "data": "server"
+      },
+      {
+        "data": "lastStatus"
+      },
+      {
+        "data": "status"
+      },
+      {
+        "data": "server",
+        "type": "html",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = '<a href="javascript:clearDeadTServers(\'' + data + '\');">clear</a>';
+          }
+          return data;
+        }
+      }
+    ]
+  });
 
-    refreshTServers();
+  // Create a table for badServers list
+  badTServersTable = $('#badtservers').DataTable({
+    "ajax": {
+      "url": '/rest/tservers',
+      "dataSrc": "badServers"
+    },
+    "stateSave": true,
+    "columnDefs": [{
+      "targets": "date",
+      "render": function (data, type) {
+        if (type === 'display' && data > 0) {
+          data = dateFormat(data);
+        }
+        return data;
+      }
+    }],
+    "columns": [{
+        "data": "id"
+      },
+      {
+        "data": "status"
+      }
+    ]
+  });
+
+  refreshTServers();
 });

--- a/server/monitor/src/main/scripts/format-js.sh
+++ b/server/monitor/src/main/scripts/format-js.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This script will attempt to format JavaScript files
+
+if hash npx 2>/dev/null; then
+  npx js-beautify -r -n -j -s 2 src/main/resources/org/apache/accumulo/monitor/resources/js/*.js
+else
+  echo "Skipping formatting of JavaScript files, since 'npx' is not present"
+fi


### PR DESCRIPTION
As part of the formatting profile during the Maven build, attempt to
format JavaScript files in the monitor if the `npx` command is available
to run js-beautify

Include formatting changes to the monitor's JavaScript files

This fixes #2713