### PR TITLE
Fix the 'clear problems' buttons in the monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -309,11 +309,11 @@ function getJSONForTable(call, sessionDataVar) {
  * Performs POST call and builds console logging message if successful
  * @param {string} call REST url called
  * @param {string} callback POST callback to execute, if available
- * @param {boolean} sanitize Whether to sanitize the call 
+ * @param {boolean} shouldSanitize Whether to sanitize the call 
  */
-function doLoggedPostCall(call, callback, sanitize) {
+function doLoggedPostCall(call, callback, shouldSanitize) {
 
-  if (sanitize) {
+  if (shouldSanitize) {
     // Change plus sign to use ASCII value to send it as a URL query parameter
     call = sanitize(call);
   }
@@ -461,7 +461,7 @@ function clearLogs() {
  * @param {string} tableID Table ID
  */
 function clearTableProblems(tableID) {
-  doLoggedPostCall('/rest/problems/summary?s=' + tableID, refreshProblems, true);
+  doLoggedPostCall('/rest/problems/summary?s=' + tableID, refresh, true);
 }
 
 /**
@@ -473,7 +473,7 @@ function clearTableProblems(tableID) {
  */
 function clearDetailsProblems(table, resource, type) {
   doLoggedPostCall('/rest/problems/details?table=' + table + '&resource=' +
-    resource + '&ptype=' + type, refreshProblems, true);
+    resource + '&ptype=' + type, refresh, true);
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/problems.js
@@ -59,7 +59,7 @@ $(document).ready(function () {
         "type": "html",
         "render": function (data, type, row, meta) {
           if (type === 'display') data = '<a href="javascript:clearTableProblemsTable(\'' +
-            row.tableID + '\');">clear ALL ' + row.tableName + ' problems</a>';
+            row.tableID + '\');">clear ALL problems with table ' + row.tableName + '</a>';
           return data;
         }
       }


### PR DESCRIPTION
Fixes #2941

This issue came from `functions.doLoggedPostCall()`. When sanitize was set to true, it would invoke a call to `sanitize()` which was not getting picked up as a call to the method with the same name (`functions.sanitize()`) but rather the boolean variable `sanitize`.

This PR changes the boolean variable name to `shouldSanitize` to avoid conflict/confusion with the method `sanitize()`.

To verify this change, follow the steps in #2941 to reproduce the issue then click the clear button. The respective entries should be cleared from the table.