### PR TITLE
Bump Jetty to 9.3 for Accumulo 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,8 @@
     <htrace.hadoop.version>4.1.0-incubating</htrace.hadoop.version>
     <htrace.version>3.1.0-incubating</htrace.version>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
-    <!-- jetty 9.2 is the last version to support jdk less than 1.8 -->
-    <jetty.version>9.2.30.v20200428</jetty.version>
+    <!-- jetty 9.3 requires JDK 8, but newer versions require bigger changes -->
+    <jetty.version>9.3.30.v20211001</jetty.version>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Fix flaky build issue with Hadoop 3 profile by using the same Jetty release series as Hadoop 3.0.3,
which is Eclipse Jetty 9.3. Select the latest patched version of 9.3.