### PR TITLE
Convert tables in bulkImport.js to DataTables

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -21,7 +21,7 @@
 var bulkListTable, bulkPerServerTable;
 
 /**
- * Fetches and populates DataTables with new data
+ * Fetches new data and updates DataTables with it
  */
 function refreshBulkImport() {
   ajaxReloadTable(bulkListTable);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/bulkImport.js
@@ -16,82 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* JSLint global definitions */
-/*global
-    $, document, sessionStorage, clearTableBody, EMPTY_ROW_THREE_CELLS, EMPTY_CELL, getBulkImports
-*/
 "use strict";
 
-/**
- * Generates the manager bulk import status table
- */
-function refreshBulkImportTable() {
-  $("#bulkListTable tbody").html(EMPTY_ROW_THREE_CELLS);
-
-  // Get the bulk import data from the session
-  var data = sessionStorage.bulkImports === undefined ? [] : JSON.parse(sessionStorage.bulkImports);
-
-  // If the data is empty, clear table, otherwise populate
-  if (data.length === 0 || data.bulkImport.length === 0) {
-    return;
-  }
-  console.log("Populate bulkListTable with " + sessionStorage.bulkImports);
-  var tableBodyHtml = "";
-  $.each(data.bulkImport, function (key, val) {
-    console.log("Append row " + key + " " + JSON.stringify(val) + " to bulkListTable");
-    tableBodyHtml += "<tr><td class='firstcell'>" + val.filename + "</td>";
-    tableBodyHtml += "<td class='center'>" + new Date(val.age) + "</td>";
-    tableBodyHtml += "<td class='center'>" + val.state + "</td></tr>";
-  });
-
-  $("#bulkListTable tbody").html(tableBodyHtml);
-}
+var bulkListTable, bulkPerServerTable;
 
 /**
- * Generates the bulkPerServerTable table
- */
-function refreshServerBulkTable() {
-  $("#bulkPerServerTable tbody").html(EMPTY_ROW_THREE_CELLS);
-
-  // get the bulkImport data from sessionStorage
-  var data = sessionStorage.bulkImports === undefined ? [] : JSON.parse(sessionStorage.bulkImports);
-
-  // if data is empty, log an error because that means no tablet servers were found
-  if (data.length === 0 || data.tabletServerBulkImport.length === 0) {
-    console.error("No tablet servers.");
-    return;
-  }
-  var tableBodyHtml = "";
-  $.each(data.tabletServerBulkImport, function (key, val) {
-    console.log("Append " + key + " " + JSON.stringify(val) + " to bulkPerServerTable");
-    var ageCell = EMPTY_CELL;
-    if (val.oldestAge > 0) {
-      ageCell = "<td>" + new Date(val.oldestAge) + "</td>";
-    }
-    tableBodyHtml += "<tr><td><a href='/tservers?s=" + val.server + "'>" + val.server + "</a></td>";
-    tableBodyHtml += "<td>" + val.importSize + "</td>";
-    tableBodyHtml += ageCell + "</tr>";
-  });
-
-  $("#bulkPerServerTable tbody").html(tableBodyHtml);
-}
-
-/**
- * Makes the REST calls, generates the tables with the new information
+ * Fetches and populates DataTables with new data
  */
 function refreshBulkImport() {
-  getBulkImports().then(function () {
-    refreshBulkImportTable();
-    refreshServerBulkTable();
-  });
+  ajaxReloadTable(bulkListTable);
+  ajaxReloadTable(bulkPerServerTable);
 }
-
-/**
- * Creates bulk import initial table
- */
-$(document).ready(function () {
-  refreshBulkImport();
-});
 
 /**
  * Used to redraw the page
@@ -99,3 +34,76 @@ $(document).ready(function () {
 function refresh() {
   refreshBulkImport();
 }
+
+/**
+ * Initializes the bulk import DataTables
+ */
+$(document).ready(function () {
+
+  const url = '/rest/bulkImports';
+  console.debug('REST url used to fetch data for the DataTables in bulkImport.js: ' + url);
+
+  // Generates the manager bulk import status table
+  bulkListTable = $('#bulkListTable').DataTable({
+    "ajax": {
+      "url": url,
+      "dataSrc": "bulkImport"
+    },
+    "stateSave": true,
+    "columns": [{
+        "data": "filename"
+      },
+      {
+        "data": "age",
+        "render": function (data, type) {
+          if (type === 'display' && Number(data) > 0) {
+            data = new Date(Number(data));
+          } else {
+            data = "-";
+          }
+          return data;
+        }
+      },
+      {
+        "data": "state"
+      }
+    ]
+  });
+
+  // Generates the bulkPerServerTable DataTable
+  bulkPerServerTable = $('#bulkPerServerTable').DataTable({
+    "ajax": {
+      "url": url,
+      "dataSrc": "tabletServerBulkImport"
+    },
+    "stateSave": true,
+    "columns": [{
+        "data": "server",
+        "type": "html",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = `<a href="/tservers?s=${data}">${data}</a>`;
+          }
+          return data;
+        }
+      },
+      {
+        "data": "importSize"
+      },
+      {
+        "data": "oldestAge",
+        "render": function (data, type) {
+          if (type === 'display' && Number(data) > 0) {
+            data = new Date(Number(data));
+          } else {
+            data = "-";
+          }
+          return data;
+        }
+      }
+    ]
+  });
+
+  refreshBulkImport();
+
+});

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/bulkImport.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/bulkImport.ftl
@@ -29,7 +29,7 @@
             <caption><span class="table-caption">Bulk Imports</span><br/></caption>
             <thead>
               <tr>
-                <th class="firstcell">Directory&nbsp;</th>
+                <th>Directory&nbsp;</th>
                 <th title="The age of the import.">Age&nbsp;</th>
                 <th title="The current state of the bulk import">State&nbsp;</th>
               </tr>
@@ -38,14 +38,14 @@
           </table>
         </div>
       </div>
-
+      </br></br>
       <div class="row">
         <div class="col-xs-12">
           <table id="bulkPerServerTable" class="table table-bordered table-striped table-condensed">
             <caption><span class="table-caption">Per TabletServer</span><br/></caption>
             <thead>
               <tr>
-                <th class="firstcell">Server</th>
+                <th>Server</th>
                 <th title="Number of imports presently running">#</th>
                 <th title="The age of the oldest import running on this server.">Oldest&nbsp;Age</th>
               </tr>


### PR DESCRIPTION
This PR changes the tables in bulkImport.js to DataTables. These changes can be viewed in the monitor at /bulkImports.

Here is the page on main:
![BulkImportOldTables](https://user-images.githubusercontent.com/47725857/175378405-2b517812-ee7f-402e-963e-74d33c27f899.png)

Here is the page on this branch:
![BulkImportDataTables](https://user-images.githubusercontent.com/47725857/175378409-36f6e3a3-0a44-4c2c-8efe-1129391e2a40.png)

Note: I hard coded data to be present at the rest endpoint used to gather data for the "Bulk Imports" table.

The various info and features that are standard with DataTables (such as the search bar and paging) can be removed if anyone thinks that is a good idea.
