### PR TITLE
Provide getProperties method on Configuration that does not filter

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
@@ -203,6 +203,17 @@ public class ClientConfConverter {
       }
 
       @Override
+      public void getProperties(Map<String,String> props, String... properties) {
+        defaults.getProperties(props, properties);
+        for (String p : properties) {
+          String value = config.getString(p);
+          if (value != null) {
+            props.put(p, value);
+          }
+        }
+      }
+
+      @Override
       public void getProperties(Map<String,String> props, Predicate<String> filter) {
         defaults.getProperties(props, filter);
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.TreeMap;
@@ -71,17 +70,13 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
   /**
    * Gets a property value from this configuration.
    *
-   * <p>
-   * Note: this is inefficient, but convenient on occasion. For retrieving multiple properties, use
-   * {@link #getProperties(Map, Predicate)} with a custom filter.
-   *
    * @param property
    *          property to get
    * @return property value
    */
   public String get(String property) {
     Map<String,String> propMap = new HashMap<>(1);
-    getProperties(propMap, key -> Objects.equals(property, key));
+    getProperties(propMap, property);
     return propMap.get(property);
   }
 
@@ -120,6 +115,16 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
   }
 
   /**
+   * Returns property key/value pairs in this configuration and parent configuration.
+   *
+   * @param props
+   *          properties object to populate
+   * @param properties
+   *          property key/values to copy to the props map. Copies all properties if null.
+   */
+  public abstract void getProperties(Map<String,String> props, String... properties);
+
+  /**
    * Returns property key/value pairs in this configuration. The pairs include those defined in this
    * configuration which pass the given filter, and those supplied from the parent configuration
    * which are not included from here.
@@ -139,9 +144,8 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
    */
   @Override
   public Iterator<Entry<String,String>> iterator() {
-    Predicate<String> all = x -> true;
     TreeMap<String,String> entries = new TreeMap<>();
-    getProperties(entries, all);
+    getProperties(entries);
     return entries.entrySet().iterator();
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -70,6 +70,11 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
   /**
    * Gets a property value from this configuration.
    *
+   * <p>
+   * Note: this is inefficient, but convenient on occasion. For retrieving multiple properties, use
+   * {@link #getProperties(Map, String...)} if the property names are known or
+   * {@link #getProperties(Map, Predicate)} with a custom filter.
+   *
    * @param property
    *          property to get
    * @return property value
@@ -128,6 +133,10 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
    * Returns property key/value pairs in this configuration. The pairs include those defined in this
    * configuration which pass the given filter, and those supplied from the parent configuration
    * which are not included from here.
+   *
+   * <p>
+   * Note: this is inefficient for retrieving fully-qualified properties, use
+   * {@link #getProperties(Map, String...)} instead.
    *
    * @param props
    *          properties object to populate

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationCopy.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationCopy.java
@@ -76,6 +76,20 @@ public class ConfigurationCopy extends AccumuloConfiguration {
   }
 
   @Override
+  public void getProperties(Map<String,String> props, String... properties) {
+    if (properties == null || properties.length == 0) {
+      props.putAll(copy);
+    } else {
+      for (String p : properties) {
+        String value = copy.get(p);
+        if (value != null) {
+          props.put(p, value);
+        }
+      }
+    }
+  }
+
+  @Override
   public void getProperties(Map<String,String> props, Predicate<String> filter) {
     for (Entry<String,String> entry : copy.entrySet()) {
       if (filter.test(entry.getKey())) {

--- a/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/DefaultConfiguration.java
@@ -55,6 +55,20 @@ public class DefaultConfiguration extends AccumuloConfiguration {
   }
 
   @Override
+  public void getProperties(Map<String,String> props, String... properties) {
+    if (properties == null || properties.length == 0) {
+      props.putAll(resolvedProps);
+    } else {
+      for (String p : properties) {
+        String value = resolvedProps.get(p);
+        if (value != null) {
+          props.put(p, value);
+        }
+      }
+    }
+  }
+
+  @Override
   public void getProperties(Map<String,String> props, Predicate<String> filter) {
     resolvedProps.entrySet().stream().filter(p -> filter.test(p.getKey()))
         .forEach(e -> props.put(e.getKey(), e.getValue()));

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -262,6 +262,17 @@ public class SiteConfiguration extends AccumuloConfiguration {
   }
 
   @Override
+  public void getProperties(Map<String,String> props, String... properties) {
+    parent.getProperties(props, properties);
+    for (String p : properties) {
+      String value = config.get(p);
+      if (value != null) {
+        props.put(p, value);
+      }
+    }
+  }
+
+  @Override
   public void getProperties(Map<String,String> props, Predicate<String> filter) {
     getProperties(props, filter, true);
   }

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -174,6 +174,19 @@ public class AccumuloConfigurationTest {
     }
 
     @Override
+    public void getProperties(Map<String,String> props, String... properties) {
+      if (parent != null) {
+        parent.getProperties(props, properties);
+      }
+      for (String p : properties) {
+        String value = props.get(p);
+        if (value != null) {
+          props.put(p, value);
+        }
+      }
+    }
+
+    @Override
     public void getProperties(Map<String,String> output, Predicate<String> filter) {
       if (parent != null) {
         parent.getProperties(output, filter);

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooBasedConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooBasedConfiguration.java
@@ -122,6 +122,18 @@ public class ZooBasedConfiguration extends AccumuloConfiguration {
   }
 
   @Override
+  public void getProperties(Map<String,String> props, String... properties) {
+    parent.getProperties(props, properties);
+    Map<String,String> theseProps = getSnapshot();
+    for (String p : properties) {
+      String value = theseProps.get(p);
+      if (value != null) {
+        props.put(p, value);
+      }
+    }
+  }
+
+  @Override
   public void getProperties(final Map<String,String> props, final Predicate<String> filter) {
 
     parent.getProperties(props, filter);

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/ServerConfigurationFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.server.conf;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -74,9 +75,7 @@ public class ServerConfigurationFactoryTest {
     propStore.registerAsListener(anyObject(), anyObject());
     expectLastCall().anyTimes();
 
-    sysConfig = createMock(SystemConfiguration.class);
-    sysConfig.getProperties(anyObject(), anyObject());
-    expectLastCall().anyTimes();
+    sysConfig = createNiceMock(SystemConfiguration.class);
 
     context = createMock(ServerContext.class);
     expect(context.getZooKeeperRoot()).andReturn("/accumulo/" + IID).anyTimes();


### PR DESCRIPTION
The getProperties method which takes a filter is inefficient when
you know that you want to get all properties or you know the names
of the properties. Provide a mechanism to get the properties w/out
using a filter