### PR TITLE
Remove TODO that has already been addressed in Combiner

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -310,7 +310,6 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
 
   @Override
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
-    // TODO test
     Combiner newInstance;
     try {
       newInstance = this.getClass().getDeclaredConstructor().newInstance();


### PR DESCRIPTION
This PR removes a TODO from Combiner.java

The TODO says to test `Combiner.deepCopy()` and it looks like it is already being tested in several places including `CombinerTest.deepCopy()`