### PR TITLE
Add ondemand table state

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1019,7 +1019,7 @@ public interface TableOperations {
    * @param tableName the table to take online
    * @throws AccumuloException when there is a general accumulo error
    * @throws AccumuloSecurityException when the user does not have the proper permissions
-   * @since 4.0.0
+   * @since 3.1.0
    */
   void onDemand(String tableName)
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException;
@@ -1031,7 +1031,7 @@ public interface TableOperations {
    * @param wait if true, then will not return until table is online
    * @throws AccumuloException when there is a general accumulo error
    * @throws AccumuloSecurityException when the user does not have the proper permissions
-   * @since 4.0.0
+   * @since 3.1.0
    */
   void onDemand(String tableName, boolean wait)
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException;
@@ -1045,7 +1045,7 @@ public interface TableOperations {
    * @param tableName the table to check if online
    * @throws AccumuloException when there is a general accumulo error
    * @return true if table's goal state is online
-   * @since 4.0.0
+   * @since 3.1.0
    */
   boolean isOnDemand(String tableName) throws AccumuloException, TableNotFoundException;
 

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/TableOperations.java
@@ -1013,4 +1013,40 @@ public interface TableOperations {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Initiates setting a table to ondemand state, but does not wait for action to complete
+   *
+   * @param tableName the table to take online
+   * @throws AccumuloException when there is a general accumulo error
+   * @throws AccumuloSecurityException when the user does not have the proper permissions
+   * @since 4.0.0
+   */
+  void onDemand(String tableName)
+      throws AccumuloSecurityException, AccumuloException, TableNotFoundException;
+
+  /**
+   * Initiates setting a table to ondemand state, optionally waits for action to complete
+   *
+   * @param tableName the table to take online
+   * @param wait if true, then will not return until table is online
+   * @throws AccumuloException when there is a general accumulo error
+   * @throws AccumuloSecurityException when the user does not have the proper permissions
+   * @since 4.0.0
+   */
+  void onDemand(String tableName, boolean wait)
+      throws AccumuloSecurityException, AccumuloException, TableNotFoundException;
+
+  /**
+   * Check if a table is ondemand through its current goal state only. Could run into issues if the
+   * current state of the table is in between states. If you require a specific state, call
+   * <code>ondemand(tableName, true)</code>, this will wait until the table reaches the desired
+   * state before proceeding.
+   *
+   * @param tableName the table to check if online
+   * @throws AccumuloException when there is a general accumulo error
+   * @return true if table's goal state is online
+   * @since 4.0.0
+   */
+  boolean isOnDemand(String tableName) throws AccumuloException, TableNotFoundException;
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1515,6 +1515,10 @@ public class TableOperationsImpl extends TableOperationsHelper {
   public boolean isOnDemand(String tableName) throws AccumuloException, TableNotFoundException {
     EXISTING_TABLE_NAME.validate(tableName);
 
+    if (tableName.equals(MetadataTable.NAME) || tableName.equals(RootTable.NAME)) {
+      return false;
+    }
+
     TableId tableId = context.getTableId(tableName);
     TableState expectedState = context.getTableState(tableId, true);
     return expectedState == TableState.ONDEMAND;
@@ -1529,6 +1533,10 @@ public class TableOperationsImpl extends TableOperationsHelper {
   @Override
   public void onDemand(String tableName, boolean wait)
       throws AccumuloSecurityException, AccumuloException, TableNotFoundException {
+
+    if (tableName.equals(MetadataTable.NAME) || tableName.equals(RootTable.NAME)) {
+      throw new AccumuloException("Cannot set table to onDemand state");
+    }
 
     EXISTING_TABLE_NAME.validate(tableName);
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1762,9 +1762,9 @@ public class TableOperationsImpl extends TableOperationsHelper {
     EXISTING_TABLE_NAME.validate(tableName);
     checkArgument(exportDir != null, "exportDir is null");
 
-    if (isOnline(tableName)) {
-      throw new IllegalStateException("The table " + tableName + " is online; exportTable requires"
-          + " a table to be offline before exporting.");
+    if (isOnline(tableName) || isOnDemand(tableName)) {
+      throw new IllegalStateException("The table " + tableName
+          + " is not offline; exportTable requires" + " a table to be offline before exporting.");
     }
 
     List<ByteBuffer> args = Arrays.asList(ByteBuffer.wrap(tableName.getBytes(UTF_8)),

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1764,7 +1764,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
 
     if (isOnline(tableName) || isOnDemand(tableName)) {
       throw new IllegalStateException("The table " + tableName
-          + " is not offline; exportTable requires" + " a table to be offline before exporting.");
+          + " is not offline; exportTable requires a table to be offline before exporting.");
     }
 
     List<ByteBuffer> args = Arrays.asList(ByteBuffer.wrap(tableName.getBytes(UTF_8)),

--- a/core/src/main/java/org/apache/accumulo/core/manager/state/tables/TableState.java
+++ b/core/src/main/java/org/apache/accumulo/core/manager/state/tables/TableState.java
@@ -25,6 +25,9 @@ public enum TableState {
   // ONLINE tablets will be assigned
   ONLINE,
 
+  // ONDEMAND tablets will be offline, unless brought online by request
+  ONDEMAND,
+
   // OFFLINE tablets will be taken offline
   OFFLINE,
 

--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -225,4 +225,15 @@ public class Validators {
     return Validator.OK;
   });
 
+  public static final Validator<TableId> NOT_METADATA_TABLE_ID = new Validator<>(id -> {
+    if (id == null) {
+      return Optional.of("Table id must not be null");
+    }
+    if (MetadataTable.ID.equals(id)) {
+      return Optional
+          .of("Table must not be the " + MetadataTable.NAME + "(Id: " + MetadataTable.ID + ") table");
+    }
+    return Validator.OK;
+  });
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/Validators.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Validators.java
@@ -230,8 +230,8 @@ public class Validators {
       return Optional.of("Table id must not be null");
     }
     if (MetadataTable.ID.equals(id)) {
-      return Optional
-          .of("Table must not be the " + MetadataTable.NAME + "(Id: " + MetadataTable.ID + ") table");
+      return Optional.of(
+          "Table must not be the " + MetadataTable.NAME + "(Id: " + MetadataTable.ID + ") table");
     }
     return Validator.OK;
   });

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TableOperation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TableOperation.java
@@ -42,7 +42,8 @@ public enum TableOperation implements org.apache.thrift.TEnum {
   COMPACT(13),
   IMPORT(14),
   EXPORT(15),
-  COMPACT_CANCEL(16);
+  COMPACT_CANCEL(16),
+  ONDEMAND(17);
 
   private final int value;
 
@@ -99,6 +100,8 @@ public enum TableOperation implements org.apache.thrift.TEnum {
         return EXPORT;
       case 16:
         return COMPACT_CANCEL;
+      case 17:
+        return ONDEMAND;
       default:
         return null;
     }

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateOperation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateOperation.java
@@ -42,7 +42,8 @@ public enum FateOperation implements org.apache.thrift.TEnum {
   NAMESPACE_CREATE(13),
   NAMESPACE_DELETE(14),
   NAMESPACE_RENAME(15),
-  TABLE_BULK_IMPORT2(16);
+  TABLE_BULK_IMPORT2(16),
+  TABLE_ONDEMAND(17);
 
   private final int value;
 
@@ -99,6 +100,8 @@ public enum FateOperation implements org.apache.thrift.TEnum {
         return NAMESPACE_RENAME;
       case 16:
         return TABLE_BULK_IMPORT2;
+      case 17:
+        return TABLE_ONDEMAND;
       default:
         return null;
     }

--- a/core/src/main/thrift/client.thrift
+++ b/core/src/main/thrift/client.thrift
@@ -39,6 +39,7 @@ enum TableOperation {
   IMPORT
   EXPORT
   COMPACT_CANCEL
+  ONDEMAND
 }
 
 enum TableOperationExceptionType {

--- a/core/src/main/thrift/manager.thrift
+++ b/core/src/main/thrift/manager.thrift
@@ -72,6 +72,7 @@ enum FateOperation {
   NAMESPACE_DELETE
   NAMESPACE_RENAME
   TABLE_BULK_IMPORT2
+  TABLE_ONDEMAND
 }
 
 enum ManagerState {

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TableOperationsHelperTest.java
@@ -192,9 +192,7 @@ public class TableOperationsHelperTest {
     public void importDirectory(String tableName, String dir, String failureDir, boolean setTime) {}
 
     @Override
-    public void offline(String tableName) {
-
-    }
+    public void offline(String tableName) {}
 
     @Override
     public boolean isOnline(String tableName) {
@@ -211,6 +209,17 @@ public class TableOperationsHelperTest {
 
     @Override
     public void online(String tableName, boolean wait) {}
+
+    @Override
+    public void onDemand(String tableName) {}
+
+    @Override
+    public void onDemand(String tableName, boolean wait) {}
+
+    @Override
+    public boolean isOnDemand(String tableName) {
+      return false;
+    }
 
     @Override
     public void clearLocatorCache(String tableName) {}

--- a/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
@@ -685,8 +685,8 @@ public class AuditedSecurityOperation extends SecurityOperation {
       "action: %s; targetTable: %s:%s";
 
   @Override
-  public boolean canOnlineOfflineOnDemandTable(TCredentials credentials, TableId tableId,
-      FateOperation op, NamespaceId namespaceId) throws ThriftSecurityException {
+  public boolean canChangeTableState(TCredentials credentials, TableId tableId, FateOperation op,
+      NamespaceId namespaceId) throws ThriftSecurityException {
     String tableName = getTableName(tableId);
     String operation = null;
     if (op == FateOperation.TABLE_ONLINE) {
@@ -699,7 +699,7 @@ public class AuditedSecurityOperation extends SecurityOperation {
       operation = "onDemandTable";
     }
     try {
-      boolean result = super.canOnlineOfflineOnDemandTable(credentials, tableId, op, namespaceId);
+      boolean result = super.canChangeTableState(credentials, tableId, op, namespaceId);
       audit(credentials, result, CAN_ONLINE_OFFLINE_TABLE_AUDIT_TEMPLATE, operation, tableName,
           tableId);
       return result;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
@@ -685,8 +685,8 @@ public class AuditedSecurityOperation extends SecurityOperation {
       "action: %s; targetTable: %s:%s";
 
   @Override
-  public boolean canOnlineOfflineOnDemandTable(TCredentials credentials, TableId tableId, FateOperation op,
-      NamespaceId namespaceId) throws ThriftSecurityException {
+  public boolean canOnlineOfflineOnDemandTable(TCredentials credentials, TableId tableId,
+      FateOperation op, NamespaceId namespaceId) throws ThriftSecurityException {
     String tableName = getTableName(tableId);
     String operation = null;
     if (op == FateOperation.TABLE_ONLINE) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/AuditedSecurityOperation.java
@@ -685,7 +685,7 @@ public class AuditedSecurityOperation extends SecurityOperation {
       "action: %s; targetTable: %s:%s";
 
   @Override
-  public boolean canOnlineOfflineTable(TCredentials credentials, TableId tableId, FateOperation op,
+  public boolean canOnlineOfflineOnDemandTable(TCredentials credentials, TableId tableId, FateOperation op,
       NamespaceId namespaceId) throws ThriftSecurityException {
     String tableName = getTableName(tableId);
     String operation = null;
@@ -695,8 +695,11 @@ public class AuditedSecurityOperation extends SecurityOperation {
     if (op == FateOperation.TABLE_OFFLINE) {
       operation = "offlineTable";
     }
+    if (op == FateOperation.TABLE_ONDEMAND) {
+      operation = "onDemandTable";
+    }
     try {
-      boolean result = super.canOnlineOfflineTable(credentials, tableId, op, namespaceId);
+      boolean result = super.canOnlineOfflineOnDemandTable(credentials, tableId, op, namespaceId);
       audit(credentials, result, CAN_ONLINE_OFFLINE_TABLE_AUDIT_TEMPLATE, operation, tableName,
           tableId);
       return result;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -525,7 +525,7 @@ public class SecurityOperation {
         || hasTablePermission(c, tableId, namespaceId, TablePermission.DROP_TABLE, false);
   }
 
-  public boolean canOnlineOfflineOnDemandTable(TCredentials c, TableId tableId, FateOperation op,
+  public boolean canChangeTableState(TCredentials c, TableId tableId, FateOperation op,
       NamespaceId namespaceId) throws ThriftSecurityException {
     authenticate(c);
     return hasSystemPermissionWithNamespaceId(c, SystemPermission.SYSTEM, namespaceId, false)

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -525,7 +525,7 @@ public class SecurityOperation {
         || hasTablePermission(c, tableId, namespaceId, TablePermission.DROP_TABLE, false);
   }
 
-  public boolean canOnlineOfflineTable(TCredentials c, TableId tableId, FateOperation op,
+  public boolean canOnlineOfflineOnDemandTable(TCredentials c, TableId tableId, FateOperation op,
       NamespaceId namespaceId) throws ThriftSecurityException {
     authenticate(c);
     return hasSystemPermissionWithNamespaceId(c, SystemPermission.SYSTEM, namespaceId, false)

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -153,13 +153,15 @@ public class TableManager {
         boolean transition = true;
         // +--------+
         // v |
-        // NEW -> (ONLINE|OFFLINE)+--- DELETING
+        // NEW -> (ONLINE|OFFLINE|ONDEMAND)+--- DELETING
         switch (oldState) {
           case NEW:
-            transition = (newState == TableState.OFFLINE || newState == TableState.ONLINE);
+            transition = (newState == TableState.OFFLINE || newState == TableState.ONLINE
+                || newState == TableState.ONDEMAND);
             break;
           case ONLINE: // fall-through intended
           case UNKNOWN:// fall through intended
+          case ONDEMAND:// fall through intended
           case OFFLINE:
             transition = (newState != TableState.NEW);
             break;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -496,7 +496,7 @@ public class GCRun implements GarbageCollectionEnvironment {
     } else if (level == DataLevel.USER) {
       Set<TableId> tableIds = new HashSet<>();
       getTableIDs().forEach((k, v) -> {
-        if (v == TableState.ONLINE || v == TableState.OFFLINE) {
+        if (v == TableState.ONLINE || v == TableState.OFFLINE || v == TableState.ONDEMAND) {
           // Don't return tables that are NEW, DELETING, or in an
           // UNKNOWN state.
           tableIds.add(k);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -396,7 +396,8 @@ class FateServiceHandler implements FateService.Iface {
       case TABLE_OFFLINE: {
         TableOperation tableOp = TableOperation.OFFLINE;
         validateArgumentCount(arguments, tableOp, 1);
-        final var tableId = validateTableIdArgument(arguments.get(0), tableOp, NOT_ROOT_TABLE_ID);
+        final var tableId = validateTableIdArgument(arguments.get(0), tableOp,
+            NOT_ROOT_TABLE_ID.and(NOT_METADATA_TABLE_ID));
         NamespaceId namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
 
         final boolean canOnlineOfflineTable;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -377,8 +377,7 @@ class FateServiceHandler implements FateService.Iface {
 
         final boolean canOnlineOfflineTable;
         try {
-          canOnlineOfflineTable =
-              manager.security.canOnlineOfflineOnDemandTable(c, tableId, op, namespaceId);
+          canOnlineOfflineTable = manager.security.canChangeTableState(c, tableId, op, namespaceId);
         } catch (ThriftSecurityException e) {
           throwIfTableMissingSecurityException(e, tableId, null, TableOperation.ONLINE);
           throw e;
@@ -402,8 +401,7 @@ class FateServiceHandler implements FateService.Iface {
 
         final boolean canOnlineOfflineTable;
         try {
-          canOnlineOfflineTable =
-              manager.security.canOnlineOfflineOnDemandTable(c, tableId, op, namespaceId);
+          canOnlineOfflineTable = manager.security.canChangeTableState(c, tableId, op, namespaceId);
         } catch (ThriftSecurityException e) {
           throwIfTableMissingSecurityException(e, tableId, null, TableOperation.OFFLINE);
           throw e;
@@ -428,8 +426,7 @@ class FateServiceHandler implements FateService.Iface {
 
         final boolean canOnDemandTable;
         try {
-          canOnDemandTable =
-              manager.security.canOnlineOfflineOnDemandTable(c, tableId, op, namespaceId);
+          canOnDemandTable = manager.security.canChangeTableState(c, tableId, op, namespaceId);
         } catch (ThriftSecurityException e) {
           throwIfTableMissingSecurityException(e, tableId, null, TableOperation.ONDEMAND);
           throw e;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -28,6 +28,7 @@ import static org.apache.accumulo.core.util.Validators.NOT_BUILTIN_NAMESPACE;
 import static org.apache.accumulo.core.util.Validators.NOT_BUILTIN_TABLE;
 import static org.apache.accumulo.core.util.Validators.NOT_METADATA_TABLE;
 import static org.apache.accumulo.core.util.Validators.NOT_ROOT_TABLE_ID;
+import static org.apache.accumulo.core.util.Validators.NOT_METADATA_TABLE_ID;
 import static org.apache.accumulo.core.util.Validators.VALID_TABLE_ID;
 import static org.apache.accumulo.core.util.Validators.sameNamespaceAs;
 
@@ -377,7 +378,7 @@ class FateServiceHandler implements FateService.Iface {
         final boolean canOnlineOfflineTable;
         try {
           canOnlineOfflineTable =
-              manager.security.canOnlineOfflineTable(c, tableId, op, namespaceId);
+              manager.security.canOnlineOfflineOnDemandTable(c, tableId, op, namespaceId);
         } catch (ThriftSecurityException e) {
           throwIfTableMissingSecurityException(e, tableId, null, TableOperation.ONLINE);
           throw e;
@@ -402,7 +403,7 @@ class FateServiceHandler implements FateService.Iface {
         final boolean canOnlineOfflineTable;
         try {
           canOnlineOfflineTable =
-              manager.security.canOnlineOfflineTable(c, tableId, op, namespaceId);
+              manager.security.canOnlineOfflineOnDemandTable(c, tableId, op, namespaceId);
         } catch (ThriftSecurityException e) {
           throwIfTableMissingSecurityException(e, tableId, null, TableOperation.OFFLINE);
           throw e;
@@ -417,6 +418,32 @@ class FateServiceHandler implements FateService.Iface {
             new TraceRepo<>(new ChangeTableState(namespaceId, tableId, tableOp)), autoCleanup,
             goalMessage);
         break;
+      }
+      case TABLE_ONDEMAND: {
+        TableOperation tableOp = TableOperation.ONDEMAND;
+        validateArgumentCount(arguments, tableOp, 1);
+        final var tableId = validateTableIdArgument(arguments.get(0), tableOp, NOT_ROOT_TABLE_ID.and(NOT_METADATA_TABLE_ID));
+        NamespaceId namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
+        
+        final boolean canOnDemandTable;
+        try {
+          canOnDemandTable =
+              manager.security.canOnlineOfflineOnDemandTable(c, tableId, op, namespaceId);
+        } catch (ThriftSecurityException e) {
+          throwIfTableMissingSecurityException(e, tableId, null, TableOperation.ONDEMAND);
+          throw e;
+        }
+
+        if (!canOnDemandTable) {
+          throw new ThriftSecurityException(c.getPrincipal(), SecurityErrorCode.PERMISSION_DENIED);
+        }
+
+        goalMessage += "Ondemand table " + tableId;
+        manager.fate().seedTransaction(op.toString(), opid,
+            new TraceRepo<>(new ChangeTableState(namespaceId, tableId, tableOp)), autoCleanup,
+            goalMessage);
+        break;
+        
       }
       case TABLE_MERGE: {
         TableOperation tableOp = TableOperation.MERGE;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/FateServiceHandler.java
@@ -27,8 +27,8 @@ import static org.apache.accumulo.core.util.Validators.NEW_TABLE_NAME;
 import static org.apache.accumulo.core.util.Validators.NOT_BUILTIN_NAMESPACE;
 import static org.apache.accumulo.core.util.Validators.NOT_BUILTIN_TABLE;
 import static org.apache.accumulo.core.util.Validators.NOT_METADATA_TABLE;
-import static org.apache.accumulo.core.util.Validators.NOT_ROOT_TABLE_ID;
 import static org.apache.accumulo.core.util.Validators.NOT_METADATA_TABLE_ID;
+import static org.apache.accumulo.core.util.Validators.NOT_ROOT_TABLE_ID;
 import static org.apache.accumulo.core.util.Validators.VALID_TABLE_ID;
 import static org.apache.accumulo.core.util.Validators.sameNamespaceAs;
 
@@ -422,9 +422,10 @@ class FateServiceHandler implements FateService.Iface {
       case TABLE_ONDEMAND: {
         TableOperation tableOp = TableOperation.ONDEMAND;
         validateArgumentCount(arguments, tableOp, 1);
-        final var tableId = validateTableIdArgument(arguments.get(0), tableOp, NOT_ROOT_TABLE_ID.and(NOT_METADATA_TABLE_ID));
+        final var tableId = validateTableIdArgument(arguments.get(0), tableOp,
+            NOT_ROOT_TABLE_ID.and(NOT_METADATA_TABLE_ID));
         NamespaceId namespaceId = getNamespaceIdFromTableId(tableOp, tableId);
-        
+
         final boolean canOnDemandTable;
         try {
           canOnDemandTable =
@@ -443,7 +444,7 @@ class FateServiceHandler implements FateService.Iface {
             new TraceRepo<>(new ChangeTableState(namespaceId, tableId, tableOp)), autoCleanup,
             goalMessage);
         break;
-        
+
       }
       case TABLE_MERGE: {
         TableOperation tableOp = TableOperation.MERGE;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -614,6 +614,7 @@ public class Manager extends AbstractServer
       case DELETING:
         return TabletGoalState.DELETED;
       case OFFLINE:
+      case ONDEMAND:
       case NEW:
         return TabletGoalState.UNASSIGNED;
       default:
@@ -1570,7 +1571,7 @@ public class Manager extends AbstractServer
   @Override
   public void stateChanged(TableId tableId, TableState state) {
     nextEvent.event("Table state in zookeeper changed for %s to %s", tableId, state);
-    if (state == TableState.OFFLINE) {
+    if (state == TableState.OFFLINE || state == TableState.ONDEMAND) {
       clearMigrations(tableId);
     }
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/ChangeTableState.java
@@ -38,7 +38,8 @@ public class ChangeTableState extends ManagerRepo {
     this.namespaceId = namespaceId;
     this.top = top;
 
-    if (top != TableOperation.ONLINE && top != TableOperation.OFFLINE) {
+    if (top != TableOperation.ONLINE && top != TableOperation.OFFLINE
+        && top != TableOperation.ONDEMAND) {
       throw new IllegalArgumentException(top.toString());
     }
   }
@@ -56,6 +57,8 @@ public class ChangeTableState extends ManagerRepo {
     TableState ts = TableState.ONLINE;
     if (top == TableOperation.OFFLINE) {
       ts = TableState.OFFLINE;
+    } else if (top == TableOperation.ONDEMAND) {
+      ts = TableState.ONDEMAND;
     }
 
     env.getTableManager().transitionTableState(tableId, ts);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -107,6 +107,7 @@ class LoadFiles extends ManagerRepo {
 
   @Override
   public Repo<Manager> call(final long tid, final Manager manager) {
+    // TODO: How are we treating ONDEMAND tables for BulkImport?
     if (bulkInfo.tableState == TableState.ONLINE) {
       return new CompleteBulkImport(bulkInfo);
     } else {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/clone/FinishCloneTable.java
@@ -50,7 +50,9 @@ class FinishCloneTable extends ManagerRepo {
     if (cloneInfo.keepOffline) {
       environment.getTableManager().transitionTableState(cloneInfo.tableId, TableState.OFFLINE);
     } else {
-      environment.getTableManager().transitionTableState(cloneInfo.tableId, TableState.ONLINE);
+      // transition clone table state to state of original table
+      TableState ts = environment.getTableManager().getTableState(cloneInfo.srcTableId);
+      environment.getTableManager().transitionTableState(cloneInfo.tableId, ts);
     }
 
     Utils.unreserveNamespace(environment, cloneInfo.srcNamespaceId, tid, false);

--- a/shell/src/main/java/org/apache/accumulo/shell/Shell.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/Shell.java
@@ -132,6 +132,7 @@ import org.apache.accumulo.shell.commands.NamespacePermissionsCommand;
 import org.apache.accumulo.shell.commands.NamespacesCommand;
 import org.apache.accumulo.shell.commands.NoTableCommand;
 import org.apache.accumulo.shell.commands.OfflineCommand;
+import org.apache.accumulo.shell.commands.OndemandCommand;
 import org.apache.accumulo.shell.commands.OnlineCommand;
 import org.apache.accumulo.shell.commands.OptUtil;
 import org.apache.accumulo.shell.commands.PasswdCommand;
@@ -400,9 +401,9 @@ public class Shell extends ShellOptions implements KeywordExecutable {
     Command[] tableCommands = {new CloneTableCommand(), new ConfigCommand(),
         new CreateTableCommand(), new DeleteTableCommand(), new DropTableCommand(), new DUCommand(),
         new ExportTableCommand(), new ImportTableCommand(), new OfflineCommand(),
-        new OnlineCommand(), new RenameTableCommand(), new TablesCommand(), new NamespacesCommand(),
-        new CreateNamespaceCommand(), new DeleteNamespaceCommand(), new RenameNamespaceCommand(),
-        new SummariesCommand()};
+        new OndemandCommand(), new OnlineCommand(), new RenameTableCommand(), new TablesCommand(),
+        new NamespacesCommand(), new CreateNamespaceCommand(), new DeleteNamespaceCommand(),
+        new RenameNamespaceCommand(), new SummariesCommand()};
     Command[] tableControlCommands = {new AddSplitsCommand(), new CompactCommand(),
         new ConstraintCommand(), new FlushCommand(), new GetGroupsCommand(), new GetSplitsCommand(),
         new MergeCommand(), new SetGroupsCommand()};

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OndemandCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OndemandCommand.java
@@ -21,7 +21,6 @@ package org.apache.accumulo.shell.commands;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -40,12 +39,8 @@ public class OndemandCommand extends TableOperation {
   @Override
   protected void doTableOp(final Shell shellState, final String tableName)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-    if (tableName.equals(MetadataTable.NAME)) {
-      Shell.log.info("  You cannot make the {} ondemand.", MetadataTable.NAME);
-    } else {
-      shellState.getAccumuloClient().tableOperations().onDemand(tableName, wait);
-      Shell.log.info("Ondemand of table {} {}", tableName, wait ? " completed." : " initiated...");
-    }
+    shellState.getAccumuloClient().tableOperations().onDemand(tableName, wait);
+    Shell.log.info("Ondemand of table {} {}", tableName, wait ? " completed." : " initiated...");
   }
 
   @Override

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/OndemandCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/OndemandCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.shell.commands;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.shell.Shell;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+public class OndemandCommand extends TableOperation {
+
+  private boolean wait;
+  private Option waitOpt;
+
+  @Override
+  public String description() {
+    return "starts the process of converting the table to ondemand";
+  }
+
+  @Override
+  protected void doTableOp(final Shell shellState, final String tableName)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+    if (tableName.equals(MetadataTable.NAME)) {
+      Shell.log.info("  You cannot make the {} ondemand.", MetadataTable.NAME);
+    } else {
+      shellState.getAccumuloClient().tableOperations().onDemand(tableName, wait);
+      Shell.log.info("Ondemand of table {} {}", tableName, wait ? " completed." : " initiated...");
+    }
+  }
+
+  @Override
+  public int execute(final String fullCommand, final CommandLine cl, final Shell shellState)
+      throws Exception {
+    wait = cl.hasOption(waitOpt.getLongOpt());
+    return super.execute(fullCommand, cl, shellState);
+  }
+
+  @Override
+  public Options getOptions() {
+    final Options opts = super.getOptions();
+    waitOpt = new Option("w", "wait", false, "wait for ondemand to finish");
+    opts.addOption(waitOpt);
+    return opts;
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/AuditMessageIT.java
@@ -203,7 +203,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
 
   @Test
   public void testTableOperationsAudits() throws AccumuloException, AccumuloSecurityException,
-      TableExistsException, TableNotFoundException, IOException {
+      TableExistsException, TableNotFoundException, InterruptedException, IOException {
 
     client.securityOperations().createLocalUser(AUDIT_USER_1, new PasswordToken(PASSWORD));
     client.securityOperations().grantSystemPermission(AUDIT_USER_1, SystemPermission.SYSTEM);
@@ -221,6 +221,7 @@ public class AuditMessageIT extends ConfigurableMacBase {
         emptyMap, emptySet);
     auditAccumuloClient.tableOperations().delete(OLD_TEST_TABLE_NAME);
     auditAccumuloClient.tableOperations().offline(NEW_TEST_TABLE_NAME);
+    auditAccumuloClient.tableOperations().onDemand(NEW_TEST_TABLE_NAME);
     auditAccumuloClient.tableOperations().delete(NEW_TEST_TABLE_NAME);
     // Testing activity ends here
 
@@ -234,6 +235,8 @@ public class AuditMessageIT extends ConfigurableMacBase {
         findAuditMessage(auditMessages, "action: cloneTable; targetTable: " + NEW_TEST_TABLE_NAME));
     assertEquals(1, findAuditMessage(auditMessages,
         "action: deleteTable; targetTable: " + OLD_TEST_TABLE_NAME));
+    assertEquals(1, findAuditMessage(auditMessages,
+        "action: onDemandTable; targetTable: " + NEW_TEST_TABLE_NAME));
     assertEquals(1, findAuditMessage(auditMessages,
         "action: offlineTable; targetTable: " + NEW_TEST_TABLE_NAME));
     assertEquals(1, findAuditMessage(auditMessages,

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -88,6 +88,28 @@ public class ManagerAssignmentIT extends AccumuloClusterHarness {
       assertNull(online.future);
       assertNotNull(online.current);
       assertEquals(online.current, online.last);
+
+      // set the table to ondemand
+      c.tableOperations().onDemand(tableName, true);
+      TabletLocationState ondemand = getTabletLocationState(c, tableId);
+      assertNull(ondemand.future);
+      assertNull(ondemand.current);
+      assertEquals(flushed.current, ondemand.last);
+
+      // put it back online
+      c.tableOperations().online(tableName, true);
+      online = getTabletLocationState(c, tableId);
+      assertNull(online.future);
+      assertNotNull(online.current);
+      assertEquals(online.current, online.last);
+
+      // set the table to ondemand
+      c.tableOperations().onDemand(tableName, true);
+      ondemand = getTabletLocationState(c, tableId);
+      assertNull(ondemand.future);
+      assertNull(ondemand.current);
+      assertEquals(flushed.current, ondemand.last);
+
     }
   }
 


### PR DESCRIPTION
This commit adds a new table state called ondemand, which is currently treated like offline. Follow-on commits will need to request that ondemand tablets be hosted for live ingest / immediate scans, modify the tablet servers to unhost ondemand tablets, implement bulk-import into ondemand tables, and more.


Closes #3210 