### PR TITLE
Cache SSLContext

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -37,7 +37,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -154,12 +153,6 @@ public class ClientContext implements AccumuloClient {
     return () -> Suppliers.memoizeWithExpiration(s::get, 100, MILLISECONDS).get();
   }
 
-  private static <T> Supplier<T> memoizeWithExpiration(Supplier<T> s, long duration,
-      TimeUnit units) {
-    // This insanity exists to make modernizer plugin happy. We are living in the future now.
-    return () -> Suppliers.memoizeWithExpiration(s::get, duration, units).get();
-  }
-
   /**
    * Create a client context with the provided configuration. Legacy client code must provide a
    * no-op SingletonReservation to preserve behavior prior to 2.x. Clients since 2.x should call
@@ -176,8 +169,7 @@ public class ClientContext implements AccumuloClient {
     this.serverConf = serverConf;
     timeoutSupplier = memoizeWithExpiration(
         () -> getConfiguration().getTimeInMillis(Property.GENERAL_RPC_TIMEOUT));
-    sslSupplier = memoizeWithExpiration(() -> SslConnectionParams.forClient(getConfiguration()), 1,
-        TimeUnit.DAYS);
+    sslSupplier = Suppliers.memoize(() -> SslConnectionParams.forClient(getConfiguration()));
     saslSupplier = memoizeWithExpiration(
         () -> SaslConnectionParams.from(getConfiguration(), getCredentials().getToken()));
     this.singletonReservation = Objects.requireNonNull(reservation);

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SslConnectionParams.java
@@ -264,7 +264,7 @@ public class SslConnectionParams {
     }
     hash = 31 * hash + clientProtocol.hashCode();
     hash = 31 * hash + Arrays.hashCode(serverProtocols);
-    return super.hashCode();
+    return hash;
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -447,6 +447,7 @@ public class ThriftUtil {
       throws TTransportException {
     SSLContext ctx = SSL_CONTEXT_CACHE.getIfPresent(params);
     if (ctx == null) {
+      log.trace("Creating new ssl context.");
       try {
         ctx = SSLContext.getInstance(params.getClientProtocol());
         TrustManagerFactory tmf = null;
@@ -477,10 +478,13 @@ public class ThriftUtil {
         } else {
           ctx.init(null, tmf.getTrustManagers(), null);
         }
-
+        log.trace("Adding context to the cache: {} -> {}", params, ctx);
+        SSL_CONTEXT_CACHE.put(params, ctx);
       } catch (Exception e) {
         throw new TTransportException("Error creating the transport", e);
       }
+    } else {
+      log.trace("Using cached ssl context.");
     }
     return ctx;
   }


### PR DESCRIPTION
Working with user testing SSL setup with Accumulo 2.1.0 and seeing general slowness.  I modified SslIT to include the following:

```
   @Override
   public void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    System.setProperty("javax.net.debug", "ssl:handshake");
+    Map<String,String> sys = new HashMap<>();
+    sys.put("javax.net.debug", "ssl:handshake");
+    cfg.setSystemProperties(sys);
+    cfg.setProperty(Property.RPC_SSL_ENABLED_PROTOCOLS, "TLSv1.3");
+    cfg.setProperty(Property.RPC_SSL_CLIENT_PROTOCOL, "TLSv1.3");
+    cfg.setProperty(Property.MONITOR_SSL_INCLUDE_PROTOCOLS, "TLSv1.3");
+    cfg.setClientProperty(Property.RPC_SSL_CLIENT_PROTOCOL.getKey(), "TLSv1.3");
     super.configure(cfg, hadoopCoreSite);
     configureForSsl(cfg,
         getSslDir(createTestDir(this.getClass().getName() + "_" + this.testName())));
   }
 
+  @Test
+  public void testScan() throws Exception {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
+      String tableName = getUniqueNames(1)[0];
+      client.tableOperations().create(tableName);
+      BatchWriter bw = client.createBatchWriter(tableName);
+      Mutation m = new Mutation("m");
+      m.put("u", "t", new ColumnVisibility(), "t");
+      bw.addMutation(m);
+      bw.flush();
+      bw.close();
+      Scanner s = client.createScanner(tableName);
+      s.iterator().next();
+      s.iterator().next();
+      s.iterator().next();
+      s.iterator().next();
+      s.iterator().next();
+    }
+  }
```

Looking at the output of the `test` thread running the `testScan` test above, there are 14 instances of `"ClientHello":`, meaning that there are 14 TLS handshakes. Running the same test on this new code yields 2 or 3 TLS handshakes (I'm assuming 1 to the Manager and then 1 or 2 to the MAC TabletServers).

This PR introduces a Cache for the SSLContext that is created for the Accumulo connections. Caching was not working intially because of the bug in `SslConnectionParams.hashCode` and the fact that a new `SslConnectionParams` object was being returned because the default `ClientContext.memoizeWithExpiration` expires the object after 100ms.