### PR TITLE
fixes #3046 limiting ample to single table

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -357,8 +357,11 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
 
     @Override
     public Options overlapping(Text startRow, boolean startInclusive, Text endRow) {
-      var encRow = TabletsSection.encodeRow(tableId, startRow == null ? new Text("") : startRow);
-      this.range = new Range(encRow, startRow == null ? true : startInclusive, null, true);
+      var metaStartRow =
+          TabletsSection.encodeRow(tableId, startRow == null ? new Text("") : startRow);
+      var metaEndRow = TabletsSection.encodeRow(tableId, endRow);
+      this.range =
+          new Range(metaStartRow, startRow == null ? true : startInclusive, metaEndRow, true);
       this.endRow = endRow;
 
       return this;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -376,7 +376,8 @@ class LoadFiles extends ManagerRepo {
       }
 
       if (cmp != 0) {
-        throw new IllegalStateException("Unexpected prev end row " + currTablet + " " + loadRange);
+        throw new IllegalStateException(
+            "Unexpected prev end row " + currTablet.getExtent() + " " + loadRange);
       }
 
       // we have found the first tablet in the range, add it to the list


### PR DESCRIPTION
In PR #3044 a bug was introduced that made an Ample operation that was intended to read a single tables metadata read multiple tables metadata.  This change fixes that bug limiting the Ample read a to a single tables metadata.