### PR TITLE
Removing replication info necessary for upgrade - resolves issue #3097

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -39,7 +39,7 @@ public class AccumuloDataVersion {
   /**
    * version (11) reflects removal of replication starting with 3.0
    */
-  public static final int REMOVE_REPLICATION = 11;
+  public static final int REMOVE_DEPRECATIONS_FOR_VERSION_3 = 11;
 
   /**
    * version (10) reflects changes to how root tablet metadata is serialized in zookeeper starting
@@ -69,7 +69,7 @@ public class AccumuloDataVersion {
    * <li>version (4) moves logging to HDFS in 1.5.0
    * </ul>
    */
-  private static final int CURRENT_VERSION = REMOVE_REPLICATION;
+  private static final int CURRENT_VERSION = REMOVE_DEPRECATIONS_FOR_VERSION_3;
 
   /**
    * Get the current Accumulo Data Version. See Javadoc of static final integers for a detailed

--- a/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AccumuloDataVersion.java
@@ -37,6 +37,11 @@ import java.util.Set;
 public class AccumuloDataVersion {
 
   /**
+   * version (11) reflects removal of replication starting with 3.0
+   */
+  public static final int REMOVE_REPLICATION = 11;
+
+  /**
    * version (10) reflects changes to how root tablet metadata is serialized in zookeeper starting
    * with 2.1. See {@link org.apache.accumulo.core.metadata.schema.RootTabletMetadata}.
    */
@@ -64,7 +69,7 @@ public class AccumuloDataVersion {
    * <li>version (4) moves logging to HDFS in 1.5.0
    * </ul>
    */
-  private static final int CURRENT_VERSION = ROOT_TABLET_META_CHANGES;
+  private static final int CURRENT_VERSION = REMOVE_REPLICATION;
 
   /**
    * Get the current Accumulo Data Version. See Javadoc of static final integers for a detailed
@@ -77,5 +82,5 @@ public class AccumuloDataVersion {
   }
 
   public static final Set<Integer> CAN_RUN =
-      Set.of(SHORTEN_RFILE_KEYS, CRYPTO_CHANGES, CURRENT_VERSION);
+      Set.of(SHORTEN_RFILE_KEYS, CRYPTO_CHANGES, ROOT_TABLET_META_CHANGES, CURRENT_VERSION);
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -50,7 +50,7 @@ public class UpgradeCoordinator {
 
   public enum UpgradeStatus {
     /**
-     * This signifies the upgrade status is in the process of being determined. Its best to assume
+     * This signifies the upgrade status is in the process of being determined. It is best to assume
      * nothing is upgraded when seeing this.
      */
     INITIAL {
@@ -103,11 +103,11 @@ public class UpgradeCoordinator {
     public abstract boolean isParentLevelUpgraded(KeyExtent extent);
   }
 
-  private static Logger log = LoggerFactory.getLogger(UpgradeCoordinator.class);
+  private static final Logger log = LoggerFactory.getLogger(UpgradeCoordinator.class);
 
   private int currentVersion;
   // map of "current version" -> upgrader to next version.
-  private Map<Integer,
+  private final Map<Integer,
       Upgrader> upgraders = Map.of(AccumuloDataVersion.SHORTEN_RFILE_KEYS, new Upgrader8to9(),
           AccumuloDataVersion.CRYPTO_CHANGES, new Upgrader9to10(),
           AccumuloDataVersion.ROOT_TABLET_META_CHANGES, new Upgrader10to11());
@@ -254,13 +254,13 @@ public class UpgradeCoordinator {
    * need to make sure there are no queued transactions from a previous version before continuing an
    * upgrade. The status of the operations is irrelevant; those in SUCCESSFUL status cause the same
    * problem as those just queued.
-   *
+   * <p>
    * Note that the Manager should not allow write access to Fate until after all upgrade steps are
    * complete.
-   *
+   * <p>
    * Should be called as a guard before performing any upgrade steps, after determining that an
    * upgrade is needed.
-   *
+   * <p>
    * see ACCUMULO-2519
    */
   @SuppressFBWarnings(value = "DM_EXIT",

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -159,7 +159,8 @@ public class UpgradeCoordinator {
           log.info("Upgrading Zookeeper - current version {} as step towards target version {}", v,
               AccumuloDataVersion.get());
           var upgrader = upgraders.get(v);
-          Objects.requireNonNull(upgrader, "Failed to find upgrader for version " + currentVersion);
+          Objects.requireNonNull(upgrader,
+              "upgrade ZooKeeper: failed to find upgrader for version " + currentVersion);
           upgrader.upgradeZookeeper(context);
         }
       }
@@ -188,9 +189,10 @@ public class UpgradeCoordinator {
               for (int v = currentVersion; v < AccumuloDataVersion.get(); v++) {
                 log.info("Upgrading Root - current version {} as step towards target version {}", v,
                     AccumuloDataVersion.get());
-                if (upgraders.get(v) != null) {
-                  upgraders.get(v).upgradeRoot(context);
-                }
+                var upgrader = upgraders.get(v);
+                Objects.requireNonNull(upgrader,
+                    "upgrade root: failed to find root upgrader for version " + currentVersion);
+                upgraders.get(v).upgradeRoot(context);
               }
 
               setStatus(UpgradeStatus.UPGRADED_ROOT, eventCoordinator);
@@ -199,9 +201,10 @@ public class UpgradeCoordinator {
                 log.info(
                     "Upgrading Metadata - current version {} as step towards target version {}", v,
                     AccumuloDataVersion.get());
-                if (upgraders.get(v) != null) {
-                  upgraders.get(v).upgradeMetadata(context);
-                }
+                var upgrader = upgraders.get(v);
+                Objects.requireNonNull(upgrader,
+                    "upgrade metadata: failed to find upgrader for version " + currentVersion);
+                upgraders.get(v).upgradeMetadata(context);
               }
 
               log.info("Updating persistent data version.");

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.Constants.ZNAMESPACES;
+import static org.apache.accumulo.core.Constants.ZTABLES;
+import static org.apache.accumulo.core.Constants.ZTABLE_STATE;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.BatchDeleter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.data.NamespaceId;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.apache.accumulo.core.manager.state.tables.TableState;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.conf.store.NamespacePropKey;
+import org.apache.accumulo.server.conf.store.PropStore;
+import org.apache.accumulo.server.conf.store.PropStoreKey;
+import org.apache.accumulo.server.conf.store.SystemPropKey;
+import org.apache.accumulo.server.conf.store.TablePropKey;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Upgrader10to11 implements Upgrader {
+
+  private static final Logger log = LoggerFactory.getLogger(Upgrader10to11.class);
+
+  // Included for upgrade code usage any other usage post 3.0 should not be used.
+  private static final TableId REPLICATION_ID = TableId.of("+rep");
+
+  public Upgrader10to11() {
+    super();
+  }
+
+  @Override
+  public void upgradeZookeeper(final ServerContext context) {
+    log.info("upgrade of ZooKeeper entries");
+
+    var zrw = context.getZooReaderWriter();
+    var iid = context.getInstanceID();
+
+    // if the replication base path (../tables/+rep) assume removed or never existed.
+    if (!checkReplicationTableInZk(iid, zrw)) {
+      log.debug("replication table root node does not exist in ZooKeeper - nothing to do");
+      return;
+    }
+
+    // if the replication table is online - stop. There could be data in transit.
+    if (!checkReplicationOffline(iid, zrw)) {
+      throw new IllegalStateException(
+          "Replication table is not offline. Cannot continue with upgrade that will remove replication with replication active");
+    }
+
+    deleteReplicationConfigs(zrw, iid, context.getPropStore());
+
+    deleteReplicationTableZkEntries(zrw, iid);
+
+  }
+
+  @Override
+  public void upgradeRoot(final ServerContext context) {
+    log.info("upgrade root - skipping, nothing to do");
+  }
+
+  @Override
+  public void upgradeMetadata(final ServerContext context) {
+    log.info("upgrade metadata entries");
+    deleteReplMetadataEntries(context);
+  }
+
+  /**
+   * remove +rep entries from metadata.
+   */
+  private void deleteReplMetadataEntries(final ServerContext context) {
+    try (BatchDeleter deleter =
+        context.createBatchDeleter(MetadataTable.NAME, Authorizations.EMPTY, 10)) {
+      deleter.setRanges(Collections.singletonList(
+          new Range(REPLICATION_ID.canonical() + ";", REPLICATION_ID.canonical() + "<")));
+      deleter.delete();
+    } catch (TableNotFoundException | MutationsRejectedException ex) {
+      throw new IllegalStateException("failed to remove replication info from metadata table", ex);
+    }
+  }
+
+  private boolean checkReplicationTableInZk(final InstanceId iid, final ZooReaderWriter zrw) {
+    try {
+      String path = buildRepTablePath(iid);
+      return zrw.exists(path);
+    } catch (KeeperException ex) {
+      throw new IllegalStateException("ZooKeeper error - cannot determine replication table status",
+          ex);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted reading replication state from ZooKeeper", ex);
+    }
+  }
+
+  /**
+   * To protect against removing replication information if replication is being used and possible
+   * active, check the replication table state in Zookeeper to see if it is ONLINE (active) or
+   * OFFLINE (inactive). If the state node does not exist, then the status is considered as OFFLINE.
+   *
+   * @return true if the replication table state is OFFLINE, false otherwise
+   */
+  private boolean checkReplicationOffline(final InstanceId iid, final ZooReaderWriter zrw) {
+    try {
+      String path = buildRepTablePath(iid) + ZTABLE_STATE;
+      byte[] bytes = zrw.getData(path);
+      if (bytes != null && bytes.length > 0) {
+        String status = new String(bytes, UTF_8);
+        return TableState.OFFLINE.name().equals(status);
+      }
+      return false;
+    } catch (KeeperException ex) {
+      throw new IllegalStateException("ZooKeeper error - cannot determine replication table status",
+          ex);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted reading replication state from ZooKeeper", ex);
+    }
+  }
+
+  /**
+   * Utility method to build the ZooKeeper replication table path. The path resolves to
+   * {@code /accumulo/INSTANCE_ID/tables/+rep}
+   */
+  static String buildRepTablePath(final InstanceId iid) {
+    return ZooUtil.getRoot(iid) + ZTABLES + "/" + REPLICATION_ID.canonical();
+  }
+
+  private void deleteReplicationTableZkEntries(ZooReaderWriter zrw, InstanceId iid) {
+    String repTablePath = buildRepTablePath(iid);
+    try {
+      zrw.recursiveDelete(repTablePath, ZooUtil.NodeMissingPolicy.SKIP);
+    } catch (KeeperException ex) {
+      throw new IllegalStateException(
+          "ZooKeeper error - failed recursive deletion on " + repTablePath, ex);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted deleting " + repTablePath + " from ZooKeeper",
+          ex);
+    }
+  }
+
+  private void deleteReplicationConfigs(ZooReaderWriter zrw, InstanceId iid, PropStore propStore) {
+    List<PropStoreKey<?>> ids = getPropKeysFromZkIds(zrw, iid);
+    for (PropStoreKey<?> storeKey : ids) {
+      log.trace("Upgrade - remove replication iterators checking: {} ", storeKey);
+      var p = propStore.get(storeKey);
+      var props = p.asMap();
+      List<String> filtered = filterReplConfigKeys(props.keySet());
+      if (filtered.size() > 0) {
+        log.debug("Upgrade filter replication iterators for: {}", storeKey);
+        propStore.removeProperties(storeKey, filtered);
+      }
+    }
+  }
+
+  /**
+   * Return a list of property keys that match replication iterator settings. This is specifically a
+   * narrow filter to avoid potential matches with user define or properties that contain
+   * replication in the property name (specifically table.file.replication which set hdfs block
+   * replication.
+   */
+  List<String> filterReplConfigKeys(Set<String> keys) {
+    String REPL_ITERATOR_PATTERN = "^table\\.iterator\\.(majc|minc|scan)\\.replcombiner$";
+    String REPL_COLUMN_PATTERN =
+        "^table\\.iterator\\.(majc|minc|scan)\\.replcombiner\\.opt\\.columns$";
+
+    Pattern p = Pattern.compile("(" + REPL_ITERATOR_PATTERN + "|" + REPL_COLUMN_PATTERN + ")");
+
+    return keys.stream().filter(e -> p.matcher(e).find()).collect(Collectors.toList());
+  }
+
+  /**
+   * Create a list of propStore keys reading the table ids directly from ZooKeeper.
+   */
+  private List<PropStoreKey<?>> getPropKeysFromZkIds(final ZooReaderWriter zrw,
+      final InstanceId iid) {
+
+    List<PropStoreKey<?>> result = new ArrayList<>();
+
+    result.add(SystemPropKey.of(iid));
+
+    // namespaces
+    String nsRoot = ZooUtil.getRoot(iid) + ZNAMESPACES;
+    try {
+      List<String> c = zrw.getChildren(nsRoot);
+      c.forEach(ns -> result.add(NamespacePropKey.of(iid, NamespaceId.of(ns))));
+    } catch (KeeperException | InterruptedException ex) {
+      throw new IllegalStateException("Failed to read namespace ids from " + nsRoot, ex);
+    }
+
+    // tables
+    String tRoot = ZooUtil.getRoot(iid) + ZTABLES;
+    try {
+      List<String> c = zrw.getChildren(tRoot);
+      c.forEach(t -> result.add(TablePropKey.of(iid, TableId.of(t))));
+    } catch (KeeperException | InterruptedException ex) {
+      throw new IllegalStateException("Failed to read table ids from " + nsRoot, ex);
+    }
+
+    return result;
+  }
+}

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
@@ -130,6 +130,10 @@ public class Upgrader10to11 implements Upgrader {
   }
 
   void deleteReplTableFiles(final ServerContext context, final List<String> replTableFiles) {
+    // short circuit if there are no files
+    if (replTableFiles.isEmpty()) {
+      return;
+    }
     // write delete mutations
     boolean haveFailures = false;
     try (BatchWriter writer = context.createBatchWriter(MetadataTable.NAME)) {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
@@ -51,11 +51,12 @@ import org.apache.accumulo.server.conf.store.PropStore;
 import org.apache.accumulo.server.conf.store.PropStoreKey;
 import org.apache.accumulo.server.conf.store.SystemPropKey;
 import org.apache.accumulo.server.conf.store.TablePropKey;
-import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.hadoop.fs.Path;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class Upgrader10to11 implements Upgrader {
 
@@ -125,12 +126,10 @@ public class Upgrader10to11 implements Upgrader {
     }
   }
 
-  private void deleteReplHdfsFiles(final ServerContext context) {
-
-    VolumeManager vmfs = context.getVolumeManager();
-    // FileSystem fs = vmfs.getFileSystemByPath(outputFile.getPath());
+  @VisibleForTesting
+  void deleteReplHdfsFiles(final ServerContext context) {
     try {
-      for (Volume volume : vmfs.getVolumes()) {
+      for (Volume volume : context.getVolumeManager().getVolumes()) {
         String dirUri = volume.getBasePath() + Constants.HDFS_TABLES_DIR + Path.SEPARATOR
             + REPLICATION_ID.canonical();
         Path replPath = new Path(dirUri);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader10to11.java
@@ -135,18 +135,18 @@ public class Upgrader10to11 implements Upgrader {
     try (BatchWriter writer = context.createBatchWriter(MetadataTable.NAME)) {
       for (String filename : replTableFiles) {
         Mutation m = createDelMutation(filename);
-        log.debug("Add delete mutation: file: {}, mutation: {}", filename, m.prettyPrint());
+        log.debug("Adding delete marker for file: {}", filename);
         writer.addMutation(m);
       }
     } catch (MutationsRejectedException ex) {
-      log.debug("Failed to write mutation {}", ex.getMessage());
+      log.debug("Failed to write delete marker {}", ex.getMessage());
       haveFailures = true;
     } catch (TableNotFoundException ex) {
       throw new IllegalStateException("failed to read replication files from metadata", ex);
     }
     if (haveFailures) {
       throw new IllegalStateException(
-          "deletes rejected adding deletion mutations for replication file entries, check log");
+          "deletes rejected adding deletion marker for replication file entries, check log");
     }
   }
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader10to11Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader10to11Test.java
@@ -23,12 +23,9 @@ import static org.apache.accumulo.core.Constants.ZNAMESPACES;
 import static org.apache.accumulo.core.Constants.ZTABLES;
 import static org.apache.accumulo.core.Constants.ZTABLE_STATE;
 import static org.apache.accumulo.manager.upgrade.Upgrader10to11.buildRepTablePath;
-import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,14 +42,10 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.volume.Volume;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
 import org.apache.accumulo.server.conf.store.PropStore;
 import org.apache.accumulo.server.conf.store.SystemPropKey;
-import org.apache.accumulo.server.fs.VolumeManager;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,39 +190,5 @@ class Upgrader10to11Test {
 
     assertEquals(6, filtered.size());
     log.info("F:{}", filtered);
-  }
-
-  @Test
-  public void removeFromHdfsTest() throws Exception {
-    ServerContext context = createMock(ServerContext.class);
-    VolumeManager vm = createMock(VolumeManager.class);
-    FileSystem fs = createMock(FileSystem.class);
-
-    Volume v1 = createMock(Volume.class);
-    Volume v2 = createMock(Volume.class);
-
-    expect(context.getVolumeManager()).andReturn(vm).anyTimes();
-    expect(vm.getVolumes()).andReturn(List.of(v1, v2)).anyTimes();
-
-    expect(v1.getBasePath()).andReturn("hdfs://accumulo1").anyTimes();
-    expect(v1.getFileSystem()).andReturn(fs).anyTimes();
-
-    expect(v2.getBasePath()).andReturn("hdfs://accumulo2").anyTimes();
-    expect(v2.getFileSystem()).andReturn(fs).anyTimes();
-
-    expect(fs.exists(isA(Path.class))).andReturn(true).once();
-    expect(fs.exists(isA(Path.class))).andReturn(true).once();
-
-    expect(fs.delete(eq(new Path("hdfs://accumulo1/tables/+rep")), anyBoolean())).andReturn(true)
-        .once();
-    expect(fs.delete(eq(new Path("hdfs://accumulo2/tables/+rep")), anyBoolean())).andReturn(true)
-        .once();
-
-    replay(context, vm, fs, v1, v2);
-
-    Upgrader10to11 upgrader = new Upgrader10to11();
-    upgrader.deleteReplHdfsFiles(context);
-
-    verify(context, vm, fs, v1, v2);
   }
 }

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader10to11Test.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/Upgrader10to11Test.java
@@ -19,8 +19,6 @@
 package org.apache.accumulo.manager.upgrade;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.core.Constants.ZNAMESPACES;
-import static org.apache.accumulo.core.Constants.ZTABLES;
 import static org.apache.accumulo.core.Constants.ZTABLE_STATE;
 import static org.apache.accumulo.manager.upgrade.Upgrader10to11.buildRepTablePath;
 import static org.easymock.EasyMock.createMock;
@@ -42,10 +40,11 @@ import org.apache.accumulo.core.data.InstanceId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
 import org.apache.accumulo.core.manager.state.tables.TableState;
+import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.codec.VersionedProperties;
 import org.apache.accumulo.server.conf.store.PropStore;
-import org.apache.accumulo.server.conf.store.SystemPropKey;
+import org.apache.accumulo.server.conf.store.TablePropKey;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,12 +78,12 @@ class Upgrader10to11Test {
     expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(true).once();
     expect(zrw.getData(buildRepTablePath(instanceId) + ZTABLE_STATE))
         .andReturn(TableState.OFFLINE.name().getBytes(UTF_8)).once();
-    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZNAMESPACES)).andReturn(List.of()).once();
-    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZTABLES)).andReturn(List.of()).once();
     zrw.recursiveDelete(buildRepTablePath(instanceId), ZooUtil.NodeMissingPolicy.SKIP);
     expectLastCall().once();
 
-    expect(propStore.get(SystemPropKey.of(instanceId))).andReturn(new VersionedProperties()).once();
+    expect(propStore.get(TablePropKey.of(instanceId, MetadataTable.ID)))
+        .andReturn(new VersionedProperties()).once();
+
     replay(context, zrw, propStore);
 
     Upgrader10to11 upgrader = new Upgrader10to11();
@@ -112,11 +111,10 @@ class Upgrader10to11Test {
     expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(true).once();
     expect(zrw.getData(buildRepTablePath(instanceId) + ZTABLE_STATE))
         .andReturn(TableState.OFFLINE.name().getBytes(UTF_8)).once();
-    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZNAMESPACES)).andReturn(List.of()).once();
-    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZTABLES)).andReturn(List.of()).once();
     zrw.recursiveDelete(buildRepTablePath(instanceId), ZooUtil.NodeMissingPolicy.SKIP);
     expectLastCall().once();
-    expect(propStore.get(SystemPropKey.of(instanceId))).andReturn(new VersionedProperties()).once();
+    expect(propStore.get(TablePropKey.of(instanceId, MetadataTable.ID)))
+        .andReturn(new VersionedProperties()).once();
 
     replay(context, zrw, propStore);
 

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgraderRemoveReplicationTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/UpgraderRemoveReplicationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.manager.upgrade;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.core.Constants.ZNAMESPACES;
+import static org.apache.accumulo.core.Constants.ZTABLES;
+import static org.apache.accumulo.core.Constants.ZTABLE_STATE;
+import static org.apache.accumulo.manager.upgrade.Upgrader10to11.buildRepTablePath;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.apache.accumulo.core.manager.state.tables.TableState;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.conf.codec.VersionedProperties;
+import org.apache.accumulo.server.conf.store.PropStore;
+import org.apache.accumulo.server.conf.store.SystemPropKey;
+import org.apache.zookeeper.KeeperException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class UpgraderRemoveReplicationTest {
+  private static final Logger log = LoggerFactory.getLogger(UpgraderRemoveReplicationTest.class);
+
+  private InstanceId instanceId = null;
+  private ServerContext context = null;
+  private ZooReaderWriter zrw = null;
+
+  private PropStore propStore = null;
+
+  @BeforeEach
+  public void initMocks() {
+    instanceId = InstanceId.of(UUID.randomUUID());
+    context = createMock(ServerContext.class);
+    zrw = createMock(ZooReaderWriter.class);
+    propStore = createMock(PropStore.class);
+
+    expect(context.getZooReaderWriter()).andReturn(zrw).anyTimes();
+    expect(context.getInstanceID()).andReturn(instanceId).anyTimes();
+  }
+
+  @Test
+  void upgradeZooKeeperGoPath() throws Exception {
+
+    expect(context.getPropStore()).andReturn(propStore).anyTimes();
+    expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(true).once();
+    expect(zrw.getData(buildRepTablePath(instanceId) + ZTABLE_STATE))
+        .andReturn(TableState.OFFLINE.name().getBytes(UTF_8)).once();
+    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZNAMESPACES)).andReturn(List.of()).once();
+    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZTABLES)).andReturn(List.of()).once();
+    zrw.recursiveDelete(buildRepTablePath(instanceId), ZooUtil.NodeMissingPolicy.SKIP);
+    expectLastCall().once();
+
+    expect(propStore.get(SystemPropKey.of(instanceId))).andReturn(new VersionedProperties()).once();
+    replay(context, zrw, propStore);
+
+    Upgrader10to11 upgrader = new Upgrader10to11();
+    upgrader.upgradeZookeeper(context);
+
+    verify(context, zrw);
+  }
+
+  @Test
+  void upgradeZookeeperNoReplTableNode() throws Exception {
+
+    expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(false).once();
+    replay(context, zrw);
+
+    Upgrader10to11 upgrader = new Upgrader10to11();
+    upgrader.upgradeZookeeper(context);
+
+    verify(context, zrw);
+  }
+
+  @Test
+  void checkReplicationStateOffline() throws Exception {
+
+    expect(context.getPropStore()).andReturn(propStore).anyTimes();
+    expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(true).once();
+    expect(zrw.getData(buildRepTablePath(instanceId) + ZTABLE_STATE))
+        .andReturn(TableState.OFFLINE.name().getBytes(UTF_8)).once();
+    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZNAMESPACES)).andReturn(List.of()).once();
+    expect(zrw.getChildren(ZooUtil.getRoot(instanceId) + ZTABLES)).andReturn(List.of()).once();
+    zrw.recursiveDelete(buildRepTablePath(instanceId), ZooUtil.NodeMissingPolicy.SKIP);
+    expectLastCall().once();
+    expect(propStore.get(SystemPropKey.of(instanceId))).andReturn(new VersionedProperties()).once();
+
+    replay(context, zrw, propStore);
+
+    Upgrader10to11 upgrader = new Upgrader10to11();
+
+    upgrader.upgradeZookeeper(context);
+
+    verify(context, zrw);
+  }
+
+  @Test
+  void checkReplicationStateOnline() throws Exception {
+    expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(true).once();
+    expect(zrw.getData(buildRepTablePath(instanceId) + ZTABLE_STATE))
+        .andReturn(TableState.ONLINE.name().getBytes(UTF_8)).anyTimes();
+    replay(context, zrw);
+
+    Upgrader10to11 upgrader = new Upgrader10to11();
+    assertThrows(IllegalStateException.class, () -> upgrader.upgradeZookeeper(context));
+
+    verify(context, zrw);
+  }
+
+  @Test
+  void checkReplicationStateNoNode() throws Exception {
+    expect(zrw.exists(buildRepTablePath(instanceId))).andReturn(true).once();
+    expect(zrw.getData(buildRepTablePath(instanceId) + ZTABLE_STATE))
+        .andThrow(new KeeperException.NoNodeException("force no node exception")).anyTimes();
+    replay(context, zrw);
+
+    Upgrader10to11 upgrader = new Upgrader10to11();
+    assertThrows(IllegalStateException.class, () -> upgrader.upgradeZookeeper(context));
+
+    verify(context, zrw);
+  }
+
+  @Test
+  public void filterTest() {
+    Map<String,String> entries = new HashMap<>();
+    entries.put("table.file.compress.blocksize", "32K");
+    entries.put("table.file.replication", "5");
+    entries.put("table.group.server", "file,log,srv,future");
+    entries.put("table.iterator.majc.bulkLoadFilter",
+        "20,org.apache.accumulo.server.iterators.MetadataBulkLoadFilter");
+    entries.put("table.iterator.majc.replcombiner",
+        "9,org.apache.accumulo.server.replication.StatusCombiner");
+    entries.put("table.iterator.majc.replcombiner.opt.columns", "stat");
+    entries.put("table.iterator.majc.vers",
+        "10,org.apache.accumulo.core.iterators.user.VersioningIterator");
+    entries.put("table.iterator.majc.vers.opt.maxVersions", "1");
+    entries.put("table.iterator.minc.replcombiner",
+        "9,org.apache.accumulo.server.replication.StatusCombiner");
+    entries.put("table.iterator.minc.replcombiner.opt.columns", "stat");
+    entries.put("table.iterator.minc.vers",
+        "10,org.apache.accumulo.core.iterators.user.VersioningIterator");
+    entries.put("table.iterator.minc.vers.opt.maxVersions", "1");
+    entries.put("table.iterator.scan.replcombiner",
+        "9,org.apache.accumulo.server.replication.StatusCombiner");
+    entries.put("table.iterator.scan.replcombiner.opt.columns", "stat");
+    entries.put("table.iterator.scan.vers",
+        "10,org.apache.accumulo.core.iterators.user.VersioningIterator");
+
+    String REPL_ITERATOR_PATTERN = "^table\\.iterator\\.(majc|minc|scan)\\.replcombiner$";
+    String REPL_COLUMN_PATTERN =
+        "^table\\.iterator\\.(majc|minc|scan)\\.replcombiner\\.opt\\.columns$";
+
+    Pattern p = Pattern.compile("(" + REPL_ITERATOR_PATTERN + "|" + REPL_COLUMN_PATTERN + ")");
+
+    List<String> filtered =
+        entries.keySet().stream().filter(e -> p.matcher(e).find()).collect(Collectors.toList());
+
+    assertEquals(6, filtered.size());
+    log.info("F:{}", filtered);
+  }
+}


### PR DESCRIPTION
Removes the replication information to allow the upgrade process to complete.  With these changes the upgrade process can successfully run from 2.1 to 3.0.

- removes replication iterator from metadata table.
- removes replication properties from values saved in ZooKeeper.

This PR adds a new data version (from 10 to 11) to separate the replication removal from other upgrade ops that occur.  With 3.0, most (if not all) of the previous upgrade ops can be assumed to have occurred be cause 3.0 will only support upgrades from 2.1.  The new data version may then be unnecessary - but it may make merging between versions easier.  The removal of unnecessary upgrades ops will be addressed as a separate PR.

