### PR TITLE
Modify LogReader to print just the crypto params

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/crypto/CryptoTest.java
@@ -312,7 +312,7 @@ public class CryptoTest {
   }
 
   @Test
-  public void testRFileEncrypted() throws Exception {
+  public void testRFileClientEncryption() throws Exception {
     AccumuloConfiguration cryptoOnConf = getAccumuloConfig(ConfigMode.CRYPTO_TABLE_ON);
     FileSystem fs = FileSystem.getLocal(hadoopConf);
     ArrayList<Key> keys = testData();

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -360,7 +360,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
         decryptingInput = cryptoService instanceof NoCryptoService ? input
             : new DataInputStream(decrypter.decryptStream(input));
       } else if (Arrays.equals(magicBuffer, magic3)) {
-        // Read logs files from Accumulo 1.9
+        // Read logs files from Accumulo 1.9 and throw an error if they are encrypted
         String cryptoModuleClassname = input.readUTF();
         if (!cryptoModuleClassname.equals("NullCryptoModule")) {
           throw new IllegalArgumentException(


### PR DESCRIPTION
* Added the -e option to LogReader to not read the whole WAL and just print the crypto params
* Make the LogReader options extend ConfigOpts to allow passing in properties and changed the -p option to --regex to differentiate from the properties option
* Added checkWALEncryption() to PerTableCryptoIT that calls the LogReader 
* Rename a test in CryptoTest
* Supports #2930 