### PR TITLE
Bump several plugin versions

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/summary/SummarizerConfiguration.java
@@ -237,7 +237,9 @@ public class SummarizerConfiguration {
      * Convenience method for adding multiple options. The following
      *
      * <pre>
-     * {@code builder.addOptions("opt1","val1","opt2","val2","opt3","val3")}
+     * {@code
+     * builder.addOptions("opt1", "val1", "opt2", "val2", "opt3", "val3")
+     * }
      * </pre>
      *
      * <p>
@@ -245,9 +247,9 @@ public class SummarizerConfiguration {
      *
      * <pre>
      * {@code
-     *   builder.addOption("opt1","val1");
-     *   builder.addOption("opt2","val2");
-     *   builder.addOption("opt3","val3");
+     * builder.addOption("opt1", "val1");
+     * builder.addOption("opt2", "val2");
+     * builder.addOption("opt3", "val3");
      * }
      * </pre>
      *

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.11.0</version>
+          <version>2.12.0</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
@@ -762,7 +762,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -773,7 +773,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.2.0</version>
           <configuration>
             <createBackupFile>false</createBackupFile>
             <expandEmptyElements>false</expandEmptyElements>
@@ -922,7 +922,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.19.0</version>
+          <version>2.20.0</version>
           <configuration>
             <configFile>${eclipseFormatterStyle}</configFile>
             <excludes>


### PR DESCRIPTION
This PR bumps the version of the following plugins:
* versions-maven-plugin
* maven-checkstyle-plugin
* sortpom-maven-plugin
* formatter-maven-plugin

The changes in `SummarizerConfiguration.java` were automatically generated and must have been due to one of these plugins being updated.