### PR TITLE
Removed API method from InstanceOperations that exposed Thrift object

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/InstanceOperations.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.clientImpl.thrift.TVersionedProperties;
 import org.apache.accumulo.core.data.InstanceId;
 
 public interface InstanceOperations {
@@ -93,14 +92,6 @@ public interface InstanceOperations {
    *         set in an accumulo.properties file, the default value for each property will be used.
    */
   Map<String,String> getSystemConfiguration() throws AccumuloException, AccumuloSecurityException;
-
-  /**
-   * Retrieve the configured System properties from zookeeper
-   *
-   * @return {@link TVersionedProperties} containing a map of system properties set in zookeeper
-   *         that can be changed as well as the version of those properties.
-   */
-  TVersionedProperties getSystemProperties() throws AccumuloException, AccumuloSecurityException;
 
   /**
    * Retrieve the site configuration (that is set in the server configuration file).

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -99,7 +99,8 @@ public class InstanceOperationsImpl implements InstanceOperations {
       ConcurrentModificationException {
     checkArgument(mapMutator != null, "mapMutator is null");
 
-    final TVersionedProperties vProperties = getSystemProperties();
+    final TVersionedProperties vProperties = ThriftClientTypes.CLIENT.execute(context,
+        client -> client.getVersionedSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()));
     mapMutator.accept(vProperties.getProperties());
 
     for (Map.Entry<String,String> entry : vProperties.getProperties().entrySet()) {
@@ -155,13 +156,6 @@ public class InstanceOperationsImpl implements InstanceOperations {
       throws AccumuloException, AccumuloSecurityException {
     return ThriftClientTypes.CLIENT.execute(context, client -> client
         .getConfiguration(TraceUtil.traceInfo(), context.rpcCreds(), ConfigurationType.CURRENT));
-  }
-
-  @Override
-  public TVersionedProperties getSystemProperties()
-      throws AccumuloException, AccumuloSecurityException {
-    return ThriftClientTypes.CLIENT.execute(context,
-        client -> client.getVersionedSystemProperties(TraceUtil.traceInfo(), context.rpcCreds()));
   }
 
   @Override


### PR DESCRIPTION
Removed API method that exposed Thrift object from InstanceOperations API. Modified method that called it to use the method internal directly and fixed up the test

Closes #2983