### PR TITLE
Attempt to make KerberosRenewalIT more stable

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
@@ -211,7 +211,7 @@ public class KerberosRenewalIT extends AccumuloITBase {
     } catch (TableExistsException e) {
       log.debug("Table {} already exists. Deleting and trying again.", tableName);
       client.tableOperations().delete(tableName);
-      createTableAndReturnTableName(client);
+      tableName = createTableAndReturnTableName(client);
     }
     // when the table is successfully created, return its name
     return tableName;

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
@@ -149,19 +149,20 @@ public class KerberosRenewalIT extends AccumuloITBase {
         rootUser.getKeytab().getAbsolutePath());
     log.info("Logged in as {}", rootUser.getPrincipal());
 
-    AccumuloClient client = mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken());
-    log.info("Created client as {}", rootUser.getPrincipal());
-    assertEquals(rootUser.getPrincipal(), client.whoami());
+    try (var client = mac.createAccumuloClient(rootUser.getPrincipal(), new KerberosToken())) {
+      log.info("Created client as {}", rootUser.getPrincipal());
+      assertEquals(rootUser.getPrincipal(), client.whoami());
 
-    long endTime = System.currentTimeMillis() + TICKET_TEST_LIFETIME;
-    final String tableName = getUniqueNames(1)[0] + "_table";
+      long endTime = System.currentTimeMillis() + TICKET_TEST_LIFETIME;
+      final String tableName = getUniqueNames(1)[0] + "_table";
 
-    // Make sure we have a couple renewals happen
-    while (System.currentTimeMillis() < endTime) {
-      // Create a table, write a record, compact, read the record, drop the table.
-      createReadWriteDrop(client, tableName);
-      // Wait a bit after
-      Thread.sleep(5000L);
+      // Make sure we have a couple renewals happen
+      while (System.currentTimeMillis() < endTime) {
+        // Create a table, write a record, compact, read the record, drop the table.
+        createReadWriteDrop(client, tableName);
+        // Wait a bit after
+        Thread.sleep(5000L);
+      }
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
@@ -153,8 +153,8 @@ public class KerberosRenewalIT extends AccumuloITBase {
       log.info("Created client as {}", rootUser.getPrincipal());
       assertEquals(rootUser.getPrincipal(), client.whoami());
 
-      long endTime = System.currentTimeMillis() + TICKET_TEST_LIFETIME;
       final String tableName = getUniqueNames(1)[0] + "_table";
+      long endTime = System.currentTimeMillis() + TICKET_TEST_LIFETIME;
 
       // Make sure we have a couple renewals happen
       while (System.currentTimeMillis() < endTime) {


### PR DESCRIPTION
Recently, KerberosRenewalIT.testReadAndWriteThroughTicketLifetime had failed once on [a jenkins build](https://ci-builds.apache.org/job/Accumulo/job/main/org.apache.accumulo$accumulo-test/388/testReport/junit/org.apache.accumulo.test.functional/KerberosRenewalIT/testReadAndWriteThroughTicketLifetime/). I couldn't find record of this test failing in the past but I figure its an easy enough change to ensure it won't fail again.

Stacktrace:
<details>

```
org.apache.accumulo.core.client.TableExistsException: Table testReadAndWriteThroughTicketLifetime_table exists
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doFateOperation(TableOperationsImpl.java:391)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doFateOperation(TableOperationsImpl.java:359)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doTableFateOperation(TableOperationsImpl.java:1693)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.create(TableOperationsImpl.java:248)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.create(TableOperationsImpl.java:220)
	at org.apache.accumulo.test.functional.KerberosRenewalIT.createReadWriteDrop(KerberosRenewalIT.java:190)
	at org.apache.accumulo.test.functional.KerberosRenewalIT.testReadAndWriteThroughTicketLifetime(KerberosRenewalIT.java:171)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.api.AssertTimeout.lambda$assertTimeoutPreemptively$4(AssertTimeout.java:138)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: ThriftTableOperationException(tableId:null, tableName:testReadAndWriteThroughTicketLifetime_table, op:CREATE, type:EXISTS, description:null)
	at org.apache.accumulo.core.manager.thrift.FateService$waitForFateOperation_result$waitForFateOperation_resultStandardScheme.read(FateService.java:4896)
	at org.apache.accumulo.core.manager.thrift.FateService$waitForFateOperation_result$waitForFateOperation_resultStandardScheme.read(FateService.java:4865)
	at org.apache.accumulo.core.manager.thrift.FateService$waitForFateOperation_result.read(FateService.java:4791)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:88)
	at org.apache.accumulo.core.manager.thrift.FateService$Client.recv_waitForFateOperation(FateService.java:161)
	at org.apache.accumulo.core.manager.thrift.FateService$Client.waitForFateOperation(FateService.java:146)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.waitForFateOperation(TableOperationsImpl.java:306)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doFateOperation(TableOperationsImpl.java:375)
```
</details>

It looks like this test failed because the table already existed for some reason. This test repeatedly creates, uses and deletes a table with the same name. My guess is the table wasn't correctly deleted for some reason on one of those cycles.

The changes in this PR...
* create a method that will delete the table and recursively try to create it again if the table already exists.
* moves a delete table call outside of an unrelated try block.