### PR TITLE
Updates to ScanAttempts

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScanServerAttemptImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScanServerAttemptImpl.java
@@ -16,23 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.spi.scan;
+package org.apache.accumulo.core.clientImpl;
 
-/**
- * This object is used to communicate what previous actions were attempted, when they were
- * attempted, and the result of those attempts
- *
- * @since 2.1.0
- */
-public interface ScanServerAttempt {
+import java.util.Objects;
 
-  // represents reasons that previous attempts to scan failed
-  enum Result {
-    BUSY, ERROR
+import org.apache.accumulo.core.spi.scan.ScanServerAttempt;
+
+class ScanServerAttemptImpl implements ScanServerAttempt {
+
+  private final String server;
+  private final Result result;
+
+  ScanServerAttemptImpl(Result result, String server) {
+    this.result = result;
+    this.server = Objects.requireNonNull(server);
   }
 
-  String getServer();
+  @Override
+  public String getServer() {
+    return server;
+  }
 
-  ScanServerAttempt.Result getResult();
+  @Override
+  public Result getResult() {
+    return result;
+  }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScanServerAttemptReporter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScanServerAttemptReporter.java
@@ -16,23 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.accumulo.core.spi.scan;
+package org.apache.accumulo.core.clientImpl;
 
-/**
- * This object is used to communicate what previous actions were attempted, when they were
- * attempted, and the result of those attempts
- *
- * @since 2.1.0
- */
-public interface ScanServerAttempt {
+import org.apache.accumulo.core.spi.scan.ScanServerAttempt;
 
-  // represents reasons that previous attempts to scan failed
-  enum Result {
-    BUSY, ERROR
-  }
-
-  String getServer();
-
-  ScanServerAttempt.Result getResult();
-
+interface ScanServerAttemptReporter {
+  void report(ScanServerAttempt.Result result);
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -344,13 +344,12 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     private List<Column> columns;
     private int semaphoreSize;
     private final long busyTimeout;
-    private final ScanServerAttemptsImpl.ScanAttemptReporter reporter;
+    private final ScanServerAttemptReporter reporter;
     private final Duration scanServerSelectorDelay;
 
     QueryTask(String tsLocation, Map<KeyExtent,List<Range>> tabletsRanges,
         Map<KeyExtent,List<Range>> failures, ResultReceiver receiver, List<Column> columns,
-        long busyTimeout, ScanServerAttemptsImpl.ScanAttemptReporter reporter,
-        Duration scanServerSelectorDelay) {
+        long busyTimeout, ScanServerAttemptReporter reporter, Duration scanServerSelectorDelay) {
       this.tsLocation = tsLocation;
       this.tabletsRanges = tabletsRanges;
       this.receiver = receiver;
@@ -487,7 +486,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     long busyTimeout = 0;
     Duration scanServerSelectorDelay = null;
-    Map<String,ScanServerAttemptsImpl.ScanAttemptReporter> reporters = Map.of();
+    Map<String,ScanServerAttemptReporter> reporters = Map.of();
 
     if (options.getConsistencyLevel().equals(ConsistencyLevel.EVENTUAL)) {
       var scanServerData = rebinToScanServers(binnedRanges);
@@ -580,7 +579,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
   private static class ScanServerData {
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges;
     ScanServerSelections actions;
-    Map<String,ScanServerAttemptsImpl.ScanAttemptReporter> reporters;
+    Map<String,ScanServerAttemptReporter> reporters;
   }
 
   private ScanServerData rebinToScanServers(Map<String,Map<KeyExtent,List<Range>>> binnedRanges) {
@@ -624,7 +623,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges2 = new HashMap<>();
 
-    Map<String,ScanServerAttemptsImpl.ScanAttemptReporter> reporters = new HashMap<>();
+    Map<String,ScanServerAttemptReporter> reporters = new HashMap<>();
 
     for (TabletIdImpl tabletId : tabletIds) {
       KeyExtent extent = tabletId.toKeyExtent();

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ScanAttemptsImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ScanAttemptsImplTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class ScanAttemptsImplTest {
 
   private Map<TabletId,Collection<String>>
-      simplify(Map<TabletId,Collection<ScanServerAttemptsImpl.ScanServerAttemptImpl>> map) {
+      simplify(Map<TabletId,Collection<ScanServerAttemptImpl>> map) {
     Map<TabletId,Collection<String>> ret = new HashMap<>();
 
     map.forEach((tabletId, scanAttempts) -> {

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -131,23 +131,16 @@ public class ConfigurableScanServerSelectorTest {
   static class TestScanServerAttempt implements ScanServerAttempt {
 
     private final String server;
-    private final long endTime;
     private final Result result;
 
-    TestScanServerAttempt(String server, long endTime, Result result) {
+    TestScanServerAttempt(String server, Result result) {
       this.server = server;
-      this.endTime = endTime;
       this.result = result;
     }
 
     @Override
     public String getServer() {
       return server;
-    }
-
-    @Override
-    public long getEndTime() {
-      return endTime;
     }
 
     @Override
@@ -204,7 +197,7 @@ public class ConfigurableScanServerSelectorTest {
     var tabletId = nti("1", "m");
 
     var tabletAttempts = Stream.iterate(1, i -> i <= busyAttempts, i -> i + 1)
-        .map(i -> (new TestScanServerAttempt("ss" + i + ":" + i, i, ScanServerAttempt.Result.BUSY)))
+        .map(i -> (new TestScanServerAttempt("ss" + i + ":" + i, ScanServerAttempt.Result.BUSY)))
         .collect(Collectors.toList());
 
     Map<TabletId,Collection<? extends ScanServerAttempt>> attempts = new HashMap<>();


### PR DESCRIPTION
As a follow-up to #2880:

* Remove unused and undocumented endTime in ScanAttempt API
* Rename ScanAttemptImpl method and variables from "mutationCounter" to
  "attemptNumber" with corresponding comments to make it clear how this
  is used for the snapshot
* Set attemptNumber in ScanAttemptImpl constructor as an immutable
  value, rather than setting it immediately after construction
* Remove unnecessary synchronization and use an AtomicLong for the
  currentAttemptNumber
* IDE changes also removed some unneeded keywords in the interface and
  converted an anonymous inner class to a lambda
* Create the snapshot using Java streams instead of using "forEach()"