### PR TITLE
re #1169: Added a property to preserve locations on tserver shutdown

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -550,13 +550,6 @@ public enum Property {
       "If a thread blocks more than this period of time waiting to get file permits,"
           + " debugging information will be written."),
 
-  TSERV_PRESERVE_LOCATION("tserver.preserve.tablet.location", "false", PropertyType.BOOLEAN,
-      "When a tablet is unloaded/suspended, the current location is preserved in the last location."
-          + " This is to allow a system's tablet locations to be retained when restarting a system."
-          + " Note that if this is used then the last location cannot be used for data locality purposes."
-          + " Also note that master.startup.tserver properties might need to be set as well to ensure"
-          + " the tserver is available before tablets are assigned."),
-
   // accumulo garbage collector properties
   GC_PREFIX("gc.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo garbage collector."),
@@ -857,6 +850,14 @@ public enum Property {
       "For tablets belonging to this table: When a tablet server dies, allow"
           + " the tablet server this duration to revive before reassigning its tablets"
           + " to other tablet servers."),
+
+  TABLE_LOCATION_MODE("table.location.mode", "locality", PropertyType.LAST_LOCATION_MODE,
+      "Describes how the system will assign tablets initially."
+          + " If 'locality' is the mode, then the system will assign tablets based on the data locality (e.g. the last major compaction location)."
+          + " If 'assignment' is the mode, then tablets will be initially assigned to the last place they were assigned which could be"
+          + " different then where they were last compacted given balancing activities."
+          + " Also note that master.startup.tserver properties might need to be set as well to ensure"
+          + " the tserver is available before tablets are initially assigned."),
 
   // VFS ClassLoader properties
   VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY(

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -550,6 +550,13 @@ public enum Property {
       "If a thread blocks more than this period of time waiting to get file permits,"
           + " debugging information will be written."),
 
+  TSERV_PRESERVE_LOCATION("tserver.preserve.tablet.location", "false", PropertyType.BOOLEAN,
+      "When a tablet is unloaded/suspended, the current location is preserved in the last location."
+          + " This is to allow a system's tablet locations to be retained when restarting a system."
+          + " Note that if this is used then the last location cannot be used for data locality purposes."
+          + " Also note that master.startup.tserver properties might need to be set as well to ensure"
+          + " the tserver is available before tablets are assigned."),
+
   // accumulo garbage collector properties
   GC_PREFIX("gc.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the accumulo garbage collector."),

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -291,6 +291,14 @@ public enum Property {
       PropertyType.TIMEDURATION,
       "The maximum amount of time that a Scanner should wait before retrying a failed RPC"),
 
+  GENERAL_LOCATION_MODE("general.location.mode", "locality", PropertyType.LAST_LOCATION_MODE,
+      "Describes how the system will assign tablets initially."
+          + " If 'locality' is the mode, then the system will assign tablets based on the data locality (e.g. the last major compaction location)."
+          + " If 'assignment' is the mode, then tablets will be initially assigned to the last place they were assigned which could be"
+          + " different then where they were last compacted given balancing activities."
+          + " Also note that master.startup.tserver properties might need to be set as well to ensure"
+          + " the tserver is available before tablets are initially assigned."),
+
   // properties that are specific to master server behavior
   MASTER_PREFIX("master.", null, PropertyType.PREFIX,
       "Properties in this category affect the behavior of the master server"),
@@ -850,14 +858,6 @@ public enum Property {
       "For tablets belonging to this table: When a tablet server dies, allow"
           + " the tablet server this duration to revive before reassigning its tablets"
           + " to other tablet servers."),
-
-  TABLE_LOCATION_MODE("table.location.mode", "locality", PropertyType.LAST_LOCATION_MODE,
-      "Describes how the system will assign tablets initially."
-          + " If 'locality' is the mode, then the system will assign tablets based on the data locality (e.g. the last major compaction location)."
-          + " If 'assignment' is the mode, then tablets will be initially assigned to the last place they were assigned which could be"
-          + " different then where they were last compacted given balancing activities."
-          + " Also note that master.startup.tserver properties might need to be set as well to ensure"
-          + " the tserver is available before tablets are initially assigned."),
 
   // VFS ClassLoader properties
   VFS_CLASSLOADER_SYSTEM_CLASSPATH_PROPERTY(

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -112,6 +112,9 @@ public enum PropertyType {
   GC_POST_ACTION("gc_post_action", in(true, null, "none", "flush", "compact"),
       "One of 'none', 'flush', or 'compact'."),
 
+  LAST_LOCATION_MODE("last_location_mode", in(true, null, "assignment", "locality"),
+      "One of 'assignment', or 'locality'."),
+
   STRING("string", x -> true,
       "An arbitrary string of characters whose format is unspecified and"
           + " interpreted based on the context of the property to which it applies."),

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
@@ -148,6 +148,12 @@ public class PropertyTypeTest {
   }
 
   @Test
+  public void testTypeLAST_LOCATION_MODE() {
+    valid(null, "locality", "assignment");
+    invalid("", "other");
+  }
+
+  @Test
   public void testTypeFRACTION() {
     valid(null, "1", "0", "1.0", "25%", "2.5%", "10.2E-3", "10.2E-3%", ".3");
     invalid("", "other", "20%%", "-0.3", "3.6a", "%25", "3%a");

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
@@ -139,6 +140,10 @@ public class MetaDataStateStore extends TabletStateStore {
       for (TabletLocationState tls : tablets) {
         Mutation m = new Mutation(tls.extent.getMetadataEntry());
         if (tls.current != null) {
+          // if configured, preserve the current location as the last location
+          if (context.getConfiguration().getBoolean(Property.TSERV_PRESERVE_LOCATION)) {
+            tls.current.putLastLocation(m);
+          }
           tls.current.clearLocation(m);
           if (logsForDeadServers != null) {
             List<Path> logs = logsForDeadServers.get(tls.current);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -142,7 +142,7 @@ public class MetaDataStateStore extends TabletStateStore {
         if (tls.current != null) {
           // if the location more is assignment, then preserve the current location in the last
           // location value
-          if ("assignment".equals(context.getConfiguration().get(Property.TABLE_LOCATION_MODE))) {
+          if ("assignment".equals(context.getConfiguration().get(Property.GENERAL_LOCATION_MODE))) {
             tls.current.putLastLocation(m);
           }
           tls.current.clearLocation(m);

--- a/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/state/MetaDataStateStore.java
@@ -140,8 +140,9 @@ public class MetaDataStateStore extends TabletStateStore {
       for (TabletLocationState tls : tablets) {
         Mutation m = new Mutation(tls.extent.getMetadataEntry());
         if (tls.current != null) {
-          // if configured, preserve the current location as the last location
-          if (context.getConfiguration().getBoolean(Property.TSERV_PRESERVE_LOCATION)) {
+          // if the location more is assignment, then preserve the current location in the last
+          // location value
+          if ("assignment".equals(context.getConfiguration().get(Property.TABLE_LOCATION_MODE))) {
             tls.current.putLastLocation(m);
           }
           tls.current.clearLocation(m);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MasterMetadataUtil.java
@@ -257,7 +257,7 @@ public class MasterMetadataUtil {
     TServerInstance self = getTServerInstance(address, zooLock);
     // if the location mode is 'locality'', then preserve the current compaction location in the
     // last location value
-    if ("locality".equals(context.getConfiguration().get(Property.TABLE_LOCATION_MODE))) {
+    if ("locality".equals(context.getConfiguration().get(Property.GENERAL_LOCATION_MODE))) {
       self.putLastLocation(m);
     }
 
@@ -336,15 +336,12 @@ public class MasterMetadataUtil {
 
       // if the location mode is 'locality'', then preserve the current compaction location in the
       // last location value
-      if ("locality".equals(context.getConfiguration().get(Property.TABLE_LOCATION_MODE))) {
+      if ("locality".equals(context.getConfiguration().get(Property.GENERAL_LOCATION_MODE))) {
         // stuff in this location
         TServerInstance self = getTServerInstance(address, zooLock);
         self.putLastLocation(m);
         // erase the old location
         if (lastLocation != null && !lastLocation.equals(self))
-          // @TODO: this does not make any sense to me as this will simply clear out the location we
-          // just set a couple lines previously
-          // clearLastLocation will clear the "last" location no matter what the value is
           lastLocation.clearLastLocation(m);
       }
 


### PR DESCRIPTION
Here is a possible mechanism to allow the tablets to be hosted to the same tserver when restarting a system.  Still looking for any cleaner solutions.