### PR TITLE
Add ALTER_NAMESPACE permission for root user to Accumulo and Default namespaces

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -22,6 +22,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -396,11 +398,15 @@ public class ZKPermHandler implements PermissionHandler {
     tablePerms.put(RootTable.ID, Collections.singleton(TablePermission.ALTER_TABLE));
     tablePerms.put(MetadataTable.ID, Collections.singleton(TablePermission.ALTER_TABLE));
     // essentially the same but on the system namespace, the ALTER_TABLE permission is now redundant
+    // After PR #2994 which added security checks for configuration we need to add ALTER_NAMESPACE
+    // to both Default and Accumulo Namespaces for the root user. Also add READ and ALTER_TABLE for
+    // consistency
     Map<NamespaceId,Set<NamespacePermission>> namespacePerms = new HashMap<>();
-    namespacePerms.put(Namespace.ACCUMULO.id(),
-        Collections.singleton(NamespacePermission.ALTER_NAMESPACE));
-    namespacePerms.put(Namespace.ACCUMULO.id(),
-        Collections.singleton(NamespacePermission.ALTER_TABLE));
+    Set<NamespacePermission> rootNsPermissions =
+        new HashSet<>(List.of(NamespacePermission.ALTER_NAMESPACE, NamespacePermission.ALTER_TABLE,
+            NamespacePermission.READ));
+    namespacePerms.put(Namespace.DEFAULT.id(), rootNsPermissions);
+    namespacePerms.put(Namespace.ACCUMULO.id(), rootNsPermissions);
 
     try {
       // prep parent node of users with root username

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -398,15 +398,14 @@ public class ZKPermHandler implements PermissionHandler {
     tablePerms.put(RootTable.ID, Collections.singleton(TablePermission.ALTER_TABLE));
     tablePerms.put(MetadataTable.ID, Collections.singleton(TablePermission.ALTER_TABLE));
     // essentially the same but on the system namespace, the ALTER_TABLE permission is now redundant
-    // After PR #2994 which added security checks for configuration we need to add ALTER_NAMESPACE
-    // to both Default and Accumulo Namespaces for the root user. Also add READ and ALTER_TABLE for
-    // consistency
+    // After PR #2994 which added security checks for configuration we need to also add
+    // ALTER_NAMESPACE
+    // to both Default and Accumulo Namespaces for the root user.
     Map<NamespaceId,Set<NamespacePermission>> namespacePerms = new HashMap<>();
-    Set<NamespacePermission> rootNsPermissions =
-        new HashSet<>(List.of(NamespacePermission.ALTER_NAMESPACE, NamespacePermission.ALTER_TABLE,
-            NamespacePermission.READ));
-    namespacePerms.put(Namespace.DEFAULT.id(), rootNsPermissions);
-    namespacePerms.put(Namespace.ACCUMULO.id(), rootNsPermissions);
+    namespacePerms.put(Namespace.DEFAULT.id(),
+        Collections.singleton(NamespacePermission.ALTER_NAMESPACE));
+    namespacePerms.put(Namespace.ACCUMULO.id(), new HashSet<>(
+        List.of(NamespacePermission.ALTER_NAMESPACE, NamespacePermission.ALTER_TABLE)));
 
     try {
       // prep parent node of users with root username


### PR DESCRIPTION
Fix the permission on initialization for the root user so that the root user is assigned ALTER_NAMESPACE for the default and accumulo namespaces properly so configs can be read.

This is part 1 of Issue #3010 