### PR TITLE
Update parent pom and some others

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>26</version>
+    <version>27</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-project</artifactId>
@@ -131,7 +131,7 @@
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
-    <hadoop.version>3.3.3</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <!-- prevent introduction of new compiler warnings -->
@@ -167,28 +167,28 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom-alpha</artifactId>
-        <version>1.17.0-alpha</version>
+        <version>1.18.0-alpha</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -209,7 +209,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>11.0.9</version>
+        <version>11.0.12</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -260,7 +260,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.7.1</version>
+        <version>4.7.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -580,7 +580,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.22.1</version>
+        <version>3.25.0</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
@@ -610,12 +610,24 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.29.0-GA</version>
+        <version>3.29.2-GA</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
         <version>3.5.0.Final</version>
+      </dependency>
+      <dependency>
+        <!-- force convergence of transitive dependency of hibernate-validator -->
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging-annotations</artifactId>
+        <version>2.2.1.Final</version>
+      </dependency>
+      <dependency>
+        <!-- force convergence of transitive dependency of hibernate-validator -->
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging-processor</artifactId>
+        <version>2.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>
@@ -637,7 +649,7 @@
         <!-- converge transitive dependency version between powermock and easymock -->
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
-        <version>3.2</version>
+        <version>3.3</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
@@ -673,7 +685,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.31</version>
+        <version>1.32</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -730,7 +742,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.7.1.0</version>
+          <version>4.7.2.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -928,7 +940,6 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.14</version>
           <configuration>
             <excludes combine.children="append">
               <exclude>src/main/resources/META-INF/services/*</exclude>
@@ -957,12 +968,6 @@
               <exclude>**/thrift/*.java</exclude>
             </excludes>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <!-- Can't use 3.0.0 due to https://issues.apache.org/jira/browse/MENFORCER-394 -->
-          <version>3.0.0-M3</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1183,7 +1188,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3.2</version>
+            <version>10.3.3</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
* Update Apache parent pom to 27
* Update Hadoop to 3.3.4
* Update Jackson, Jetty, Micrometer, Opentelemetry, checker-qual, snakeyaml, objenesis, javassist
* Add dependency convergence for jboss transitive logging deps
* Update plugins spotbugs, checkstyle