### PR TITLE
alternate approach to issue 2968 - ReadOnlyRepo NPE issue

### DIFF
--- a/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
+++ b/core/src/main/java/org/apache/accumulo/fate/ReadOnlyStore.java
@@ -72,7 +72,9 @@ public class ReadOnlyStore<T> implements ReadOnlyTStore<T> {
      *          may not be null
      */
     public ReadOnlyRepoWrapper(Repo<X> repo) {
-      requireNonNull(repo);
+      if (repo == null) {
+        repo = new DummyReo<>();
+      }
       this.repo = repo;
     }
 
@@ -120,5 +122,34 @@ public class ReadOnlyStore<T> implements ReadOnlyTStore<T> {
   @Override
   public long timeCreated(long tid) {
     return store.timeCreated(tid);
+  }
+
+  static class DummyReo<X> implements Repo<X> {
+    private static final long serialVersionUID = 1;
+
+    @Override
+    public long isReady(long tid, X environment) throws Exception {
+      return 0;
+    }
+
+    @Override
+    public String getName() {
+      return "";
+    }
+
+    @Override
+    public Repo<X> call(long tid, X environment) throws Exception {
+      return null;
+    }
+
+    @Override
+    public void undo(long tid, X environment) throws Exception {
+      // empty
+    }
+
+    @Override
+    public String getReturn() {
+      return "";
+    }
   }
 }


### PR DESCRIPTION
Issue https://github.com/apache/accumulo/issues/2968 identified an issue with handling FATEs when there are transactions without a `top` and when using ReadOnlyRepo.

This is an experiment to see if ReadOnlyRepo can be used instead of reverting code to use ZooStore.

Metrics and status commands only need to read FATE status and it would be a coding error if they attempted to update a FATE.  It was assumed (I guess incorrectly) that ZooStore when wrapped by a ReadOnlyRepo was functional equivalent for read operations.

This replace the requireNonNull check with a DummyRepo when a null Repo is used to create a ReadOnlyRepo.

All sunny tests pass, and using and uno instance and a slow iterator - I created and then failed a compaction, killed theAccumulo processes and then restarted.  The manager came up without the reported error and the `admin fate --summary` command works.  I think this replicates the failing conditions, but not sure.

```
Report Time: 2022-09-27T23:14:06Z
Status counts:
  FAILED: 1
Command counts:
  TABLE_COMPACT: 1
Step counts:
  : 1

Fate transactions (oldest first):
Status Filters: [NONE]
Running	txn_id				Status		Command		Step (top)		locks held:(table id, name)	locks waiting:(table id, name)
0:12:04	6859ad991d4ebd0a	FAILED	TABLE_COMPACT		held:[]	waiting:[]


```
This submitted as a draft for review.  I am not sure that I replicated the necessary failure cases to trigger the issue or if this approach is desired, but it does seem to point to alternative approaches may be possible.
