### PR TITLE
convert text to printable string before logging in merge tablets

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -227,7 +227,7 @@ public class Merge {
       Text start = sizes.get(0).extent.prevEndRow();
       Text end = sizes.get(numToMerge - 1).extent.endRow();
       message("Merging %d tablets from (%s to %s]", numToMerge,
-          start == null ? "-inf" : Key.toPrintableString(start.getBytes(), 0, start.getLength(), end.getLength()),
+          start == null ? "-inf" : Key.toPrintableString(start.getBytes(), 0, start.getLength(), start.getLength()),
           end == null ? "+inf" : Key.toPrintableString(end.getBytes(), 0, end.getLength(), end.getLength()));
       client.tableOperations().merge(table, start, end);
     } catch (Exception ex) {

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.ConfigurationTypeHelper;
 import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
@@ -225,8 +226,9 @@ public class Merge {
     try {
       Text start = sizes.get(0).extent.prevEndRow();
       Text end = sizes.get(numToMerge - 1).extent.endRow();
-      message("Merging %d tablets from (%s to %s]", numToMerge, start == null ? "-inf" : start,
-          end == null ? "+inf" : end);
+      message("Merging %d tablets from (%s to %s]", numToMerge,
+          start == null ? "-inf" : Key.toPrintableString(start.getBytes(), 0, start.getLength(), end.getLength()),
+          end == null ? "+inf" : Key.toPrintableString(end.getBytes(), 0, end.getLength(), end.getLength()));
       client.tableOperations().merge(table, start, end);
     } catch (Exception ex) {
       throw new MergeException(ex);

--- a/core/src/main/java/org/apache/accumulo/core/util/Merge.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Merge.java
@@ -227,8 +227,10 @@ public class Merge {
       Text start = sizes.get(0).extent.prevEndRow();
       Text end = sizes.get(numToMerge - 1).extent.endRow();
       message("Merging %d tablets from (%s to %s]", numToMerge,
-          start == null ? "-inf" : Key.toPrintableString(start.getBytes(), 0, start.getLength(), start.getLength()),
-          end == null ? "+inf" : Key.toPrintableString(end.getBytes(), 0, end.getLength(), end.getLength()));
+          start == null ? "-inf"
+              : Key.toPrintableString(start.getBytes(), 0, start.getLength(), start.getLength()),
+          end == null ? "+inf"
+              : Key.toPrintableString(end.getBytes(), 0, end.getLength(), end.getLength()));
       client.tableOperations().merge(table, start, end);
     } catch (Exception ex) {
       throw new MergeException(ex);


### PR DESCRIPTION
I went with `toPrintableString` since that format is pretty readable, but if some other encoding is preferred for some reason, I don't have a preference. Just want to avoid getting vt100 control characters that reconfigure my terminal. 