### PR TITLE
Cleanup Accumulo Admin utilities

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -238,8 +238,8 @@ public class Admin implements KeywordExecutable {
     DumpConfigCommand dumpConfigCommand = new DumpConfigCommand();
     cl.addCommand("dumpConfig", dumpConfigCommand);
 
-    ListInstancesCommand listIntancesOpts = new ListInstancesCommand();
-    cl.addCommand("listInstances", listIntancesOpts);
+    ListInstancesCommand listInstancesOpts = new ListInstancesCommand();
+    cl.addCommand("listInstances", listInstancesOpts);
 
     TabletServerLocksCommand tServerLocksOpts = new TabletServerLocksCommand();
     cl.addCommand("locks", tServerLocksOpts);
@@ -292,8 +292,8 @@ public class Admin implements KeywordExecutable {
       int rc = 0;
 
       if (cl.getParsedCommand().equals("listInstances")) {
-        ListInstances.listInstances(context.getZooKeepers(), listIntancesOpts.printAll,
-            listIntancesOpts.printErrors);
+        ListInstances.listInstances(context.getZooKeepers(), listInstancesOpts.printAll,
+            listInstancesOpts.printErrors);
       } else if (cl.getParsedCommand().equals("ping")) {
         if (ping(context, pingCommand.args) != 0)
           rc = 4;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -226,48 +226,51 @@ public class Admin implements KeywordExecutable {
     JCommander cl = new JCommander(opts);
     cl.setProgramName("accumulo admin");
 
-    CheckTabletsCommand checkTabletsCommand = new CheckTabletsCommand();
-    cl.addCommand("checkTablets", checkTabletsCommand);
-
     ChangeSecretCommand changeSecretCommand = new ChangeSecretCommand();
     cl.addCommand("changeSecret", changeSecretCommand);
+
+    CheckTabletsCommand checkTabletsCommand = new CheckTabletsCommand();
+    cl.addCommand("checkTablets", checkTabletsCommand);
 
     DeleteZooInstanceCommand deleteZooInstanceOpts = new DeleteZooInstanceCommand();
     cl.addCommand("deleteZooInstance", deleteZooInstanceOpts);
 
-    RestoreZooCommand restoreZooOpts = new RestoreZooCommand();
-    cl.addCommand("restoreZoo", restoreZooOpts);
+    DumpConfigCommand dumpConfigCommand = new DumpConfigCommand();
+    cl.addCommand("dumpConfig", dumpConfigCommand);
 
     ListInstancesCommand listIntancesOpts = new ListInstancesCommand();
     cl.addCommand("listInstances", listIntancesOpts);
 
+    TabletServerLocksCommand tServerLocksOpts = new TabletServerLocksCommand();
+    cl.addCommand("locks", tServerLocksOpts);
+
     PingCommand pingCommand = new PingCommand();
     cl.addCommand("ping", pingCommand);
 
-    DumpConfigCommand dumpConfigCommand = new DumpConfigCommand();
-    cl.addCommand("dumpConfig", dumpConfigCommand);
-
-    VolumesCommand volumesCommand = new VolumesCommand();
-    cl.addCommand("volumes", volumesCommand);
-
-    StopCommand stopOpts = new StopCommand();
-    cl.addCommand("stop", stopOpts);
-    StopAllCommand stopAllOpts = new StopAllCommand();
-    cl.addCommand("stopAll", stopAllOpts);
-    StopManagerCommand stopManagerOpts = new StopManagerCommand();
-    cl.addCommand("stopManager", stopManagerOpts);
-    StopMasterCommand stopMasterOpts = new StopMasterCommand();
-    cl.addCommand("stopMaster", stopMasterOpts);
+    RestoreZooCommand restoreZooOpts = new RestoreZooCommand();
+    cl.addCommand("restoreZoo", restoreZooOpts);
 
     RandomizeVolumesCommand randomizeVolumesOpts = new RandomizeVolumesCommand();
     cl.addCommand("randomizeVolumes", randomizeVolumesOpts);
 
-    TabletServerLocksCommand tServerLocksOpts = new TabletServerLocksCommand();
-    cl.addCommand("locks", tServerLocksOpts);
+    StopCommand stopOpts = new StopCommand();
+    cl.addCommand("stop", stopOpts);
+
+    StopAllCommand stopAllOpts = new StopAllCommand();
+    cl.addCommand("stopAll", stopAllOpts);
+
+    StopManagerCommand stopManagerOpts = new StopManagerCommand();
+    cl.addCommand("stopManager", stopManagerOpts);
+
+    StopMasterCommand stopMasterOpts = new StopMasterCommand();
+    cl.addCommand("stopMaster", stopMasterOpts);
 
     VerifyTabletAssignmentsCommand verifyTabletAssignmentsOpts =
         new VerifyTabletAssignmentsCommand();
     cl.addCommand("verifyTabletAssigns", verifyTabletAssignmentsOpts);
+
+    VolumesCommand volumesCommand = new VolumesCommand();
+    cl.addCommand("volumes", volumesCommand);
 
     cl.parse(args);
 
@@ -318,17 +321,16 @@ public class Admin implements KeywordExecutable {
       } else if (cl.getParsedCommand().equals("randomizeVolumes")) {
         System.out.println(RV_DEPRECATION_MSG);
       } else if (cl.getParsedCommand().equals("verifyTabletAssigns")) {
-        VerifyTabletAssignments.verifyTableAssignments(opts.getClientProps(),
-            verifyTabletAssignmentsOpts.verbose);
+        VerifyTabletAssignments.execute(opts.getClientProps(), verifyTabletAssignmentsOpts.verbose);
       } else if (cl.getParsedCommand().equals("changeSecret")) {
-        ChangeSecret.changeSecret(context, conf);
+        ChangeSecret.execute(context, conf);
       } else if (cl.getParsedCommand().equals("deleteZooInstance")) {
-        DeleteZooInstance.deleteZooInstance(deleteZooInstanceOpts.instance);
+        DeleteZooInstance.execute(deleteZooInstanceOpts.instance);
       } else if (cl.getParsedCommand().equals("restoreZoo")) {
-        RestoreZookeeper.restoreZookeeper(conf, restoreZooOpts.file, restoreZooOpts.overwrite);
+        RestoreZookeeper.execute(conf, restoreZooOpts.file, restoreZooOpts.overwrite);
       } else if (cl.getParsedCommand().equals("locks")) {
-        TabletServerLocks.tabletServerLocks("accumulo locks", context,
-            args.length > 2 ? args[2] : null, tServerLocksOpts.delete);
+        TabletServerLocks.execute(context, args.length > 2 ? args[2] : null,
+            tServerLocksOpts.delete);
       } else {
         everything = cl.getParsedCommand().equals("stopAll");
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.volume.Volume;
@@ -37,7 +36,6 @@ import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.ServerDirs;
-import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -55,16 +53,7 @@ import io.opentelemetry.context.Scope;
 
 public class ChangeSecret {
 
-  public static void main(String[] args) throws Exception {
-    var siteConfig = SiteConfiguration.auto();
-    ServerUtilOpts opts = new ServerUtilOpts();
-    opts.parseArgs(ChangeSecret.class.getName(), args);
-
-    ServerContext context = opts.getServerContext();
-    changeSecret(context, siteConfig);
-  }
-
-  public static void changeSecret(final ServerContext context, final AccumuloConfiguration conf)
+  public static void execute(final ServerContext context, final AccumuloConfiguration conf)
       throws Exception {
 
     try (var fs = context.getVolumeManager()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/DeleteZooInstance.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/DeleteZooInstance.java
@@ -25,20 +25,12 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
 import org.apache.zookeeper.KeeperException;
 
-import com.beust.jcommander.Parameter;
-
 public class DeleteZooInstance {
-
-  static class Opts extends Help {
-    @Parameter(names = {"-i", "--instance"}, description = "the instance name or id to delete")
-    String instance;
-  }
 
   static void deleteRetry(ZooReaderWriter zk, String path) throws Exception {
     for (int i = 0; i < 10; i++) {
@@ -53,7 +45,7 @@ public class DeleteZooInstance {
     }
   }
 
-  public static void deleteZooInstance(final String instance) throws Exception {
+  public static void execute(final String instance) throws Exception {
     Objects.requireNonNull(instance, "Instance must not be null");
 
     var zk = new ZooReaderWriter(SiteConfiguration.auto());
@@ -77,16 +69,6 @@ public class DeleteZooInstance {
       }
       deleteRetry(zk, Constants.ZROOT + "/" + instance);
     }
-  }
-
-  /**
-   * @param args
-   *          : the name or UUID of the instance to be deleted
-   */
-  public static void main(String[] args) throws Exception {
-    Opts opts = new Opts();
-    opts.parseArgs(DeleteZooInstance.class.getName(), args);
-    deleteZooInstance(opts.instance);
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/DumpZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/DumpZookeeper.java
@@ -80,6 +80,10 @@ public class DumpZookeeper implements KeywordExecutable {
     }
   }
 
+  public static void main(String[] args) throws KeeperException, InterruptedException {
+    new DumpZookeeper().execute(args);
+  }
+
   private static void writeXml(PrintStream out, String root)
       throws KeeperException, InterruptedException {
     write(out, 0, "<dump root='%s'>", root);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/DumpZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/DumpZookeeper.java
@@ -80,10 +80,6 @@ public class DumpZookeeper implements KeywordExecutable {
     }
   }
 
-  public static void main(String[] args) throws KeeperException, InterruptedException {
-    new DumpZookeeper().execute(args);
-  }
-
   private static void writeXml(PrintStream out, String root)
       throws KeeperException, InterruptedException {
     write(out, 0, "<dump root='%s'>", root);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
@@ -28,16 +28,12 @@ import java.util.Stack;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.zookeeper.KeeperException;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
-
-import com.beust.jcommander.Parameter;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -108,16 +104,9 @@ public class RestoreZookeeper {
     }
   }
 
-  static class Opts extends Help {
-    @Parameter(names = "--overwrite")
-    boolean overwrite = false;
-    @Parameter(names = "--file")
-    String file;
-  }
-
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
       justification = "code runs in same security context as user who provided input")
-  public static void restoreZookeeper(final AccumuloConfiguration conf, final String file,
+  public static void execute(final AccumuloConfiguration conf, final String file,
       final boolean overwrite) throws Exception {
     var zoo = new ZooReaderWriter(conf);
 
@@ -135,9 +124,4 @@ public class RestoreZookeeper {
     in.close();
   }
 
-  public static void main(String[] args) throws Exception {
-    Opts opts = new Opts();
-    opts.parseArgs(RestoreZookeeper.class.getName(), args);
-    restoreZookeeper(SiteConfiguration.auto(), opts.file, opts.overwrite);
-  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/VerifyTabletAssignments.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.clientImpl.ClientContext;
-import org.apache.accumulo.core.clientImpl.thrift.ThriftSecurityException;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -49,20 +48,16 @@ import org.apache.accumulo.core.metadata.MetadataServicer;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.tabletserver.thrift.NoSuchScanIDException;
 import org.apache.accumulo.core.tabletserver.thrift.TabletScanClientService;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.accumulo.server.cli.ServerUtilOpts;
 import org.apache.hadoop.io.Text;
 import org.apache.thrift.TException;
 import org.apache.thrift.TServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.beust.jcommander.Parameter;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
@@ -70,14 +65,7 @@ import io.opentelemetry.context.Scope;
 public class VerifyTabletAssignments {
   private static final Logger log = LoggerFactory.getLogger(VerifyTabletAssignments.class);
 
-  static class Opts extends ServerUtilOpts {
-    @Parameter(names = {"-v", "--verbose"},
-        description = "verbose mode (prints locations of tablets)")
-    boolean verbose = false;
-  }
-
-  public static void verifyTableAssignments(Properties clientProps, boolean verbose)
-      throws Exception {
+  public static void execute(Properties clientProps, boolean verbose) throws Exception {
     Span span = TraceUtil.startSpan(VerifyTabletAssignments.class, "main");
     try (Scope scope = span.makeCurrent()) {
       try (AccumuloClient client = Accumulo.newClient().from(clientProps).build()) {
@@ -87,13 +75,6 @@ public class VerifyTabletAssignments {
         span.end();
       }
     }
-  }
-
-  public static void main(String[] args) throws Exception {
-    Opts opts = new Opts();
-    opts.parseArgs(VerifyTabletAssignments.class.getName(), args);
-    verifyTableAssignments(opts.getClientProps(), opts.verbose);
-
   }
 
   private static void checkTable(final ClientContext context, final boolean verbose,
@@ -165,8 +146,7 @@ public class VerifyTabletAssignments {
   }
 
   private static void checkTabletServer(ClientContext context,
-      Entry<HostAndPort,List<KeyExtent>> entry, HashSet<KeyExtent> failures)
-      throws ThriftSecurityException, TException, NoSuchScanIDException {
+      Entry<HostAndPort,List<KeyExtent>> entry, HashSet<KeyExtent> failures) throws TException {
     TabletScanClientService.Iface client =
         ThriftUtil.getClient(ThriftClientTypes.TABLET_SCAN, entry.getKey(), context);
 


### PR DESCRIPTION
Remove main methods from utilities now that they are exposed through
KeywordExecutable and the accumulo command. Also sort the commands in
the help section alphabetically.