### PR TITLE
Convert table.js to DataTables

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -18,14 +18,13 @@
  */
 "use strict";
 
-var tableID;
+var tableServersTable;
+
 /**
  * Makes the REST calls, generates the tables with the new information
  */
 function refreshTable() {
-  getTableServers(tableID).then(function () {
-    refreshTableServersTable();
-  });
+  ajaxReloadTable(tableServersTable);
 }
 
 /**
@@ -36,75 +35,107 @@ function refresh() {
 }
 
 /**
- * Generates the table servers table
+ * Initialize the table
+ * 
+ * @param {String} tableID the accumulo table ID
  */
-function refreshTableServersTable() {
-  clearTableBody('participatingTServers');
+function initTableServerTable(tableID) {
 
-  var data = sessionStorage.tableServers === undefined ? [] : JSON.parse(sessionStorage.tableServers);
+  const url = '/rest/tables/' + tableID;
+  console.debug('REST url used to fetch data for table.js DataTable: ' + url);
 
-  if (data.length === 0 || data.servers.length === 0) {
-    var items = [];
-    items.push(createEmptyRow(13, 'Empty'));
-    $('<tr/>', {
-      html: items.join('')
-    }).appendTo('#participatingTServers tbody');
-  } else {
+  tableServersTable = $('#participatingTServers').DataTable({
+    "ajax": {
+      "url": url,
+      "dataSrc": "servers"
+    },
+    "stateSave": true,
+    "columnDefs": [{
+        "targets": "big-num",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(data);
+          }
+          return data;
+        }
+      },
+      {
+        "targets": "duration",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = timeDuration(data);
+          }
+          return data;
+        }
+      },
+      {
+        "targets": "percent",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = Math.round(data * 100) + '%';
+          }
+          return data;
+        }
+      }
+    ],
+    "columns": [{
+        "data": "hostname",
+        "type": "html",
+        "render": function (data, type, row) {
+          if (type === 'display') {
+            data = `<a href="/tservers?s=${row.id}">${data}</a>`;
+          }
+          return data;
+        }
+      },
+      {
+        "data": "tablets"
+      },
+      {
+        "data": "lastContact"
+      },
+      {
+        "data": "entries"
+      },
+      {
+        "data": "ingest"
+      },
+      {
+        "data": "query"
+      },
+      {
+        "data": "holdtime"
+      },
+      {
+        "data": "compactions.scans.running"
+      },
+      {
+        "data": "compactions.scans.queued"
+      },
+      {
+        "data": "compactions.minor.running"
+      },
+      {
+        "data": "compactions.minor.queued"
+      },
+      {
+        "data": "compactions.major.running"
+      },
+      {
+        "data": "compactions.major.queued"
+      },
+      {
+        "data": "indexCacheHitRate"
+      },
+      {
+        "data": "dataCacheHitRate"
+      },
+      {
+        "data": "osload"
+      }
+    ]
+  });
 
-    $.each(data.servers, function (key, val) {
-      var items = [];
-      items.push(createFirstCell(val.hostname, '<a href="/tservers?s=' +
-        val.id + '">' + val.hostname + '</a>'));
+  refreshTable();
 
-      items.push(createRightCell(val.tablets,
-        bigNumberForQuantity(val.tablets)));
-
-      items.push(createRightCell(val.lastContact,
-        timeDuration(val.lastContact)));
-
-      items.push(createRightCell(val.entries,
-        bigNumberForQuantity(val.entries)));
-
-      items.push(createRightCell(val.ingest,
-        bigNumberForQuantity(Math.floor(val.ingest))));
-
-      items.push(createRightCell(val.query,
-        bigNumberForQuantity(Math.floor(val.query))));
-
-      items.push(createRightCell(val.holdtime,
-        timeDuration(val.holdtime)));
-
-      items.push(createRightCell((val.compactions.scans.running +
-          val.compactions.scans.queued),
-        bigNumberForQuantity(val.compactions.scans.running) +
-        '&nbsp;(' + bigNumberForQuantity(val.compactions.scans.queued) +
-        ')'));
-
-      items.push(createRightCell((val.compactions.minor.running +
-          val.compactions.minor.queued),
-        bigNumberForQuantity(val.compactions.minor.running) +
-        '&nbsp;(' + bigNumberForQuantity(val.compactions.minor.queued) +
-        ')'));
-
-      items.push(createRightCell((val.compactions.major.running +
-          val.compactions.major.queued),
-        bigNumberForQuantity(val.compactions.major.running) +
-        '&nbsp;(' + bigNumberForQuantity(val.compactions.major.queued) +
-        ')'));
-
-      items.push(createRightCell(val.indexCacheHitRate * 100,
-        Math.round(val.indexCacheHitRate * 100) + '%'));
-
-      items.push(createRightCell(val.dataCacheHitRate * 100,
-        Math.round(val.dataCacheHitRate * 100) + '%'));
-
-      items.push(createRightCell(val.osload,
-        bigNumberForQuantity(val.osload)));
-
-      $('<tr/>', {
-        html: items.join('')
-      }).appendTo('#participatingTServers tbody');
-
-    });
-  }
 }

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/table.js
@@ -34,6 +34,10 @@ function refresh() {
   refreshTable();
 }
 
