### PR TITLE
Fix async bug when clearing logs in monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -323,7 +323,7 @@ function doLoggedPostCall(call, callback, sanitize) {
   // Make the rest call, passing success function callback
   $.post(call, function () {
     console.debug("REST POST call to " + call + ": success");
-    if (callback !== null && callback !== undefined) {
+    if (callback !== null) {
       console.debug("Now calling the provided callback function");
       callback();
     }
@@ -479,8 +479,8 @@ function getLogs() {
 /**
  * REST POST call to clear logs
  */
-function clearLogs(callback) {
-  doLoggedPostCall('/rest/logs/clear', callback, false);
+function clearLogs() {
+  doLoggedPostCall('/rest/logs/clear', refresh, false);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -323,7 +323,7 @@ function doLoggedPostCall(call, callback, sanitize) {
   // Make the rest call, passing success function callback
   $.post(call, function () {
     console.debug("REST POST call to " + call + ": success");
-    if (callback !== null) {
+    if (callback != null) {
       console.debug("Now calling the provided callback function");
       callback();
     }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -323,7 +323,8 @@ function doLoggedPostCall(call, callback, sanitize) {
   // Make the rest call, passing success function callback
   $.post(call, function () {
     console.debug("REST POST call to " + call + ": success");
-    if (callback !== null) {
+    if (callback !== null && callback !== undefined) {
+      console.debug("Now calling the provided callback function");
       callback();
     }
   });
@@ -478,8 +479,9 @@ function getLogs() {
 /**
  * REST POST call to clear logs
  */
-function clearLogs() {
-  doLoggedPostCall('/rest/logs/clear', null, false);
+function clearLogs(callback) {
+  console.debug('clearLogs callback: ' + callback);
+  doLoggedPostCall('/rest/logs/clear', callback, false);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -480,7 +480,6 @@ function getLogs() {
  * REST POST call to clear logs
  */
 function clearLogs(callback) {
-  console.debug('clearLogs callback: ' + callback);
   doLoggedPostCall('/rest/logs/clear', callback, false);
 }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/log.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/log.ftl
@@ -127,5 +127,5 @@
         </table>
       </div>
       <div>
-       <button type="button" class="btn btn-info" onclick="clearLogs();refresh();">Clear Logs</button>
+       <button type="button" class="btn btn-info" onclick="clearLogs(refresh);">Clear Logs</button>
       </div>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/log.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/log.ftl
@@ -127,5 +127,5 @@
         </table>
       </div>
       <div>
-       <button type="button" class="btn btn-info" onclick="clearLogs(refresh);">Clear Logs</button>
+       <button type="button" class="btn btn-info" onclick="clearLogs();">Clear Logs</button>
       </div>


### PR DESCRIPTION
Fixes #2731

There was an issue where the refresh() function was being called before the POST request to clear the table was completed so when clicking the clear logs button, the logs would not be cleared.

This PR adds a parameter to functions.clearLogs() so that we can refresh via a callback which will be called only after the POST request completes to clear the page.