### PR TITLE
Modified FileCompactor to ignore TABLE_MAJC_OUTPUT_DROP_CACHE for minc

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -964,6 +964,11 @@ public enum Property {
       "1.3.5"),
   TABLE_ARBITRARY_PROP_PREFIX("table.custom.", null, PropertyType.PREFIX,
       "Prefix to be used for user defined arbitrary properties.", "1.7.0"),
+  TABLE_MINC_OUTPUT_DROP_CACHE("table.compaction.minor.output.drop.cache", "false",
+      PropertyType.BOOLEAN,
+      "Setting this property to true will call"
+          + "FSDataOutputStream.setDropBehind(true) on the minor compaction output stream.",
+      "2.1.1"),
   TABLE_MAJC_OUTPUT_DROP_CACHE("table.compaction.major.output.drop.cache", "false",
       PropertyType.BOOLEAN,
       "Setting this property to true will call"

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileOperations.WriterBuilder;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.FileSKVWriter;
+import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.IteratorConfigUtil;
@@ -219,6 +220,7 @@ public class FileCompactor implements Callable<CompactionStats> {
 
       boolean dropCacheBehindMajcOutput = !RootTable.ID.equals(this.extent.tableId())
           && !MetadataTable.ID.equals(this.extent.tableId())
+          && !(env.getIteratorScope() == IteratorUtil.IteratorScope.minc)
           && acuTableConf.getBoolean(Property.TABLE_MAJC_OUTPUT_DROP_CACHE);
 
       WriterBuilder outBuilder = fileFactory.newWriterBuilder()
@@ -387,8 +389,6 @@ public class FileCompactor implements Callable<CompactionStats> {
       SortedKeyValueIterator<Key,Value> delIter =
           DeletingIterator.wrap(citr, propagateDeletes, DeletingIterator.getBehavior(acuTableConf));
       ColumnFamilySkippingIterator cfsi = new ColumnFamilySkippingIterator(delIter);
-
-      // if(env.getIteratorScope() )
 
       SystemIteratorEnvironment iterEnv =
           env.createIteratorEnv(context, acuTableConf, getExtent().tableId());


### PR DESCRIPTION
FileCompactor is also used by MinorCompactor then when the property TABLE_MAJC_OUTPUT_DROP_CACHE is set to true, the output file was being created with CreateFlag.SYNC_BLOCK and setDropBehind. This change modifies FileCompactor to not do that for minc output files.