### PR TITLE
Modify snapshot synchronization

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -18,8 +18,15 @@
  */
 package org.apache.accumulo.server.conf;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -29,15 +36,31 @@ import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.fate.zookeeper.ZooReader;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.conf.store.NamespacePropKey;
+import org.apache.accumulo.server.conf.store.PropChangeListener;
+import org.apache.accumulo.server.conf.store.PropStoreKey;
 import org.apache.accumulo.server.conf.store.SystemPropKey;
+import org.apache.accumulo.server.conf.store.TablePropKey;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Suppliers;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * A factor for configurations used by a server process. Instance of this class are thread-safe.
  */
+@SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
+    justification = "random number not used in secure context")
 public class ServerConfigurationFactory extends ServerConfiguration {
+  private final static Logger log = LoggerFactory.getLogger(ServerConfigurationFactory.class);
+
+  public static final int REFRESH_PERIOD_MINUTES = 15;
 
   private final Map<TableId,NamespaceConfiguration> tableParentConfigs = new ConcurrentHashMap<>();
   private final Map<TableId,TableConfiguration> tableConfigs = new ConcurrentHashMap<>();
@@ -48,11 +71,32 @@ public class ServerConfigurationFactory extends ServerConfiguration {
   private final SiteConfiguration siteConfig;
   private final Supplier<SystemConfiguration> systemConfig;
 
+  private final ScheduledFuture<?> refreshTaskFuture;
+
+  private final DeleteWatcher deleteWatcher =
+      new DeleteWatcher(tableConfigs, namespaceConfigs, tableParentConfigs);
+
   public ServerConfigurationFactory(ServerContext context, SiteConfiguration siteConfig) {
     this.context = context;
     this.siteConfig = siteConfig;
     systemConfig = Suppliers.memoize(
         () -> new SystemConfiguration(context, SystemPropKey.of(context), getSiteConfiguration()));
+
+    if (context.threadPools() != null) {
+      // simplify testing - only create refresh thread when operating in a context with thread pool
+      // initialized
+      ScheduledThreadPoolExecutor threadPool = context.threadPools()
+          .createScheduledExecutorService(1, this.getClass().getSimpleName(), false);
+      Runnable refreshTask = this::verifySnapshotVersions;
+      // randomly stagger initial and then subsequent calls across cluster
+      int randDelay =
+          ThreadLocalRandom.current().nextInt(REFRESH_PERIOD_MINUTES / 4, REFRESH_PERIOD_MINUTES);
+      refreshTaskFuture = threadPool.scheduleWithFixedDelay(refreshTask, randDelay,
+          REFRESH_PERIOD_MINUTES, MINUTES);
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> refreshTaskFuture.cancel(true)));
+    } else {
+      refreshTaskFuture = null;
+    }
   }
 
   public ServerContext getServerContext() {
@@ -76,6 +120,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
   public TableConfiguration getTableConfiguration(TableId tableId) {
     return tableConfigs.computeIfAbsent(tableId, key -> {
       if (context.tableNodeExists(tableId)) {
+        context.getPropStore().registerAsListener(TablePropKey.of(context, tableId), deleteWatcher);
         var conf =
             new TableConfiguration(context, tableId, getNamespaceConfigurationForTable(tableId));
         ConfigCheckUtil.validate(conf);
@@ -99,10 +144,139 @@ public class ServerConfigurationFactory extends ServerConfiguration {
   @Override
   public NamespaceConfiguration getNamespaceConfiguration(NamespaceId namespaceId) {
     return namespaceConfigs.computeIfAbsent(namespaceId, key -> {
+      context.getPropStore().registerAsListener(NamespacePropKey.of(context, namespaceId),
+          deleteWatcher);
       var conf = new NamespaceConfiguration(context, namespaceId, getSystemConfiguration());
       ConfigCheckUtil.validate(conf);
       return conf;
     });
   }
 
+  /**
+   * Check that the stored version in ZooKeeper matches the version held in the local snapshot. When
+   * a mismatch is detected, a change event is sent to the prop store which will cause a re-load. If
+   * the Zookeeper node has been deleted, the local cache entries are removed.
+   * <p>
+   * This method is designed to be called as a scheduled task, so it does not propagate exceptions
+   * so the scheduled tasks will continue to run.
+   */
+  private void verifySnapshotVersions() {
+
+    int nsRefreshCount = 0;
+    int tblRefreshCount = 0;
+
+    long refreshStart = System.nanoTime();
+
+    ZooReader zooReader = context.getZooReader();
+
+    try {
+      refresh(systemConfig.get(), zooReader);
+    } catch (Throwable t) {
+      log.debug("Exception occurred during system config refresh", t.getCause());
+    }
+
+    try {
+      for (Map.Entry<NamespaceId,NamespaceConfiguration> entry : namespaceConfigs.entrySet()) {
+        if (!refresh(entry.getValue(), zooReader)) {
+          namespaceConfigs.remove(entry.getKey());
+        }
+        nsRefreshCount++;
+      }
+    } catch (Throwable t) {
+      log.debug(
+          "Exception occurred during namespace refresh - cycle may not have completed on this pass",
+          t.getCause());
+    }
+    try {
+      for (Map.Entry<TableId,TableConfiguration> entry : tableConfigs.entrySet()) {
+        if (!refresh(entry.getValue(), zooReader)) {
+          tableConfigs.remove(entry.getKey());
+          tableParentConfigs.remove(entry.getKey());
+        }
+        tblRefreshCount++;
+      }
+    } catch (Throwable t) {
+      log.debug(
+          "Exception occurred during table refresh - cycle may not have completed on this pass",
+          t.getCause());
+    }
+
+    log.debug(
+        "configuration snapshot refresh completed. Total runtime {} ms for local namespaces: {}, tables: {}",
+        MILLISECONDS.convert(System.nanoTime() - refreshStart, NANOSECONDS), nsRefreshCount,
+        tblRefreshCount);
+  }
+
+  private boolean refresh(ZooBasedConfiguration config, ZooReader zooReader) {
+    final PropStoreKey<?> key = config.getPropStoreKey();
+    try {
+      Stat stat = zooReader.getStatus(key.getPath());
+      log.trace("configuration snapshot refresh: stat returned: {} for {}", stat, key);
+      if (stat == null) {
+        return false;
+      }
+      if (config.getDataVersion() != stat.getVersion()) {
+        log.debug(
+            "configuration snapshot refresh - difference found. forcing configuration update for {}}",
+            key);
+        config.zkChangeEvent(key);
+      }
+      // add small jitter between calls.
+      int randDelay = ThreadLocalRandom.current().nextInt(0, 23);
+      Thread.sleep(randDelay);
+    } catch (KeeperException.NoNodeException ex) {
+      config.zkChangeEvent(key);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted reading from ZooKeeper during snapshot refresh.",
+          ex);
+    } catch (KeeperException | IllegalStateException ex) {
+      log.debug("configuration snapshot refresh: Exception during refresh - key" + key, ex);
+    }
+    return true;
+  }
+
+  private static class DeleteWatcher implements PropChangeListener {
+
+    final Map<TableId,TableConfiguration> tableConfigs;
+    final Map<NamespaceId,NamespaceConfiguration> namespaceConfigs;
+    final Map<TableId,NamespaceConfiguration> tableParentConfigs;
+
+    DeleteWatcher(final Map<TableId,TableConfiguration> tableConfigs,
+        final Map<NamespaceId,NamespaceConfiguration> namespaceConfigs,
+        final Map<TableId,NamespaceConfiguration> tableParentConfigs) {
+      this.tableConfigs = tableConfigs;
+      this.namespaceConfigs = namespaceConfigs;
+      this.tableParentConfigs = tableParentConfigs;
+    }
+
+    @Override
+    public void zkChangeEvent(PropStoreKey<?> propStoreKey) {
+      // no-op. changes handled by prop store impl
+    }
+
+    @Override
+    public void cacheChangeEvent(PropStoreKey<?> propStoreKey) {
+      // no-op. changes handled by prop store impl
+    }
+
+    @Override
+    public void deleteEvent(PropStoreKey<?> propStoreKey) {
+      if (propStoreKey instanceof NamespacePropKey) {
+        log.trace("configuration snapshot refresh: Handle namespace delete for {}", propStoreKey);
+        namespaceConfigs.remove(((NamespacePropKey) propStoreKey).getId());
+        return;
+      }
+      if (propStoreKey instanceof TablePropKey) {
+        log.trace("configuration snapshot refresh: Handle table delete for {}", propStoreKey);
+        tableConfigs.remove(((TablePropKey) propStoreKey).getId());
+        tableConfigs.remove(((TablePropKey) propStoreKey).getId());
+      }
+    }
+
+    @Override
+    public void connectionEvent() {
+      // no-op. changes handled by prop store impl
+    }
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImpl.java
@@ -39,7 +39,7 @@ import com.github.benmanes.caffeine.cache.Ticker;
 public class PropCacheCaffeineImpl implements PropCache {
 
   public static final TimeUnit BASE_TIME_UNITS = TimeUnit.MINUTES;
-  public static final int REFRESH_MIN = 15;
+  // public static final int REFRESH_MIN = 15;
   public static final int EXPIRE_MIN = 60;
   private static final Logger log = LoggerFactory.getLogger(PropCacheCaffeineImpl.class);
   private static final Executor executor = ThreadPools.getServerThreadPools().createThreadPool(1,
@@ -52,8 +52,8 @@ public class PropCacheCaffeineImpl implements PropCache {
   private PropCacheCaffeineImpl(final CacheLoader<PropStoreKey<?>,VersionedProperties> cacheLoader,
       final PropStoreMetrics metrics, final Ticker ticker, boolean runTasksInline) {
     this.metrics = metrics;
-    var builder = Caffeine.newBuilder().refreshAfterWrite(REFRESH_MIN, BASE_TIME_UNITS)
-        .expireAfterAccess(EXPIRE_MIN, BASE_TIME_UNITS).evictionListener(this::evictionNotifier);
+    var builder = Caffeine.newBuilder().expireAfterAccess(EXPIRE_MIN, BASE_TIME_UNITS)
+        .evictionListener(this::evictionNotifier);
     if (runTasksInline) {
       builder = builder.executor(Runnable::run);
     } else {

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -29,8 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.conf.SiteConfiguration;
@@ -47,6 +49,8 @@ import org.apache.accumulo.server.conf.store.impl.ZooPropStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class ServerConfigurationFactoryTest {
   private static final String ZK_HOST = "localhost";
@@ -81,6 +85,9 @@ public class ServerConfigurationFactoryTest {
     expect(context.getSiteConfiguration()).andReturn(siteConfig).anyTimes();
     expect(context.tableNodeExists(TID)).andReturn(true).anyTimes();
     expect(context.getPropStore()).andReturn(propStore).anyTimes();
+    expect(context.threadPools()).andReturn(null).anyTimes(); // disable snapshot refresh
+
+    replay(context);
 
     scf = new ServerConfigurationFactory(context, siteConfig) {
       @Override
@@ -92,7 +99,7 @@ public class ServerConfigurationFactoryTest {
       }
     };
 
-    replay(propStore, context);
+    replay(propStore);
   }
 
   @AfterEach
@@ -121,4 +128,13 @@ public class ServerConfigurationFactoryTest {
     assertSame(tableConfigSingleton, scf.getTableConfiguration(TID));
   }
 
+  @SuppressFBWarnings(value = "PREDICTABLE_RANDOM",
+      justification = "random number is not used in a security sensitive context")
+  @Test
+  public void x() {
+    for (int d = 0; d < 10; d++) {
+      int i = ThreadLocalRandom.current().nextInt(1, 19);
+      System.out.println(Duration.ofMillis(i));
+    }
+  }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImplTest.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.server.conf.store.impl;
 
 import static org.apache.accumulo.core.conf.Property.TABLE_BULK_MAX_TABLETS;
 import static org.apache.accumulo.core.conf.Property.TABLE_FILE_BLOCK_SIZE;
-import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
@@ -31,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -153,27 +151,6 @@ public class PropCacheCaffeineImplTest {
     // check that values are not in cache - will not call load
     assertNull(cache.getWithoutCaching(tablePropKey));
     assertNull(cache.getWithoutCaching(table2PropKey));
-  }
-
-  VersionedProperties asyncProps() {
-    return vProps;
-  }
-
-  @Test
-  public void refreshTest() throws Exception {
-
-    expect(zooPropLoader.load(eq(tablePropKey))).andReturn(vProps).once();
-
-    var future = CompletableFuture.supplyAsync(this::asyncProps);
-
-    expect(zooPropLoader.asyncReload(eq(tablePropKey), eq(vProps), anyObject())).andReturn(future)
-        .once();
-
-    replay(context, propStoreWatcher, zooPropLoader);
-    assertNotNull(cache.get(tablePropKey)); // will call load and place into cache
-
-    ticker.advance(30, TimeUnit.MINUTES);
-    assertNotNull(cache.get(tablePropKey)); // will async check stat and then reload
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/master/balancer/BaseHostRegexTableLoadBalancerTest.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.core.master.thrift.TableInfo;
 import org.apache.accumulo.core.master.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.tabletserver.thrift.TabletStats;
+import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.NamespaceConfiguration;
 import org.apache.accumulo.server.conf.ServerConfigurationFactory;
@@ -180,7 +181,7 @@ public abstract class BaseHostRegexTableLoadBalancerTest extends HostRegexTableL
     expect(mockContext.getZooKeepersSessionTimeOut()).andReturn(30).anyTimes();
     expect(mockContext.getInstanceID()).andReturn(instanceId).anyTimes();
     expect(mockContext.getZooKeeperRoot()).andReturn(Constants.ZROOT + "/1111").anyTimes();
-
+    expect(mockContext.threadPools()).andReturn(ThreadPools.getServerThreadPools()).anyTimes();
     expect(mockContext.getPropStore()).andReturn(propStore).anyTimes();
     propStore.registerAsListener(anyObject(), anyObject());
     expectLastCall().anyTimes();


### PR DESCRIPTION
Modify the synchronization of configurations cached in the ServerConfigurationFactory with ZooKeeper.

The previous implementation leveraged the caffeine cache refresh after write capability - however, the secondary caching of configurations in the SeverConfigurationFactory makes that capability less effective. Because the secondary cache and the data versions use the secondary cache, the prop cache implementation is read less frequently. The use of data versions is an optimization for iterators that avoids any overhead from reading the entire property payload.

These changes provide the following benefits over the original implementation:
- deletions are detected and eliminate the persistent caching of configurations.
- detected changes are propagated to the prop store.
- uses lighter weight getStatus calls.
- provides jitter between calls and staggered invocations to reduce ZooKeeper load


