### PR TITLE
Support writing cluster config parser output to a file

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -66,7 +66,7 @@ function parse_config {
 
   trap 'rm -f "$CONFIG_FILE"' EXIT
   CONFIG_FILE=$(mktemp) || exit 1
-  ${accumulo_cmd} org.apache.accumulo.core.conf.cluster.ClusterConfigParser "${conf}"/cluster.yaml >"$CONFIG_FILE" || parse_fail
+  ${accumulo_cmd} org.apache.accumulo.core.conf.cluster.ClusterConfigParser "${conf}"/cluster.yaml "$CONFIG_FILE" || parse_fail
   #shellcheck source=/dev/null
   . "$CONFIG_FILE"
   rm -f "$CONFIG_FILE"

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.conf.cluster;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -135,12 +136,23 @@ public class ClusterConfigParser {
     out.flush();
   }
 
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
+      justification = "Path provided for output file is intentional")
   public static void main(String[] args) throws IOException {
-    if (args == null || args.length != 1) {
-      System.err.println("Usage: ClusterConfigParser <configFile>");
+    if (args == null || args.length < 1 || args.length > 2) {
+      System.err.println("Usage: ClusterConfigParser <configFile> [<outputFile>]");
       System.exit(1);
     }
-    outputShellVariables(parseConfiguration(args[0]), System.out);
+
+    if (args.length == 2) {
+      // Write to a file instead of System.out if provided as an argument
+      try (OutputStream os = Files.newOutputStream(Paths.get(args[1]), StandardOpenOption.CREATE);
+          PrintStream out = new PrintStream(os)) {
+        outputShellVariables(parseConfiguration(args[0]), new PrintStream(out));
+      }
+    } else {
+      outputShellVariables(parseConfiguration(args[0]), System.out);
+    }
   }
 
 }


### PR DESCRIPTION
- This commit adds support to provide an optional argument to ClusterConfigParser to write the output to a file instead of System.out so that only the output we want is captured and not everything that's written to standard out.
-  This the accumulo-cluster script has also been updated to to provide the temp file as an output file argument instead of capturing System.out so that there are not parsing errors by the script if other output is written to the standard out stream.

This fixes parsing issues if there's anything that writes to standard out/error but the main reason for this PR is to fix https://github.com/apache/accumulo-classloaders/issues/18 because the debug output (or any other output) by the classloader to standard out/err will no longer interfere with the parsing by the accumulo-cluster script.