### PR TITLE
Remove synchronized modifier from NoFlushOutputStream.write

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/crypto/streams/NoFlushOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/streams/NoFlushOutputStream.java
@@ -33,7 +33,7 @@ public class NoFlushOutputStream extends DataOutputStream {
    * calls write a single byte at a time and will kill performance.
    */
   @Override
-  public synchronized void write(byte[] b, int off, int len) throws IOException {
+  public void write(byte[] b, int off, int len) throws IOException {
     out.write(b, off, len);
   }
 


### PR DESCRIPTION
Writes to the DFSLogger output stream are already synchronized
by the DFSLogger.write method. Looking at the other output streams
in the write stack (DataOutputStream, FSDataOutputStream,
BlockedOutputStream, etc.) their write methods are not synchronized.

Related to #2165