### PR TITLE
Added mechanism to prevent OOME caused by reading of large values

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Value.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Value.java
@@ -26,6 +26,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.Supplier;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
@@ -178,6 +179,15 @@ public class Value implements WritableComparable<Object> {
   @Override
   public void readFields(final DataInput in) throws IOException {
     this.value = new byte[in.readInt()];
+    in.readFully(this.value, 0, this.value.length);
+  }
+
+  public void readFields(final DataInput in, Supplier<Long> freeMemorySupplier) throws IOException {
+    int length = in.readInt();
+    while (freeMemorySupplier.get() < length) {
+      Thread.onSpinWait();
+    }
+    this.value = new byte[length];
     in.readFully(this.value, 0, this.value.length);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -127,6 +127,7 @@ public class RFile {
             lock.lock();
             try {
               FREE_MEMORY.set(Runtime.getRuntime().freeMemory());
+              LOG.info("Free Memory set to: {}", FREE_MEMORY.get());
               latchRef.set(new CountDownLatch(1));
             } finally {
               lock.unlock();
@@ -141,8 +142,8 @@ public class RFile {
 
     private static final Runtime RUNTIME = Runtime.getRuntime();
     private static final Logger LOG = LoggerFactory.getLogger(RFileMemoryProtection.class);
-    private static final String ENABLED_PROPERTY = "EnableRFileMemoryProtection";
-    private static final String SIZE_THRESHOLD_PROPERTY = "RFileMemoryProtectionSizeThreshold";
+    public static final String ENABLED_PROPERTY = "EnableRFileMemoryProtection";
+    public static final String SIZE_THRESHOLD_PROPERTY = "RFileMemoryProtectionSizeThreshold";
     private static final AtomicLong FREE_MEMORY = new AtomicLong(RUNTIME.freeMemory());
     private static final FreeMemoryUpdater UPDATER = new FreeMemoryUpdater();
 
@@ -175,6 +176,7 @@ public class RFile {
     }
 
     static long getFreeMemory() {
+      LOG.info("getFreeMemory called from Value.readFields");
       return FREE_MEMORY.get();
     }
 
@@ -190,6 +192,7 @@ public class RFile {
       if (n.getType().equals("com.sun.management.gc.notification")) {
         // We just got a notification that a GC completed in one of the GC memory pools. Queue up
         // an action to determine amount of free memory
+        LOG.info("GC Notification");
         UPDATER.update();
       }
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RelativeKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RelativeKey.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.memory.MemoryProtection;
 import org.apache.accumulo.core.util.MutableByteSequence;
 import org.apache.accumulo.core.util.UnsynchronizedBuffer;
 import org.apache.hadoop.io.Writable;
@@ -445,7 +446,10 @@ public class RelativeKey implements Writable {
   private static void read(DataInput in, MutableByteSequence mbseqDestination, int len)
       throws IOException {
     if (mbseqDestination.getBackingArray().length < len) {
-      mbseqDestination.setArray(new byte[UnsynchronizedBuffer.nextArraySize(len)], 0, 0);
+      final int nextArraySize = UnsynchronizedBuffer.nextArraySize(len);
+      MemoryProtection.protect(nextArraySize, () -> {
+        mbseqDestination.setArray(new byte[nextArraySize], 0, 0);
+      });
     }
 
     in.readFully(mbseqDestination.getBackingArray(), 0, len);

--- a/core/src/main/java/org/apache/accumulo/core/memory/MemoryProtection.java
+++ b/core/src/main/java/org/apache/accumulo/core/memory/MemoryProtection.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.memory;
+
+import java.io.IOException;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+
+import org.apache.accumulo.core.util.threads.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MemoryProtection implements NotificationListener {
+
+  private static class FreeMemoryUpdater implements Runnable {
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final AtomicReference<CountDownLatch> latchRef =
+        new AtomicReference<>(new CountDownLatch(1));
+
+    public void update() {
+      lock.lock();
+      try {
+        latchRef.get().countDown();
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public void run() {
+      try {
+        while (true) {
+          CountDownLatch latch = latchRef.get();
+          // TODO: Could use latch.await(long, TimeUnit) to update free memory
+          // when GC does not occur. It's probable that memory allocations
+          // will occur without GC happening, depending on the memory pool
+          // sizes.
+          latch.await();
+          // acquiring a lock here so that we don't miss a call to update() while
+          // we are getting the current free memory
+          lock.lock();
+          try {
+            FREE_MEMORY.set(calculateFreeMemory());
+            LOG.info("Free Memory set to: {}", FREE_MEMORY.get());
+            latchRef.set(new CountDownLatch(1));
+          } finally {
+            lock.unlock();
+          }
+        }
+      } catch (InterruptedException e) {
+        throw new RuntimeException("RFileMemoryProtection thread interrupted");
+      }
+    }
+
+  }
+
+  public interface ProtectedAction {
+    void execute() throws IOException;
+  }
+
+  public static final String ENABLED_PROPERTY = "EnableRFileMemoryProtection";
+  public static final String SIZE_THRESHOLD_PROPERTY = "RFileMemoryProtectionSizeThreshold";
+
+  private static final Logger LOG = LoggerFactory.getLogger(MemoryProtection.class);
+  private static final Runtime RUNTIME = Runtime.getRuntime();
+  private static final AtomicLong FREE_MEMORY = new AtomicLong(RUNTIME.freeMemory());
+  private static final FreeMemoryUpdater UPDATER = new FreeMemoryUpdater();
+
+  private static final int MB = 1048576;
+  private static final int MB10 = 10 * MB;
+  private static final int MB50 = 50 * MB;
+  private static final int MB100 = 100 * MB;
+  private static final int MB512 = 512 * MB;
+  private static final int GB1 = 1024 * MB;
+  private static final int FREE_MEMORY_BUFFER = 24 * MB;
+
+  private static boolean IS_ENABLED = false;
+  private static int SIZE_THRESHOLD = (int) (RUNTIME.maxMemory() * 0.05);
+
+  static {
+    IS_ENABLED = Boolean.parseBoolean(System.getProperty(ENABLED_PROPERTY, "false"));
+    if (IS_ENABLED) {
+      try {
+        SIZE_THRESHOLD = Integer.parseInt(
+            System.getProperty(SIZE_THRESHOLD_PROPERTY, Integer.toString(SIZE_THRESHOLD)));
+      } catch (NumberFormatException e) {
+        LOG.warn("{} system property value is not a valid Integer: {}", SIZE_THRESHOLD_PROPERTY,
+            SIZE_THRESHOLD);
+      }
+      LOG.info("Enabled for Value sizes over {}", SIZE_THRESHOLD);
+      List<GarbageCollectorMXBean> gcMBeans = ManagementFactory.getGarbageCollectorMXBeans();
+      NotificationListener listener = new MemoryProtection();
+      gcMBeans
+          .forEach(mb -> ((NotificationEmitter) mb).addNotificationListener(listener, null, null));
+      Threads.createThread("MemoryProtectionThread", UPDATER).start();
+    }
+  }
+
+  private MemoryProtection() {}
+
+  // private static double getBufferSize(int size) {
+  // if (size < MB10) {
+  // return 2.0;
+  // } else if (size < MB50) {
+  // return 1.5;
+  // } else if (size < MB100) {
+  // return 1.25;
+  // } else if (size < MB512) {
+  // return 1.10;
+  // } else if (size < GB1) {
+  // return 1.02;
+  // } else {
+  // return 1.01;
+  // }
+  // }
+
+  private static long calculateFreeMemory() {
+    long maxConfiguredMemory = RUNTIME.maxMemory();
+    long allocatedMemory = RUNTIME.totalMemory();
+    long allocatedFreeMemory = RUNTIME.freeMemory();
+    return (maxConfiguredMemory - (allocatedMemory - allocatedFreeMemory));
+  }
+
+  public static <R> void protect(int size, ProtectedAction action) throws IOException {
+    if (IS_ENABLED) {
+      final long threshold = (long) ((size /* * getBufferSize(size) */) + FREE_MEMORY_BUFFER);
+      while (FREE_MEMORY.get() < threshold /* && calculateFreeMemory() < threshold */) {
+        LOG.info("Spinning, current: {}, threshold: {}", FREE_MEMORY.get(), threshold);
+        try {
+          Thread.sleep(10000);
+        } catch (InterruptedException e) {
+          Thread.interrupted();
+          throw new IOException("thread interrupted", e);
+        }
+      }
+      LOG.info("Free Memory larger than {}", threshold);
+    }
+    action.execute();
+  }
+
+  @Override
+  public void handleNotification(Notification n, Object callbackObject) {
+    // TODO: Replace "com.sun.management.gc.notification" with reference to
+    // GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION. Need to figure
+    // out how to get jdk.management module enabled in IDE and for compilation
+    if (n.getType().equals("com.sun.management.gc.notification")) {
+      // We just got a notification that a GC completed in one of the GC memory pools. Queue up
+      // an action to determine amount of free memory
+      UPDATER.update();
+    }
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
@@ -177,7 +177,7 @@ public class ValueTest {
         if (times.get() < 5) {
           return 1L;
         } else {
-          return (long) DATA.length;
+          return (long) (DATA.length * 1.03);
         }
       }
     };
@@ -190,7 +190,7 @@ public class ValueTest {
     ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
     DataInputStream dis = new DataInputStream(bais);
     Value v2 = new Value();
-    v2.readFields(dis, freeMemorySupplier);
+    v2.readFields(dis, 1, freeMemorySupplier);
     dis.close();
     assertArrayEquals(DATA, v2.get());
     assertEquals(5, times.get());

--- a/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/data/ValueTest.java
@@ -35,8 +35,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeEach;
@@ -162,38 +160,6 @@ public class ValueTest {
     v2.readFields(dis);
     dis.close();
     assertArrayEquals(DATA, v2.get());
-  }
-
-  @Test
-  public void testWriteSupplierRead() throws Exception {
-
-    final AtomicInteger times = new AtomicInteger(0);
-
-    Supplier<Long> freeMemorySupplier = new Supplier<Long>() {
-
-      @Override
-      public Long get() {
-        times.incrementAndGet();
-        if (times.get() < 5) {
-          return 1L;
-        } else {
-          return (long) (DATA.length * 1.03);
-        }
-      }
-    };
-
-    Value v = new Value(DATA);
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(baos);
-    v.write(dos);
-    dos.close();
-    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-    DataInputStream dis = new DataInputStream(bais);
-    Value v2 = new Value();
-    v2.readFields(dis, 1, freeMemorySupplier);
-    dis.close();
-    assertArrayEquals(DATA, v2.get());
-    assertEquals(5, times.get());
   }
 
   @Test

--- a/test/src/main/java/org/apache/accumulo/test/functional/ReadLargeKVIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ReadLargeKVIT.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.minicluster.MemoryUnit;
+import org.apache.accumulo.minicluster.ServerType;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
+import org.bouncycastle.util.Arrays;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Iterables;
+
+public class ReadLargeKVIT extends SharedMiniClusterBase {
+
+  
+  private static class ReadLargeKVITConfiguration implements MiniClusterConfigurationCallback {
+
+    @Override
+    public void configureMiniCluster(MiniAccumuloConfigImpl cfg,
+        org.apache.hadoop.conf.Configuration coreSite) {
+      cfg.setNumTservers(1);
+      cfg.setMemory(ServerType.TABLET_SERVER, 256, MemoryUnit.MEGABYTE);
+      Map<String,String> sysProps = new HashMap<>();
+      // Enable RFileMemoryProtection for any Value
+      // over 10MB in size.
+      sysProps.put("EnableRFileMemoryProtection", "true");
+      sysProps.put("RFileMemoryProtectionSizeThreshold", Integer.toString(100 * 1024 * 1024));
+      cfg.setSystemProperties(sysProps);
+    }
+  }
+
+  @BeforeAll
+  public static void start() throws Exception {
+    startMiniClusterWithConfig(new ReadLargeKVITConfiguration());
+  }
+
+  @AfterAll
+  public static void stop() throws Exception {
+    stopMiniCluster();
+  }
+
+  @Test
+  public void test() throws Exception {
+
+    final int NUM_ROWS = 10;
+    byte[] EMPTY = new byte[0];
+    byte[] VALUE = new byte[11 * 1024 * 1024];
+    Arrays.fill(VALUE, (byte) '1');
+
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+
+      String table = getUniqueNames(1)[0];
+      TableOperations to = client.tableOperations();
+      to.create(table);
+
+      // Insert several K/V pairs with 11MB values
+      BatchWriterConfig bwc = new BatchWriterConfig();
+      bwc.setMaxMemory(24 * 1024 * 1024);
+      try (BatchWriter writer = client.createBatchWriter(table, bwc)) {
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Mutation m = new Mutation("test" + i);
+          m.put(EMPTY, EMPTY, VALUE);
+          writer.addMutation(m);
+        }
+      }
+
+      // Validate NUM_ROWS in table
+      long start = System.currentTimeMillis();
+      try (Scanner scanner = client.createScanner(table)) {
+        assertEquals(10, Iterables.size(scanner));
+      }
+      long firstRunTime = System.currentTimeMillis() - start;
+
+      final AtomicReference<Throwable> ERROR = new AtomicReference<>();
+
+      Thread t = new Thread(() -> {
+        try (AccumuloClient client2 = Accumulo.newClient().from(getClientProps()).build()) {
+          try (Scanner scanner2 = client2.createScanner(table)) {
+            IteratorSetting is = new IteratorSetting(11, SlowMemoryConsumingIterator.class,
+                Map.of("sleepTime", "30000"));
+            scanner2.addScanIterator(is);
+          } catch (TableNotFoundException | AccumuloSecurityException | AccumuloException e) {
+            e.printStackTrace();
+            ERROR.set(e);
+          }
+        }
+      });
+      t.start();
+      Thread.sleep(5000);
+
+      long start2 = System.currentTimeMillis();
+      try (Scanner scanner3 = client.createScanner(table)) {
+        // SlowMemoryConsumingIterator is set to sleep for 30s
+        // and consume all free memory except for 5MB. In theory,
+        // getting the first K/V pair should take close to 30s.
+        scanner3.setBatchSize(1);
+        scanner3.setReadaheadThreshold(1);
+        scanner3.setBatchTimeout(1, TimeUnit.MINUTES);
+        Iterator<Entry<Key,Value>> iter = scanner3.iterator();
+        assertTrue(iter.hasNext());
+        Entry<Key,Value> e = iter.next();
+        assertEquals(11 * 1024 * 1024, e.getValue().get().length);
+      }
+      long secondRunTime = System.currentTimeMillis() - start2;
+
+      assertTrue(secondRunTime > firstRunTime);
+      assertTrue(secondRunTime > 250000);
+      t.join();
+      assertNull(ERROR.get());
+
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/SlowMemoryConsumingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SlowMemoryConsumingIterator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SlowMemoryConsumingIterator extends SlowIterator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlowMemoryConsumingIterator.class);
+  
+  @Override
+  public void next() throws IOException {
+    
+    LOG.info("next called");
+    
+    System.gc();
+    long freeMem = Runtime.getRuntime().freeMemory();
+    if (freeMem > Integer.MAX_VALUE) {
+      throw new IOException("Unsupported memory size for tablet server when using this iterator");
+    }
+    int free = (int) freeMem;
+    int fiveMegs = 5 * 1024 * 1024;
+    int amountToConsume = free - fiveMegs;
+
+    LOG.info("allocating memory: " + amountToConsume);
+    byte[] buffer = new byte[amountToConsume];
+    Arrays.fill(buffer, (byte) '1');
+    try {
+      LOG.info("sleeping");
+      super.next();
+      LOG.info("exiting next");
+    } finally {
+      buffer = null;
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/SlowMemoryConsumingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SlowMemoryConsumingIterator.java
@@ -20,37 +20,75 @@ package org.apache.accumulo.test.functional;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SlowMemoryConsumingIterator extends SlowIterator {
+import com.google.common.util.concurrent.Uninterruptibles;
+
+public class SlowMemoryConsumingIterator extends WrappingIterator {
+
+  public static class SlowMemoryConsumingWaitingIterator extends WrappingIterator {
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
+        throws IOException {
+      LOG.info("Waiting iterator is waiting");
+      try {
+        LATCH.await();
+      } catch (InterruptedException e) {
+        Thread.interrupted();
+        throw new IOException("thread interrupted", e);
+      }
+      LOG.info("Waiting iterator is free");
+      super.seek(range, columnFamilies, inclusive);
+    }
+
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(SlowMemoryConsumingIterator.class);
-  
-  @Override
-  public void next() throws IOException {
-    
-    LOG.info("next called");
-    
+
+  private static final CountDownLatch LATCH = new CountDownLatch(1);
+  private static final int MEMORY_BUFFER_SIZE = 36 * 1024 * 1024;
+
+  private int getAmountToConsume() {
     System.gc();
-    long freeMem = Runtime.getRuntime().freeMemory();
+    Runtime runtime = Runtime.getRuntime();
+    long maxConfiguredMemory = runtime.maxMemory();
+    long allocatedMemory = runtime.totalMemory();
+    long allocatedFreeMemory = runtime.freeMemory();
+    long freeMem = (maxConfiguredMemory - (allocatedMemory - allocatedFreeMemory));
     if (freeMem > Integer.MAX_VALUE) {
-      throw new IOException("Unsupported memory size for tablet server when using this iterator");
+      throw new IllegalStateException(
+          "Unsupported memory size for tablet server when using this iterator");
     }
     int free = (int) freeMem;
-    int fiveMegs = 5 * 1024 * 1024;
-    int amountToConsume = free - fiveMegs;
+    return (free - MEMORY_BUFFER_SIZE);
+  }
 
+  @Override
+  public void next() throws IOException {
+    LOG.info("next called");
+    int amountToConsume = getAmountToConsume();
     LOG.info("allocating memory: " + amountToConsume);
     byte[] buffer = new byte[amountToConsume];
+    LOG.info("memory allocated");
+    LATCH.countDown();
     Arrays.fill(buffer, (byte) '1');
     try {
       LOG.info("sleeping");
+      Uninterruptibles.sleepUninterruptibly(30, TimeUnit.MILLISECONDS);
       super.next();
       LOG.info("exiting next");
     } finally {
       buffer = null;
+      LOG.info("next complete");
     }
   }
 


### PR DESCRIPTION
Provide an optional mechanism that attempts to protect the JVM from running into an OOME due to the construction of large objects.