### PR TITLE
Replace all instances of Guava cache with Caffeine

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/classloader/URLContextClassLoaderFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/URLContextClassLoaderFactory.java
@@ -23,7 +23,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.spi.common.ContextClassLoaderFactory;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/apache/accumulo/core/classloader/URLContextClassLoaderFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/URLContextClassLoaderFactory.java
@@ -70,7 +70,7 @@ public class URLContextClassLoaderFactory implements ContextClassLoaderFactory {
         } catch (MalformedURLException e) {
           throw new RuntimeException(e);
         }
-      }).collect(Collectors.toList()).toArray(new URL[] {}), ClassLoader.getSystemClassLoader());
+      }).toArray(URL[]::new), ClassLoader.getSystemClassLoader());
     });
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/classloader/URLContextClassLoaderFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/classloader/URLContextClassLoaderFactory.java
@@ -22,7 +22,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -30,8 +29,8 @@ import org.apache.accumulo.core.spi.common.ContextClassLoaderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * The default implementation of ContextClassLoaderFactory. This classloader returns a
@@ -49,7 +48,7 @@ public class URLContextClassLoaderFactory implements ContextClassLoaderFactory {
   // Classes that are loaded contain a reference to the class loader used to load them
   // so the class loader will be garbage collected when no more classes are loaded that reference it
   private final Cache<String,URLClassLoader> classloaders =
-      CacheBuilder.newBuilder().weakValues().build();
+      Caffeine.newBuilder().weakValues().build();
 
   public URLContextClassLoaderFactory() {
     if (!isInstantiated.compareAndSet(false, true)) {
@@ -63,19 +62,15 @@ public class URLContextClassLoaderFactory implements ContextClassLoaderFactory {
       throw new IllegalArgumentException("Unknown context");
     }
 
-    try {
-      return classloaders.get(context, () -> {
-        LOG.debug("Creating URLClassLoader for context, uris: {}", context);
-        return new URLClassLoader(Arrays.stream(context.split(",")).map(url -> {
-          try {
-            return new URL(url);
-          } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-          }
-        }).collect(Collectors.toList()).toArray(new URL[] {}), ClassLoader.getSystemClassLoader());
-      });
-    } catch (ExecutionException e) {
-      throw new RuntimeException(e);
-    }
+    return classloaders.get(context, k -> {
+      LOG.debug("Creating URLClassLoader for context, uris: {}", context);
+      return new URLClassLoader(Arrays.stream(context.split(",")).map(url -> {
+        try {
+          return new URL(url);
+        } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+        }
+      }).collect(Collectors.toList()).toArray(new URL[] {}), ClassLoader.getSystemClassLoader());
+    });
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -85,9 +85,9 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Preconditions;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Sets;
 
 public class BulkImport implements ImportDestinationArguments, ImportMappingOptions {
@@ -379,7 +379,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
     Map<String,Long> absFileLens = new HashMap<>();
     fileLens.forEach((k, v) -> absFileLens.put(pathToCacheId(new Path(dir, k)), v));
 
-    Cache<String,Long> fileLenCache = CacheBuilder.newBuilder().build();
+    Cache<String,Long> fileLenCache = Caffeine.newBuilder().build();
 
     fileLenCache.putAll(absFileLens);
 

--- a/core/src/main/java/org/apache/accumulo/core/data/InstanceId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/InstanceId.java
@@ -20,10 +20,9 @@ package org.apache.accumulo.core.data;
 
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * A strongly typed representation of an Accumulo instance ID. The constructor for this class will
@@ -36,7 +35,7 @@ public class InstanceId extends AbstractId<InstanceId> {
   // cache is for canonicalization/deduplication of created objects,
   // to limit the number of InstanceId objects in the JVM at any given moment
   // WeakReferences are used because we don't need them to stick around any longer than they need to
-  static final Cache<String,InstanceId> cache = CacheBuilder.newBuilder().weakValues().build();
+  static final Cache<String,InstanceId> cache = Caffeine.newBuilder().weakValues().build();
 
   private InstanceId(String canonical) {
     super(canonical);
@@ -49,12 +48,7 @@ public class InstanceId extends AbstractId<InstanceId> {
    * @return InstanceId object
    */
   public static InstanceId of(final String canonical) {
-    try {
-      return cache.get(canonical, () -> new InstanceId(canonical));
-    } catch (ExecutionException e) {
-      throw new AssertionError(
-          "This should never happen: ID constructor should never return null.");
-    }
+    return cache.get(canonical, k -> new InstanceId(canonical));
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/data/NamespaceId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/NamespaceId.java
@@ -18,10 +18,8 @@
  */
 package org.apache.accumulo.core.data;
 
-import java.util.concurrent.ExecutionException;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * A strongly typed representation of a namespace ID. This class cannot be used to get a namespace
@@ -35,7 +33,7 @@ public class NamespaceId extends AbstractId<NamespaceId> {
   // cache is for canonicalization/deduplication of created objects,
   // to limit the number of NamespaceId objects in the JVM at any given moment
   // WeakReferences are used because we don't need them to stick around any longer than they need to
-  static final Cache<String,NamespaceId> cache = CacheBuilder.newBuilder().weakValues().build();
+  static final Cache<String,NamespaceId> cache = Caffeine.newBuilder().weakValues().build();
 
   private NamespaceId(String canonical) {
     super(canonical);
@@ -48,11 +46,6 @@ public class NamespaceId extends AbstractId<NamespaceId> {
    * @return NamespaceId object
    */
   public static NamespaceId of(final String canonical) {
-    try {
-      return cache.get(canonical, () -> new NamespaceId(canonical));
-    } catch (ExecutionException e) {
-      throw new AssertionError(
-          "This should never happen: ID constructor should never return null.");
-    }
+    return cache.get(canonical, k -> new NamespaceId(canonical));
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/data/TableId.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/TableId.java
@@ -18,10 +18,8 @@
  */
 package org.apache.accumulo.core.data;
 
-import java.util.concurrent.ExecutionException;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * A strongly typed representation of a table ID. This class cannot be used to get a table ID from a
@@ -35,7 +33,7 @@ public class TableId extends AbstractId<TableId> {
   // cache is for canonicalization/deduplication of created objects,
   // to limit the number of TableId objects in the JVM at any given moment
   // WeakReferences are used because we don't need them to stick around any longer than they need to
-  static final Cache<String,TableId> cache = CacheBuilder.newBuilder().weakValues().build();
+  static final Cache<String,TableId> cache = Caffeine.newBuilder().weakValues().build();
 
   private TableId(final String canonical) {
     super(canonical);
@@ -48,11 +46,6 @@ public class TableId extends AbstractId<TableId> {
    * @return TableId object
    */
   public static TableId of(final String canonical) {
-    try {
-      return cache.get(canonical, () -> new TableId(canonical));
-    } catch (ExecutionException e) {
-      throw new AssertionError(
-          "This should never happen: ID constructor should never return null.");
-    }
+    return cache.get(canonical, k -> new TableId(canonical));
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.FileOutputCommitter;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 
 public abstract class FileOperations {
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -190,7 +190,7 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
 
   private void sawDelete() {
     if (isMajorCompaction && !reduceOnFullCompactionOnly) {
-      loggedMsgCache.get(this.getClass().getName(), k -> {
+      var ignored = loggedMsgCache.get(this.getClass().getName(), k -> {
         sawDeleteLog.error(
             "Combiner of type {} saw a delete during a"
                 + " partial compaction. This could cause undesired results. See"

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.IteratorSetting.Column;
@@ -43,10 +42,10 @@ import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 
 /**
@@ -187,23 +186,19 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
 
   @VisibleForTesting
   static final Cache<String,Boolean> loggedMsgCache =
-      CacheBuilder.newBuilder().expireAfterWrite(1, HOURS).maximumSize(10000).build();
+      Caffeine.newBuilder().expireAfterWrite(1, HOURS).maximumSize(10000).build();
 
   private void sawDelete() {
     if (isMajorCompaction && !reduceOnFullCompactionOnly) {
-      try {
-        loggedMsgCache.get(this.getClass().getName(), () -> {
-          sawDeleteLog.error(
-              "Combiner of type {} saw a delete during a"
-                  + " partial compaction. This could cause undesired results. See"
-                  + " ACCUMULO-2232. Will not log subsequent occurrences for at least 1 hour.",
-              Combiner.this.getClass().getSimpleName());
-          // the value is not used and does not matter
-          return Boolean.TRUE;
-        });
-      } catch (ExecutionException e) {
-        throw new RuntimeException(e);
-      }
+      loggedMsgCache.get(this.getClass().getName(), k -> {
+        sawDeleteLog.error(
+            "Combiner of type {} saw a delete during a"
+                + " partial compaction. This could cause undesired results. See"
+                + " ACCUMULO-2232. Will not log subsequent occurrences for at least 1 hour.",
+            Combiner.this.getClass().getSimpleName());
+        // the value is not used and does not matter
+        return Boolean.TRUE;
+      });
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooser.java
@@ -25,7 +25,6 @@ import java.security.SecureRandom;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -35,9 +34,8 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 /**
  * A {@link PreferredVolumeChooser} that takes remaining HDFS space into account when making a
@@ -68,11 +66,7 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
 
   @Override
   public String choose(VolumeChooserEnvironment env, Set<String> options) {
-    try {
-      return getCache(env).get(getPreferredVolumes(env, options)).next();
-    } catch (ExecutionException e) {
-      throw new IllegalStateException("Execution exception when attempting to cache choice", e);
-    }
+    return getCache(env).get(getPreferredVolumes(env, options)).next();
   }
 
   private synchronized LoadingCache<Set<String>,WeightedRandomCollection>
@@ -84,13 +78,8 @@ public class SpaceAwareVolumeChooser extends PreferredVolumeChooser {
       long computationCacheDuration = StringUtils.isNotBlank(propertyValue)
           ? Long.parseLong(propertyValue) : defaultComputationCacheDuration;
 
-      choiceCache = CacheBuilder.newBuilder()
-          .expireAfterWrite(computationCacheDuration, MILLISECONDS).build(new CacheLoader<>() {
-            @Override
-            public WeightedRandomCollection load(Set<String> key) {
-              return new WeightedRandomCollection(key, env);
-            }
-          });
+      choiceCache = Caffeine.newBuilder().expireAfterWrite(computationCacheDuration, MILLISECONDS)
+          .build(key -> new WeightedRandomCollection(key, env));
     }
 
     return choiceCache;

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -83,8 +83,8 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.base.Preconditions;
-import com.google.common.cache.Cache;
 import com.google.common.hash.Hashing;
 import com.google.common.net.HostAndPort;
 

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummaryReader.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.WritableUtils;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 
 public class SummaryReader {
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/CombinerTestUtil.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/CombinerTestUtil.java
@@ -24,6 +24,6 @@ public class CombinerTestUtil {
   }
 
   public static long cacheSize() {
-    return Combiner.loggedMsgCache.size();
+    return Combiner.loggedMsgCache.estimatedSize();
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/fs/SpaceAwareVolumeChooserTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.util.concurrent.UncheckedExecutionException;
-
 public class SpaceAwareVolumeChooserTest {
 
   VolumeChooserEnvironment chooserEnv = null;
@@ -124,7 +122,7 @@ public class SpaceAwareVolumeChooserTest {
   @Test
   public void testNoFreeSpace() {
     testSpecificSetup(0L, 0L, null, 1, false);
-    assertThrows(UncheckedExecutionException.class, this::makeChoices);
+    assertThrows(IllegalStateException.class, this::makeChoices);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -1129,6 +1129,10 @@
                   <property name="format" value="&amp;quot; [+] &amp;quot;" />
                   <property name="message" value="Unnecessary concatenation of string literals" />
                 </module>
+                <module name="RegexpSinglelineJava">
+                  <property name="format" value="com.google.common.cache[.]" />
+                  <property name="message" value="Please use Caffeine Cache, not Guava" />
+                </module>
                 <module name="OuterTypeFilename" />
                 <module name="AvoidStarImport" />
                 <module name="NoLineWrap" />

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -61,7 +61,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 
 public class FileManager {
 

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -32,6 +32,10 @@
   <description>The manager server for Apache Accumulo for load balancing and other system-wide operations.</description>
   <dependencies>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>

--- a/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/recovery/RecoveryManager.java
@@ -22,13 +22,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -52,8 +52,8 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 public class RecoveryManager {
 
@@ -70,7 +70,7 @@ public class RecoveryManager {
   public RecoveryManager(Manager manager, long timeToCacheExistsInMillis) {
     this.manager = manager;
     existenceCache =
-        CacheBuilder.newBuilder().expireAfterWrite(timeToCacheExistsInMillis, TimeUnit.MILLISECONDS)
+        Caffeine.newBuilder().expireAfterWrite(timeToCacheExistsInMillis, TimeUnit.MILLISECONDS)
             .maximumWeight(10_000_000).weigher((path, exist) -> path.toString().length()).build();
 
     executor = ThreadPools.getServerThreadPools().createScheduledExecutorService(4,
@@ -144,8 +144,14 @@ public class RecoveryManager {
 
   private boolean exists(final Path path) throws IOException {
     try {
-      return existenceCache.get(path, () -> manager.getVolumeManager().exists(path));
-    } catch (ExecutionException e) {
+      return existenceCache.get(path, k -> {
+        try {
+          return manager.getVolumeManager().exists(path);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+    } catch (Exception e) {
       throw new IOException(e);
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -133,7 +133,7 @@ import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -79,10 +79,10 @@ import org.apache.accumulo.tserver.tablet.Tablet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -365,7 +365,7 @@ public class TabletServerResourceManager {
     int maxOpenFiles = acuConf.getCount(Property.TSERV_SCAN_MAX_OPENFILES);
 
     fileLenCache =
-        CacheBuilder.newBuilder().maximumSize(Math.min(maxOpenFiles * 1000L, 100_000)).build();
+        Caffeine.newBuilder().maximumSize(Math.min(maxOpenFiles * 1000L, 100_000)).build();
 
     fileManager = new FileManager(context, maxOpenFiles, fileLenCache);
 


### PR DESCRIPTION
[Caffeine](https://github.com/ben-manes/caffeine) is the replacement for the Guava cache api and has several improvements including efficiency with its admission [policy](https://github.com/ben-manes/caffeine/wiki/Efficiency) and [performance](https://github.com/ben-manes/caffeine/wiki/Benchmarks). Currently the Accumulo code base has a mixture where some places use Guava and some places use Caffeine so it is not consistent. Switching to Caffeine is nearly a drop in replacement and this commit replaces all instances of Guava with Caffeine for consistency and also adds a checkstyle rule to prevent using Guava in the future.

From the Guava [docs](https://guava.dev/releases/31.1-jre/api/docs/com/google/common/cache/CacheBuilder.html) regarding Caffeine: 

> **Prefer [Caffeine](https://github.com/ben-manes/caffeine/wiki) over Guava's caching API**
**The successor to Guava's caching API is [Caffeine](https://github.com/ben-manes/caffeine/wiki). Its API is designed to make it a nearly drop-in replacement** -- though it requires Java 8 APIs, is not available for Android or GWT/j2cl, and may have [different (usually better) behavior](https://github.com/ben-manes/caffeine/wiki/Guava) when multiple threads attempt concurrent mutations. Its equivalent to CacheBuilder is its [Caffeine](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/Caffeine.html) class. **Caffeine offers better performance, more features (including asynchronous loading), and fewer [bugs](https://github.com/google/guava/issues?q=is%3Aopen+is%3Aissue+label%3Apackage%3Dcache+label%3Atype%3Ddefect).**