### PR TITLE
Fix serializable warnings

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/MutationsRejectedException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.core.client;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,10 +38,10 @@ import org.apache.accumulo.core.data.TabletId;
 public class MutationsRejectedException extends AccumuloException {
   private static final long serialVersionUID = 1L;
 
-  private List<ConstraintViolationSummary> cvsl;
-  private Map<TabletId,Set<SecurityErrorCode>> af;
-  private Collection<String> es;
-  private int unknownErrors;
+  private final ArrayList<ConstraintViolationSummary> cvsl = new ArrayList<>();
+  private final HashMap<TabletId,Set<SecurityErrorCode>> af = new HashMap<>();
+  private final HashSet<String> es = new HashSet<>();
+  private final int unknownErrors;
 
   /**
    *
@@ -65,9 +66,9 @@ public class MutationsRejectedException extends AccumuloException {
         "# constraint violations : " + cvsList.size() + "  security codes: " + hashMap.toString()
             + "  # server errors " + serverSideErrors.size() + " # exceptions " + unknownErrors,
         cause);
-    this.cvsl = cvsList;
-    this.af = hashMap;
-    this.es = serverSideErrors;
+    this.cvsl.addAll(cvsList);
+    this.af.putAll(hashMap);
+    this.es.addAll(serverSideErrors);
     this.unknownErrors = unknownErrors;
   }
 
@@ -93,9 +94,9 @@ public class MutationsRejectedException extends AccumuloException {
     super("# constraint violations : " + cvsList.size() + "  security codes: "
         + format(hashMap, (ClientContext) client) + "  # server errors " + serverSideErrors.size()
         + " # exceptions " + unknownErrors, cause);
-    this.cvsl = cvsList;
-    this.af = hashMap;
-    this.es = serverSideErrors;
+    this.cvsl.addAll(cvsList);
+    this.af.putAll(hashMap);
+    this.es.addAll(serverSideErrors);
     this.unknownErrors = unknownErrors;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/TimedOutException.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/TimedOutException.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.client;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -27,7 +28,7 @@ import java.util.Set;
  */
 public class TimedOutException extends RuntimeException {
 
-  private Set<String> timedoutServers;
+  private final HashSet<String> timedoutServers = new HashSet<>();
 
   private static final long serialVersionUID = 1L;
 
@@ -41,13 +42,12 @@ public class TimedOutException extends RuntimeException {
 
   public TimedOutException(Set<String> timedoutServers) {
     super("Servers timed out " + shorten(timedoutServers));
-    this.timedoutServers = timedoutServers;
+    this.timedoutServers.addAll(timedoutServers);
 
   }
 
   public TimedOutException(String msg) {
     super(msg);
-    this.timedoutServers = Collections.emptySet();
   }
 
   public Set<String> getTimedOutSevers() {


### PR DESCRIPTION
* Change private interface types to concrete classes to stop Java 18
warnings about non-serializable types
* Supports #2776