### PR TITLE
Refactor TabletMetadata.Location to encapsulate TServerInstance

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1405,7 +1405,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           lastRow = tablet.getExtent().toMetaRow();
 
           if (loc != null) {
-            serverCounts.increment(loc.getHostPortSession(), 1);
+            serverCounts.increment(loc.getServerInstance().getHostPortSession(), 1);
           }
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -1405,7 +1405,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           lastRow = tablet.getExtent().toMetaRow();
 
           if (loc != null) {
-            serverCounts.increment(loc.getServerInstance().getHostPortSession(), 1);
+            serverCounts.increment(loc.getHostPortSession(), 1);
           }
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
@@ -83,6 +83,22 @@ public class TabletLocationState {
   public final Collection<Collection<String>> walogs;
   public final boolean chopped;
 
+  public TServerInstance getCurrentServer() {
+    return serverInstance(current);
+  }
+
+  public TServerInstance getFutureServer() {
+    return serverInstance(future);
+  }
+
+  public TServerInstance getLastServer() {
+    return serverInstance(last);
+  }
+
+  public TServerInstance futureOrCurrentServer() {
+    return serverInstance(futureOrCurrent());
+  }
+
   public Location futureOrCurrent() {
     if (hasCurrent()) {
       return current;
@@ -90,9 +106,8 @@ public class TabletLocationState {
     return future;
   }
 
-  @Override
-  public String toString() {
-    return extent + "@(" + future + "," + current + "," + last + ")" + (chopped ? " chopped" : "");
+  public TServerInstance getServer() {
+    return serverInstance(getLocation());
   }
 
   public Location getLocation() {
@@ -133,10 +148,20 @@ public class TabletLocationState {
     }
   }
 
-  private static Location validateLocation(Location location, TabletMetadata.LocationType type) {
+  @Override
+  public String toString() {
+    return extent + "@(" + future + "," + current + "," + last + ")" + (chopped ? " chopped" : "");
+  }
+
+  private static Location validateLocation(final Location location,
+      final TabletMetadata.LocationType type) {
     if (location != null && !location.getType().equals(type)) {
       throw new IllegalArgumentException("Location type is required to be of type " + type);
     }
     return location;
+  }
+
+  protected static TServerInstance serverInstance(final Location location) {
+    return location != null ? location.getServerInstance() : null;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
 
@@ -54,9 +55,9 @@ public class TabletLocationState {
     }
   }
 
-  public TabletLocationState(KeyExtent extent, TabletMetadata.Location future,
-      TabletMetadata.Location current, TabletMetadata.Location last, SuspendingTServer suspend,
-      Collection<Collection<String>> walogs, boolean chopped) throws BadLocationStateException {
+  public TabletLocationState(KeyExtent extent, Location future, Location current, Location last,
+      SuspendingTServer suspend, Collection<Collection<String>> walogs, boolean chopped)
+      throws BadLocationStateException {
     this.extent = extent;
     this.future = validateLocation(future, TabletMetadata.LocationType.FUTURE);
     this.current = validateLocation(current, TabletMetadata.LocationType.CURRENT);
@@ -75,14 +76,14 @@ public class TabletLocationState {
   }
 
   public final KeyExtent extent;
-  public final TabletMetadata.Location future;
-  public final TabletMetadata.Location current;
-  public final TabletMetadata.Location last;
+  public final Location future;
+  public final Location current;
+  public final Location last;
   public final SuspendingTServer suspend;
   public final Collection<Collection<String>> walogs;
   public final boolean chopped;
 
-  public TabletMetadata.Location futureOrCurrent() {
+  public Location futureOrCurrent() {
     if (hasCurrent()) {
       return current;
     }
@@ -94,8 +95,8 @@ public class TabletLocationState {
     return extent + "@(" + future + "," + current + "," + last + ")" + (chopped ? " chopped" : "");
   }
 
-  public TabletMetadata.Location getLocation() {
-    TabletMetadata.Location result = null;
+  public Location getLocation() {
+    Location result = null;
     if (hasCurrent()) {
       result = current;
     } else if (hasFuture()) {
@@ -132,8 +133,7 @@ public class TabletLocationState {
     }
   }
 
-  private static TabletMetadata.Location validateLocation(TabletMetadata.Location location,
-      TabletMetadata.LocationType type) {
+  private static Location validateLocation(Location location, TabletMetadata.LocationType type) {
     if (location != null && !location.getType().equals(type)) {
       throw new IllegalArgumentException("Location type is required to be of type " + type);
     }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletLocationState.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.io.Text;
 
@@ -53,13 +54,13 @@ public class TabletLocationState {
     }
   }
 
-  public TabletLocationState(KeyExtent extent, TServerInstance future, TServerInstance current,
-      TServerInstance last, SuspendingTServer suspend, Collection<Collection<String>> walogs,
-      boolean chopped) throws BadLocationStateException {
+  public TabletLocationState(KeyExtent extent, TabletMetadata.Location future,
+      TabletMetadata.Location current, TabletMetadata.Location last, SuspendingTServer suspend,
+      Collection<Collection<String>> walogs, boolean chopped) throws BadLocationStateException {
     this.extent = extent;
-    this.future = future;
-    this.current = current;
-    this.last = last;
+    this.future = validateLocation(future, TabletMetadata.LocationType.FUTURE);
+    this.current = validateLocation(current, TabletMetadata.LocationType.CURRENT);
+    this.last = validateLocation(last, TabletMetadata.LocationType.LAST);
     this.suspend = suspend;
     if (walogs == null) {
       walogs = Collections.emptyList();
@@ -74,14 +75,14 @@ public class TabletLocationState {
   }
 
   public final KeyExtent extent;
-  public final TServerInstance future;
-  public final TServerInstance current;
-  public final TServerInstance last;
+  public final TabletMetadata.Location future;
+  public final TabletMetadata.Location current;
+  public final TabletMetadata.Location last;
   public final SuspendingTServer suspend;
   public final Collection<Collection<String>> walogs;
   public final boolean chopped;
 
-  public TServerInstance futureOrCurrent() {
+  public TabletMetadata.Location futureOrCurrent() {
     if (hasCurrent()) {
       return current;
     }
@@ -93,8 +94,8 @@ public class TabletLocationState {
     return extent + "@(" + future + "," + current + "," + last + ")" + (chopped ? " chopped" : "");
   }
 
-  public TServerInstance getLocation() {
-    TServerInstance result = null;
+  public TabletMetadata.Location getLocation() {
+    TabletMetadata.Location result = null;
     if (hasCurrent()) {
       result = current;
     } else if (hasFuture()) {
@@ -119,15 +120,23 @@ public class TabletLocationState {
 
   public TabletState getState(Set<TServerInstance> liveServers) {
     if (hasFuture()) {
-      return liveServers.contains(future) ? TabletState.ASSIGNED
+      return liveServers.contains(future.getServerInstance()) ? TabletState.ASSIGNED
           : TabletState.ASSIGNED_TO_DEAD_SERVER;
     } else if (hasCurrent()) {
-      return liveServers.contains(current) ? TabletState.HOSTED
+      return liveServers.contains(current.getServerInstance()) ? TabletState.HOSTED
           : TabletState.ASSIGNED_TO_DEAD_SERVER;
     } else if (hasSuspend()) {
       return TabletState.SUSPENDED;
     } else {
       return TabletState.UNASSIGNED;
     }
+  }
+
+  private static TabletMetadata.Location validateLocation(TabletMetadata.Location location,
+      TabletMetadata.LocationType type) {
+    if (location != null && !location.getType().equals(type)) {
+      throw new IllegalArgumentException("Location type is required to be of type " + type);
+    }
+    return location;
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.hadoop.io.Text;
 
@@ -256,9 +257,9 @@ public interface Ample {
 
     TabletMutator putFlushId(long flushId);
 
-    TabletMutator putLocation(TabletMetadata.Location location);
+    TabletMutator putLocation(Location location);
 
-    TabletMutator deleteLocation(TabletMetadata.Location location);
+    TabletMutator deleteLocation(Location location);
 
     TabletMutator putZooLock(ServiceLock zooLock);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -35,7 +35,6 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.hadoop.io.Text;
 
@@ -257,9 +256,9 @@ public interface Ample {
 
     TabletMutator putFlushId(long flushId);
 
-    TabletMutator putLocation(TServerInstance tserver, LocationType type);
+    TabletMutator putLocation(TabletMetadata.Location location);
 
-    TabletMutator deleteLocation(TServerInstance tserver, LocationType type);
+    TabletMutator deleteLocation(TabletMetadata.Location location);
 
     TabletMutator putZooLock(ServiceLock zooLock);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -197,7 +197,7 @@ public class TabletMetadata {
     }
 
     public static Location last(final String server, final String session) {
-      return current(new TServerInstance(HostAndPort.fromString(server), session));
+      return last(new TServerInstance(HostAndPort.fromString(server), session));
     }
 
     public static Location current(TServerInstance instance) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -137,11 +137,11 @@ public class TabletMetadata {
     private final TServerInstance tServerInstance;
     private final LocationType lt;
 
-    public Location(final String server, final String session, final LocationType lt) {
+    private Location(final String server, final String session, final LocationType lt) {
       this(new TServerInstance(HostAndPort.fromString(server), session), lt);
     }
 
-    public Location(final TServerInstance tServerInstance, final LocationType lt) {
+    private Location(final TServerInstance tServerInstance, final LocationType lt) {
       this.tServerInstance =
           Objects.requireNonNull(tServerInstance, "tServerInstance must not be null");
       this.lt = Objects.requireNonNull(lt, "locationType must not be null");
@@ -196,12 +196,24 @@ public class TabletMetadata {
       return new Location(instance, LocationType.LAST);
     }
 
+    public static Location last(final String server, final String session) {
+      return current(new TServerInstance(HostAndPort.fromString(server), session));
+    }
+
     public static Location current(TServerInstance instance) {
       return new Location(instance, LocationType.CURRENT);
     }
 
+    public static Location current(final String server, final String session) {
+      return current(new TServerInstance(HostAndPort.fromString(server), session));
+    }
+
     public static Location future(TServerInstance instance) {
       return new Location(instance, LocationType.FUTURE);
+    }
+
+    public static Location future(final String server, final String session) {
+      return future(new TServerInstance(HostAndPort.fromString(server), session));
     }
 
   }
@@ -449,7 +461,7 @@ public class TabletMetadata {
           te.setLocationOnce(val, qual, LocationType.FUTURE);
           break;
         case LastLocationColumnFamily.STR_NAME:
-          te.last = new Location(val, qual, LocationType.LAST);
+          te.last = Location.last(val, qual);
           break;
         case SuspendLocationColumn.STR_NAME:
           te.suspend = SuspendingTServer.fromValue(kv.getValue());

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -133,17 +133,77 @@ public class TabletMetadata {
     ECOMP
   }
 
-  public static class Location extends TServerInstance {
+  public static class Location {
+    private final TServerInstance tServerInstance;
     private final LocationType lt;
 
-    public Location(String server, String session, LocationType lt) {
-      super(HostAndPort.fromString(server), session);
-      this.lt = lt;
+    public Location(final String server, final String session, final LocationType lt) {
+      this(new TServerInstance(HostAndPort.fromString(server), session), lt);
+    }
+
+    public Location(final TServerInstance tServerInstance, final LocationType lt) {
+      this.tServerInstance =
+          Objects.requireNonNull(tServerInstance, "tServerInstance must not be null");
+      this.lt = Objects.requireNonNull(lt, "locationType must not be null");
     }
 
     public LocationType getType() {
       return lt;
     }
+
+    public TServerInstance getServerInstance() {
+      return tServerInstance;
+    }
+
+    public String getHostPortSession() {
+      return tServerInstance.getHostPortSession();
+    }
+
+    public String getHost() {
+      return tServerInstance.getHost();
+    }
+
+    public String getHostPort() {
+      return tServerInstance.getHostPort();
+    }
+
+    public HostAndPort getHostAndPort() {
+      return tServerInstance.getHostAndPort();
+    }
+
+    public String getSession() {
+      return tServerInstance.getSession();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Location location = (Location) o;
+      return Objects.equals(tServerInstance, location.tServerInstance) && lt == location.lt;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(tServerInstance, lt);
+    }
+
+    public static Location last(TServerInstance instance) {
+      return new Location(instance, LocationType.LAST);
+    }
+
+    public static Location current(TServerInstance instance) {
+      return new Location(instance, LocationType.CURRENT);
+    }
+
+    public static Location future(TServerInstance instance) {
+      return new Location(instance, LocationType.FUTURE);
+    }
+
   }
 
   public TableId getTableId() {
@@ -283,8 +343,8 @@ public class TabletMetadata {
     ensureFetched(ColumnType.LAST);
     ensureFetched(ColumnType.SUSPEND);
     try {
-      TServerInstance current = null;
-      TServerInstance future = null;
+      Location current = null;
+      Location future = null;
       if (hasCurrent()) {
         current = location;
       } else {

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -196,7 +196,7 @@ public class TabletMetadataTest {
     TabletState state = tm.getTabletState(tservers);
 
     assertEquals(TabletState.ASSIGNED, state);
-    assertEquals(ser1, tm.getLocation());
+    assertEquals(ser1, tm.getLocation().getServerInstance());
     assertEquals(ser1.getSession(), tm.getLocation().getSession());
     assertEquals(LocationType.FUTURE, tm.getLocation().getType());
     assertFalse(tm.hasCurrent());
@@ -210,7 +210,7 @@ public class TabletMetadataTest {
     tm = TabletMetadata.convertRow(rowMap.entrySet().iterator(), colsToFetch, false);
 
     assertEquals(TabletState.HOSTED, tm.getTabletState(tservers));
-    assertEquals(ser2, tm.getLocation());
+    assertEquals(ser2, tm.getLocation().getServerInstance());
     assertEquals(ser2.getSession(), tm.getLocation().getSession());
     assertEquals(LocationType.CURRENT, tm.getLocation().getType());
     assertTrue(tm.hasCurrent());
@@ -224,7 +224,7 @@ public class TabletMetadataTest {
     tm = TabletMetadata.convertRow(rowMap.entrySet().iterator(), colsToFetch, false);
 
     assertEquals(TabletState.ASSIGNED_TO_DEAD_SERVER, tm.getTabletState(tservers));
-    assertEquals(deadSer, tm.getLocation());
+    assertEquals(deadSer, tm.getLocation().getServerInstance());
     assertEquals(deadSer.getSession(), tm.getLocation().getSession());
     assertEquals(LocationType.CURRENT, tm.getLocation().getType());
     assertTrue(tm.hasCurrent());

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/balancer/BalancerEnvironmentImpl.java
@@ -24,6 +24,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
@@ -36,6 +37,7 @@ import org.apache.accumulo.core.dataImpl.TabletIdImpl;
 import org.apache.accumulo.core.manager.balancer.TabletServerIdImpl;
 import org.apache.accumulo.core.manager.balancer.TabletStatisticsImpl;
 import org.apache.accumulo.core.manager.state.tables.TableState;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -75,7 +77,8 @@ public class BalancerEnvironmentImpl extends ServiceEnvironmentImpl implements B
     for (var tm : TabletsMetadata.builder(getContext()).forTable(tableId).fetch(LOCATION, PREV_ROW)
         .build()) {
       tablets.put(new TabletIdImpl(tm.getExtent()),
-          TabletServerIdImpl.fromThrift(tm.getLocation()));
+          TabletServerIdImpl.fromThrift(Optional.ofNullable(tm.getLocation())
+              .map(TabletMetadata.Location::getServerInstance).orElse(null)));
     }
     return tablets;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
@@ -126,7 +126,7 @@ class MetaDataStateStore implements TabletStateStore {
         if (tls.suspend != null && suspensionTimestamp < 0) {
           tabletMutator.deleteSuspension();
         }
-        if (tls.future != null) {
+        if (tls.hasFuture()) {
           tabletMutator.deleteLocation(tls.future);
         }
         tabletMutator.mutate();

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataStateStore.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.server.util.ManagerMetadataUtil;
 import org.apache.hadoop.fs.Path;
@@ -62,10 +62,10 @@ class MetaDataStateStore implements TabletStateStore {
     try (var tabletsMutator = ample.mutateTablets()) {
       for (Assignment assignment : assignments) {
         TabletMutator tabletMutator = tabletsMutator.mutateTablet(assignment.tablet);
-        tabletMutator.putLocation(TabletMetadata.Location.current(assignment.server));
+        tabletMutator.putLocation(Location.current(assignment.server));
         ManagerMetadataUtil.updateLastForAssignmentMode(context, ample, tabletMutator,
             assignment.tablet, assignment.server);
-        tabletMutator.deleteLocation(TabletMetadata.Location.future(assignment.server));
+        tabletMutator.deleteLocation(Location.future(assignment.server));
         tabletMutator.deleteSuspension();
         tabletMutator.mutate();
       }
@@ -80,7 +80,7 @@ class MetaDataStateStore implements TabletStateStore {
     try (var tabletsMutator = ample.mutateTablets()) {
       for (Assignment assignment : assignments) {
         tabletsMutator.mutateTablet(assignment.tablet).deleteSuspension()
-            .putLocation(TabletMetadata.Location.future(assignment.server)).mutate();
+            .putLocation(Location.future(assignment.server)).mutate();
       }
     } catch (RuntimeException ex) {
       throw new DistributedStoreException(ex);

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
@@ -52,7 +52,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.La
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.cleaner.CleanerUtil;
 import org.apache.hadoop.io.Text;
@@ -146,9 +146,9 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       throws IOException, BadLocationStateException {
     final SortedMap<Key,Value> decodedRow = WholeRowIterator.decodeRow(k, v);
     KeyExtent extent = null;
-    TabletMetadata.Location future = null;
-    TabletMetadata.Location current = null;
-    TabletMetadata.Location last = null;
+    Location future = null;
+    Location current = null;
+    Location last = null;
     SuspendingTServer suspend = null;
     long lastTimestamp = 0;
     List<Collection<String>> walogs = new ArrayList<>();
@@ -162,16 +162,14 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       Text cq = key.getColumnQualifier();
 
       if (cf.compareTo(FutureLocationColumnFamily.NAME) == 0) {
-        TabletMetadata.Location location =
-            TabletMetadata.Location.future(new TServerInstance(entry.getValue(), cq));
+        Location location = Location.future(new TServerInstance(entry.getValue(), cq));
         if (future != null) {
           throw new BadLocationStateException("found two assignments for the same extent " + row
               + ": " + future + " and " + location, row);
         }
         future = location;
       } else if (cf.compareTo(CurrentLocationColumnFamily.NAME) == 0) {
-        TabletMetadata.Location location =
-            TabletMetadata.Location.current(new TServerInstance(entry.getValue(), cq));
+        Location location = Location.current(new TServerInstance(entry.getValue(), cq));
         if (current != null) {
           throw new BadLocationStateException("found two locations for the same extent " + row
               + ": " + current + " and " + location, row);
@@ -182,7 +180,7 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
         walogs.add(Arrays.asList(split));
       } else if (cf.compareTo(LastLocationColumnFamily.NAME) == 0) {
         if (lastTimestamp < entry.getKey().getTimestamp()) {
-          last = TabletMetadata.Location.last(new TServerInstance(entry.getValue(), cq));
+          last = Location.last(new TServerInstance(entry.getValue(), cq));
         }
       } else if (cf.compareTo(ChoppedColumnFamily.NAME) == 0) {
         chopped = true;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
@@ -52,6 +52,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.La
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.LogColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.cleaner.CleanerUtil;
 import org.apache.hadoop.io.Text;
@@ -145,9 +146,9 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       throws IOException, BadLocationStateException {
     final SortedMap<Key,Value> decodedRow = WholeRowIterator.decodeRow(k, v);
     KeyExtent extent = null;
-    TServerInstance future = null;
-    TServerInstance current = null;
-    TServerInstance last = null;
+    TabletMetadata.Location future = null;
+    TabletMetadata.Location current = null;
+    TabletMetadata.Location last = null;
     SuspendingTServer suspend = null;
     long lastTimestamp = 0;
     List<Collection<String>> walogs = new ArrayList<>();
@@ -161,14 +162,16 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       Text cq = key.getColumnQualifier();
 
       if (cf.compareTo(FutureLocationColumnFamily.NAME) == 0) {
-        TServerInstance location = new TServerInstance(entry.getValue(), cq);
+        TabletMetadata.Location location =
+            TabletMetadata.Location.future(new TServerInstance(entry.getValue(), cq));
         if (future != null) {
           throw new BadLocationStateException("found two assignments for the same extent " + row
               + ": " + future + " and " + location, row);
         }
         future = location;
       } else if (cf.compareTo(CurrentLocationColumnFamily.NAME) == 0) {
-        TServerInstance location = new TServerInstance(entry.getValue(), cq);
+        TabletMetadata.Location location =
+            TabletMetadata.Location.current(new TServerInstance(entry.getValue(), cq));
         if (current != null) {
           throw new BadLocationStateException("found two locations for the same extent " + row
               + ": " + current + " and " + location, row);
@@ -179,7 +182,7 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
         walogs.add(Arrays.asList(split));
       } else if (cf.compareTo(LastLocationColumnFamily.NAME) == 0) {
         if (lastTimestamp < entry.getKey().getTimestamp()) {
-          last = new TServerInstance(entry.getValue(), cq);
+          last = TabletMetadata.Location.last(new TServerInstance(entry.getValue(), cq));
         }
       } else if (cf.compareTo(ChoppedColumnFamily.NAME) == 0) {
         chopped = true;

--- a/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/master/balancer/GroupBalancer.java
@@ -94,7 +94,7 @@ public abstract class GroupBalancer extends TabletBalancer {
     Map<KeyExtent,TServerInstance> tablets = new LinkedHashMap<>();
     for (var tm : TabletsMetadata.builder(context).forTable(tableId).fetch(LOCATION, PREV_ROW)
         .build()) {
-      tablets.put(tm.getExtent(), tm.getLocation());
+      tablets.put(tm.getExtent(), tm.getLocation().getServerInstance());
     }
     return tablets;
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -45,6 +45,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.server.ServerContext;
@@ -142,16 +143,17 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putLocation(TServerInstance tsi, LocationType type) {
+  public Ample.TabletMutator putLocation(TabletMetadata.Location location) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    mutation.put(getLocationFamily(type), tsi.getSession(), tsi.getHostPort());
+    mutation.put(getLocationFamily(location.getType()), location.getSession(),
+        location.getHostPort());
     return this;
   }
 
   @Override
-  public Ample.TabletMutator deleteLocation(TServerInstance tsi, LocationType type) {
+  public Ample.TabletMutator deleteLocation(TabletMetadata.Location location) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    mutation.putDelete(getLocationFamily(type), tsi.getSession());
+    mutation.putDelete(getLocationFamily(location.getType()), location.getSession());
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.SuspendLocationColumn;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.server.ServerContext;
@@ -143,7 +143,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putLocation(TabletMetadata.Location location) {
+  public Ample.TabletMutator putLocation(Location location) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.put(getLocationFamily(location.getType()), location.getSession(),
         location.getHostPort());
@@ -151,7 +151,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator deleteLocation(TabletMetadata.Location location) {
+  public Ample.TabletMutator deleteLocation(Location location) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.putDelete(getLocationFamily(location.getType()), location.getSession());
     return this;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -56,7 +56,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.hadoop.io.Text;
@@ -69,7 +68,7 @@ public class ManagerMetadataUtil {
   private static final Logger log = LoggerFactory.getLogger(ManagerMetadataUtil.class);
 
   public static void addNewTablet(ServerContext context, KeyExtent extent, String dirName,
-      TServerInstance location, Map<StoredTabletFile,DataFileValue> datafileSizes,
+      TServerInstance tServerInstance, Map<StoredTabletFile,DataFileValue> datafileSizes,
       Map<Long,? extends Collection<TabletFile>> bulkLoadedFiles, MetadataTime time,
       long lastFlushID, long lastCompactID, ServiceLock zooLock) {
 
@@ -87,9 +86,9 @@ public class ManagerMetadataUtil {
       tablet.putCompactionId(lastCompactID);
     }
 
-    if (location != null) {
-      tablet.putLocation(location, LocationType.CURRENT);
-      tablet.deleteLocation(location, LocationType.FUTURE);
+    if (tServerInstance != null) {
+      tablet.putLocation(TabletMetadata.Location.current(tServerInstance));
+      tablet.deleteLocation(TabletMetadata.Location.future(tServerInstance));
     }
 
     datafileSizes.forEach(tablet::putFile);
@@ -190,7 +189,8 @@ public class ManagerMetadataUtil {
   public static void replaceDatafiles(ServerContext context, KeyExtent extent,
       Set<StoredTabletFile> datafilesToDelete, Set<StoredTabletFile> scanFiles,
       Optional<StoredTabletFile> path, Long compactionId, DataFileValue size, String address,
-      TServerInstance lastLocation, ServiceLock zooLock, Optional<ExternalCompactionId> ecid) {
+      TabletMetadata.Location lastLocation, ServiceLock zooLock,
+      Optional<ExternalCompactionId> ecid) {
 
     context.getAmple().putGcCandidates(extent.tableId(), datafilesToDelete);
 
@@ -223,8 +223,8 @@ public class ManagerMetadataUtil {
    */
   public static Optional<StoredTabletFile> updateTabletDataFile(ServerContext context,
       KeyExtent extent, TabletFile newDatafile, DataFileValue dfv, MetadataTime time,
-      String address, ServiceLock zooLock, Set<String> unusedWalLogs, TServerInstance lastLocation,
-      long flushId) {
+      String address, ServiceLock zooLock, Set<String> unusedWalLogs,
+      TabletMetadata.Location lastLocation, long flushId) {
 
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
     // if there are no entries, the path doesn't get stored in metadata table, only the flush ID
@@ -264,8 +264,9 @@ public class ManagerMetadataUtil {
     // location value
     if ("assignment".equals(context.getConfiguration().get(Property.TSERV_LAST_LOCATION_MODE))) {
       TabletMetadata lastMetadata = ample.readTablet(extent, TabletMetadata.ColumnType.LAST);
-      TServerInstance lastLocation = (lastMetadata == null ? null : lastMetadata.getLast());
-      ManagerMetadataUtil.updateLast(tabletMutator, lastLocation, location);
+      TabletMetadata.Location lastLocation = (lastMetadata == null ? null : lastMetadata.getLast());
+      ManagerMetadataUtil.updateLocation(tabletMutator, lastLocation,
+          TabletMetadata.Location.last(location));
     }
   }
 
@@ -280,31 +281,32 @@ public class ManagerMetadataUtil {
    * @param zooLock The zookeeper lock
    */
   public static void updateLastForCompactionMode(ClientContext context, TabletMutator tabletMutator,
-      TServerInstance lastLocation, String address, ServiceLock zooLock) {
+      TabletMetadata.Location lastLocation, String address, ServiceLock zooLock) {
     // if the location mode is 'compaction', then preserve the current compaction location in the
     // last location value
     if ("compaction".equals(context.getConfiguration().get(Property.TSERV_LAST_LOCATION_MODE))) {
-      TServerInstance newLocation = getTServerInstance(address, zooLock);
-      updateLast(tabletMutator, lastLocation, newLocation);
+      TabletMetadata.Location newLocation =
+          TabletMetadata.Location.last(getTServerInstance(address, zooLock));
+      updateLocation(tabletMutator, lastLocation, newLocation);
     }
   }
 
   /**
-   * Update the last location, deleting the previous location if needed
+   * Update the location, deleting the previous location if needed
    *
    * @param tabletMutator The mutator being built
-   * @param lastLocation The last location (may be null)
+   * @param previousLocation The location (may be null)
    * @param newLocation The new location
    */
-  public static void updateLast(TabletMutator tabletMutator, TServerInstance lastLocation,
-      TServerInstance newLocation) {
-    if (lastLocation != null) {
-      if (!lastLocation.equals(newLocation)) {
-        tabletMutator.deleteLocation(lastLocation, LocationType.LAST);
-        tabletMutator.putLocation(newLocation, LocationType.LAST);
+  private static void updateLocation(TabletMutator tabletMutator,
+      TabletMetadata.Location previousLocation, TabletMetadata.Location newLocation) {
+    if (previousLocation != null) {
+      if (!previousLocation.equals(newLocation)) {
+        tabletMutator.deleteLocation(previousLocation);
+        tabletMutator.putLocation(newLocation);
       }
     } else {
-      tabletMutator.putLocation(newLocation, LocationType.LAST);
+      tabletMutator.putLocation(newLocation);
     }
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
@@ -102,7 +102,7 @@ public class RootTabletStateStoreTest {
     int count = 0;
     for (TabletLocationState location : tstore) {
       assertEquals(location.extent, root);
-      assertEquals(location.future, server);
+      assertEquals(location.future.getServerInstance(), server);
       assertNull(location.current);
       count++;
     }
@@ -112,13 +112,14 @@ public class RootTabletStateStoreTest {
     for (TabletLocationState location : tstore) {
       assertEquals(location.extent, root);
       assertNull(location.future);
-      assertEquals(location.current, server);
+      assertEquals(location.current.getServerInstance(), server);
       count++;
     }
     assertEquals(count, 1);
     TabletLocationState assigned = null;
     try {
-      assigned = new TabletLocationState(root, server, null, null, null, null, false);
+      assigned = new TabletLocationState(root, TabletMetadata.Location.future(server), null, null,
+          null, null, false);
     } catch (BadLocationStateException e) {
       fail("Unexpected error " + e);
     }
@@ -139,8 +140,9 @@ public class RootTabletStateStoreTest {
     assertThrows(IllegalArgumentException.class, () -> tstore.setFutureLocations(assignmentList));
 
     try {
-      TabletLocationState broken =
-          new TabletLocationState(notRoot, server, null, null, null, null, false);
+      TabletLocationState broken = new TabletLocationState(notRoot,
+          new TabletMetadata.Location(server, TabletMetadata.LocationType.FUTURE), null, null, null,
+          null, false);
       final var assignmentList1 = List.of(broken);
       assertThrows(IllegalArgumentException.class, () -> tstore.unassign(assignmentList1, null));
     } catch (BadLocationStateException e) {

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/RootTabletStateStoreTest.java
@@ -40,6 +40,7 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.HostAndPort;
 import org.apache.accumulo.server.MockServerContext;
@@ -118,8 +119,8 @@ public class RootTabletStateStoreTest {
     assertEquals(count, 1);
     TabletLocationState assigned = null;
     try {
-      assigned = new TabletLocationState(root, TabletMetadata.Location.future(server), null, null,
-          null, null, false);
+      assigned =
+          new TabletLocationState(root, Location.future(server), null, null, null, null, false);
     } catch (BadLocationStateException e) {
       fail("Unexpected error " + e);
     }
@@ -140,9 +141,8 @@ public class RootTabletStateStoreTest {
     assertThrows(IllegalArgumentException.class, () -> tstore.setFutureLocations(assignmentList));
 
     try {
-      TabletLocationState broken = new TabletLocationState(notRoot,
-          new TabletMetadata.Location(server, TabletMetadata.LocationType.FUTURE), null, null, null,
-          null, false);
+      TabletLocationState broken =
+          new TabletLocationState(notRoot, Location.future(server), null, null, null, null, false);
       final var assignmentList1 = List.of(broken);
       assertThrows(IllegalArgumentException.class, () -> tstore.unassign(assignmentList1, null));
     } catch (BadLocationStateException e) {

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletState;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,17 +52,17 @@ public class TabletLocationStateTest {
   }
 
   private KeyExtent keyExtent;
-  private TServerInstance future;
-  private TServerInstance current;
-  private TServerInstance last;
+  private TabletMetadata.Location future;
+  private TabletMetadata.Location current;
+  private TabletMetadata.Location last;
   private TabletLocationState tls;
 
   @BeforeEach
   public void setUp() {
     keyExtent = createMock(KeyExtent.class);
-    future = createMock(TServerInstance.class);
-    current = createMock(TServerInstance.class);
-    last = createMock(TServerInstance.class);
+    future = TabletMetadata.Location.future(createMock(TServerInstance.class));
+    current = TabletMetadata.Location.current(createMock(TServerInstance.class));
+    last = TabletMetadata.Location.last(createMock(TServerInstance.class));
   }
 
   @Test
@@ -141,7 +142,7 @@ public class TabletLocationStateTest {
   @Test
   public void testGetState_Assigned() throws Exception {
     Set<TServerInstance> liveServers = new java.util.HashSet<>();
-    liveServers.add(future);
+    liveServers.add(future.getServerInstance());
     tls = new TabletLocationState(keyExtent, future, null, last, null, walogs, true);
     assertEquals(TabletState.ASSIGNED, tls.getState(liveServers));
   }
@@ -149,7 +150,7 @@ public class TabletLocationStateTest {
   @Test
   public void testGetState_Hosted() throws Exception {
     Set<TServerInstance> liveServers = new java.util.HashSet<>();
-    liveServers.add(current);
+    liveServers.add(current.getServerInstance());
     tls = new TabletLocationState(keyExtent, null, current, last, null, walogs, true);
     assertEquals(TabletState.HOSTED, tls.getState(liveServers));
   }
@@ -157,7 +158,7 @@ public class TabletLocationStateTest {
   @Test
   public void testGetState_Dead1() throws Exception {
     Set<TServerInstance> liveServers = new java.util.HashSet<>();
-    liveServers.add(current);
+    liveServers.add(current.getServerInstance());
     tls = new TabletLocationState(keyExtent, future, null, last, null, walogs, true);
     assertEquals(TabletState.ASSIGNED_TO_DEAD_SERVER, tls.getState(liveServers));
   }
@@ -165,7 +166,7 @@ public class TabletLocationStateTest {
   @Test
   public void testGetState_Dead2() throws Exception {
     Set<TServerInstance> liveServers = new java.util.HashSet<>();
-    liveServers.add(future);
+    liveServers.add(future.getServerInstance());
     tls = new TabletLocationState(keyExtent, null, current, last, null, walogs, true);
     assertEquals(TabletState.ASSIGNED_TO_DEAD_SERVER, tls.getState(liveServers));
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/manager/state/TabletLocationStateTest.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletState;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,17 +52,17 @@ public class TabletLocationStateTest {
   }
 
   private KeyExtent keyExtent;
-  private TabletMetadata.Location future;
-  private TabletMetadata.Location current;
-  private TabletMetadata.Location last;
+  private Location future;
+  private Location current;
+  private Location last;
   private TabletLocationState tls;
 
   @BeforeEach
   public void setUp() {
     keyExtent = createMock(KeyExtent.class);
-    future = TabletMetadata.Location.future(createMock(TServerInstance.class));
-    current = TabletMetadata.Location.current(createMock(TServerInstance.class));
-    last = TabletMetadata.Location.last(createMock(TServerInstance.class));
+    future = Location.future(createMock(TServerInstance.class));
+    current = Location.current(createMock(TServerInstance.class));
+    last = Location.last(createMock(TServerInstance.class));
   }
 
   @Test

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -306,7 +306,7 @@ public class GarbageCollectWriteAheadLogs {
       // Tablet is still assigned to a dead server. Manager has moved markers and reassigned it
       // Easiest to just ignore all the WALs for the dead server.
       if (state.getState(liveServers) == TabletState.ASSIGNED_TO_DEAD_SERVER) {
-        Set<UUID> idsToIgnore = candidates.remove(state.current);
+        Set<UUID> idsToIgnore = candidates.remove(state.current.getServerInstance());
         if (idsToIgnore != null) {
           result.keySet().removeAll(idsToIgnore);
           recoveryLogs.keySet().removeAll(idsToIgnore);

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -36,7 +36,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.replication.ReplicationSchema;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Pair;
@@ -74,10 +74,10 @@ public class GarbageCollectWriteAheadLogsTest {
 
   {
     try {
-      tabletAssignedToServer1 = new TabletLocationState(extent, null,
-          TabletMetadata.Location.current(server1), null, null, walogs, false);
-      tabletAssignedToServer2 = new TabletLocationState(extent, null,
-          TabletMetadata.Location.current(server2), null, null, walogs, false);
+      tabletAssignedToServer1 = new TabletLocationState(extent, null, Location.current(server1),
+          null, null, walogs, false);
+      tabletAssignedToServer2 = new TabletLocationState(extent, null, Location.current(server2),
+          null, null, walogs, false);
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ReplicationSection;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.replication.ReplicationSchema;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Pair;
@@ -73,10 +74,10 @@ public class GarbageCollectWriteAheadLogsTest {
 
   {
     try {
-      tabletAssignedToServer1 =
-          new TabletLocationState(extent, null, server1, null, null, walogs, false);
-      tabletAssignedToServer2 =
-          new TabletLocationState(extent, null, server2, null, null, walogs, false);
+      tabletAssignedToServer1 = new TabletLocationState(extent, null,
+          TabletMetadata.Location.current(server1), null, null, walogs, false);
+      tabletAssignedToServer2 = new TabletLocationState(extent, null,
+          TabletMetadata.Location.current(server2), null, null, walogs, false);
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/Manager.java
@@ -629,7 +629,7 @@ public class Manager extends AbstractServer
         return TabletGoalState.UNASSIGNED;
       }
 
-      if (tls.current != null && serversToShutdown.contains(tls.current)) {
+      if (tls.current != null && serversToShutdown.contains(tls.current.getServerInstance())) {
         return TabletGoalState.SUSPENDED;
       }
       // Handle merge transitions
@@ -670,7 +670,7 @@ public class Manager extends AbstractServer
       if (state == TabletGoalState.HOSTED) {
         // Maybe this tablet needs to be migrated
         TServerInstance dest = migrations.get(extent);
-        if (dest != null && tls.current != null && !dest.equals(tls.current)) {
+        if (dest != null && tls.current != null && !dest.equals(tls.current.getServerInstance())) {
           return TabletGoalState.UNASSIGNED;
         }
       }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/ManagerClientServiceHandler.java
@@ -201,7 +201,7 @@ public class ManagerClientServiceHandler implements ManagerClientService.Iface {
           if ((tablet.hasCurrent() || logs > 0) && tablet.getFlushId().orElse(-1) < flushID) {
             tabletsToWaitFor++;
             if (tablet.hasCurrent()) {
-              serversToFlush.add(tablet.getLocation());
+              serversToFlush.add(tablet.getLocation().getServerInstance());
             }
           }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/TabletGroupWatcher.java
@@ -74,7 +74,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Fu
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.util.threads.Threads.AccumuloDaemonThread;
@@ -241,7 +241,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
             return mStats != null ? mStats : new MergeStats(new MergeInfo());
           });
           TabletGoalState goal = manager.getGoalState(tls, mergeStats.getMergeInfo());
-          TabletMetadata.Location location = tls.getLocation();
+          Location location = tls.getLocation();
           TabletState state = tls.getState(currentTServers.keySet());
 
           TabletLogger.missassigned(tls.extent, goal.toString(), state.toString(),
@@ -974,7 +974,7 @@ abstract class TabletGroupWatcher extends AccumuloDaemonThread {
     }
   }
 
-  private static TServerInstance getServerInstance(TabletMetadata.Location location) {
+  private static TServerInstance getServerInstance(Location location) {
     return location != null ? location.getServerInstance() : null;
   }
 }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.rpc.ThriftUtil;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
@@ -209,7 +210,7 @@ class LoadFiles extends ManagerRepo {
         // send files to tablet sever
         // ideally there should only be one tablet location to send all the files
 
-        TabletMetadata.Location location = tablet.getLocation();
+        Location location = tablet.getLocation();
         HostAndPort server = null;
         if (location == null) {
           locationLess++;

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/compact/CompactionDriver.java
@@ -110,7 +110,7 @@ class CompactionDriver extends ManagerRepo {
       if (tablet.getCompactId().orElse(-1) < compactId) {
         tabletsToWaitFor++;
         if (tablet.hasCurrent()) {
-          serversToFlush.increment(tablet.getLocation(), 1);
+          serversToFlush.increment(tablet.getLocation().getServerInstance(), 1);
         }
       }
 

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -70,7 +70,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.Sk
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -289,15 +289,15 @@ public class Upgrader9to10 implements Upgrader {
       tabletMutator.putDirName(upgradeDirColumn(dir));
 
       if (last != null) {
-        tabletMutator.putLocation(TabletMetadata.Location.last(last));
+        tabletMutator.putLocation(Location.last(last));
       }
 
       if (future != null) {
-        tabletMutator.putLocation(TabletMetadata.Location.future(future));
+        tabletMutator.putLocation(Location.future(future));
       }
 
       if (current != null) {
-        tabletMutator.putLocation(TabletMetadata.Location.current(current));
+        tabletMutator.putLocation(Location.current(current));
       }
 
       logs.forEach(tabletMutator::putWal);

--- a/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/upgrade/Upgrader9to10.java
@@ -70,7 +70,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.Sk
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.RootTabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.compaction.SimpleCompactionDispatcher;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -289,15 +289,15 @@ public class Upgrader9to10 implements Upgrader {
       tabletMutator.putDirName(upgradeDirColumn(dir));
 
       if (last != null) {
-        tabletMutator.putLocation(last, LocationType.LAST);
+        tabletMutator.putLocation(TabletMetadata.Location.last(last));
       }
 
       if (future != null) {
-        tabletMutator.putLocation(future, LocationType.FUTURE);
+        tabletMutator.putLocation(TabletMetadata.Location.future(future));
       }
 
       if (current != null) {
-        tabletMutator.putLocation(current, LocationType.CURRENT);
+        tabletMutator.putLocation(TabletMetadata.Location.current(current));
       }
 
       logs.forEach(tabletMutator::putWal);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -278,7 +278,7 @@ class AssignmentHandler implements Runnable {
     TabletMetadata.Location loc = meta.getLocation();
 
     if (!ignoreLocationCheck && (loc == null || loc.getType() != TabletMetadata.LocationType.FUTURE
-        || !instance.equals(loc))) {
+        || !instance.equals(loc.getServerInstance()))) {
       log.info(METADATA_ISSUE + "Unexpected location {} {}", extent, loc);
       return false;
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/AssignmentHandler.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.accumulo.server.manager.state.Assignment;
@@ -275,7 +276,7 @@ class AssignmentHandler implements Runnable {
           METADATA_ISSUE + "metadata entry does not have time (" + meta.getExtent() + ")");
     }
 
-    TabletMetadata.Location loc = meta.getLocation();
+    Location loc = meta.getLocation();
 
     if (!ignoreLocationCheck && (loc == null || loc.getType() != TabletMetadata.LocationType.FUTURE
         || !instance.equals(loc.getServerInstance()))) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
@@ -26,6 +26,7 @@ import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletLocationState.BadLocationStateException;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.tabletserver.thrift.TUnloadTabletGoal;
 import org.apache.accumulo.server.manager.state.DistributedStoreException;
 import org.apache.accumulo.server.manager.state.TabletStateStore;
@@ -111,7 +112,8 @@ class UnloadTabletHandler implements Runnable {
           new TServerInstance(server.clientAddress, server.getLock().getSessionId());
       TabletLocationState tls = null;
       try {
-        tls = new TabletLocationState(extent, null, instance, null, null, null, false);
+        tls = new TabletLocationState(extent, null, TabletMetadata.Location.current(instance), null,
+            null, null, false);
       } catch (BadLocationStateException e) {
         log.error("Unexpected error", e);
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/UnloadTabletHandler.java
@@ -26,7 +26,7 @@ import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletLocationState.BadLocationStateException;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tabletserver.thrift.TUnloadTabletGoal;
 import org.apache.accumulo.server.manager.state.DistributedStoreException;
 import org.apache.accumulo.server.manager.state.TabletStateStore;
@@ -112,8 +112,8 @@ class UnloadTabletHandler implements Runnable {
           new TServerInstance(server.clientAddress, server.getLock().getSessionId());
       TabletLocationState tls = null;
       try {
-        tls = new TabletLocationState(extent, null, TabletMetadata.Location.current(instance), null,
-            null, null, false);
+        tls = new TabletLocationState(extent, null, Location.current(instance), null, null, null,
+            false);
       } catch (BadLocationStateException e) {
         log.error("Unexpected error", e);
       }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -39,10 +39,10 @@ import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.Pair;
@@ -457,7 +457,7 @@ class DatafileManager {
       rename(vm, tmpDatafile.getPath(), newDatafile.getPath());
     }
 
-    TServerInstance lastLocation = null;
+    TabletMetadata.Location lastLocation = null;
     Optional<StoredTabletFile> newFile;
 
     if (dfv.getNumEntries() > 0) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -42,7 +42,7 @@ import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.MapCounter;
 import org.apache.accumulo.core.util.Pair;
@@ -457,7 +457,7 @@ class DatafileManager {
       rename(vm, tmpDatafile.getPath(), newDatafile.getPath());
     }
 
-    TabletMetadata.Location lastLocation = null;
+    Location lastLocation = null;
     Optional<StoredTabletFile> newFile;
 
     if (dfv.getNumEntries() > 0) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -78,6 +78,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.protobuf.ProtobufUtil;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
@@ -150,7 +151,7 @@ public class Tablet extends TabletBase {
   private final Object timeLock = new Object();
   private long persistedTime;
 
-  private TabletMetadata.Location lastLocation = null;
+  private Location lastLocation = null;
   private volatile Set<Path> checkedTabletDirs = new ConcurrentSkipListSet<>();
 
   private final AtomicLong dataSourceDeletions = new AtomicLong(0);
@@ -2018,8 +2019,8 @@ public class Tablet extends TabletBase {
     computeNumEntries();
   }
 
-  public TabletMetadata.Location resetLastLocation() {
-    TabletMetadata.Location result = lastLocation;
+  public Location resetLastLocation() {
+    Location result = lastLocation;
     lastLocation = null;
     return result;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -70,7 +70,6 @@ import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.master.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -151,7 +150,7 @@ public class Tablet extends TabletBase {
   private final Object timeLock = new Object();
   private long persistedTime;
 
-  private TServerInstance lastLocation = null;
+  private TabletMetadata.Location lastLocation = null;
   private volatile Set<Path> checkedTabletDirs = new ConcurrentSkipListSet<>();
 
   private final AtomicLong dataSourceDeletions = new AtomicLong(0);
@@ -2019,8 +2018,8 @@ public class Tablet extends TabletBase {
     computeNumEntries();
   }
 
-  public TServerInstance resetLastLocation() {
-    TServerInstance result = lastLocation;
+  public TabletMetadata.Location resetLastLocation() {
+    TabletMetadata.Location result = lastLocation;
     lastLocation = null;
     return result;
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -33,6 +33,7 @@ import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 
 /*
@@ -45,7 +46,7 @@ public class TabletData {
   private HashSet<StoredTabletFile> scanFiles = new HashSet<>();
   private long flushID = -1;
   private long compactID = -1;
-  private TabletMetadata.Location lastLocation = null;
+  private Location lastLocation = null;
   private Map<Long,List<TabletFile>> bulkImported = new HashMap<>();
   private long splitTime = 0;
   private String directoryName = null;
@@ -76,7 +77,7 @@ public class TabletData {
 
   // Data pulled from an existing tablet to make a split
   public TabletData(String dirName, SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes,
-      MetadataTime time, long lastFlushID, long lastCompactID, TabletMetadata.Location lastLocation,
+      MetadataTime time, long lastFlushID, long lastCompactID, Location lastLocation,
       Map<Long,List<TabletFile>> bulkIngestedFiles) {
     this.directoryName = dirName;
     this.dataFiles = highDatafileSizes;
@@ -113,7 +114,7 @@ public class TabletData {
     return compactID;
   }
 
-  public TabletMetadata.Location getLastLocation() {
+  public Location getLastLocation() {
     return lastLocation;
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -27,7 +27,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
@@ -46,7 +45,7 @@ public class TabletData {
   private HashSet<StoredTabletFile> scanFiles = new HashSet<>();
   private long flushID = -1;
   private long compactID = -1;
-  private TServerInstance lastLocation = null;
+  private TabletMetadata.Location lastLocation = null;
   private Map<Long,List<TabletFile>> bulkImported = new HashMap<>();
   private long splitTime = 0;
   private String directoryName = null;
@@ -77,7 +76,7 @@ public class TabletData {
 
   // Data pulled from an existing tablet to make a split
   public TabletData(String dirName, SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes,
-      MetadataTime time, long lastFlushID, long lastCompactID, TServerInstance lastLocation,
+      MetadataTime time, long lastFlushID, long lastCompactID, TabletMetadata.Location lastLocation,
       Map<Long,List<TabletFile>> bulkIngestedFiles) {
     this.directoryName = dirName;
     this.dataFiles = highDatafileSizes;
@@ -114,7 +113,7 @@ public class TabletData {
     return compactID;
   }
 
-  public TServerInstance getLastLocation() {
+  public TabletMetadata.Location getLastLocation() {
     return lastLocation;
   }
 

--- a/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
+++ b/shell/src/main/java/org/apache/accumulo/shell/commands/ListTabletsCommand.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.util.NumUtil;
 import org.apache.accumulo.shell.Shell;
@@ -422,7 +423,7 @@ public class ListTabletsCommand extends Command {
         return this;
       }
 
-      public Factory location(TabletMetadata.Location location) {
+      public Factory location(Location location) {
         if (location == null) {
           this.location = "None";
         } else {

--- a/shell/src/test/java/org/apache/accumulo/shell/commands/ListTabletsCommandTest.java
+++ b/shell/src/test/java/org/apache/accumulo/shell/commands/ListTabletsCommandTest.java
@@ -35,7 +35,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.TabletState;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.shell.Shell;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -91,8 +91,7 @@ public class ListTabletsCommandTest {
       KeyExtent ke1 = new KeyExtent(tableId, new Text("a"), null);
       KeyExtent ke2 = new KeyExtent(tableId, new Text("m"), new Text("a"));
       KeyExtent ke3 = new KeyExtent(tableId, null, new Text("m"));
-      TabletMetadata.Location loc =
-          new TabletMetadata.Location("localhost", "", TabletMetadata.LocationType.CURRENT);
+      Location loc = Location.current("localhost", "");
       ListTabletsCommand.TabletRowInfo.Factory factory =
           new ListTabletsCommand.TabletRowInfo.Factory(tableName, ke1).dir("t-dir1").numFiles(1)
               .numWalLogs(1).numEntries(1).size(100).status(TabletState.HOSTED.toString())
@@ -169,8 +168,7 @@ public class ListTabletsCommandTest {
     Text startRow = new Text("a");
     Text endRow = new Text("z");
     KeyExtent ke = new KeyExtent(id, endRow, startRow);
-    TabletMetadata.Location loc =
-        new TabletMetadata.Location("localhost", "", TabletMetadata.LocationType.CURRENT);
+    Location loc = Location.current("localhost", "");
     ListTabletsCommand.TabletRowInfo.Factory factory =
         new ListTabletsCommand.TabletRowInfo.Factory("aName", ke).numFiles(1).numWalLogs(2)
             .numEntries(3).size(4).status(TabletState.HOSTED.toString()).location(loc)

--- a/test/src/main/java/org/apache/accumulo/test/functional/AssignLocationModeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/AssignLocationModeIT.java
@@ -67,7 +67,7 @@ public class AssignLocationModeIT extends ConfigurableMacBase {
         newTablet = getTabletLocationState(c, tableId);
       } while (newTablet.current == null);
       // this would be null if the mode was not "assign"
-      assertEquals(newTablet.current, newTablet.last);
+      assertEquals(newTablet.getCurrentServer(), newTablet.getLastServer());
       assertNull(newTablet.future);
 
       // put something in it
@@ -83,7 +83,7 @@ public class AssignLocationModeIT extends ConfigurableMacBase {
       // last location should not be set yet
       TabletLocationState unflushed = getTabletLocationState(c, tableId);
       assertEquals(newTablet.current, unflushed.current);
-      assertEquals(newTablet.current, unflushed.last);
+      assertEquals(newTablet.getCurrentServer(), unflushed.getLastServer());
       assertNull(newTablet.future);
 
       // take the tablet offline
@@ -91,7 +91,7 @@ public class AssignLocationModeIT extends ConfigurableMacBase {
       TabletLocationState offline = getTabletLocationState(c, tableId);
       assertNull(offline.future);
       assertNull(offline.current);
-      assertEquals(newTablet.current, offline.last);
+      assertEquals(newTablet.getCurrentServer(), offline.getLastServer());
 
       // put it back online, should have the same last location
       c.tableOperations().online(tableName, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/CompactLocationModeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/CompactLocationModeIT.java
@@ -90,7 +90,7 @@ public class CompactLocationModeIT extends ConfigurableMacBase {
 
       TabletLocationState flushed = getTabletLocationState(c, tableId);
       assertEquals(newTablet.current, flushed.current);
-      assertEquals(flushed.current, flushed.last);
+      assertEquals(flushed.getCurrentServer(), flushed.getLastServer());
       assertNull(newTablet.future);
 
       // take the tablet offline
@@ -98,7 +98,7 @@ public class CompactLocationModeIT extends ConfigurableMacBase {
       TabletLocationState offline = getTabletLocationState(c, tableId);
       assertNull(offline.future);
       assertNull(offline.current);
-      assertEquals(flushed.current, offline.last);
+      assertEquals(flushed.getCurrentServer(), offline.getLastServer());
 
       // put it back online, should have the same last location
       c.tableOperations().online(tableName, true);

--- a/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/ManagerAssignmentIT.java
@@ -72,7 +72,7 @@ public class ManagerAssignmentIT extends AccumuloClusterHarness {
 
       TabletLocationState flushed = getTabletLocationState(c, tableId);
       assertEquals(newTablet.current, flushed.current);
-      assertEquals(flushed.current, flushed.last);
+      assertEquals(flushed.getCurrentServer(), flushed.getLastServer());
       assertNull(newTablet.future);
 
       // take the tablet offline
@@ -80,14 +80,14 @@ public class ManagerAssignmentIT extends AccumuloClusterHarness {
       TabletLocationState offline = getTabletLocationState(c, tableId);
       assertNull(offline.future);
       assertNull(offline.current);
-      assertEquals(flushed.current, offline.last);
+      assertEquals(flushed.getCurrentServer(), offline.getLastServer());
 
       // put it back online
       c.tableOperations().online(tableName, true);
       TabletLocationState online = getTabletLocationState(c, tableId);
       assertNull(online.future);
       assertNotNull(online.current);
-      assertEquals(online.current, online.last);
+      assertEquals(online.getCurrentServer(), online.getLastServer());
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -66,6 +66,7 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.server.ServerContext;
@@ -210,7 +211,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     Assignment assignment = new Assignment(high, instance);
 
     TabletMutator tabletMutator = context.getAmple().mutateTablet(extent);
-    tabletMutator.putLocation(TabletMetadata.Location.future(assignment.server));
+    tabletMutator.putLocation(Location.future(assignment.server));
     tabletMutator.mutate();
 
     if (steps >= 1) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -66,7 +66,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.Se
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata.LocationType;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.ColumnFQ;
 import org.apache.accumulo.server.ServerContext;
@@ -211,7 +210,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     Assignment assignment = new Assignment(high, instance);
 
     TabletMutator tabletMutator = context.getAmple().mutateTablet(extent);
-    tabletMutator.putLocation(assignment.server, LocationType.FUTURE);
+    tabletMutator.putLocation(TabletMetadata.Location.future(assignment.server));
     tabletMutator.mutate();
 
     if (steps >= 1) {

--- a/test/src/main/java/org/apache/accumulo/test/manager/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/MergeStateIT.java
@@ -43,7 +43,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -204,10 +204,8 @@ public class MergeStateIT extends ConfigurableMacBase {
       // take it offline
       m = TabletColumnFamily.createPrevRowMutation(tablet);
       Collection<Collection<String>> walogs = Collections.emptyList();
-      metaDataStateStore.unassign(
-          Collections.singletonList(new TabletLocationState(tablet, null,
-              TabletMetadata.Location.current(state.someTServer), null, null, walogs, false)),
-          null);
+      metaDataStateStore.unassign(Collections.singletonList(new TabletLocationState(tablet, null,
+          Location.current(state.someTServer), null, null, walogs, false)), null);
 
       // now we can split
       stats = scan(state, metaDataStateStore);

--- a/test/src/main/java/org/apache/accumulo/test/manager/MergeStateIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/MergeStateIT.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ChoppedColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.CurrentLocationColumnFamily;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.TabletColumnFamily;
+import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.util.HostAndPort;
@@ -204,8 +205,8 @@ public class MergeStateIT extends ConfigurableMacBase {
       m = TabletColumnFamily.createPrevRowMutation(tablet);
       Collection<Collection<String>> walogs = Collections.emptyList();
       metaDataStateStore.unassign(
-          Collections.singletonList(
-              new TabletLocationState(tablet, null, state.someTServer, null, null, walogs, false)),
+          Collections.singletonList(new TabletLocationState(tablet, null,
+              TabletMetadata.Location.current(state.someTServer), null, null, walogs, false)),
           null);
 
       // now we can split

--- a/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/manager/SuspendedTabletsIT.java
@@ -183,7 +183,7 @@ public class SuspendedTabletsIT extends ConfigurableMacBase {
       for (TabletLocationState tls : locs.locationStates.values()) {
         if (tls.current != null) {
           // add to set of all servers
-          tserverSet.add(tls.current);
+          tserverSet.add(tls.current.getServerInstance());
 
           // get server that the current tablets metadata is on
           TabletLocator.TabletLocation tab =


### PR DESCRIPTION
The previous version where Location extends TServerInstance was error prone if euqals/hashcode was overriden. This fixes things by encapsulating TServerInstance and creating proper equals/hashcode methods so comparsions won't fail.

This fixes #3254