### PR TITLE
Reduce logging when external compactions are cancelled

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -258,6 +258,9 @@ public class FileCompactor implements Callable<CompactionStats> {
 
       majCStats.setFileSize(mfwTmp.getLength());
       return majCStats;
+    } catch (CompactionCanceledException e) {
+      log.debug("Compaction canceled {}", extent);
+      throw e;
     } catch (IOException | RuntimeException e) {
       log.error("{}", e.getMessage(), e);
       throw e;
@@ -280,7 +283,13 @@ public class FileCompactor implements Callable<CompactionStats> {
           }
         }
       } catch (IOException | RuntimeException e) {
-        log.warn("{}", e.getMessage(), e);
+        // If compaction was cancelled then this may happen due to an
+        // InterruptedException etc so suppress logging
+        if (!env.isCompactionEnabled()) {
+          log.warn("{}", e.getMessage(), e);
+        } else {
+          log.debug("{}", e.getMessage(), e);
+        }
       }
     }
   }
@@ -392,7 +401,8 @@ public class FileCompactor implements Callable<CompactionStats> {
             try {
               mfw.close();
             } catch (IOException e) {
-              log.error("{}", e.getMessage(), e);
+              log.warn("{}", e.getMessage());
+              log.debug("{}", e.getMessage(), e);
             }
             fs.deleteRecursively(outputFile.getPath());
           } catch (Exception e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -286,9 +286,9 @@ public class FileCompactor implements Callable<CompactionStats> {
         // If compaction was cancelled then this may happen due to an
         // InterruptedException etc so suppress logging
         if (!env.isCompactionEnabled()) {
-          log.warn("{}", e.getMessage(), e);
-        } else {
           log.debug("{}", e.getMessage(), e);
+        } else {
+          log.warn("{}", e.getMessage(), e);
         }
       }
     }

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -578,6 +578,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
         TCompactionStatusUpdate update2 = new TCompactionStatusUpdate(TCompactionState.SUCCEEDED,
             "Compaction completed successfully", -1, -1, -1);
         updateCompactionState(job, update2);
+      } catch (FileCompactor.CompactionCanceledException cce) {
+        LOG.debug("Compaction canceled {}", job.getExternalCompactionId());
       } catch (Exception e) {
         LOG.error("Compaction failed", e);
         err.set(e);


### PR DESCRIPTION
Also only shows stack traces in FileCompactor on file writer close errors when debug is enabled.

This closes #3023