### PR TITLE
Make Mini call initialize code directly

### DIFF
--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterImpl.java
@@ -581,13 +581,16 @@ public class MiniAccumuloClusterImpl implements AccumuloCluster {
         }
 
         log.warn("Initializing ZooKeeper");
-        try (var vm = VolumeManagerImpl.get(siteConfig, config.getHadoopConfiguration())) {
+        var hadoopConfig = new Configuration(false);
+        File csFile = new File(config.getConfDir(), "core-site.xml");
+        hadoopConfig.addResource(csFile.toURI().toURL());
+
+        try (var vm = VolumeManagerImpl.get(siteConfig, hadoopConfig)) {
           log.info("Calling init with {}", args);
           Initialize init = new Initialize();
           Initialize.Opts opts = new Initialize.Opts();
           opts.parseArgs("accumulo init", args.toArray(new String[0]));
-          InitialConfiguration initConfig =
-              new InitialConfiguration(config.getHadoopConfiguration(), siteConfig);
+          InitialConfiguration initConfig = new InitialConfiguration(hadoopConfig, siteConfig);
           init.doInit(new ZooReaderWriter(siteConfig), opts, vm, initConfig);
         } catch (Exception e) {
           throw new IllegalStateException("Exception during Initialize. Check the logs in "

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -91,9 +91,9 @@ public class MiniAccumuloConfigImpl {
   private String[] classpathItems = null;
 
   private String[] nativePathItems = null;
-
-  // These are only used on top of existing instances
   private Configuration hadoopConf;
+
+  // This is only used on top of existing instances
   private SiteConfiguration accumuloConf;
 
   /**
@@ -107,6 +107,7 @@ public class MiniAccumuloConfigImpl {
   public MiniAccumuloConfigImpl(File dir, String rootPassword) {
     this.dir = dir;
     this.rootPassword = rootPassword;
+    this.hadoopConf = new Configuration();
   }
 
   /**
@@ -695,28 +696,20 @@ public class MiniAccumuloConfigImpl {
    *
    * @param accumuloProps
    *          a File representation of the accumulo.properties file for the instance being run
-   * @param hadoopConfDir
+   * @param hadoopConfigDir
    *          a File representation of the hadoop configuration directory containing core-site.xml
    *          and hdfs-site.xml
-   *
-   * @return MiniAccumuloConfigImpl which uses an existing accumulo configuration
-   *
-   * @since 1.6.2
-   *
-   * @throws IOException
-   *           when there are issues converting the provided Files to URLs
    */
-  public MiniAccumuloConfigImpl useExistingInstance(File accumuloProps, File hadoopConfDir)
-      throws IOException {
+  public void useExistingInstance(File accumuloProps, File hadoopConfigDir) throws IOException {
     if (existingInstance != null && !existingInstance) {
       throw new UnsupportedOperationException(
           "Cannot set to useExistingInstance after specifying config/zookeeper");
     }
 
-    this.existingInstance = Boolean.TRUE;
+    existingInstance = Boolean.TRUE;
 
     System.setProperty("accumulo.properties", "accumulo.properties");
-    this.hadoopConfDir = hadoopConfDir;
+    hadoopConfDir = hadoopConfigDir;
     hadoopConf = new Configuration(false);
     accumuloConf = SiteConfiguration.fromFile(accumuloProps).build();
     File coreSite = new File(hadoopConfDir, "core-site.xml");
@@ -734,8 +727,6 @@ public class MiniAccumuloConfigImpl {
       siteConfigMap.put(e.getKey(), e.getValue());
     }
     _setSiteConfig(siteConfigMap);
-
-    return this;
   }
 
   /**

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloConfigImpl.java
@@ -91,9 +91,9 @@ public class MiniAccumuloConfigImpl {
   private String[] classpathItems = null;
 
   private String[] nativePathItems = null;
-  private Configuration hadoopConf;
 
-  // This is only used on top of existing instances
+  // These are only used on top of existing instances
+  private Configuration hadoopConf;
   private SiteConfiguration accumuloConf;
 
   /**
@@ -107,7 +107,6 @@ public class MiniAccumuloConfigImpl {
   public MiniAccumuloConfigImpl(File dir, String rootPassword) {
     this.dir = dir;
     this.rootPassword = rootPassword;
-    this.hadoopConf = new Configuration();
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/InitialConfiguration.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Joiner;
 
-class InitialConfiguration {
+public class InitialConfiguration {
 
   // config only for root table
   private final HashMap<String,String> initialRootConf = new HashMap<>();
@@ -57,7 +57,7 @@ class InitialConfiguration {
   private final Configuration hadoopConf;
   private final SiteConfiguration siteConf;
 
-  InitialConfiguration(Configuration hadoopConf, SiteConfiguration siteConf) {
+  public InitialConfiguration(Configuration hadoopConf, SiteConfiguration siteConf) {
     this.hadoopConf = hadoopConf;
     this.siteConf = siteConf;
     initialRootConf.put(Property.TABLE_COMPACTION_DISPATCHER.getKey(),

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -130,7 +130,7 @@ public class Initialize implements KeywordExecutable {
         initConfig.get(Property.INSTANCE_VOLUMES));
   }
 
-  private boolean doInit(ZooReaderWriter zoo, Opts opts, VolumeManager fs,
+  public boolean doInit(ZooReaderWriter zoo, Opts opts, VolumeManager fs,
       InitialConfiguration initConfig) {
     String instanceNamePath;
     String instanceName;
@@ -443,7 +443,7 @@ public class Initialize implements KeywordExecutable {
     return createDirs(fs, instanceId, uinitializedDirs);
   }
 
-  private static class Opts extends Help {
+  public static class Opts extends Help {
     @Parameter(names = "--add-volumes",
         description = "Initialize any uninitialized volumes listed in instance.volumes")
     boolean addVolumes = false;


### PR DESCRIPTION
* Refactor MiniAccumuloClusterImpl to call Initialize code directly instead of running in a separate process
* Also clean up some code in MiniAccumuloConfigImpl.useExistingInstance()