### PR TITLE
Added error details for Compaction Configuration failures

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -128,8 +128,8 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
     final Long maxSize;
 
     public Executor(CompactionExecutorId ceid, Long maxSize) {
-      Preconditions.checkArgument(maxSize == null || maxSize > 0);
-      this.ceid = Objects.requireNonNull(ceid);
+      Preconditions.checkArgument(maxSize == null || maxSize > 0, "Invalid value for maxSize");
+      this.ceid = Objects.requireNonNull(ceid, "Compaction ID is null");
       this.maxSize = maxSize;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionPlannerInitParams.java
@@ -33,7 +33,6 @@ import org.apache.accumulo.core.spi.compaction.ExecutorManager;
 import com.google.common.base.Preconditions;
 
 public class CompactionPlannerInitParams implements CompactionPlanner.InitParameters {
-
   private final Map<String,String> plannerOpts;
   private final Map<CompactionExecutorId,Integer> requestedExecutors;
   private final Set<CompactionExecutorId> requestedExternalExecutors;
@@ -72,7 +71,8 @@ public class CompactionPlannerInitParams implements CompactionPlanner.InitParame
         Preconditions.checkArgument(threads > 0, "Positive number of threads required : %s",
             threads);
         var ceid = CompactionExecutorIdImpl.internalId(serviceId, executorName);
-        Preconditions.checkState(!getRequestedExecutors().containsKey(ceid));
+        Preconditions.checkState(!getRequestedExecutors().containsKey(ceid),
+            "Duplicate Compaction Executor ID found");
         getRequestedExecutors().put(ceid, threads);
         return ceid;
       }


### PR DESCRIPTION
Added additional error details for a couple of Compaction configuration failure conditions.

The use of duplicate Compaction Executor ID's in configuration will return an explicit message detailing the issue in the error output.

Similarly, maxSize errors or null Compaction ID's will detail the issue in the error output.