### PR TITLE
Switch log level to trace

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
@@ -76,13 +76,13 @@ public class SystemPropUtil {
     if (!Property.isValidZooPropertyKey(property)) {
       IllegalArgumentException iae =
           new IllegalArgumentException("Zookeeper property is not mutable: " + property);
-      log.error("Encountered error setting zookeeper property", iae);
+      log.debug("Encountered error setting zookeeper property", iae);
       throw iae;
     }
     if (!Property.isValidProperty(property, value)) {
       IllegalArgumentException iae = new IllegalArgumentException(
           "Property " + property + " with value: " + value + " is not valid");
-      log.error("Encountered error setting zookeeper property", iae);
+      log.debug("Encountered error setting zookeeper property", iae);
       throw iae;
     }
 
@@ -100,7 +100,7 @@ public class SystemPropUtil {
         && !foundProp.getType().isValidFormat(value)))) {
       IllegalArgumentException iae = new IllegalArgumentException(
           "Ignoring property " + property + " it is either null or in an invalid format");
-      log.error("Attempted to set zookeeper property.  Value is either null or invalid", iae);
+      log.debug("Attempted to set zookeeper property.  Value is either null or invalid", iae);
       throw iae;
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/SystemPropUtil.java
@@ -76,13 +76,13 @@ public class SystemPropUtil {
     if (!Property.isValidZooPropertyKey(property)) {
       IllegalArgumentException iae =
           new IllegalArgumentException("Zookeeper property is not mutable: " + property);
-      log.debug("Encountered error setting zookeeper property", iae);
+      log.trace("Encountered error setting zookeeper property", iae);
       throw iae;
     }
     if (!Property.isValidProperty(property, value)) {
       IllegalArgumentException iae = new IllegalArgumentException(
           "Property " + property + " with value: " + value + " is not valid");
-      log.debug("Encountered error setting zookeeper property", iae);
+      log.trace("Encountered error setting zookeeper property", iae);
       throw iae;
     }
 
@@ -100,7 +100,7 @@ public class SystemPropUtil {
         && !foundProp.getType().isValidFormat(value)))) {
       IllegalArgumentException iae = new IllegalArgumentException(
           "Ignoring property " + property + " it is either null or in an invalid format");
-      log.debug("Attempted to set zookeeper property.  Value is either null or invalid", iae);
+      log.trace("Attempted to set zookeeper property.  Value is either null or invalid", iae);
       throw iae;
     }
 


### PR DESCRIPTION
The exceptions thrown here are already logged at the error level via the calling method `modifySystemProperties` from the
`ManagerClientServiceHandler` class.

https://github.com/apache/accumulo/blob/2.1/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java#L461-L462

Writing these exceptions at the error level would result in duplicate exception messages in the logs.

Switching these back to only log the exceptions at the debug level.