+function getQueuedAndRunning(data) {
+  return `${data.running}(${data.queued})`;
+}
+
 /**
  * Initialize the table
  * 
@@ -107,22 +111,19 @@ function initTableServerTable(tableID) {
         "data": "holdtime"
       },
       {
-        "data": "compactions.scans.running"
+        "data": function (row) {
+          return getQueuedAndRunning(row.compactions.scans);
+        }
       },
       {
-        "data": "compactions.scans.queued"
+        "data": function (row) {
+          return getQueuedAndRunning(row.compactions.minor);
+        }
       },
       {
-        "data": "compactions.minor.running"
-      },
-      {
-        "data": "compactions.minor.queued"
-      },
-      {
-        "data": "compactions.major.running"
-      },
-      {
-        "data": "compactions.major.queued"
+        "data": function (row) {
+          return getQueuedAndRunning(row.compactions.major);
+        }
       },
       {
         "data": "indexCacheHitRate"

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -37,27 +37,19 @@
             <caption><span class="table-caption">${table}</span></caption>
             <thead>
               <tr>
-                <th rowspan="2">Server&nbsp;</th>
-                <th rowspan="2" class="big-num">Hosted<br/>Tablets&nbsp;</th>
-                <th rowspan="2" class="duration">Last&nbsp;Contact&nbsp;</th>
-                <th rowspan="2" class="big-num" title="Key/value pairs over each instance, table or tablet.">Entries&nbsp;</th>
-                <th rowspan="2" class="big-num" title="The number of Key/Value pairs inserted. (Note that deletes are considered inserted)">Ingest&nbsp;</th>
-                <th rowspan="2" class="big-num" title="The number of key/value pairs returned to clients. (Not the number of scans)">Query&nbsp;</th>
-                <th rowspan="2" class="duration" title="The amount of time live ingest operations (mutations, batch writes) have been waiting for the tserver to free up memory.">Hold&nbsp;Time&nbsp;</th>
-                <th colspan="2" title="Information about the scans threads. Shows how many threads are running and how much work is queued for the threads.">Scans&nbsp;</th>
-                <th colspan="2" title="The action of flushing memory to disk. Multiple tablets can be compacted simultaneously, but sometimes they must wait for resources to be available. The number of tablets waiting for compaction are in parentheses.">Minor&nbsp;Compactions&nbsp;</th>
-                <th colspan="2" title="The action of gathering up many small files and rewriting them as one larger file.">Major&nbsp;Compactions&nbsp;</th>
-                <th rowspan="2" class="percent" title="The recent index cache hit rate.">Index Cache<br/>Hit Rate&nbsp;</th>
-                <th rowspan="2" class="percent" title="The recent data cache hit rate.">Data Cache<br/>Hit Rate&nbsp;</th>
-                <th rowspan="2" class="big-num" title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load&nbsp;</th>
-              </tr>
-              <tr>
-                <th class="big-num">Running</th>
-                <th class="big-num">Queued</th>
-                <th class="big-num">Running</th>
-                <th class="big-num">Queued</th>
-                <th class="big-num">Running</th>
-                <th class="big-num">Queued</th>
+                <th>Server&nbsp;</th>
+                <th class="big-num">Hosted<br/>Tablets&nbsp;</th>
+                <th class="duration">Last&nbsp;Contact&nbsp;</th>
+                <th class="big-num" title="Key/value pairs over each instance, table or tablet.">Entries&nbsp;</th>
+                <th class="big-num" title="The number of Key/Value pairs inserted. (Note that deletes are considered inserted)">Ingest&nbsp;</th>
+                <th class="big-num" title="The number of key/value pairs returned to clients. (Not the number of scans)">Query&nbsp;</th>
+                <th class="duration" title="The amount of time live ingest operations (mutations, batch writes) have been waiting for the tserver to free up memory.">Hold&nbsp;Time&nbsp;</th>
+                <th title="Information about the scans threads. Shows how many threads are running and, in parentheses, how much work is queued for the threads.">Scans&nbsp;</th>
+                <th title="The action of flushing memory to disk. Multiple tablets can be compacted simultaneously, but sometimes they must wait for resources to be available. The number of tablets waiting for compaction is in parentheses.">Minor&nbsp;Compactions&nbsp;</th>
+                <th title="The action of gathering up many small files and rewriting them as one larger file. The number of queued major compactions is in parentheses.">Major&nbsp;Compactions&nbsp;</th>
+                <th class="percent" title="The recent index cache hit rate.">Index Cache<br/>Hit Rate&nbsp;</th>
+                <th class="percent" title="The recent data cache hit rate.">Data Cache<br/>Hit Rate&nbsp;</th>
+                <th class="big-num" title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load&nbsp;</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/table.ftl
@@ -20,12 +20,11 @@
 -->
       <script>
         /**
-         * Creates participating Tservers initial table, passes the table and tableID from the template
+         * Creates participating Tservers initial table, passes the tableID from the template
          */
