### PR TITLE
Add empty method to CloneConfiguration API

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/CloneConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/CloneConfiguration.java
@@ -35,14 +35,14 @@ public interface CloneConfiguration {
    *
    * @return true if memory is flushed in the source table before cloning.
    */
-  public boolean isFlush();
+  boolean isFlush();
 
   /**
    * The source table properties are copied. This allows overriding of some of those properties.
    *
    * @return The source table properties to override.
    */
-  public Map<String,String> getPropertiesToSet();
+  Map<String,String> getPropertiesToSet();
 
   /**
    * The source table properties are copied, this allows reverting to system defaults for some of
@@ -50,7 +50,7 @@ public interface CloneConfiguration {
    *
    * @return The properties that are to be reverted to system defaults.
    */
-  public Set<String> getPropertiesToExclude();
+  Set<String> getPropertiesToExclude();
 
   /**
    * The new table is normally brought online after the cloning process. This allows leaving the new
@@ -58,21 +58,21 @@ public interface CloneConfiguration {
    *
    * @return true if the new table is to be kept offline after cloning.
    */
-  public boolean isKeepOffline();
+  boolean isKeepOffline();
 
   /**
    * A CloneConfiguration builder
    *
    * @since 1.10 and 2.1
    */
-  public static interface Builder {
+  interface Builder {
     /**
      * Determines if memory is flushed in the source table before cloning.
      *
      * @param flush
      *          true if memory is flushed in the source table before cloning.
      */
-    public Builder setFlush(boolean flush);
+    Builder setFlush(boolean flush);
 
     /**
      * The source table properties are copied. This allows overriding of some of those properties.
@@ -80,7 +80,7 @@ public interface CloneConfiguration {
      * @param propertiesToSet
      *          The source table properties to override.
      */
-    public Builder setPropertiesToSet(Map<String,String> propertiesToSet);
+    Builder setPropertiesToSet(Map<String,String> propertiesToSet);
 
     /**
      * The source table properties are copied, this allows reverting to system defaults for some of
@@ -89,7 +89,7 @@ public interface CloneConfiguration {
      * @param propertiesToExclude
      *          The properties that are to be reverted to system defaults.
      */
-    public Builder setPropertiesToExclude(Set<String> propertiesToExclude);
+    Builder setPropertiesToExclude(Set<String> propertiesToExclude);
 
     /**
      * The new table is normally brought online after the cloning process. This allows leaving the
@@ -98,21 +98,29 @@ public interface CloneConfiguration {
      * @param keepOffline
      *          true if the new table is to be kept offline after cloning.
      */
-    public Builder setKeepOffline(boolean keepOffline);
+    Builder setKeepOffline(boolean keepOffline);
 
     /**
      * Build the clone configuration
      *
      * @return the built immutable clone configuration
      */
-    public CloneConfiguration build();
+    CloneConfiguration build();
   }
 
   /**
    * @return a {@link CloneConfiguration} builder
    */
-  public static CloneConfiguration.Builder builder() {
+  static CloneConfiguration.Builder builder() {
     return new CloneConfigurationImpl();
+  }
+
+  /**
+   * @return an empty configuration object with the default settings.
+   * @since 2.1.0
+   */
+  static CloneConfiguration empty() {
+    return builder().build();
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/CloneConfigurationImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/CloneConfigurationImpl.java
@@ -33,8 +33,7 @@ import com.google.common.base.Preconditions;
  */
 public class CloneConfigurationImpl implements CloneConfiguration, CloneConfiguration.Builder {
 
-  // The purpose of this is to allow building an immutable CloneConfiguration object without
-  // creating
+  // This boolean allows building an immutable CloneConfiguration object without creating
   // separate Builder and CloneConfiguration objects. This is done to reduce object creation and
   // copying. This could easily be changed to two objects without changing the interfaces.
   private boolean built = false;
@@ -62,14 +61,14 @@ public class CloneConfigurationImpl implements CloneConfiguration, CloneConfigur
   @Override
   public Map<String,String> getPropertiesToSet() {
     Preconditions.checkState(built);
-    return (propertiesToSet == null ? Collections.<String,String>emptyMap()
+    return (propertiesToSet == null ? Collections.emptyMap()
         : Collections.unmodifiableMap(propertiesToSet));
   }
 
   @Override
   public Set<String> getPropertiesToExclude() {
     Preconditions.checkState(built);
-    return (propertiesToExclude == null ? Collections.<String>emptySet()
+    return (propertiesToExclude == null ? Collections.emptySet()
         : Collections.unmodifiableSet(propertiesToExclude));
   }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -301,9 +301,9 @@ class FateServiceHandler implements FateService.Iface {
         Set<String> propertiesToExclude = new HashSet<>();
 
         for (Entry<String,String> entry : options.entrySet()) {
-          if (entry.getKey().startsWith(TableOperationsImpl.CLONE_EXCLUDE_PREFIX)) {
-            propertiesToExclude
-                .add(entry.getKey().substring(TableOperationsImpl.CLONE_EXCLUDE_PREFIX.length()));
+          if (entry.getKey().startsWith(TableOperationsImpl.PROPERTY_EXCLUDE_PREFIX)) {
+            propertiesToExclude.add(
+                entry.getKey().substring(TableOperationsImpl.PROPERTY_EXCLUDE_PREFIX.length()));
             continue;
           }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CloneTestIT.java
@@ -318,7 +318,7 @@ public class CloneTestIT extends AccumuloClusterHarness {
         bw.addMutations(mutations);
       }
 
-      client.tableOperations().clone(tables[0], tables[1], true, null, null);
+      client.tableOperations().clone(tables[0], tables[1], CloneConfiguration.empty());
 
       client.tableOperations().deleteRows(tables[1], new Text("4"), new Text("8"));
 
@@ -338,15 +338,15 @@ public class CloneTestIT extends AccumuloClusterHarness {
   public void testCloneRootTable() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       assertThrows(AccumuloException.class,
-          () -> client.tableOperations().clone(RootTable.NAME, "rc1", true, null, null));
+          () -> client.tableOperations().clone(RootTable.NAME, "rc1", CloneConfiguration.empty()));
     }
   }
 
   @Test
   public void testCloneMetadataTable() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
-      assertThrows(AccumuloException.class,
-          () -> client.tableOperations().clone(MetadataTable.NAME, "mc1", true, null, null));
+      assertThrows(AccumuloException.class, () -> client.tableOperations().clone(MetadataTable.NAME,
+          "mc1", CloneConfiguration.empty()));
     }
   }
 }


### PR DESCRIPTION
* Add new convenience method for empty object and use in CloneTestIT
* Create private methods for sharing in TableOperationsImpl
* Clean up on the CloneConfiguration interface