### PR TITLE
rename ScannerOptions timeOut to scanTimeOut, fix possible bug

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -213,7 +213,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
     smi = new ScannerTranslatorImpl(scanner, scanner.getSamplerConfiguration());
     this.range = scanner.getRange();
     this.size = scanner.getBatchSize();
-    this.timeOut = scanner.getTimeout(MILLISECONDS);
+    this.scanTimeOut = scanner.getTimeout(MILLISECONDS);
     this.batchTimeOut = scanner.getTimeout(MILLISECONDS);
     this.readaheadThreshold = scanner.getReadaheadThreshold();
     SamplerConfiguration samplerConfig = scanner.getSamplerConfiguration();
@@ -232,7 +232,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
     smi.scanner.setBatchSize(size);
-    smi.scanner.setTimeout(timeOut, MILLISECONDS);
+    smi.scanner.setTimeout(scanTimeOut, MILLISECONDS);
     smi.scanner.setBatchTimeout(batchTimeOut, MILLISECONDS);
     smi.scanner.setReadaheadThreshold(readaheadThreshold);
     if (isolated) {

--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -49,7 +49,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
     private Entry<Key,Value> nextRowStart;
     private Iterator<Entry<Key,Value>> rowIter;
     private ByteSequence lastRow = null;
-    private long timeout;
+    private long iteratorTimeout;
 
     private final Scanner scanner;
     private ScannerOptions opts;
@@ -125,7 +125,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
       synchronized (scanner) {
         scanner.enableIsolation();
         scanner.setBatchSize(batchSize);
-        scanner.setTimeout(timeout, MILLISECONDS);
+        scanner.setTimeout(iteratorTimeout, MILLISECONDS);
         scanner.setRange(r);
         scanner.setReadaheadThreshold(readaheadThreshold);
         setOptions((ScannerOptions) scanner, opts);
@@ -139,7 +139,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
       this.scanner = scanner;
       this.opts = new ScannerOptions(opts);
       this.range = range;
-      this.timeout = timeout;
+      this.iteratorTimeout = timeout;
       this.batchSize = batchSize;
       this.readaheadThreshold = readaheadThreshold;
 
@@ -227,7 +227,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
   public IsolatedScanner(Scanner scanner, RowBufferFactory bufferFactory) {
     this.scanner = scanner;
     this.range = scanner.getRange();
-    this.timeOut = scanner.getTimeout(MILLISECONDS);
+    this.scanTimeOut = scanner.getTimeout(MILLISECONDS);
     this.batchTimeOut = scanner.getBatchTimeout(MILLISECONDS);
     this.batchSize = scanner.getBatchSize();
     this.readaheadThreshold = scanner.getReadaheadThreshold();
@@ -236,8 +236,8 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
-    return new RowBufferingIterator(scanner, this, range, timeOut, batchSize, readaheadThreshold,
-        bufferFactory);
+    return new RowBufferingIterator(scanner, this, range, scanTimeOut, batchSize,
+        readaheadThreshold, bufferFactory);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/ScannerBase.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ScannerBase.java
@@ -84,7 +84,7 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
   void updateScanIteratorOption(String iteratorName, String key, String value);
 
   /**
-   * Adds a column family to the list of columns that will be fetched by this scanner. By default
+   * Adds a column family to the list of columns that will be fetched by this scanner. By default,
    * when no columns have been added the scanner fetches all columns. To fetch multiple column
    * families call this function multiple times.
    *
@@ -101,7 +101,7 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
   void fetchColumnFamily(Text col);
 
   /**
-   * Adds a column family to the list of columns that will be fetched by this scanner. By default
+   * Adds a column family to the list of columns that will be fetched by this scanner. By default,
    * when no columns have been added the scanner fetches all columns. To fetch multiple column
    * families call this function multiple times.
    *
@@ -123,12 +123,12 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
 
   /**
    * Adds a column to the list of columns that will be fetched by this scanner. The column is
-   * identified by family and qualifier. By default when no columns have been added the scanner
+   * identified by family and qualifier. By default, when no columns have been added the scanner
    * fetches all columns.
    *
    * <p>
    * <b>WARNING</b>. Using this method with custom iterators may have unexpected results. Iterators
-   * have control over which column families are fetched. However iterators have no control over
+   * have control over which column families are fetched. However, iterators have no control over
    * which column qualifiers are fetched. When this method is called it activates a system iterator
    * that only allows the requested family/qualifier pairs through. This low level filtering
    * prevents custom iterators from requesting additional column families when calling seek.
@@ -152,7 +152,7 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
 
   /**
    * Adds a column to the list of columns that will be fetched by this scanner. The column is
-   * identified by family and qualifier. By default when no columns have been added the scanner
+   * identified by family and qualifier. By default, when no columns have been added the scanner
    * fetches all columns. See the warning on {@link #fetchColumn(Text, Text)}
    *
    *
@@ -238,11 +238,11 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
 
   /**
    * Setting this will cause the scanner to read sample data, as long as that sample data was
-   * generated with the given configuration. By default this is not set and all data is read.
+   * generated with the given configuration. By default, this is not set and all data is read.
    *
    * <p>
    * One way to use this method is as follows, where the sampler configuration is obtained from the
-   * table configuration. Sample data can be generated in many different ways, so its important to
+   * table configuration. Sample data can be generated in many different ways, so it is important to
    * verify the sample data configuration meets expectations.
    *
    * <pre>
@@ -262,7 +262,7 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
    *
    * <p>
    * If sample data is not present or sample data was generated with a different configuration, then
-   * the scanner iterator will throw a {@link SampleNotPresentException}. Also if a table's sampler
+   * the scanner iterator will throw a {@link SampleNotPresentException}. Also, if a table's sampler
    * configuration is changed while a scanner is iterating over a table, a
    * {@link SampleNotPresentException} may be thrown.
    *
@@ -370,7 +370,7 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
    * @return consistency level
    * @since 2.1.0
    */
-  public ConsistencyLevel getConsistencyLevel();
+  ConsistencyLevel getConsistencyLevel();
 
   /**
    * Set the desired consistency level for this scanner.
@@ -378,7 +378,7 @@ public interface ScannerBase extends Iterable<Entry<Key,Value>>, AutoCloseable {
    * @param level consistency level
    * @since 2.1.0
    */
-  public void setConsistencyLevel(ConsistencyLevel level);
+  void setConsistencyLevel(ConsistencyLevel level);
 
   /**
    * Stream the Scanner results sequentially from this scanner's iterator

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -53,7 +53,7 @@ public class ScannerOptions implements ScannerBase {
 
   protected SortedSet<Column> fetchedColumns = new TreeSet<>();
 
-  protected long timeOut = Long.MAX_VALUE;
+  protected long scanTimeOut = Long.MAX_VALUE;
 
   protected long batchTimeOut = Long.MAX_VALUE;
 
@@ -197,20 +197,20 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public synchronized void setTimeout(long timeout, TimeUnit timeUnit) {
-    if (timeOut < 0) {
-      throw new IllegalArgumentException("TimeOut must be positive : " + timeOut);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("TimeOut must be positive : " + timeout);
     }
 
     if (timeout == 0) {
-      this.timeOut = Long.MAX_VALUE;
+      this.scanTimeOut = Long.MAX_VALUE;
     } else {
-      this.timeOut = timeUnit.toMillis(timeout);
+      this.scanTimeOut = timeUnit.toMillis(timeout);
     }
   }
 
   @Override
   public synchronized long getTimeout(TimeUnit timeunit) {
-    return timeunit.convert(timeOut, MILLISECONDS);
+    return timeunit.convert(scanTimeOut, MILLISECONDS);
   }
 
   @Override
@@ -241,8 +241,8 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public void setBatchTimeout(long timeout, TimeUnit timeUnit) {
-    if (timeOut < 0) {
-      throw new IllegalArgumentException("Batch timeout must be positive : " + timeOut);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("Batch timeout must be positive : " + timeout);
     }
     if (timeout == 0) {
       this.batchTimeOut = Long.MAX_VALUE;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -116,6 +116,6 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
     }
 
     return new TabletServerBatchReaderIterator(context, tableId, tableName, authorizations, ranges,
-        numThreads, queryThreadPool, this, timeOut);
+        numThreads, queryThreadPool, this, scanTimeOut);
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerIT.java
@@ -20,7 +20,6 @@ package org.apache.accumulo.test;
 
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -52,7 +51,6 @@ import org.apache.accumulo.test.functional.ReadWriteIT;
 import org.apache.accumulo.test.functional.SlowIterator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -167,7 +165,6 @@ public class ScanServerIT extends SharedMiniClusterBase {
   }
 
   @Test
-  @Disabled("Scanner.setTimeout does not work, issue #2606")
   @Timeout(value = 20)
   public void testScannerTimeout() throws Exception {
     // Configure the client to use different scan server selector property values
@@ -187,8 +184,8 @@ public class ScanServerIT extends SharedMiniClusterBase {
         scanner.addScanIterator(slow);
         scanner.setRange(new Range());
         scanner.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
-        scanner.setTimeout(10, TimeUnit.SECONDS);
-        assertFalse(scanner.stream().findAny().isPresent(),
+        scanner.setTimeout(500, TimeUnit.MILLISECONDS);
+        assertThrows(RuntimeException.class, () -> scanner.stream().findAny().isPresent(),
             "The scanner should not see any entries");
       }
     }


### PR DESCRIPTION
- rename variable in ScannerOptions from timeOut to scanTimeOut
- fixes possible bug where input variable (timeout) was using the instance value for checks
- rename variable in IsolatedScanner from timeOut to iteratorTimeout
- fix some flagged grammar suggestions.

In IsolatedScanner, the two timeouts are confusing and it could be an error that there are two values when one was intended, but I preserved current behavior.

There are other code style issues that can be addressed in these files, but I didn't want those changes to hide the timeout renaming with even more unrelated changes.

I ran into the timeout naming while trying to look at synchronization warnings and having timeout, and timeOut available as valid code completion options made it harder to reason about the correct value.