### PR TITLE
Remove comma separator from FileCompaction log

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -246,8 +246,8 @@ public class FileCompactor implements Callable<CompactionStats> {
       }
 
       log.trace(String.format(
-          "Compaction %s %,d read | %,d written | %,6d entries/sec"
-              + " | %,6.3f secs | %,12d bytes | %9.3f byte/sec",
+          "Compaction %s %d read | %d written | %6d entries/sec"
+              + " | %6.3f secs | %12d bytes | %9.3f byte/sec",
           extent, majCStats.getEntriesRead(), majCStats.getEntriesWritten(),
           (int) (majCStats.getEntriesRead() / ((t2 - t1) / 1000.0)), (t2 - t1) / 1000.0,
           mfwTmp.getLength(), mfwTmp.getLength() / ((t2 - t1) / 1000.0)));


### PR DESCRIPTION
When using log aggregation on a large system having comma separators for decimals adds added complexity when parsing logs and creating fields for the values.