### PR TITLE
Fix scan thread resource starvation

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -94,7 +94,7 @@ jobs:
           echo "'hostname -I' shows '$(hostname -I)'"
         fi
     - name: Build with Maven (${{ matrix.profile.name }})
-      timeout-minutes: 60
+      timeout-minutes: 70
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}
       env:
         MAVEN_OPTS: -Djansi.force=true

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -94,7 +94,7 @@ jobs:
           echo "'hostname -I' shows '$(hostname -I)'"
         fi
     - name: Build with Maven (${{ matrix.profile.name }})
-      timeout-minutes: 70
+      timeout-minutes: 60
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}
       env:
         MAVEN_OPTS: -Djansi.force=true

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/FileManager.java
@@ -178,7 +178,8 @@ public class FileManager {
     this.indexCache = indexCache;
     this.fileLenCache = fileLenCache;
 
-    this.filePermits = new Semaphore(maxOpen, false);
+    // Creates a fair semaphore to ensure thread starvation doesn't occur
+    this.filePermits = new Semaphore(maxOpen, true);
     this.maxOpen = maxOpen;
     this.fs = fs;
 
@@ -295,17 +296,17 @@ public class FileManager {
       long waitTime = System.currentTimeMillis() - start;
 
       if (waitTime >= slowFilePermitMillis) {
-        log.info("Slow file permits request: {} ms, files requested: {}, tablet: {}", waitTime,
-            files.size(), tablet);
+        log.warn("Slow file permits request: {} ms, files requested: {}, "
+            + "max open files: {}, tablet: {}", waitTime, files.size(), maxOpen, tablet);
       }
     }
 
-    // now that the we are past the semaphore, we have the authority
+    // now that we are past the semaphore, we have the authority
     // to open files.size() files
 
     // determine what work needs to be done in sync block
     // but do the work of opening and closing files outside
-    // a synch block
+    // the block
     synchronized (this) {
 
       filesToOpen = takeOpenFiles(files, readersReserved);


### PR DESCRIPTION
This commit switches the filePermits semaphore to a "fair" semaphore which ensures that threads requesting reserved readers are handled in a FIFO queue vs ending up in a starvation state for resources.

This also switches the log statement from an info to a warn since that message is thrown when a property value is exceeded. 
Since the property is configurable, the system should warn that scans are taking that long vs just being a normal info level message. 

Fixes #3198 
