### PR TITLE
Revert "Allow ScanServers to scan offline tables"

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -707,8 +707,8 @@ public class ClientContext implements AccumuloClient {
       int numQueryThreads) throws TableNotFoundException {
     ensureOpen();
     checkArgument(authorizations != null, "authorizations is null");
-    return new TabletServerBatchReader(this, getTableId(tableName), tableName, authorizations,
-        numQueryThreads);
+    return new TabletServerBatchReader(this, requireNotOffline(getTableId(tableName), tableName),
+        tableName, authorizations, numQueryThreads);
   }
 
   @Override
@@ -795,7 +795,8 @@ public class ClientContext implements AccumuloClient {
       throws TableNotFoundException {
     ensureOpen();
     checkArgument(authorizations != null, "authorizations is null");
-    Scanner scanner = new ScannerImpl(this, getTableId(tableName), authorizations);
+    Scanner scanner =
+        new ScannerImpl(this, requireNotOffline(getTableId(tableName), tableName), authorizations);
     Integer batchSize = ClientProperty.SCANNER_BATCH_SIZE.getInteger(getProperties());
     if (batchSize != null) {
       scanner.setBatchSize(batchSize);

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerImpl.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Scanner;
-import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
@@ -153,16 +152,6 @@ public class ScannerImpl extends ScannerOptions implements Scanner {
   @Override
   public synchronized Iterator<Entry<Key,Value>> iterator() {
     ensureOpen();
-
-    if (getConsistencyLevel() == ConsistencyLevel.IMMEDIATE) {
-      try {
-        String tableName = context.getTableName(tableId);
-        context.requireNotOffline(tableId, tableName);
-      } catch (TableNotFoundException e) {
-        throw new RuntimeException("Table not found", e);
-      }
-    }
-
     ScannerIterator iter = new ScannerIterator(context, tableId, authorizations, range, size,
         getTimeout(SECONDS), this, isolated, readaheadThreshold, new Reporter());
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -115,10 +115,6 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
       throw new IllegalStateException("batch reader closed");
     }
 
-    if (getConsistencyLevel() == ConsistencyLevel.IMMEDIATE) {
-      context.requireNotOffline(tableId, tableName);
-    }
-
     return new TabletServerBatchReaderIterator(context, tableId, tableName, authorizations, ranges,
         numThreads, queryThreadPool, this, timeOut);
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
@@ -384,8 +383,7 @@ public class GCRun implements GarbageCollectionEnvironment {
         }
         return Maps.immutableEntry(file, stat);
       });
-    } catch (org.apache.accumulo.core.replication.ReplicationTableOfflineException
-        | TableOfflineException e) {
+    } catch (org.apache.accumulo.core.replication.ReplicationTableOfflineException e) {
       // No elements that we need to preclude
       return Collections.emptyIterator();
     }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -31,7 +31,6 @@ import java.util.UUID;
 
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.gc.thrift.GCStatus;
@@ -358,8 +357,7 @@ public class GarbageCollectWriteAheadLogs {
           candidates.remove(id);
           log.info("Ignore closed log " + id + " because it is being replicated");
         }
-      } catch (org.apache.accumulo.core.replication.ReplicationTableOfflineException
-          | TableOfflineException ex) {
+      } catch (org.apache.accumulo.core.replication.ReplicationTableOfflineException ex) {
         return candidates.size();
       }
 


### PR DESCRIPTION
Reverts apache/accumulo#3082

This reverts the changes in #3082 from the 2.1 branch. The changes in this PR are not enough to allow Scan Servers to scan offline tables and more work is being done in #3091. #3091 is going to be included in 3.0, so I will duplicate these changes in that PR.