### PR TITLE
Remove htrace4 from the binary distribution

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -288,11 +288,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.htrace</groupId>
-      <artifactId>htrace-core4</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
     <hadoop.version>3.3.4</hadoop.version>
-    <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
@@ -529,11 +528,6 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-tools</artifactId>
         <version>${hadoop.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.htrace</groupId>
-        <artifactId>htrace-core4</artifactId>
-        <version>${htrace.hadoop.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
The htrace4 dependency is not needed for Accumulo. It may or may not be a dependency of Hadoop, but if it is needed for that, it can be brought in via the Hadoop lib directory and added to Accumulo's runtime class path. However, since it is not needed for Accumulo itself, it should not be redistributed by Accumulo.