### PR TITLE
Prevents bulk import from hanging.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCache.java
@@ -88,13 +88,15 @@ class ConcurrentKeyExtentCache implements KeyExtentCache {
 
   @VisibleForTesting
   protected Stream<KeyExtent> lookupExtents(Text row) {
-    return TabletsMetadata.builder(ctx).forTable(tableId).overlapping(row, null).checkConsistency()
-        .fetch(PREV_ROW).build().stream().limit(100).map(TabletMetadata::getExtent);
+    return TabletsMetadata.builder(ctx).forTable(tableId).overlapping(row, true, null)
+        .checkConsistency().fetch(PREV_ROW).build().stream().limit(100)
+        .map(TabletMetadata::getExtent);
   }
 
   @Override
   public KeyExtent lookup(Text row) {
     while (true) {
+
       KeyExtent ke = getFromCache(row);
       if (ke != null)
         return ke;

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -500,8 +500,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
       verifyData(c, tableName, 333, 333, false);
 
       Map<String,Set<String>> hashes = new HashMap<>();
-      hashes.put("0333", new HashSet<>());
-      hashes.get("0333").add(h1);
+      hashes.put("0333", Set.of(h1));
       hashes.put("null", new HashSet<>());
       verifyMetadata(c, tableName, hashes);
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -501,7 +501,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
 
       Map<String,Set<String>> hashes = new HashMap<>();
       hashes.put("0333", Set.of(h1));
-      hashes.put("null", new HashSet<>());
+      hashes.put("null", Set.of());
       verifyMetadata(c, tableName, hashes);
     }
   }


### PR DESCRIPTION
Fixes a bug where bulk import would hang when the first row of the file was equal to the last row of the first tablet.