### PR TITLE
Address #2635 by lazy loading prop store in ServerContext

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -96,7 +96,7 @@ public class ServerContext extends ClientContext {
   private final ServerInfo info;
   private final ZooReaderWriter zooReaderWriter;
   private final ServerDirs serverDirs;
-  private final PropStore propStore;
+  private final Supplier<ZooPropStore> propStore;
 
   // lazily loaded resources, only loaded when needed
   private final Supplier<TableManager> tableManager;
@@ -119,7 +119,8 @@ public class ServerContext extends ClientContext {
     this.info = info;
     zooReaderWriter = new ZooReaderWriter(info.getSiteConfiguration());
     serverDirs = info.getServerDirs();
-    propStore = ZooPropStore.initialize(info.getInstanceID(), zooReaderWriter);
+
+    propStore = memoize(() -> ZooPropStore.initialize(getInstanceID(), getZooReaderWriter()));
 
     tableManager = memoize(() -> new TableManager(this));
     nameAllocator = memoize(() -> new UniqueNameAllocator(this));
@@ -443,7 +444,7 @@ public class ServerContext extends ClientContext {
   }
 
   public PropStore getPropStore() {
-    return propStore;
+    return propStore.get();
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.server.conf;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -33,12 +32,9 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.conf.store.PropChangeListener;
 import org.apache.accumulo.server.conf.store.PropStoreKey;
-import org.apache.accumulo.server.conf.store.SystemPropKey;
 import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Suppliers;
 
 /**
  * A factor for configurations used by a server process. Instance of this class are thread-safe.
@@ -53,15 +49,11 @@ public class ServerConfigurationFactory extends ServerConfiguration {
 
   private final ServerContext context;
   private final SiteConfiguration siteConfig;
-  private final Supplier<SystemConfiguration> systemConfig;
-
   private final DeleteWatcher deleteWatcher = new DeleteWatcher();
 
   public ServerConfigurationFactory(ServerContext context, SiteConfiguration siteConfig) {
     this.context = context;
     this.siteConfig = siteConfig;
-    systemConfig = Suppliers.memoize(
-        () -> new SystemConfiguration(context, SystemPropKey.of(context), getSiteConfiguration()));
   }
 
   public ServerContext getServerContext() {
@@ -78,7 +70,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
 
   @Override
   public AccumuloConfiguration getSystemConfiguration() {
-    return systemConfig.get();
+    return context.getConfiguration();
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropStore.java
@@ -123,7 +123,7 @@ public class ZooPropStore implements PropStore, PropChangeListener {
     }
   }
 
-  public static PropStore initialize(@NonNull final InstanceId instanceId,
+  public static ZooPropStore initialize(@NonNull final InstanceId instanceId,
       @NonNull final ZooReaderWriter zrw) {
     return new ZooPropStore(instanceId, zrw);
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -58,6 +58,7 @@ public class ServerConfigurationFactoryTest {
 
   private PropStore propStore;
   private ServerContext context;
+  private SystemConfiguration sysConfig;
   private ServerConfigurationFactory scf;
 
   @BeforeEach
@@ -73,6 +74,10 @@ public class ServerConfigurationFactoryTest {
     propStore.registerAsListener(anyObject(), anyObject());
     expectLastCall().anyTimes();
 
+    sysConfig = createMock(SystemConfiguration.class);
+    sysConfig.getProperties(anyObject(), anyObject());
+    expectLastCall().anyTimes();
+
     context = createMock(ServerContext.class);
     expect(context.getZooKeeperRoot()).andReturn("/accumulo/" + IID).anyTimes();
     expect(context.getInstanceID()).andReturn(IID).anyTimes();
@@ -81,7 +86,7 @@ public class ServerConfigurationFactoryTest {
     expect(context.getSiteConfiguration()).andReturn(siteConfig).anyTimes();
     expect(context.tableNodeExists(TID)).andReturn(true).anyTimes();
     expect(context.getPropStore()).andReturn(propStore).anyTimes();
-
+    expect(context.getConfiguration()).andReturn(sysConfig).anyTimes();
     scf = new ServerConfigurationFactory(context, siteConfig) {
       @Override
       public NamespaceConfiguration getNamespaceConfigurationForTable(TableId tableId) {
@@ -92,12 +97,12 @@ public class ServerConfigurationFactoryTest {
       }
     };
 
-    replay(propStore, context);
+    replay(propStore, context, sysConfig);
   }
 
   @AfterEach
   public void verifyMocks() {
-    verify(propStore, context);
+    verify(propStore, context, sysConfig);
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/conf/util/ConfigTransformerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/util/ConfigTransformerIT.java
@@ -101,7 +101,7 @@ public class ConfigTransformerIT {
     for (LegacyPropData.PropNode node : nodes) {
       zrw.putPersistentData(node.getPath(), node.getData(), ZooUtil.NodeExistsPolicy.SKIP);
     }
-    propStore = (ZooPropStore) ZooPropStore.initialize(instanceId, zrw);
+    propStore = ZooPropStore.initialize(instanceId, zrw);
 
     context = createMock(ServerContext.class);
     expect(context.getInstanceID()).andReturn(instanceId).anyTimes();

--- a/test/src/main/java/org/apache/accumulo/test/conf/util/TransformTokenIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/conf/util/TransformTokenIT.java
@@ -89,7 +89,7 @@ public class TransformTokenIT {
       zrw.putPersistentData(node.getPath(), node.getData(), ZooUtil.NodeExistsPolicy.SKIP);
     }
 
-    ZooPropStore propStore = (ZooPropStore) ZooPropStore.initialize(instanceId, zrw);
+    ZooPropStore propStore = ZooPropStore.initialize(instanceId, zrw);
 
     context = createMock(ServerContext.class);
     expect(context.getInstanceID()).andReturn(instanceId).anyTimes();


### PR DESCRIPTION
Lazy load the PropStore to reduce the potential for creating multiple prop store instances.

Also addresses a duplicate server configuration being create in ServerConfigurationFactory - uses the instance from the context.