### PR TITLE
Block use of fate in Manager until fate is ready

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -108,7 +108,7 @@ class FateServiceHandler implements FateService.Iface {
   public long beginFateOperation(TInfo tinfo, TCredentials credentials)
       throws ThriftSecurityException {
     authenticate(credentials);
-    return manager.fate.startTransaction();
+    return manager.fate().startTransaction();
   }
 
   @Override
@@ -128,7 +128,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Create " + namespace + " namespace.";
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new CreateNamespace(c.getPrincipal(), namespace, options)), autoCleanup,
             goalMessage);
         break;
@@ -146,7 +146,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Rename " + oldName + " namespace to " + newName;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new RenameNamespace(namespaceId, oldName, newName)), autoCleanup,
             goalMessage);
         break;
@@ -163,7 +163,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Delete namespace Id: " + namespaceId;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new DeleteNamespace(namespaceId)), autoCleanup, goalMessage);
         break;
       }
@@ -220,7 +220,7 @@ class FateServiceHandler implements FateService.Iface {
         goalMessage += "Create table " + tableName + " " + initialTableState + " with " + splitCount
             + " splits.";
 
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new CreateTable(c.getPrincipal(), tableName, timeType, options,
                 splitsPath, splitCount, splitsDirsPath, initialTableState, namespaceId)),
             autoCleanup, goalMessage);
@@ -254,7 +254,7 @@ class FateServiceHandler implements FateService.Iface {
         goalMessage += "Rename table " + oldTableName + "(" + tableId + ") to " + oldTableName;
 
         try {
-          manager.fate.seedTransaction(op.toString(), opid,
+          manager.fate().seedTransaction(op.toString(), opid,
               new TraceRepo<>(new RenameTable(namespaceId, tableId, oldTableName, newTableName)),
               autoCleanup, goalMessage);
         } catch (NamespaceNotFoundException e) {
@@ -320,7 +320,7 @@ class FateServiceHandler implements FateService.Iface {
         if (keepOffline)
           goalMessage += " and keep offline.";
 
-        manager.fate.seedTransaction(
+        manager.fate().seedTransaction(
             op.toString(), opid, new TraceRepo<>(new CloneTable(c.getPrincipal(), namespaceId,
                 srcTableId, tableName, propertiesToSet, propertiesToExclude, keepOffline)),
             autoCleanup, goalMessage);
@@ -349,7 +349,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Delete table " + tableName + "(" + tableId + ")";
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new PreDeleteTable(namespaceId, tableId)), autoCleanup, goalMessage);
         break;
       }
@@ -372,7 +372,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Online table " + tableId;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new ChangeTableState(namespaceId, tableId, tableOp)), autoCleanup,
             goalMessage);
         break;
@@ -396,7 +396,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Offline table " + tableId;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new ChangeTableState(namespaceId, tableId, tableOp)), autoCleanup,
             goalMessage);
         break;
@@ -430,7 +430,7 @@ class FateServiceHandler implements FateService.Iface {
             startRowStr, endRowStr);
         goalMessage += "Merge table " + tableName + "(" + tableId + ") splits from " + startRowStr
             + " to " + endRowStr;
-        manager.fate.seedTransaction(op.toString(), opid, new TraceRepo<>(
+        manager.fate().seedTransaction(op.toString(), opid, new TraceRepo<>(
             new TableRangeOp(MergeInfo.Operation.MERGE, namespaceId, tableId, startRow, endRow)),
             autoCleanup, goalMessage);
         break;
@@ -461,7 +461,7 @@ class FateServiceHandler implements FateService.Iface {
 
         goalMessage +=
             "Delete table " + tableName + "(" + tableId + ") range " + startRow + " to " + endRow;
-        manager.fate.seedTransaction(op.toString(), opid, new TraceRepo<>(
+        manager.fate().seedTransaction(op.toString(), opid, new TraceRepo<>(
             new TableRangeOp(MergeInfo.Operation.DELETE, namespaceId, tableId, startRow, endRow)),
             autoCleanup, goalMessage);
         break;
@@ -494,7 +494,7 @@ class FateServiceHandler implements FateService.Iface {
         manager.updateBulkImportStatus(dir, BulkImportState.INITIAL);
         goalMessage +=
             "Bulk import " + dir + " to " + tableName + "(" + tableId + ") failing to " + failDir;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new org.apache.accumulo.manager.tableOps.bulkVer1.BulkImport(tableId,
                 dir, failDir, setTime)),
             autoCleanup, goalMessage);
@@ -520,7 +520,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Compact table (" + tableId + ") with config " + compactionConfig;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new CompactRange(namespaceId, tableId, compactionConfig)), autoCleanup,
             goalMessage);
         break;
@@ -543,7 +543,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Cancel compaction of table (" + tableId + ")";
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new CancelCompactions(namespaceId, tableId)), autoCleanup, goalMessage);
         break;
       }
@@ -583,7 +583,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Import table with new name: " + tableName + " from " + exportDirs;
-        manager.fate
+        manager.fate()
             .seedTransaction(
                 op.toString(), opid, new TraceRepo<>(new ImportTable(c.getPrincipal(), tableName,
                     exportDirs, namespaceId, keepMappings, !keepOffline)),
@@ -613,7 +613,7 @@ class FateServiceHandler implements FateService.Iface {
           throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
 
         goalMessage += "Export table " + tableName + "(" + tableId + ") to " + exportDir;
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new ExportTable(namespaceId, tableName, tableId, exportDir)),
             autoCleanup, goalMessage);
         break;
