### PR TITLE
Update log4j and remove log4j-core dependency

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -299,11 +299,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jcl</artifactId>
       <optional>true</optional>
     </dependency>

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -299,6 +299,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jcl</artifactId>
       <optional>true</optional>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -160,12 +160,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/hadoop-mapreduce/pom.xml
+++ b/hadoop-mapreduce/pom.xml
@@ -72,12 +72,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/iterator-test-harness/pom.xml
+++ b/iterator-test-harness/pom.xml
@@ -60,12 +60,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -129,10 +129,6 @@
       <artifactId>log4j-1.2-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Even with the bug from https://issues.apache.org/jira/browse/LOG4J2-3601
-      log4j2-core is not needed to be listed because accumulo-monitor has a
-      transitive dependency already.
-    -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.19.0</version>
+        <version>2.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1014,8 +1014,6 @@
                 <unused>org.apache.logging.log4j:log4j-1.2-api:jar:*</unused>
                 <unused>org.apache.logging.log4j:log4j-slf4j2-impl:jar:*</unused>
                 <unused>org.apache.logging.log4j:log4j-web:jar:*</unused>
-                <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-                <unused>org.apache.logging.log4j:log4j-core:jar:*</unused>
                 <!-- This should be removed upon completion of migrating junit 4 to 5 -->
                 <unused>org.junit.vintage:junit-vintage-engine:jar:*</unused>
                 <unused>org.junit.jupiter:junit-jupiter-engine:jar:*</unused>

--- a/server/base/pom.xml
+++ b/server/base/pom.xml
@@ -118,12 +118,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/compaction-coordinator/pom.xml
+++ b/server/compaction-coordinator/pom.xml
@@ -77,12 +77,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/compactor/pom.xml
+++ b/server/compactor/pom.xml
@@ -80,12 +80,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/gc/pom.xml
+++ b/server/gc/pom.xml
@@ -90,12 +90,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/manager/pom.xml
+++ b/server/manager/pom.xml
@@ -110,12 +110,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/native/pom.xml
+++ b/server/native/pom.xml
@@ -41,12 +41,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/server/tserver/pom.xml
+++ b/server/tserver/pom.xml
@@ -119,12 +119,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -106,12 +106,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -70,12 +70,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- needed because https://issues.apache.org/jira/browse/LOG4J2-3601 -->
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -220,10 +220,6 @@
       <artifactId>accumulo-iterator-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Even with the bug from https://issues.apache.org/jira/browse/LOG4J2-3601
-      log4j2-core is not needed to be listed because accumulo-monitor has a
-      transitive dependency already.
-    -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>


### PR DESCRIPTION
Duplicate of the changes in #3204 targeting 2.1

Removes the log4j-core dependency which was previously needed due to https://issues.apache.org/jira/browse/LOG4J2-3601 which is fixed as of version 2.20