### PR TITLE
Add missing deprecation annotations in Mutation

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/ConditionalMutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/ConditionalMutation.java
@@ -105,6 +105,7 @@ public class ConditionalMutation extends Mutation {
     return result;
   }
 
+  @Deprecated
   @Override
   public void setReplicationSources(Set<String> sources) {
     throw new UnsupportedOperationException(

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -91,7 +91,7 @@ public class Mutation implements Writable {
    * Formats available for serializing Mutations. The formats are described in a
    * <a href="doc-files/mutation-serialization.html">separate document</a>.
    */
-  public static enum SERIALIZED_FORMAT {
+  public enum SERIALIZED_FORMAT {
     VERSION1, VERSION2
   }
 
@@ -1507,6 +1507,7 @@ public class Mutation implements Writable {
    *          the peer to add
    * @since 1.7.0
    */
+  @Deprecated(since = "2.1.1")
   public void addReplicationSource(String peer) {
     if (replicationSources == null || replicationSources == EMPTY) {
       replicationSources = new HashSet<>();
@@ -1522,6 +1523,7 @@ public class Mutation implements Writable {
    *          Set of peer names which have processed this update
    * @since 1.7.0
    */
+  @Deprecated(since = "2.1.1")
   public void setReplicationSources(Set<String> sources) {
     requireNonNull(sources);
     this.replicationSources = sources;
@@ -1532,6 +1534,7 @@ public class Mutation implements Writable {
    *
    * @return An unmodifiable view of the replication sources
    */
+  @Deprecated(since = "2.1.1")
   public Set<String> getReplicationSources() {
     if (replicationSources == null) {
       return EMPTY;

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -1506,6 +1506,10 @@ public class Mutation implements Writable {
    * @param peer
    *          the peer to add
    * @since 1.7.0
+   * @deprecated The feature pertaining to this method was deprecated in 2.1.0, but this method was
+   *             overlooked when annotating the code. It is being marked as deprecated in 2.1.1 in
+   *             order to correct that oversight, and will be removed in 3.0.0 with the rest of the
+   *             code pertaining to this feature.
    */
   @Deprecated(since = "2.1.1")
   public void addReplicationSource(String peer) {
@@ -1522,6 +1526,10 @@ public class Mutation implements Writable {
    * @param sources
    *          Set of peer names which have processed this update
    * @since 1.7.0
+   * @deprecated The feature pertaining to this method was deprecated in 2.1.0, but this method was
+   *             overlooked when annotating the code. It is being marked as deprecated in 2.1.1 in
+   *             order to correct that oversight, and will be removed in 3.0.0 with the rest of the
+   *             code pertaining to this feature.
    */
   @Deprecated(since = "2.1.1")
   public void setReplicationSources(Set<String> sources) {
@@ -1533,6 +1541,10 @@ public class Mutation implements Writable {
    * Return the replication sources for this Mutation
    *
    * @return An unmodifiable view of the replication sources
+   * @deprecated The feature pertaining to this method was deprecated in 2.1.0, but this method was
+   *             overlooked when annotating the code. It is being marked as deprecated in 2.1.1 in
+   *             order to correct that oversight, and will be removed in 3.0.0 with the rest of the
+   *             code pertaining to this feature.
    */
   @Deprecated(since = "2.1.1")
   public Set<String> getReplicationSources() {


### PR DESCRIPTION
Add deprecation annotations for replication APIs in Mutation that should have been included in 2.1.0 along with the rest of the replication feature in #2335, but were unintentionally overlooked at the time.