### PR TITLE
Set root location property for paths to contrib files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,6 @@
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
     <curator.version>5.3.0</curator.version>
-    <!-- relative path for Eclipse format; should override in child modules if necessary -->
-    <eclipseFormatterStyle>${project.parent.basedir}/contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <errorprone.version>2.15.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
@@ -714,7 +712,7 @@
           <configuration>
             <licenseSets>
               <licenseSet>
-                <header>${session.executionRootDirectory}/contrib/license-header.txt</header>
+                <header>${rootlocation}/contrib/license-header.txt</header>
                 <excludes combine.children="append">
                   <exclude>**/DEPENDENCIES</exclude>
                   <exclude>**/LICENSE</exclude>
@@ -928,7 +926,7 @@
           <artifactId>formatter-maven-plugin</artifactId>
           <version>2.21.0</version>
           <configuration>
-            <configFile>${eclipseFormatterStyle}</configFile>
+            <configFile>${rootlocation}/contrib/Eclipse-Accumulo-Codestyle.xml</configFile>
             <excludes>
               <exclude>**/thrift/*.java</exclude>
               <exclude>**/proto/*.java</exclude>
@@ -1034,6 +1032,13 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
+          <execution>
+            <!-- create property named 'rootlocation' to point to top of multi-module project -->
+            <id>create-rootlocation-property</id>
+            <goals>
+              <goal>rootlocation</goal>
+            </goals>
+          </execution>
           <execution>
             <id>create-automatic-module-name</id>
             <goals>


### PR DESCRIPTION
Replace poorly supported `session.executionRootDirectory` property, and fragile, hierarchy-dependent `project.parent.basedir` property for paths to files at the root of the project that are needed by plugin executions in child modules.

Instead, use the build-helper-maven-plugin's rootlocation goal to explicitly set a property that points to the root of the multi-module project to resolve the location of those files consistently.