### PR TITLE
Remove stale Javadoc comment that references closed Jira issue

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/BatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/BatchWriter.java
@@ -31,8 +31,7 @@ import org.apache.accumulo.core.data.Mutation;
  * written.
  * <p>
  * In the event that an MutationsRejectedException exception is thrown by one of the methods on a
- * BatchWriter instance, the user should close the current instance and create a new instance. This
- * is a known limitation which will be addressed by ACCUMULO-2990 in the future.
+ * BatchWriter instance, the user should close the current instance and create a new instance.
  */
 public interface BatchWriter extends AutoCloseable {
 


### PR DESCRIPTION
Comment refers to an upcoming fix in [ACCUMULO-2990](https://issues.apache.org/jira/browse/ACCUMULO-2990) but that issue was closed as could not reproduce.