### PR TITLE
Move DataTable errors to console to avoid alerts

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/ec.js
@@ -31,6 +31,10 @@ $(document).ready(function () {
   if (sessionStorage.ecDetailsJSON === undefined) {
     sessionStorage.ecDetailsJSON = JSON.stringify([]);
   }
+
+  // display datatables errors in the console instead of in alerts
+  $.fn.dataTable.ext.errMode = 'throw';
+
   compactorsTable = $('#compactorsTable').DataTable({
     "ajax": {
       "url": '/rest/ec/compactors',


### PR DESCRIPTION
Closes #3057

This change makes DataTable errors get logged to console instead of creating many, spammy alerts on the page.