### PR TITLE
Added servers per host to cluster.yaml

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -121,8 +121,8 @@ function control_service() {
 
   local last_instance_id
   last_instance_id=1
-  [[ $service == "tserver" ]] && last_instance_id=${NUM_TSERVERS:-1}
-  [[ $service == "sserver" ]] && last_instance_id=${NUM_SSERVERS:-1}
+  [[ $service == "tserver" ]] && last_instance_id=${NUM_TSERVERS:-1} && echo "INFO: ${NUM_TSERVERS} tserver per host"
+  [[ $service == "sserver" ]] && last_instance_id=${NUM_SSERVERS:-1} && echo "INFO: ${NUM_SSERVERS} sserver per host"
 
   for ((inst_id = 1; inst_id <= last_instance_id; inst_id++)); do
     ACCUMULO_SERVICE_INSTANCE=""
@@ -497,6 +497,9 @@ tserver:
 #    - q2:
 #        - localhost
 #
+
+tservers_per_host: 1
+sservers_per_host: 1
 
 EOF
       ;;

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -112,6 +112,9 @@ function parse_config {
     GC_HOSTS=$manager1
   fi
 
+  echo "INFO: ${NUM_TSERVERS} tservers will be started per host"
+  echo "INFO: ${NUM_SSERVERS} sservers will be started per host"
+
 }
 
 function control_service() {
@@ -121,8 +124,8 @@ function control_service() {
 
   local last_instance_id
   last_instance_id=1
-  [[ $service == "tserver" ]] && last_instance_id=${NUM_TSERVERS:-1} && echo "INFO: ${NUM_TSERVERS} tserver per host"
-  [[ $service == "sserver" ]] && last_instance_id=${NUM_SSERVERS:-1} && echo "INFO: ${NUM_SSERVERS} sserver per host"
+  [[ $service == "tserver" ]] && last_instance_id=${NUM_TSERVERS:-1}
+  [[ $service == "sserver" ]] && last_instance_id=${NUM_SSERVERS:-1}
 
   for ((inst_id = 1; inst_id <= last_instance_id; inst_id++)); do
     ACCUMULO_SERVICE_INSTANCE=""
@@ -498,6 +501,16 @@ tserver:
 #        - localhost
 #
 
+# The accumulo-cluster script uses the environment variables NUM_TSERVERS and NUM_SSERVERS
+# to control how many of these services are started per host. When this yaml file is parsed
+# by the accumulo-cluster script it will create these environment variables using the values
+# set below. If these configuration settings are not supplied, they both default to 1.
+#
+# The environment variables are specified in such a way as to allow for other values to be
+# set in the environment and to override both the default of 1 and the value set here. For
+# example, the NUM_TSERVER environment variable is set as: NUM_TSERVERS=${NUM_TSERVERS:=1},
+# where "1" is the value from the tservers_per_host setting below.
+#
 tservers_per_host: 1
 sservers_per_host: 1
 

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -506,15 +506,12 @@ tserver:
 #        - localhost
 #
 
-# The accumulo-cluster script uses the environment variables NUM_TSERVERS and NUM_SSERVERS
-# to control how many of these services are started per host. When this yaml file is parsed
-# by the accumulo-cluster script it will create these environment variables using the values
-# set below. If these configuration settings are not supplied, they both default to 1.
 #
-# The environment variables are specified in such a way as to allow for other values to be
-# set in the environment and to override both the default of 1 and the value set here. For
-# example, the NUM_TSERVER environment variable is set as: NUM_TSERVERS=${NUM_TSERVERS:=1},
-# where "1" is the value from the tservers_per_host setting below.
+# The following are used by the accumulo-cluster script to determine how many servers
+# to start on each host. If the following variables are not set, then they default to 1.
+# If the environment variable NUM_TSERVERS is set when running accumulo_cluster
+# then its value will override what is set in this file for tservers_per_host. Likewise if
+# NUM_SSERVERS is set then it will override sservers_per_host.
 #
 tservers_per_host: 1
 sservers_per_host: 1

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -116,6 +116,7 @@ function parse_config {
     echo "INFO: ${NUM_TSERVERS} tservers will be started per host"
   fi
 
+  # shellcheck disable=SC2153
   if [[ -z $NUM_SSERVERS ]]; then
     echo "INFO: ${NUM_SSERVERS} sservers will be started per host"
   fi

--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -112,9 +112,13 @@ function parse_config {
     GC_HOSTS=$manager1
   fi
 
-  echo "INFO: ${NUM_TSERVERS} tservers will be started per host"
-  echo "INFO: ${NUM_SSERVERS} sservers will be started per host"
+  if [[ -z $NUM_TSERVERS ]]; then
+    echo "INFO: ${NUM_TSERVERS} tservers will be started per host"
+  fi
 
+  if [[ -z $NUM_SSERVERS ]]; then
+    echo "INFO: ${NUM_SSERVERS} sservers will be started per host"
+  fi
 }
 
 function control_service() {

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -76,6 +76,9 @@ public class ClusterConfigParser {
       @SuppressWarnings("unchecked")
       Map<String,Object> map = (Map<String,Object>) value;
       map.forEach((k, v) -> flatten(parent + key, k, v, results));
+    } else if (value instanceof Number) {
+      results.put(parent + key, value.toString());
+      return;
     } else {
       throw new RuntimeException("Unhandled object type: " + value.getClass());
     }
@@ -122,6 +125,12 @@ public class ClusterConfigParser {
       sserverGroups.forEach(ssg -> out.printf(PROPERTY_FORMAT, "SSERVER_HOSTS_" + ssg,
           config.get(sserverPrefix + ssg)));
     }
+
+    String numTservers = config.getOrDefault("tservers_per_host", "1");
+    out.print("NUM_TSERVERS=\"${NUM_TSERVERS:=" + numTservers + "}\"\n");
+
+    String numSservers = config.getOrDefault("sservers_per_host", "1");
+    out.print("NUM_SSERVERS=\"${NUM_SSERVERS:=" + numSservers + "}\"\n");
 
     out.flush();
   }

--- a/core/src/test/resources/org/apache/accumulo/core/conf/cluster/cluster-with-optional-services.yaml
+++ b/core/src/test/resources/org/apache/accumulo/core/conf/cluster/cluster-with-optional-services.yaml
@@ -57,3 +57,6 @@ compaction:
     - q2:
         - localhost3
         - localhost4
+
+tservers_per_host: 2
+sservers_per_host: 1


### PR DESCRIPTION
Added tservers_per_host and sservers_per_host to cluster.yaml file. This file is parsed
and transformed into environment variables that are read in by the accumulo-cluster script.
This change adds the environment variables NUM_TSERVERS and NUM_SSERVERS to the environment
with a default value of 1 if not specified in cluster.yaml and in a way that the value is
in cluster.yaml is overridden if the environment variable already exists in the environment