### PR TITLE
Created TabletMetadataCache

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -57,13 +57,6 @@ jobs:
       run: contrib/ci/find-unapproved-chars.sh
     - name: Check for unapproved JUnit API usage
       run: contrib/ci/find-unapproved-junit.sh
-    #
-    # Use an older version of Maven due to issues with plugins in Maven 3.9.0
-    #
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.5
-      with:
-        maven-version: 3.8.7
     - name: Build with Maven (Fast Build)
       timeout-minutes: 20
       run: mvn -B -V -e -ntp "-Dstyle.color=always" clean package dependency:resolve -DskipTests -DskipFormat -DverifyFormat

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -70,7 +70,7 @@ jobs:
         profile:
           - {name: 'unit-tests',    javaver: 11, args: 'verify -PskipQA -DskipTests=false'}
           - {name: 'qa-checks',     javaver: 11, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.5.10'}
+          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.6.0'}
           - {name: 'errorprone',    javaver: 11, args: 'verify -Perrorprone,skipQA'}
           - {name: 'jdk17',         javaver: 17, args: 'verify -DskipITs'}
       fail-fast: false

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -57,6 +57,13 @@ jobs:
       run: contrib/ci/find-unapproved-chars.sh
     - name: Check for unapproved JUnit API usage
       run: contrib/ci/find-unapproved-junit.sh
+    #
+    # Use an older version of Maven due to issues with plugins in Maven 3.9.0
+    #
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.8.7
     - name: Build with Maven (Fast Build)
       timeout-minutes: 20
       run: mvn -B -V -e -ntp "-Dstyle.color=always" clean package dependency:resolve -DskipTests -DskipFormat -DverifyFormat
@@ -70,7 +77,7 @@ jobs:
         profile:
           - {name: 'unit-tests',    javaver: 11, args: 'verify -PskipQA -DskipTests=false'}
           - {name: 'qa-checks',     javaver: 11, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.6.1'}
+          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.6.4'}
           - {name: 'errorprone',    javaver: 11, args: 'verify -Perrorprone,skipQA'}
           - {name: 'jdk17',         javaver: 17, args: 'verify -DskipITs'}
       fail-fast: false

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -70,7 +70,7 @@ jobs:
         profile:
           - {name: 'unit-tests',    javaver: 11, args: 'verify -PskipQA -DskipTests=false'}
           - {name: 'qa-checks',     javaver: 11, args: 'verify javadoc:jar -Psec-bugs -DskipTests -Dspotbugs.timeout=3600000'}
-          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.6.0'}
+          - {name: 'compat',        javaver: 11, args: 'package -DskipTests -Dhadoop.version=3.0.3 -Dzookeeper.version=3.6.1'}
           - {name: 'errorprone',    javaver: 11, args: 'verify -Perrorprone,skipQA'}
           - {name: 'jdk17',         javaver: 17, args: 'verify -DskipITs'}
       fail-fast: false

--- a/core/src/main/java/org/apache/accumulo/core/Constants.java
+++ b/core/src/main/java/org/apache/accumulo/core/Constants.java
@@ -47,6 +47,8 @@ public class Constants {
   public static final String ZTABLE_COMPACT_CANCEL_ID = "/compact-cancel-id";
   public static final String ZTABLE_NAMESPACE = "/namespace";
 
+  public static final String ZTABLET_CACHE = "/tablet_cache";
+
   public static final String ZNAMESPACES = "/namespaces";
   public static final String ZNAMESPACE_NAME = "/name";
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -520,7 +520,7 @@ public class TabletMetadata {
   }
 
   @VisibleForTesting
-  static TabletMetadata create(String id, String prevEndRow, String endRow) {
+  public static TabletMetadata create(String id, String prevEndRow, String endRow) {
     TabletMetadata te = new TabletMetadata();
     te.tableId = TableId.of(id);
     te.sawPrevEndRow = true;

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
-    <curator.version>5.3.0</curator.version>
+    <curator.version>5.4.0</curator.version>
     <!-- relative path for Eclipse format; should override in child modules if necessary -->
     <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <errorprone.version>2.15.0</errorprone.version>
@@ -450,6 +450,11 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-framework</artifactId>
+        <version>${curator.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-recipes</artifactId>
         <version>${curator.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -454,11 +454,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
-        <artifactId>curator-recipes</artifactId>
-        <version>${curator.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
         <version>${curator.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,14 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -85,6 +85,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-api</artifactId>
     </dependency>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -85,10 +85,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-recipes</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-api</artifactId>
     </dependency>

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.AmpleImpl;
 import org.apache.accumulo.core.rpc.SslConnectionParams;
 import org.apache.accumulo.core.singletons.SingletonReservation;
 import org.apache.accumulo.core.spi.crypto.CryptoServiceFactory;
@@ -135,7 +136,8 @@ public class ServerContext extends ClientContext {
         memoize(() -> new AuditedSecurityOperation(this, SecurityOperation.getAuthorizor(this),
             SecurityOperation.getAuthenticator(this), SecurityOperation.getPermHandler(this)));
     lowMemoryDetector = memoize(() -> new LowMemoryDetector());
-    tabletMetadataCache = memoize(() -> new TabletMetadataCache(this));
+    tabletMetadataCache = memoize(
+        () -> new TabletMetadataCache(info.getInstanceID(), zooReaderWriter, new AmpleImpl(this)));
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -474,6 +474,10 @@ public class ServerContext extends ClientContext {
     }
   }
 
+  public boolean isTabletMetadataCacheInitialized() {
+    return tabletMetadataCacheInitialized;
+  }
+
   @Override
   public synchronized void close() {
     super.close();

--- a/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/ZooKeeperInitializer.java
@@ -162,6 +162,8 @@ public class ZooKeeperInitializer {
         ZooUtil.NodeExistsPolicy.FAIL);
     zoo.putPersistentData(zkInstanceRoot + Constants.ZSSERVERS, EMPTY_BYTE_ARRAY,
         ZooUtil.NodeExistsPolicy.FAIL);
+    zoo.putPersistentData(zkInstanceRoot + Constants.ZTABLET_CACHE, EMPTY_BYTE_ARRAY,
+        ZooUtil.NodeExistsPolicy.FAIL);
   }
 
   /**

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMetadataCache.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMetadataCache.java
@@ -1,138 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.accumulo.server.metadata;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.Closeable;
+import java.util.concurrent.CountDownLatch;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
-import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.server.ServerContext;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.WatcherRemoveCuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheBuilder;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.framework.recipes.cache.CuratorCacheStorage;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class TabletMetadataCache {
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 
+/**
+ * Object that uses ZooKeeper for signaling Tablet metadata changes to keep a cache of Tablet
+ * metadata up to date.
+ *
+ */
+public class TabletMetadataCache implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TabletMetadataCache.class);
   private static final Long INITIAL_VALUE = Long.valueOf(0);
-  private final Map<KeyExtent,TabletMetadata> cache = new HashMap<>();
-  private final ServerContext ctx;
-  private final InstanceId iid;
+
+  private final String znodeBasePath;
   private final ZooReaderWriter zrw;
+  private final CuratorFramework cf;
+  private final WatcherRemoveCuratorFramework watcherWrapper;
+  private final CuratorCache tabletStateCache;
+  private final LoadingCache<KeyExtent,TabletMetadata> tabletMetadataCache;
 
-  public TabletMetadataCache(ServerContext ctx) {
-    this.ctx = ctx;
-    this.iid = this.ctx.getInstanceID();
-    this.zrw = this.ctx.getZooReaderWriter();
-  }
+  public TabletMetadataCache(final ServerContext ctx) {
 
-  public void put(final KeyExtent extent, final TabletMetadata metadata)
-      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
-    TabletMetadata priorVal = cache.putIfAbsent(extent, metadata);
-    if (priorVal == null) {
-      final String path = getPath(extent);
-      this.zrw.mutateOrCreate(path, serialize(INITIAL_VALUE), (currVal) -> {
-        return serialize(deserialize(currVal) + 1);
-      });
-      watch(path, extent);
-    }
-  }
+    this.zrw = ctx.getZooReaderWriter();
 
-  private void watch(final String path, final KeyExtent extent) {
+    final String rootPath = Constants.ZROOT + "/" + ctx.getInstanceID() + Constants.ZTABLET_CACHE;
+    znodeBasePath = rootPath + "/";
 
-    final Watcher watcher = new Watcher() {
+    // TODO: Likely want to set a max size and eviction parameters
+    tabletMetadataCache =
+        Caffeine.newBuilder().recordStats().scheduler(Scheduler.systemScheduler()).build((k) -> {
+          try {
+            TabletMetadata tm = ctx.getAmple().readTablet(k, ColumnType.values());
+            LOG.info("Loading tablet metadata for extent: {}. Returned: {}", k, tm);
+            return tm;
+          } catch (Exception e) {
+            LOG.error("Error loading tablet metadata for extent: {}", k, e);
+            throw e;
+          }
+        });
+
+    CuratorFrameworkFactory.Builder curatorBuilder = CuratorFrameworkFactory.builder();
+    curatorBuilder.connectString(ctx.getZooKeepers());
+    curatorBuilder.sessionTimeoutMs(ctx.getZooKeepersSessionTimeOut());
+    curatorBuilder.retryPolicy(new RetryNTimes(5, 2000));
+    cf = curatorBuilder.build();
+    cf.start();
+    watcherWrapper = cf.newWatcherRemoveCuratorFramework();
+
+    CuratorCacheBuilder cacheBuilder = CuratorCache.builder(watcherWrapper, rootPath);
+    cacheBuilder.withStorage(CuratorCacheStorage.standard());
+    this.tabletStateCache = cacheBuilder.build();
+    CountDownLatch initializedLatch = new CountDownLatch(1);
+    CuratorCacheListener listener = new CuratorCacheListener() {
       @Override
-      public void process(WatchedEvent event) {
-        switch (event.getType()) {
-          case NodeChildrenChanged:
-          case ChildWatchRemoved:
-          case PersistentWatchRemoved:
-          case DataWatchRemoved:
-          case NodeCreated:
-            // I don't think we care about these cases, but we need
-            // to recreate this watcher
-            watch(path, extent);
+      public void event(Type type, ChildData oldData, ChildData newData) {
+        LOG.info("Received event type: {}, old: {}, new: {}", type, oldData, newData);
+        String path = newData.getPath();
+        switch (type) {
+          case NODE_CREATED:
+            // Do nothing, cache will be populated on clients first call to get()
             break;
-          case None:
-            Event.KeeperState state = event.getState();
-            switch (state) {
-              case AuthFailed:
-              case Closed:
-              case ConnectedReadOnly:
-              case Disconnected:
-              case Expired:
-                // remove all entries on connection issue
-                cache.clear();
-                // case NoSyncConnected:
-                // case SaslAuthenticated:
-                // case SyncConnected:
-                // case Unknown:
-              default:
-                // don't care
-                break;
-            }
-          case NodeDataChanged:
-          case NodeDeleted:
-            remove(extent);
-            break;
+          case NODE_CHANGED:
+          case NODE_DELETED:
           default:
+            // Remove the tablet metadata cache entry on update or delete.
+            KeyExtent extent = getExtent(path);
+            LOG.info("Invalidating extent: {}", extent);
+            tabletMetadataCache.invalidate(extent);
             break;
+
         }
       }
-    };
-    // Place the watcher
-    try {
-      this.zrw.exists(path, watcher);
-    } catch (KeeperException | InterruptedException e) {
-      // TODO: Handle this
-    }
-  }
 
-  public TabletMetadata get(final KeyExtent extent)
-      throws AcceptableThriftTableOperationException, KeeperException, InterruptedException {
-    final String path = getPath(extent);
-    TabletMetadata val = cache.computeIfAbsent(extent, (k) -> {
-      return this.ctx.getAmple().readTablet(k, ColumnType.values());
-    });
-    this.zrw.mutateOrCreate(path, serialize(INITIAL_VALUE), (currVal) -> {
-      return serialize(deserialize(currVal) + 1);
-    });
-    watch(path, extent);
-    return val;
-  }
-
-  public void remove(KeyExtent extent) {
-    TabletMetadata priorVal = cache.remove(extent);
-    if (priorVal != null) {
-      try {
-        this.zrw.delete(getPath(extent));
-      } catch (InterruptedException | KeeperException e) {
-        // TODO: handle this
+      @Override
+      public void initialized() {
+        initializedLatch.countDown();
       }
+    };
+    tabletStateCache.listenable()
+        .addListener(CuratorCacheListener.builder().forAll(listener).afterInitialized().build());
+    tabletStateCache.start();
+    try {
+      initializedLatch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Thread interrupted waiting for tabletStateCache to initialize",
+          e);
     }
   }
 
-  private String getPath(KeyExtent extent) {
-    return Constants.ZROOT + "/" + this.iid + Constants.ZTABLET_CACHE + "/" + extent.toString();
+  protected KeyExtent getExtent(String path) {
+    return deserializeKeyExtent(path.substring(znodeBasePath.length()));
   }
 
-  private Long deserialize(byte[] value) {
+  protected String getPath(KeyExtent extent) {
+    return znodeBasePath + serializeKeyExtent(extent);
+  }
+
+  public TabletMetadata get(KeyExtent extent) {
+    return tabletMetadataCache.get(extent);
+  }
+
+  protected int getTabletMetadataCacheSize() {
+    return tabletMetadataCache.asMap().size();
+  }
+
+  protected CacheStats getTabletMetadataCacheStats() {
+    return tabletMetadataCache.stats();
+  }
+
+  /**
+   * Updates the data of the znode for this extent which will trigger TabletMetadataCache watchers
+   * to reload the TabletMetadata for this extent.
+   *
+   * @param extent
+   */
+  public void tabletMetadataChanged(KeyExtent extent) {
+    final String path = getPath(extent);
+    try {
+      // remove entry from local cache
+      LOG.info("Invalidating extent due to local tablet change: {}", extent);
+      tabletMetadataCache.invalidate(extent);
+      // mutate ZK entry for this tablet
+      this.zrw.mutateOrCreate(path, serializeData(INITIAL_VALUE), (currVal) -> {
+        return serializeData(deserializeData(currVal) + 1);
+      });
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted updating ZooKeeper at: " + path, e);
+
+    } catch (AcceptableThriftTableOperationException | KeeperException e) {
+      throw new RuntimeException("Error updating ZooKeeper at: " + path, e);
+    }
+  }
+
+  public static String serializeKeyExtent(KeyExtent ke) {
+    Text entry = new Text(ke.tableId().canonical());
+    entry.append(new byte[] {';'}, 0, 1);
+    if (ke.endRow() != null) {
+      entry.append(ke.endRow().getBytes(), 0, ke.endRow().getLength());
+    }
+    entry.append(new byte[] {';'}, 0, 1);
+    if (ke.prevEndRow() != null) {
+      entry.append(ke.prevEndRow().getBytes(), 0, ke.prevEndRow().getLength());
+    }
+    return entry.toString();
+  }
+
+  private static KeyExtent deserializeKeyExtent(String zkNode) {
+    String[] parts = zkNode.split(";");
+    assert (parts.length == 3);
+    String tid = parts[0];
+    String end = parts[1];
+    String prev = parts[2];
+    return new KeyExtent(TableId.of(tid), end == null ? null : new Text(end),
+        prev == null ? null : new Text(prev));
+  }
+
+  private static Long deserializeData(byte[] value) {
     return Long.parseLong(new String(value, UTF_8));
   }
 
-  private byte[] serialize(Long value) {
+  private static byte[] serializeData(Long value) {
     return value.toString().getBytes(UTF_8);
   }
 
-  public void tabletMetadataChanged(KeyExtent extent)
-      throws AcceptableThriftTableOperationException, KeeperException, InterruptedException {
-    this.zrw.mutateOrCreate(getPath(extent), serialize(INITIAL_VALUE), (currVal) -> {
-      return serialize(deserialize(currVal) + 1);
-    });
+  @Override
+  public void close() {
+    tabletMetadataCache.invalidateAll();
+    tabletMetadataCache.cleanUp();
+    tabletStateCache.close();
+    watcherWrapper.removeWatchers();
+    cf.close();
   }
+
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMetadataCache.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMetadataCache.java
@@ -1,0 +1,138 @@
+package org.apache.accumulo.server.metadata;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+public class TabletMetadataCache {
+
+  private static final Long INITIAL_VALUE = Long.valueOf(0);
+  private final Map<KeyExtent,TabletMetadata> cache = new HashMap<>();
+  private final ServerContext ctx;
+  private final InstanceId iid;
+  private final ZooReaderWriter zrw;
+
+  public TabletMetadataCache(ServerContext ctx) {
+    this.ctx = ctx;
+    this.iid = this.ctx.getInstanceID();
+    this.zrw = this.ctx.getZooReaderWriter();
+  }
+
+  public void put(final KeyExtent extent, final TabletMetadata metadata)
+      throws KeeperException, InterruptedException, AcceptableThriftTableOperationException {
+    TabletMetadata priorVal = cache.putIfAbsent(extent, metadata);
+    if (priorVal == null) {
+      final String path = getPath(extent);
+      this.zrw.mutateOrCreate(path, serialize(INITIAL_VALUE), (currVal) -> {
+        return serialize(deserialize(currVal) + 1);
+      });
+      watch(path, extent);
+    }
+  }
+
+  private void watch(final String path, final KeyExtent extent) {
+
+    final Watcher watcher = new Watcher() {
+      @Override
+      public void process(WatchedEvent event) {
+        switch (event.getType()) {
+          case NodeChildrenChanged:
+          case ChildWatchRemoved:
+          case PersistentWatchRemoved:
+          case DataWatchRemoved:
+          case NodeCreated:
+            // I don't think we care about these cases, but we need
+            // to recreate this watcher
+            watch(path, extent);
+            break;
+          case None:
+            Event.KeeperState state = event.getState();
+            switch (state) {
+              case AuthFailed:
+              case Closed:
+              case ConnectedReadOnly:
+              case Disconnected:
+              case Expired:
+                // remove all entries on connection issue
+                cache.clear();
+                // case NoSyncConnected:
+                // case SaslAuthenticated:
+                // case SyncConnected:
+                // case Unknown:
+              default:
+                // don't care
+                break;
+            }
+          case NodeDataChanged:
+          case NodeDeleted:
+            remove(extent);
+            break;
+          default:
+            break;
+        }
+      }
+    };
+    // Place the watcher
+    try {
+      this.zrw.exists(path, watcher);
+    } catch (KeeperException | InterruptedException e) {
+      // TODO: Handle this
+    }
+  }
+
+  public TabletMetadata get(final KeyExtent extent)
+      throws AcceptableThriftTableOperationException, KeeperException, InterruptedException {
+    final String path = getPath(extent);
+    TabletMetadata val = cache.computeIfAbsent(extent, (k) -> {
+      return this.ctx.getAmple().readTablet(k, ColumnType.values());
+    });
+    this.zrw.mutateOrCreate(path, serialize(INITIAL_VALUE), (currVal) -> {
+      return serialize(deserialize(currVal) + 1);
+    });
+    watch(path, extent);
+    return val;
+  }
+
+  public void remove(KeyExtent extent) {
+    TabletMetadata priorVal = cache.remove(extent);
+    if (priorVal != null) {
+      try {
+        this.zrw.delete(getPath(extent));
+      } catch (InterruptedException | KeeperException e) {
+        // TODO: handle this
+      }
+    }
+  }
+
+  private String getPath(KeyExtent extent) {
+    return Constants.ZROOT + "/" + this.iid + Constants.ZTABLET_CACHE + "/" + extent.toString();
+  }
+
+  private Long deserialize(byte[] value) {
+    return Long.parseLong(new String(value, UTF_8));
+  }
+
+  private byte[] serialize(Long value) {
+    return value.toString().getBytes(UTF_8);
+  }
+
+  public void tabletMetadataChanged(KeyExtent extent)
+      throws AcceptableThriftTableOperationException, KeeperException, InterruptedException {
+    this.zrw.mutateOrCreate(getPath(extent), serialize(INITIAL_VALUE), (currVal) -> {
+      return serialize(deserialize(currVal) + 1);
+    });
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -56,13 +56,15 @@ import com.google.common.base.Preconditions;
 
 public abstract class TabletMutatorBase implements Ample.TabletMutator {
 
-  private final ServerContext context;
+  protected final ServerContext context;
+  protected final KeyExtent extent;
   private final Mutation mutation;
   protected AutoCloseable closeAfterMutate;
   private boolean updatesEnabled = true;
 
   protected TabletMutatorBase(ServerContext context, KeyExtent extent) {
     this.context = context;
+    this.extent = extent;
     mutation = new Mutation(extent.toMetaRow());
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
@@ -43,7 +43,7 @@ class TabletMutatorImpl extends TabletMutatorBase implements Ample.TabletMutator
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    this.context.getTabletMetadataCache().tabletMetadataChanged(extent);
+    TabletMetadataCache.tabletMetadataChanged(context, extent);
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
@@ -43,6 +43,7 @@ class TabletMutatorImpl extends TabletMutatorBase implements Ample.TabletMutator
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+    this.context.getTabletMetadataCache().tabletMetadataChanged(extent);
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -96,6 +96,7 @@ import org.apache.accumulo.core.util.FastFormat;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.gc.AllVolumesDirectory;
+import org.apache.accumulo.server.metadata.TabletMetadataCache;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,7 +159,7 @@ public class MetadataTableUtil {
       try {
         t.update(m);
         if (!extent.isMeta()) {
-          context.getTabletMetadataCache().tabletMetadataChanged(extent);
+          TabletMetadataCache.tabletMetadataChanged(context, extent);
         }
         return;
       } catch (AccumuloException | TableNotFoundException | AccumuloSecurityException e) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -157,6 +157,9 @@ public class MetadataTableUtil {
     while (true) {
       try {
         t.update(m);
+        if (!extent.isMeta()) {
+          context.getTabletMetadataCache().tabletMetadataChanged(extent);
+        }
         return;
       } catch (AccumuloException | TableNotFoundException | AccumuloSecurityException e) {
         logUpdateFailure(m, extent, e);

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
@@ -71,19 +71,22 @@ public class TabletMetadataCacheIT {
       return super.getExtent(path);
     }
 
-    @Override
-    public String getPath(KeyExtent extent) {
-      return super.getPath(extent);
+    /**
+     * Return size of the cache
+     *
+     * @return size
+     */
+    protected int getTabletMetadataCacheSize() {
+      return tabletMetadataCache.asMap().size();
     }
 
-    @Override
-    public int getTabletMetadataCacheSize() {
-      return super.getTabletMetadataCacheSize();
-    }
-
-    @Override
+    /**
+     * Return Cache stats object
+     *
+     * @return cache stats
+     */
     protected CacheStats getTabletMetadataCacheStats() {
-      return super.getTabletMetadataCacheStats();
+      return tabletMetadataCache.stats();
     }
 
   }
@@ -145,11 +148,11 @@ public class TabletMetadataCacheIT {
   @Test
   public void testPathParsing() {
     try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
-      String path = cache.getPath(ke1);
+      String path = TabletMetadataCache.getPath(context, ke1);
       assertEquals("/accumulo/" + IID + Constants.ZTABLET_CACHE + "/2;b;", path);
       KeyExtent result = cache.getExtent(path);
       assertEquals(ke1, result);
-      String path2 = cache.getPath(ke2);
+      String path2 = TabletMetadataCache.getPath(context, ke2);
       assertEquals("/accumulo/" + IID + Constants.ZTABLET_CACHE + "/2;d;b", path2);
       KeyExtent result2 = cache.getExtent(path2);
       assertEquals(ke2.toMetaRow(), result2.toMetaRow());
@@ -159,7 +162,7 @@ public class TabletMetadataCacheIT {
   @Test
   public void testCachingLocalTabletChange() {
     try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
-      cache.tabletMetadataChanged(ke1); // This will perform a create in ZK
+      TabletMetadataCache.tabletMetadataChanged(context, ke1); // This will perform a create in ZK
       assertEquals(0, cache.getTabletMetadataCacheStats().loadCount());
       assertEquals(0, cache.getTabletMetadataCacheSize());
       TabletMetadata result = cache.get(ke1);
@@ -167,7 +170,8 @@ public class TabletMetadataCacheIT {
       assertEquals(1, cache.getTabletMetadataCacheStats().requestCount());
       assertEquals(1, cache.getTabletMetadataCacheStats().loadSuccessCount());
       assertEquals(tm1, result);
-      cache.tabletMetadataChanged(ke1); // This will perform an update and trigger invalidation
+      TabletMetadataCache.tabletMetadataChanged(context, ke1); // This will perform an update and
+                                                               // trigger invalidation
       assertEquals(0, cache.getTabletMetadataCacheSize());
       result = cache.get(ke1);
       assertEquals(1, cache.getTabletMetadataCacheSize());
@@ -209,7 +213,7 @@ public class TabletMetadataCacheIT {
   @Test
   public void testCachingThreadTabletChange() throws InterruptedException {
     try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
-      cache.tabletMetadataChanged(ke2); // This will perform a create in ZK
+      TabletMetadataCache.tabletMetadataChanged(context, ke2); // This will perform a create in ZK
 
       assertEquals(0, cache.getTabletMetadataCacheStats().loadCount());
       assertEquals(0, cache.getTabletMetadataCacheSize());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
@@ -146,8 +146,13 @@ public class TabletMetadataCacheIT {
   public void testPathParsing() {
     try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
       String path = cache.getPath(ke1);
+      assertEquals("/accumulo/" + IID + Constants.ZTABLET_CACHE + "/2;b;", path);
       KeyExtent result = cache.getExtent(path);
-      assertEquals(ke1.toMetaRow(), result.toMetaRow());
+      assertEquals(ke1, result);
+      String path2 = cache.getPath(ke2);
+      assertEquals("/accumulo/" + IID + Constants.ZTABLET_CACHE + "/2;d;b", path2);
+      KeyExtent result2 = cache.getExtent(path2);
+      assertEquals(ke2.toMetaRow(), result2.toMetaRow());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
@@ -253,7 +253,6 @@ public class TabletMetadataCacheIT {
     assertEquals(tm2, result);
   }
 
-
   @Test
   @Order(4)
   public void testZooKeeperConnectionRestart() throws Exception {

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataCacheIT.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.accumulo.harness.AccumuloITBase.ZOOKEEPER_TESTING_SERVER;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.UUID;
+
+import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.clientImpl.AcceptableThriftTableOperationException;
+import org.apache.accumulo.core.data.InstanceId;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.fate.zookeeper.ZooUtil;
+import org.apache.accumulo.core.metadata.schema.AmpleImpl;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.metadata.TabletMetadataCache;
+import org.apache.accumulo.test.zookeeper.ZooKeeperTestingServer;
+import org.apache.hadoop.io.Text;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+@Tag(ZOOKEEPER_TESTING_SERVER)
+public class TabletMetadataCacheIT {
+
+  /**
+   * Class for test that exists to expose protected methods for test
+   */
+  public static class TestTabletMetadataCache extends TabletMetadataCache {
+
+    public TestTabletMetadataCache(ServerContext ctx) {
+      super(ctx);
+    }
+
+    @Override
+    public KeyExtent getExtent(String path) {
+      return super.getExtent(path);
+    }
+
+    @Override
+    public String getPath(KeyExtent extent) {
+      return super.getPath(extent);
+    }
+
+    @Override
+    public int getTabletMetadataCacheSize() {
+      return super.getTabletMetadataCacheSize();
+    }
+
+    @Override
+    protected CacheStats getTabletMetadataCacheStats() {
+      return super.getTabletMetadataCacheStats();
+    }
+
+  }
+
+  @TempDir
+  private static File tempDir;
+
+  private static final InstanceId IID = InstanceId.of(UUID.randomUUID());
+
+  private static ZooKeeperTestingServer szk = null;
+  private static ZooKeeper zooKeeper;
+
+  private ServerContext context;
+  private KeyExtent ke1, ke2, ke3, ke4;
+  private TabletMetadata tm1, tm2, tm3, tm4;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    szk = new ZooKeeperTestingServer(tempDir);
+    szk.initPaths(ZooUtil.getRoot(IID) + Constants.ZTABLET_CACHE);
+    zooKeeper = szk.getZooKeeper();
+    ZooUtil.digestAuth(zooKeeper, ZooKeeperTestingServer.SECRET);
+  }
+
+  @AfterAll
+  public static void teardown() throws Exception {
+    szk.close();
+  }
+
+  @BeforeEach
+  public void before() {
+    context = EasyMock.createNiceMock(ServerContext.class);
+    AmpleImpl ample = EasyMock.createStrictMock(AmpleImpl.class);
+    expect(context.getInstanceID()).andReturn(IID).anyTimes();
+    expect(context.getZooReaderWriter()).andReturn(szk.getZooReaderWriter()).anyTimes();
+    expect(context.getAmple()).andReturn(ample).anyTimes();
+    expect(context.getZooKeepers()).andReturn(szk.getConn());
+    expect(context.getZooKeepersSessionTimeOut()).andReturn((30000));
+
+    TableId tid = TableId.of("2");
+    ke1 = new KeyExtent(tid, new Text("b"), null);
+    ke2 = new KeyExtent(tid, new Text("d"), new Text("b"));
+    ke3 = new KeyExtent(tid, new Text("g"), new Text("d"));
+    ke4 = new KeyExtent(tid, new Text("m"), new Text("g"));
+
+    tm1 = TabletMetadata.create(tid.canonical(), null, "b");
+    tm2 = TabletMetadata.create(tid.canonical(), "b", "d");
+    tm3 = TabletMetadata.create(tid.canonical(), "d", "g");
+    tm4 = TabletMetadata.create(tid.canonical(), "g", "m");
+
+    expect(ample.readTablet(ke1, ColumnType.values())).andReturn(tm1).anyTimes();
+    expect(ample.readTablet(ke2, ColumnType.values())).andReturn(tm2).anyTimes();
+    expect(ample.readTablet(ke3, ColumnType.values())).andReturn(tm3).anyTimes();
+    expect(ample.readTablet(ke4, ColumnType.values())).andReturn(tm4).anyTimes();
+
+    replay(context, ample);
+  }
+
+  @Test
+  public void testPathParsing() {
+    try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
+      String path = cache.getPath(ke1);
+      KeyExtent result = cache.getExtent(path);
+      assertEquals(ke1.toMetaRow(), result.toMetaRow());
+    }
+  }
+
+  @Test
+  public void testCachingLocalTabletChange() {
+    try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
+      cache.tabletMetadataChanged(ke1); // This will perform a create in ZK
+      assertEquals(0, cache.getTabletMetadataCacheStats().loadCount());
+      assertEquals(0, cache.getTabletMetadataCacheSize());
+      TabletMetadata result = cache.get(ke1);
+      assertEquals(1, cache.getTabletMetadataCacheSize());
+      assertEquals(1, cache.getTabletMetadataCacheStats().requestCount());
+      assertEquals(1, cache.getTabletMetadataCacheStats().loadSuccessCount());
+      assertEquals(tm1, result);
+      cache.tabletMetadataChanged(ke1); // This will perform an update and trigger invalidation
+      assertEquals(0, cache.getTabletMetadataCacheSize());
+      result = cache.get(ke1);
+      assertEquals(1, cache.getTabletMetadataCacheSize());
+      assertEquals(2, cache.getTabletMetadataCacheStats().requestCount());
+      assertEquals(2, cache.getTabletMetadataCacheStats().loadSuccessCount());
+      assertEquals(tm1, result);
+    }
+  }
+
+  public class TabletChangedThread implements Runnable {
+
+    private final Logger LOG = LoggerFactory.getLogger(TabletChangedThread.class);
+
+    private Long deserialize(byte[] value) {
+      return Long.parseLong(new String(value, UTF_8));
+    }
+
+    private byte[] serialize(Long value) {
+      return value.toString().getBytes(UTF_8);
+    }
+
+    @Override
+    public void run() {
+
+      // mutate ZK entry for this tablet
+      String path = Constants.ZROOT + "/" + IID + Constants.ZTABLET_CACHE + "/"
+          + TabletMetadataCache.serializeKeyExtent(ke2);
+      try {
+        LOG.info("Mutating node at path: {}", path);
+        szk.getZooReaderWriter().mutateOrCreate(path, serialize(Long.valueOf(0)), (currVal) -> {
+          return serialize(deserialize(currVal) + 1);
+        });
+      } catch (AcceptableThriftTableOperationException | KeeperException | InterruptedException e) {
+        LOG.error("***ERROR***", e);
+      }
+    }
+  }
+
+  @Test
+  public void testCachingThreadTabletChange() throws InterruptedException {
+    try (TestTabletMetadataCache cache = new TestTabletMetadataCache(context)) {
+      cache.tabletMetadataChanged(ke2); // This will perform a create in ZK
+
+      assertEquals(0, cache.getTabletMetadataCacheStats().loadCount());
+      assertEquals(0, cache.getTabletMetadataCacheSize());
+      TabletMetadata result = cache.get(ke2);
+      assertEquals(1, cache.getTabletMetadataCacheSize());
+      assertEquals(1, cache.getTabletMetadataCacheStats().requestCount());
+      assertEquals(1, cache.getTabletMetadataCacheStats().loadSuccessCount());
+      assertEquals(tm2, result);
+
+      Thread t = new Thread(new TabletChangedThread());
+      t.start();
+      t.join();
+
+      // wait for zk watcher to remove cache entry
+      while (cache.getTabletMetadataCacheSize() != 0) {
+        Thread.sleep(100);
+      }
+
+      assertEquals(0, cache.getTabletMetadataCacheSize());
+      result = cache.get(ke2);
+      assertEquals(1, cache.getTabletMetadataCacheSize());
+      assertEquals(2, cache.getTabletMetadataCacheStats().requestCount());
+      assertEquals(2, cache.getTabletMetadataCacheStats().loadSuccessCount());
+      assertEquals(tm2, result);
+    }
+  }
+
+}

--- a/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/zookeeper/ZooKeeperTestingServer.java
@@ -130,6 +130,12 @@ public class ZooKeeperTestingServer implements AutoCloseable {
     }
   }
 
+  public void restart() throws Exception {
+    if (zkServer != null) {
+      zkServer.restart();
+    }
+  }
+
   @Override
   public void close() throws IOException {
     if (zkServer != null) {


### PR DESCRIPTION
TabletMetadataCache (TMC) caches TabletMetadata for a KeyExtent. TMC loads TabletMetadata via Ample.readTablet with all columns specified and removes TabletMetadata when it has been changed. TMC uses ZooKeeper for signaling TabletMetadata changes. TMC will reduce the load on the metadata and root table where server processes load/unload Tablets frequently for on-demand processing.
