### PR TITLE
Use -source-release.tar.gz vs. -src.tar.gz

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -603,35 +603,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <!-- attach source release when it is created by the apache-release profile -->
-      <id>apache-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-source-release-assembly</id>
-                <goals>
-                  <goal>attach-artifact</goal>
-                </goals>
-                <configuration>
-                  <artifacts>
-                    <artifact>
-                      <file>${project.parent.build.directory}/${project.artifactId}-${project.version}-source-release.tar.gz</file>
-                      <type>tar.gz</type>
-                      <classifier>src</classifier>
-                    </artifact>
-                  </artifacts>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -863,7 +863,7 @@
             <goals>clean deploy</goals>
             <preparationGoals>clean package</preparationGoals>
             <tagNameFormat>rel/@{project.version}</tagNameFormat>
-            <releaseProfiles>apache-release,accumulo-release</releaseProfiles>
+            <releaseProfiles>accumulo-release</releaseProfiles>
             <useReleaseProfile>false</useReleaseProfile>
             <pushChanges>false</pushChanges>
             <localCheckout>true</localCheckout>
@@ -1373,26 +1373,6 @@
         <skipTests>true</skipTests>
         <spotbugs.skip>true</spotbugs.skip>
       </properties>
-    </profile>
-    <profile>
-      <!-- set proper source assembly name with apache-release and don't attach here -->
-      <id>apache-release</id>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-assembly-plugin</artifactId>
-              <inherited>false</inherited>
-              <configuration>
-                <!-- source assembly gets attached in the assemble module -->
-                <attach>false</attach>
-                <finalName>accumulo-${project.version}</finalName>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
     </profile>
     <profile>
       <!-- off by default, but enable with '-P verifyformat' or '-DverifyFormat' -->


### PR DESCRIPTION
Modify the primary project pom.xml file and the assemble pom.xml by removing the apache-release profiles. Doing so results in the binary and source distros being located and named to default values and locations.

The binary tarball retains the same name and location as before, whereas the source tarball will be placed in the same directory structure but now named accumulo-<VERSION>-source-release.tar.gz, where VERSION is the current version listed in the pom file.

This update could be merged into the 3.0 release.