### PR TITLE
Partial revert changes from #1519

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1205,7 +1205,7 @@ public class Tablet extends TabletBase {
     try {
       // we should make .25 below configurable
       keys = FileUtil.findMidPoint(context, tableConfiguration, chooseTabletDir(),
-          extent.prevEndRow(), extent.endRow(), files, .25, true);
+          extent.prevEndRow(), extent.endRow(), FileUtil.toPathStrings(files), .25, true);
     } catch (IOException e) {
       log.error("Failed to find midpoint {}", e.getMessage());
       return null;
@@ -1450,8 +1450,9 @@ public class Tablet extends TabletBase {
         splitPoint = findSplitRow(getDatafileManager().getFiles());
       } else {
         Text tsp = new Text(sp);
+        var fileStrings = FileUtil.toPathStrings(getDatafileManager().getFiles());
         var ratio = FileUtil.estimatePercentageLTE(context, tableConfiguration, chooseTabletDir(),
-            extent.prevEndRow(), extent.endRow(), getDatafileManager().getFiles(), tsp);
+            extent.prevEndRow(), extent.endRow(), fileStrings, tsp);
         splitPoint = new SplitRowSpec(ratio, tsp);
       }
 


### PR DESCRIPTION
* Revert some changes to FileUtil that used TabletFile. If a tablet is splitting and exceeds the tserver.tablet.split.midpoint.files.max then we will reduce the number of index files using temporary files. These temporary files don't conform to standard TabletFile directories so just use strings in this special case.
* Closes #2977