### PR TITLE
fix parameter check and minor variable rename

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -239,8 +239,8 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
     smi = new ScannerTranslatorImpl(scanner, scanner.getSamplerConfiguration());
     this.range = scanner.getRange();
     this.size = scanner.getBatchSize();
-    this.timeOut = scanner.getTimeout(TimeUnit.MILLISECONDS);
-    this.batchTimeOut = scanner.getTimeout(TimeUnit.MILLISECONDS);
+    this.retryTimeout = scanner.getTimeout(TimeUnit.MILLISECONDS);
+    this.batchTimeout = scanner.getTimeout(TimeUnit.MILLISECONDS);
     this.readaheadThreshold = scanner.getReadaheadThreshold();
     SamplerConfiguration samplerConfig = scanner.getSamplerConfiguration();
     if (samplerConfig != null)
@@ -257,8 +257,8 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
     smi.scanner.setBatchSize(size);
-    smi.scanner.setTimeout(timeOut, TimeUnit.MILLISECONDS);
-    smi.scanner.setBatchTimeout(batchTimeOut, TimeUnit.MILLISECONDS);
+    smi.scanner.setTimeout(retryTimeout, TimeUnit.MILLISECONDS);
+    smi.scanner.setBatchTimeout(batchTimeout, TimeUnit.MILLISECONDS);
     smi.scanner.setReadaheadThreshold(readaheadThreshold);
     if (isolated)
       smi.scanner.enableIsolation();

--- a/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/IsolatedScanner.java
@@ -228,8 +228,8 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
   public IsolatedScanner(Scanner scanner, RowBufferFactory bufferFactory) {
     this.scanner = scanner;
     this.range = scanner.getRange();
-    this.timeOut = scanner.getTimeout(TimeUnit.MILLISECONDS);
-    this.batchTimeOut = scanner.getBatchTimeout(TimeUnit.MILLISECONDS);
+    this.retryTimeout = scanner.getTimeout(TimeUnit.MILLISECONDS);
+    this.batchTimeout = scanner.getBatchTimeout(TimeUnit.MILLISECONDS);
     this.batchSize = scanner.getBatchSize();
     this.readaheadThreshold = scanner.getReadaheadThreshold();
     this.bufferFactory = bufferFactory;
@@ -237,8 +237,8 @@ public class IsolatedScanner extends ScannerOptions implements Scanner {
 
   @Override
   public Iterator<Entry<Key,Value>> iterator() {
-    return new RowBufferingIterator(scanner, this, range, timeOut, batchSize, readaheadThreshold,
-        bufferFactory);
+    return new RowBufferingIterator(scanner, this, range, retryTimeout, batchSize,
+        readaheadThreshold, bufferFactory);
   }
 
   @Deprecated

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerIterator.java
@@ -122,7 +122,7 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
     scanState = new ScanState(context, tableId, authorizations, new Range(range),
         options.fetchedColumns, size, options.serverSideIteratorList,
         options.serverSideIteratorOptions, isolated, readaheadThreshold,
-        options.getSamplerConfiguration(), options.batchTimeOut, options.classLoaderContext);
+        options.getSamplerConfiguration(), options.batchTimeout, options.classLoaderContext);
 
     // If we want to start readahead immediately, don't wait for hasNext to be called
     if (0l == readaheadThreshold) {

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerOptions.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ScannerOptions.java
@@ -49,9 +49,9 @@ public class ScannerOptions implements ScannerBase {
 
   protected SortedSet<Column> fetchedColumns = new TreeSet<>();
 
-  protected long timeOut = Long.MAX_VALUE;
+  protected long retryTimeout = Long.MAX_VALUE;
 
-  protected long batchTimeOut = Long.MAX_VALUE;
+  protected long batchTimeout = Long.MAX_VALUE;
 
   private String regexIterName = null;
 
@@ -178,7 +178,7 @@ public class ScannerOptions implements ScannerBase {
           dst.serverSideIteratorOptions.put(entry.getKey(), new HashMap<>(entry.getValue()));
 
         dst.samplerConfig = src.samplerConfig;
-        dst.batchTimeOut = src.batchTimeOut;
+        dst.batchTimeout = src.batchTimeout;
       }
     }
   }
@@ -190,19 +190,19 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public synchronized void setTimeout(long timeout, TimeUnit timeUnit) {
-    if (timeOut < 0) {
-      throw new IllegalArgumentException("TimeOut must be positive : " + timeOut);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("retry timeout must be positive : " + timeout);
     }
 
     if (timeout == 0)
-      this.timeOut = Long.MAX_VALUE;
+      this.retryTimeout = Long.MAX_VALUE;
     else
-      this.timeOut = timeUnit.toMillis(timeout);
+      this.retryTimeout = timeUnit.toMillis(timeout);
   }
 
   @Override
   public synchronized long getTimeout(TimeUnit timeunit) {
-    return timeunit.convert(timeOut, TimeUnit.MILLISECONDS);
+    return timeunit.convert(retryTimeout, TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -233,19 +233,19 @@ public class ScannerOptions implements ScannerBase {
 
   @Override
   public void setBatchTimeout(long timeout, TimeUnit timeUnit) {
-    if (timeOut < 0) {
-      throw new IllegalArgumentException("Batch timeout must be positive : " + timeOut);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("Batch timeout must be positive : " + timeout);
     }
     if (timeout == 0) {
-      this.batchTimeOut = Long.MAX_VALUE;
+      this.batchTimeout = Long.MAX_VALUE;
     } else {
-      this.batchTimeOut = timeUnit.toMillis(timeout);
+      this.batchTimeout = timeUnit.toMillis(timeout);
     }
   }
 
   @Override
   public long getBatchTimeout(TimeUnit timeUnit) {
-    return timeUnit.convert(batchTimeOut, TimeUnit.MILLISECONDS);
+    return timeUnit.convert(batchTimeout, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/TabletServerBatchReader.java
@@ -117,6 +117,6 @@ public class TabletServerBatchReader extends ScannerOptions implements BatchScan
     }
 
     return new TabletServerBatchReaderIterator(context, tableId, authorizations, ranges, numThreads,
-        queryThreadPool, this, timeOut);
+        queryThreadPool, this, retryTimeout);
   }
 }


### PR DESCRIPTION
- Fixes parameter check that was using instance variable (timeOut) instead of passed value (timeout)
- Renames variable timeOut to retryTimeout to improve readability and reflect usage
- Renames variable batchTimeOut to batchTimeout for consistent case convention.

Replaces https://github.com/apache/accumulo/pull/3172 that was based on 2.1