-        $(document).ready(function() {
-          tableID = '${tableID}';
-          refreshTable();
-        });
+        $(document).ready(function () {
+            initTableServerTable('${tableID}');
+          });
       </script>
       <div class="row">
         <div class="col-xs-12">
@@ -38,19 +37,27 @@
             <caption><span class="table-caption">${table}</span></caption>
             <thead>
               <tr>
-                <th class="firstcell">Server&nbsp;</th>
-                <th>Hosted&nbsp;Tablets&nbsp;</th>
-                <th>Last&nbsp;Contact&nbsp;</th>
-                <th title="Key/value pairs over each instance, table or tablet.">Entries&nbsp;</th>
-                <th title="The number of Key/Value pairs inserted. (Note that deletes are considered inserted)">Ingest&nbsp;</th>
-                <th title="The number of key/value pairs returned to clients. (Not the number of scans)">Query&nbsp;</th>
-                <th title="The amount of time live ingest operations (mutations, batch writes) have been waiting for the tserver to free up memory.">Hold&nbsp;Time&nbsp;</th>
-                <th title="Information about the scans threads. Shows how many threads are running and how much work is queued for the threads.">Running<br/>Scans&nbsp;</th>
-                <th title="The action of flushing memory to disk. Multiple tablets can be compacted simultaneously, but sometimes they must wait for resources to be available. The number of tablets waiting for compaction are in parentheses.">Minor<br/>Compactions&nbsp;</th>
-                <th title="The action of gathering up many small files and rewriting them as one larger file.">Major<br/>Compactions&nbsp;</th>
-                <th title="The recent index cache hit rate.">Index Cache<br/>Hit Rate&nbsp;</th>
-                <th title="The recent data cache hit rate.">Data Cache<br/>Hit Rate&nbsp;</th>
-                <th title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load&nbsp;</th>
+                <th rowspan="2">Server&nbsp;</th>
+                <th rowspan="2" class="big-num">Hosted<br/>Tablets&nbsp;</th>
+                <th rowspan="2" class="duration">Last&nbsp;Contact&nbsp;</th>
+                <th rowspan="2" class="big-num" title="Key/value pairs over each instance, table or tablet.">Entries&nbsp;</th>
+                <th rowspan="2" class="big-num" title="The number of Key/Value pairs inserted. (Note that deletes are considered inserted)">Ingest&nbsp;</th>
+                <th rowspan="2" class="big-num" title="The number of key/value pairs returned to clients. (Not the number of scans)">Query&nbsp;</th>
+                <th rowspan="2" class="duration" title="The amount of time live ingest operations (mutations, batch writes) have been waiting for the tserver to free up memory.">Hold&nbsp;Time&nbsp;</th>
+                <th colspan="2" title="Information about the scans threads. Shows how many threads are running and how much work is queued for the threads.">Scans&nbsp;</th>
+                <th colspan="2" title="The action of flushing memory to disk. Multiple tablets can be compacted simultaneously, but sometimes they must wait for resources to be available. The number of tablets waiting for compaction are in parentheses.">Minor&nbsp;Compactions&nbsp;</th>
+                <th colspan="2" title="The action of gathering up many small files and rewriting them as one larger file.">Major&nbsp;Compactions&nbsp;</th>
+                <th rowspan="2" class="percent" title="The recent index cache hit rate.">Index Cache<br/>Hit Rate&nbsp;</th>
+                <th rowspan="2" class="percent" title="The recent data cache hit rate.">Data Cache<br/>Hit Rate&nbsp;</th>
+                <th rowspan="2" class="big-num" title="The Unix one minute load average. The average number of processes in the run queue over a one minute interval.">OS&nbsp;Load&nbsp;</th>
+              </tr>
+              <tr>
+                <th class="big-num">Running</th>
+                <th class="big-num">Queued</th>
+                <th class="big-num">Running</th>
+                <th class="big-num">Queued</th>
+                <th class="big-num">Running</th>
+                <th class="big-num">Queued</th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
This PR converts the table in table.js to a DataTable.

The table should behave the same except for one small change:

Current table:
![Screenshot from 2022-06-08 15-06-11](https://user-images.githubusercontent.com/47725857/172941728-4ff87fe6-c6e1-4291-9886-18096a18523c.png)

Table with the changes from this PR:
![Screenshot from 2022-06-09 15-53-55](https://user-images.githubusercontent.com/47725857/172941899-659ecc36-4125-4e16-80f7-3cdd6c6b7bb7.png)

I broke the scans and compactions columns up into running and queued instead of having the queued compactions in the same column within the parenthesis.

