### PR TITLE
Convert table in replication.js to DataTable

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
@@ -18,20 +18,13 @@
  */
 "use strict";
 
-/**
- * Creates replication initial table
- */
-$(document).ready(function () {
-  refreshReplication();
-});
+var replicationStatsTable;
 
 /**
- * Makes the REST calls, generates the tables with the new information
+ * Populates the table with the new information
  */
 function refreshReplication() {
-  getReplication().then(function () {
-    refreshReplicationsTable();
-  });
+  ajaxReloadTable(replicationStatsTable);
 }
 
 /**
@@ -42,37 +35,40 @@ function refresh() {
 }
 
 /**
- * Generates the replication table
+ * Creates replication initial table
  */
-function refreshReplicationsTable() {
-  clearTableBody('replicationStats');
+$(document).ready(function () {
 
-  var data = sessionStorage.replication === undefined ? [] : JSON.parse(sessionStorage.replication);
+  replicationStatsTable = $('#replicationStats').DataTable({
+    "ajax": {
+      "url": "/rest/replication",
+      "dataSrc": ""
+    },
+    "stateSave": true,
+    "columns": [{
+        "data": "tableName"
+      },
+      {
+        "data": "peerName"
+      },
+      {
+        "data": "remoteIdentifier"
+      },
+      {
+        "data": "replicaSystemType"
+      },
+      {
+        "data": "filesNeedingReplication",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(data);
+          }
+          return data;
+        }
+      }
+    ]
+  });
 
-  if (data.length === 0) {
-    var items = [];
-    items.push(createEmptyRow(5, 'Replication is disabled by default. Replication table is currently offline.'));
-    $('<tr/>', {
-      html: items.join('')
-    }).appendTo('#replicationStats tbody');
-  } else {
-    $.each(data, function (key, val) {
-      var items = [];
-      items.push(createFirstCell(val.tableName, val.tableName));
+  refreshReplication();
 
-      items.push(createRightCell(val.peerName, val.peerName));
-
-      items.push(createRightCell(val.remoteIdentifier, val.remoteIdentifier));
-
-      items.push(createRightCell(val.replicaSystemType, val.replicaSystemType));
-
-      items.push(createRightCell(val.filesNeedingReplication,
-        bigNumberForQuantity(val.filesNeedingReplication)));
-
-      $('<tr/>', {
-        html: items.join('')
-      }).appendTo('#replicationStats tbody');
-
-    });
-  }
-}
+});

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/replication.js
@@ -46,19 +46,24 @@ $(document).ready(function () {
     },
     "stateSave": true,
     "columns": [{
-        "data": "tableName"
+        "data": "tableName",
+        "width": "25%"
       },
       {
-        "data": "peerName"
+        "data": "peerName",
+        "width": "20%"
       },
       {
-        "data": "remoteIdentifier"
+        "data": "remoteIdentifier",
+        "width": "25%"
       },
       {
-        "data": "replicaSystemType"
+        "data": "replicaSystemType",
+        "width": "15%"
       },
       {
         "data": "filesNeedingReplication",
+        "width": "15%",
         "render": function (data, type) {
           if (type === 'display') {
             data = bigNumberForQuantity(data);

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/replication.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/replication.ftl
@@ -28,7 +28,7 @@
           <table id="replicationStats" class="table table-bordered table-striped table-condensed">
             <thead>
               <tr>
-                <th class="firstcell">Table&nbsp;</th>
+                <th>Table&nbsp;</th>
                 <th>Peer&nbsp;</th>
                 <th>Remote&nbsp;Identifier&nbsp;</th>
                 <th>Replica&nbsp;System&nbsp;Type&nbsp;</th>


### PR DESCRIPTION
The PR converts the table in replication.js to a DataTable. This table is present at '/replication' in the monitor.

Here is the table before and after these changes. I hard coded example data to be returned from the rest endpoint for these examples:

before:
![image](https://user-images.githubusercontent.com/47725857/176509335-86b3bcc2-e4b4-4960-8d05-6e0ba18ce1b6.png)

after:
![replicationDatatable](https://user-images.githubusercontent.com/47725857/176509226-4469ddbf-cdb1-4ec0-9cd4-9edb42776de6.png)
