### PR TITLE
bump sec-bugs version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1591,7 +1591,7 @@
                 <plugin>
                   <groupId>com.h3xstream.findsecbugs</groupId>
                   <artifactId>findsecbugs-plugin</artifactId>
-                  <version>1.8.0</version>
+                  <version>1.12.0</version>
                 </plugin>
               </plugins>
             </configuration>


### PR DESCRIPTION
Noticed there is a more recent version of sec-bugs.  qa checks pass without any changes needed.