### PR TITLE
Fix usage of Wait.waitFor() in ITs

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/LargeSplitRowIT.java
@@ -235,9 +235,7 @@ public class LargeSplitRowIT extends ConfigurableMacBase {
       // Make sure a split occurs
       Wait.Condition splitsToBePresent =
           () -> client.tableOperations().listSplits(tableName).stream().findAny().isPresent();
-      Wait.waitFor(splitsToBePresent, SECONDS.toMillis(60L), 250L);
-
-      assertTrue(client.tableOperations().listSplits(tableName).stream().findAny().isPresent());
+      assertTrue(Wait.waitFor(splitsToBePresent, SECONDS.toMillis(60L), 250L));
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/KerberosRenewalIT.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.test.functional;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Map;
@@ -188,6 +189,6 @@ public class KerberosRenewalIT extends AccumuloITBase {
       assertEquals("d", entry.getValue().toString());
     }
     client.tableOperations().delete(tableName);
-    Wait.waitFor(() -> !client.tableOperations().exists(tableName), 20_000L, 200L);
+    assertTrue(Wait.waitFor(() -> !client.tableOperations().exists(tableName), 20_000L, 200L));
   }
 }


### PR DESCRIPTION
After reviewing #3177 I realized that some of the spots that `Wait.waitFor()` is used in the tests does not check the value of the returned `boolean`. This PR asserts that the cases that were not being checked, now are.