### PR TITLE
replace sleepUninterruptibly() with Thread.sleep() in tests

### DIFF
--- a/core/src/test/java/org/apache/accumulo/core/client/TestThrift1474.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/TestThrift1474.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.client;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,7 +73,7 @@ public class TestThrift1474 {
     Thread thread = new Thread(server::serve);
     thread.start();
     while (!server.isServing()) {
-      sleepUninterruptibly(10, MILLISECONDS);
+      Thread.sleep(10);
     }
 
     TTransport transport = new TSocket("localhost", port);

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.clientImpl.bulk;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,8 +34,6 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 public class ConcurrentKeyExtentCacheTest {
 
@@ -83,8 +80,12 @@ public class ConcurrentKeyExtentCacheTest {
         }
       }
 
-      Uninterruptibles.sleepUninterruptibly(3, MILLISECONDS);
-
+      try {
+        Thread.sleep(3);
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted during sleep", ex);
+      }
       return extents.subList(index, extents.size()).stream().limit(73);
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/bulk/ConcurrentKeyExtentCacheTest.java
@@ -83,8 +83,7 @@ public class ConcurrentKeyExtentCacheTest {
       try {
         Thread.sleep(3);
       } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-        throw new IllegalStateException("interrupted during sleep", ex);
+        // ignore exception
       }
       return extents.subList(index, extents.size()).stream().limit(73);
     }

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloInputFormatIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.hadoop.its.mapreduce;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.lang.System.currentTimeMillis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,7 +32,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -125,7 +123,7 @@ public class AccumuloInputFormatIT extends AccumuloClusterHarness {
       splitsToAdd.add(new Text(String.format("%09d", i)));
     }
     client.tableOperations().addSplits(table, splitsToAdd);
-    sleepUninterruptibly(500, TimeUnit.MILLISECONDS); // wait for splits to be propagated
+    Thread.sleep(500); // wait for splits to be propagated
 
     // get splits without setting any range
     // No ranges set on the job so it'll start with -inf

