### PR TITLE
WIP: Make scan initial wait configurable

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -88,6 +88,9 @@ public class ClientConfiguration extends CompositeConfiguration {
     INSTANCE_ID("instance.id", null, PropertyType.STRING,
         "UUID of Accumulo instance to connect to"),
 
+    // Scanning
+    SCAN_INITIAL_WAIT_ENABLED(Property.SCAN_INITIAL_WAIT_ENABLED),
+
     // Tracing
     TRACE_SPAN_RECEIVERS(Property.TRACE_SPAN_RECEIVERS),
     TRACE_SPAN_RECEIVER_PREFIX(Property.TRACE_SPAN_RECEIVER_PREFIX),

--- a/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientConfiguration.java
@@ -89,7 +89,7 @@ public class ClientConfiguration extends CompositeConfiguration {
         "UUID of Accumulo instance to connect to"),
 
     // Scanning
-    SCAN_INITIAL_WAIT_ENABLED(Property.SCAN_INITIAL_WAIT_ENABLED),
+    TSERV_SCAN_INITIAL_WAIT_ENABLED(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED),
 
     // Tracing
     TRACE_SPAN_RECEIVERS(Property.TRACE_SPAN_RECEIVERS),

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -117,7 +117,7 @@ public class ThriftScanner {
 
         TabletType ttype = TabletType.type(extent);
         boolean waitForWrites = false;
-        if (context.getConfiguration().getBoolean(Property.SCAN_INITIAL_WAIT_ENABLED)) {
+        if (context.getConfiguration().getBoolean(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED)) {
           waitForWrites = !serversWaitedForWrites.get(ttype).contains(server);
         }
         InitialScan isr = client.startScan(tinfo, scanState.context.rpcCreds(), extent.toThrift(),
@@ -463,7 +463,7 @@ public class ThriftScanner {
 
         TabletType ttype = TabletType.type(loc.tablet_extent);
         boolean waitForWrites = false;
-        if (context.getConfiguration().getBoolean(Property.SCAN_INITIAL_WAIT_ENABLED)) {
+        if (context.getConfiguration().getBoolean(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED)) {
           waitForWrites = !serversWaitedForWrites.get(ttype).contains(loc.tablet_location);
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -116,7 +116,10 @@ public class ThriftScanner {
             Constants.SCANNER_DEFAULT_READAHEAD_THRESHOLD, null, batchTimeOut, classLoaderContext);
 
         TabletType ttype = TabletType.type(extent);
-        boolean waitForWrites = !serversWaitedForWrites.get(ttype).contains(server);
+        boolean waitForWrites = false;
+        if (context.getConfiguration().getBoolean(Property.SCAN_INITIAL_WAIT_ENABLED)) {
+          waitForWrites = !serversWaitedForWrites.get(ttype).contains(server);
+        }
         InitialScan isr = client.startScan(tinfo, scanState.context.rpcCreds(), extent.toThrift(),
             scanState.range.toThrift(), Translator.translate(scanState.columns, Translators.CT),
             scanState.size, scanState.serverSideIteratorList, scanState.serverSideIteratorOptions,
@@ -459,7 +462,10 @@ public class ThriftScanner {
         }
 
         TabletType ttype = TabletType.type(loc.tablet_extent);
-        boolean waitForWrites = !serversWaitedForWrites.get(ttype).contains(loc.tablet_location);
+        boolean waitForWrites = false;
+        if (context.getConfiguration().getBoolean(Property.SCAN_INITIAL_WAIT_ENABLED)) {
+          waitForWrites = !serversWaitedForWrites.get(ttype).contains(loc.tablet_location);
+        }
 
         InitialScan is =
             client.startScan(tinfo, scanState.context.rpcCreds(), loc.tablet_extent.toThrift(),

--- a/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/impl/ThriftScanner.java
@@ -117,7 +117,8 @@ public class ThriftScanner {
 
         TabletType ttype = TabletType.type(extent);
         boolean waitForWrites = false;
-        if (context.getConfiguration().getBoolean(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED)) {
+        if (context.getConfiguration().getBoolean(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED)
+            && ttype == TabletType.USER) {
           waitForWrites = !serversWaitedForWrites.get(ttype).contains(server);
         }
         InitialScan isr = client.startScan(tinfo, scanState.context.rpcCreds(), extent.toThrift(),
@@ -463,7 +464,8 @@ public class ThriftScanner {
 
         TabletType ttype = TabletType.type(loc.tablet_extent);
         boolean waitForWrites = false;
-        if (context.getConfiguration().getBoolean(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED)) {
+        if (context.getConfiguration().getBoolean(Property.TSERV_SCAN_INITIAL_WAIT_ENABLED)
+            && ttype == TabletType.USER) {
           waitForWrites = !serversWaitedForWrites.get(ttype).contains(loc.tablet_location);
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -419,6 +419,9 @@ public enum Property {
       PropertyType.COUNT, "Max number of files a major compaction thread can open at once. "),
   TSERV_SCAN_MAX_OPENFILES("tserver.scan.files.open.max", "100", PropertyType.COUNT,
       "Maximum total files that all tablets in a tablet server can open for scans. "),
+  @Experimental
+  TSERV_SCAN_INITIAL_WAIT_ENABLED("tserver.scan.initial.wait.enabled", "true", PropertyType.BOOLEAN,
+      "Determines if the client waits for writes before scanning a table for the first time"),
   TSERV_MAX_IDLE("tserver.files.open.idle", "1m", PropertyType.TIMEDURATION,
       "Tablet servers leave previously used files open for future queries. This "
           + "setting determines how much time an unused file should be kept open until "
@@ -931,10 +934,7 @@ public enum Property {
       "The sampling percentage to use for replication traces"),
   REPLICATION_RPC_TIMEOUT("replication.rpc.timeout", "2m", PropertyType.TIMEDURATION,
       "Amount of time for a single replication RPC call to last before failing"
-          + " the attempt. See replication.work.attempts."),
-  @Experimental
-  SCAN_INITIAL_WAIT_ENABLED("scan.initial.wait.enabled", "true", PropertyType.BOOLEAN,
-      "Determines if the client waits for writes before scanning a table for the first time"),;
+          + " the attempt. See replication.work.attempts."),;
 
   private String key;
   private String defaultValue;

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -421,7 +421,8 @@ public enum Property {
       "Maximum total files that all tablets in a tablet server can open for scans. "),
   @Experimental
   TSERV_SCAN_INITIAL_WAIT_ENABLED("tserver.scan.initial.wait.enabled", "true", PropertyType.BOOLEAN,
-      "Determines if the client waits for writes before scanning a table for the first time"),
+      "Determines if the client waits for writes in progress before scanning a user table for the first time."
+          + "This wait is to ensure that the client scan sees all the data that was previously written."),
   TSERV_MAX_IDLE("tserver.files.open.idle", "1m", PropertyType.TIMEDURATION,
       "Tablet servers leave previously used files open for future queries. This "
           + "setting determines how much time an unused file should be kept open until "
@@ -934,7 +935,7 @@ public enum Property {
       "The sampling percentage to use for replication traces"),
   REPLICATION_RPC_TIMEOUT("replication.rpc.timeout", "2m", PropertyType.TIMEDURATION,
       "Amount of time for a single replication RPC call to last before failing"
-          + " the attempt. See replication.work.attempts."),;
+          + " the attempt. See replication.work.attempts.");
 
   private String key;
   private String defaultValue;

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -932,8 +932,9 @@ public enum Property {
   REPLICATION_RPC_TIMEOUT("replication.rpc.timeout", "2m", PropertyType.TIMEDURATION,
       "Amount of time for a single replication RPC call to last before failing"
           + " the attempt. See replication.work.attempts."),
-
-  ;
+  @Experimental
+  SCAN_INITIAL_WAIT_ENABLED("scan.initial.wait.enabled", "true", PropertyType.BOOLEAN,
+      "Determines if the client waits for writes before scanning a table for the first time"),;
 
   private String key;
   private String defaultValue;

--- a/core/src/test/java/org/apache/accumulo/core/client/ClientConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/ClientConfigurationTest.java
@@ -69,7 +69,7 @@ public class ClientConfigurationTest {
     forth.addProperty(ClientProperty.INSTANCE_ZK_HOST.getKey(), "thirdZkHosts");
     forth.addProperty(ClientProperty.INSTANCE_NAME.getKey(), "thirdInstanceName");
     forth.addProperty(ClientProperty.INSTANCE_ZK_TIMEOUT.getKey(), "123s");
-    forth.addProperty(ClientProperty.SCAN_INITIAL_WAIT_ENABLED.getKey(), "false");
+    forth.addProperty(ClientProperty.TSERV_SCAN_INITIAL_WAIT_ENABLED.getKey(), "false");
     @SuppressWarnings("deprecation")
     ClientConfiguration clientConf = new ClientConfiguration(Arrays.asList(first, second, third));
     return clientConf;

--- a/core/src/test/java/org/apache/accumulo/core/client/ClientConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/ClientConfigurationTest.java
@@ -65,6 +65,11 @@ public class ClientConfigurationTest {
     third.addProperty(ClientProperty.INSTANCE_ZK_HOST.getKey(), "thirdZkHosts");
     third.addProperty(ClientProperty.INSTANCE_NAME.getKey(), "thirdInstanceName");
     third.addProperty(ClientProperty.INSTANCE_ZK_TIMEOUT.getKey(), "123s");
+    Configuration forth = new PropertiesConfiguration();
+    forth.addProperty(ClientProperty.INSTANCE_ZK_HOST.getKey(), "thirdZkHosts");
+    forth.addProperty(ClientProperty.INSTANCE_NAME.getKey(), "thirdInstanceName");
+    forth.addProperty(ClientProperty.INSTANCE_ZK_TIMEOUT.getKey(), "123s");
+    forth.addProperty(ClientProperty.SCAN_INITIAL_WAIT_ENABLED.getKey(), "false");
     @SuppressWarnings("deprecation")
     ClientConfiguration clientConf = new ClientConfiguration(Arrays.asList(first, second, third));
     return clientConf;

--- a/test/src/main/java/org/apache/accumulo/test/ScanWithoutInitialWaitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanWithoutInitialWaitIT.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.test;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.ConnectorImpl;
+import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.fate.util.UtilWaitThread;
+import org.apache.accumulo.harness.AccumuloClusterHarness;
+import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.test.functional.SlowIterator;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScanWithoutInitialWaitIT extends AccumuloClusterHarness {
+
+  @Override
+  public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setProperty(Property.INSTANCE_ZK_TIMEOUT, "15s");
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(ScanWithoutInitialWaitIT.class);
+
+  @Override
+  protected int defaultTimeoutSeconds() {
+    return 120;
+  }
+
+  @Test
+  public void test() throws Exception {
+    log.info("Creating table");
+    String tableName = getUniqueNames(1)[0];
+    Connector waitConn = getConnector();
+
+    ClientConfiguration conf = clusterConf.getClientConf();
+    conf.setProperty(ClientProperty.TSERV_SCAN_INITIAL_WAIT_ENABLED, "false");
+    Credentials credentials = new Credentials(getAdminPrincipal(), getAdminToken());
+    ClientContext clientContext = new ClientContext(waitConn.getInstance(), credentials, conf);
+    Connector noWaitConn = new ConnectorImpl(clientContext);
+
+    waitConn.tableOperations().create(tableName);
+    log.info("Adding slow iterator");
+    IteratorSetting setting = new IteratorSetting(50, SlowIterator.class);
+    SlowIterator.setSleepTime(setting, 1000);
+    waitConn.tableOperations().attachIterator(tableName, setting);
+    log.info("Splitting the table");
+    SortedSet<Text> partitionKeys = new TreeSet<>();
+    partitionKeys.add(new Text("5"));
+    waitConn.tableOperations().addSplits(tableName, partitionKeys);
+    log.info("waiting for zookeeper propagation");
+    UtilWaitThread.sleep(5 * 1000);
+    log.info("Adding a few entries");
+    BatchWriter bw = waitConn.createBatchWriter(tableName, null);
+    for (int i = 0; i < 10; i++) {
+      Mutation m = new Mutation("" + i);
+      m.put("", "", "");
+      bw.addMutation(m);
+    }
+    bw.close();
+    log.info("Fetching some entries: should timeout and return something");
+
+    log.info("Testing Scanner Times");
+    Scanner waitConnScanner = waitConn.createScanner(tableName, Authorizations.EMPTY);
+    waitConnScanner.setBatchTimeout(500, TimeUnit.MILLISECONDS);
+    long waitScanTime = testScanner(waitConnScanner, 1200);
+
+    Scanner noWaitConnScanner = noWaitConn.createScanner(tableName, Authorizations.EMPTY);
+    noWaitConnScanner.setBatchTimeout(500, TimeUnit.MILLISECONDS);
+    long noWaitScanTime = testScanner(noWaitConnScanner, 1200);
+
+    assertTrue(waitScanTime > noWaitScanTime);
+
+    log.info("Testing Batch Scanner Times");
+    BatchScanner waitBatchScanner = waitConn.createBatchScanner(tableName, Authorizations.EMPTY, 5);
+    waitBatchScanner.setBatchTimeout(500, TimeUnit.MILLISECONDS);
+    waitBatchScanner.setRanges(Collections.singletonList(new Range()));
+    long waitBatchScanTime = testScanner(waitBatchScanner, 1200);
+
+    BatchScanner noWaitBatchScanner =
+        noWaitConn.createBatchScanner(tableName, Authorizations.EMPTY, 5);
+    noWaitBatchScanner.setBatchTimeout(500, TimeUnit.MILLISECONDS);
+    noWaitBatchScanner.setRanges(Collections.singletonList(new Range()));
+    long noWaitBatchScanTime = testScanner(noWaitBatchScanner, 1200);
+
+    assertTrue(waitBatchScanTime > noWaitBatchScanTime);
+  }
+
+  private long testScanner(ScannerBase s, long expected) {
+    long now = System.currentTimeMillis();
+    try {
+      s.iterator().next();
+    } finally {
+      s.close();
+    }
+    long scanDuration = System.currentTimeMillis() - now;
+    log.info("Scan Duration = {}", scanDuration);
+    assertTrue("Scanner taking too long to return intermediate results: " + scanDuration,
+        scanDuration < expected);
+    return scanDuration;
+  }
+}


### PR DESCRIPTION
Add new property `tserver.scan.inital.wait.enabled` to allow clients the option to wait for writes on inital scans.