### PR TITLE
Make use of GitHub Actions environment files

### DIFF
--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -85,7 +85,7 @@ jobs:
   mvn:
     needs: creatematrix
     strategy:
-      matrix: ${{ fromJson(needs.creatematrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.creatematrix.outputs.CUSTOM_MATRIX) }}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -85,7 +85,7 @@ jobs:
   mvn:
     needs: creatematrix
     strategy:
-      matrix: ${{ fromJson(needs.creatematrix.outputs.CUSTOM_MATRIX) }}
+      matrix: ${{ fromJson(jobs.creatematrix.steps.set-matrix.outputs.CUSTOM_MATRIX) }}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven-full-its.yaml
+++ b/.github/workflows/maven-full-its.yaml
@@ -72,7 +72,7 @@ jobs:
     needs: fastbuild
     timeout-minutes: 5
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.outputs.CUSTOM_MATRIX }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -85,7 +85,7 @@ jobs:
   mvn:
     needs: creatematrix
     strategy:
-      matrix: ${{ fromJson(jobs.creatematrix.steps.set-matrix.outputs.CUSTOM_MATRIX) }}
+      matrix: ${{ fromJson(needs.creatematrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/contrib/ci/it-matrix.sh
+++ b/contrib/ci/it-matrix.sh
@@ -50,4 +50,4 @@ function createTestMatrix() {
   { echo "Finished creating matrix ($count tasks)" | tee "$GITHUB_STEP_SUMMARY"; } 1>&2
 }
 
-echo "CUSTOM_MATRIX='$(createTestMatrix "$testsPerJob")'" | tee -a "$GITHUB_OUTPUT"
+echo "CUSTOM_MATRIX=$(createTestMatrix "$testsPerJob")" | tee -a "$GITHUB_OUTPUT"

--- a/contrib/ci/it-matrix.sh
+++ b/contrib/ci/it-matrix.sh
@@ -22,16 +22,32 @@ testsPerJob=15
 if [[ -n $1 && $1 =~ ^[0-9]*$ ]]; then
   testsPerJob=$1
 fi
-echo "Creating matrix (tests per job: $testsPerJob)..."
 
-gitRootDir=$(git rev-parse --show-toplevel)
-# this only works because our test paths don't have spaces; we should keep it that way
-count=0
-echo -n '::set-output name=matrix::{"profile":['
-for x in $(find "$gitRootDir" -name '*IT.java' -exec basename '{}' .java \; | sort -u | xargs -n "$testsPerJob" | tr ' ' ','); do
-  [[ $count -gt 0 ]] && echo -n ','
-  echo -n "{\"name\":\"task_$count\",\"its\":\"$x\"}"
-  ((count = count + 1))
-done
-echo ']}'
-echo "Finished creating matrix ($count tasks)"
+# set these to /dev/null if they aren't defined in the environment
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+function createTestMatrix() {
+
+  local count=0
+  local chunk=$1
+  local batch
+  local gitRootDir
+
+  { echo "Creating matrix (tests per job: $chunk)..." | tee -a "$GITHUB_STEP_SUMMARY"; } 1>&2
+
+  gitRootDir=$(git rev-parse --show-toplevel)
+
+  # this only works because our test paths don't have spaces; we should keep it that way
+  echo -n '{"profile":['
+  for batch in $(find "$gitRootDir" -name '*IT.java' -exec basename '{}' .java \; | sort -u | xargs -n "$chunk" | tr ' ' ','); do
+    [[ $count -gt 0 ]] && echo -n ','
+    echo -n '{"name":"task_'"$count"'","its":"'"$batch"'"}'
+    ((count = count + 1))
+  done
+  echo ']}'
+
+  { echo "Finished creating matrix ($count tasks)" | tee "$GITHUB_STEP_SUMMARY"; } 1>&2
+}
+
+echo "CUSTOM_MATRIX='$(createTestMatrix "$testsPerJob")'" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
set-output was previously used to create the IT matrix, but it is now deprecated. So, this change makes use of the environment files instead.

See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files