### PR TITLE
Remove TODOs and rename PerTableVolumeChooser

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
@@ -30,16 +30,14 @@ import org.slf4j.LoggerFactory;
 /**
  * A {@link VolumeChooser} that delegates to another volume chooser based on other properties:
  * table.custom.volume.chooser for tables, and general.custom.volume.chooser.scoped for scopes.
- * general.custom.volume.chooser.{scope} can override the system wide setting for
- * general.custom.volume.chooser.scoped. At the this this was written, the only known scope was
+ * general.custom.volume.chooser.{scope} can override the system-wide setting for
+ * general.custom.volume.chooser.scoped. At the time this was written, the only known scope was
  * "logger".
  *
  * @since 2.1.0
  */
-public class PerTableVolumeChooser implements VolumeChooser {
-  // TODO rename this class to DelegatingChooser? It delegates for more than just per-table scope
-  private static final Logger log = LoggerFactory.getLogger(PerTableVolumeChooser.class);
-  // TODO Add hint of expected size to construction, see ACCUMULO-3410
+public class DelegatingChooser implements VolumeChooser {
+  private static final Logger log = LoggerFactory.getLogger(DelegatingChooser.class);
   /* Track VolumeChooser instances so they can keep state. */
   private final ConcurrentHashMap<TableId,VolumeChooser> tableSpecificChooserCache =
       new ConcurrentHashMap<>();

--- a/core/src/test/java/org/apache/accumulo/core/spi/fs/DelegatingChooserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/fs/DelegatingChooserTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class PerTableVolumeChooserTest {
+public class DelegatingChooserTest {
 
   private static final String TABLE_CUSTOM_SUFFIX = "volume.chooser";
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/fs/PerTableVolumeChooserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/fs/PerTableVolumeChooserTest.java
@@ -47,7 +47,7 @@ public class PerTableVolumeChooserTest {
 
   private ServiceEnvironment serviceEnv;
   private Configuration tableConf;
-  private PerTableVolumeChooser chooser;
+  private DelegatingChooser chooser;
   private Configuration systemConf;
 
   public static class MockChooser1 extends RandomVolumeChooser {}
@@ -58,7 +58,7 @@ public class PerTableVolumeChooserTest {
   public void before() {
     serviceEnv = createStrictMock(ServiceEnvironment.class);
 
-    chooser = new PerTableVolumeChooser();
+    chooser = new DelegatingChooser();
 
     tableConf = createStrictMock(Configuration.class);
     systemConf = createStrictMock(Configuration.class);

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
@@ -25,12 +25,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @Deprecated(since = "2.1.0")
 @SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
     justification = "Same name used for compatibility during deprecation cycle")
-public class PerTableVolumeChooser extends org.apache.accumulo.core.spi.fs.PerTableVolumeChooser
+public class PerTableVolumeChooser extends org.apache.accumulo.core.spi.fs.DelegatingChooser
     implements VolumeChooser {
   public PerTableVolumeChooser() {
     LoggerFactory.getLogger(PerTableVolumeChooser.class).warn(
         "The class {} is deprecated.  Please configure {} instead.",
         PerTableVolumeChooser.class.getName(),
-        org.apache.accumulo.core.spi.fs.PerTableVolumeChooser.class.getName());
+        org.apache.accumulo.core.spi.fs.DelegatingChooser.class.getName());
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/PerTableVolumeChooser.java
@@ -18,19 +18,14 @@
  */
 package org.apache.accumulo.server.fs;
 
+import org.apache.accumulo.core.spi.fs.DelegatingChooser;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 @Deprecated(since = "2.1.0")
-@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
-    justification = "Same name used for compatibility during deprecation cycle")
-public class PerTableVolumeChooser extends org.apache.accumulo.core.spi.fs.DelegatingChooser
-    implements VolumeChooser {
+public class PerTableVolumeChooser extends DelegatingChooser implements VolumeChooser {
   public PerTableVolumeChooser() {
     LoggerFactory.getLogger(PerTableVolumeChooser.class).warn(
         "The class {} is deprecated.  Please configure {} instead.",
-        PerTableVolumeChooser.class.getName(),
-        org.apache.accumulo.core.spi.fs.DelegatingChooser.class.getName());
+        PerTableVolumeChooser.class.getName(), DelegatingChooser.class.getName());
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeChooserIT.java
@@ -50,7 +50,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.spi.fs.PerTableVolumeChooser;
+import org.apache.accumulo.core.spi.fs.DelegatingChooser;
 import org.apache.accumulo.core.spi.fs.PreferredVolumeChooser;
 import org.apache.accumulo.core.spi.fs.RandomVolumeChooser;
 import org.apache.accumulo.core.spi.fs.VolumeChooserEnvironment.Scope;
@@ -100,10 +100,10 @@ public class VolumeChooserIT extends ConfigurableMacBase {
     namespace1 = "ns_" + getUniqueNames(2)[0];
     namespace2 = "ns_" + getUniqueNames(2)[1];
 
-    // Set the general volume chooser to the PerTableVolumeChooser so that different choosers can be
+    // Set the general volume chooser to the DelegatingChooser so that different choosers can be
     // specified
     Map<String,String> siteConfig = new HashMap<>();
-    siteConfig.put(Property.GENERAL_VOLUME_CHOOSER.getKey(), PerTableVolumeChooser.class.getName());
+    siteConfig.put(Property.GENERAL_VOLUME_CHOOSER.getKey(), DelegatingChooser.class.getName());
     // if a table doesn't have a volume chooser, use the preferred volume chooser
     siteConfig.put(PERTABLE_CHOOSER_PROP, PreferredVolumeChooser.class.getName());
 


### PR DESCRIPTION
Addresses #2699 

This PR addresses the following:

- Removal of some of the TODOs throughout the code. 
- Changes the name of `PerTableVolumeChooser` to `DelegatingChooser` where needed.
- Renames `PerTableVolumeChooser.java` to `DelegatingChooser.java`
- Fixes a grammatical error addressed in original issue