### PR TITLE
Serialize location in BadLocationStateException

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
@@ -18,11 +18,14 @@
  */
 package org.apache.accumulo.core.metadata;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -35,16 +38,18 @@ import org.apache.hadoop.io.Text;
 public class TabletLocationState {
 
   public static class BadLocationStateException extends Exception {
-    private static final long serialVersionUID = 1L;
-    private transient final Text metadataTableEntry;
+    private static final long serialVersionUID = 2L;
+
+    // store as byte array because Text isn't Serializable
+    private final byte[] metadataTableEntry;
 
     public BadLocationStateException(String msg, Text row) {
       super(msg);
-      this.metadataTableEntry = row;
+      this.metadataTableEntry = TextUtil.getBytes(requireNonNull(row));
     }
 
     public Text getEncodedEndRow() {
-      return metadataTableEntry;
+      return new Text(metadataTableEntry);
     }
   }
 


### PR DESCRIPTION
To ensure that the location is correctly serialized in this exception,
do not mark it transient, but convert it to a byte array, since Text is
not Serializable.

This addresses the warning in #2776 without assuming the exception will
never be serialized, which was made in #2897. Instead, this change
avoids errors if it ever were to be serialized and the location were
silently changed to a null value because the field was transient.