### PR TITLE
Add missing logic to Configuration.getProperties

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientConfConverter.java
@@ -205,10 +205,14 @@ public class ClientConfConverter {
       @Override
       public void getProperties(Map<String,String> props, String... properties) {
         defaults.getProperties(props, properties);
-        for (String p : properties) {
-          String value = config.getString(p);
-          if (value != null) {
-            props.put(p, value);
+        if (properties == null || properties.length == 0) {
+          config.getKeys().forEachRemaining(key -> props.put(key, config.getString(key)));
+        } else {
+          for (String p : properties) {
+            String value = config.getString(p);
+            if (value != null) {
+              props.put(p, value);
+            }
           }
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -264,10 +264,14 @@ public class SiteConfiguration extends AccumuloConfiguration {
   @Override
   public void getProperties(Map<String,String> props, String... properties) {
     parent.getProperties(props, properties);
-    for (String p : properties) {
-      String value = config.get(p);
-      if (value != null) {
-        props.put(p, value);
+    if (properties == null || properties.length == 0) {
+      props.putAll(config);
+    } else {
+      for (String p : properties) {
+        String value = config.get(p);
+        if (value != null) {
+          props.put(p, value);
+        }
       }
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ZooBasedConfiguration.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ZooBasedConfiguration.java
@@ -125,10 +125,14 @@ public class ZooBasedConfiguration extends AccumuloConfiguration {
   public void getProperties(Map<String,String> props, String... properties) {
     parent.getProperties(props, properties);
     Map<String,String> theseProps = getSnapshot();
-    for (String p : properties) {
-      String value = theseProps.get(p);
-      if (value != null) {
-        props.put(p, value);
+    if (properties == null || properties.length == 0) {
+      props.putAll(theseProps);
+    } else {
+      for (String p : properties) {
+        String value = theseProps.get(p);
+        if (value != null) {
+          props.put(p, value);
+        }
       }
     }
   }


### PR DESCRIPTION
#2834  added a getProperties method to AccumuloConfiguration.
Most of the implementations handled the case where the varargs
parameter is null or empty. This commit adds the same
logic to the classes where it was missing

Related to #2834