### PR TITLE
fix code style warnings in Shell code

### DIFF
--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -72,10 +72,6 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-vfs2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-api</artifactId>
     </dependency>

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -1089,7 +1089,7 @@ public class Shell extends ShellOptions implements KeywordExecutable {
   }
 
   public static String repeat(String s, int c) {
-    return String.valueOf(s).repeat(Math.max(0, c));
+    return s.repeat(Math.max(0, c));
   }
 
   public void checkTableState() {


### PR DESCRIPTION
These changes should not modify the behavior.  (Noticed the class had a lot of warning while working something else)  

This fixes all but two - wanting to autoclose the terminal printWriter (line 986 - wants a try-with-resources) and an empty if (line 786) but changing the condition removing that seemed make the code more confusing.