### PR TITLE
Change List to SortedSet in RecoveryLogsIterator

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -138,7 +139,10 @@ public class RecoveryLogsIterator
    */
   private SortedSet<Path> getFiles(VolumeManager fs, Path directory) throws IOException {
     boolean foundFinish = false;
-    SortedSet<Path> logFiles = new TreeSet<>();
+    // Path::getName compares the last component of each Path value. In this case, the last
+    // component should
+    // always have the format 'part-r-XXXXX.rf', where XXXXX are one-up values.
+    SortedSet<Path> logFiles = new TreeSet<>(Comparator.comparing(Path::getName));
     for (FileStatus child : fs.listStatus(directory)) {
       if (child.getPath().getName().startsWith("_"))
         continue;


### PR DESCRIPTION
This ticket closes #3017 (SortedLogRecoveryTest failures).

That issue described a situation where a large number of tests within SortedLogRecoverTest.java were failing within certain environments. It failed consistently for me as well as on the Apache Jenkins server.

The problem was tracked down to a issue where the 'getFiles' method within RecoveryLogsIterator was returning a List of logFiles that were presumed to be in lexicographical order by file name. But on my particular instance (and presumably the Jenkins server), the files were not returned in that order. Therefore when 'validateFirstKey' retrieved the first file from the provided list, it was not actually checking the first key, but instead, whatever key was in the first file provided by the list. In cases where the order was not as assumed, the check failed and an exception was thrown.

The 'getFiles' method has been updated to return a SortedSet of files, thereby supplying 'validateFirstKey' with the logFiles in expected order. This change allowed all tests to pass without any additional code modification.