### PR TITLE
Fix AccumuloConfiguration.get(String) to get Property by key

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/AccumuloConfiguration.java
@@ -80,10 +80,10 @@ public abstract class AccumuloConfiguration implements Iterable<Entry<String,Str
    * @return property value
    */
   public String get(String property) {
-    try {
-      return get(Property.valueOf(property));
-    } catch (IllegalArgumentException e) {
-      // Could be a client or custom property, fall back to filtering
+    Property p = Property.getPropertyByKey(property);
+    if (p != null) {
+      return get(p);
+    } else {
       Map<String,String> propMap = new HashMap<>(1);
       getProperties(propMap, key -> Objects.equals(property, key));
       return propMap.get(property);


### PR DESCRIPTION
Prior commit attempted to create a Property by enum value using the key.
Fixed this to call Property.getPropertyByKey instead.