### PR TITLE
Improves scan server resolution in batch scanner code.

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/RootTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/RootTabletLocator.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.clientImpl.TabletLocatorImpl.TabletServerLockChecker;
@@ -67,14 +68,13 @@ public class RootTabletLocator extends TabletLocator {
   }
 
   @Override
-  public List<Range> binRanges(ClientContext context, List<Range> ranges,
-      Map<String,Map<KeyExtent,List<Range>>> binnedRanges) {
+  public List<Range> locateTablets(ClientContext context, List<Range> ranges,
+      BiConsumer<TabletLocation,Range> rangeConsumer) {
 
     TabletLocation rootTabletLocation = getRootTabletLocation(context);
     if (rootTabletLocation != null) {
       for (Range range : ranges) {
-        TabletLocatorImpl.addRange(binnedRanges, rootTabletLocation.getTserverLocation(),
-            RootTable.EXTENT, range);
+        rangeConsumer.accept(rootTabletLocation, range);
       }
       return Collections.emptyList();
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/SyncingTabletLocator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/SyncingTabletLocator.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.clientImpl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -77,6 +78,13 @@ public class SyncingTabletLocator extends TabletLocator {
       Map<String,TabletServerMutations<T>> binnedMutations, List<T> failures)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
     syncLocator().binMutations(context, mutations, binnedMutations, failures);
+  }
+
+  @Override
+  public List<Range> locateTablets(ClientContext context, List<Range> ranges,
+      BiConsumer<TabletLocation,Range> rangeConsumer)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+    return syncLocator().locateTablets(context, ranges, rangeConsumer);
   }
 
   @Override

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -34,6 +34,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -238,21 +239,36 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     Map<String,Map<KeyExtent,List<Range>>> binnedRanges = new HashMap<>();
 
-    binRanges(locator, ranges, binnedRanges);
+    var ssd = binRanges(locator, ranges, binnedRanges);
 
-    doLookups(binnedRanges, receiver, columns);
+    doLookups(binnedRanges, receiver, columns, ssd);
   }
 
