### PR TITLE
Add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -37,6 +37,9 @@ on:
         required: true
         default: 15
 
+permissions:
+  contents: read
+
 jobs:
   # fast build to populate the local maven repository cache
   fastbuild:

--- a/.github/workflows/maven-on-demand.yaml
+++ b/.github/workflows/maven-on-demand.yaml
@@ -54,6 +54,9 @@ on:
         required: true
         default: -Dspotbugs.skip -Dcheckstyle.skip -DskipFormat -DverifyFormat
 
+permissions:
+  contents: read
+
 jobs:
   mvn:
     name: mvn (triggered by ${{ github.event.sender.login }})

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -29,6 +29,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   # fast build to populate the local maven repository cache
   fastbuild:

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -29,6 +29,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   shfmt:
     name: shfmt


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows. 

GitHub Actions workflows have a GITHUB_TOKEN with `write` access to multiple scopes. 
Here is an example of the permissions in one of the workflows:
https://github.com/apache/accumulo/runs/8277621128?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for each workflow. 

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced. 
- GitHub recommends defining minimum GITHUB_TOKEN permissions. 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>