### PR TITLE
Simplify config handling for compaction tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -437,7 +437,7 @@
                   <configuration>
                     <reuseForks>false</reuseForks>
                     <excludes combine.self="override" />
-                    <includes>
+                    <includes combine.self="override">
                       <include>**/InternerTest.java</include>
                       <include>**/NamespaceIdTest.java</include>
                       <include>**/TableIdTest.java</include>

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
@@ -160,6 +160,11 @@ public class ClientConfConverter {
     return new AccumuloConfiguration() {
 
       @Override
+      public boolean isPropertySet(Property prop) {
+        return config.containsKey(prop.getKey());
+      }
+
+      @Override
       public String get(Property property) {
         final String key = property.getKey();
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -407,9 +407,7 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
     }
   }
 
-  public boolean isPropertySet(Property prop) {
-    throw new UnsupportedOperationException();
-  }
+  public abstract boolean isPropertySet(Property prop);
 
   // deprecation property warning could get spammy in tserver so only warn once
   boolean depPropWarned = false;

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -195,7 +195,7 @@
                   <configuration>
                     <reuseForks>false</reuseForks>
                     <excludes combine.self="override" />
-                    <includes>
+                    <includes combine.self="override">
                       <include>**/AuthenticationTokenSecretManagerTest.java</include>
                     </includes>
                   </configuration>

--- a/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/UserImpersonationTest.java
@@ -25,11 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Predicate;
-
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.Property;
@@ -42,38 +37,15 @@ import com.google.common.base.Joiner;
 
 public class UserImpersonationTest {
 
-  private ConfigurationCopy cc;
-  private AccumuloConfiguration conf;
+  private ConfigurationCopy conf;
 
   @BeforeEach
   public void setup() {
-    cc = new ConfigurationCopy(new HashMap<>());
-    conf = new AccumuloConfiguration() {
-      DefaultConfiguration defaultConfig = DefaultConfiguration.getInstance();
-
-      @Override
-      public String get(Property property) {
-        String value = cc.get(property);
-        if (null == value) {
-          return defaultConfig.get(property);
-        }
-        return value;
-      }
-
-      @Override
-      public void getProperties(Map<String,String> props, Predicate<String> filter) {
-        cc.getProperties(props, filter);
-      }
-
-      @Override
-      public long getUpdateCount() {
-        return 0;
-      }
-    };
+    conf = new ConfigurationCopy(DefaultConfiguration.getInstance());
   }
 
   private void setValidHosts(String... hosts) {
-    cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_HOST_IMPERSONATION.getKey(),
+    conf.set(Property.INSTANCE_RPC_SASL_ALLOWED_HOST_IMPERSONATION.getKey(),
         Joiner.on(';').join(hosts));
   }
 
@@ -88,7 +60,7 @@ public class UserImpersonationTest {
       }
       sb.append(remoteToAllowedUsers[v - 1]).append(":").append(remoteToAllowedUsers[v]);
     }
-    cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION, sb.toString());
+    conf.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION, sb.toString());
   }
 
   @Test
