### PR TITLE
centralizes wrapping per file iterators based on metadata

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/DataFileValue.java
@@ -21,6 +21,8 @@ package org.apache.accumulo.core.metadata.schema;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
+import org.apache.accumulo.core.iteratorsImpl.system.TimeSettingIterator;
 
 public class DataFileValue {
   private long size;
@@ -113,5 +115,24 @@ public class DataFileValue {
       throw new IllegalArgumentException();
     }
     this.time = time;
+  }
+
+  /**
+   * @return true if {@link #wrapFileIterator} would wrap a given iterator, false otherwise.
+   */
+  public boolean willWrapIterator() {
+    return isTimeSet();
+  }
+
+  /**
+   * Use per file information from the metadata table to wrap the raw iterator over a file with
+   * iterators that may take action based on data set in the metadata table.
+   */
+  public InterruptibleIterator wrapFileIterator(InterruptibleIterator iter) {
+    if (isTimeSet()) {
+      return new TimeSettingIterator(iter, getTime());
+    } else {
+      return iter;
+    }
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -52,8 +52,8 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.IteratorConfigUtil;
 import org.apache.accumulo.core.iteratorsImpl.system.ColumnFamilySkippingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.DeletingIterator;
+import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
-import org.apache.accumulo.core.iteratorsImpl.system.TimeSettingIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
@@ -344,12 +344,10 @@ public class FileCompactor implements Callable<CompactionStats> {
 
         readers.add(reader);
 
-        SortedKeyValueIterator<Key,Value> iter = new ProblemReportingIterator(context,
-            extent.tableId(), mapFile.getPathStr(), false, reader);
+        InterruptibleIterator iter = new ProblemReportingIterator(context, extent.tableId(),
+            mapFile.getPathStr(), false, reader);
 
-        if (filesToCompact.get(mapFile).isTimeSet()) {
-          iter = new TimeSettingIterator(iter, filesToCompact.get(mapFile).getTime());
-        }
+        iter = filesToCompact.get(mapFile).wrapFileIterator(iter);
 
         iters.add(iter);
 


### PR DESCRIPTION
Centralized wrapping per file iterators based on per file information from the metadata tables. This allows scans and compactions to use the same code to setup their per file iterators. 