### PR TITLE
Use AtomicInteger for index pointers in SeekableByteArrayInputStream

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -43,13 +43,14 @@ public class SeekableByteArrayInputStream extends InputStream {
   @SuppressFBWarnings(value = "VO_VOLATILE_REFERENCE_TO_ARRAY",
       justification = "see explanation above")
   private volatile byte[] buffer;
-  private final AtomicInteger cur;
+  private final AtomicInteger cur = new AtomicInteger(0);
   private final int max;
 
   @Override
   public int read() {
-    if (cur.get() < max) {
-      return buffer[cur.getAndIncrement()] & 0xff;
+    int currentValue = cur.getAndAccumulate(1, (x, i) -> x < max ? x + i : x);
+    if (currentValue < max) {
+      return buffer[currentValue] & 0xff;
     } else {
       return -1;
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -48,7 +48,7 @@ public class SeekableByteArrayInputStream extends InputStream {
 
   @Override
   public int read() {
-    int currentValue = cur.getAndAccumulate(1, (x, i) -> x < max ? x + i : x);
+    final int currentValue = cur.getAndAccumulate(1, (x, i) -> x < max ? x + i : x);
     if (currentValue < max) {
       return buffer[currentValue] & 0xff;
     } else {
@@ -126,14 +126,12 @@ public class SeekableByteArrayInputStream extends InputStream {
   public SeekableByteArrayInputStream(byte[] buf) {
     requireNonNull(buf, "bug argument was null");
     this.buffer = buf;
-    this.cur = new AtomicInteger(0);
     this.max = buf.length;
   }
 
   public SeekableByteArrayInputStream(byte[] buf, int maxOffset) {
     requireNonNull(buf, "bug argument was null");
     this.buffer = buf;
-    this.cur = new AtomicInteger(0);
     this.max = maxOffset;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -42,7 +42,7 @@ public class SeekableByteArrayInputStream extends InputStream {
   // thread 2 sees all of thread 1 changes before setting the volatile.
   @SuppressFBWarnings(value = "VO_VOLATILE_REFERENCE_TO_ARRAY",
       justification = "see explanation above")
-  private volatile byte[] buffer;
+  private final byte[] buffer;
   private final AtomicInteger cur = new AtomicInteger(0);
   private final int max;
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -99,16 +99,21 @@ public class SeekableByteArrayInputStream extends InputStream {
 
   @Override
   public long skip(long requestedSkip) {
-    int actualSkip = available();
-    if (requestedSkip < actualSkip) {
-      if (requestedSkip < 0) {
-        actualSkip = 0;
-      } else {
-        actualSkip = (int) requestedSkip;
+    IntBinaryOperator add = (cur1, skip) -> {
+      int actual = max - cur1;
+      if (skip < actual) {
+        actual = Math.max(skip, 0);
       }
+      return cur1 + actual;
+    };
+
+    int currentValue = cur.getAndAccumulate((int) requestedSkip, add);
+
+    int actualSkip = max - currentValue;
+    if (requestedSkip < actualSkip) {
+      actualSkip = Math.max((int) requestedSkip, 0);
     }
 
-    cur.getAndAdd(actualSkip);
     return actualSkip;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -26,24 +26,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.IntBinaryOperator;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * This class is like byte array input stream with two differences. It supports seeking and avoids
  * synchronization.
  */
 public class SeekableByteArrayInputStream extends InputStream {
 
-  // making this volatile for the following case
-  // * thread 1 creates and initializes byte array
-  // * thread 2 reads from bye array
-  // spotbugs complains about this because thread2 may not see any changes to the byte array after
-  // thread 1 set the volatile,
-  // however the expectation is that the byte array is static. In the case of it being static,
-  // volatile ensures that
-  // thread 2 sees all of thread 1 changes before setting the volatile.
-  @SuppressFBWarnings(value = "VO_VOLATILE_REFERENCE_TO_ARRAY",
-      justification = "see explanation above")
   private final byte[] buffer;
   private final AtomicInteger cur = new AtomicInteger(0);
   private final int max;

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/impl/SeekableByteArrayInputStream.java
@@ -44,11 +44,11 @@ public class SeekableByteArrayInputStream extends InputStream {
       justification = "see explanation above")
   private volatile byte[] buffer;
   private final AtomicInteger cur;
-  private final AtomicInteger max;
+  private final int max;
 
   @Override
   public int read() {
-    if (cur.get() < max.get()) {
+    if (cur.get() < max) {
       return buffer[cur.getAndIncrement()] & 0xff;
     } else {
       return -1;
@@ -101,7 +101,7 @@ public class SeekableByteArrayInputStream extends InputStream {
 
   @Override
   public int available() {
-    return max.get() - cur.get();
+    return max - cur.get();
   }
 
   @Override
@@ -126,18 +126,18 @@ public class SeekableByteArrayInputStream extends InputStream {
     requireNonNull(buf, "bug argument was null");
     this.buffer = buf;
     this.cur = new AtomicInteger(0);
-    this.max = new AtomicInteger(buf.length);
+    this.max = buf.length;
   }
 
   public SeekableByteArrayInputStream(byte[] buf, int maxOffset) {
     requireNonNull(buf, "bug argument was null");
     this.buffer = buf;
     this.cur = new AtomicInteger(0);
-    this.max = new AtomicInteger(maxOffset);
+    this.max = maxOffset;
   }
 
   public void seek(int position) {
-    if (position < 0 || position >= max.get()) {
+    if (position < 0 || position >= max) {
       throw new IllegalArgumentException("position = " + position + " maxOffset = " + max);
     }
     this.cur.set(position);


### PR DESCRIPTION
Fixes #3218 

This PR converts `cur` and `max` to `AtomicInteger`. This should address the concerns in the ticket.

One thing I considered is converting `buffer` from a `volatile` variable to an `AtomicRefference` but I am not too familiar with the trade offs associated. If anyone has any insight into this that would be helpful.