### PR TITLE
Fix additional spotbugs errors in core

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RegExFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RegExFilter.java
@@ -35,6 +35,8 @@ import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * A Filter that matches entries based on Java regular expressions.
  */
@@ -169,6 +171,8 @@ public class RegExFilter extends Filter {
   }
 
   @Override
+  @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+      justification = "Pattern.compile used to validate - no matching performed")
   public boolean validateOptions(Map<String,String> options) {
     if (!super.validateOptions(options))
       return false;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
@@ -115,9 +115,9 @@ public class MetadataLocationObtainer implements TabletLocationObtainer {
         range = new Range(results.lastKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME),
             true, new Key(stopRow).followingKey(PartialKey.ROW), false);
         encodedResults.clear();
-        more = ThriftScanner.getBatchFromServer(context, range, src.tablet_extent,
-            src.tablet_location, encodedResults, locCols, serverSideIteratorList,
-            serverSideIteratorOptions, Constants.SCAN_BATCH_SIZE, Authorizations.EMPTY, 0L, null);
+        ThriftScanner.getBatchFromServer(context, range, src.tablet_extent, src.tablet_location,
+            encodedResults, locCols, serverSideIteratorList, serverSideIteratorOptions,
+            Constants.SCAN_BATCH_SIZE, Authorizations.EMPTY, 0L, null);
 
         decodeRows(encodedResults, results);
       }

--- a/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/LocalityGroupUtil.java
@@ -54,6 +54,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class LocalityGroupUtil {
 
   private static final Logger log = LoggerFactory.getLogger(LocalityGroupUtil.class);
@@ -274,6 +276,8 @@ public class LocalityGroupUtil {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_UNUSUAL",
+        justification = "method expected to be unused or overridden")
     public boolean equals(Object o) {
       throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ZooStore.java
@@ -208,7 +208,7 @@ public class ZooStore<T> implements TStore<T> {
           }
         }
       }
