### PR TITLE
Ensure ServerUtilOpts is parsed

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/util/ConfigPropertyUpgrader.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/util/ConfigPropertyUpgrader.java
@@ -67,7 +67,7 @@ public class ConfigPropertyUpgrader implements KeywordExecutable {
 
   @Override
   public void execute(final String[] args) throws Exception {
-    ConfigPropertyUpgrader.Opts opts = new ConfigPropertyUpgrader.Opts();
+    ServerUtilOpts opts = new ServerUtilOpts();
     opts.parseArgs(ConfigPropertyUpgrader.class.getName(), args);
 
     ServerContext context = opts.getServerContext();
@@ -132,7 +132,5 @@ public class ConfigPropertyUpgrader implements KeywordExecutable {
           "Interrupted reading tables from ZooKeeper for path: " + zkPathTableBase, ex);
     }
   }
-
-  static class Opts extends ServerUtilOpts {}
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -59,6 +59,8 @@ public class ChangeSecret {
     var hadoopConf = new Configuration();
 
     ServerUtilOpts opts = new ServerUtilOpts();
+    opts.parseArgs(ChangeSecret.class.getName(), args);
+
     ServerContext context = opts.getServerContext();
     try (var fs = context.getVolumeManager()) {
       ServerDirs serverDirs = new ServerDirs(siteConfig, hadoopConf);
@@ -66,6 +68,7 @@ public class ChangeSecret {
 
       String oldPass = String.valueOf(System.console().readPassword("Old secret: "));
       String newPass = String.valueOf(System.console().readPassword("New secret: "));
+
       Span span = TraceUtil.startSpan(ChangeSecret.class, "main");
       try (Scope scope = span.makeCurrent()) {
 


### PR DESCRIPTION
As follow-on to #2651, I noticed that the help no longer worked:
`bin/accumulo org.apache.accumulo.server.util.ChangeSecret --help`

This change ensures that the ServerUtilOpts is parsed in ChangeSecret,
so that if the config file name is specified, the ServerContext can
still be constructed correctly, and so the help feature works correctly
to view the command's usage.

Also, remove an unnecessary subclass of ServerUtilOpts that didn't add
any new parameters, and use the ServerUtilOpts class directly in
ConfigPropertyUpgrader.