### PR TITLE
fix parameter timeout checks, rename timeOut to retryTimeout

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -213,7 +213,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
     smi = new ScannerTranslatorImpl(scanner, scanner.getSamplerConfiguration());
     this.range = scanner.getRange();
     this.size = scanner.getBatchSize();
-    this.timeOut = scanner.getTimeout(MILLISECONDS);
+    this.retryTimeout = scanner.getTimeout(MILLISECONDS);
     this.batchTimeOut = scanner.getTimeout(MILLISECONDS);
     this.readaheadThreshold = scanner.getReadaheadThreshold();
     SamplerConfiguration samplerConfig = scanner.getSamplerConfiguration();
@@ -232,7 +232,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
     smi.scanner.setBatchSize(size);
-    smi.scanner.setTimeout(timeOut, MILLISECONDS);
+    smi.scanner.setTimeout(retryTimeout, MILLISECONDS);
     smi.scanner.setBatchTimeout(batchTimeOut, MILLISECONDS);
     smi.scanner.setReadaheadThreshold(readaheadThreshold);
     if (isolated) {

--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -227,7 +227,7 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
   public IsolatedScanner(Scanner scanner, RowBufferFactory bufferFactory) {
     this.scanner = scanner;
     this.range = scanner.getRange();
-    this.timeOut = scanner.getTimeout(MILLISECONDS);
+    this.retryTimeout = scanner.getTimeout(MILLISECONDS);
     this.batchTimeOut = scanner.getBatchTimeout(MILLISECONDS);
     this.batchSize = scanner.getBatchSize();
     this.readaheadThreshold = scanner.getReadaheadThreshold();
@@ -236,8 +236,8 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
-    return new RowBufferingIterator(scanner, this, range, timeOut, batchSize, readaheadThreshold,
-        bufferFactory);
+    return new RowBufferingIterator(scanner, this, range, retryTimeout, batchSize,
+        readaheadThreshold, bufferFactory);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerOptions.java
@@ -53,7 +53,7 @@ public class ScannerOptions implements ScannerBase {
 
   protected SortedSet<Column> fetchedColumns = new TreeSet<>();
 
-  protected long timeOut = Long.MAX_VALUE;
+  protected long retryTimeout = Long.MAX_VALUE;
 
   protected long batchTimeOut = Long.MAX_VALUE;
 
@@ -197,20 +197,20 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public synchronized void setTimeout(long timeout, TimeUnit timeUnit) {
-    if (timeOut < 0) {
-      throw new IllegalArgumentException("TimeOut must be positive : " + timeOut);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("TimeOut must be positive : " + timeout);
     }
 
     if (timeout == 0) {
-      this.timeOut = Long.MAX_VALUE;
+      this.retryTimeout = Long.MAX_VALUE;
     } else {
-      this.timeOut = timeUnit.toMillis(timeout);
+      this.retryTimeout = timeUnit.toMillis(timeout);
     }
   }
 
   @Override
   public synchronized long getTimeout(TimeUnit timeunit) {
-    return timeunit.convert(timeOut, MILLISECONDS);
+    return timeunit.convert(retryTimeout, MILLISECONDS);
   }
 
   @Override
@@ -241,8 +241,8 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public void setBatchTimeout(long timeout, TimeUnit timeUnit) {
-    if (timeOut < 0) {
-      throw new IllegalArgumentException("Batch timeout must be positive : " + timeOut);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("Batch timeout must be positive : " + timeout);
     }
     if (timeout == 0) {
       this.batchTimeOut = Long.MAX_VALUE;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReader.java
@@ -116,6 +116,6 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
     }
 
     return new TabletServerBatchReaderIterator(context, tableId, tableName, authorizations, ranges,
-        numThreads, queryThreadPool, this, timeOut);
+        numThreads, queryThreadPool, this, retryTimeout);
   }
 }


### PR DESCRIPTION
Fixes parameter validation of timeout where the instance variable timeOut was used.
Renames instance variable timeOut to retryTimeout to reflect the intended purpose in the javadoc.

This replaces #3166.

There may be follow-on work to rename the setter / getters for timeout as a follow-on and this PR helps distinguish variations in timeout used in the code, As is this a minimal set of changes for quick review.