### PR TITLE
Fix recently broken ZooKeeper ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/conf/store/PropStoreZooKeeperIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/store/PropStoreZooKeeperIT.java
@@ -87,6 +87,7 @@ public class PropStoreZooKeeperIT {
     // using default zookeeper port - we don't have a full configuration
     testZk = new ZooKeeperTestingServer(tempDir);
     zooKeeper = testZk.getZooKeeper();
+    ZooUtil.digestAuth(zooKeeper, ZooKeeperTestingServer.SECRET);
   }
 
   @AfterAll

--- a/test/src/main/java/org/apache/accumulo/test/conf/store/ZooBasedConfigIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/store/ZooBasedConfigIT.java
@@ -104,6 +104,7 @@ public class ZooBasedConfigIT {
     // using default zookeeper port - we don't have a full configuration
     testZk = new ZooKeeperTestingServer(tempDir);
     zooKeeper = testZk.getZooKeeper();
+    ZooUtil.digestAuth(zooKeeper, ZooKeeperTestingServer.SECRET);
     zrw = testZk.getZooReaderWriter();
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/conf/util/ConfigTransformerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/util/ConfigTransformerIT.java
@@ -22,8 +22,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -82,6 +84,7 @@ public class ConfigTransformerIT {
     // using default zookeeper port - we don't have a full configuration
     testZk = new ZooKeeperTestingServer(tempDir);
     zooKeeper = testZk.getZooKeeper();
+    ZooUtil.digestAuth(zooKeeper, ZooKeeperTestingServer.SECRET);
     zrw = testZk.getZooReaderWriter();
   }
 
@@ -106,6 +109,8 @@ public class ConfigTransformerIT {
     expect(context.getPropStore()).andReturn(propStore).anyTimes();
 
     watcher = createMock(PropStoreWatcher.class);
+    watcher.process(anyObject());
+    expectLastCall().anyTimes();
 
     replay(context, watcher);
 

--- a/test/src/main/java/org/apache/accumulo/test/upgrade/ConfigPropertyUpgraderIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/upgrade/ConfigPropertyUpgraderIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.upgrade;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
@@ -74,7 +73,7 @@ public class ConfigPropertyUpgraderIT {
     // using default zookeeper port - we don't have a full configuration
     testZk = new ZooKeeperTestingServer(tempDir);
     zooKeeper = testZk.getZooKeeper();
-    zooKeeper.addAuthInfo("digest", "accumulo:test".getBytes(UTF_8));
+    ZooUtil.digestAuth(zooKeeper, ZooKeeperTestingServer.SECRET);
 
     zrw = testZk.getZooReaderWriter();
 

--- a/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
@@ -42,6 +42,7 @@ import com.google.common.base.Preconditions;
 public class ZooKeeperTestingServer implements AutoCloseable {
 
   private static final Logger log = LoggerFactory.getLogger(ZooKeeperTestingServer.class);
+  public static final String SECRET = "secret";
 
   private TestingServer zkServer;
   private final ZooKeeper zoo;
@@ -101,7 +102,7 @@ public class ZooKeeperTestingServer implements AutoCloseable {
   }
 
   public ZooReaderWriter getZooReaderWriter() {
-    return new ZooReader(getConn(), 30000).asWriter("secret");
+    return new ZooReader(getConn(), 30000).asWriter(SECRET);
   }
 
   public String getConn() {


### PR DESCRIPTION
Fix ZooKeeper-related ITs broken by #2721, which added authentication to
configuration nodes stored in ZooKeeper. This adds the auth info to the
ZooKeeper object used by the ITs, matching the ZooKeeperTestingServer's
SECRET.