### PR TITLE
Convert Bulk Import metadata actions to use Ample

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -340,14 +340,31 @@ public interface Ample {
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Create a Bulk Load In Progress flag in the metadata table
+   *
+   * @param path The bulk directory filepath
+   * @param fateTxid The id of the Bulk Import Fate operation.
+   */
   default void addBulkLoadInProgressFlag(String path, long fateTxid) {
     throw new RuntimeException();
   }
 
+  /**
+   * Remove a Bulk Load In Progress flag from the metadata table.
+   *
+   * @param path The bulk directory filepath
+   */
   default void removeBulkLoadInProgressFlag(String path) {
     throw new RuntimeException();
   }
 
+  /**
+   * Remove all the Bulk Load transaction ids from a given table's metadata
+   *
+   * @param tableId Table ID for transaction removals
+   * @param tid Transaction ID to remove
+   */
   default void removeBulkLoadEntries(TableId tableId, long tid) throws Exception {}
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -347,4 +347,7 @@ public interface Ample {
   default void removeBulkLoadInProgressFlag(String path) {
     throw new RuntimeException();
   }
+
+  default void removeBulkLoadEntries(TableId tableId, long tid) throws Exception {}
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -347,7 +347,7 @@ public interface Ample {
    * @param fateTxid The id of the Bulk Import Fate operation.
    */
   default void addBulkLoadInProgressFlag(String path, long fateTxid) {
-    throw new RuntimeException();
+    throw new UnsupportedOperationException();
   }
 
   /**
@@ -356,7 +356,7 @@ public interface Ample {
    * @param path The bulk directory filepath
    */
   default void removeBulkLoadInProgressFlag(String path) {
-    throw new RuntimeException();
+    throw new UnsupportedOperationException();
   }
 
   /**
@@ -365,6 +365,8 @@ public interface Ample {
    * @param tableId Table ID for transaction removals
    * @param tid Transaction ID to remove
    */
-  default void removeBulkLoadEntries(TableId tableId, long tid) throws Exception {}
+  default void removeBulkLoadEntries(TableId tableId, long tid) {
+    throw new UnsupportedOperationException();
+  }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -339,4 +339,12 @@ public interface Ample {
   default void deleteScanServerFileReferences(String serverAddress, UUID serverSessionId) {
     throw new UnsupportedOperationException();
   }
+
+  default void addBulkLoadInProgressFlag(String path, long fateTxid) {
+    throw new RuntimeException();
+  }
+
+  default void removeBulkLoadInProgressFlag(String path) {
+    throw new RuntimeException();
+  }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.google.common.base.Preconditions;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.MutationsRejectedException;
@@ -135,8 +136,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   @Override
   public void putGcFileAndDirCandidates(TableId tableId, Collection<ReferenceFile> candidates) {
 
-    if (RootTable.ID.equals(tableId)) {
-
+    if (DataLevel.of(tableId) == DataLevel.ROOT) {
       // Directories are unexpected for the root tablet, so convert to stored tablet file
       mutateRootGcCandidates(rgcc -> rgcc.add(candidates.stream()
           .map(reference -> new StoredTabletFile(reference.getMetadataEntry()))));
@@ -184,6 +184,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
   @Override
   public void removeBulkLoadEntries(TableId tableId, long tid) {
+    Preconditions.checkArgument(DataLevel.of(tableId) == DataLevel.USER);
     try (
         Scanner mscanner =
             new IsolatedScanner(context.createScanner(MetadataTable.NAME, Authorizations.EMPTY));

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -159,14 +159,12 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
     // Bulk Import operations are not supported on the metadata table, so no entries will ever be
     // required on the root table.
-    KeyExtent extent = new KeyExtent(TableId.of("placeholder"), null, null);
     Mutation m = new Mutation(BlipSection.getRowPrefix() + path);
     m.put(EMPTY_TEXT, EMPTY_TEXT, new Value(FateTxId.formatTid(fateTxid)));
 
-    // Uses a "placeholder" table name to create a metadata table writer.
-    try (BatchWriter bw = createWriter(extent.tableId())) {
+    try (BatchWriter bw = context.createBatchWriter(MetadataTable.NAME)) {
       bw.addMutation(m);
-    } catch (MutationsRejectedException e) {
+    } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new RuntimeException(e);
     }
   }
@@ -176,14 +174,12 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
 
     // Bulk Import operations are not supported on the metadata table, so no entries will ever be
     // required on the root table.
-    KeyExtent extent = new KeyExtent(TableId.of("placeholder"), null, null);
     Mutation m = new Mutation(BlipSection.getRowPrefix() + path);
     m.putDelete(EMPTY_TEXT, EMPTY_TEXT);
 
-    // Uses a "placeholder" table name to create a metadata table writer.
-    try (BatchWriter writer = createWriter(extent.tableId())) {
-      writer.addMutation(m);
-    } catch (MutationsRejectedException e) {
+    try (BatchWriter bw = context.createBatchWriter(MetadataTable.NAME)) {
+      bw.addMutation(m);
+    } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new RuntimeException(e);
     }
   }
@@ -208,10 +204,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
           bw.addMutation(m);
         }
       }
-    } catch (MutationsRejectedException e) {
-      throw new RuntimeException(e);
-    } catch (TableNotFoundException e) {
-      // If the table is not found, could these entries already be deleted?
+    } catch (MutationsRejectedException | TableNotFoundException e) {
       throw new RuntimeException(e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -189,7 +189,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
   }
 
   @Override
-  public void removeBulkLoadEntries(TableId tableId, long tid) throws Exception {
+  public void removeBulkLoadEntries(TableId tableId, long tid) {
     try (
         Scanner mscanner =
             new IsolatedScanner(context.createScanner(MetadataTable.NAME, Authorizations.EMPTY));
@@ -208,6 +208,11 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
           bw.addMutation(m);
         }
       }
+    } catch (MutationsRejectedException e) {
+      throw new RuntimeException(e);
+    } catch (TableNotFoundException e) {
+      // If the table is not found, could these entries already be deleted?
+      throw new RuntimeException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.google.common.base.Preconditions;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IsolatedScanner;
 import org.apache.accumulo.core.client.MutationsRejectedException;
@@ -68,6 +67,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 public class ServerAmpleImpl extends AmpleImpl implements Ample {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -62,7 +62,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.zookeeper.ServiceLock;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.metadata.MetadataTable;
@@ -73,7 +72,6 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
-import org.apache.accumulo.core.metadata.schema.MetadataSchema.BlipSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
@@ -687,27 +685,6 @@ public class MetadataTableUtil {
         }
       }
     }
-  }
-
-  public static void addBulkLoadInProgressFlag(ServerContext context, String path, long fateTxid) {
-
-    Mutation m = new Mutation(BlipSection.getRowPrefix() + path);
-    m.put(EMPTY_TEXT, EMPTY_TEXT, new Value(FateTxId.formatTid(fateTxid)));
-
-    // new KeyExtent is only added to force update to write to the metadata table, not the root
-    // table
-    // because bulk loads aren't supported to the metadata table
-    update(context, m, new KeyExtent(TableId.of("anythingNotMetadata"), null, null));
-  }
-
-  public static void removeBulkLoadInProgressFlag(ServerContext context, String path) {
-
-    Mutation m = new Mutation(BlipSection.getRowPrefix() + path);
-    m.putDelete(EMPTY_TEXT, EMPTY_TEXT);
-
-    // new KeyExtent is only added to force update to write to the metadata table, not the root
-    // table because bulk loads aren't supported to the metadata table
-    update(context, m, new KeyExtent(TableId.of("anythingNotMetadata"), null, null));
   }
 
   public static SortedMap<Text,SortedMap<ColumnFQ,Value>>

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/BulkImport.java
@@ -47,7 +47,6 @@ import org.apache.accumulo.manager.tableOps.Utils;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.tablets.UniqueNameAllocator;
-import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -199,7 +198,7 @@ public class BulkImport extends ManagerRepo {
       TableId tableId, long tid) throws Exception {
     final Path bulkDir = createNewBulkDir(manager, fs, dir, tableId);
 
-    MetadataTableUtil.addBulkLoadInProgressFlag(manager,
+    manager.getAmple().addBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName(), tid);
 
     Path dirPath = new Path(dir);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
@@ -21,16 +21,15 @@ package org.apache.accumulo.manager.tableOps.bulkVer1;
 import java.util.Collections;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
+import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
-import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -59,13 +58,13 @@ public class CleanUpBulkImport extends ManagerRepo {
     manager.updateBulkImportStatus(source, BulkImportState.CLEANUP);
     log.debug("removing the bulkDir processing flag file in " + bulk);
     Path bulkDir = new Path(bulk);
-    manager.getContext().getAmple().removeBulkLoadInProgressFlag(
+    Ample metadataActions = manager.getContext().getAmple();
+    metadataActions.removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
-    manager.getContext().getAmple().putGcFileAndDirCandidates(tableId,
+    metadataActions.putGcFileAndDirCandidates(tableId,
         Collections.singleton(new ReferenceFile(tableId, bulkDir.toString())));
     log.debug("removing the metadata table markers for loaded files");
-    AccumuloClient client = manager.getContext();
-    MetadataTableUtil.removeBulkLoadEntries(client, tableId, tid);
+    metadataActions.removeBulkLoadEntries(tableId, tid);
     log.debug("releasing HDFS reservations for " + source + " and " + error);
     Utils.unreserveHdfsDirectory(manager, source, tid);
     Utils.unreserveHdfsDirectory(manager, error, tid);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
@@ -59,7 +59,7 @@ public class CleanUpBulkImport extends ManagerRepo {
     manager.updateBulkImportStatus(source, BulkImportState.CLEANUP);
     log.debug("removing the bulkDir processing flag file in " + bulk);
     Path bulkDir = new Path(bulk);
-    MetadataTableUtil.removeBulkLoadInProgressFlag(manager.getContext(),
+    manager.getContext().getAmple().removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
     manager.getContext().getAmple().putGcFileAndDirCandidates(tableId,
         Collections.singleton(new ReferenceFile(tableId, bulkDir.toString())));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer1/CleanUpBulkImport.java
@@ -58,13 +58,13 @@ public class CleanUpBulkImport extends ManagerRepo {
     manager.updateBulkImportStatus(source, BulkImportState.CLEANUP);
     log.debug("removing the bulkDir processing flag file in " + bulk);
     Path bulkDir = new Path(bulk);
-    Ample metadataActions = manager.getContext().getAmple();
-    metadataActions.removeBulkLoadInProgressFlag(
+    Ample ample = manager.getContext().getAmple();
+    ample.removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
-    metadataActions.putGcFileAndDirCandidates(tableId,
+    ample.putGcFileAndDirCandidates(tableId,
         Collections.singleton(new ReferenceFile(tableId, bulkDir.toString())));
     log.debug("removing the metadata table markers for loaded files");
-    metadataActions.removeBulkLoadEntries(tableId, tid);
+    ample.removeBulkLoadEntries(tableId, tid);
     log.debug("releasing HDFS reservations for " + source + " and " + error);
     Utils.unreserveHdfsDirectory(manager, source, tid);
     Utils.unreserveHdfsDirectory(manager, error, tid);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkImportMove.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/BulkImportMove.java
@@ -36,7 +36,6 @@ import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.server.fs.VolumeManager;
-import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -103,9 +102,8 @@ class BulkImportMove extends ManagerRepo {
    */
   private void moveFiles(long tid, Path sourceDir, Path bulkDir, Manager manager,
       final VolumeManager fs, Map<String,String> renames) throws Exception {
-    MetadataTableUtil.addBulkLoadInProgressFlag(manager.getContext(),
+    manager.getContext().getAmple().addBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName(), tid);
-
     AccumuloConfiguration aConf = manager.getConfiguration();
     @SuppressWarnings("deprecation")
     int workerCount = aConf.getCount(

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -52,15 +52,15 @@ public class CleanUpBulkImport extends ManagerRepo {
   public Repo<Manager> call(long tid, Manager manager) throws Exception {
     manager.updateBulkImportStatus(info.sourceDir, BulkImportState.CLEANUP);
     log.debug("removing the bulkDir processing flag file in " + info.bulkDir);
-    Ample metadataActions = manager.getContext().getAmple();
+    Ample ample = manager.getContext().getAmple();
     Path bulkDir = new Path(info.bulkDir);
-    metadataActions.removeBulkLoadInProgressFlag(
+    ample.removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
-    metadataActions.putGcFileAndDirCandidates(info.tableId,
+    ample.putGcFileAndDirCandidates(info.tableId,
         Collections.singleton(new ReferenceFile(info.tableId, bulkDir.toString())));
     if (info.tableState == TableState.ONLINE) {
       log.debug("removing the metadata table markers for loaded files");
-      metadataActions.removeBulkLoadEntries(info.tableId, tid);
+      ample.removeBulkLoadEntries(info.tableId, tid);
     }
     Utils.unreserveHdfsDirectory(manager, info.sourceDir, tid);
     Utils.getReadLock(manager, info.tableId, tid).unlock();

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -54,7 +54,7 @@ public class CleanUpBulkImport extends ManagerRepo {
     manager.updateBulkImportStatus(info.sourceDir, BulkImportState.CLEANUP);
     log.debug("removing the bulkDir processing flag file in " + info.bulkDir);
     Path bulkDir = new Path(info.bulkDir);
-    MetadataTableUtil.removeBulkLoadInProgressFlag(manager.getContext(),
+    manager.getContext().getAmple().removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
     manager.getContext().getAmple().putGcFileAndDirCandidates(info.tableId,
         Collections.singleton(new ReferenceFile(info.tableId, bulkDir.toString())));

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -22,16 +22,15 @@ import java.io.IOException;
 import java.util.Collections;
 
 import org.apache.accumulo.core.Constants;
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
+import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
-import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.accumulo.server.zookeeper.TransactionWatcher.ZooArbitrator;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -53,15 +52,15 @@ public class CleanUpBulkImport extends ManagerRepo {
   public Repo<Manager> call(long tid, Manager manager) throws Exception {
     manager.updateBulkImportStatus(info.sourceDir, BulkImportState.CLEANUP);
     log.debug("removing the bulkDir processing flag file in " + info.bulkDir);
+    Ample metadataActions = manager.getContext().getAmple();
     Path bulkDir = new Path(info.bulkDir);
-    manager.getContext().getAmple().removeBulkLoadInProgressFlag(
+    metadataActions.removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
-    manager.getContext().getAmple().putGcFileAndDirCandidates(info.tableId,
+    metadataActions.putGcFileAndDirCandidates(info.tableId,
         Collections.singleton(new ReferenceFile(info.tableId, bulkDir.toString())));
     if (info.tableState == TableState.ONLINE) {
       log.debug("removing the metadata table markers for loaded files");
-      AccumuloClient client = manager.getContext();
-      MetadataTableUtil.removeBulkLoadEntries(client, info.tableId, tid);
+      metadataActions.removeBulkLoadEntries(info.tableId, tid);
     }
     Utils.unreserveHdfsDirectory(manager, info.sourceDir, tid);
     Utils.getReadLock(manager, info.tableId, tid).unlock();


### PR DESCRIPTION
Refactor's the Bulk Import metadata operations from the MetadataTableUtil class and migrate them to use Ample instead. 

This is a part of #3208. 