### PR TITLE
Add VFS type mapping for new jar mime type

### DIFF
--- a/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
+++ b/start/src/main/java/org/apache/accumulo/start/classloader/vfs/AccumuloVFSClassLoader.java
@@ -284,6 +284,7 @@ public class AccumuloVFSClassLoader {
     vfs.addExtensionMap("tbz2", "tar");
     vfs.addExtensionMap("tgz", "tar");
     vfs.addExtensionMap("bz2", "bz2");
+    vfs.addMimeTypeMap("application/java-archive", "jar");
     vfs.addMimeTypeMap("application/x-tar", "tar");
     vfs.addMimeTypeMap("application/x-gzip", "gz");
     vfs.addMimeTypeMap("application/zip", "zip");

--- a/start/src/test/java/org/apache/accumulo/start/test/AccumuloDFSBase.java
+++ b/start/src/test/java/org/apache/accumulo/start/test/AccumuloDFSBase.java
@@ -107,6 +107,7 @@ public class AccumuloDFSBase {
       vfs.addExtensionMap("tbz2", "tar");
       vfs.addExtensionMap("tgz", "tar");
       vfs.addExtensionMap("bz2", "bz2");
+      vfs.addMimeTypeMap("application/java-archive", "jar");
       vfs.addMimeTypeMap("application/x-tar", "tar");
       vfs.addMimeTypeMap("application/x-gzip", "gz");
       vfs.addMimeTypeMap("application/zip", "zip");


### PR DESCRIPTION
Add VFS type mapping for the new jar mime type added in newer versions of Java 11 and 17, application/java-archive, to ensure it is associated with the "jar" scheme in VFS. This ensures VFS loads jars correctly when run on a newer version of Java.

This fixes #3068

Commit cherry-picked and updated from #2683 