### PR TITLE
Add log messages to initialization, checkstyle fixes

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -294,10 +294,10 @@ public class Initialize implements KeywordExecutable {
         } else {
           success = fs.createNewFile(iidPath);
           // the exists() call provides positive check that the instanceId file is present
-          if (!success || fs.exists(iidPath)) {
+          if (success && fs.exists(iidPath)) {
             log.info("Created instanceId file {} in hdfs", iidPath);
           } else {
-            log.warn("Failed to create instanceId file {} in hdfs", iidPath);
+            log.warn("May have failed to create instanceId file {} in hdfs", iidPath);
           }
         }
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -405,7 +405,7 @@ public class Initialize implements KeywordExecutable {
 
   /**
    * Create warning message related to initial password, if appropriate.
-   * </p>
+   * <p>
    * ACCUMULO-2907 Remove unnecessary security warning from console message unless its actually
    * appropriate. The warning message should only be displayed when the value of
    * <code>instance.security.authenticator</code> differs between the SiteConfiguration and the

--- a/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/Initialize.java
@@ -254,8 +254,7 @@ public class Initialize implements KeywordExecutable {
   /**
    * Create the version directory and the instance id path and file. The method tries to create the
    * directories and instance id file for all base directories provided unless an IOException is
-   * thrown. The IOException is not rethrown, but the method not try to create additional entries
-   * and will return false.
+   * thrown. If an IOException occurs, this method won't retry and will return false.
    *
    * @return false if an IOException occurred, true otherwise.
    */


### PR DESCRIPTION
Logs when instance id is written to hdfs

  - Add checking for successful file instance id creation
  - Other checkstyle fixes

Supplements changes made in https://github.com/apache/accumulo/pull/2873