@@ -649,7 +649,7 @@ class FateServiceHandler implements FateService.Iface {
         manager.updateBulkImportStatus(dir, BulkImportState.INITIAL);
 
         goalMessage += "Bulk import (v2)  " + dir + " to " + tableName + "(" + tableId + ")";
-        manager.fate.seedTransaction(op.toString(), opid,
+        manager.fate().seedTransaction(op.toString(), opid,
             new TraceRepo<>(new PrepBulkImport(tableId, dir, setTime)), autoCleanup, goalMessage);
         break;
       default:
@@ -703,9 +703,9 @@ class FateServiceHandler implements FateService.Iface {
       throws ThriftSecurityException, ThriftTableOperationException {
     authenticate(credentials);
 
-    TStatus status = manager.fate.waitForCompletion(opid);
+    TStatus status = manager.fate().waitForCompletion(opid);
     if (status == TStatus.FAILED) {
-      Exception e = manager.fate.getException(opid);
+      Exception e = manager.fate().getException(opid);
       if (e instanceof ThriftTableOperationException)
         throw (ThriftTableOperationException) e;
       else if (e instanceof ThriftSecurityException)
@@ -716,7 +716,7 @@ class FateServiceHandler implements FateService.Iface {
         throw new RuntimeException(e);
     }
 
-    String ret = manager.fate.getReturn(opid);
+    String ret = manager.fate().getReturn(opid);
     if (ret == null)
       ret = ""; // thrift does not like returning null
     return ret;
@@ -726,7 +726,7 @@ class FateServiceHandler implements FateService.Iface {
   public void finishFateOperation(TInfo tinfo, TCredentials credentials, long opid)
       throws ThriftSecurityException {
     authenticate(credentials);
-    manager.fate.delete(opid);
+    manager.fate().delete(opid);
   }
 
   protected void authenticate(TCredentials credentials) throws ThriftSecurityException {
@@ -822,7 +822,7 @@ class FateServiceHandler implements FateService.Iface {
       throw new ThriftSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED);
 
-    return manager.fate.cancel(opid);
+    return manager.fate().cancel(opid);
   }
 
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -296,7 +296,7 @@ public class Manager extends AbstractServer
     }
 
     if (oldState != newState && (newState == ManagerState.NORMAL)) {
-      if (fateReadyLatch.getCount() > 0) {
+      if (fateReadyLatch.getCount() == 0) {
         throw new IllegalStateException("Access to Fate should not have been"
             + " initialized prior to the Manager finishing upgrades. Please save"
             + " all logs and file a bug.");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -299,7 +299,7 @@ public class Manager extends AbstractServer
     }
 
     if (oldState != newState && (newState == ManagerState.NORMAL)) {
-      if (fateReadyLatch.getCount() == 0) {
+      if (fateRef.get() != null) {
         throw new IllegalStateException("Access to Fate should not have been"
             + " initialized prior to the Manager finishing upgrades. Please save"
             + " all logs and file a bug.");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -247,7 +247,7 @@ public class Manager extends AbstractServer
           + " at time " + System.currentTimeMillis();
       // include stack trace so we know where it's coming from, in case we need to troubleshoot it
       log.warn("{} blocked until fate starts", msgPrefix,
-          new IllegalStateException("Attempted fate action before fate was started; "
+          "Attempted fate action before manager finished starting up; "
               + "if this doesn't make progress, please report it as a bug to the developers"));
       try {
         fateReadyLatch.await();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -247,7 +247,7 @@ public class Manager extends AbstractServer
           + " at time " + System.currentTimeMillis();
       // include stack trace so we know where it's coming from, in case we need to troubleshoot it
       log.warn("{} blocked until fate starts", msgPrefix,
-          "Attempted fate action before manager finished starting up; "
+          new IllegalStateException("Attempted fate action before manager finished starting up; "
               + "if this doesn't make progress, please report it as a bug to the developers"));
       try {
         fateReadyLatch.await();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -316,8 +316,8 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
 
     String msg = "Shutdown tserver " + tabletServer;
 
-    fate.seedTransaction("ShutdownTServer", tid, new TraceRepo<>(new ShutdownTServer(doomed, force)),
-        false, msg);
+    fate.seedTransaction("ShutdownTServer", tid,
+        new TraceRepo<>(new ShutdownTServer(doomed, force)), false, msg);
     fate.waitForCompletion(tid);
     fate.delete(tid);
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -80,6 +80,7 @@ import org.apache.accumulo.core.securityImpl.thrift.TDelegationToken;
 import org.apache.accumulo.core.securityImpl.thrift.TDelegationTokenConfig;
 import org.apache.accumulo.core.trace.thrift.TInfo;
 import org.apache.accumulo.core.util.ByteBufferUtil;
+import org.apache.accumulo.fate.Fate;
 import org.apache.accumulo.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.manager.tableOps.TraceRepo;
 import org.apache.accumulo.manager.tserverOps.ShutdownTServer;
@@ -310,14 +311,15 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
       }
     }
 
-    long tid = manager.fate.startTransaction();
+    Fate<Manager> fate = manager.fate();
+    long tid = fate.startTransaction();
 
     String msg = "Shutdown tserver " + tabletServer;
 
-    manager.fate.seedTransaction("ShutdownTServer", tid,
-        new TraceRepo<>(new ShutdownTServer(doomed, force)), false, msg);
-    manager.fate.waitForCompletion(tid);
-    manager.fate.delete(tid);
+    fate.seedTransaction("ShutdownTServer", tid, new TraceRepo<>(new ShutdownTServer(doomed, force)),
+        false, msg);
+    fate.waitForCompletion(tid);
+    fate.delete(tid);
 
     log.debug("FATE op shutting down " + tabletServer + " finished");
   }


### PR DESCRIPTION
Explicitly block use of fate in the Manager service until the Manager starts up the fate functionality and it is ready for use. Attempt to provide useful logging information when this occurs, to ease troubleshooting, because this should not normally happen.

Fix #2980