### PR TITLE
Improve use of Futures in Gatherer

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -393,6 +393,16 @@ public class Gatherer {
     }
 
     @Override
+    public boolean isCancelled() {
+      return future.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+      return future.isDone();
+    }
+
+    @Override
     public SummaryCollection get() throws InterruptedException, ExecutionException {
       return future.get();
     }
@@ -403,15 +413,6 @@ public class Gatherer {
       return future.get(timeout, unit);
     }
 
-    @Override
-    public boolean isCancelled() {
-      return future.isCancelled();
-    }
-
-    @Override
-    public boolean isDone() {
-      return future.isDone();
-    }
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -378,7 +378,7 @@ public class Gatherer {
             (pf1, pf2) -> ProcessedFiles.merge(pf1, pf2, factory), ProcessedFiles::new);
       };
       future = CompletableFutureUtil
-          .iterateWhile(go,
+          .iterateUntil(go,
               previousWork -> previousWork != null && previousWork.failedFiles.isEmpty(), null)
           .thenApply(pf -> pf.summaries);
     }

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -378,7 +378,7 @@ public class Gatherer {
             (pf1, pf2) -> ProcessedFiles.merge(pf1, pf2, factory), ProcessedFiles::new);
       };
       future = CompletableFutureUtil
-          .iterateWhileAsync(go,
+          .iterateWhile(go,
               previousWork -> previousWork != null && previousWork.failedFiles.isEmpty(), null)
           .thenApply(pf -> pf.summaries);
     }

--- a/core/src/main/java/org/apache/accumulo/core/util/CompletableFutureUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CompletableFutureUtil.java
@@ -57,7 +57,7 @@ public class CompletableFutureUtil {
    * The step function should always return an asynchronous {@code
    * CompletableFuture} in order to avoid stack overflows.
    */
-  public static <T> CompletableFuture<T> iterateWhile(Function<T,CompletableFuture<T>> step,
+  public static <T> CompletableFuture<T> iterateUntil(Function<T,CompletableFuture<T>> step,
       Predicate<T> isDone, T init) {
     // We'd like to use a lambda here, but lambdas don't have
     // `this`, so we would have to use some clumsy indirection to

--- a/core/src/test/java/org/apache/accumulo/core/util/CompletableFutureUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/CompletableFutureUtilTest.java
@@ -19,13 +19,17 @@
 package org.apache.accumulo.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +56,46 @@ public class CompletableFutureUtilTest {
       assertEquals(0, mergedFutures.get().intValue());
     } finally {
       es.shutdown();
+    }
+  }
+
+  @Test
+  public void testIterateUntil() throws Exception {
+    ExecutorService es = Executors.newFixedThreadPool(1);
+    Function<Integer,CompletableFuture<Integer>> step =
+        n -> CompletableFuture.supplyAsync(() -> n - 1, es);
+    Predicate<Integer> isDone = n -> n == 0;
+    // The call stack should overflow before 10,000 calls, so this
+    // effectively tests whether iterateUntil avoids stack overflows
+    // when given async futures.
+    for (int n : new int[] {0, 1, 2, 3, 100, 10_000}) {
+      assertEquals(0, CompletableFutureUtil.iterateUntil(step, isDone, n).get());
+    }
+    // Test throwing an exception in the step function.
+    {
+      Function<Integer,CompletableFuture<Integer>> badStep = n -> {
+        throw new RuntimeException();
+      };
+      assertThrows(ExecutionException.class,
+          () -> CompletableFutureUtil.iterateUntil(badStep, isDone, 100).get());
+    }
+    // Test throwing an exception in the future returned by the step
+    // function.
+    {
+      Function<Integer,CompletableFuture<Integer>> badStep =
+          n -> CompletableFuture.supplyAsync(() -> {
+            throw new RuntimeException();
+          }, es);
+      assertThrows(ExecutionException.class,
+          () -> CompletableFutureUtil.iterateUntil(badStep, isDone, 100).get());
+    }
+    // Test throwing an exception in the predicate.
+    {
+      Predicate<Integer> badIsDone = n -> {
+        throw new RuntimeException();
+      };
+      assertThrows(ExecutionException.class,
+          () -> CompletableFutureUtil.iterateUntil(step, badIsDone, 100).get());
     }
   }
 }


### PR DESCRIPTION
Attempt to fix #2696. This replaces the complicated mutation retry logic in `Gatherer` with a more structured/algebraic approach. 

This new approach is recursive. Making the recursive call asynchronously should prevent a stack overflow (it does in the tests that I've run), since the task is submitted to the common ForkJoinPool rather than being called directly. This probably imposes a performance penalty, but I don't know how that compares to the cost of the I/O in this codepath.