### PR TITLE
Make it so the instance name is not highlighted in the monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/navbar.ftl
@@ -21,7 +21,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
         <div class="navbar-header">
-          <a class="navbar-brand" id="headertitle" href="/">
+          <a class="navbar-brand" id="headertitle" style="text-decoration: none" href="/">
             <img id="accumulo-avatar" alt="accumulo" class="navbar-left" src="/resources/images/accumulo-avatar.png" />
             ${instance_name}
           </a>


### PR DESCRIPTION
Fixes #2944 

This PR removes the underlining when hovering over the instance name in the top left corner of the monitor.

Before this change:
![Screenshot from 2022-09-20 14-37-27](https://user-images.githubusercontent.com/47725857/191347094-8efcd6ab-658a-4e9b-af9c-83c6dd5e993e.png)

After this change:
![Screenshot from 2022-09-20 15-25-19](https://user-images.githubusercontent.com/47725857/191347092-806de09c-906c-4f8c-b668-c6bfc8783826.png)
