### PR TITLE
fixes #3045 remove stale compactions from coordinator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1701,7 +1701,7 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED</extraTestArgs>
+        <extraTestArgs>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</extraTestArgs>
       </properties>
     </profile>
   </profiles>

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -22,6 +22,7 @@ import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.coordinator.QueueSummaries.PrioTserver;
 import org.apache.accumulo.core.Constants;
@@ -55,7 +57,9 @@ import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -90,6 +94,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.Sets;
 
 public class CompactionCoordinator extends AbstractServer
     implements CompactionCoordinatorService.Iface, LiveTServerSet.Listener {
@@ -100,8 +105,14 @@ public class CompactionCoordinator extends AbstractServer
 
   protected static final QueueSummaries QUEUE_SUMMARIES = new QueueSummaries();
 
-  /* Map of compactionId to RunningCompactions */
-  protected static final Map<ExternalCompactionId,RunningCompaction> RUNNING =
+  /*
+   * Map of compactionId to RunningCompactions. This is an informational cache of what external
+   * compactions may be running. Its possible it may contain external compactions that are not
+   * actually running. It may not contain compactions that are actually running. The metadata table
+   * is the most authoritative source of what external compactions are currently running, but it
+   * does not have the stats that this map has.
+   */
+  protected static final Map<ExternalCompactionId,RunningCompaction> RUNNING_CACHE =
       new ConcurrentHashMap<>();
 
   private static final Cache<ExternalCompactionId,RunningCompaction> COMPLETED =
@@ -277,7 +288,7 @@ public class CompactionCoordinator extends AbstractServer
         update.setState(TCompactionState.IN_PROGRESS);
         update.setMessage("Coordinator restarted, compaction found in progress");
         rc.addUpdate(System.currentTimeMillis(), update);
-        RUNNING.put(ExternalCompactionId.of(rc.getJob().getExternalCompactionId()), rc);
+        RUNNING_CACHE.put(ExternalCompactionId.of(rc.getJob().getExternalCompactionId()), rc);
       });
     }
 
@@ -446,7 +457,10 @@ public class CompactionCoordinator extends AbstractServer
           prioTserver = QUEUE_SUMMARIES.getNextTserver(queue);
           continue;
         }
-        RUNNING.put(ExternalCompactionId.of(job.getExternalCompactionId()),
+        // It is possible that by the time this added that the tablet has already canceled the
+        // compaction or the compactor that made this request is dead. In these cases the compaction
+        // is not actually running.
+        RUNNING_CACHE.put(ExternalCompactionId.of(job.getExternalCompactionId()),
             new RunningCompaction(job, compactorAddress, queue));
         LOG.debug("Returning external job {} to {}", job.externalCompactionId, compactorAddress);
         result = job;
@@ -523,15 +537,7 @@ public class CompactionCoordinator extends AbstractServer
     // It's possible that RUNNING might not have an entry for this ecid in the case
     // of a coordinator restart when the Coordinator can't find the TServer for the
     // corresponding external compaction.
-    final RunningCompaction rc = RUNNING.get(ecid);
-    if (null != rc) {
-      RUNNING.remove(ecid, rc);
-      COMPLETED.put(ecid, rc);
-    } else {
-      LOG.warn(
-          "Compaction completed called by Compactor for {}, but no running compaction for that id.",
-          externalCompactionId);
-    }
+    recordCompletion(ecid);
   }
 
   @Override
