### PR TITLE
Make auths classes in Authorizations

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -44,8 +44,8 @@ public class Authorizations implements Iterable<byte[]>, Serializable, Authoriza
 
   private static final long serialVersionUID = 1L;
 
-  private Set<ByteSequence> auths = new HashSet<>();
-  private List<byte[]> authsList = new ArrayList<>(); // sorted order
+  private final HashSet<ByteSequence> auths = new HashSet<>();
+  private final ArrayList<byte[]> authsList = new ArrayList<>(); // sorted order
 
   /**
    * An empty set of authorizations.

--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.security;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -40,12 +39,10 @@ import org.apache.accumulo.core.util.ByteBufferUtil;
 /**
  * A collection of authorization strings.
  */
-public class Authorizations implements Iterable<byte[]>, Serializable, AuthorizationContainer {
+public class Authorizations implements Iterable<byte[]>, AuthorizationContainer {
 
-  private static final long serialVersionUID = 1L;
-
-  private Set<ByteSequence> auths = new HashSet<>();
-  private List<byte[]> authsList = new ArrayList<>(); // sorted order
+  private final Set<ByteSequence> auths = new HashSet<>();
+  private final List<byte[]> authsList = new ArrayList<>(); // sorted order
 
   /**
    * An empty set of authorizations.

--- a/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/Authorizations.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.security;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -39,10 +40,12 @@ import org.apache.accumulo.core.util.ByteBufferUtil;
 /**
  * A collection of authorization strings.
  */
-public class Authorizations implements Iterable<byte[]>, AuthorizationContainer {
+public class Authorizations implements Iterable<byte[]>, Serializable, AuthorizationContainer {
 
-  private final Set<ByteSequence> auths = new HashSet<>();
-  private final List<byte[]> authsList = new ArrayList<>(); // sorted order
+  private static final long serialVersionUID = 1L;
+
+  private Set<ByteSequence> auths = new HashSet<>();
+  private List<byte[]> authsList = new ArrayList<>(); // sorted order
 
   /**
    * An empty set of authorizations.


### PR DESCRIPTION
It looks like all the serialization done for `Authorizations` is done with custom methods that we have created over the years.  I am not sure why we need the interface on the class anymore.