### PR TITLE
Don't log full stack trace by default when unable to load compression codec

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionAlgorithm.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/CompressionAlgorithm.java
@@ -297,7 +297,10 @@ public class CompressionAlgorithm extends Configured {
       updateBuffer(config, bufferSizeConfigOpt, bufferSize);
       return (CompressionCodec) ReflectionUtils.newInstance(Class.forName(clazz), config);
     } catch (ClassNotFoundException e) {
-      LOG.debug("Unable to load codec class {} for {}", clazz, codecClazzProp, e);
+      LOG.debug(
+          "ClassNotFoundException creating codec class {} for {}. Enable trace logging for stacktrace.",
+          clazz, codecClazzProp);
+      LOG.trace("Unable to load codec class due to ", e);
     }
     return null;
   }


### PR DESCRIPTION

Closes #2835