### PR TITLE
Log the client address when FrameBuffer read or write methods return false

### DIFF
--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -78,11 +78,6 @@ logger.zookeeper.level = error
 logger.accumulo.name = org.apache.accumulo
 logger.accumulo.level = debug
 
-# uncomment if you start seeing Thrift FrameBuffer error messages
-# in the log (GitHub issue #3042)
-#logger.framebuffer.name = org.apache.accumulo.server.rpc.CustomNonBlockingServer
-#logger.framebuffer.level = trace
-
 # uncomment for separate audit logs
 #logger.audit.name = org.apache.accumulo.audit
 #logger.audit.level = info

--- a/assemble/conf/log4j2-service.properties
+++ b/assemble/conf/log4j2-service.properties
@@ -78,6 +78,11 @@ logger.zookeeper.level = error
 logger.accumulo.name = org.apache.accumulo
 logger.accumulo.level = debug
 
+# uncomment if you start seeing Thrift FrameBuffer error messages
+# in the log (GitHub issue #3042)
+#logger.framebuffer.name = org.apache.accumulo.server.rpc.CustomNonBlockingServer
+#logger.framebuffer.level = trace
+
 # uncomment for separate audit logs
 #logger.audit.name = org.apache.accumulo.audit
 #logger.audit.level = info

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
@@ -128,6 +128,27 @@ public class CustomNonBlockingServer extends THsHaServer {
       }
       super.invoke();
     }
+
+    @Override
+    public boolean read() {
+      boolean result = super.read();
+      if (!result) {
+        log.trace("CustomFrameBuffer.read returned false when reading data from client: {}",
+            TServerUtils.clientAddress.get());
+      }
+      return result;
+    }
+
+    @Override
+    public boolean write() {
+      boolean result = super.write();
+      if (!result) {
+        log.trace("CustomFrameBuffer.write returned false when writing data to client: {}",
+            TServerUtils.clientAddress.get());
+      }
+      return result;
+    }
+
   }
 
 }


### PR DESCRIPTION
When FrameBuffer read and write methods return false it MAY be due to an error. Log at trace level the client address that it was trying to read from or write to. This will allow the user to modify the log level at runtime when they are seeing FrameBuffer errors being logged to try and identify the client.

Closes #3042