--- a/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/BadDeleteMarkersCreatedIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -29,7 +29,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
@@ -173,7 +172,7 @@ public class BadDeleteMarkersCreatedIT extends AccumuloClusterHarness {
       c.tableOperations().delete(tableName);
       log.info("Sleeping to let garbage collector run");
       // let gc run
-      sleepUninterruptibly(timeoutFactor * 15, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(timeoutFactor * 15L));
       log.info("Verifying that delete markers were deleted");
       // look for delete markers
       try (Scanner scanner = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {

--- a/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CleanWalIT.java
@@ -18,12 +18,11 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -105,7 +104,7 @@ public class CleanWalIT extends AccumuloClusterHarness {
       client.tableOperations().flush(RootTable.NAME, null, null, true);
       try {
         getCluster().getClusterControl().stopAllServers(ServerType.TABLET_SERVER);
-        sleepUninterruptibly(3, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(3));
       } finally {
         getCluster().getClusterControl().startAllServers(ServerType.TABLET_SERVER);
       }

--- a/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ConditionalWriterIT.java
@@ -18,8 +18,9 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -43,7 +44,6 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -882,7 +882,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
       NewTableConfiguration ntc = new NewTableConfiguration().withSplits(nss("2", "4", "6"));
       client.tableOperations().create(tableName, ntc);
 
-      sleepUninterruptibly(2, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(2));
 
       int num = 100;
 
@@ -1289,7 +1289,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
         tp.shutdown();
 
         while (!tp.isTerminated()) {
-          tp.awaitTermination(1, TimeUnit.MINUTES);
+          tp.awaitTermination(1, MINUTES);
         }
 
         assertFalse(failed.get(), "A MutatorTask failed with an exception");
@@ -1385,7 +1385,7 @@ public class ConditionalWriterIT extends SharedMiniClusterBase {
 
       try (
           ConditionalWriter cw = client.createConditionalWriter(table,
-              new ConditionalWriterConfig().setTimeout(3, TimeUnit.SECONDS));
+              new ConditionalWriterConfig().setTimeout(3, SECONDS));
           Scanner scanner = client.createScanner(table, Authorizations.EMPTY)) {
 
         ConditionalMutation cm1 = new ConditionalMutation("r1", new Condition("tx", "seq"));

--- a/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
@@ -18,7 +18,8 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URL;
@@ -31,7 +32,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -162,10 +162,10 @@ public class CountNameNodeOpsBulkIT extends ConfigurableMacBase {
         err.get();
       }
       es.shutdown();
-      es.awaitTermination(2, TimeUnit.MINUTES);
+      es.awaitTermination(2, MINUTES);
       log.info(
           String.format("Completed in %.2f seconds", (System.currentTimeMillis() - now) / 1000.));
-      sleepUninterruptibly(30, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(30));
       Map<?,?> map = getStats();
       map.forEach((k, v) -> {
         try {

--- a/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MetaGetsReadersIT.java
@@ -18,14 +18,12 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -99,7 +97,7 @@ public class MetaGetsReadersIT extends ConfigurableMacBase {
       t1.start();
       Thread t2 = slowScan(c, tableName, stop);
       t2.start();
-      sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+      Thread.sleep(500);
       long now = System.currentTimeMillis();
 
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {

--- a/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/MultiTableRecoveryIT.java
@@ -18,14 +18,13 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -125,7 +124,7 @@ public class MultiTableRecoveryIT extends ConfigurableMacBase {
       try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
         int i = 0;
         while (!stop.get()) {
-          sleepUninterruptibly(10, TimeUnit.SECONDS);
+          Thread.sleep(SECONDS.toMillis(10));
           System.out.println("Restarting");
           getCluster().getClusterControl().stop(ServerType.TABLET_SERVER);
           getCluster().start();

--- a/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/NamespacesIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,7 +39,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.cluster.ClusterUser;
 import org.apache.accumulo.core.client.Accumulo;
@@ -403,7 +402,7 @@ public class NamespacesIT extends SharedMiniClusterBase {
       c.namespaceOperations().checkIteratorConflicts(namespace, setting,
           EnumSet.allOf(IteratorScope.class));
       c.namespaceOperations().attachIterator(namespace, setting);
-      sleepUninterruptibly(2, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(2));
       var e = assertThrows(AccumuloException.class, () -> c.namespaceOperations()
           .checkIteratorConflicts(namespace, setting, EnumSet.allOf(IteratorScope.class)));
       assertEquals(IllegalArgumentException.class, e.getCause().getClass());
@@ -420,7 +419,7 @@ public class NamespacesIT extends SharedMiniClusterBase {
       // verify can see inserted entry again
       c.namespaceOperations().removeIterator(namespace, setting.getName(),
           EnumSet.allOf(IteratorScope.class));
-      sleepUninterruptibly(2, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(2));
       assertFalse(c.namespaceOperations().listIterators(namespace).containsKey(iterName));
       assertFalse(c.tableOperations().listIterators(t1).containsKey(iterName));
     }
@@ -908,7 +907,7 @@ public class NamespacesIT extends SharedMiniClusterBase {
     // set the filter, verify that accumulo namespace is the only one unaffected
     c.instanceOperations().setProperty(k, v);
     // doesn't take effect immediately, needs time to propagate to tserver's ZooKeeper cache
-    sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+    Thread.sleep(250);
     assertTrue(c.instanceOperations().getSystemConfiguration().containsValue(v));
     assertEquals(systemNamespaceShouldInherit,
         checkNamespaceHasProp(Namespace.ACCUMULO.name(), k, v));
@@ -922,7 +921,7 @@ public class NamespacesIT extends SharedMiniClusterBase {
     // verify it is no longer inherited
     c.instanceOperations().removeProperty(k);
     // doesn't take effect immediately, needs time to propagate to tserver's ZooKeeper cache
-    sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+    Thread.sleep(250);
     assertFalse(c.instanceOperations().getSystemConfiguration().containsValue(v));
     assertFalse(checkNamespaceHasProp(Namespace.ACCUMULO.name(), k, v));
     assertFalse(checkTableHasProp(RootTable.NAME, k, v));

--- a/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/SplitRecoveryIT.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
@@ -86,7 +84,7 @@ public class SplitRecoveryIT extends AccumuloClusterHarness {
         // take the table offline
         client.tableOperations().offline(tableName);
         while (!isOffline(tableName, client)) {
-          sleepUninterruptibly(200, MILLISECONDS);
+          Thread.sleep(200);
         }
 
         // poke a partial split into the metadata table

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -296,7 +295,12 @@ public class TableOperationsIT extends AccumuloClusterHarness {
     list.add(new IteratorSetting(15, BadIterator.class));
     accumuloClient.tableOperations().compact(tableName, null, null, list, true, false); // don't
                                                                                         // block
-    sleepUninterruptibly(2, TimeUnit.SECONDS); // start compaction
+    try {
+      Thread.sleep(SECONDS.toMillis(2)); // start compaction
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new AccumuloException("interrupted during sleep", ex);
+    }
     accumuloClient.tableOperations().cancelCompaction(tableName);
 
     try (Scanner scanner = accumuloClient.createScanner(tableName, Authorizations.EMPTY)) {

--- a/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TableOperationsIT.java
@@ -287,20 +287,17 @@ public class TableOperationsIT extends AccumuloClusterHarness {
   /** Test recovery from bad majc iterator via compaction cancel. */
   @Test
   public void testCompactEmptyTablesWithBadIterator_FailsAndCancel() throws TableExistsException,
-      AccumuloException, AccumuloSecurityException, TableNotFoundException {
+      AccumuloException, AccumuloSecurityException, TableNotFoundException, InterruptedException {
     String tableName = getUniqueNames(1)[0];
     accumuloClient.tableOperations().create(tableName);
 
     List<IteratorSetting> list = new ArrayList<>();
     list.add(new IteratorSetting(15, BadIterator.class));
-    accumuloClient.tableOperations().compact(tableName, null, null, list, true, false); // don't
-                                                                                        // block
-    try {
-      Thread.sleep(SECONDS.toMillis(2)); // start compaction
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      throw new AccumuloException("interrupted during sleep", ex);
-    }
+    // don't block
+    accumuloClient.tableOperations().compact(tableName, null, null, list, true, false);
+
+    Thread.sleep(SECONDS.toMillis(2)); // start compaction
+
     accumuloClient.tableOperations().cancelCompaction(tableName);
 
     try (Scanner scanner = accumuloClient.createScanner(tableName, Authorizations.EMPTY)) {

--- a/test/src/main/java/org/apache/accumulo/test/TabletServerGivesUpIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TabletServerGivesUpIT.java
@@ -18,11 +18,10 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Duration;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -77,7 +76,7 @@ public class TabletServerGivesUpIT extends ConfigurableMacBase {
       splitter.start();
       // wait for the tserver to give up on writing to the WAL
       while (client.instanceOperations().getTabletServers().size() == 1) {
-        sleepUninterruptibly(1, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(1));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/TotalQueuedIT.java
@@ -18,11 +18,10 @@
  */
 package org.apache.accumulo.test;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -68,12 +67,12 @@ public class TotalQueuedIT extends ConfigurableMacBase {
       c.tableOperations().create(tableName);
       c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "9999");
       c.tableOperations().setProperty(tableName, Property.TABLE_FILE_MAX.getKey(), "999");
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
       // get an idea of how fast the syncs occur
       byte[] row = new byte[250];
       BatchWriterConfig cfg = new BatchWriterConfig();
       cfg.setMaxWriteThreads(10);
-      cfg.setMaxLatency(1, TimeUnit.SECONDS);
+      cfg.setMaxLatency(1, SECONDS);
       cfg.setMaxMemory(1024 * 1024);
       long realSyncs = getSyncs(c);
       long now = System.currentTimeMillis();
@@ -101,7 +100,7 @@ public class TotalQueuedIT extends ConfigurableMacBase {
       c.instanceOperations().setProperty(Property.TSERV_TOTAL_MUTATION_QUEUE_MAX.getKey(),
           "" + LARGE_QUEUE_SIZE);
       c.tableOperations().flush(tableName, null, null, true);
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
       try (BatchWriter bw = c.createBatchWriter(tableName, cfg)) {
         now = System.currentTimeMillis();
         bytesSent = 0;

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.QUEUE1;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.compact;
 import static org.apache.accumulo.test.compaction.ExternalCompactionTestUtils.createTable;
@@ -32,7 +31,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.compactor.Compactor;
@@ -113,7 +111,12 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
       try {
         while (!compactionFinished.get()) {
           checkRunning();
-          sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("interrupted during sleep", ex);
+          }
         }
       } catch (TException e) {
         log.warn("{}", e.getMessage(), e);

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionProgressIT.java
@@ -114,8 +114,8 @@ public class ExternalCompactionProgressIT extends AccumuloClusterHarness {
           try {
             Thread.sleep(1000);
           } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("interrupted during sleep", ex);
+            log.debug("interrupted during sleep, forcing compaction finished as completed");
+            compactionFinished.set(true);
           }
         }
       } catch (TException e) {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/SplitCancelsMajCIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/SplitCancelsMajCIT.java
@@ -18,14 +18,13 @@
  */
 package org.apache.accumulo.test.compaction;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.EnumSet;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -89,7 +88,7 @@ public class SplitCancelsMajCIT extends SharedMiniClusterBase {
       thread.start();
 
       long now = System.currentTimeMillis();
-      sleepUninterruptibly(10, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(10));
       // split the table, interrupts the compaction
       SortedSet<Text> partitionKeys = new TreeSet<>();
       partitionKeys.add(new Text("10"));

--- a/test/src/main/java/org/apache/accumulo/test/functional/AddSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AddSplitIT.java
@@ -18,14 +18,11 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -61,7 +58,7 @@ public class AddSplitIT extends AccumuloClusterHarness {
 
       c.tableOperations().addSplits(tableName, splits);
 
-      sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+      Thread.sleep(100);
 
       Collection<Text> actualSplits = c.tableOperations().listSplits(tableName);
 
@@ -81,7 +78,7 @@ public class AddSplitIT extends AccumuloClusterHarness {
 
       c.tableOperations().addSplits(tableName, splits);
 
-      sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+      Thread.sleep(100);
 
       actualSplits = c.tableOperations().listSplits(tableName);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BadIteratorMincIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BadIteratorMincIT.java
@@ -18,12 +18,11 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.EnumSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -61,7 +60,7 @@ public class BadIteratorMincIT extends AccumuloClusterHarness {
       }
 
       c.tableOperations().flush(tableName, null, null, false);
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
 
       // minc should fail, so there should be no files
       FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);
@@ -75,7 +74,7 @@ public class BadIteratorMincIT extends AccumuloClusterHarness {
         c.tableOperations().removeIterator(tableName, BadIterator.class.getSimpleName(),
             EnumSet.of(IteratorScope.minc));
 
-        sleepUninterruptibly(5, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(5));
 
         // minc should complete
         FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 1, 1);
@@ -95,12 +94,12 @@ public class BadIteratorMincIT extends AccumuloClusterHarness {
         }
 
         // make sure property is given time to propagate
-        sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+        Thread.sleep(500);
 
         c.tableOperations().flush(tableName, null, null, false);
 
         // make sure the flush has time to start
-        sleepUninterruptibly(1, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(1));
 
         // this should not hang
         c.tableOperations().delete(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BatchScanSplitIT.java
@@ -18,14 +18,11 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -79,7 +76,7 @@ public class BatchScanSplitIT extends AccumuloClusterHarness {
 
       Collection<Text> splits = c.tableOperations().listSplits(tableName);
       while (splits.size() < 2) {
-        sleepUninterruptibly(1, TimeUnit.MILLISECONDS);
+        Thread.sleep(1);
         splits = c.tableOperations().listSplits(tableName);
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
@@ -18,10 +18,9 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -106,11 +105,11 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
       // initiate splits
       c.tableOperations().setProperty(tableName, Property.TABLE_SPLIT_THRESHOLD.getKey(), "100K");
 
-      sleepUninterruptibly(2, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(2));
 
       // wait until over split threshold -- should be 78 splits
       while (c.tableOperations().listSplits(tableName).size() < 75) {
-        sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+        Thread.sleep(500);
       }
 
       FunctionalTestUtils.checkSplits(c, tableName, 50, 100);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestReader.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
@@ -28,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.fate.zookeeper.ZooCache;
 import org.apache.accumulo.core.fate.zookeeper.ZooReader;
@@ -88,7 +86,7 @@ public class CacheTestReader {
       fos.close();
       oos.close();
 
-      sleepUninterruptibly(20, TimeUnit.MILLISECONDS);
+      Thread.sleep(20);
     }
 
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CacheTestWriter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.accumulo.harness.AccumuloITBase.random;
 
@@ -30,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
@@ -162,7 +160,7 @@ public class CacheTestWriter {
           }
         }
 
-        sleepUninterruptibly(5, TimeUnit.MILLISECONDS);
+        Thread.sleep(5);
       }
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConcurrencyIT.java
@@ -18,12 +18,9 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-
 import java.time.Duration;
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -123,7 +120,7 @@ public class ConcurrencyIT extends AccumuloClusterHarness {
     ScanTask st1 = new ScanTask(c, tableName, 100);
     st1.start();
 
-    sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+    Thread.sleep(50);
     c.tableOperations().flush(tableName, null, null, true);
 
     for (int i = 0; i < 50; i++) {
@@ -150,7 +147,7 @@ public class ConcurrencyIT extends AccumuloClusterHarness {
     ScanTask st3 = new ScanTask(c, tableName, 150);
     st3.start();
 
-    sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+    Thread.sleep(50);
     c.tableOperations().flush(tableName, null, null, false);
 
     st3.join();

--- a/test/src/main/java/org/apache/accumulo/test/functional/ConstraintIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ConstraintIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -163,7 +162,7 @@ public class ConstraintIT extends AccumuloClusterHarness {
 
       // remove the numeric value constraint
       client.tableOperations().removeConstraint(tableName, 2);
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
 
       // now should be able to add a non numeric value
       bw = client.createBatchWriter(tableName);
@@ -190,7 +189,7 @@ public class ConstraintIT extends AccumuloClusterHarness {
       // add a constraint that references a non-existent class
       client.tableOperations().setProperty(tableName, Property.TABLE_CONSTRAINT_PREFIX + "1",
           "com.foobar.nonExistentClass");
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
 
       // add a mutation
       bw = client.createBatchWriter(tableName);
@@ -233,7 +232,7 @@ public class ConstraintIT extends AccumuloClusterHarness {
 
       // remove the bad constraint
       client.tableOperations().removeConstraint(tableName, 1);
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
 
       // try the mutation again
       bw = client.createBatchWriter(tableName);

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteEverythingIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteEverythingIT.java
@@ -18,12 +18,11 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -105,7 +104,7 @@ public class DeleteEverythingIT extends AccumuloClusterHarness {
         c.tableOperations().flush(tableName, null, null, true);
 
         c.tableOperations().setProperty(tableName, Property.TABLE_MAJC_RATIO.getKey(), "1.0");
-        sleepUninterruptibly(4, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(4));
 
         FunctionalTestUtils.checkRFiles(c, tableName, 1, 1, 0, 0);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/DeleteRowsSplitIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -102,7 +100,7 @@ public class DeleteRowsSplitIT extends AccumuloClusterHarness {
         });
         t.start();
 
-        sleepUninterruptibly(test * 2, TimeUnit.MILLISECONDS);
+        Thread.sleep(test * 2);
 
         client.tableOperations().deleteRows(tableName, start, end);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.Accumulo;
@@ -138,7 +137,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       log.info("Counted {} files in path: {}", before, pathString);
 
       while (true) {
-        sleepUninterruptibly(1, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(1));
         int more = countFiles(pathString);
         if (more <= before) {
           break;
@@ -149,7 +148,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       // restart GC
       log.info("Restarting GC...");
       getCluster().start();
-      sleepUninterruptibly(15, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(15));
       log.info("Again Counting files in path: {}", pathString);
 
       int after = countFiles(pathString);
@@ -169,7 +168,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       addEntries(c);
       cluster.getConfig().setDefaultMemory(32, MemoryUnit.MEGABYTE);
       ProcessInfo gc = cluster.exec(SimpleGarbageCollector.class);
-      sleepUninterruptibly(20, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(20));
       String output = "";
       while (!output.contains("has exceeded the threshold")) {
         try {
@@ -193,7 +192,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       c.tableOperations().create(table);
       // let gc run for a bit
       cluster.start();
-      sleepUninterruptibly(20, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(20));
       killMacGc();
       // kill tservers
       for (ProcessReference ref : cluster.getProcesses().get(ServerType.TABLET_SERVER)) {
@@ -246,7 +245,7 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
       try {
         String output = "";
         while (!output.contains("Ignoring invalid deletion candidate")) {
-          sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+          Thread.sleep(250);
           try {
             output = gc.readStdOut();
           } catch (UncheckedIOException ioe) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/LargeRowIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -134,7 +133,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
               .setProperties(singletonMap(Property.TABLE_MAX_END_ROW_SIZE.getKey(), "256K"))
               .withSplits(splitPoints));
 
-      sleepUninterruptibly(3, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(3));
       test1(c);
       test2(c);
     }
@@ -147,7 +146,7 @@ public class LargeRowIT extends AccumuloClusterHarness {
     c.tableOperations().setProperty(REG_TABLE_NAME, Property.TABLE_SPLIT_THRESHOLD.getKey(),
         "" + SPLIT_THRESH);
 
-    sleepUninterruptibly(timeoutFactor * 12, TimeUnit.SECONDS);
+    Thread.sleep(SECONDS.toMillis(timeoutFactor * 12));
     log.info("checking splits");
     FunctionalTestUtils.checkSplits(c, REG_TABLE_NAME, NUM_PRE_SPLITS / 2, NUM_PRE_SPLITS * 4);
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryConsumingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryConsumingIterator.java
@@ -18,19 +18,18 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.iterators.WrappingIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -82,7 +81,12 @@ public class MemoryConsumingIterator extends WrappingIterator {
       } else {
         LOG.info("Waiting for LowMemoryDetector to recognize low on memory condition.");
       }
-      Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+      try {
+        Thread.sleep(SECONDS.toMillis(1));
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw new IOException("interrupted during sleep", ex);
+      }
     }
     LOG.info("Running low on memory == true");
     super.seek(range, columnFamilies, inclusive);

--- a/test/src/main/java/org/apache/accumulo/test/functional/MemoryFreeingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MemoryFreeingIterator.java
@@ -18,17 +18,16 @@
  */
 package org.apache.accumulo.test.functional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iterators.WrappingIterator;
-
-import com.google.common.util.concurrent.Uninterruptibles;
 
 public class MemoryFreeingIterator extends WrappingIterator {
 
@@ -39,7 +38,12 @@ public class MemoryFreeingIterator extends WrappingIterator {
     MemoryConsumingIterator.freeBuffers();
     while (this.isRunningLowOnMemory()) {
       // wait for LowMemoryDetector to recognize the memory is free.
-      Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+      try {
+        Thread.sleep(SECONDS.toMillis(1));
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw new IOException("wait for low memory detector interrupted", ex);
+      }
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.FILES;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LAST;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOCATION;
@@ -35,7 +34,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -131,7 +129,7 @@ public class MetadataIT extends AccumuloClusterHarness {
       try (Scanner s = c.createScanner(RootTable.NAME, Authorizations.EMPTY)) {
         s.setRange(DeletesSection.getRange());
         while (s.stream().findAny().isEmpty()) {
-          sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+          Thread.sleep(100);
         }
         assertEquals(0, c.tableOperations().listSplits(MetadataTable.NAME).size());
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataMaxFilesIT.java
@@ -18,13 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Duration;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -69,7 +68,7 @@ public class MetadataMaxFilesIT extends ConfigurableMacBase {
       c.tableOperations().setProperty(MetadataTable.NAME, Property.TABLE_SPLIT_THRESHOLD.getKey(),
           "10000");
       // propagation time
-      sleepUninterruptibly(5, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(5));
       for (int i = 0; i < 2; i++) {
         String tableName = "table" + i;
         log.info("Creating {} with splits", tableName);
@@ -97,7 +96,7 @@ public class MetadataMaxFilesIT extends ConfigurableMacBase {
         if (tablets == 2002) {
           break;
         }
-        sleepUninterruptibly(1, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(1));
       }
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataSplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataSplitIT.java
@@ -18,13 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -56,7 +55,7 @@ public class MetadataSplitIT extends ConfigurableMacBase {
         c.tableOperations().create("table" + i);
         c.tableOperations().flush(MetadataTable.NAME, null, null, true);
       }
-      sleepUninterruptibly(10, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(10));
       assertTrue(c.tableOperations().listSplits(MetadataTable.NAME).size() > 2);
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.cluster.ClusterControl;
 import org.apache.accumulo.core.Constants;
@@ -85,7 +84,7 @@ public class RestartIT extends AccumuloClusterHarness {
       svc.shutdown();
     }
 
-    while (!svc.awaitTermination(10, TimeUnit.SECONDS)) {
+    while (!svc.awaitTermination(10, SECONDS)) {
       log.info("Waiting for threadpool to terminate");
     }
   }
@@ -145,7 +144,7 @@ public class RestartIT extends AccumuloClusterHarness {
       } while (managerLockData.isPresent());
 
       cluster.start();
-      sleepUninterruptibly(5, TimeUnit.MILLISECONDS);
+      Thread.sleep(5);
       control.stopAllServers(ServerType.MANAGER);
 
       managerLockData = null;

--- a/test/src/main/java/org/apache/accumulo/test/functional/RestartStressIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/RestartStressIT.java
@@ -18,14 +18,13 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.cluster.ClusterControl;
 import org.apache.accumulo.core.client.Accumulo;
@@ -77,7 +76,7 @@ public class RestartStressIT extends AccumuloClusterHarness {
       svc.shutdown();
     }
 
-    while (!svc.awaitTermination(10, TimeUnit.SECONDS)) {
+    while (!svc.awaitTermination(10, SECONDS)) {
       log.info("Waiting for threadpool to terminate");
     }
   }
@@ -103,7 +102,7 @@ public class RestartStressIT extends AccumuloClusterHarness {
       });
 
       for (int i = 0; i < 2; i++) {
-        sleepUninterruptibly(10, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(10));
         control.stopAllServers(ServerType.TABLET_SERVER);
         control.startAllServers(ServerType.TABLET_SERVER);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -136,7 +135,7 @@ public class ScanIdIT extends AccumuloClusterHarness {
 
         if (resultsByWorker.size() < NUM_SCANNERS) {
           log.trace("Results reported {}", resultsByWorker.size());
-          sleepUninterruptibly(750, TimeUnit.MILLISECONDS);
+          Thread.sleep(750);
         } else {
           // each worker has reported at least one result.
           testInProgress.set(false);
@@ -144,7 +143,7 @@ public class ScanIdIT extends AccumuloClusterHarness {
           log.debug("Final result count {}", resultsByWorker.size());
 
           // delay to allow scanners to react to end of test and cleanly close.
-          sleepUninterruptibly(1, TimeUnit.SECONDS);
+          Thread.sleep(SECONDS.toMillis(1));
         }
 
       }
@@ -316,7 +315,12 @@ public class ScanIdIT extends AccumuloClusterHarness {
 
       client.tableOperations().offline(tableName, true);
 
-      sleepUninterruptibly(2, TimeUnit.SECONDS);
+      try {
+        Thread.sleep(SECONDS.toMillis(2));
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted during sleep", ex);
+      }
       client.tableOperations().online(tableName, true);
 
       for (Text split : client.tableOperations().listSplits(tableName)) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanIdIT.java
@@ -305,7 +305,8 @@ public class ScanIdIT extends AccumuloClusterHarness {
    *
    * @param client Accumulo client to test cluster or MAC instance.
    */
-  private void addSplits(final AccumuloClient client, final String tableName) {
+  private void addSplits(final AccumuloClient client, final String tableName)
+      throws InterruptedException {
 
     SortedSet<Text> splits = createSplits();
 
@@ -315,12 +316,8 @@ public class ScanIdIT extends AccumuloClusterHarness {
 
       client.tableOperations().offline(tableName, true);
 
-      try {
-        Thread.sleep(SECONDS.toMillis(2));
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-        throw new IllegalStateException("interrupted during sleep", ex);
-      }
+      Thread.sleep(SECONDS.toMillis(2));
+
       client.tableOperations().online(tableName, true);
 
       for (Text split : client.tableOperations().listSplits(tableName)) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ScanSessionTimeOutIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ScanSessionTimeOutIT.java
@@ -18,13 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -120,7 +119,7 @@ public class ScanSessionTimeOutIT extends AccumuloClusterHarness {
         verify(iter, 0, 200);
 
         // sleep three times the session timeout
-        sleepUninterruptibly(9, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(9));
 
         verify(iter, 200, 100000);
       }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ServerSideErrorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ServerSideErrorIT.java
@@ -18,14 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -88,7 +86,7 @@ public class ServerSideErrorIT extends AccumuloClusterHarness {
         }
       });
 
-      sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+      Thread.sleep(500);
 
       // should be able to scan now
       try (Scanner scanner = c.createScanner(tableName, Authorizations.EMPTY)) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/ShutdownIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ShutdownIT.java
@@ -18,14 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -48,7 +46,7 @@ public class ShutdownIT extends ConfigurableMacBase {
   public void shutdownDuringIngest() throws Exception {
     Process ingest = cluster
         .exec(TestIngest.class, "-c", cluster.getClientPropsPath(), "--createTable").getProcess();
-    sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    Thread.sleep(100);
     assertEquals(0, cluster.exec(Admin.class, "stopAll").getProcess().waitFor());
     ingest.destroy();
   }
@@ -60,7 +58,7 @@ public class ShutdownIT extends ConfigurableMacBase {
             .getProcess().waitFor());
     Process verify =
         cluster.exec(VerifyIngest.class, "-c", cluster.getClientPropsPath()).getProcess();
-    sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    Thread.sleep(100);
     assertEquals(0, cluster.exec(Admin.class, "stopAll").getProcess().waitFor());
     verify.destroy();
   }
@@ -72,7 +70,7 @@ public class ShutdownIT extends ConfigurableMacBase {
             .getProcess().waitFor());
     Process deleter =
         cluster.exec(TestRandomDeletes.class, "-c", cluster.getClientPropsPath()).getProcess();
-    sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    Thread.sleep(100);
     assertEquals(0, cluster.exec(Admin.class, "stopAll").getProcess().waitFor());
     deleter.destroy();
   }
@@ -94,7 +92,7 @@ public class ShutdownIT extends ConfigurableMacBase {
         }
       });
       async.start();
-      sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+      Thread.sleep(100);
       assertEquals(0, cluster.exec(Admin.class, "stopAll").getProcess().waitFor());
       if (ref.get() != null) {
         throw ref.get();

--- a/test/src/main/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SimpleBalancerFairnessIT.java
@@ -18,14 +18,13 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -72,7 +71,7 @@ public class SimpleBalancerFairnessIT extends ConfigurableMacBase {
       params.rows = 5000;
       TestIngest.ingest(c, params);
       c.tableOperations().flush("test_ingest", null, null, false);
-      sleepUninterruptibly(45, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(45));
       Credentials creds = new Credentials("root", new PasswordToken(ROOT_PASSWORD));
 
       int unassignedTablets = 1;

--- a/test/src/main/java/org/apache/accumulo/test/functional/SlowConstraint.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SlowConstraint.java
@@ -18,10 +18,9 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.constraints.Constraint;
@@ -35,7 +34,12 @@ public class SlowConstraint implements Constraint {
 
   @Override
   public List<Short> check(Environment env, Mutation mutation) {
-    sleepUninterruptibly(20, TimeUnit.SECONDS);
+    try {
+      Thread.sleep(SECONDS.toMillis(20));
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted during sleep", ex);
+    }
     return null;
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SlowIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SlowIterator.java
@@ -18,12 +18,9 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -57,14 +54,24 @@ public class SlowIterator extends WrappingIterator {
 
   @Override
   public void next() throws IOException {
-    sleepUninterruptibly(sleepTime, TimeUnit.MILLISECONDS);
+    try {
+      Thread.sleep(sleepTime);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted during sleep", ex);
+    }
     super.next();
   }
 
   @Override
   public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
       throws IOException {
-    sleepUninterruptibly(seekSleepTime, TimeUnit.MILLISECONDS);
+    try {
+      Thread.sleep(seekSleepTime);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted during sleep", ex);
+    }
     super.seek(range, columnFamilies, inclusive);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -28,7 +28,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -138,7 +137,7 @@ public class SplitIT extends AccumuloClusterHarness {
       TestIngest.ingest(c, params);
       VerifyIngest.verifyIngest(c, params);
       while (c.tableOperations().listSplits(table).size() < 10) {
-        sleepUninterruptibly(15, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(15));
       }
       TableId id = TableId.of(c.tableOperations().tableIdMap().get(table));
       try (Scanner s = c.createScanner(MetadataTable.NAME, Authorizations.EMPTY)) {
@@ -175,9 +174,9 @@ public class SplitIT extends AccumuloClusterHarness {
 
       c.tableOperations().create(tableName, new NewTableConfiguration().setProperties(props));
 
-      sleepUninterruptibly(5, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(5));
       ReadWriteIT.interleaveTest(c, tableName);
-      sleepUninterruptibly(5, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(5));
       int numSplits = c.tableOperations().listSplits(tableName).size();
       while (numSplits <= 20) {
         log.info("Waiting for splits to happen");
@@ -197,7 +196,7 @@ public class SplitIT extends AccumuloClusterHarness {
       DeleteIT.deleteTest(c, getCluster(), tableName);
       c.tableOperations().flush(tableName, null, null, true);
       for (int i = 0; i < 5; i++) {
-        sleepUninterruptibly(10, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(10));
         if (c.tableOperations().listSplits(tableName).size() > 20) {
           break;
         }

--- a/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TabletMetadataIT.java
@@ -18,13 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.minicluster.ServerType.TABLET_SERVER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -59,7 +58,7 @@ public class TabletMetadataIT extends ConfigurableMacBase {
     try (AccumuloClient c = Accumulo.newClient().from(getClientProperties()).build()) {
       while (c.instanceOperations().getTabletServers().size() != NUM_TSERVERS) {
         log.info("Waiting for tservers to start up...");
-        sleepUninterruptibly(5, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(5));
       }
       Set<TServerInstance> servers = TabletMetadata.getLiveTServers((ClientContext) c);
       assertEquals(NUM_TSERVERS, servers.size());
@@ -70,7 +69,7 @@ public class TabletMetadataIT extends ConfigurableMacBase {
 
       while (c.instanceOperations().getTabletServers().size() == NUM_TSERVERS) {
         log.info("Waiting for a tserver to die...");
-        sleepUninterruptibly(5, TimeUnit.SECONDS);
+        Thread.sleep(SECONDS.toMillis(5));
       }
       servers = TabletMetadata.getLiveTServers((ClientContext) c);
       assertEquals(NUM_TSERVERS - 1, servers.size());

--- a/test/src/main/java/org/apache/accumulo/test/functional/TimeoutIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/TimeoutIT.java
@@ -18,12 +18,11 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -59,10 +58,10 @@ public class TimeoutIT extends AccumuloClusterHarness {
     client.tableOperations().addConstraint(tableName, SlowConstraint.class.getName());
 
     // give constraint time to propagate through zookeeper
-    sleepUninterruptibly(1, TimeUnit.SECONDS);
+    Thread.sleep(SECONDS.toMillis(1));
 
-    BatchWriter bw = client.createBatchWriter(tableName,
-        new BatchWriterConfig().setTimeout(3, TimeUnit.SECONDS));
+    BatchWriter bw =
+        client.createBatchWriter(tableName, new BatchWriterConfig().setTimeout(3, SECONDS));
 
     Mutation mut = new Mutation("r1");
     mut.put("cf1", "cq1", "v1");
@@ -94,7 +93,7 @@ public class TimeoutIT extends AccumuloClusterHarness {
       // should not timeout
       bs.forEach((k, v) -> {});
 
-      bs.setTimeout(5, TimeUnit.SECONDS);
+      bs.setTimeout(5, SECONDS);
       IteratorSetting iterSetting = new IteratorSetting(100, SlowIterator.class);
       iterSetting.addOption("sleepTime", 2000 + "");
       bs.addScanIterator(iterSetting);

--- a/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/WALSunnyDayIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.core.conf.Property.GC_CYCLE_DELAY;
 import static org.apache.accumulo.core.conf.Property.GC_CYCLE_START;
 import static org.apache.accumulo.core.conf.Property.INSTANCE_ZK_TIMEOUT;
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -124,14 +123,14 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       for (String table : new String[] {tableName, MetadataTable.NAME, RootTable.NAME}) {
         c.tableOperations().flush(table, null, null, true);
       }
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
       // rolled WAL is no longer in use, but needs to be GC'd
       Map<String,WalState> walsAfterflush = getWALsAndAssertCount(context, 3);
       assertEquals(2, countInUse(walsAfterflush.values()), "inUse should be 2");
 
       // let the GC run for a little bit
       control.start(GARBAGE_COLLECTOR);
-      sleepUninterruptibly(5, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(5));
       // make sure the unused WAL goes away
       getWALsAndAssertCount(context, 2);
       control.stop(GARBAGE_COLLECTOR);
@@ -144,7 +143,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       // wait for the metadata table to go back online
       getRecoveryMarkers(c);
       // allow a little time for the manager to notice ASSIGNED_TO_DEAD_SERVER tablets
-      sleepUninterruptibly(5, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(5));
       Map<KeyExtent,List<String>> markers = getRecoveryMarkers(c);
       // log.debug("markers " + markers);
       assertEquals(1, markers.size(), "one tablet should have markers");
@@ -160,7 +159,7 @@ public class WALSunnyDayIT extends ConfigurableMacBase {
       // log.debug("wals after " + walsAfterRestart);
       assertEquals(4, countInUse(walsAfterRestart.values()), "used WALs after restart should be 4");
       control.start(GARBAGE_COLLECTOR);
-      sleepUninterruptibly(5, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(5));
       Map<String,WalState> walsAfterRestartAndGC = getWALsAndAssertCount(context, 2);
       assertEquals(2, countInUse(walsAfterRestartAndGC.values()), "logs in use should be 2");
     }

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZombieTServer.java
@@ -18,12 +18,11 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static org.apache.accumulo.harness.AccumuloITBase.random;
 
 import java.util.HashMap;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService;
@@ -87,7 +86,12 @@ public class ZombieTServer {
           return result;
         }
       }
-      sleepUninterruptibly(Integer.MAX_VALUE, TimeUnit.DAYS);
+      try {
+        Thread.sleep(DAYS.toMillis(Integer.MAX_VALUE));
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        log.info("probably received shutdown, interrupted during infinite sleep", ex);
+      }
       return null;
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/ZookeeperRestartIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ZookeeperRestartIT.java
@@ -18,13 +18,12 @@
  */
 package org.apache.accumulo.test.functional;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -71,7 +70,7 @@ public class ZookeeperRestartIT extends ConfigurableMacBase {
       }
 
       // give the servers time to react
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
 
       // start zookeeper back up
       cluster.start();

--- a/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/NullTserver.java
@@ -18,7 +18,7 @@
  */
 package org.apache.accumulo.test.performance;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.clientImpl.thrift.ClientService;
@@ -372,7 +371,7 @@ public class NullTserver {
     store.setLocations(assignments);
 
     while (true) {
-      sleepUninterruptibly(10, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(10));
     }
   }
 }

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -18,8 +18,8 @@
  */
 package org.apache.accumulo.test.shell;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.accumulo.harness.AccumuloITBase.MINI_CLUSTER_ONLY;
 import static org.apache.accumulo.harness.AccumuloITBase.SUNNY_DAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +44,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.accumulo.core.Constants;
@@ -549,7 +548,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
         ts.exec("getauths", true, "bar", true);
         passed = true;
       } catch (AssertionError | Exception e) {
-        sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+        Thread.sleep(500);
       }
     }
     assertTrue(passed, "Could not successfully see updated authoriations");
@@ -1018,7 +1017,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("constraint -l -t " + table, true, "VisibilityConstraint=2", true);
     ts.exec("constraint -t " + table + " -d 2", true, "Removed constraint 2 from table " + table);
     // wait for zookeeper updates to propagate
-    sleepUninterruptibly(1, TimeUnit.SECONDS);
+    Thread.sleep(SECONDS.toMillis(1));
     ts.exec("constraint -l -t " + table, true, "VisibilityConstraint=2", false);
     ts.exec("deletetable -f " + table);
   }
@@ -1380,7 +1379,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     ts.exec("scan -b 02", true, "value", false);
     ts.exec("interpreter -i org.apache.accumulo.core.util.interpret.HexScanInterpreter", true);
     // Need to allow time for this to propagate through zoocache/zookeeper
-    sleepUninterruptibly(3, TimeUnit.SECONDS);
+    Thread.sleep(SECONDS.toMillis(3));
 
     ts.exec("interpreter -l", true, "HexScan", true);
     ts.exec("scan -b 02", true, "value", true);
@@ -1453,7 +1452,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
       if (ts.output.get().split("\n").length == 3) {
         break;
       }
-      sleepUninterruptibly(1, TimeUnit.SECONDS);
+      Thread.sleep(SECONDS.toMillis(1));
 
     }
     assertEquals(2, ts.output.get().split("\n").length);
@@ -1534,7 +1533,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
             log.info("Ignoring scan because of wrong table: {}", currentScan);
           }
         }
-        sleepUninterruptibly(300, TimeUnit.MILLISECONDS);
+        Thread.sleep(300);
       }
       thread.join();
 
@@ -1584,19 +1583,33 @@ public class ShellServerIT extends SharedMiniClusterBase {
         "config -t " + table + " -s " + Property.TABLE_CLASSLOADER_CONTEXT.getKey() + "=" + context,
         true);
 
-    sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
-
+    try {
+      Thread.sleep(250);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted during sleep", ex);
+    }
     // We can't use the setiter command as Filter implements OptionDescriber which
     // forces us to enter more input that I don't know how to input
     // Instead, we can just manually set the property on the table.
     ts.exec("config -t " + table + " -s " + Property.TABLE_ITERATOR_PREFIX.getKey()
         + "scan.foo=10,org.apache.accumulo.test.FooFilter");
 
-    sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+    try {
+      Thread.sleep(250);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted during sleep", ex);
+    }
 
     ts.exec("insert foo f q v", true);
 
-    sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+    try {
+      Thread.sleep(250);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted during sleep", ex);
+    }
 
     ts.exec("scan -np", true, "foo", false);
 

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -1572,7 +1572,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
   }
 
   public void verifyPerTableClasspath(final String table, final File fooConstraintJar)
-      throws IOException {
+      throws IOException, InterruptedException {
 
     File fooFilterJar = initJar("/org/apache/accumulo/test/FooFilter.jar", "FooFilter", rootPath);
 
@@ -1583,33 +1583,19 @@ public class ShellServerIT extends SharedMiniClusterBase {
         "config -t " + table + " -s " + Property.TABLE_CLASSLOADER_CONTEXT.getKey() + "=" + context,
         true);
 
-    try {
-      Thread.sleep(250);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      throw new IOException("interrupted during sleep", ex);
-    }
+    Thread.sleep(250);
+
     // We can't use the setiter command as Filter implements OptionDescriber which
     // forces us to enter more input that I don't know how to input
     // Instead, we can just manually set the property on the table.
     ts.exec("config -t " + table + " -s " + Property.TABLE_ITERATOR_PREFIX.getKey()
         + "scan.foo=10,org.apache.accumulo.test.FooFilter");
 
-    try {
-      Thread.sleep(250);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      throw new IOException("interrupted during sleep", ex);
-    }
+    Thread.sleep(250);
 
     ts.exec("insert foo f q v", true);
 
-    try {
-      Thread.sleep(250);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      throw new IOException("interrupted during sleep", ex);
-    }
+    Thread.sleep(250);
 
     ts.exec("scan -np", true, "foo", false);
 


### PR DESCRIPTION
This is a subset (and supersedes) https://github.com/apache/accumulo/pull/3202 and focuses on replacements only in test code.

- replace occurrences of sleepUninterruptibly with Thread.sleep()
- prefer static import of TimeUnits instead of using TimeUnit.[UNIT] in files that had changes.
