### PR TITLE
Add id info to config check utility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,6 +138,10 @@
       <artifactId>zookeeper-jute</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import org.apache.accumulo.core.data.AbstractId;
 import org.apache.accumulo.core.spi.crypto.CryptoServiceFactory;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +44,11 @@ public class ConfigCheckUtil {
    * {@link Property#INSTANCE_ZK_TIMEOUT} within a valid range.
    *
    * @param entries iterable through configuration keys and values
+   * @param source the namespace, table id, site or system config where for diagnostic messages
    * @throws ConfigCheckException if a fatal configuration error is found
    */
-  public static void validate(Iterable<Entry<String,String>> entries, AbstractId<?> source) {
+  public static void validate(Iterable<Entry<String,String>> entries, @NonNull String source) {
     String instanceZkTimeoutValue = null;
-    String idName = source != null ? source.toString() : "site";
     for (Entry<String,String> entry : entries) {
       String key = entry.getKey();
       String value = entry.getValue();
@@ -56,12 +56,12 @@ public class ConfigCheckUtil {
       if (prop == null && Property.isValidPropertyKey(key)) {
         continue; // unknown valid property (i.e. has proper prefix)
       } else if (prop == null) {
-        log.warn(PREFIX + "unrecognized property key ({}) for {}", key, idName);
+        log.warn(PREFIX + "unrecognized property key ({}) for {}", key, source);
       } else if (prop.getType() == PropertyType.PREFIX) {
-        fatal(PREFIX + "incomplete property key (" + key + ") for " + idName);
+        fatal(PREFIX + "incomplete property key (" + key + ") for " + source);
       } else if (!prop.getType().isValidFormat(value)) {
         fatal(PREFIX + "improperly formatted value for key (" + key + ", type=" + prop.getType()
-            + ") : " + value + " for " + idName);
+            + ") : " + value + " for " + source);
       }
 
       if (key.equals(Property.INSTANCE_ZK_TIMEOUT.getKey())) {
@@ -130,7 +130,7 @@ public class ConfigCheckUtil {
   }
 
   /**
-   * The exception thrown when {@link ConfigCheckUtil#validate(Iterable, AbstractId)} fails.
+   * The exception thrown when {@link ConfigCheckUtil#validate(Iterable, String)} fails.
    */
   public static class ConfigCheckException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -209,7 +209,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
   private final Map<String,String> config;
 
   private SiteConfiguration(Map<String,String> config) {
-    ConfigCheckUtil.validate(config.entrySet());
+    ConfigCheckUtil.validate(config.entrySet(), null);
     this.config = config;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/SiteConfiguration.java
@@ -209,7 +209,7 @@ public class SiteConfiguration extends AccumuloConfiguration {
   private final Map<String,String> config;
 
   private SiteConfiguration(Map<String,String> config) {
-    ConfigCheckUtil.validate(config.entrySet(), null);
+    ConfigCheckUtil.validate(config.entrySet(), "site config");
     this.config = config;
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
@@ -40,51 +40,51 @@ public class ConfigCheckUtilTest {
     m.put(Property.MANAGER_TABLET_BALANCER.getKey(),
         "org.apache.accumulo.server.manager.balancer.TableLoadBalancer");
     m.put(Property.MANAGER_BULK_RETRIES.getKey(), "3");
-    ConfigCheckUtil.validate(m.entrySet(), null);
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testPass_Empty() {
-    ConfigCheckUtil.validate(m.entrySet(), null);
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testPass_UnrecognizedValidProperty() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey() + "something", "abcdefg");
-    ConfigCheckUtil.validate(m.entrySet(), null);
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testPass_UnrecognizedProperty() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put("invalid.prefix.value", "abcdefg");
-    ConfigCheckUtil.validate(m.entrySet(), null);
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 
   @Test
   public void testFail_Prefix() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey(), "oops");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), null));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), "test"));
   }
 
   @Test
   public void testFail_InstanceZkTimeoutOutOfRange() {
     m.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "10ms");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), null));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), "test"));
   }
 
   @Test
   public void testFail_badCryptoFactory() {
     m.put(Property.INSTANCE_CRYPTO_FACTORY.getKey(), "DoesNotExistCryptoFactory");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), null));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), "test"));
   }
 
   @Test
   public void testPass_defaultCryptoFactory() {
     m.put(Property.INSTANCE_CRYPTO_FACTORY.getKey(),
         Property.INSTANCE_CRYPTO_FACTORY.getDefaultValue());
-    ConfigCheckUtil.validate(m.entrySet(), null);
+    ConfigCheckUtil.validate(m.entrySet(), "test");
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/ConfigCheckUtilTest.java
@@ -40,51 +40,51 @@ public class ConfigCheckUtilTest {
     m.put(Property.MANAGER_TABLET_BALANCER.getKey(),
         "org.apache.accumulo.server.manager.balancer.TableLoadBalancer");
     m.put(Property.MANAGER_BULK_RETRIES.getKey(), "3");
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), null);
   }
 
   @Test
   public void testPass_Empty() {
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), null);
   }
 
   @Test
   public void testPass_UnrecognizedValidProperty() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey() + "something", "abcdefg");
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), null);
   }
 
   @Test
   public void testPass_UnrecognizedProperty() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put("invalid.prefix.value", "abcdefg");
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), null);
   }
 
   @Test
   public void testFail_Prefix() {
     m.put(Property.MANAGER_CLIENTPORT.getKey(), "9999");
     m.put(Property.MANAGER_PREFIX.getKey(), "oops");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), null));
   }
 
   @Test
   public void testFail_InstanceZkTimeoutOutOfRange() {
     m.put(Property.INSTANCE_ZK_TIMEOUT.getKey(), "10ms");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), null));
   }
 
   @Test
   public void testFail_badCryptoFactory() {
     m.put(Property.INSTANCE_CRYPTO_FACTORY.getKey(), "DoesNotExistCryptoFactory");
-    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet()));
+    assertThrows(ConfigCheckException.class, () -> ConfigCheckUtil.validate(m.entrySet(), null));
   }
 
   @Test
   public void testPass_defaultCryptoFactory() {
     m.put(Property.INSTANCE_CRYPTO_FACTORY.getKey(),
         Property.INSTANCE_CRYPTO_FACTORY.getDefaultValue());
-    ConfigCheckUtil.validate(m.entrySet());
+    ConfigCheckUtil.validate(m.entrySet(), null);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/DefaultConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/DefaultConfigurationTest.java
@@ -52,6 +52,6 @@ public class DefaultConfigurationTest {
 
   @Test
   public void testSanityCheck() {
-    ConfigCheckUtil.validate(c);
+    ConfigCheckUtil.validate(c, null);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/DefaultConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/DefaultConfigurationTest.java
@@ -52,6 +52,6 @@ public class DefaultConfigurationTest {
 
   @Test
   public void testSanityCheck() {
-    ConfigCheckUtil.validate(c, null);
+    ConfigCheckUtil.validate(c, "test");
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -105,7 +105,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
         context.getPropStore().registerAsListener(TablePropKey.of(context, tableId), deleteWatcher);
         var conf =
             new TableConfiguration(context, tableId, getNamespaceConfigurationForTable(tableId));
-        ConfigCheckUtil.validate(conf, tableId);
+        ConfigCheckUtil.validate(conf, tableId.toString());
         return conf;
       }
       return null;
@@ -129,7 +129,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
       context.getPropStore().registerAsListener(NamespacePropKey.of(context, namespaceId),
           deleteWatcher);
       var conf = new NamespaceConfiguration(context, namespaceId, getSystemConfiguration());
-      ConfigCheckUtil.validate(conf, namespaceId);
+      ConfigCheckUtil.validate(conf, namespaceId.toString());
       return conf;
     });
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -105,7 +105,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
         context.getPropStore().registerAsListener(TablePropKey.of(context, tableId), deleteWatcher);
         var conf =
             new TableConfiguration(context, tableId, getNamespaceConfigurationForTable(tableId));
-        ConfigCheckUtil.validate(conf);
+        ConfigCheckUtil.validate(conf, tableId);
         return conf;
       }
       return null;
@@ -129,7 +129,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
       context.getPropStore().registerAsListener(NamespacePropKey.of(context, namespaceId),
           deleteWatcher);
       var conf = new NamespaceConfiguration(context, namespaceId, getSystemConfiguration());
-      ConfigCheckUtil.validate(conf);
+      ConfigCheckUtil.validate(conf, namespaceId);
       return conf;
     });
   }


