### PR TITLE
Fixes a minor scan server bug and adds some since tags

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelector.java
@@ -144,6 +144,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * will keep increasing the busy timeout by multiplying 8 until the maximum of 20 minutes is
  * reached. For this profile it will choose from scan servers in the group {@literal lowcost}.
  * </p>
+ *
+ * @since 2.1.0
  */
 public class ConfigurableScanServerSelector implements ScanServerSelector {
 
@@ -284,10 +286,10 @@ public class ConfigurableScanServerSelector implements ScanServerSelector {
 
         defaultProfile = prof;
       }
+    }
 
-      if (defaultProfile == null) {
-        throw new IllegalArgumentException("No default profile specified");
-      }
+    if (defaultProfile == null) {
+      throw new IllegalArgumentException("No default profile specified");
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanServerSelections.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/scan/ScanServerSelections.java
@@ -22,6 +22,12 @@ import java.time.Duration;
 
 import org.apache.accumulo.core.data.TabletId;
 
+/**
+ * Returned by {@link ScanServerSelector#selectServers(ScanServerSelector.SelectorParameters)} to
+ * specify what scan servers to use and how to use them.
+ *
+ * @since 2.1.0
+ */
 public interface ScanServerSelections {
 
   /**

--- a/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/scan/ConfigurableScanServerSelectorTest.java
@@ -294,8 +294,10 @@ public class ConfigurableScanServerSelectorTest {
         "{'scanTypeActivations':['mega'],'maxBusyTimeout':'60m','busyTimeoutMultiplier':2, "
             + "'attemptPlans':[{'servers':'100%', 'busyTimeout':'10m'}]}";
 
+    // Intentionally put the default profile in 2nd position. There was a bug where config parsing
+    // would fail if the default did not come first.
     var opts = Map.of("profiles",
-        "[" + defaultProfile + ", " + profile1 + "," + profile2 + "]".replace('\'', '"'));
+        "[" + profile1 + ", " + defaultProfile + "," + profile2 + "]".replace('\'', '"'));
 
     runBusyTest(1000, 0, 5, 5, opts);
     runBusyTest(1000, 1, 20, 33, opts);


### PR DESCRIPTION
The pluggable scan server selector provided by Accumulo had a minor bug in its configration parsing.  It expected the default profile to always come first in the config, even though it could occur any position.

Also some since tags were missing the for scan servers SPIs, added those.