### PR TITLE
fix #2955 - upgrade zk authorization check

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooUtil.java
+++ b/core/src/main/java/org/apache/accumulo/fate/zookeeper/ZooUtil.java
@@ -167,10 +167,10 @@ public class ZooUtil {
 
   /**
    * Get the ZooKeeper digest based on the instance secret that is used within ZooKeeper for
-   * authentication. This method is primary intended to be used to valid ZooKeeper ACLs. Use
+   * authentication. This method is primary intended to be used to validate ZooKeeper ACLs. Use
    * {@link #digestAuth(ZooKeeper, String)} to add authorizations to ZooKeeper.
    */
-  public static Id getZkAuthId(final String secret) {
+  public static Id getZkDigestAuthId(final String secret) {
     try {
       final String scheme = "digest";
       String auth = DigestAuthenticationProvider.generateDigest("accumulo:" + secret);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -151,7 +151,7 @@ public class Upgrader9to10 implements Upgrader {
     final String rootPath = context.getZooKeeperRoot();
 
     final Id zkDigest =
-        ZooUtil.getZkAuthId(context.getConfiguration().get(Property.INSTANCE_SECRET));
+        ZooUtil.getZkDigestAuthId(context.getConfiguration().get(Property.INSTANCE_SECRET));
     final List<ACL> privateWithAuth = new ArrayList<>();
     privateWithAuth.add(new ACL(ZooDefs.Perms.ALL, zkDigest));
     final List<ACL> publicWithAuth = new ArrayList<>(privateWithAuth);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -94,6 +94,7 @@ import org.apache.zookeeper.ZKUtil;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Id;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,6 +149,14 @@ public class Upgrader9to10 implements Upgrader {
     final ZooReaderWriter zrw = context.getZooReaderWriter();
     final ZooKeeper zk = zrw.getZooKeeper();
     final String rootPath = context.getZooKeeperRoot();
+
+    final Id zkDigest =
+        ZooUtil.getZkAuthId(context.getConfiguration().get(Property.INSTANCE_SECRET));
+    final List<ACL> privateWithAuth = new ArrayList<>();
+    privateWithAuth.add(new ACL(ZooDefs.Perms.ALL, zkDigest));
+    final List<ACL> publicWithAuth = new ArrayList<>(privateWithAuth);
+    publicWithAuth.add(new ACL(ZooDefs.Perms.READ, ZooDefs.Ids.ANYONE_ID_UNSAFE));
+
     try {
       ZKUtil.visitSubTreeDFS(zk, rootPath, false, (rc, path, ctx, name) -> {
         try {
@@ -156,7 +165,7 @@ public class Upgrader9to10 implements Upgrader {
 
           if (((path.equals(Constants.ZROOT) || path.equals(Constants.ZROOT + Constants.ZINSTANCES))
               && !acls.equals(ZooDefs.Ids.OPEN_ACL_UNSAFE))
-              || (!ZooUtil.PRIVATE.equals(acls) && !ZooUtil.PUBLIC.equals(acls))) {
+              || (!privateWithAuth.equals(acls) && !publicWithAuth.equals(acls))) {
             log.error("ZNode at {} has unexpected ACL: {}", path, acls);
             aclErrorOccurred.set(true);
           } else {


### PR DESCRIPTION
Fixes https://github.com/apache/accumulo/issues/2955 by using ZooKeeper digest in ACL checks.  (Code was provided by @dlmarion)

Manually performed upgrade from 2.0.1 to 2.1-0-SNAPHOT without problems.

Original issue is https://github.com/apache/accumulo/issues/2890