### PR TITLE
Match new[] with delete[]

### DIFF
--- a/server/native/src/main/c++/nativeMap/Field.h
+++ b/server/native/src/main/c++/nativeMap/Field.h
@@ -138,7 +138,7 @@ struct LocalField : public Field {
   }
 
   ~LocalField(){
-    delete(field);
+    delete[] field;
   }
 };
 #endif

--- a/server/native/src/main/c++/nativeMap/SubKey.h
+++ b/server/native/src/main/c++/nativeMap/SubKey.h
@@ -183,7 +183,7 @@ struct LocalSubKey : public SubKey {
   LocalSubKey(JNIEnv *env, jbyteArray cf, jbyteArray cq, jbyteArray cv, jlong ts, jboolean del):SubKey(NULL, env, cf, cq, cv, ts, del, INT_MAX){}
 
   ~LocalSubKey(){
-    delete(keyData);
+    delete[] keyData;
   }
 };
 


### PR DESCRIPTION
The C++ standard requires that memory allocated via operator new[] be
freed via operator delete[], but we were freeing it via operator
delete() in a few places.  This was UB, and it causing warnings on GCC
12 with -Wmismatched-new-delete.

Fixes #2719 .