-    } catch (Exception e) {
+    } catch (InterruptedException | KeeperException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/client/ClientPropertiesTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/ClientPropertiesTest.java
@@ -42,7 +42,7 @@ public class ClientPropertiesTest {
     ClientProperty.validate(props1);
 
     Properties props2 =
-        Accumulo.newClientProperties().from(props1).as("user2", Paths.get("/path2")).build();
+        Accumulo.newClientProperties().from(props1).as("user2", Paths.get("./path2")).build();
 
     // verify props1 is unchanged
     assertEquals("inst1", ClientProperty.INSTANCE_NAME.getValue(props1));
@@ -56,7 +56,7 @@ public class ClientPropertiesTest {
     assertEquals("zoo1", ClientProperty.INSTANCE_ZOOKEEPERS.getValue(props2));
     assertEquals("user2", ClientProperty.AUTH_PRINCIPAL.getValue(props2));
     assertEquals("kerberos", ClientProperty.AUTH_TYPE.getValue(props2));
-    assertEquals("/path2", ClientProperty.AUTH_TOKEN.getValue(props2));
+    assertEquals("./path2", ClientProperty.AUTH_TOKEN.getValue(props2));
 
     props2.remove(ClientProperty.AUTH_PRINCIPAL.getKey());
     var e = assertThrows(IllegalArgumentException.class, () -> ClientProperty.validate(props2));

--- a/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/balancer/TableLoadBalancerTest.java
@@ -81,7 +81,7 @@ public class TableLoadBalancerTest {
     return new TServerStatusImpl(thriftStatus);
   }
 
-  static SortedMap<TabletServerId,TServerStatus> state;
+  private static final SortedMap<TabletServerId,TServerStatus> state = new TreeMap<>();
 
   static List<TabletStatistics> generateFakeTablets(TabletServerId tserver, TableId tableId) {
     List<TabletStatistics> result = new ArrayList<>();
@@ -133,7 +133,7 @@ public class TableLoadBalancerTest {
 
     String t1Id = TABLE_ID_MAP.get("t1"), t2Id = TABLE_ID_MAP.get("t2"),
         t3Id = TABLE_ID_MAP.get("t3");
-    state = new TreeMap<>();
+    state.clear();
     TabletServerId svr = mkts("10.0.0.1", 1234, "0x01020304");
     state.put(svr, status(t1Id, 10, t2Id, 10, t3Id, 10));
 

--- a/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.core.spi.fs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.IOException;
 import java.util.Set;
 
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
@@ -62,7 +61,7 @@ public class SpaceAwareVolumeChooserTest {
   }
 
   private void testSpecificSetup(long percentage1, long percentage2, String cacheDuration,
-      int timesToCallPreferredVolumeChooser, boolean anyTimes) throws IOException {
+      int timesToCallPreferredVolumeChooser, boolean anyTimes) {
     int max = iterations + 1;
     int min = 1;
     int updatePropertyMax = timesToCallPreferredVolumeChooser + iterations;
@@ -99,75 +98,75 @@ public class SpaceAwareVolumeChooserTest {
   }
 
   @Test
-  public void testEvenWeightsWithCaching() throws IOException {
+  public void testEvenWeightsWithCaching() {
 
     testSpecificSetup(10L, 10L, null, iterations, false);
 
     makeChoices();
 
-    assertEquals(iterations / 2, vol1Count, iterations / 10);
-    assertEquals(iterations / 2, vol2Count, iterations / 10);
+    assertEquals(iterations / 2.0, vol1Count, iterations / 10.0);
+    assertEquals(iterations / 2.0, vol2Count, iterations / 10.0);
 
   }
 
   @Test
-  public void testEvenWeightsNoCaching() throws IOException {
+  public void testEvenWeightsNoCaching() {
 
     testSpecificSetup(10L, 10L, "0", iterations, true);
 
     makeChoices();
 
-    assertEquals(iterations / 2, vol1Count, iterations / 10);
-    assertEquals(iterations / 2, vol2Count, iterations / 10);
+    assertEquals(iterations / 2.0, vol1Count, iterations / 10.0);
+    assertEquals(iterations / 2.0, vol2Count, iterations / 10.0);
 
   }
 
   @Test
-  public void testNoFreeSpace() throws IOException {
+  public void testNoFreeSpace() {
     testSpecificSetup(0L, 0L, null, 1, false);
     assertThrows(UncheckedExecutionException.class, this::makeChoices);
   }
 
   @Test
-  public void testNinetyTen() throws IOException {
+  public void testNinetyTen() {
 
     testSpecificSetup(90L, 10L, null, iterations, false);
 
     makeChoices();
 
-    assertEquals(iterations * .9, vol1Count, iterations / 10);
-    assertEquals(iterations * .1, vol2Count, iterations / 10);
+    assertEquals(iterations * .9, vol1Count, iterations / 10.0);
+    assertEquals(iterations * .1, vol2Count, iterations / 10.0);
 
   }
 
   @Test
-  public void testTenNinety() throws IOException {
+  public void testTenNinety() {
 
     testSpecificSetup(10L, 90L, null, iterations, false);
 
     makeChoices();
 
-    assertEquals(iterations * .1, vol1Count, iterations / 10);
-    assertEquals(iterations * .9, vol2Count, iterations / 10);
+    assertEquals(iterations * .1, vol1Count, iterations / 10.0);
+    assertEquals(iterations * .9, vol2Count, iterations / 10.0);
 
   }
 
   @Test
-  public void testWithNoCaching() throws IOException {
+  public void testWithNoCaching() {
 
     testSpecificSetup(10L, 90L, "0", iterations, true);
 
     makeChoices();
 
-    assertEquals(iterations * .1, vol1Count, iterations / 10);
-    assertEquals(iterations * .9, vol2Count, iterations / 10);
+    assertEquals(iterations * .1, vol1Count, iterations / 10.0);
+    assertEquals(iterations * .9, vol2Count, iterations / 10.0);
 
   }
 
   private void makeChoices() {
     SpaceAwareVolumeChooser chooser = new SpaceAwareVolumeChooser() {
       @Override
-      protected double getFreeSpace(String uri) throws IOException {
+      protected double getFreeSpace(String uri) {
         if (uri.equals(volumeOne))
           return free1;
         if (uri.equals(volumeTwo))

--- a/core/src/test/java/org/apache/accumulo/core/util/PreAllocatedArrayTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/PreAllocatedArrayTest.java
@@ -27,6 +27,10 @@ import java.util.Iterator;
 
 import org.junit.jupiter.api.Test;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+    justification = "lambda assertThrows testing exception thrown")
 public class PreAllocatedArrayTest {
 
   /**
@@ -97,14 +101,16 @@ public class PreAllocatedArrayTest {
   @Test
   public void testGetIndexHigh() {
     PreAllocatedArray<String> strings = new PreAllocatedArray<>(3);
-    strings.get(2);
+    assertNull(strings.get(2));
+    // spotbugs error suppressed at class level for lambda
     assertThrows(IndexOutOfBoundsException.class, () -> strings.get(3));
   }
 
   @Test
   public void testGetIndexNegative() {
     PreAllocatedArray<String> strings = new PreAllocatedArray<>(3);
-    strings.get(0);
+    assertNull(strings.get(0));
+    // spotbugs error suppressed at class level for lambda
     assertThrows(IndexOutOfBoundsException.class, () -> strings.get(-3));
   }
 }

--- a/core/src/test/java/org/apache/accumulo/fate/util/RetryTest.java
+++ b/core/src/test/java/org/apache/accumulo/fate/util/RetryTest.java
@@ -81,7 +81,7 @@ public class RetryTest {
     for (int i = 0; i < MAX_RETRIES; i++) {
       assertEquals(i, retry.retriesCompleted());
       // canRetry doesn't alter retry's state
-      retry.canRetry();
+      assertTrue(retry.canRetry());
       assertEquals(i, retry.retriesCompleted());
       // Using the retry will increase the internal count
       retry.useRetry();


### PR DESCRIPTION
Fix spotbugs errors identified by temporarily setting the spotbugs effort maxRank at 17 (normally 16).  In core, there are 35 errors identified - this PR address 17 of them.

<details>
  <summary>Fixed errors - Click to expand!</summary>
  
  - [ERROR] Medium: Hard coded reference to an absolute pathname in org.apache.accumulo.core.client.ClientPropertiesTest.testBasic() [org.apache.accumulo.core.client.ClientPropertiesTest] At ClientPropertiesTest.java:[line 45] DMI_HARDCODED_ABSOLUTE_FILENAME
  - [ERROR] Medium: Return value of java.util.regex.Pattern.matcher(CharSequence) ignored, but method has no side effect [org.apache.accumulo.core.iterators.user.RegExFilter, org.apache.accumulo.core.iterators.user.RegExFilter, org.apache.accumulo.core.iterators.user.RegExFilter, org.apache.accumulo.core.iterators.user.RegExFilter] At RegExFilter.java:[line 178]Another occurrence at RegExFilter.java:[line 181]Another occurrence at RegExFilter.java:[line 184]Another occurrence at RegExFilter.java:[line 187] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
  - [ERROR] Medium: Dead store to more in org.apache.accumulo.core.metadata.MetadataLocationObtainer.lookupTablet(ClientContext, TabletLocator$TabletLocation, Text, Text, TabletLocator) [org.apache.accumulo.core.metadata.MetadataLocationObtainer] At MetadataLocationObtainer.java:[line 118] DLS_DEAD_LOCAL_STORE
  - [ERROR] Medium: Write to static field org.apache.accumulo.core.spi.balancer.TableLoadBalancerTest.state from instance method org.apache.accumulo.core.spi.balancer.TableLoadBalancerTest.test() [org.apache.accumulo.core.spi.balancer.TableLoadBalancerTest] At TableLoadBalancerTest.java:[line 136] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
  - [ERROR] Medium: Integral division result cast to double or float in org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest.testEvenWeightsNoCaching() [org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest, org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest] At SpaceAwareVolumeChooserTest.java:[line 120]Another occurrence at SpaceAwareVolumeChooserTest.java:[line 121] ICAST_IDIV_CAST_TO_DOUBLE
  - [ERROR] Medium: Integral division result cast to double or float in org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest.testEvenWeightsWithCaching() [org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest, org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest] At SpaceAwareVolumeChooserTest.java:[line 108]Another occurrence at SpaceAwareVolumeChooserTest.java:[line 109] ICAST_IDIV_CAST_TO_DOUBLE
  - [ERROR] Medium: Integral division result cast to double or float in org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest.testNinetyTen() [org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest, org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest] At SpaceAwareVolumeChooserTest.java:[line 138]Another occurrence at SpaceAwareVolumeChooserTest.java:[line 139] ICAST_IDIV_CAST_TO_DOUBLE
  - [ERROR] Medium: Integral division result cast to double or float in org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest.testTenNinety() [org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest, org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest] At SpaceAwareVolumeChooserTest.java:[line 150]Another occurrence at SpaceAwareVolumeChooserTest.java:[line 151] ICAST_IDIV_CAST_TO_DOUBLE
  - [ERROR] Medium: Integral division result cast to double or float in org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest.testWithNoCaching() [org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest, org.apache.accumulo.core.spi.fs.SpaceAwareVolumeChooserTest] At SpaceAwareVolumeChooserTest.java:[line 162]Another occurrence at SpaceAwareVolumeChooserTest.java:[line 163] ICAST_IDIV_CAST_TO_DOUBLE
  - [ERROR] Medium: org.apache.accumulo.core.util.LocalityGroupUtil$PartitionedMutation.equals(Object) is unusual [org.apache.accumulo.core.util.LocalityGroupUtil$PartitionedMutation] At LocalityGroupUtil.java:[line 278] EQ_UNUSUAL
  - [ERROR] Medium: Return value of PreAllocatedArray.get(int) ignored, but method has no side effect [org.apache.accumulo.core.util.PreAllocatedArrayTest] At PreAllocatedArrayTest.java:[line 101] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
  - [ERROR] Medium: Return value of PreAllocatedArray.get(int) ignored, but method has no side effect [org.apache.accumulo.core.util.PreAllocatedArrayTest] At PreAllocatedArrayTest.java:[line 108] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
  - [ERROR] Medium: Return value of PreAllocatedArray.get(int) ignored, but method has no side effect [org.apache.accumulo.core.util.PreAllocatedArrayTest] At PreAllocatedArrayTest.java:[line 100] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
  - [ERROR] Medium: Return value of PreAllocatedArray.get(int) ignored, but method has no side effect [org.apache.accumulo.core.util.PreAllocatedArrayTest] At PreAllocatedArrayTest.java:[line 107] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
  - [ERROR] Medium: Exception is caught when Exception is not thrown in org.apache.accumulo.fate.ZooStore.reserve() [org.apache.accumulo.fate.ZooStore] At ZooStore.java:[line 211] REC_CATCH_EXCEPTION
  - [ERROR] Medium: Return value of Retry.canRetry() ignored, but method has no side effect [org.apache.accumulo.fate.util.RetryTest] At RetryTest.java:[line 84] RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT

</details>