### PR TITLE
Keep new exception when closing socket

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/rpc/TTimeoutTransport.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/TTimeoutTransport.java
@@ -114,6 +114,7 @@ public class TTimeoutTransport {
       if (socket != null)
         socket.close();
     } catch (IOException ioe) {
+      e.addSuppressed(ioe);
       log.error("Failed to close socket after unsuccessful I/O stream setup", e);
     }
   }


### PR DESCRIPTION
When closing a socket as the result of an exception, also keep any
exception from the attempt to close it, appended to the original
exception as a suppressed exception