### PR TITLE
Fix flaky AuthenticationTokenSecretManagerTest

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -208,7 +208,7 @@ public class AuthenticationTokenSecretManagerTest extends WithTestNames {
     assertArrayEquals(password, secretManager.retrievePassword(id));
 
     // Make a second token for the same user
-    // Sleep for 1 millisecond to guarantee token is unique
+    // Briefly sleep to guarantee token is unique, since the token is based on the time
     Thread.sleep(100);
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> pair2 =
         secretManager.generateToken(principal, cfg);

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -209,7 +209,7 @@ public class AuthenticationTokenSecretManagerTest extends WithTestNames {
 
     // Make a second token for the same user
     // Sleep for 1 millisecond to guarantee token is unique
-    Thread.sleep(1);
+    Thread.sleep(100);
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> pair2 =
         secretManager.generateToken(principal, cfg);
     Token<AuthenticationTokenIdentifier> token2 = pair2.getKey();

--- a/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManagerTest.java
@@ -208,6 +208,8 @@ public class AuthenticationTokenSecretManagerTest extends WithTestNames {
     assertArrayEquals(password, secretManager.retrievePassword(id));
 
     // Make a second token for the same user
+    // Sleep for 1 millisecond to guarantee token is unique
+    Thread.sleep(1);
     Entry<Token<AuthenticationTokenIdentifier>,AuthenticationTokenIdentifier> pair2 =
         secretManager.generateToken(principal, cfg);
     Token<AuthenticationTokenIdentifier> token2 = pair2.getKey();


### PR DESCRIPTION
Part of the ID of the generated token is the issue date which is the current time in millis so this adds a 1 millisecond sleep in between token generation to guarantee the tokens will be unique.

This fixes #3075