### PR TITLE
Add JVM flag UnlockDiagnosticVMOptions to default JVM options

### DIFF
--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -76,6 +76,7 @@ read -r -a accumulo_initial_opts < <(echo "$ACCUMULO_JAVA_OPTS")
 JAVA_OPTS=(
   '-XX:OnOutOfMemoryError=kill -9 %p'
   '-XX:-OmitStackTraceInFastThrow'
+  '-XX:+UnlockDiagnosticVMOptions'
   '-Djava.net.preferIPv4Stack=true'
   "-Daccumulo.native.lib.path=${lib}/native"
   "${accumulo_initial_opts[@]}"


### PR DESCRIPTION
Was recently working with a customer that was doing some performance testing. Customer was experiencing about a 10x performance decrease vs earlier testing runs. It appears that the JVM flag `-XX:+UnlockDiagnosticVMOptions` was lost between the customer test runs. Based on helping customer debug this and reading about it this JVM flag activates many performance related things to include intrinsics and inlining. To see this you can compare the output of:

    1. `java -XX:+PrintFlagsFinal -version | grep Intrinsic` and `java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -version | grep Intrinsic`, and
    2. `java -XX:+PrintFlagsFinal -version | grep Native`and `java -XX:+PrintFlagsFinal -XX:+UnlockDiagnosticVMOptions -version | grep Native`