### PR TITLE
Call setDropBehind() when reading/writing WAL files

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -417,6 +417,13 @@ public class DfsLogger implements Comparable<DfsLogger> {
       else
         logFile = fs.create(logfilePath, true, 0, replication, blockSize);
 
+      // Tell the DataNode that the write ahead log does not need to be cached in the OS page cache
+      try {
+        logFile.setDropBehind(Boolean.TRUE);
+      } catch (IOException | UnsupportedOperationException e) {
+        log.debug("setDropBehind writes not enabled for wal file: {}", logFile);
+      }
+
       // check again that logfile can be sync'd
       if (!fs.canSyncAndFlush(logfilePath)) {
         log.warn("sync not supported for log file {}. Data loss may occur.", logPath);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -142,6 +142,14 @@ public class LogSorter {
       fs.deleteRecursively(new Path(destPath));
 
       input = fs.open(srcPath);
+
+      // Tell the DataNode that the write ahead log does not need to be cached in the OS page cache
+      try {
+        input.setDropBehind(Boolean.TRUE);
+      } catch (IOException | UnsupportedOperationException e) {
+        log.debug("setDropBehind writes not enabled for wal file: {}", input);
+      }
+
       try {
         decryptingInput = DfsLogger.getDecryptingStream(input, cryptoService);
       } catch (LogHeaderIncompleteException e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -147,7 +147,7 @@ public class LogSorter {
       try {
         input.setDropBehind(Boolean.TRUE);
       } catch (IOException | UnsupportedOperationException e) {
-        log.debug("setDropBehind writes not enabled for wal file: {}", input);
+        log.debug("setDropBehind reads not enabled for wal file: {}", input);
       }
 
       try {


### PR DESCRIPTION
WAL files are not read after being written unless there is a failure that causes recovery. We can call setDropBehind on the DFSInputStream and DFSOutputStream to inform the DataNodes that they don't have to cache the WAL information after the file has been read or written.