### PR TITLE
fixes user compaction stuck when producing no output

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -182,9 +182,9 @@ public class ManagerMetadataUtil {
   }
 
   public static void replaceDatafiles(ServerContext context, KeyExtent extent,
-      Set<StoredTabletFile> datafilesToDelete, Set<StoredTabletFile> scanFiles, TabletFile path,
-      Long compactionId, DataFileValue size, String address, TServerInstance lastLocation,
-      ServiceLock zooLock, Optional<ExternalCompactionId> ecid) {
+      Set<StoredTabletFile> datafilesToDelete, Set<StoredTabletFile> scanFiles,
+      Optional<StoredTabletFile> path, Long compactionId, DataFileValue size, String address,
+      TServerInstance lastLocation, ServiceLock zooLock, Optional<ExternalCompactionId> ecid) {
 
     context.getAmple().putGcCandidates(extent.tableId(), datafilesToDelete);
 
@@ -193,8 +193,8 @@ public class ManagerMetadataUtil {
     datafilesToDelete.forEach(tablet::deleteFile);
     scanFiles.forEach(tablet::putScan);
 
-    if (size.getNumEntries() > 0)
-      tablet.putFile(path, size);
+    if (path.isPresent())
+      tablet.putFile(path.get(), size);
 
     if (compactionId != null)
       tablet.putCompactionId(compactionId);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -570,7 +570,7 @@ public class CompactableUtils {
   /**
    * Finish major compaction by bringing the new file online and returning the completed file.
    */
-  static StoredTabletFile bringOnline(DatafileManager datafileManager,
+  static Optional<StoredTabletFile> bringOnline(DatafileManager datafileManager,
       CompactableImpl.CompactionInfo cInfo, CompactionStats stats,
       Map<StoredTabletFile,DataFileValue> compactFiles,
       SortedMap<StoredTabletFile,DataFileValue> allFiles, CompactionKind kind,

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplFileManagerTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplFileManagerTest.java
@@ -428,7 +428,7 @@ public class CompactableImplFileManagerTest {
     }
 
     void completed(TestCompactionJob job, StoredTabletFile newFile) {
-      super.completed(job, job.getSTFiles(), newFile);
+      super.completed(job, job.getSTFiles(), Optional.ofNullable(newFile));
     }
 
     @Override

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactionIT.java
@@ -508,8 +508,10 @@ public class CompactionIT extends AccumuloClusterHarness {
 
       var beforeCount = countFiles(c);
 
+      final int NUM_ENTRIES_AND_FILES = 60;
+
       try (var writer = c.createBatchWriter(tableName)) {
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < NUM_ENTRIES_AND_FILES; i++) {
           Mutation m = new Mutation("r" + i);
           m.put("f1", "q1", "v" + i);
           writer.addMutation(m);
@@ -519,12 +521,12 @@ public class CompactionIT extends AccumuloClusterHarness {
       }
 
       try (var scanner = c.createScanner(tableName)) {
-        assertEquals(60, scanner.stream().count());
+        assertEquals(NUM_ENTRIES_AND_FILES, scanner.stream().count());
       }
 
       var afterCount = countFiles(c);
 
-      assertTrue(afterCount >= beforeCount + 60);
+      assertTrue(afterCount >= beforeCount + NUM_ENTRIES_AND_FILES);
 
       CompactionConfig comactionConfig = new CompactionConfig();
       // configure an iterator that drops all data


### PR DESCRIPTION
This commit fixes a bug where :

 * user compactions take multiple compaction steps (because the tablet has many files)
 * the intermediate steps produce no output

When the above happened CompactableImpl and Tablet would disagree about what files there were. The Tablet code would ignore the empty file produced by an intermediate compaction. CompactableImpl would expect Tablet to know of this file. When this happened things would hang until a tserver was restarted.

Ran into this bug while continually running Bulk random walk test to reproduce #2667