### PR TITLE
Use constants for tables instead of string literals

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
@@ -126,7 +127,7 @@ public class MetadataConstraintsTest {
 
     assertNull(violations);
 
-    m = new Mutation(new Text("!0<"));
+    m = new Mutation(new Text(MetadataTable.ID.canonical() + "<"));
     TabletColumnFamily.PREV_ROW_COLUMN.put(m, new Value("bar"));
 
     violations = mc.check(createEnv(), m);

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -48,6 +48,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.gc.Reference;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ScanServerFileReferenceSection;
@@ -232,7 +233,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
         assertNotNull(iter.next());
 
         List<Entry<Key,Value>> metadataEntries = null;
-        try (Scanner scanner2 = client.createScanner("accumulo.metadata", Authorizations.EMPTY)) {
+        try (Scanner scanner2 = client.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
           scanner2.setRange(ScanServerFileReferenceSection.getRange());
           metadataEntries = scanner2.stream().distinct().collect(Collectors.toList());
         }

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -60,6 +60,8 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.data.constraints.DefaultKeySizeConstraint;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
@@ -341,13 +343,15 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     assertEquals(TimeType.LOGICAL, timeType);
 
     // check system tables
-    timeType = accumuloClient.tableOperations().getTimeType("accumulo.metadata");
+    timeType = accumuloClient.tableOperations().getTimeType(MetadataTable.NAME);
     assertEquals(TimeType.LOGICAL, timeType);
 
-    timeType = accumuloClient.tableOperations().getTimeType("accumulo.replication");
+    @SuppressWarnings("deprecation")
+    var REPL_TABLE_NAME = org.apache.accumulo.core.replication.ReplicationTable.NAME;
+    timeType = accumuloClient.tableOperations().getTimeType(REPL_TABLE_NAME);
     assertEquals(TimeType.LOGICAL, timeType);
 
-    timeType = accumuloClient.tableOperations().getTimeType("accumulo.root");
+    timeType = accumuloClient.tableOperations().getTimeType(RootTable.NAME);
     assertEquals(TimeType.LOGICAL, timeType);
 
     // test non-existent table

--- a/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VerifySerialRecoveryIT.java
@@ -34,6 +34,8 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloClusterImpl.ProcessInfo;
@@ -124,7 +126,7 @@ public class VerifySerialRecoveryIT extends ConfigurableMacBase {
           Pattern.compile(".*recovered \\d+ mutations creating \\d+ entries from \\d+ walogs.*");
       for (String line : result.split("\n")) {
         // ignore metadata tables
-        if (line.contains("!0") || line.contains("+r"))
+        if (line.contains(MetadataTable.ID.canonical()) || line.contains(RootTable.ID.canonical()))
           continue;
         if (line.contains("recovering data from walogs")) {
           assertFalse(started);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/CompactionExecutorIT.java
@@ -51,6 +51,7 @@ import org.apache.accumulo.core.client.admin.compaction.CompressionConfigurer;
 import org.apache.accumulo.core.client.admin.compaction.TooManyDeletesSelector;
 import org.apache.accumulo.core.client.summary.SummarizerConfiguration;
 import org.apache.accumulo.core.client.summary.summarizers.DeletesSummarizer;
+import org.apache.accumulo.core.clientImpl.Namespace;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -177,7 +178,9 @@ public class CompactionExecutorIT extends SharedMiniClusterBase {
   public void cleanup() {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       client.tableOperations().list().stream()
-          .filter(tableName -> !tableName.startsWith("accumulo.")).forEach(tableName -> {
+          .filter(
+              tableName -> !tableName.startsWith(Namespace.ACCUMULO.name() + Namespace.SEPARATOR))
+          .forEach(tableName -> {
             try {
               client.tableOperations().delete(tableName);
             } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompaction_1_IT.java
@@ -76,6 +76,7 @@ import org.apache.accumulo.core.iterators.Filter;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionFinalState.FinalState;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -420,7 +421,7 @@ public class ExternalCompaction_1_IT extends SharedMiniClusterBase {
       tm.close();
 
       // Force a flush on the metadata table before killing our tserver
-      client.tableOperations().flush("accumulo.metadata");
+      client.tableOperations().flush(MetadataTable.NAME);
 
       // Stop our TabletServer. Need to perform a normal shutdown so that the WAL is closed
       // normally.


### PR DESCRIPTION
Use existing constants for referencing the table names and IDs for built-in tables in a few places that previously used hard-coded string literals. These aren't likely to change, but it makes it easier to find references of these built-ins when they use the constant, and it's easier to avoid typos.

I found these while working on #3080. They are very trivial, but nice to have.