### PR TITLE
Added property to enable Monitor web server to bind to all interfaces

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -872,6 +872,10 @@ public enum Property {
   // properties that are specific to the monitor server behavior
   MONITOR_PREFIX("monitor.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the monitor web server.", "1.3.5"),
+  MONITOR_BIND_ALL_INTERFACES("monitor.bind.all.interfaces", "false", PropertyType.BOOLEAN,
+      "The embedded web server will bind to all interfaces if true instead of binding"
+          + " to the supplied address (-a) or the resolved address for the host.",
+      "2.1.0"),
   MONITOR_PORT("monitor.port.client", "9995", PropertyType.PORT,
       "The listening port for the monitor's http service", "1.3.5"),
   MONITOR_SSL_KEYSTORE("monitor.ssl.keyStore", "", PropertyType.PATH,

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/EmbeddedWebServer.java
@@ -51,7 +51,11 @@ public class EmbeddedWebServer {
     secure = requireForSecure.stream().map(conf::get).allMatch(s -> s != null && !s.isEmpty());
 
     connector = new ServerConnector(server, getConnectionFactories(conf, secure));
-    connector.setHost(monitor.getHostname());
+    if (conf.getBoolean(Property.MONITOR_BIND_ALL_INTERFACES)) {
+      connector.setHost("0.0.0.0");
+    } else {
+      connector.setHost(monitor.getHostname());
+    }
     connector.setPort(port);
 
     handler =


### PR DESCRIPTION
Currently the Monitor uses either the supplied address (-a arg) or the resolved
address for the hostname for advertising it's location in ZooKeeper and the
bind address for the embedded Jetty web server. This commit introduces a new
property that will set the bind address to "0.0.0.0" for the Jetty web server
but will leave the Monitor's ZooKeeper address unchanged. This change is being
made because of some constraints in containerized environments