### PR TITLE
Mark ScanInterpreter related API as deprecated (#2787)

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -1113,8 +1113,11 @@ public enum Property {
       "1.3.5"),
   TABLE_FORMATTER_CLASS("table.formatter", DefaultFormatter.class.getName(), PropertyType.STRING,
       "The Formatter class to apply on results in the shell", "1.4.0"),
+  @Deprecated(since = "2.1.0")
   TABLE_INTERPRETER_CLASS("table.interepreter", DefaultScanInterpreter.class.getName(),
-      PropertyType.STRING, "The ScanInterpreter class to apply on scan arguments in the shell",
+      PropertyType.STRING,
+      "The ScanInterpreter class to apply on scan arguments in the shell. "
+          + "Note that this property is deprecated and will be removed in a future version.",
       "1.5.0"),
   TABLE_CLASSLOADER_CONTEXT("table.class.loader.context", "", PropertyType.STRING,
       "The context to use for loading per-table resources, such as iterators"

--- a/core/src/main/java/org/apache/accumulo/core/util/format/HexFormatter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/format/HexFormatter.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.io.Text;
 /**
  * A simple formatter that print the row, column family, column qualifier, and value as hex
  */
+@Deprecated(since = "2.1.0")
 public class HexFormatter implements Formatter, ScanInterpreter {
 
   private char[] chars =

--- a/core/src/main/java/org/apache/accumulo/core/util/interpret/DefaultScanInterpreter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/interpret/DefaultScanInterpreter.java
@@ -20,6 +20,10 @@ package org.apache.accumulo.core.util.interpret;
 
 import org.apache.hadoop.io.Text;
 
+/**
+ * @deprecated since 2.1.0 This will be removed in a future version in favor of JShell
+ */
+@Deprecated(since = "2.1.0")
 public class DefaultScanInterpreter implements ScanInterpreter {
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/util/interpret/HexScanInterpreter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/interpret/HexScanInterpreter.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.util.format.HexFormatter;
  * {@link HexFormatter} back to binary. The hex input can contain dashes (because
  * {@link HexFormatter} outputs dashes) which are ignored.
  */
+@Deprecated(since = "2.1.0")
 public class HexScanInterpreter extends HexFormatter {
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/interpret/ScanInterpreter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/interpret/ScanInterpreter.java
@@ -23,7 +23,10 @@ import org.apache.hadoop.io.Text;
 /**
  * A simple interface for creating shell plugins that translate the range and column arguments for
  * the shell's scan command.
+ *
+ * @deprecated since 2.1.0 This will be removed in a future version in favor of JShell
  */
+@Deprecated(since = "2.1.0")
 public interface ScanInterpreter {
 
   Text interpretRow(Text row);

--- a/core/src/test/java/org/apache/accumulo/core/util/format/HexFormatterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/format/HexFormatterTest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@Deprecated(since = "2.1.0")
 public class HexFormatterTest {
   HexFormatter formatter;
 

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -377,6 +377,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
 
     rootToken = new Token();
 
+    @SuppressWarnings("deprecation")
     Command[] dataCommands = {new DeleteCommand(), new DeleteManyCommand(), new DeleteRowsCommand(),
         new EGrepCommand(), new FormatterCommand(), new InterpreterCommand(), new GrepCommand(),
         new ImportDirectoryCommand(), new InsertCommand(), new MaxRowCommand(), new ScanCommand()};

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/DeleteManyCommand.java
@@ -42,6 +42,7 @@ public class DeleteManyCommand extends ScanCommand {
       throws Exception {
     final String tableName = OptUtil.getTableOpt(cl, shellState);
 
+    @SuppressWarnings("deprecation")
     final ScanInterpreter interpeter = getInterpreter(cl, tableName, shellState);
 
     // handle first argument, if present, the authorizations list to

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FormatterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FormatterCommand.java
@@ -57,6 +57,7 @@ public class FormatterCommand extends ShellPluginConfigurationCommand {
     return options;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   protected void setPlugin(final CommandLine cl, final Shell shellState, final String tableName,
       final String className) throws AccumuloException, AccumuloSecurityException {
@@ -67,6 +68,7 @@ public class FormatterCommand extends ShellPluginConfigurationCommand {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   protected void removePlugin(final CommandLine cl, final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/GrepCommand.java
@@ -51,6 +51,7 @@ public class GrepCommand extends ScanCommand {
         throw new MissingArgumentException("No terms specified");
       }
       final Class<? extends Formatter> formatter = getFormatter(cl, tableName, shellState);
+      @SuppressWarnings("deprecation")
       final ScanInterpreter interpeter = getInterpreter(cl, tableName, shellState);
 
       // handle first argument, if present, the authorizations list to

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/InterpreterCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/InterpreterCommand.java
@@ -22,6 +22,10 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.util.interpret.ScanInterpreter;
 import org.apache.accumulo.shell.Shell;
 
+/**
+ * @deprecated since 2.1.0 This will be removed in a future version
+ */
+@Deprecated(since = "2.1.0")
 public class InterpreterCommand extends ShellPluginConfigurationCommand {
 
   public InterpreterCommand() {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/MaxRowCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/MaxRowCommand.java
@@ -36,6 +36,7 @@ public class MaxRowCommand extends ScanCommand {
       throws Exception {
     final String tableName = OptUtil.getTableOpt(cl, shellState);
 
+    @SuppressWarnings("deprecation")
     final ScanInterpreter interpeter = getInterpreter(cl, tableName, shellState);
 
     final Range range = getRange(cl, interpeter);

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ScanCommand.java
@@ -93,6 +93,7 @@ public class ScanCommand extends Command {
       final String tableName = OptUtil.getTableOpt(cl, shellState);
 
       final Class<? extends Formatter> formatter = getFormatter(cl, tableName, shellState);
+      @SuppressWarnings("deprecation")
       final ScanInterpreter interpeter = getInterpreter(cl, tableName, shellState);
 
       String classLoaderContext = null;
@@ -215,6 +216,7 @@ public class ScanCommand extends Command {
     }
   }
 
+  @Deprecated(since = "2.1.0")
   protected ScanInterpreter getInterpreter(final CommandLine cl, final String tableName,
       final Shell shellState) throws Exception {
 
@@ -270,7 +272,8 @@ public class ScanCommand extends Command {
   }
 
   protected void fetchColumns(final CommandLine cl, final ScannerBase scanner,
-      final ScanInterpreter formatter) throws UnsupportedEncodingException {
+      @SuppressWarnings("deprecation") final ScanInterpreter formatter)
+      throws UnsupportedEncodingException {
 
     if ((cl.hasOption(scanOptCf.getOpt()) || cl.hasOption(scanOptCq.getOpt()))
         && cl.hasOption(scanOptColumns.getOpt())) {
@@ -296,7 +299,8 @@ public class ScanCommand extends Command {
     }
   }
 
-  private void fetchColumsWithCFAndCQ(CommandLine cl, Scanner scanner, ScanInterpreter interpeter) {
+  private void fetchColumsWithCFAndCQ(CommandLine cl, Scanner scanner,
+      @SuppressWarnings("deprecation") ScanInterpreter interpeter) {
     String cf = "";
     String cq = "";
     if (cl.hasOption(scanOptCf.getOpt())) {
@@ -322,7 +326,8 @@ public class ScanCommand extends Command {
 
   }
 
-  protected Range getRange(final CommandLine cl, final ScanInterpreter formatter)
+  protected Range getRange(final CommandLine cl,
+      @SuppressWarnings("deprecation") final ScanInterpreter formatter)
       throws UnsupportedEncodingException {
     if ((cl.hasOption(OptUtil.START_ROW_OPT) || cl.hasOption(OptUtil.END_ROW_OPT))
         && cl.hasOption(scanOptRow.getOpt())) {


### PR DESCRIPTION
I just did a quick commit here to mark the API as deprecated as there's already some comments that print for the shell output if used.

Do we want to specify when it will be removed? I would think targeting 2.2 for removal would be good. Is there anything else to do here? 