### PR TITLE
address #3053 set ThreadPool creation logging to trace

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -474,7 +474,7 @@ public class ThreadPools {
   public ThreadPoolExecutor createThreadPool(int coreThreads, int maxThreads, long timeOut,
       TimeUnit units, final String name, BlockingQueue<Runnable> queue, OptionalInt priority,
       boolean emitThreadPoolMetrics) {
-    LOG.debug(
+    LOG.trace(
         "Creating ThreadPoolExecutor for {} with {} core threads and {} max threads {} {} timeout",
         name, coreThreads, maxThreads, timeOut, units);
     var result = new ThreadPoolExecutor(coreThreads, maxThreads, timeOut, units, queue,
@@ -544,7 +544,7 @@ public class ThreadPools {
    */
   public ScheduledThreadPoolExecutor createScheduledExecutorService(int numThreads,
       final String name, boolean emitThreadPoolMetrics) {
-    LOG.debug("Creating ScheduledThreadPoolExecutor for {} with {} threads", name, numThreads);
+    LOG.trace("Creating ScheduledThreadPoolExecutor for {} with {} threads", name, numThreads);
     var result =
         new ScheduledThreadPoolExecutor(numThreads, new NamedThreadFactory(name, handler)) {
 


### PR DESCRIPTION
This addresses #3053 by setting thread pool creation logging to trace.  If merged, a follow-on for 3.0 will be created to examine thread pool usage to see if the are places for optimization. 