### PR DESCRIPTION
The `ConfigCheckUtil.validate` function logs  issues with properties, but does not include an id to help  find where the issue is occurring.  This PR adds the namespace or table id - or if an id is not provided, it assumes the property is from the site configuration.

This was noticed after upgrading a 2.1 instance with replication configured. PR #3137 is independent of these changes, but this PR does provide additional information once upgrades are possible with PR #3137

Before the changes, the logs looks like:
```
2022-12-27T17:55:57,477 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.name)
2022-12-27T17:55:57,477 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.password.peer1)
2022-12-27T17:55:57,477 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.peer1)
2022-12-27T17:55:57,477 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.user.peer1)
2022-12-27T17:55:57,485 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.name)
2022-12-27T17:55:57,485 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.password.peer1)
2022-12-27T17:55:57,485 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.peer1)
2022-12-27T17:55:57,485 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.user.peer1)

```

With these changes:
```
2022-12-27T22:15:30,945 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.name) for site

2022-12-27T18:49:40,286 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.name) for +accumulo
2022-12-27T18:49:40,286 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.password.peer1) for +accumulo
2022-12-27T18:49:40,286 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.peer1) for +accumulo
2022-12-27T18:49:40,286 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.user.peer1) for +accumulo
2022-12-27T18:49:40,293 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.name) for +r
2022-12-27T18:49:40,293 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.password.peer1) for +r
2022-12-27T18:49:40,293 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.peer1) for +r
2022-12-27T18:49:40,293 [conf.ConfigCheckUtil] WARN : BAD CONFIG unrecognized property key (replication.peer.user.peer1) for +r
2022-12-27T18:49:40,299 [balancer.TableLoadBalancer] INFO : Loaded class org.apache.accumulo.core.spi.balancer.SimpleLoadBalancer for table +r

```
