### PR TITLE
add log4j-core for test logging

### DIFF
--- a/hadoop-mapreduce/pom.xml
+++ b/hadoop-mapreduce/pom.xml
@@ -73,6 +73,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hadoop-mapreduce/pom.xml
+++ b/hadoop-mapreduce/pom.xml
@@ -73,11 +73,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hadoop-mapreduce/pom.xml
+++ b/hadoop-mapreduce/pom.xml
@@ -72,6 +72,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -61,6 +61,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -60,6 +60,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -61,11 +61,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -131,11 +131,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -129,6 +129,10 @@
       <artifactId>log4j-1.2-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Even with the bug from https://issues.apache.org/jira/browse/LOG4J2-3601
+      log4j2-core is not needed to be listed because accumulo-monitor has a
+      transitive dependency already.
+    -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -131,6 +131,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -695,11 +695,6 @@
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -695,6 +695,11 @@
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -119,6 +119,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -119,11 +119,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -118,6 +118,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -78,11 +78,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -77,6 +77,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -78,6 +78,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -81,6 +81,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -81,11 +81,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -80,6 +80,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -91,11 +91,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -90,6 +90,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -91,6 +91,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -111,11 +111,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -110,6 +110,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -111,6 +111,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/native/pom.xml
+++ b/server/native/pom.xml
@@ -41,6 +41,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -119,6 +119,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -102,6 +102,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -70,6 +70,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -220,11 +220,10 @@
       <artifactId>accumulo-iterator-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <!-- Even with the bug from https://issues.apache.org/jira/browse/LOG4J2-3601
+      log4j2-core is not needed to be listed because accumulo-monitor has a
+      transitive dependency already.
+    -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -222,6 +222,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Updates to log4j versions require log4j-core to be present for test logging.