-  private void binRanges(TabletLocator tabletLocator, List<Range> ranges,
+  private ScanServerData binRanges(TabletLocator tabletLocator, List<Range> ranges,
       Map<String,Map<KeyExtent,List<Range>>> binnedRanges)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
 
     int lastFailureSize = Integer.MAX_VALUE;
 
+    ScanServerData ssd;
+
+    long startTime = System.currentTimeMillis();
+
     while (true) {
 
       binnedRanges.clear();
-      List<Range> failures = tabletLocator.binRanges(context, ranges, binnedRanges);
+
+      List<Range> failures;
+
+      if (options.getConsistencyLevel().equals(ConsistencyLevel.IMMEDIATE)) {
+        failures = tabletLocator.binRanges(context, ranges, binnedRanges);
+        ssd = new ScanServerData();
+      } else if (options.getConsistencyLevel().equals(ConsistencyLevel.EVENTUAL)) {
+        ssd = binRangesForScanServers(tabletLocator, ranges, binnedRanges);
+        failures = ssd.failures;
+      } else {
+        throw new IllegalStateException();
+      }
 
       if (failures.isEmpty()) {
         break;
@@ -273,6 +289,12 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         if (log.isTraceEnabled()) {
           log.trace("Failed to bin {} ranges, tablet locations were null, retrying in 100ms",
               failures.size());
+        }
+
+        if (System.currentTimeMillis() - startTime > retryTimeout) {
+          // TODO exception used for timeout is inconsistent
+          throw new TimedOutException(
+              "Failed to find servers to process scans before timeout was exceeded.");
         }
 
         try {
@@ -302,6 +324,8 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     binnedRanges.clear();
     binnedRanges.putAll(binnedRanges2);
+
+    return ssd;
   }
 
   private void processFailures(Map<KeyExtent,List<Range>> failures, ResultReceiver receiver,
@@ -337,9 +361,10 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
     // since the first call to binRanges clipped the ranges to within a tablet, we should not get
     // only
     // bin to the set of failed tablets
-    binRanges(locator, allRanges, binnedRanges);
 
-    doLookups(binnedRanges, receiver, columns);
+    var ssd = binRanges(locator, allRanges, binnedRanges);
+
+    doLookups(binnedRanges, receiver, columns, ssd);
   }
 
   private String getTableInfo() {
@@ -494,21 +519,11 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
   }
 
   private void doLookups(Map<String,Map<KeyExtent,List<Range>>> binnedRanges,
-      final ResultReceiver receiver, List<Column> columns) {
+      final ResultReceiver receiver, List<Column> columns, ScanServerData ssd) {
 
     int maxTabletsPerRequest = Integer.MAX_VALUE;
 
-    long busyTimeout = 0;
-    Duration scanServerSelectorDelay = null;
-    Map<String,ScanServerAttemptReporter> reporters = Map.of();
-
-    if (options.getConsistencyLevel().equals(ConsistencyLevel.EVENTUAL)) {
-      var scanServerData = rebinToScanServers(binnedRanges);
-      busyTimeout = scanServerData.actions.getBusyTimeout().toMillis();
-      reporters = scanServerData.reporters;
-      scanServerSelectorDelay = scanServerData.actions.getDelay();
-      binnedRanges = scanServerData.binnedRanges;
-    } else {
+    if (options.getConsistencyLevel().equals(ConsistencyLevel.IMMEDIATE)) {
       // when there are lots of threads and a few tablet servers
       // it is good to break request to tablet servers up, the
       // following code determines if this is the case
@@ -558,16 +573,16 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       final Map<KeyExtent,List<Range>> tabletsRanges = binnedRanges.get(tsLocation);
       if (maxTabletsPerRequest == Integer.MAX_VALUE || tabletsRanges.size() == 1) {
         QueryTask queryTask = new QueryTask(tsLocation, tabletsRanges, failures, receiver, columns,
-            busyTimeout, reporters.getOrDefault(tsLocation, r -> {}), scanServerSelectorDelay);
+            ssd.getBusyTimeout(), ssd.reporters.getOrDefault(tsLocation, r -> {}), ssd.getDelay());
         queryTasks.add(queryTask);
       } else {
         HashMap<KeyExtent,List<Range>> tabletSubset = new HashMap<>();
         for (Entry<KeyExtent,List<Range>> entry : tabletsRanges.entrySet()) {
           tabletSubset.put(entry.getKey(), entry.getValue());
           if (tabletSubset.size() >= maxTabletsPerRequest) {
-            QueryTask queryTask =
-                new QueryTask(tsLocation, tabletSubset, failures, receiver, columns, busyTimeout,
-                    reporters.getOrDefault(tsLocation, r -> {}), scanServerSelectorDelay);
+            QueryTask queryTask = new QueryTask(tsLocation, tabletSubset, failures, receiver,
+                columns, ssd.getBusyTimeout(), ssd.reporters.getOrDefault(tsLocation, r -> {}),
+                ssd.getDelay());
             queryTasks.add(queryTask);
             tabletSubset = new HashMap<>();
           }
@@ -575,7 +590,8 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
         if (!tabletSubset.isEmpty()) {
           QueryTask queryTask = new QueryTask(tsLocation, tabletSubset, failures, receiver, columns,
-              busyTimeout, reporters.getOrDefault(tsLocation, r -> {}), scanServerSelectorDelay);
+              ssd.getBusyTimeout(), ssd.reporters.getOrDefault(tsLocation, r -> {}),
+              ssd.getDelay());
           queryTasks.add(queryTask);
         }
       }
@@ -591,17 +607,59 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
   }
 
   private static class ScanServerData {
-    Map<String,Map<KeyExtent,List<Range>>> binnedRanges;
-    ScanServerSelections actions;
-    Map<String,ScanServerAttemptReporter> reporters;
+    final List<Range> failures;
+    final ScanServerSelections actions;
+    final Map<String,ScanServerAttemptReporter> reporters;
+
+    public ScanServerData(List<Range> failures) {
+      this.failures = failures;
+      this.actions = null;
+      this.reporters = Map.of();
+    }
+
+    public ScanServerData(ScanServerSelections actions,
+        Map<String,ScanServerAttemptReporter> reporters) {
+      this.actions = actions;
+      this.reporters = reporters;
+      this.failures = List.of();
+    }
+
+    public ScanServerData() {
+      this.failures = List.of();
+      this.actions = null;
+      this.reporters = Map.of();
+    }
+
+    public long getBusyTimeout() {
+      return actions == null ? 0L : actions.getBusyTimeout().toMillis();
+    }
+
+    public Duration getDelay() {
+      return actions == null ? null : actions.getDelay();
+    }
   }
 
-  private ScanServerData rebinToScanServers(Map<String,Map<KeyExtent,List<Range>>> binnedRanges) {
+  private ScanServerData binRangesForScanServers(TabletLocator tabletLocator, List<Range> ranges,
+      Map<String,Map<KeyExtent,List<Range>>> binnedRanges)
+      throws AccumuloException, TableNotFoundException, AccumuloSecurityException {
+
     ScanServerSelector ecsm = context.getScanServerSelector();
 
-    List<TabletIdImpl> tabletIds =
-        binnedRanges.values().stream().flatMap(extentMap -> extentMap.keySet().stream())
-            .map(TabletIdImpl::new).collect(Collectors.toList());
+    Map<KeyExtent,String> extentToTserverMap = new HashMap<>();
+    Map<KeyExtent,List<Range>> extentToRangesMap = new HashMap<>();
+
+    Set<TabletIdImpl> tabletIds = new HashSet<>();
+
+    List<Range> failures = tabletLocator.locateTablets(context, ranges, (cachedTablet, range) -> {
+      extentToTserverMap.put(cachedTablet.getExtent(), cachedTablet.getTserverLocation());
+      extentToRangesMap.computeIfAbsent(cachedTablet.getExtent(), k -> new ArrayList<>())
+          .add(range);
+      tabletIds.add(new TabletIdImpl(cachedTablet.getExtent()));
+    });
+
+    if (!failures.isEmpty()) {
+      return new ScanServerData(failures);
+    }
 
     // get a snapshot of this once,not each time the plugin request it
     var scanAttemptsSnapshot = scanAttempts.snapshot();
@@ -625,18 +683,6 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
 
     var actions = ecsm.selectServers(params);
 
-    Map<KeyExtent,String> extentToTserverMap = new HashMap<>();
-    Map<KeyExtent,List<Range>> extentToRangesMap = new HashMap<>();
-
-    binnedRanges.forEach((server, extentMap) -> {
-      extentMap.forEach((extent, ranges) -> {
-        extentToTserverMap.put(extent, server);
-        extentToRangesMap.put(extent, ranges);
-      });
-    });
-
-    Map<String,Map<KeyExtent,List<Range>>> binnedRanges2 = new HashMap<>();
-
     Map<String,ScanServerAttemptReporter> reporters = new HashMap<>();
 
     for (TabletIdImpl tabletId : tabletIds) {
@@ -644,25 +690,26 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
       String serverToUse = actions.getScanServer(tabletId);
       if (serverToUse == null) {
         // no scan server was given so use the tablet server
-        serverToUse = extentToTserverMap.get(extent);
+        serverToUse = Objects.requireNonNull(extentToTserverMap.get(extent));
         log.trace("For tablet {} scan server selector chose tablet_server", tabletId);
       } else {
         log.trace("For tablet {} scan server selector chose scan_server:{}", tabletId, serverToUse);
       }
 
-      var rangeMap = binnedRanges2.computeIfAbsent(serverToUse, k -> new HashMap<>());
-      List<Range> ranges = extentToRangesMap.get(extent);
-      rangeMap.put(extent, ranges);
+      var rangeMap = binnedRanges.computeIfAbsent(serverToUse, k -> new HashMap<>());
+      List<Range> extentRanges = extentToRangesMap.get(extent);
+      rangeMap.put(extent, extentRanges);
 
       var server = serverToUse;
       reporters.computeIfAbsent(serverToUse, k -> scanAttempts.createReporter(server, tabletId));
     }
 
-    ScanServerData ssd = new ScanServerData();
+    if (!failures.isEmpty()) {
+      return new ScanServerData(failures);
+    }
 
-    ssd.binnedRanges = binnedRanges2;
-    ssd.actions = actions;
-    ssd.reporters = reporters;
+    ScanServerData ssd = new ScanServerData(actions, reporters);
+
     log.trace("Scan server selector chose delay:{} busyTimeout:{}", actions.getDelay(),
         actions.getBusyTimeout());
     return ssd;

--- a/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/client/BulkImporterTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 
 import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.clientImpl.TabletLocator;
@@ -83,8 +84,8 @@ public class BulkImporterTest {
     }
 
     @Override
-    public List<Range> binRanges(ClientContext context, List<Range> ranges,
-        Map<String,Map<KeyExtent,List<Range>>> binnedRanges) {
+    public List<Range> locateTablets(ClientContext context, List<Range> ranges,
+        BiConsumer<TabletLocation,Range> rangeConsumer) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Refactors the batch scanner code to make two improvements.  First mapping ranges to scan servers or tservers was moved under one method. Second the process of mapping ranges to scan servers using the tablet location cache was improved.  The tablet location cache used to organized data in a a way that was useful for immediate scans and eventual scans had to reorganize the data.  A new method was added to the tablet location cache that passes the raw data to a consumer that can orgranize it in any way.  This new method is used for scan servers.