@@ -549,17 +555,7 @@ public class CompactionCoordinator extends AbstractServer
 
   void compactionFailed(Map<ExternalCompactionId,KeyExtent> compactions) {
     compactionFinalizer.failCompactions(compactions);
-    compactions.forEach((k, v) -> {
-      final RunningCompaction rc = RUNNING.get(k);
-      if (null != rc) {
-        RUNNING.remove(k, rc);
-        COMPLETED.put(k, rc);
-      } else {
-        LOG.warn(
-            "Compaction failed called by Compactor for {}, but no running compaction for that id.",
-            k);
-      }
-    });
+    compactions.forEach((k, v) -> recordCompletion(k));
   }
 
   /**
@@ -589,10 +585,59 @@ public class CompactionCoordinator extends AbstractServer
     }
     LOG.debug("Compaction status update, id: {}, timestamp: {}, update: {}", externalCompactionId,
         timestamp, update);
-    final RunningCompaction rc = RUNNING.get(ExternalCompactionId.of(externalCompactionId));
+    final RunningCompaction rc = RUNNING_CACHE.get(ExternalCompactionId.of(externalCompactionId));
     if (null != rc) {
       rc.addUpdate(timestamp, update);
     }
+  }
+
+  protected long lastCleanUp = System.nanoTime();
+
+  static final Duration CLEANUP_DELAY = Duration.ofSeconds(60);
+
+  private void recordCompletion(ExternalCompactionId ecid) {
+    var rc = RUNNING_CACHE.remove(ecid);
+    if (rc != null) {
+      COMPLETED.put(ecid, rc);
+    }
+  }
+
+  protected Set<ExternalCompactionId> readExternalCompactionIds() {
+    return getContext().getAmple().readTablets().forLevel(Ample.DataLevel.USER)
+        .fetch(TabletMetadata.ColumnType.ECOMP).build().stream()
+        .flatMap(tm -> tm.getExternalCompactions().keySet().stream()).collect(Collectors.toSet());
+  }
+
+  /**
+   * The RUNNING_CACHE set may contain external compactions that are not actually running. This
+   * method periodically cleans those up.
+   */
+  protected void cleanUpRunning(long currNanoTime) {
+
+    var timeSinceCleanup = Duration.ofNanos(currNanoTime - lastCleanUp);
+
+    if (timeSinceCleanup.compareTo(CLEANUP_DELAY) < 0) {
+      return;
+    }
+
+    // grab a snapshot of the ids in the set before reading the metadata table. This is done to
+    // avoid removing things that are added while reading the metadata.
+    Set<ExternalCompactionId> idsSnapshot = Set.copyOf(RUNNING_CACHE.keySet());
+
+    // grab the ids that are listed as running in the metadata table. It important that this is done
+    // after getting the snapshot.
+    Set<ExternalCompactionId> idsInMetadata = readExternalCompactionIds();
+
+    var idsToRemove = Sets.difference(idsSnapshot, idsInMetadata);
+
+    // remove ids that are in the running set but not in the metadata table
+    idsToRemove.forEach(ecid -> recordCompletion(ecid));
+
+    if (idsToRemove.size() > 0) {
+      LOG.debug("Removed stale entries from RUNNING_CACHE : {}", idsToRemove);
+    }
+
+    lastCleanUp = System.nanoTime();
   }
 
   /**
@@ -614,8 +659,11 @@ public class CompactionCoordinator extends AbstractServer
       throw new AccumuloSecurityException(credentials.getPrincipal(),
           SecurityErrorCode.PERMISSION_DENIED).asThriftException();
     }
+
+    cleanUpRunning(System.nanoTime());
+
     final TExternalCompactionList result = new TExternalCompactionList();
-    RUNNING.forEach((ecid, rc) -> {
+    RUNNING_CACHE.forEach((ecid, rc) -> {
       TExternalCompaction trc = new TExternalCompaction();
       trc.setQueueName(rc.getQueueName());
       trc.setCompactor(rc.getCompactorAddress());
@@ -660,7 +708,7 @@ public class CompactionCoordinator extends AbstractServer
   @Override
   public void cancel(TInfo tinfo, TCredentials credentials, String externalCompactionId)
       throws TException {
-    var runningCompaction = RUNNING.get(ExternalCompactionId.of(externalCompactionId));
+    var runningCompaction = RUNNING_CACHE.get(ExternalCompactionId.of(externalCompactionId));
     var extent = KeyExtent.fromThrift(runningCompaction.getJob().getExtent());
     try {
       NamespaceId nsId = getContext().getNamespaceId(extent.tableId());

--- a/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
+++ b/server/compaction-coordinator/src/test/java/org/apache/accumulo/coordinator/CompactionCoordinatorTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -638,15 +637,13 @@ public class CompactionCoordinatorTest {
     coordinator.getRunning().put(ecid2, new RunningCompaction(new TExternalCompaction()));
     coordinator.getRunning().put(ecid3, new RunningCompaction(new TExternalCompaction()));
 
-    coordinator.setMetadataCompactionIds(Set.of(ecid1, ecid2));
-
-    coordinator.cleanUpRunning(coordinator.lastCleanUp);
+    coordinator.cleanUpRunning();
 
     assertEquals(Set.of(ecid1, ecid2, ecid3), coordinator.getRunning().keySet());
 
-    coordinator.cleanUpRunning(
-        Duration.ofNanos(coordinator.lastCleanUp).plus(CompactionCoordinator.CLEANUP_DELAY)
-            .plus(CompactionCoordinator.CLEANUP_DELAY).toNanos());
+    coordinator.setMetadataCompactionIds(Set.of(ecid1, ecid2));
+
+    coordinator.cleanUpRunning();
 
     assertEquals(Set.of(ecid1, ecid2), coordinator.getRunning().keySet());
 


### PR DESCRIPTION
I added a unit test and I ran all ITs that matched the pattern `*Compaction*IT` but have not tested the scenario in #3045 with these changes.  The unit test shows it working in isolation, but not end to end.