@@ -284,8 +256,8 @@ public class UserImpersonationTest {
   @Test
   public void testSingleUser() {
     final String server = "server/hostname@EXAMPLE.COM", client = "client@EXAMPLE.COM";
-    cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION, server + ":" + client);
-    cc.set(Property.INSTANCE_RPC_SASL_ALLOWED_HOST_IMPERSONATION, "*");
+    conf.set(Property.INSTANCE_RPC_SASL_ALLOWED_USER_IMPERSONATION, server + ":" + client);
+    conf.set(Property.INSTANCE_RPC_SASL_ALLOWED_HOST_IMPERSONATION, "*");
     UserImpersonation impersonation = new UserImpersonation(conf);
 
     UsersWithHosts uwh = impersonation.get(server);

--- a/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
+++ b/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.coordinator;
 
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -36,7 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -60,7 +62,6 @@ import org.apache.accumulo.server.rpc.ServerAddress;
 import org.apache.accumulo.server.security.AuditedSecurityOperation;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.zookeeper.KeeperException;
-import org.easymock.EasyMock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
@@ -86,11 +87,10 @@ public class CompactionCoordinatorTest {
     private final ServerAddress client;
     private final TabletClientService.Client tabletServerClient;
 
-    protected TestCoordinator(AccumuloConfiguration conf, CompactionFinalizer finalizer,
-        LiveTServerSet tservers, ServerAddress client,
-        TabletClientService.Client tabletServerClient, ServerContext context,
+    protected TestCoordinator(CompactionFinalizer finalizer, LiveTServerSet tservers,
+        ServerAddress client, TabletClientService.Client tabletServerClient, ServerContext context,
         AuditedSecurityOperation security) {
-      super(new ServerOpts(), new String[] {}, conf);
+      super(new ServerOpts(), new String[] {}, context.getConfiguration());
       this.compactionFinalizer = finalizer;
       this.tserverSet = tservers;
       this.client = client;
@@ -186,35 +186,34 @@ public class CompactionCoordinatorTest {
     PowerMock.suppress(PowerMock.methods(DeadCompactionDetector.class, "detectDeadCompactions",
         "detectDanglingFinalStateMarkers"));
 
-    AccumuloConfiguration conf = PowerMock.createNiceMock(AccumuloConfiguration.class);
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
 
     PowerMock.mockStatic(ExternalCompactionUtil.class);
     List<RunningCompaction> runningCompactions = new ArrayList<>();
-    EasyMock.expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
+    expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
         .andReturn(runningCompactions);
 
     CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
-    EasyMock.expect(tservers.getCurrentServers()).andReturn(Collections.emptySet()).anyTimes();
+    expect(tservers.getCurrentServers()).andReturn(Collections.emptySet()).anyTimes();
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
-    EasyMock.expect(client.getAddress()).andReturn(address).anyTimes();
+    expect(client.getAddress()).andReturn(address).anyTimes();
 
     TServerInstance tsi = PowerMock.createNiceMock(TServerInstance.class);
-    EasyMock.expect(tsi.getHostPort()).andReturn("localhost:9997").anyTimes();
+    expect(tsi.getHostPort()).andReturn("localhost:9997").anyTimes();
 
     TabletClientService.Client tsc = PowerMock.createNiceMock(TabletClientService.Client.class);
-    EasyMock.expect(tsc.getCompactionQueueInfo(EasyMock.anyObject(), EasyMock.anyObject()))
-        .andReturn(Collections.emptyList()).anyTimes();
+    expect(tsc.getCompactionQueueInfo(anyObject(), anyObject())).andReturn(Collections.emptyList())
+        .anyTimes();
 
     AuditedSecurityOperation security = PowerMock.createNiceMock(AuditedSecurityOperation.class);
 
     PowerMock.replayAll();
 
-    TestCoordinator coordinator =
-        new TestCoordinator(conf, finalizer, tservers, client, tsc, context, security);
+    var coordinator = new TestCoordinator(finalizer, tservers, client, tsc, context, security);
     coordinator.resetInternals();
     assertEquals(0, coordinator.getQueues().size());
     assertEquals(0, coordinator.getIndex().size());
@@ -237,41 +236,41 @@ public class CompactionCoordinatorTest {
     PowerMock.suppress(PowerMock.methods(DeadCompactionDetector.class, "detectDeadCompactions",
         "detectDanglingFinalStateMarkers"));
 
-    AccumuloConfiguration conf = PowerMock.createNiceMock(AccumuloConfiguration.class);
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
-    EasyMock.expect(context.rpcCreds()).andReturn(creds);
+    expect(context.rpcCreds()).andReturn(creds);
 
     PowerMock.mockStatic(ExternalCompactionUtil.class);
     List<RunningCompaction> runningCompactions = new ArrayList<>();
-    EasyMock.expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
+    expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
         .andReturn(runningCompactions);
 
     CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
-    EasyMock.expect(tservers.getCurrentServers()).andReturn(Collections.singleton(instance)).once();
+    expect(tservers.getCurrentServers()).andReturn(Collections.singleton(instance)).once();
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
-    EasyMock.expect(client.getAddress()).andReturn(address).anyTimes();
+    expect(client.getAddress()).andReturn(address).anyTimes();
 
     TServerInstance tsi = PowerMock.createNiceMock(TServerInstance.class);
-    EasyMock.expect(tsi.getHostPort()).andReturn("localhost:9997").anyTimes();
+    expect(tsi.getHostPort()).andReturn("localhost:9997").anyTimes();
 
     TabletClientService.Client tsc = PowerMock.createNiceMock(TabletClientService.Client.class);
     TCompactionQueueSummary queueSummary = PowerMock.createNiceMock(TCompactionQueueSummary.class);
-    EasyMock.expect(tsc.getCompactionQueueInfo(EasyMock.anyObject(), EasyMock.anyObject()))
+    expect(tsc.getCompactionQueueInfo(anyObject(), anyObject()))
         .andReturn(Collections.singletonList(queueSummary)).anyTimes();
-    EasyMock.expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
-    EasyMock.expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
+    expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
+    expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
 
     AuditedSecurityOperation security = PowerMock.createNiceMock(AuditedSecurityOperation.class);
 
     PowerMock.replayAll();
 
-    TestCoordinator coordinator =
-        new TestCoordinator(conf, finalizer, tservers, client, tsc, context, security);
+    var coordinator = new TestCoordinator(finalizer, tservers, client, tsc, context, security);
     coordinator.resetInternals();
     assertEquals(0, coordinator.getQueues().size());
     assertEquals(0, coordinator.getIndex().size());
@@ -308,43 +307,43 @@ public class CompactionCoordinatorTest {
     PowerMock.suppress(PowerMock.methods(DeadCompactionDetector.class, "detectDeadCompactions",
         "detectDanglingFinalStateMarkers"));
 
-    AccumuloConfiguration conf = PowerMock.createNiceMock(AccumuloConfiguration.class);
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
-    EasyMock.expect(context.rpcCreds()).andReturn(creds);
+    expect(context.rpcCreds()).andReturn(creds);
 
     CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
     HostAndPort tserverAddress = HostAndPort.fromString("localhost:9997");
-    EasyMock.expect(instance.getHostAndPort()).andReturn(tserverAddress).anyTimes();
-    EasyMock.expect(tservers.getCurrentServers()).andReturn(Sets.newHashSet(instance)).once();
+    expect(instance.getHostAndPort()).andReturn(tserverAddress).anyTimes();
+    expect(tservers.getCurrentServers()).andReturn(Sets.newHashSet(instance)).once();
     tservers.startListeningForTabletServerChanges();
 
     PowerMock.mockStatic(ExternalCompactionUtil.class);
     List<RunningCompaction> runningCompactions = new ArrayList<>();
-    EasyMock.expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
+    expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
         .andReturn(runningCompactions);
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
-    EasyMock.expect(client.getAddress()).andReturn(address).anyTimes();
+    expect(client.getAddress()).andReturn(address).anyTimes();
 
-    EasyMock.expect(instance.getHostPort()).andReturn("localhost:9997").anyTimes();
+    expect(instance.getHostPort()).andReturn("localhost:9997").anyTimes();
 
     TabletClientService.Client tsc = PowerMock.createNiceMock(TabletClientService.Client.class);
     TCompactionQueueSummary queueSummary = PowerMock.createNiceMock(TCompactionQueueSummary.class);
-    EasyMock.expect(tsc.getCompactionQueueInfo(EasyMock.anyObject(), EasyMock.anyObject()))
+    expect(tsc.getCompactionQueueInfo(anyObject(), anyObject()))
         .andReturn(Collections.singletonList(queueSummary)).anyTimes();
-    EasyMock.expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
-    EasyMock.expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
+    expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
+    expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
 
     AuditedSecurityOperation security = PowerMock.createNiceMock(AuditedSecurityOperation.class);
 
     PowerMock.replayAll();
 
-    TestCoordinator coordinator =
-        new TestCoordinator(conf, finalizer, tservers, client, tsc, context, security);
+    var coordinator = new TestCoordinator(finalizer, tservers, client, tsc, context, security);
     coordinator.resetInternals();
     assertEquals(0, coordinator.getQueues().size());
     assertEquals(0, coordinator.getIndex().size());
@@ -382,49 +381,49 @@ public class CompactionCoordinatorTest {
     PowerMock.suppress(PowerMock.methods(DeadCompactionDetector.class, "detectDeadCompactions",
         "detectDanglingFinalStateMarkers"));
 
-    AccumuloConfiguration conf = PowerMock.createNiceMock(AccumuloConfiguration.class);
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
-    EasyMock.expect(context.rpcCreds()).andReturn(creds);
+    expect(context.rpcCreds()).andReturn(creds);
 
     CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
     HostAndPort tserverAddress = HostAndPort.fromString("localhost:9997");
-    EasyMock.expect(instance.getHostAndPort()).andReturn(tserverAddress).anyTimes();
-    EasyMock.expect(tservers.getCurrentServers()).andReturn(Sets.newHashSet(instance)).once();
+    expect(instance.getHostAndPort()).andReturn(tserverAddress).anyTimes();
+    expect(tservers.getCurrentServers()).andReturn(Sets.newHashSet(instance)).once();
     tservers.startListeningForTabletServerChanges();
 
     PowerMock.mockStatic(ExternalCompactionUtil.class);
     List<RunningCompaction> runningCompactions = new ArrayList<>();
     ExternalCompactionId eci = ExternalCompactionId.generate(UUID.randomUUID());
     TExternalCompactionJob job = PowerMock.createNiceMock(TExternalCompactionJob.class);
-    EasyMock.expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
+    expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
     TKeyExtent extent = new TKeyExtent();
     extent.setTable("1".getBytes());
     runningCompactions.add(new RunningCompaction(job, tserverAddress.toString(), "queue"));
-    EasyMock.expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
+    expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
         .andReturn(runningCompactions);
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
-    EasyMock.expect(client.getAddress()).andReturn(address).anyTimes();
+    expect(client.getAddress()).andReturn(address).anyTimes();
 
-    EasyMock.expect(instance.getHostPort()).andReturn("localhost:9997").anyTimes();
+    expect(instance.getHostPort()).andReturn("localhost:9997").anyTimes();
 
     TabletClientService.Client tsc = PowerMock.createNiceMock(TabletClientService.Client.class);
     TCompactionQueueSummary queueSummary = PowerMock.createNiceMock(TCompactionQueueSummary.class);
-    EasyMock.expect(tsc.getCompactionQueueInfo(EasyMock.anyObject(), EasyMock.anyObject()))
+    expect(tsc.getCompactionQueueInfo(anyObject(), anyObject()))
         .andReturn(Collections.singletonList(queueSummary)).anyTimes();
-    EasyMock.expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
-    EasyMock.expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
+    expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
+    expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
 
     AuditedSecurityOperation security = PowerMock.createNiceMock(AuditedSecurityOperation.class);
 
     PowerMock.replayAll();
 
-    TestCoordinator coordinator =
-        new TestCoordinator(conf, finalizer, tservers, client, tsc, context, security);
+    var coordinator = new TestCoordinator(finalizer, tservers, client, tsc, context, security);
     coordinator.resetInternals();
     assertEquals(0, coordinator.getQueues().size());
     assertEquals(0, coordinator.getIndex().size());
@@ -461,53 +460,51 @@ public class CompactionCoordinatorTest {
     PowerMock.suppress(PowerMock.methods(DeadCompactionDetector.class, "detectDeadCompactions",
         "detectDanglingFinalStateMarkers"));
 
-    AccumuloConfiguration conf = PowerMock.createNiceMock(AccumuloConfiguration.class);
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
-    EasyMock.expect(context.rpcCreds()).andReturn(creds).anyTimes();
+    expect(context.rpcCreds()).andReturn(creds).anyTimes();
 
     PowerMock.mockStatic(ExternalCompactionUtil.class);
     List<RunningCompaction> runningCompactions = new ArrayList<>();
-    EasyMock.expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
+    expect(ExternalCompactionUtil.getCompactionsRunningOnCompactors(context))
         .andReturn(runningCompactions);
 
     CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
     LiveTServerSet tservers = PowerMock.createNiceMock(LiveTServerSet.class);
     TServerInstance instance = PowerMock.createNiceMock(TServerInstance.class);
-    EasyMock.expect(tservers.getCurrentServers()).andReturn(Collections.singleton(instance)).once();
+    expect(tservers.getCurrentServers()).andReturn(Collections.singleton(instance)).once();
     HostAndPort tserverAddress = HostAndPort.fromString("localhost:9997");
-    EasyMock.expect(instance.getHostAndPort()).andReturn(tserverAddress).anyTimes();
+    expect(instance.getHostAndPort()).andReturn(tserverAddress).anyTimes();
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
-    EasyMock.expect(client.getAddress()).andReturn(address).anyTimes();
+    expect(client.getAddress()).andReturn(address).anyTimes();
 
     TServerInstance tsi = PowerMock.createNiceMock(TServerInstance.class);
-    EasyMock.expect(tsi.getHostPort()).andReturn("localhost:9997").anyTimes();
+    expect(tsi.getHostPort()).andReturn("localhost:9997").anyTimes();
 
     TabletClientService.Client tsc = PowerMock.createNiceMock(TabletClientService.Client.class);
     TCompactionQueueSummary queueSummary = PowerMock.createNiceMock(TCompactionQueueSummary.class);
-    EasyMock.expect(tsc.getCompactionQueueInfo(EasyMock.anyObject(), EasyMock.anyObject()))
+    expect(tsc.getCompactionQueueInfo(anyObject(), anyObject()))
         .andReturn(Collections.singletonList(queueSummary)).anyTimes();
-    EasyMock.expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
-    EasyMock.expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
+    expect(queueSummary.getQueue()).andReturn("R2DQ").anyTimes();
+    expect(queueSummary.getPriority()).andReturn((short) 1).anyTimes();
 
     ExternalCompactionId eci = ExternalCompactionId.generate(UUID.randomUUID());
     TExternalCompactionJob job = PowerMock.createNiceMock(TExternalCompactionJob.class);
-    EasyMock.expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
+    expect(job.getExternalCompactionId()).andReturn(eci.toString()).anyTimes();
     TInfo trace = TraceUtil.traceInfo();
-    EasyMock
-        .expect(
-            tsc.reserveCompactionJob(trace, creds, "R2DQ", 1, "localhost:10241", eci.toString()))
+    expect(tsc.reserveCompactionJob(trace, creds, "R2DQ", 1, "localhost:10241", eci.toString()))
         .andReturn(job).anyTimes();
 
     AuditedSecurityOperation security = PowerMock.createNiceMock(AuditedSecurityOperation.class);
-    EasyMock.expect(security.canPerformSystemActions(creds)).andReturn(true);
+    expect(security.canPerformSystemActions(creds)).andReturn(true);
 
     PowerMock.replayAll();
 
-    TestCoordinator coordinator =
-        new TestCoordinator(conf, finalizer, tservers, client, tsc, context, security);
+    var coordinator = new TestCoordinator(finalizer, tservers, client, tsc, context, security);
     coordinator.resetInternals();
     assertEquals(0, coordinator.getQueues().size());
     assertEquals(0, coordinator.getIndex().size());
@@ -559,8 +556,9 @@ public class CompactionCoordinatorTest {
     PowerMock.resetAll();
     PowerMock.suppress(PowerMock.constructor(AbstractServer.class));
 
-    AccumuloConfiguration conf = PowerMock.createNiceMock(AccumuloConfiguration.class);
     ServerContext context = PowerMock.createNiceMock(ServerContext.class);
+    expect(context.getConfiguration()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
+
     TCredentials creds = PowerMock.createNiceMock(TCredentials.class);
 
     CompactionFinalizer finalizer = PowerMock.createNiceMock(CompactionFinalizer.class);
@@ -568,17 +566,16 @@ public class CompactionCoordinatorTest {
 
     ServerAddress client = PowerMock.createNiceMock(ServerAddress.class);
     HostAndPort address = HostAndPort.fromString("localhost:10240");
-    EasyMock.expect(client.getAddress()).andReturn(address).anyTimes();
+    expect(client.getAddress()).andReturn(address).anyTimes();
 
     TabletClientService.Client tsc = PowerMock.createNiceMock(TabletClientService.Client.class);
 
     AuditedSecurityOperation security = PowerMock.createNiceMock(AuditedSecurityOperation.class);
-    EasyMock.expect(security.canPerformSystemActions(creds)).andReturn(true);
+    expect(security.canPerformSystemActions(creds)).andReturn(true);
 
     PowerMock.replayAll();
 
-    TestCoordinator coordinator =
-        new TestCoordinator(conf, finalizer, tservers, client, tsc, context, security);
+    var coordinator = new TestCoordinator(finalizer, tservers, client, tsc, context, security);
     coordinator.resetInternals();
     TExternalCompactionJob job = coordinator.getCompactionJob(TraceUtil.traceInfo(), creds, "R2DQ",
         "localhost:10240", UUID.randomUUID().toString());

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -194,7 +194,7 @@
                   <configuration>
                     <reuseForks>false</reuseForks>
                     <excludes combine.self="override" />
-                    <includes>
+                    <includes combine.self="override">
                       <include>**/AssignmentWatcherTest.java</include>
                     </includes>
                   </configuration>


### PR DESCRIPTION
In pom.xml files:
* ensure unit tests configured to run without reusing forks explicitly
  override any other includes

In compaction tests:
* avoid use of mock object for AccumuloConfiguration when
  DefaultConfiguration or ConfigurationCopy will suffice
* use static import for EasyMock
* Remove unnecessary parameter in test class for AccumuloConfiguration
  (retrieve from mocked context object instead)
* use `var` in a few places where it made sense

Avoid UnsupportedOperationException in AccumuloConfiguration:
* Make AccumuloConfiguration.isPropertySet abstract and add missing
  implementation
* Remove unnecessary anonymous inner class subclass instances of
  AccumuloConfiguration when ConfigurationCopy initialized with
  DefaultConfiguration would suffice

Small Compaction constructor improvements:
* Remove redundant constructor code in Compactor and
  CompactionCoordinator and ensure code uses the provided
  AccumuloConfiguration from tests for all tasks