### PR TITLE
Clear ServerConfigurationFactory cache on ZooKeeper notifications. Improve ShellServerIT test.

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -138,16 +138,20 @@ public class ServerConfigurationFactory extends ServerConfiguration {
 
     @Override
     public void zkChangeEvent(PropStoreKey<?> propStoreKey) {
-      // no-op. changes handled by prop store impl
+      clearLocalOnEvent(propStoreKey);
     }
 
     @Override
     public void cacheChangeEvent(PropStoreKey<?> propStoreKey) {
-      // no-op. changes handled by prop store impl
+      clearLocalOnEvent(propStoreKey);
     }
 
     @Override
     public void deleteEvent(PropStoreKey<?> propStoreKey) {
+      clearLocalOnEvent(propStoreKey);
+    }
+
+    private void clearLocalOnEvent(PropStoreKey<?> propStoreKey) {
       if (propStoreKey instanceof NamespacePropKey) {
         log.trace("configuration snapshot refresh: Handle namespace delete for {}", propStoreKey);
         namespaceConfigs.remove(((NamespacePropKey) propStoreKey).getId());

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -177,6 +177,7 @@ public class ShellServerIT extends SharedMiniClusterBase {
     make10();
     ts.exec("addsplits row5", true);
     ts.exec("config -t " + table + " -s table.split.threshold=345M", true);
+    Thread.sleep(100);
     ts.exec("offline " + table, true);
     File exportDir = new File(rootPath, "ShellServerIT.export");
     String exportUri = "file://" + exportDir;

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -168,8 +168,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
       client.securityOperations().grantNamespacePermission(getPrincipal(), "",
           NamespacePermission.ALTER_NAMESPACE);
 
-      final String table = getUniqueNames(1)[0] + "_export_src";
-      final String table2 = table + "_import_tgt";
+      final String tableBase = getUniqueNames(1)[0];
+      final String table = tableBase + "_export_src";
+      final String table2 = tableBase + "_import_tgt";
 
       // exporttable / importtable
       ts.exec("createtable " + table + " -evc", true);
@@ -239,8 +240,6 @@ public class ShellServerIT extends SharedMiniClusterBase {
       make10();
       ts.exec("addsplits row5", true);
 
-      // ts.exec("config -t " + table + " -s table.bloom.enabled=true", true);
-      // ts.exec("config -t " + table + " -s table.scan.max.memory=256K", true);
       ts.exec("config -t " + table + " -s table.split.threshold=345M", true);
       for (int i = 0; i < 50; i++) {
         String expected = (100 + i) + "M";

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -454,10 +454,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
       ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30 -name cfcounter",
           true);
 
-      assertTrue(Wait.waitFor(
-          () -> client.tableOperations().getConfiguration(tableName0)
-              .get("table.iterator.scan.cfcounter").equals("30," + COLUMN_FAMILY_COUNTER_ITERATOR),
-          5000, 500));
+      String expectedKey = "table.iterator.scan.cfcounter";
+      String expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
+      checkTableForProperty(client, tableName0, expectedKey, expectedValue);
 
       ts.exec("deletetable " + tableName0, true);
 
@@ -469,10 +468,9 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
       // Name on the CLI should override OptionDescriber (or user input name, in this case)
       ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30", true);
-
-      assertTrue(Wait.waitFor(() -> client.tableOperations().getConfiguration(tableName1)
-          .get("table.iterator.scan.customcfcounter")
-          .equals("30," + COLUMN_FAMILY_COUNTER_ITERATOR), 5000, 500));
+      expectedKey = "table.iterator.scan.customcfcounter";
+      expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
+      checkTableForProperty(client, tableName1, expectedKey, expectedValue);
 
       ts.exec("deletetable " + tableName1, true);
 
@@ -484,21 +482,16 @@ public class ShellServerIT extends SharedMiniClusterBase {
 
       // Name on the CLI should override OptionDescriber (or user input name, in this case)
       ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30", true);
-      assertTrue(Wait.waitFor(() -> client.tableOperations().getConfiguration(tableName2)
-          .get("table.iterator.scan.customcfcounter")
-          .equals("30," + COLUMN_FAMILY_COUNTER_ITERATOR), 5000, 500));
 
-      assertTrue(
-          Wait.waitFor(
-              () -> client.tableOperations().getConfiguration(tableName2)
-                  .get("table.iterator.scan.customcfcounter.opt.name1").equals("value1"),
-              5000, 500));
-
-      assertTrue(
-          Wait.waitFor(
-              () -> client.tableOperations().getConfiguration(tableName2)
-                  .get("table.iterator.scan.customcfcounter.opt.name2").equals("value2"),
-              5000, 500));
+      expectedKey = "table.iterator.scan.customcfcounter";
+      expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
+      checkTableForProperty(client, tableName2, expectedKey, expectedValue);
+      expectedKey = "table.iterator.scan.customcfcounter.opt.name1";
+      expectedValue = "value1";
+      checkTableForProperty(client, tableName2, expectedKey, expectedValue);
+      expectedKey = "table.iterator.scan.customcfcounter.opt.name2";
+      expectedValue = "value2";
+      checkTableForProperty(client, tableName2, expectedKey, expectedValue);
 
       ts.exec("deletetable " + tableName2, true);
 
@@ -511,23 +504,26 @@ public class ShellServerIT extends SharedMiniClusterBase {
       // Name on the CLI should override OptionDescriber (or user input name, in this case)
       ts.exec("setiter -scan -class " + COLUMN_FAMILY_COUNTER_ITERATOR + " -p 30 -name cfcounter",
           true);
-
-      assertTrue(Wait.waitFor(
-          () -> client.tableOperations().getConfiguration(tableName3)
-              .get("table.iterator.scan.cfcounter").equals("30," + COLUMN_FAMILY_COUNTER_ITERATOR),
-          5000, 500));
-
-      assertTrue(Wait.waitFor(
-          () -> client.tableOperations().getConfiguration(tableName3)
-              .get("table.iterator.scan.cfcounter.opt.name1").equals("value1.1,value1.2,value1.3"),
-          5000, 500));
-
-      assertTrue(Wait.waitFor(() -> client.tableOperations().getConfiguration(tableName3)
-          .get("table.iterator.scan.cfcounter.opt.name2").equals("value2"), 5000, 500));
+      expectedKey = "table.iterator.scan.cfcounter";
+      expectedValue = "30," + COLUMN_FAMILY_COUNTER_ITERATOR;
+      checkTableForProperty(client, tableName3, expectedKey, expectedValue);
+      expectedKey = "table.iterator.scan.cfcounter.opt.name1";
+      expectedValue = "value1.1,value1.2,value1.3";
+      checkTableForProperty(client, tableName3, expectedKey, expectedValue);
+      expectedKey = "table.iterator.scan.cfcounter.opt.name2";
+      expectedValue = "value2";
+      checkTableForProperty(client, tableName3, expectedKey, expectedValue);
 
       ts.exec("deletetable " + tableName3, true);
-
     }
+  }
+
+  protected void checkTableForProperty(final AccumuloClient client, final String tableName,
+      final String expectedKey, final String expectedValue) throws Exception {
+    assertTrue(
+        Wait.waitFor(() -> client.tableOperations().getConfiguration(tableName).get(expectedKey)
+            .equals(expectedValue), 5000, 500),
+        "Failed to find expected value for key: " + expectedKey);
   }
 
   @Test


### PR DESCRIPTION
* Clear secondary prop cache in ServerConfigurationFactory more aggressivly on ZooKeeper prop changes
* Add test to ShellServerIT
* Change ShellServerIT to use 'Wait.waitFor()'
 
The shell server IT exporttable Importtable test occasionally fails. It sets a property, exports then imports a table - expecting to see a modified value for the property in the new, imported table.  There is a race condition and the changed property is not written with the exported configuration.

There is a secondary property cache in ServerConfigurationFactory that was not directly updated / cleared but deferred updates to the property cache.  This change clears the cached item (based in property id) on any ZooKeeper notification for that id. 