### PR TITLE
Reduce merge overlap logging

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -593,7 +593,6 @@ public class Manager extends AbstractServer
         final boolean overlaps = mergeInfo.overlaps(extent);
 
         if (overlaps) {
-          log.debug("mergeInfo overlaps: {} true", extent);
           switch (mergeInfo.getState()) {
             case NONE:
             case COMPLETE:
@@ -615,8 +614,6 @@ public class Manager extends AbstractServer
             case MERGING:
               return TabletGoalState.UNASSIGNED;
           }
-        } else {
-          log.trace("mergeInfo overlaps: {} false", extent);
         }
       }
 


### PR DESCRIPTION
Reduce merge overlap logging by removing it from the Manager and into
the MergeInfo.overlap method. Further, only perform the logging the first
time another extent is evaluated and put into a map.