### PR TITLE
Modify PropUtil to a true utility class with static methods

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -78,7 +78,6 @@ import org.apache.accumulo.server.security.SecurityUtil;
 import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
 import org.apache.accumulo.server.tables.TableManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
-import org.apache.accumulo.server.util.PropUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.zookeeper.KeeperException;
@@ -106,7 +105,6 @@ public class ServerContext extends ClientContext {
   private final Supplier<CryptoService> cryptoService;
   private final Supplier<ScheduledThreadPoolExecutor> sharedScheduledThreadPool;
   private final Supplier<AuditedSecurityOperation> securityOperation;
-  private final Supplier<PropUtil> propUtilSupplier;
 
   public ServerContext(SiteConfiguration siteConfig) {
     this(new ServerInfo(siteConfig));
@@ -134,7 +132,6 @@ public class ServerContext extends ClientContext {
     securityOperation =
         memoize(() -> new AuditedSecurityOperation(this, SecurityOperation.getAuthorizor(this),
             SecurityOperation.getAuthenticator(this), SecurityOperation.getPermHandler(this)));
-    propUtilSupplier = memoize(() -> new PropUtil(this));
   }
 
   /**
@@ -451,10 +448,6 @@ public class ServerContext extends ClientContext {
 
   public AuditedSecurityOperation getSecurityOperation() {
     return securityOperation.get();
-  }
-
-  public PropUtil propUtil() {
-    return propUtilSupplier.get();
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.conf.store.PropStore;
 import org.apache.accumulo.server.conf.store.TablePropKey;
+import org.apache.accumulo.server.util.PropUtil;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
@@ -225,8 +226,8 @@ public class TableManager {
         + Constants.ZTABLE_CONF;
     zoo.recursiveCopyPersistentOverwrite(srcTablePath, newTablePath);
 
-    context.propUtil().setProperties(TablePropKey.of(context, tableId), propertiesToSet);
-    context.propUtil().removeProperties(TablePropKey.of(context, tableId), propertiesToExclude);
+    PropUtil.setProperties(context, TablePropKey.of(context, tableId), propertiesToSet);
+    PropUtil.removeProperties(context, TablePropKey.of(context, tableId), propertiesToExclude);
 
     updateTableStateCache(tableId);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PropUtil.java
@@ -25,13 +25,9 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.store.PropStoreKey;
 
-public class PropUtil {
+public final class PropUtil {
 
-  protected final ServerContext context;
-
-  public PropUtil(ServerContext context) {
-    this.context = context;
-  }
+  private PropUtil() {}
 
   /**
    * Method to set provided properties for the provided AbstractId.
@@ -42,7 +38,7 @@ public class PropUtil {
    * @throws IllegalArgumentException
    *           if a provided property is not valid
    */
-  public void setProperties(final PropStoreKey<?> propStoreKey,
+  public static void setProperties(final ServerContext context, final PropStoreKey<?> propStoreKey,
       final Map<String,String> properties) {
     for (Map.Entry<String,String> prop : properties.entrySet()) {
       if (!Property.isTablePropertyValid(prop.getKey(), prop.getValue())) {
@@ -53,8 +49,8 @@ public class PropUtil {
     context.getPropStore().putAll(propStoreKey, properties);
   }
 
-  public void removeProperties(final PropStoreKey<?> propStoreKey,
-      final Collection<String> propertyNames) {
+  public static void removeProperties(final ServerContext context,
+      final PropStoreKey<?> propStoreKey, final Collection<String> propertyNames) {
     context.getPropStore().removeProperties(propStoreKey, propertyNames);
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -86,6 +86,7 @@ import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.accumulo.server.manager.LiveTServerSet.TServerConnection;
 import org.apache.accumulo.server.replication.proto.Replication.Status;
 import org.apache.accumulo.server.security.delegation.AuthenticationTokenSecretManager;
+import org.apache.accumulo.server.util.PropUtil;
 import org.apache.accumulo.server.util.SystemPropUtil;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
@@ -401,10 +402,10 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
     try {
       if (value == null) {
-        manager.getContext().propUtil().removeProperties(
+        PropUtil.removeProperties(manager.getContext(),
             NamespacePropKey.of(manager.getContext(), namespaceId), List.of(property));
       } else {
-        manager.getContext().propUtil().setProperties(
+        PropUtil.setProperties(manager.getContext(),
             NamespacePropKey.of(manager.getContext(), namespaceId), Map.of(property, value));
       }
     } catch (IllegalStateException ex) {
@@ -426,11 +427,11 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
     try {
       if (value == null || value.isEmpty()) {
-        manager.getContext().propUtil()
-            .removeProperties(TablePropKey.of(manager.getContext(), tableId), List.of(property));
+        PropUtil.removeProperties(manager.getContext(),
+            TablePropKey.of(manager.getContext(), tableId), List.of(property));
       } else {
-        manager.getContext().propUtil()
-            .setProperties(TablePropKey.of(manager.getContext(), tableId), Map.of(property, value));
+        PropUtil.setProperties(manager.getContext(), TablePropKey.of(manager.getContext(), tableId),
+            Map.of(property, value));
       }
     } catch (IllegalStateException ex) {
       log.warn("Invalid table property, tried to set: tableId: " + tableId.canonical() + " to: "

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/create/PopulateZookeeper.java
@@ -27,6 +27,7 @@ import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.TableInfo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.TablePropKey;
+import org.apache.accumulo.server.util.PropUtil;
 
 class PopulateZookeeper extends ManagerRepo {
 
@@ -58,7 +59,7 @@ class PopulateZookeeper extends ManagerRepo {
           tableInfo.getTableName());
 
       try {
-        manager.getContext().propUtil().setProperties(
+        PropUtil.setProperties(manager.getContext(),
             TablePropKey.of(manager.getContext(), tableInfo.getTableId()), tableInfo.props);
       } catch (IllegalStateException ex) {
         throw new ThriftTableOperationException(null, tableInfo.getTableName(),

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/namespace/create/PopulateZookeeperWithNamespace.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.tables.TableManager;
+import org.apache.accumulo.server.util.PropUtil;
 
 class PopulateZookeeperWithNamespace extends ManagerRepo {
 
@@ -54,7 +55,7 @@ class PopulateZookeeperWithNamespace extends ManagerRepo {
       TableManager.prepareNewNamespaceState(manager.getContext(), namespaceInfo.namespaceId,
           namespaceInfo.namespaceName, NodeExistsPolicy.OVERWRITE);
 
-      manager.getContext().propUtil().setProperties(
+      PropUtil.setProperties(manager.getContext(),
           NamespacePropKey.of(manager.getContext(), namespaceInfo.namespaceId),
           namespaceInfo.props);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/tableImport/ImportPopulateZookeeper.java
@@ -34,6 +34,7 @@ import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.accumulo.server.util.PropUtil;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -89,8 +90,8 @@ class ImportPopulateZookeeper extends ManagerRepo {
     VolumeManager volMan = env.getVolumeManager();
 
     try {
-      env.getContext().propUtil().setProperties(
-          TablePropKey.of(env.getContext(), tableInfo.tableId), getExportedProps(volMan));
+      PropUtil.setProperties(env.getContext(), TablePropKey.of(env.getContext(), tableInfo.tableId),
+          getExportedProps(volMan));
     } catch (IllegalStateException ex) {
       throw new AcceptableThriftTableOperationException(tableInfo.tableId.canonical(),
           tableInfo.tableName, TableOperation.IMPORT, TableOperationExceptionType.OTHER,

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -81,6 +81,7 @@ import org.apache.accumulo.server.gc.AllVolumesDirectory;
 import org.apache.accumulo.server.gc.GcVolumeUtil;
 import org.apache.accumulo.server.metadata.RootGcCandidates;
 import org.apache.accumulo.server.metadata.TabletMutatorBase;
+import org.apache.accumulo.server.util.PropUtil;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -166,7 +167,7 @@ public class Upgrader9to10 implements Upgrader {
             var dispatcherPropsMap = Map.of(Property.TABLE_COMPACTION_DISPATCHER.getKey(),
                 SimpleCompactionDispatcher.class.getName(),
                 Property.TABLE_COMPACTION_DISPATCHER_OPTS.getKey() + "service", dispatcherService);
-            context.propUtil().setProperties(TablePropKey.of(context, tableId), dispatcherPropsMap);
+            PropUtil.setProperties(context, TablePropKey.of(context, tableId), dispatcherPropsMap);
           };
 
       // root compaction props

--- a/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ZooKeeperPropertiesIT.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.store.NamespacePropKey;
 import org.apache.accumulo.server.conf.store.TablePropKey;
+import org.apache.accumulo.server.util.PropUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -71,7 +72,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
       assertEquals("false", properties.get(Property.TABLE_BLOOM_ENABLED.getKey()));
 
       final TablePropKey tablePropKey = TablePropKey.of(context, TableId.of(tid));
-      context.propUtil().setProperties(tablePropKey,
+      PropUtil.setProperties(context, tablePropKey,
           Map.of(Property.TABLE_BLOOM_ENABLED.getKey(), "true"));
 
       // add a sleep to give the property change time to propagate
@@ -85,7 +86,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
         properties = client.tableOperations().getConfiguration(tableName);
       }
 
-      context.propUtil().removeProperties(tablePropKey,
+      PropUtil.removeProperties(context, tablePropKey,
           List.of(Property.TABLE_BLOOM_ENABLED.getKey()));
 
       properties = client.tableOperations().getConfiguration(tableName);
@@ -100,7 +101,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
 
       // Add invalid property
       assertThrows(IllegalArgumentException.class,
-          () -> context.propUtil().setProperties(tablePropKey,
+          () -> PropUtil.setProperties(context, tablePropKey,
               Map.of("NOT_A_PROPERTY", "not_a_value")),
           "Expected IllegalArgumentException to be thrown.");
     }
@@ -124,7 +125,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
 
       final NamespaceId namespaceId = NamespaceId.of(nid);
       final NamespacePropKey namespacePropKey = NamespacePropKey.of(context, namespaceId);
-      context.propUtil().setProperties(namespacePropKey,
+      PropUtil.setProperties(context, namespacePropKey,
           Map.of(Property.TABLE_FILE_MAX.getKey(), "31"));
 
       // add a sleep to give the property change time to propagate
@@ -138,7 +139,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
         properties = client.namespaceOperations().getConfiguration(namespace);
       }
 
-      context.propUtil().removeProperties(namespacePropKey,
+      PropUtil.removeProperties(context, namespacePropKey,
           List.of(Property.TABLE_FILE_MAX.getKey()));
 
       properties = client.namespaceOperations().getConfiguration(namespace);
@@ -153,7 +154,7 @@ public class ZooKeeperPropertiesIT extends AccumuloClusterHarness {
 
       // Add invalid property
       assertThrows(IllegalArgumentException.class,
-          () -> context.propUtil().setProperties(namespacePropKey,
+          () -> PropUtil.setProperties(context, namespacePropKey,
               Map.of("NOT_A_PROPERTY", "not_a_value")),
           "Expected IllegalArgumentException to be thrown.");
     }


### PR DESCRIPTION
The PropUtil class does not require any state - this modifies the class to only contain static methods and to prevent instantiation.