### PR TITLE
Check Prop Value Format and Key types.

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTest.java
@@ -95,6 +95,20 @@ public class PropertyTest {
     }
   }
 
+  @Test
+  public void testBooleans() {
+    for (Property prop : Property.values()) {
+      if (prop.getType().equals(PropertyType.BOOLEAN)) {
+        assertFalse(prop.getType().isValidFormat("foo"));
+        assertTrue(prop.getType().isValidFormat(null));
+        assertTrue(prop.getType().isValidFormat("true"));
+        assertTrue(prop.getType().isValidFormat("True"));
+        assertTrue(prop.getType().isValidFormat("false"));
+        assertTrue(prop.getType().isValidFormat("False"));
+      }
+    }
+  }
+
   // This test verifies all "sensitive" properties are properly marked as sensitive
   @Test
   public void testSensitiveKeys() {

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ConfigCommand.java
@@ -127,9 +127,14 @@ public class ConfigCommand extends Command {
       value = pair[1];
 
       if (tableName != null) {
-        if (!Property.isValidTablePropertyKey(property)) {
-          throw new BadArgumentException("Invalid per-table property.", fullCommand,
-              fullCommand.indexOf(property));
+        if (!Property.isTablePropertyValid(property, value)) {
+          if (!Property.isValidTablePropertyKey(property)) {
+            throw new BadArgumentException("Invalid per-table property.", fullCommand,
+                fullCommand.indexOf(property));
+          } else {
+            throw new BadArgumentException("Invalid property value.", fullCommand,
+                fullCommand.indexOf(value));
+          }
         }
         if (property.equals(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY.getKey())) {
           new ColumnVisibility(value); // validate that it is a valid expression
@@ -137,9 +142,14 @@ public class ConfigCommand extends Command {
         shellState.getAccumuloClient().tableOperations().setProperty(tableName, property, value);
         Shell.log.debug("Successfully set table configuration option.");
       } else if (namespace != null) {
-        if (!Property.isValidTablePropertyKey(property)) {
-          throw new BadArgumentException("Invalid per-table property.", fullCommand,
-              fullCommand.indexOf(property));
+        if (!Property.isTablePropertyValid(property, value)) {
+          if (!Property.isValidTablePropertyKey(property)) {
+            throw new BadArgumentException("Invalid per-table property.", fullCommand,
+                fullCommand.indexOf(property));
+          } else {
+            throw new BadArgumentException("Invalid property value.", fullCommand,
+                fullCommand.indexOf(value));
+          }
         }
         if (property.equals(Property.TABLE_DEFAULT_SCANTIME_VISIBILITY.getKey())) {
           new ColumnVisibility(value); // validate that it is a valid expression
@@ -151,6 +161,12 @@ public class ConfigCommand extends Command {
         if (!Property.isValidZooPropertyKey(property)) {
           throw new BadArgumentException("Property cannot be modified in zookeeper", fullCommand,
               fullCommand.indexOf(property));
+        }
+        if (!Property.getPropertyByKey(property).getType().isValidFormat(value)) {
+          throw new BadArgumentException(
+              "Invalid Property value (requires type: "
+                  + Property.getPropertyByKey(property).getType().toString() + ")",
+              fullCommand, fullCommand.indexOf(value));
         }
         shellState.getAccumuloClient().instanceOperations().setProperty(property, value);
         Shell.log.debug("Successfully set system configuration option.");

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.conf.PropertyType;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.shell.Shell;
 import org.jline.reader.LineReader;
@@ -468,6 +470,92 @@ public class ShellIT extends SharedMiniClusterBase {
     exec("grep r -st -f 1", true, expectedTimestamp);
     exec("setauths -c", true);
     exec("deletetable t -f", true, "Table: [t] has been deleted");
+  }
+
+  @Test
+  void configTest() throws IOException {
+    Shell.log.debug("Starting config property type test -------------------------");
+
+    String testTable = "test";
+    exec("createtable " + testTable, true);
+
+    for (Property property : Property.values()) {
+      PropertyType propertyType = property.getType();
+      String invalidValue, validValue = property.getDefaultValue();
+
+      // Skip test if we can't set this property via shell
+      if (!Property.isValidZooPropertyKey(property.getKey())) {
+        Shell.log.debug("Property {} with type {} cannot be modified by shell", property.getKey(),
+            propertyType.toString());
+        continue;
+      }
+
+      switch (propertyType) {
+        case PATH:
+        case PREFIX:
+        case STRING:
+          Shell.log.debug("Skipping " + propertyType + " Property Types");
+          continue;
+        case TIMEDURATION:
+          invalidValue = "1h30min";
+          break;
+        case BYTES:
+          invalidValue = "1M500k";
+          break;
+        case MEMORY:
+          invalidValue = "1.5G";
+          break;
+        case HOSTLIST:
+          invalidValue = ":1000";
+          break;
+        case PORT:
+          invalidValue = "65539";
+          break;
+        case COUNT:
+          invalidValue = "-1";
+          break;
+        case FRACTION:
+          invalidValue = "10Percent";
+          break;
+        case ABSOLUTEPATH:
+          invalidValue = "~/foo";
+          break;
+        case CLASSNAME:
+          Shell.log.debug("CLASSNAME properties currently fail this test");
+          Shell.log.debug("Regex used for CLASSNAME property types may need to be modified");
+          continue;
+        case CLASSNAMELIST:
+          invalidValue = "String,Object";
+          break;
+        case DURABILITY:
+          invalidValue = "rinse";
+          break;
+        case GC_POST_ACTION:
+          invalidValue = "expand";
+          break;
+        case BOOLEAN:
+          invalidValue = "fooFalse";
+          break;
+        case URI:
+          invalidValue = "12///\\{}:;123!";
+          break;
+        default:
+          Shell.log
+              .debug("Property Type: " + propertyType.toString() + " has no defined test case");
+          invalidValue = "foo";
+      }
+      String setCommand = "config -s ";
+      if (Property.isValidTablePropertyKey(property.getKey())) {
+        setCommand = "config -t " + testTable + " -s ";
+      }
+      Shell.log.debug("Testing Property {} with Type {}", property.getKey(),
+          propertyType.toString());
+      Shell.log.debug("Invalid property value of \"{}\"", invalidValue);
+      exec(setCommand + property.getKey() + "=" + invalidValue, false,
+          "Invalid Property value (requires type: " + propertyType.toString() + ")");
+      exec(setCommand + property.getKey() + "=" + validValue, true);
+    }
+    exec("deletetable " + testTable + " -f", true);
   }
 
   @Test


### PR DESCRIPTION
relates to #3145

The shell config command was only checking Property Key Types and not Value Formats on Set operations. Changed Set operation to also validate value types to ensure proper format before setting properties.

This changes the shell client behavior to now throw an error message to the user on an invalid property setting.

Boolean Example: 
```
root@uno> config -s tserver.port.search=123
2022-12-30T15:14:21,363 [shell.Shell] ERROR: org.apache.accumulo.core.util.BadArgumentException: Invalid Property value (requires type: boolean) near index 30
config -s tserver.port.search=123
```

Port Example:
```
root@uno> config -s tserver.port.client=65539
2022-12-30T15:15:29,328 [shell.Shell] ERROR: org.apache.accumulo.core.util.BadArgumentException: Invalid Property value (requires type: port) near index 30
config -s tserver.port.client=65539
```

This PR is staged against main, but we may want to backport this change.