### PR TITLE
fixes unencountered bug in ample

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -69,8 +69,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   @Override
   public Ample.TabletMutator putPrevEndRow(Text per) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    TabletColumnFamily.PREV_ROW_COLUMN.put(mutation,
-        TabletColumnFamily.encodePrevEndRow(extent.prevEndRow()));
+    TabletColumnFamily.PREV_ROW_COLUMN.put(mutation, TabletColumnFamily.encodePrevEndRow(per));
     return this;
   }
 


### PR DESCRIPTION
Fixes a bug in Ample that no current code is encountering.  Ran into this bug while working on #3232 and trying to write new code that splits a tablet using conditional mutations. Fixing this bug in 2.1 in case any new code is written that would encounter the bug.