### PR TITLE
Update validation of options in Sampler code

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/RowColumnSampler.java
@@ -84,9 +84,12 @@ public class RowColumnSampler extends AbstractHashSampler {
 
   @Override
   public void validateOptions(Map<String,String> config) {
+    // The required base options are validated in the super class.
     super.validateOptions(config);
+    // RowColumnSampler specific options are validated here.
     for (String option : config.keySet()) {
-      checkArgument(VALID_OPTIONS.contains(option), "Unknown option : %s", option);
+      checkArgument(VALID_OPTIONS.contains(option) || REQUIRED_SAMPLER_OPTIONS.contains(option),
+          "Unknown option : %s", option);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.sample.RowColumnSampler;
 import org.apache.accumulo.core.client.sample.RowSampler;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.KerberosToken;
@@ -901,7 +902,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
   }
 
   @Test
-  public void testScanScample() throws Exception {
+  public void testScanSample() throws Exception {
     final String table = getUniqueNames(1)[0];
 
     // compact
@@ -929,7 +930,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("scan --sample", true, "accumulo", false);
     ts.exec("grep --sample acc", true, "accumulo", false);
 
-    // create table where table sample config differs from whats in file
+    // Create table where table sample config differs from what's in file
     String clone2 = table + "_clone_2";
     ts.exec("clonetable -s"
         + " table.sampler.opt.hasher=murmur3_32,table.sampler.opt.modulus=2,table.sampler="
@@ -948,6 +949,80 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
     ts.exec("scan --sample", true, "8934", false);
     ts.exec("grep --sample 89", true, "8934", false);
+  }
+
+  // Feb 2023 - the sample example utilizing RowColumnSampler was failing. Analysis found that
+  // the AbstractHashSampler was throwing an exception when additional options were utilized,
+  // i.e., options beyond the required base 'hasher' and 'modulus' options. Additionally, the
+  // RowColumnSampler threw an exception when the base options were parsed.
+  // This test exercises a sampler that utilizes additional options and verifies options are parsed
+  // successfully.
+  @Test
+  public void testScanSampleOptions() throws Exception {
+    final String table = getUniqueNames(1)[0];
+
+    ts.exec("createtable " + table);
+
+    ts.exec("insert 9255 doc content 'abcde'");
+    ts.exec("insert 9255 doc url file://foo.txt");
+    ts.exec("insert 8934 doc content 'accumulo scales'");
+    ts.exec("insert 8934 doc url file://accumulo_notes.txt");
+    ts.exec("insert 5454 image size 2024,800");
+    ts.exec("insert 7000 image metadata '2023/01/02 12:34:43'");
+    ts.exec("insert 7000 image uri file://image1.jpg");
+    ts.exec("insert 2317 doc content 'milk, eggs, bread, parmigiano-reggiano'");
+    ts.exec("insert 2317 doc url file://groceries/9.txt");
+    ts.exec("insert 3900 doc content 'EC2 ate my homework'");
+    ts.exec("insert 3900 doc url file://final_project.txt");
+
+    // Verify sampler with more than just base options parses correctly
+    String clone1 = table + "_clone_1";
+    ts.exec("clonetable -s"
+        + " table.sampler.opt.hasher=murmur3_32,table.sampler.opt.modulus=3,table.sampler.opt.qualifier="
+        + "true,table.sampler=" + RowColumnSampler.class.getName() + " " + table + " " + clone1);
+    ts.exec("compact -t " + clone1 + " -w --sf-no-sample");
+    ts.exec("table " + clone1);
+    ts.exec("scan --sample", true);
+    for (String expected : Arrays.asList("groceries", "final_project", "accumulo_notes",
+        "foo.txt")) {
+      ts.exec("scan --sample", true, expected, true);
+      ts.exec("grep --sample " + expected.substring(0, 2), true, expected, true);
+    }
+    for (String notExpected : Arrays.asList("bread", "homework", "scales", "abcde", "1024", "2023",
+        "image1")) {
+      ts.exec("scan --sample", true, notExpected, false);
+      ts.exec("grep --sample " + notExpected.substring(0, 2), true, notExpected, false);
+    }
+
+    // Verify failure to provide a base option results in empty sample result
+    String clone2 = table + "_clone_2";
+    ts.exec("clonetable -s table.sampler.opt.hasher=murmur3_32,table.sampler.opt.qualifier="
+        + "true,table.sampler=" + RowColumnSampler.class.getName() + " " + table + " " + clone2);
+    ts.exec("compact -t " + clone2 + " -w --sf-no-sample");
+    ts.exec("table " + clone2, true);
+    ts.exec("config -t " + clone2 + " -f sampler", true);
+    ts.exec("scan --sample", true);
+    // None of the expected rows/values should be returned from scan
+    for (String notExpected : Arrays.asList("2317", "3900", "5454", "7000", "8934", "9255")) {
+      ts.exec("scan --sample", true, notExpected, false);
+      ts.exec("grep --sample " + notExpected.substring(0, 3), true, notExpected, false);
+    }
+
+    // Verify providing an invalid option results in empty sample result
+    String clone3 = table + "_clone_3";
+    ts.exec("clonetable -s "
+        + "table.sampler.opt.hasher=murmur3_32,table.sampler.opt.modulus=5,table.sampler.opt.qualifier="
+        + "true,table.sampler.opt.badprop=42,table.sampler=" + RowColumnSampler.class.getName()
+        + " " + table + " " + clone3);
+    ts.exec("compact -t " + clone3 + " -w --sf-no-sample");
+    ts.exec("table " + clone3, true);
+    ts.exec("scan --sample", true);
+    // None of the expected rows/values should be returned from scan
+    for (String expected : Arrays.asList("2317", "3900", "5454", "7000", "8934", "9255")) {
+      ts.exec("scan --sample", true, expected, false);
+      ts.exec("grep --sample " + expected.substring(0, 3), true, expected, false);
+    }
+
   }
 
   @Test


### PR DESCRIPTION
Discovered a bug in AbstractHashSampler and RowColumnSampler classes while examining the Sample example. The final portion of the example was failing to return any data. Found that the AbstractHashSampler would produce and error any time an any additional option were provided. It would only handle the required hasher and modulus options correctly.

Conversely, the RowColumnSampler would fail when presented with the require hasher and modulus options.

Updated such that the RowColumnSampler will ignore the required options, allowing the AbstractHashSampler to handle them, and only validate options specific to the RowColumnSampler.

The AbstractHashSampler was updated to ignore any non-required options.

Added comments to indicate that the AbstractHashSampler validates required options while calling sub-classes should handle any additional Sampler specific options.