### PR TITLE
WIP - Prototype Ranged RFile Reader

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/HeapIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/system/HeapIterator.java
@@ -109,7 +109,7 @@ public abstract class HeapIterator implements SortedKeyValueIterator<Key,Value> 
     }
   }
 
-  protected final void clear() {
+  public final void clear() {
     heap.clear();
     topIdx = null;
     nextKey = null;

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -134,7 +134,7 @@ public class MultiThreadedRFileTest {
     public TestRFile deepCopy() throws IOException {
       TestRFile copy = new TestRFile(accumuloConfiguration);
       // does not copy any writer resources. This would be for read only.
-      copy.reader = (Reader) reader.deepCopy(null);
+      copy.reader = reader.deepCopy(null);
       copy.rfile = rfile;
       copy.iter = new ColumnFamilySkippingIterator(copy.reader);
       copy.deepCopy = true;

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileMetricsTest.java
@@ -81,8 +81,9 @@ public class RFileMetricsTest {
 
     public VisMetricsGatherer gatherMetrics() throws IOException {
       VisMetricsGatherer vmg = new VisMetricsGatherer();
-      reader.registerMetrics(vmg);
-      Map<String,ArrayList<ByteSequence>> localityGroupCF = reader.getLocalityGroupCF();
+      ((RFile.Reader) reader).registerMetrics(vmg);
+      Map<String,ArrayList<ByteSequence>> localityGroupCF =
+          ((RFile.Reader) reader).getLocalityGroupCF();
 
       for (String lgName : localityGroupCF.keySet()) {
         LocalityGroupUtil.seek(reader, new Range(), lgName, localityGroupCF);

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RangedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RangedRFileTest.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.file.rfile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.crypto.CryptoTest;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class RangedRFileTest extends RFileTest {
+
+  @BeforeAll
+  public static void setupCryptoKeyFile() throws Exception {
+    CryptoTest.setupKeyFiles(RangedRFileTest.class);
+  }
+
+  public static class RangedTestRfile extends TestRFile {
+    final List<Range> ranges;
+
+    public RangedTestRfile(AccumuloConfiguration accumuloConfiguration, List<Range> ranges) {
+      super(accumuloConfiguration);
+      this.ranges = ranges;
+    }
+
+    @Override
+    protected RFile.RFileReader newReader(CachableBlockFile.CachableBuilder cb) throws IOException {
+      return new RFile.RangedReader(cb, ranges);
+    }
+  }
+
+  @Test
+  public void testFencingNoRange() throws IOException {
+    // Test with infinite start/end range
+    // Expect entire range to be seen
+    assertEquals(1024, testFencing(List.of(new Range()), List.of(new Range())));
+  }
+
+  @Test
+  public void testFencing1() throws IOException {
+    // Test with fenced starting range at beginning and infinite end range
+    // Expect entire range to be seen
+    assertEquals(1024, testFencing(List.of(new Range("r_000000", null)), List.of(new Range())));
+  }
+
+  @Test
+  public void testFencing2() throws IOException {
+    // Test with 2 ranges that are continuous which should be merged
+    // Expect entire range to be seen
+    assertEquals(1024, testFencing(
+        List.of(new Range(null, "r_000002"), new Range("r_000002", null)), List.of(new Range())));
+  }
+
+  @Test
+  public void testFencing3() throws IOException {
+    // Create a fence that contains only row 0 row 2
+    // Expect only to see values from those two rows and not row 1 or row 3
+    final List<Range> ranges = List.of(new Range(null, true, "r_000001", false),
+        new Range("r_000002", true, "r_000003", false));
+
+    // Use the same range for the fence and testing to make sure only the expected keys were seen
+    // Should only be 512 keys as 2 rows * 256
+    assertEquals(512, testFencing(ranges, ranges));
+  }
+
+  // Should fail
+  @Test
+  public void testFencing4() throws IOException {
+    // Create a fence that contains row 0 and row 2 only
+    final List<Range> ranges = List.of(new Range(null, true, "r_000001", false),
+        new Range("r_000002", true, "r_000003", false));
+
+    // Expected range contains only row 2 so should fail as row 1 should also be seen
+    final List<Range> ranges2 = List.of(new Range(null, true, "r_000002", false));
+
+    boolean failed = false;
+    try {
+      testFencing(ranges, ranges2);
+    } catch (AssertionError e) {
+      // expected
+      failed = true;
+    }
+
+    assertTrue(failed, "should have failed");
+  }
+
+  @Test
+  public void testFencing5() throws IOException {
+    // Test all 4 rows individually, should expect entire file
+    final List<Range> ranges = List.of(new Range("r_000000", true, "r_000001", false),
+        new Range("r_000001", true, "r_000002", false),
+        new Range("r_000002", true, "r_000003", false),
+        new Range("r_000003", true, "r_000004", false));
+
+    assertEquals(1024, testFencing(ranges, List.of(new Range())));
+  }
+
+  @Test
+  public void testFencing6() throws IOException {
+    // Set range to 2.5 rows out of 4
+    // Skip row 0, start row 1 and CF 2 (middle row 1), include row 3/4)
+    Key start = Key.builder().row("r_000001").family("cf_000002").build();
+
+    // Create a fence that starts at partial row 1
+    final List<Range> ranges = List.of(new Range(start, true, null, true));
+
+    // 2.5 rows equals 640 keys as each row contains 256 mutations (1024 total across all 4 rows)
+    assertEquals(640, testFencing(ranges, ranges));
+  }
+
+  @Test
+  public void testFencing7() throws IOException {
+    // Set range to 3/4 of 1 row spanning part of row 1 and row 2
+    Key start = Key.builder().row("r_000001").family("cf_000002").build();
+    Key end = Key.builder().row("r_000002").family("cf_000001").build();
+
+    // Create a fence
+    final List<Range> ranges = List.of(new Range(start, true, end, true));
+
+    // 3/4 of 1 rows equals 192 keys as each row contains 256 mutations
+    assertEquals(192, testFencing(ranges, ranges));
+  }
+
+  @Test
+  public void testFencing8() throws IOException {
+    // Test exclusive end key
+
+    // Create a fence for 2 rows
+    final List<Range> ranges = List.of(new Range("r_000001", true, "r_000003", false));
+
+    // None of row 2 should be included because end key is exclusive
+    assertEquals(512, testFencing(ranges, ranges));
+  }
+
+  @Test
+  public void testFencing9() throws IOException {
+    // Test out of order ranges that should still cover whole file.
+    final List<Range> ranges = List.of(new Range("r_000002", true, "r_000003", false),
+        new Range("r_000003", true, "r_000004", false),
+        new Range("r_000000", true, "r_000001", false),
+        new Range("r_000001", true, "r_000002", false));
+
+    assertEquals(1024, testFencing(ranges, List.of(new Range())));
+  }
+
+  @Test
+  public void testFencing10() throws IOException {
+    // Test overlap - 2 rows
+    final List<Range> ranges = List.of(new Range("r_000002", true, "r_000003", false),
+        new Range("r_000002", true, "r_000004", false));
+
+    assertEquals(512, testFencing(ranges, ranges));
+  }
+
+  private int testFencing(List<Range> fencedRange, List<Range> expectedRange) throws IOException {
+    // test an rfile with multiple rows having multiple columns
+
+    final TestRFile trf = new RangedTestRfile(conf, fencedRange);
+
+    trf.openWriter();
+
+    ArrayList<Key> expectedKeys = new ArrayList<>(10000);
+    ArrayList<Value> expectedValues = new ArrayList<>(10000);
+
+    write(trf, expectedKeys, expectedValues, expectedRange);
+
+    trf.closeWriter();
+
+    trf.openReader();
+    // seek before everything
+    trf.iter.seek(new Range((Key) null, null), EMPTY_COL_FAMS, false);
+    verify(trf, expectedKeys.iterator(), expectedValues.iterator());
+
+    // seek to the middle
+    int index = expectedKeys.size() / 2;
+    trf.seek(expectedKeys.get(index));
+    verify(trf, expectedKeys.subList(index, expectedKeys.size()).iterator(),
+        expectedValues.subList(index, expectedKeys.size()).iterator());
+
+    // seek the first key
+    index = 0;
+    trf.seek(expectedKeys.get(index));
+    verify(trf, expectedKeys.subList(index, expectedKeys.size()).iterator(),
+        expectedValues.subList(index, expectedKeys.size()).iterator());
+
+    // seek to the last key
+    index = expectedKeys.size() - 1;
+    trf.seek(expectedKeys.get(index));
+    verify(trf, expectedKeys.subList(index, expectedKeys.size()).iterator(),
+        expectedValues.subList(index, expectedKeys.size()).iterator());
+
+    // seek after everything
+    index = expectedKeys.size();
+    trf.seek(new Key(new Text("z")));
+    verify(trf, expectedKeys.subList(index, expectedKeys.size()).iterator(),
+        expectedValues.subList(index, expectedKeys.size()).iterator());
+
+    // test seeking to the current location
+    index = expectedKeys.size() / 2;
+    trf.seek(expectedKeys.get(index));
+    assertTrue(trf.iter.hasTop());
+    assertEquals(expectedKeys.get(index), trf.iter.getTopKey());
+    assertEquals(expectedValues.get(index), trf.iter.getTopValue());
+
+    trf.iter.next();
+    index++;
+    assertTrue(trf.iter.hasTop());
+    assertEquals(expectedKeys.get(index), trf.iter.getTopKey());
+    assertEquals(expectedValues.get(index), trf.iter.getTopValue());
+
+    trf.seek(expectedKeys.get(index));
+
+    assertTrue(trf.iter.hasTop());
+    assertEquals(expectedKeys.get(index), trf.iter.getTopKey());
+    assertEquals(expectedValues.get(index), trf.iter.getTopValue());
+
+    // test seeking to each location in the file
+    index = 0;
+    for (Key key : expectedKeys) {
+      trf.seek(key);
+      assertTrue(trf.iter.hasTop());
+      assertEquals(key, trf.iter.getTopKey());
+      assertEquals(expectedValues.get(index), trf.iter.getTopValue());
+
+      if (index > 0) {
+        // Key pkey =
+        expectedKeys.get(index - 1);
+        // assertEquals(pkey, trf.reader.getPrevKey());
+      }
+
+      index++;
+    }
+
+    // test seeking backwards to each key
+    for (int i = expectedKeys.size() - 1; i >= 0; i--) {
+      Key key = expectedKeys.get(i);
+
+      trf.seek(key);
+      assertTrue(trf.iter.hasTop());
+      assertEquals(key, trf.iter.getTopKey());
+      assertEquals(expectedValues.get(i), trf.iter.getTopValue());
+
+      if (i - 1 > 0) {
+        // Key pkey =
+        expectedKeys.get(i - 1);
+        // assertEquals(pkey, trf.reader.getPrevKey());
+      }
+    }
+
+    // test seeking to random location and reading all data from that point
+    // there was an off by one bug with this in the transient index
+    for (int i = 0; i < 12; i++) {
+      index = random.nextInt(expectedKeys.size());
+      trf.seek(expectedKeys.get(index));
+      for (; index < expectedKeys.size(); index++) {
+        assertTrue(trf.iter.hasTop());
+        assertEquals(expectedKeys.get(index), trf.iter.getTopKey());
+        assertEquals(expectedValues.get(index), trf.iter.getTopValue());
+        trf.iter.next();
+      }
+    }
+
+    trf.closeReader();
+
+    return expectedKeys.size();
+  }
+
+  private void write(final TestRFile trf, final List<Key> expectedKeys,
+      final List<Value> expectedValues, List<Range> expected) throws IOException {
+    int val = 0;
+
+    for (int row = 0; row < 4; row++) {
+      String rowS = formatString("r_", row);
+      for (int cf = 0; cf < 4; cf++) {
+        String cfS = formatString("cf_", cf);
+        for (int cq = 0; cq < 4; cq++) {
+          String cqS = formatString("cq_", cq);
+          for (int cv = 'A'; cv < 'A' + 4; cv++) {
+            String cvS = "" + (char) cv;
+            for (int ts = 4; ts > 0; ts--) {
+              Key k = newKey(rowS, cfS, cqS, cvS, ts);
+              // check below ensures when all key sizes are same more than one index block is
+              // created
+              assertEquals(27, k.getSize());
+              Value v = newValue("" + val);
+              trf.writer.append(k, v);
+              final Key finalK = k;
+              if (expected.stream().anyMatch(range -> range.contains(finalK))) {
+                expectedKeys.add(k);
+                expectedValues.add(v);
+              }
+              val++;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  protected RFile.RFileReader newReader(CachableBlockFile.CachableBuilder cb) throws IOException {
+    return new RFile.RangedReader(cb);
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
@@ -310,7 +311,11 @@ public class FileManager {
         FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
             .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
             .withTableConfiguration(tableConf).withCacheProvider(cacheProvider)
-            .withFileLenCache(fileLenCache).build();
+            // Note: This is a placeholder with a list of one range that is the entire file -
+            // eventually the ranges would come from the metadata TableFile -
+            // using this for now demonstrates the RangedReader
+            // still works even with a range of 1 covering the whole file
+            .withFileLenCache(fileLenCache).withRanges(List.of(new Range())).build();
         readersReserved.put(reader, file);
       } catch (Exception e) {
 


### PR DESCRIPTION
#### Goal

Th is a WIP draft PR that is a proof of concept to create an RFile reader that can fence off an RFile and the goal is to provide an iterator that will allow for iterating only over the optionally provided collection of ranges. This functionality will be the basis for no-chop merges as we need to track ranges that are active for the file if we want to avoid "chop" major compactions as described in #1327.

#### New Iterators

There are two main abstractions that I added. I started trying to use the MultiIterator class but ended up creating new iterators but borrowing logic from that class as I needed to make a few modifications and it is pretty simple logic.

1. The first new iterator is [FencedReader](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java#L1710) that is protected and its purpose is to simply wrap an existing [Reader](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java#L1162) and fence by a single Range and mostly meant to be used internally to the RFile class. The seek logic is similar to MultiIterator. It implements `FileSKVIterator`, like the original Reader iterator so that we can return a sample. Note that `getFirstKey()` and `getLastKey()` are not currently supported since those methods return first/last for the entire file. These values are quick to compute since they just use the index normally. If we wanted to get them but fenced off by the range I think we'd have to actually search for the first and last key that were in the range but I don't see a use for this right now unless we need the information for splits or compactions later and I don't know that we do.
2. The second new iterator is [RangedReader](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java#L1569) and it's purpose to to fence off an RFile by a collection of ranges. This is a public iterator and meant to be used by a Scanner/Reader. The iterator works by taking in 1 or more ranges and then building a list of FencedReaders for each range. To allow a range for the whole file you can simply call the constructor with no Range collection or pass in a single Range that doesn't set the start/end keys. It extends `HeapIterator` and each `FencedReader` is added to the heap.

I also created a new interface called [RFileReader](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java#L1816) just so that the `RangedReader` and original `Reader` can implement it which I thought would make it a bit easier to swap out readers. `RFileReader` extends `FileSKVIterator`. The idea is that all the current places for scanning/reading that use an RFile reader expect `FileSKVIterator` which is why I implemented that. If we only implemented `SortedKeyValueIterator` it would be tricky since that doesn't support things like samples.

#### Other Implementation Notes

- Inside of `RangedReader`, just like `FencedReader`, getFirstKey()/getLastKey() are not implemented as they apply to the entire file and not really a good way to apply it to a fenced off file. I also had to comment out [closeDeepCopies()](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java#L1661) as we need the deep copies to stay open in between calls to close which happens normally while scanning. See [FileManager#releaseReaders()](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java#L367) and[ ScanDataSource#close() ](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java#L102)methods
- Also note that similar to closeDeepCopies() I had to make a change to the original `Reader` in [setInterruptFlag(](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java#L1534)) for this to work. I'm not entirely sure of the correct way to handle it but the existing implementation throws an exception if you call the method on a deep copy. This will not work because we deep copy for each Range so every time the interrupt flag was called it broke when testing scanning. I commented out that logic that throws the error for now and instead set the flag on the copies.

#### Testing

- I added `RangedRFileTest` which extends `RFileTest`. The reason to extend it is to show that running the original tests still work using the new iterator (some tweaks had to be made, like using getFirstKey()/getLastKey() of the original reader for test assertions). I also added 10 new ranged tests to show the iterator works to fence off by ranges. It's certainly not a complete list of tests but it at least demonstrates some basics.
- Also, I swapped out the `Reader` for a `RangedReader` in `RFileOperations` when a reader is [opened](https://github.com/cshannon/accumulo/blob/f4e5e66df9bca02d951a1801b5e9d459d815aea3/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java#L85) for files. Right now it's just using a single range for the whole file so not really fencing but I wanted to A) have a placeholder for when we do store ranges to pass in and 2) demonstrate the existing tests that scan work with the iterator. I've run this PR against the Sunny tests and everything passes.

#### Future Steps

So as noted this is still a work in progress and I expect significant changes of course based on feed back so please point out any things I might have missed or any suggestions. There are 2 other main pieces to supporting no-chop merges. The next thing to do would be to update the `StoredTabletFile` schema and to support storing a list of valid ranges for each file metadata entry and then update Accumulo to store this information. For now it could just be null/empty range to signal entire file. This part may be easier than the fenced reader and I should be able to start working on that concurrently with this PR now.

After that the third piece once we are can store ranges for a file and we have a reader that fences would be to update Accumulo to use the reader everywhere it needs to (ie for scans) and to update the compaction logic for merges to use the new iterator and metadata information instead of having to do chop compactions.