### PR TITLE
Properly format timestamps in Accumulo Monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -134,7 +134,8 @@ function bigNumberForQuantity(quantity) {
  */
 function dateFormat(timestamp) {
   var date = new Date(timestamp);
-  return date.toLocaleString([], { timeZoneName: 'short' }).split(' ').join('&nbsp;');
+  var isoDate = date.toISOString().split('T');
+  return isoDate[0] + " " + isoDate[1].replace('.',',')
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -134,8 +134,7 @@ function bigNumberForQuantity(quantity) {
  */
 function dateFormat(timestamp) {
   var date = new Date(timestamp);
-  date.toLocaleString().split(' ').join('&nbsp;');
-  return date;
+  return date.toLocaleString([], { timeZoneName: 'short' }).split(' ').join('&nbsp;');
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -135,7 +135,7 @@ function bigNumberForQuantity(quantity) {
 function dateFormat(timestamp) {
   var date = new Date(timestamp);
   var isoDate = date.toISOString().split('T');
-  return isoDate[0] + " " + isoDate[1].replace('.',',')
+  return [isoDate[0], isoDate[1].replace('.',',')].join('&nbsp;');
 }
 
 /**

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/functions.js
@@ -134,8 +134,8 @@ function bigNumberForQuantity(quantity) {
  */
 function dateFormat(timestamp) {
   var date = new Date(timestamp);
-  var isoDate = date.toISOString().split('T');
-  return [isoDate[0], isoDate[1].replace('.',',')].join('&nbsp;');
+  return date.toLocaleString([], {timeStyle: 'long', dateStyle: 'medium' })
+    .split(' ').join('&nbsp;');
 }
 
 /**


### PR DESCRIPTION
Fixes the issue in #3048 where the `dateFormat()` function has a bug and returns the original date and not a formatted timestamp.

~~An example of the new format is: `10/28/2022, 11:49:29 AM EDT`~~

Update: I switched to use a modified version of the toISOString() method so the date is YYYY-MM-DD based on comments.

Updated sample of the new format: `2022-10-28 18:51:36,072Z`