### PR TITLE
Create new method in FastFormat for FATE

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/FastFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/FastFormat.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.base.Preconditions;
 
 public class FastFormat {
+  private static final byte[] EMPTY_BYTES = new byte[] {};
 
   // this 7 to 8 times faster than String.format("%s%06d",prefix, num)
   public static byte[] toZeroPaddedString(long num, int width, int radix, byte[] prefix) {
@@ -33,6 +34,10 @@ public class FastFormat {
       throw new RuntimeException(" Did not format to expected width " + num + " " + width + " "
           + radix + " " + new String(prefix, UTF_8));
     return ret;
+  }
+
+  public static byte[] toZeroPaddedHex(long hexadecimal) {
+    return toZeroPaddedString(hexadecimal, 16, 16, EMPTY_BYTES);
   }
 
   public static int toZeroPaddedString(byte[] output, int outputOffset, long num, int width,
@@ -63,5 +68,22 @@ public class FastFormat {
     }
 
     return index - outputOffset;
+  }
+
+  /**
+   * Create a zero padded string from a hexadecimal number. This is a faster replacement for:
+   * String.format("%s%016x%s", PREFIX, tid, SUFFIX);
+   */
+  public static String toHexString(String prefix, long hexadecimal, String suffix) {
+    return prefix + new String(toZeroPaddedString(hexadecimal, 16, 16, EMPTY_BYTES), UTF_8)
+        + suffix;
+  }
+
+  /**
+   * Create a zero padded string from a hexadecimal number. This is a faster replacement for:
+   * String.format("%016x", tid)
+   */
+  public static String toHexString(long hexadecimal) {
+    return toHexString("", hexadecimal, "");
   }
 }

--- a/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/AdminUtil.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.zookeeper.FateLock;
 import org.apache.accumulo.fate.zookeeper.FateLock.FateLockPath;
@@ -96,7 +97,7 @@ public class AdminUtil<T> {
      *         are in the Accumulo logs.
      */
     public String getTxid() {
-      return String.format("%016x", txid);
+      return FastFormat.toHexString(txid);
     }
 
     public TStatus getStatus() {
@@ -165,7 +166,7 @@ public class AdminUtil<T> {
 
       Map<String,List<String>> ret = new HashMap<>();
       for (Entry<Long,List<String>> entry : danglocks.entrySet()) {
-        ret.put(String.format("%016x", entry.getKey()),
+        ret.put(FastFormat.toHexString(entry.getKey()),
             Collections.unmodifiableList(entry.getValue()));
       }
       return Collections.unmodifiableMap(ret);

--- a/core/src/main/java/org/apache/accumulo/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/fate/Fate.java
@@ -322,7 +322,7 @@ public class Fate<T> {
    *         false otherwise
    */
   public boolean cancel(long tid) {
-    String tidStr = Long.toHexString(tid);
+    String tidStr = FateTxId.formatTid(tid);
     for (int retries = 0; retries < 5; retries++) {
       if (store.tryReserve(tid)) {
         try {
@@ -332,12 +332,11 @@ public class Fate<T> {
             store.setProperty(tid, EXCEPTION_PROP, new TApplicationException(
                 TApplicationException.INTERNAL_ERROR, "Fate transaction cancelled by user"));
             store.setStatus(tid, FAILED_IN_PROGRESS);
-            log.info(
-                "Updated status for Repo {} to FAILED_IN_PROGRESS because it was cancelled by user",
+            log.info("Updated status for {} to FAILED_IN_PROGRESS because it was cancelled by user",
                 tidStr);
             return true;
           } else {
-            log.info("Repo {} cancelled by user but already in progress or finished state", tidStr);
+            log.info("{} cancelled by user but already in progress or finished state", tidStr);
             return false;
           }
         } finally {

--- a/core/src/main/java/org/apache/accumulo/fate/FateTxId.java
+++ b/core/src/main/java/org/apache/accumulo/fate/FateTxId.java
@@ -56,8 +56,6 @@ public class FateTxId {
    */
   public static String formatTid(long tid) {
     // do not change how this formats without considering implications for persistence
-    // original format: String.format("%s%016x%s", PREFIX, tid, SUFFIX);
-    // Since 2.1, this format was replaced with the faster version below
     return FastFormat.toHexString(PREFIX, tid, SUFFIX);
   }
 

--- a/core/src/main/java/org/apache/accumulo/fate/FateTxId.java
+++ b/core/src/main/java/org/apache/accumulo/fate/FateTxId.java
@@ -20,6 +20,8 @@ package org.apache.accumulo.fate;
 
 import java.util.regex.Pattern;
 
+import org.apache.accumulo.core.util.FastFormat;
+
 import com.google.common.base.Preconditions;
 
 public class FateTxId {
@@ -54,7 +56,9 @@ public class FateTxId {
    */
   public static String formatTid(long tid) {
     // do not change how this formats without considering implications for persistence
-    return String.format("%s%016x%s", PREFIX, tid, SUFFIX);
+    // original format: String.format("%s%016x%s", PREFIX, tid, SUFFIX);
+    // Since 2.1, this format was replaced with the faster version below
+    return FastFormat.toHexString(PREFIX, tid, SUFFIX);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -94,7 +95,7 @@ public class ZooStore<T> implements TStore<T> {
   }
 
   private String getTXPath(long tid) {
-    return String.format("%s/tx_%016x", path, tid);
+    return FastFormat.toHexString(path + "/tx_", tid, "");
   }
 
   private long parseTid(String txdir) {

--- a/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
@@ -128,9 +128,13 @@ public class FastFormatTest {
     assertEquals(formattedTxId, hexStr);
     long txid = FateTxId.fromString("FATE[2e429160071c63d8]");
     assertEquals("FATE[2e429160071c63d8]", FastFormat.toHexString(PREFIX, txid, SUFFIX));
+    assertEquals(String.format("%016x", 64L), FastFormat.toHexString(64L));
+    assertEquals(String.format("%016x", 0X2e429160071c63d8L),
+        FastFormat.toHexString(0X2e429160071c63d8L));
 
     assertEquals("-0000000000000040-", FastFormat.toHexString("-", 64L, "-"));
     assertEquals("-00000000075bcd15", FastFormat.toHexString("-", 123456789L, ""));
+    assertEquals("000000000000000a", FastFormat.toHexString(0XaL));
     assertEquals("000000000000000a", FastFormat.toHexString(10L));
     assertEquals("0000000000000009", FastFormat.toHexString(9L));
     assertEquals("0000000000000000", FastFormat.toHexString(0L));
@@ -143,5 +147,10 @@ public class FastFormatTest {
     str = FastFormat.toZeroPaddedHex(123456789L);
     assertEquals(16, str.length);
     assertEquals("00000000075bcd15", new String(str, UTF_8));
+
+    Arrays.fill(str, (byte) '-');
+    str = FastFormat.toZeroPaddedHex(0X2e429160071c63d8L);
+    assertEquals(16, str.length);
+    assertEquals("2e429160071c63d8", new String(str, UTF_8));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
+import org.apache.accumulo.fate.FateTxId;
 import org.junit.jupiter.api.Test;
 
 public class FastFormatTest {
@@ -116,5 +117,31 @@ public class FastFormatTest {
     byte[] str = new byte[8];
     assertThrows(ArrayIndexOutOfBoundsException.class,
         () -> FastFormat.toZeroPaddedString(str, 4, 64L, 4, 16, new byte[] {'P'}));
+  }
+
+  @Test
+  public void testHexString() {
+    final String PREFIX = "FATE[";
+    final String SUFFIX = "]";
+    String formattedTxId = FateTxId.formatTid(64L);
+    String hexStr = FastFormat.toHexString(PREFIX, 64L, SUFFIX);
+    assertEquals(formattedTxId, hexStr);
+    long txid = FateTxId.fromString("FATE[2e429160071c63d8]");
+    assertEquals("FATE[2e429160071c63d8]", FastFormat.toHexString(PREFIX, txid, SUFFIX));
+
+    assertEquals("-0000000000000040-", FastFormat.toHexString("-", 64L, "-"));
+    assertEquals("-00000000075bcd15", FastFormat.toHexString("-", 123456789L, ""));
+    assertEquals("000000000000000a", FastFormat.toHexString(10L));
+    assertEquals("0000000000000009", FastFormat.toHexString(9L));
+    assertEquals("0000000000000000", FastFormat.toHexString(0L));
+  }
+
+  @Test
+  public void testZeroPaddedHex() {
+    byte[] str = new byte[8];
+    Arrays.fill(str, (byte) '-');
+    str = FastFormat.toZeroPaddedHex(123456789L);
+    assertEquals(16, str.length);
+    assertEquals("0000000000000040", new String(str, UTF_8));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/FastFormatTest.java
@@ -142,6 +142,6 @@ public class FastFormatTest {
     Arrays.fill(str, (byte) '-');
     str = FastFormat.toZeroPaddedHex(123456789L);
     assertEquals(16, str.length);
-    assertEquals("0000000000000040", new String(str, UTF_8));
+    assertEquals("00000000075bcd15", new String(str, UTF_8));
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -66,6 +66,7 @@ import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.core.util.Validator;
 import org.apache.accumulo.core.util.tables.TableNameUtil;
 import org.apache.accumulo.core.volume.Volume;
@@ -800,7 +801,7 @@ class FateServiceHandler implements FateService.Iface {
    */
   public Path mkTempDir(long opid) throws IOException {
     Volume vol = manager.getVolumeManager().getFirst();
-    Path p = vol.prefixChild("/tmp/fate-" + String.format("%016x", opid));
+    Path p = vol.prefixChild("/tmp/fate-" + FastFormat.toHexString(opid));
     FileSystem fs = vol.getFileSystem();
     if (fs.exists(p))
       fs.delete(p, true);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactRange.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.clientImpl.thrift.TableOperation;
 import org.apache.accumulo.core.clientImpl.thrift.TableOperationExceptionType;
 import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
@@ -106,7 +107,7 @@ public class CompactRange extends ManagerRepo {
         String[] tokens = cvs.split(",");
         long flushID = Long.parseLong(tokens[0]) + 1;
 
-        String txidString = String.format("%016x", tid);
+        String txidString = FastFormat.toHexString(tid);
 
         for (int i = 1; i < tokens.length; i++) {
           if (tokens[i].startsWith(txidString))
@@ -155,7 +156,7 @@ public class CompactRange extends ManagerRepo {
         String[] tokens = cvs.split(",");
         long flushID = Long.parseLong(tokens[0]);
 
-        String txidString = String.format("%016x", txid);
+        String txidString = FastFormat.toHexString(txid);
 
         StringBuilder encodedIterators = new StringBuilder();
         for (int i = 1; i < tokens.length; i++) {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/FateCommand.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.manager.thrift.FateService;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
+import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.core.util.tables.TableMap;
 import org.apache.accumulo.fate.AdminUtil;
 import org.apache.accumulo.fate.FateTxId;
@@ -113,11 +114,11 @@ public class FateCommand extends Command {
 
   // the purpose of this class is to be serialized as JSon for display
   public static class FateStack {
-    String txid;
+    String txIdString;
     List<ReadOnlyRepo<FateCommand>> stack;
 
     FateStack(Long txid, List<ReadOnlyRepo<FateCommand>> stack) {
-      this.txid = String.format("%016x", txid);
+      this.txIdString = FastFormat.toHexString(txid);
       this.stack = stack;
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/fate/zookeeper/FateIT.java
@@ -46,6 +46,7 @@ import org.apache.accumulo.core.data.NamespaceId;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.fate.AgeOffStore;
 import org.apache.accumulo.fate.Fate;
+import org.apache.accumulo.fate.FateTxId;
 import org.apache.accumulo.fate.ReadOnlyTStore.TStatus;
 import org.apache.accumulo.fate.Repo;
 import org.apache.accumulo.fate.ZooStore;
@@ -98,14 +99,14 @@ public class FateIT {
 
     @Override
     public Repo<Manager> call(long tid, Manager manager) throws Exception {
-      LOG.debug("Entering call {}", Long.toHexString(tid));
+      LOG.debug("Entering call {}", FateTxId.formatTid(tid));
       try {
         FateIT.inCall();
         return null;
       } finally {
         Utils.unreserveNamespace(manager, namespaceId, tid, false);
         Utils.unreserveTable(manager, tableId, tid, true);
-        LOG.debug("Leaving call {}", Long.toHexString(tid));
+        LOG.debug("Leaving call {}", FateTxId.formatTid(tid));
       }
 
     }
@@ -232,7 +233,7 @@ public class FateIT {
       finishCall = new CountDownLatch(1);
 
       long txid = fate.startTransaction();
-      LOG.debug("Starting test testCancelWhileNew with {}", Long.toHexString(txid));
+      LOG.debug("Starting test testCancelWhileNew with {}", FateTxId.formatTid(txid));
       assertEquals(NEW, getTxStatus(zk, txid));
       // cancel the transaction
       assertTrue(fate.cancel(txid));
@@ -271,7 +272,7 @@ public class FateIT {
     finishCall = new CountDownLatch(1);
 
     long txid = fate.startTransaction();
-    LOG.debug("Starting test testCancelWhileSubmitted with {}", Long.toHexString(txid));
+    LOG.debug("Starting test testCancelWhileSubmitted with {}", FateTxId.formatTid(txid));
     assertEquals(NEW, getTxStatus(zk, txid));
     fate.seedTransaction(txid, new TestOperation(NS, TID), true, "Test Op");
     assertEquals(SUBMITTED, getTxStatus(zk, txid));
@@ -305,7 +306,7 @@ public class FateIT {
       finishCall = new CountDownLatch(1);
 
       long txid = fate.startTransaction();
-      LOG.debug("Starting test testCancelWhileSubmitted with {}", Long.toHexString(txid));
+      LOG.debug("Starting test testCancelWhileSubmitted with {}", FateTxId.formatTid(txid));
       assertEquals(NEW, getTxStatus(zk, txid));
       fate.seedTransaction(txid, new TestOperation(NS, TID), true, "Test Op");
       assertEquals(SUBMITTED, getTxStatus(zk, txid));
@@ -347,7 +348,7 @@ public class FateIT {
       finishCall = new CountDownLatch(1);
 
       long txid = fate.startTransaction();
-      LOG.debug("Starting test testCancelWhileInCall with {}", Long.toHexString(txid));
+      LOG.debug("Starting test testCancelWhileInCall with {}", FateTxId.formatTid(txid));
       assertEquals(NEW, getTxStatus(zk, txid));
       fate.seedTransaction(txid, new TestOperation(NS, TID), true, "Test Op");
       assertEquals(SUBMITTED, getTxStatus(zk, txid));


### PR DESCRIPTION
* Replace String.format() with new method in FastFormat that should be faster
* Modify FateTxId.formatTid to use new method that should be equivalent
* Replace uses of Long.toHexString in Utils with FateTxId.formatTid to
improve logging
* Add new tests to FastFormatTest
* Supports #2495