### PR TITLE
Fix NPE in suspend logging

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/LoggingTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/LoggingTabletStateStore.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
+import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.hadoop.fs.Path;
 
 /**
@@ -85,8 +86,13 @@ class LoggingTabletStateStore implements TabletStateStore {
       logsForDeadServers = Map.of();
 
     for (TabletLocationState tls : tablets) {
-      TabletLogger.suspended(tls.extent, tls.current.getHostAndPort(), suspensionTimestamp,
-          TimeUnit.MILLISECONDS, logsForDeadServers.size());
+      var location = tls.getLocation();
+      HostAndPort server = null;
+      if (location != null) {
+        server = location.getHostAndPort();
+      }
+      TabletLogger.suspended(tls.extent, server, suspensionTimestamp, TimeUnit.MILLISECONDS,
+          logsForDeadServers.size());
     }
   }
 


### PR DESCRIPTION
After restarting my Uno test cluster, a NullPointerException was thrown while trying to log suspended Tablets.
<pre>
2022-09-27T11:24:49,611 [manager.Manager] ERROR: Error processing table state for store Normal Tablets
java.lang.NullPointerException: null
        at org.apache.accumulo.server.manager.state.LoggingTabletStateStore.suspend(LoggingTabletStateStore.java:88) ~[accumulo-server-base-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.manager.TabletGroupWatcher.handleDeadTablets(TabletGroupWatcher.java:868) ~[accumulo-manager-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.manager.TabletGroupWatcher.flushChanges(TabletGroupWatcher.java:918) ~[accumulo-manager-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
        at org.apache.accumulo.manager.TabletGroupWatcher.run(TabletGroupWatcher.java:320) ~[accumulo-manager-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
</pre>