### PR TITLE
Adding CleanZookeeper utility to accumulo admin command

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/Admin.java
@@ -183,6 +183,15 @@ public class Admin implements KeywordExecutable {
     String delete = null;
   }
 
+  @Parameters(
+      commandDescription = "Deletes old instances from zookeeper. This command will not delete the instance pointed to by the local accumulo.properties file.")
+  static class CleanZooCommand {
+    @Parameter(names = {"--password"},
+        description = "The system secret, if different than instance.secret in accumulo.properties",
+        password = true)
+    String auth;
+  }
+
   @Parameters(commandDescription = "Deletes instance name or id from zookeeper.")
   static class DeleteZooInstanceCommand {
     @Parameter(names = {"-i", "--instance"}, description = "the instance name or id to delete")
@@ -231,6 +240,9 @@ public class Admin implements KeywordExecutable {
 
     CheckTabletsCommand checkTabletsCommand = new CheckTabletsCommand();
     cl.addCommand("checkTablets", checkTabletsCommand);
+
+    CleanZooCommand cleanZooOpts = new CleanZooCommand();
+    cl.addCommand("cleanZoo", cleanZooOpts);
 
     DeleteZooInstanceCommand deleteZooInstanceOpts = new DeleteZooInstanceCommand();
     cl.addCommand("deleteZooInstance", deleteZooInstanceOpts);
@@ -331,6 +343,8 @@ public class Admin implements KeywordExecutable {
       } else if (cl.getParsedCommand().equals("locks")) {
         TabletServerLocks.execute(context, args.length > 2 ? args[2] : null,
             tServerLocksOpts.delete);
+      } else if (cl.getParsedCommand().equals("cleanZoo")) {
+        CleanZookeeper.execute(context, cleanZooOpts.auth);
       } else {
         everything = cl.getParsedCommand().equals("stopAll");
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CleanZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CleanZookeeper.java
@@ -21,8 +21,6 @@ package org.apache.accumulo.server.util;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.cli.Help;
-import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.fate.zookeeper.ZooUtil.NodeMissingPolicy;
@@ -31,34 +29,17 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.beust.jcommander.Parameter;
-
 public class CleanZookeeper {
 
   private static final Logger log = LoggerFactory.getLogger(CleanZookeeper.class);
 
-  static class Opts extends Help {
-    @Parameter(names = {"--password"},
-        description = "The system secret, if different than instance.secret in accumulo.properties",
-        password = true)
-    String auth;
-  }
+  public static void execute(ServerContext context, String auth) throws Exception {
 
-  /**
-   * @param args
-   *          must contain one element: the address of a zookeeper node a second parameter provides
-   *          an additional authentication value
-   */
-  public static void main(String[] args) {
-    Opts opts = new Opts();
-    opts.parseArgs(CleanZookeeper.class.getName(), args);
-
-    try (var context = new ServerContext(SiteConfiguration.auto())) {
-
-      String root = Constants.ZROOT;
-      ZooReaderWriter zk = context.getZooReaderWriter();
-      if (opts.auth != null) {
-        ZooUtil.digestAuth(zk.getZooKeeper(), opts.auth);
+    try {
+      final String root = Constants.ZROOT;
+      final ZooReaderWriter zk = context.getZooReaderWriter();
+      if (auth != null) {
+        ZooUtil.digestAuth(zk.getZooKeeper(), auth);
       }
 
       for (String child : zk.getChildren(root)) {
@@ -67,24 +48,25 @@ public class CleanZookeeper {
             String instanceNamePath = root + Constants.ZINSTANCES + "/" + instanceName;
             byte[] id = zk.getData(instanceNamePath);
             if (id != null && !new String(id, UTF_8).equals(context.getInstanceID().canonical())) {
-              try {
-                zk.recursiveDelete(instanceNamePath, NodeMissingPolicy.SKIP);
-              } catch (KeeperException.NoAuthException ex) {
-                log.warn("Unable to delete {}", instanceNamePath);
-              }
+              delete(zk, instanceNamePath);
+              System.out.println("Deleted instance " + instanceName);
             }
           }
         } else if (!child.equals(context.getInstanceID().canonical())) {
-          String path = root + "/" + child;
-          try {
-            zk.recursiveDelete(path, NodeMissingPolicy.SKIP);
-          } catch (KeeperException.NoAuthException ex) {
-            log.warn("Unable to delete {}", path);
-          }
+          delete(zk, root + "/" + child);
         }
       }
     } catch (Exception ex) {
       System.out.println("Error Occurred: " + ex);
+    }
+  }
+
+  private static void delete(final ZooReaderWriter zk, final String path)
+      throws InterruptedException, KeeperException {
+    try {
+      zk.recursiveDelete(path, NodeMissingPolicy.SKIP);
+    } catch (KeeperException.NoAuthException ex) {
+      log.warn("Unable to delete {}", path);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CleanZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CleanZookeeper.java
@@ -49,7 +49,7 @@ public class CleanZookeeper {
             byte[] id = zk.getData(instanceNamePath);
             if (id != null && !new String(id, UTF_8).equals(context.getInstanceID().canonical())) {
               delete(zk, instanceNamePath);
-              System.out.println("Deleted instance " + instanceName);
+              System.out.println("Deleted instance: " + instanceName);
             }
           }
         } else if (!child.equals(context.getInstanceID().canonical())) {


### PR DESCRIPTION
Found another utility that can be moved to the accumulo admin command. This utility cleans all old instances out of Zookeeper (except the current one). It's a bit different than the DeleteZooInstance command as that command allows deleting a single instance that is specified so it's worth having both.

This is a follow on to https://github.com/apache/accumulo/issues/2807