### PR TITLE
Update Maven plugins to support Maven 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -728,7 +728,7 @@
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>2.4.0</version>
+          <version>2.5.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
@@ -954,7 +954,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.7.0</version>
+          <version>1.8.0</version>
           <configuration>
             <removeUnused>true</removeUnused>
             <groups>java.,javax.,jakarta.,org.,com.</groups>


### PR DESCRIPTION
Jenkins build is failing after switch to Maven 3.9.0 due to plugin issues. This updates the plugins to fix it.

- modernizer-maven-plugin: 2.5.0
- impsort-maven-plugin: 1.8.0

Example in 2.1 failure: https://github.com/apache/accumulo/actions/runs/4323146250/jobs/7546578107