### PR TITLE
Enforce sort order of data version for upgraders

### DIFF
--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.manager.upgrade;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -107,11 +108,11 @@ public class UpgradeCoordinator {
 
   private int currentVersion;
 
-  // map of "current version" -> upgrader to next version.
+  // unmodifiable map of "current version" -> upgrader to next version.
   // Sorted so upgrades execute in order from the oldest supported data version to current
   private Map<Integer,Upgrader> upgraders =
-      new TreeMap<>(Map.of(AccumuloDataVersion.SHORTEN_RFILE_KEYS, new Upgrader8to9(),
-          AccumuloDataVersion.CRYPTO_CHANGES, new Upgrader9to10()));
+      Collections.unmodifiableMap(new TreeMap<>(Map.of(AccumuloDataVersion.SHORTEN_RFILE_KEYS,
+          new Upgrader8to9(), AccumuloDataVersion.CRYPTO_CHANGES, new Upgrader9to10())));
 
   private volatile UpgradeStatus status;
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/UpgradeCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.upgrade;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
@@ -105,8 +106,12 @@ public class UpgradeCoordinator {
   private static Logger log = LoggerFactory.getLogger(UpgradeCoordinator.class);
 
   private int currentVersion;
-  private Map<Integer,Upgrader> upgraders = Map.of(AccumuloDataVersion.SHORTEN_RFILE_KEYS,
-      new Upgrader8to9(), AccumuloDataVersion.CRYPTO_CHANGES, new Upgrader9to10());
+
+  // map of "current version" -> upgrader to next version.
+  // Sorted so upgrades execute in order from the oldest supported data version to current
+  private Map<Integer,Upgrader> upgraders =
+      new TreeMap<>(Map.of(AccumuloDataVersion.SHORTEN_RFILE_KEYS, new Upgrader8to9(),
+          AccumuloDataVersion.CRYPTO_CHANGES, new Upgrader9to10()));
 
   private volatile UpgradeStatus status;
 


### PR DESCRIPTION
The map  of data version was using Map.of - use TreeMap to guarantee the sort order by data version. Noticed by @ctubbsii while working #3160 