### PR TITLE
Add option to only skip trash for Import files

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -747,7 +747,7 @@ public enum Property {
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN,
       "Do not use the Trash, even if it is configured.", "1.5.0"),
   GC_TRASH_IGNORE_IMPORTS_ONLY("gc.trash.ignore.imports.only", "false", PropertyType.BOOLEAN,
-      "Skip trash only for Import files when gc.trash.ignore is true.", "2.1.0"),
+      "Skip trash only for Import files when gc.trash.ignore is true.", "3.0.0"),
   GC_SAFEMODE("gc.safemode", "false", PropertyType.BOOLEAN,
       "Provides listing of files to be deleted but does not delete any files", "2.1.0"),
   GC_USE_FULL_COMPACTION("gc.post.metadata.action", "flush", PropertyType.GC_POST_ACTION,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -746,6 +746,8 @@ public enum Property {
       "The number of threads used to delete RFiles and write-ahead logs", "1.3.5"),
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN,
       "Do not use the Trash, even if it is configured.", "1.5.0"),
+  GC_TRASH_IGNORE_IMPORTS_ONLY("gc.trash.ignore.imports.only", "false", PropertyType.BOOLEAN,
+      "Skip trash only for Import files when gc.trash.ignore is true.", "2.1.0"),
   GC_SAFEMODE("gc.safemode", "false", PropertyType.BOOLEAN,
       "Provides listing of files to be deleted but does not delete any files", "2.1.0"),
   GC_USE_FULL_COMPACTION("gc.post.metadata.action", "flush", PropertyType.GC_POST_ACTION,

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -747,7 +747,7 @@ public enum Property {
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN,
       "Do not use the Trash, even if it is configured.", "1.5.0"),
   GC_TRASH_IGNORE_IMPORTS_ONLY("gc.trash.ignore.imports.only", "false", PropertyType.BOOLEAN,
-      "Skip trash only for Import files when gc.trash.ignore is true.", "3.0.0"),
+      "Skip Trash for Import files when the trash is in use.", "3.0.0"),
   GC_SAFEMODE("gc.safemode", "false", PropertyType.BOOLEAN,
       "Provides listing of files to be deleted but does not delete any files", "2.1.0"),
   GC_USE_FULL_COMPACTION("gc.post.metadata.action", "flush", PropertyType.GC_POST_ACTION,

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -443,29 +443,34 @@ public class GCRun implements GarbageCollectionEnvironment {
   }
 
   private boolean shouldUseTrash(Path path) {
+    // If gc.trash.ignore.imports.only is set to true and
+    // this is a bulk import file, then return false so
+    // that we don't use the trash. Otherwise, use the value
+    // of gc.trash.ignore
+    if (isSkipTrashImportsOnly() && path.getName().startsWith("I")) {
+      return false;
+    }
 
-    // If this is a bulk import file, then we will skipTrash if
-    // the gc.trash.ignore.imports.only is set to true.
-    boolean forceBulkImportSkipTrash = isSkipTrashImportsOnly() && !path.getName().startsWith("I");
-
-    if (isUsingTrash() || forceBulkImportSkipTrash) {
+    if (isUsingTrash()) {
       return true;
     }
     return false;
-
   }
 
   /**
-   * Checks if the volume manager should move files to the trash rather than delete them.
+   * if gc.trash.ignore is set to true, then we won't use the trash even if it is configured.
    *
-   * @return true if trash is used
+   * @return true if gc.trash.ignore is false
    */
   boolean isUsingTrash() {
     return !config.getBoolean(Property.GC_TRASH_IGNORE);
   }
 
   /**
-   * Checks if the volume manager should only skip trash for files that are not bulk imports
+   * if gc.trash.ignore.imports.only is set to true, then we won't use the trash for bulk import
+   * files, even if gc.trash.ignore is set to true.
+   *
+   * @return value of gc.trash.ignore.imports.only
    */
   boolean isSkipTrashImportsOnly() {
     return config.getBoolean(Property.GC_TRASH_IGNORE_IMPORTS_ONLY);

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -432,7 +432,7 @@ public class GCRun implements GarbageCollectionEnvironment {
    */
   boolean moveToTrash(Path path) throws IOException {
     final VolumeManager fs = context.getVolumeManager();
-    if (!isUsingTrash() && (!isSkipTrashImportsOnly() || path.getName().startsWith("I"))) {
+    if (!shouldUseTrash(path)) {
       return false;
     }
     try {
@@ -440,6 +440,19 @@ public class GCRun implements GarbageCollectionEnvironment {
     } catch (FileNotFoundException ex) {
       return false;
     }
+  }
+
+  private boolean shouldUseTrash(Path path) {
+
+    // If this is a bulk import file, then we will skipTrash if
+    // the gc.trash.ignore.imports.only is set to true.
+    boolean forceBulkImportSkipTrash = isSkipTrashImportsOnly() && !path.getName().startsWith("I");
+
+    if (isUsingTrash() || forceBulkImportSkipTrash) {
+      return true;
+    }
+    return false;
+
   }
 
   /**

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -432,7 +432,7 @@ public class GCRun implements GarbageCollectionEnvironment {
    */
   boolean moveToTrash(Path path) throws IOException {
     final VolumeManager fs = context.getVolumeManager();
-    if (!isUsingTrash()) {
+    if (!isUsingTrash() && (!isSkipTrashImportsOnly() || path.getName().startsWith("I"))) {
       return false;
     }
     try {
@@ -449,6 +449,13 @@ public class GCRun implements GarbageCollectionEnvironment {
    */
   boolean isUsingTrash() {
     return !config.getBoolean(Property.GC_TRASH_IGNORE);
+  }
+
+  /**
+   * Checks if the volume manager should only skip trash for files that are not bulk imports
+   */
+  boolean isSkipTrashImportsOnly() {
+    return config.getBoolean(Property.GC_TRASH_IGNORE_IMPORTS_ONLY);
   }
 
   /**

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.gc.thrift.GCStatus;
 import org.apache.accumulo.core.gc.thrift.GcCycleStats;
 import org.apache.accumulo.core.metadata.TServerInstance;
@@ -70,13 +71,12 @@ public class GarbageCollectWriteAheadLogs {
    *
    * @param context the collection server's context
    * @param fs volume manager to use
-   * @param useTrash true to move files to trash rather than delete them
    */
   GarbageCollectWriteAheadLogs(final ServerContext context, final VolumeManager fs,
-      final LiveTServerSet liveServers, boolean useTrash) {
+      final LiveTServerSet liveServers) {
     this.context = context;
     this.fs = fs;
-    this.useTrash = useTrash;
+    this.useTrash = !context.getConfiguration().getBoolean(Property.GC_TRASH_IGNORE);
     this.liveServers = liveServers;
     this.walMarker = new WalStateManager(context);
     this.store = () -> Iterators.concat(

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -343,7 +343,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
    */
   boolean moveToTrash(Path path) throws IOException {
     final VolumeManager fs = getContext().getVolumeManager();
-    if (!isUsingTrash() && (!isSkipTrashImportsOnly() || path.getName().startsWith("I"))) {
+    if (!shouldUseTrash(path)) {
       return false;
     }
     try {
@@ -351,6 +351,19 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
     } catch (FileNotFoundException ex) {
       return false;
     }
+  }
+
+  private boolean shouldUseTrash(Path path) {
+
+    // If this is a bulk import file, then we will skipTrash if
+    // the gc.trash.ignore.imports.only is set to true.
+    boolean forceBulkImportSkipTrash = isSkipTrashImportsOnly() && !path.getName().startsWith("I");
+
+    if (isUsingTrash() || forceBulkImportSkipTrash) {
+      return true;
+    }
+    return false;
+
   }
 
   private void getZooLock(HostAndPort addr) throws KeeperException, InterruptedException {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -121,6 +121,13 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
   }
 
   /**
+   * Checks if the volume manager should only skip trash for files that are not bulk imports
+   */
+  boolean isSkipTrashImportsOnly() {
+    return getConfiguration().getBoolean(Property.GC_TRASH_IGNORE_IMPORTS_ONLY);
+  }
+
+  /**
    * Gets the number of threads used for deleting files.
    *
    * @return number of delete threads
@@ -336,7 +343,7 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
    */
   boolean moveToTrash(Path path) throws IOException {
     final VolumeManager fs = getContext().getVolumeManager();
-    if (!isUsingTrash()) {
+    if (!isUsingTrash() && (!isSkipTrashImportsOnly() || path.getName().startsWith("I"))) {
       return false;
     }
     try {

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -142,10 +142,12 @@ public class SimpleGarbageCollectorTest {
     systemConfig.set(Property.GC_TRASH_IGNORE.getKey(), "true");
     systemConfig.set(Property.GC_TRASH_IGNORE_IMPORTS_ONLY.getKey(), "true");
     Path iFilePath = new Path("Ifile");
+    Path iFileWithFullPath = new Path("hdfs://namenode/accumulo/Ifile");
     Path notIFilePath = new Path("notIfile");
-    expect(volMgr.moveToTrash(notIFilePath)).andReturn(true);
+    expect(volMgr.moveToTrash(notIFilePath)).andReturn(true).times(1);
     replay(volMgr);
     assertFalse(gc.moveToTrash(iFilePath));
+    assertFalse(gc.moveToTrash(iFileWithFullPath));
     assertTrue(gc.moveToTrash(notIFilePath));
     verify(volMgr);
   }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -141,14 +141,19 @@ public class SimpleGarbageCollectorTest {
   public void testMoveToTrash_NotUsingTrash_importsOnlyEnabled() throws Exception {
     systemConfig.set(Property.GC_TRASH_IGNORE.getKey(), "true");
     systemConfig.set(Property.GC_TRASH_IGNORE_IMPORTS_ONLY.getKey(), "true");
-    Path iFilePath = new Path("Ifile");
-    Path iFileWithFullPath = new Path("hdfs://namenode/accumulo/Ifile");
-    Path notIFilePath = new Path("notIfile");
+    Path iFilePath = new Path("I0000070.rf");
+    Path iFileWithFullPath =
+        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/I0000070.rf");
+    Path notIFilePath = new Path("F0000070.rf");
+    Path notIFileWithFullPath =
+        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf");
     expect(volMgr.moveToTrash(notIFilePath)).andReturn(true).times(1);
+    expect(volMgr.moveToTrash(notIFileWithFullPath)).andReturn(true).times(1);
     replay(volMgr);
     assertFalse(gc.moveToTrash(iFilePath));
     assertFalse(gc.moveToTrash(iFileWithFullPath));
     assertTrue(gc.moveToTrash(notIFilePath));
+    assertTrue(gc.moveToTrash(notIFileWithFullPath));
     verify(volMgr);
   }
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -138,6 +138,19 @@ public class SimpleGarbageCollectorTest {
   }
 
   @Test
+  public void testMoveToTrash_NotUsingTrash_importsOnlyEnabled() throws Exception {
+    systemConfig.set(Property.GC_TRASH_IGNORE.getKey(), "true");
+    systemConfig.set(Property.GC_TRASH_IGNORE_IMPORTS_ONLY.getKey(), "true");
+    Path iFilePath = new Path("Ifile");
+    Path notIFilePath = new Path("notIfile");
+    expect(volMgr.moveToTrash(notIFilePath)).andReturn(true);
+    replay(volMgr);
+    assertFalse(gc.moveToTrash(iFilePath));
+    assertTrue(gc.moveToTrash(notIFilePath));
+    verify(volMgr);
+  }
+
+  @Test
   public void testIsDir() {
     assertTrue(SimpleGarbageCollector.isDir("tid1/dir1"));
     assertTrue(SimpleGarbageCollector.isDir("/dir1"));


### PR DESCRIPTION
This MR adds an option to optionally skip trash for Import files only.
On our clusters, we find that we have to skip trash due to pressure on the namenodes and the scale that we deal with.

We have seen a few instances of files going missing. We are still in the process of investigating (we thought it would be fixed by #2792 but was not.). When this happens because of our use case we can typically track down the data that contributed to Import files. However, data that has been compacted by one or more tablet servers is more difficult to tack down. By enabling this new option, we will have time to catch this issue and recover the data before the trash is emptied while we determine the cause of the files going missing.

Intention is to backport this to 1.10 once the approach is agreed upon