### PR TITLE
checks if file already exists in accumulo-cluster create-config

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -429,6 +429,10 @@ function main() {
 
   case "$1" in
     create-config)
+      if [[ -f "$conf"/cluster.yaml ]]; then
+         echo "ERROR : $conf/cluster.yaml already exists, not overwriting"
+         exit 1
+      fi
       cat <<EOF >"$conf"/cluster.yaml
 manager:
   - localhost

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -430,8 +430,8 @@ function main() {
   case "$1" in
     create-config)
       if [[ -f "$conf"/cluster.yaml ]]; then
-         echo "ERROR : $conf/cluster.yaml already exists, not overwriting"
-         exit 1
+        echo "ERROR : $conf/cluster.yaml already exists, not overwriting"
+        exit 1
       fi
       cat <<EOF >"$conf"/cluster.yaml
 manager:


### PR DESCRIPTION
I was playing around with the `accumulo-cluster create-config` command and accidentally blew my config away.  Thinking it would be best if this command only created the file if didn't exists.