### PR TITLE
Source accumulo-env.sh from accumulo-cluster script

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -462,9 +462,16 @@ function main() {
   basedir=$(cd -P "${bin}"/.. && pwd)
   conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
 
+  #
+  # Source accumulo-env.sh to get NUM_TSERVERS, NUM_SSERVERS
+  # Reset CLASSPATH afterwards as it causes an issue when starting
+  # services on localhost
+  #
   if [[ -f "${conf}/accumulo-env.sh" ]]; then
+    OLD_CLASSPATH=$CLASSPATH
     #shellcheck source=../conf/accumulo-env.sh
     source "${conf}/accumulo-env.sh"
+    CLASSPATH=$OLD_CLASSPATH
   fi
 
   accumulo_cmd="${bin}/accumulo"

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -462,6 +462,10 @@ function main() {
   basedir=$(cd -P "${bin}"/.. && pwd)
   conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
 
+  if [[ -f "${conf}/accumulo-env.sh" ]]; then
+    source "${conf}/accumulo-env.sh"
+  fi
+
   accumulo_cmd="${bin}/accumulo"
   SSH='ssh -qnf -o ConnectTimeout=2'
 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -463,6 +463,7 @@ function main() {
   conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
 
   if [[ -f "${conf}/accumulo-env.sh" ]]; then
+    #shellcheck source=../conf/accumulo-env.sh
     source "${conf}/accumulo-env.sh"
   fi
 

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -144,3 +144,10 @@ esac
 
 ## Specifies command that will be placed before calls to Java in accumulo script
 # export ACCUMULO_JAVA_PREFIX=""
+
+###############################################
+# Variables used by accumulo-cluster to start
+# multiple server processes per host
+###############################################
+NUM_TSERVERS=1
+NUM_SSERVERS=1

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -149,5 +149,5 @@ esac
 # Variables used by accumulo-cluster to start
 # multiple server processes per host
 ###############################################
-export NUM_TSERVERS=1
-export NUM_SSERVERS=1
+export NUM_TSERVERS=${NUM_TSERVERS:=1}
+export NUM_SSERVERS=${NUM_SSERVERS:=1}

--- a/assemble/conf/accumulo-env.sh
+++ b/assemble/conf/accumulo-env.sh
@@ -149,5 +149,5 @@ esac
 # Variables used by accumulo-cluster to start
 # multiple server processes per host
 ###############################################
-NUM_TSERVERS=1
-NUM_SSERVERS=1
+export NUM_TSERVERS=1
+export NUM_SSERVERS=1


### PR DESCRIPTION
Users can set env vars to control the number of tservers/sservers
started per host. accumulo-env.sh is sourced from other scripts in
bin, except accumulo-cluster. This commit adds the variables to
accumulo-env.sh (with default of 1) and modifies accumulo-cluster
to source the file like the other scripts in bin do.