### PR TITLE
Remove unneeded TODO comments in TabletBalancer

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/TabletBalancer.java
@@ -213,10 +213,6 @@ public abstract class TabletBalancer
     @Override
     public void run() {
       balancerLog.warn("Not balancing due to {} outstanding migrations.", migrations.size());
-      /*
-       * TODO ACCUMULO-2938 redact key extents in this output to avoid leaking protected
-       * information.
-       */
       balancerLog.debug("Sample up to 10 outstanding migrations: {}",
           migrations.stream().limit(10).collect(toList()));
     }


### PR DESCRIPTION
Trivial change to remove TODO comments from within the TabletBalancer.java `run` method.

The TODO referenced an older Jira ticket, ACCUMUO-2938, that has been marked resolved and closed. The TODO is no longer relevant.