### PR TITLE
rename method getWithoutCaching to getIfCached

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/PropStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/PropStore.java
@@ -136,7 +136,7 @@ public interface PropStore {
   PropCache getCache();
 
   @Nullable
-  VersionedProperties getWithoutCaching(PropStoreKey<?> propStoreKey);
+  VersionedProperties getIfCached(PropStoreKey<?> propStoreKey);
 
   /**
    * Compare the stored data version with the expected version. Notifies subscribers of the change

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImpl.java
@@ -109,7 +109,7 @@ public class PropCacheCaffeineImpl implements PropCache {
    *          the property id
    * @return the version properties if cached, otherwise return null.
    */
-  public @Nullable VersionedProperties getWithoutCaching(PropStoreKey<?> propStoreKey) {
+  public @Nullable VersionedProperties getIfCached(PropStoreKey<?> propStoreKey) {
     return cache.getIfPresent(propStoreKey);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/store/impl/ZooPropStore.java
@@ -291,7 +291,7 @@ public class ZooPropStore implements PropStore, PropChangeListener {
 
     try {
 
-      VersionedProperties vProps = cache.getWithoutCaching(propStoreKey);
+      VersionedProperties vProps = cache.getIfCached(propStoreKey);
       if (vProps == null) {
         vProps = readPropsFromZk(propStoreKey);
       }
@@ -330,7 +330,7 @@ public class ZooPropStore implements PropStore, PropChangeListener {
 
     try {
       // Grab the current properties
-      VersionedProperties vProps = cache.getWithoutCaching(propStoreKey);
+      VersionedProperties vProps = cache.getIfCached(propStoreKey);
       if (vProps == null) {
         vProps = readPropsFromZk(propStoreKey);
       }
@@ -451,8 +451,8 @@ public class ZooPropStore implements PropStore, PropChangeListener {
   }
 
   @Override
-  public @Nullable VersionedProperties getWithoutCaching(PropStoreKey<?> propStoreKey) {
-    return cache.getWithoutCaching(propStoreKey);
+  public @Nullable VersionedProperties getIfCached(PropStoreKey<?> propStoreKey) {
+    return cache.getIfCached(propStoreKey);
   }
 
   @Override

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/PropCacheCaffeineImplTest.java
@@ -115,11 +115,11 @@ public class PropCacheCaffeineImplTest {
     expect(zooPropLoader.load(eq(table2PropKey))).andReturn(vProps).once();
 
     replay(context, propStoreWatcher, zooPropLoader);
-    var props = cache.getWithoutCaching(tablePropKey);
+    var props = cache.getIfCached(tablePropKey);
     assertNull(props);
 
     assertNotNull(cache.get(table2PropKey)); // load into cache
-    assertNotNull(cache.getWithoutCaching(table2PropKey)); // read from cache - no load call.
+    assertNotNull(cache.getIfCached(table2PropKey)); // read from cache - no load call.
   }
 
   @Test
@@ -149,8 +149,8 @@ public class PropCacheCaffeineImplTest {
     cache.removeAll();
 
     // check that values are not in cache - will not call load
-    assertNull(cache.getWithoutCaching(tablePropKey));
-    assertNull(cache.getWithoutCaching(table2PropKey));
+    assertNull(cache.getIfCached(tablePropKey));
+    assertNull(cache.getIfCached(table2PropKey));
   }
 
   @Test

--- a/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ZooPropLoaderTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/conf/store/impl/ZooPropLoaderTest.java
@@ -267,14 +267,14 @@ public class ZooPropLoaderTest {
   }
 
   @Test
-  public void getWithoutCachingTest() {
+  public void getIfCachedTest() {
 
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
     PropCacheCaffeineImpl cache =
         new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).forTests(ticker).build();
 
-    assertNull(cache.getWithoutCaching(propStoreKey));
+    assertNull(cache.getIfCached(propStoreKey));
 
   }
 
@@ -305,8 +305,8 @@ public class ZooPropLoaderTest {
     cache.remove(tablePropKey);
 
     // verify retrieved from cache without loading.
-    assertNotNull(cache.getWithoutCaching(sysPropKey));
-    assertNull(cache.getWithoutCaching(tablePropKey));
+    assertNotNull(cache.getIfCached(sysPropKey));
+    assertNull(cache.getIfCached(tablePropKey));
   }
 
   @Test
@@ -336,19 +336,19 @@ public class ZooPropLoaderTest {
     cache.removeAll();
 
     // verify retrieved from cache without loading.
-    assertNull(cache.getWithoutCaching(sysPropKey));
-    assertNull(cache.getWithoutCaching(tablePropKey));
+    assertNull(cache.getIfCached(sysPropKey));
+    assertNull(cache.getIfCached(tablePropKey));
   }
 
   @Test
-  public void getWithoutCachingNotPresentTest() {
+  public void getIfCachedNotPresentTest() {
     replay(context, zrw, propStoreWatcher, cacheMetrics);
 
     PropCacheCaffeineImpl cache =
         new PropCacheCaffeineImpl.Builder(loader, cacheMetrics).forTests(ticker).build();
 
     // load into cache
-    assertNull(cache.getWithoutCaching(propStoreKey));
+    assertNull(cache.getIfCached(propStoreKey));
   }
 
   @Test


### PR DESCRIPTION
While working on the concurrent property updates in https://github.com/apache/accumulo/issues/2996 noticed that the getWithoutCaching name could be misleading - changing to getIfCached to highlight that it only returns a value from the cache (and will not load values from ZooKeeper)