### PR TITLE
Fix conditional in LowMemoryDetector

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/mem/LowMemoryDetector.java
@@ -89,9 +89,9 @@ public class LowMemoryDetector {
       }
       boolean isEnabled = context.getConfiguration().getBoolean(p);
       // Only incur the penalty of accessing the volatile variable when enabled for this scope
-      if (isEnabled) {
+      if (isEnabled && runningLowOnMemory) {
         action.execute();
-        return runningLowOnMemory;
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
The check was executing the action before returning whether or not the server was running low on memory. For actions that included a wait, this would cause those processes to wait unnecessarily. This changes the method such that the action is only executed if the server is running low on memory

Closes #3240