### PR TITLE
Discussion for #2830 - Update StoredTabletFile equals to fix spotbugs warning

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -72,4 +72,14 @@ public class StoredTabletFile extends TabletFile {
           + " does not match what was in the metadata: " + metadataEntry);
     }
   }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }


### PR DESCRIPTION
This overrides equals in `StoredTabletFile` by delegating to the parent`TabletFile.equals()` - this seems to preserve current behavior - but not sure that it should.  Provided for reference - this should not be merged until #2830 discussion is resolved. 