### PR TITLE
Use NamespaceOperations.modifyProperties() in more places

### DIFF
--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
@@ -63,11 +63,11 @@ public class CreateNamespaceCommand extends Command {
       }
     }
     if (configuration != null) {
-      var propsToAdd = configuration.entrySet().stream()
-          .filter(entry -> Property.isValidTablePropertyKey(entry.getKey()))
-          .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+      final Map<String,String> config = configuration;
       shellState.getAccumuloClient().namespaceOperations().modifyProperties(namespace,
-          properties -> properties.putAll(propsToAdd));
+          properties -> config.entrySet().stream()
+              .filter(entry -> Property.isValidTablePropertyKey(entry.getKey()))
+              .forEach(entry -> properties.put(entry.getKey(), entry.getValue())));
     }
 
     return 0;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.shell.commands;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -62,12 +63,11 @@ public class CreateNamespaceCommand extends Command {
       }
     }
     if (configuration != null) {
-      for (Entry<String,String> entry : configuration.entrySet()) {
-        if (Property.isValidTablePropertyKey(entry.getKey())) {
-          shellState.getAccumuloClient().namespaceOperations().setProperty(namespace,
-              entry.getKey(), entry.getValue());
-        }
-      }
+      var propsToAdd = configuration.entrySet().stream()
+          .filter(entry -> Property.isValidTablePropertyKey(entry.getKey()))
+          .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+      shellState.getAccumuloClient().namespaceOperations().modifyProperties(namespace,
+          properties -> properties.putAll(propsToAdd));
     }
 
     return 0;

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/CreateNamespaceCommand.java
@@ -20,8 +20,6 @@ package org.apache.accumulo.shell.commands;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -400,7 +400,7 @@ public class NamespacesIT extends SharedMiniClusterBase {
       assertFalse(s.iterator().hasNext());
 
       // verify can see inserted entry again
-      c.namespaceOperations().  removeIterator(namespace, setting.getName(),
+      c.namespaceOperations().removeIterator(namespace, setting.getName(),
           EnumSet.allOf(IteratorScope.class));
       sleepUninterruptibly(2, TimeUnit.SECONDS);
       assertFalse(c.namespaceOperations().listIterators(namespace).containsKey(iterName));

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -400,7 +400,7 @@ public class NamespacesIT extends SharedMiniClusterBase {
       assertFalse(s.iterator().hasNext());
 
       // verify can see inserted entry again
-      c.namespaceOperations().removeIterator(namespace, setting.getName(),
+      c.namespaceOperations().  removeIterator(namespace, setting.getName(),
           EnumSet.allOf(IteratorScope.class));
       sleepUninterruptibly(2, TimeUnit.SECONDS);
       assertFalse(c.namespaceOperations().listIterators(namespace).containsKey(iterName));


### PR DESCRIPTION
Similar to #2965 

This PR aims to use `NamespaceOperations.modifyProperties()` in places where it seems to be a better fit. Mostly looked for places where multiple properties where being set with concurrent calls to `setProperty()`, often in a loop.