### PR TITLE
Revert ReadOnlyStore wrapping in FateMetrics

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/metrics/fate/FateMetrics.java
@@ -28,7 +28,6 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.metrics.MetricsProducer;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.util.threads.ThreadPools;
-import org.apache.accumulo.fate.ReadOnlyStore;
 import org.apache.accumulo.fate.ReadOnlyTStore;
 import org.apache.accumulo.fate.ZooStore;
 import org.apache.accumulo.server.ServerContext;
@@ -50,7 +49,7 @@ public class FateMetrics implements MetricsProducer {
   private static final String OP_TYPE_TAG = "op.type";
 
   private final ServerContext context;
-  private final ReadOnlyStore<FateMetrics> zooStore;
+  private final ReadOnlyTStore<FateMetrics> zooStore;
   private final String fateRootPath;
   private final long refreshDelay;
 
@@ -72,8 +71,7 @@ public class FateMetrics implements MetricsProducer {
     this.refreshDelay = Math.max(DEFAULT_MIN_REFRESH_DELAY, minimumRefreshDelay);
 
     try {
-      this.zooStore =
-          new ReadOnlyStore<>(new ZooStore<>(fateRootPath, context.getZooReaderWriter()));
+      this.zooStore = new ZooStore<>(fateRootPath, context.getZooReaderWriter());
     } catch (KeeperException ex) {
       throw new IllegalStateException(
           "FATE Metrics - Failed to create zoo store - metrics unavailable", ex);
@@ -122,8 +120,9 @@ public class FateMetrics implements MetricsProducer {
       }
     }
 
-    metricValues.getOpTypeCounters().forEach((name, count) -> Metrics
-        .gauge(METRICS_FATE_TYPE_IN_PROGRESS, Tags.of(OP_TYPE_TAG, name), count));
+    metricValues.getOpTypeCounters().forEach((name, count) -> {
+      Metrics.gauge(METRICS_FATE_TYPE_IN_PROGRESS, Tags.of(OP_TYPE_TAG, name), count);
+    });
   }
 
   @Override


### PR DESCRIPTION
* Revert "Modify FateMetrics to enforce ReadOnlyStore required for Zooeeper (#2810)"
* This reverts commit 76092fc58eab7a3d4cc1fb87c376dc25b6f87537.
* Fixes #2968