### PR TITLE
Add support for storing ranges in DataFileValue

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -447,7 +447,7 @@ public class TabletMetadata {
           }
           break;
         case DataFileColumnFamily.STR_NAME:
-          filesBuilder.put(new StoredTabletFile(qual), new DataFileValue(val));
+          filesBuilder.put(new StoredTabletFile(qual), DataFileValue.decode(val));
           break;
         case BulkFileColumnFamily.STR_NAME:
           loadedFilesBuilder.put(new StoredTabletFile(qual),

--- a/core/src/main/java/org/apache/accumulo/core/util/json/RangeAdapter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/json/RangeAdapter.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util.json;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+import org.apache.accumulo.core.data.Range;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Gson adapter that can serialize {@link Range} objects to Base64 encoding.
+ *
+ * Ranges will first be serialized to a byte array and then to Base64. Null ranges will be
+ * serialized as a byte array of size 0.
+ */
+public class RangeAdapter implements JsonSerializer<Range>, JsonDeserializer<Range> {
+
+  private static final ByteArrayToBase64TypeAdapter BASE64_SERIALIZER =
+      new ByteArrayToBase64TypeAdapter();
+
+  @Override
+  public Range deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    return decodeRange(BASE64_SERIALIZER.deserialize(json, typeOfT, context));
+  }
+
+  @Override
+  public JsonElement serialize(Range src, Type typeOfSrc, JsonSerializationContext context) {
+    return BASE64_SERIALIZER.serialize(encodeRange(src), typeOfSrc, context);
+  }
+
+  /**
+   * Helper methods to encode and decode a range to/from byte arrays. Note that the Gson serializer
+   * won't pass in null values as they are handled separately
+   */
+
+  private static byte[] encodeRange(final Range range) {
+    try {
+      try (DataOutputBuffer buffer = new DataOutputBuffer()) {
+        range.write(buffer);
+        return buffer.getData();
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static Range decodeRange(byte[] serialized) {
+    try {
+      try (DataInputBuffer buffer = new DataInputBuffer()) {
+        final Range range = new Range();
+        buffer.reset(serialized, serialized.length);
+        range.readFields(buffer);
+        return range;
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Creates a new Gson instance that registers a {@link RangeAdapter} for handling
+   * serializing/deserializing byte[] types as Base64 encoded
+   *
+   * @return Gson instance
+   */
+  public static Gson createRangeGson() {
+    return registerRangeAdapter(new GsonBuilder()).create();
+  }
+
+  /**
+   * Register {@link RangeAdapter} for handling {@link Range} types on an existing GsonBuilder
+   *
+   * @param gsonBuilder existing GsonBuilder
+   * @return GsonBuilder
+   */
+  public static GsonBuilder registerRangeAdapter(final GsonBuilder gsonBuilder) {
+    return Objects.requireNonNull(gsonBuilder).registerTypeHierarchyAdapter(Range.class,
+        new RangeAdapter());
+  }
+}

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/DataFileValueTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/DataFileValueTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.junit.jupiter.api.Test;
+
+public class DataFileValueTest {
+
+  @Test
+  public void testNoTimeOrRanges() {
+    final String json = new DataFileValue(555, 23).encodeAsString();
+    final DataFileValue dfv = DataFileValue.decode(json);
+
+    assertEquals(555, dfv.getSize());
+    assertEquals(23, dfv.getNumEntries());
+    assertEquals(-1, dfv.getTime());
+    assertEquals(0, dfv.getRanges().size());
+  }
+
+  @Test
+  public void testTimeNoRanges() {
+    long time = System.currentTimeMillis();
+    final String json = new DataFileValue(555, 23, time).encodeAsString();
+    final DataFileValue dfv = DataFileValue.decode(json);
+
+    assertEquals(555, dfv.getSize());
+    assertEquals(23, dfv.getNumEntries());
+    assertEquals(time, dfv.getTime());
+    assertEquals(0, dfv.getRanges().size());
+  }
+
+  @Test
+  public void testInfiniteRange() {
+    long time = System.currentTimeMillis();
+    final DataFileValue dfv = new DataFileValue(555, 23, time, List.of(new Range()));
+    assertEquals(1, dfv.getRanges().size());
+    assertEquals(new Range(), dfv.getRanges().get(0));
+
+    // Verify serialization
+    final String json = new DataFileValue(555, 23, time, List.of(new Range())).encodeAsString();
+    final DataFileValue decoded = DataFileValue.decode(json);
+
+    assertEquals(555, decoded.getSize());
+    assertEquals(23, decoded.getNumEntries());
+    assertEquals(time, decoded.getTime());
+    assertEquals(1, decoded.getRanges().size());
+    assertEquals(new Range(), decoded.getRanges().get(0));
+  }
+
+  @Test
+  public void testComplexRange() {
+    final Key key1 = new Key("row1", "cf1", "cq1", 50);
+    final Key key2 = new Key("row2", "cf2", "cq2", 100);
+    final String json = new DataFileValue(555, 23, List.of(new Range(key1, key2))).encodeAsString();
+    final DataFileValue dfv = DataFileValue.decode(json);
+
+    assertEquals(555, dfv.getSize());
+    assertEquals(23, dfv.getNumEntries());
+    assertEquals(-1, dfv.getTime());
+    assertEquals(1, dfv.getRanges().size());
+    assertEquals(new Range(key1, key2), dfv.getRanges().get(0));
+  }
+
+  @Test
+  public void testOverlappingRanges() {
+    long time = System.currentTimeMillis();
+    final DataFileValue dfv =
+        new DataFileValue(555, 23, time, List.of(new Range("abc", "xyz"), new Range("def")));
+    // Second range is part of first range so should collapse into 1
+    assertEquals(1, dfv.getRanges().size());
+    assertEquals(new Range("abc", "xyz"), dfv.getRanges().get(0));
+  }
+
+  @Test
+  public void testMultipleRanges() {
+    long time = System.currentTimeMillis();
+    final DataFileValue dfv =
+        new DataFileValue(555, 23, time, List.of(new Range("abc", "xyz"), new Range("123", "789")));
+
+    // Ranges will be sorted
+    assertEquals(2, dfv.getRanges().size());
+    assertEquals(new Range("123", "789"), dfv.getRanges().get(0));
+    assertEquals(new Range("abc", "xyz"), dfv.getRanges().get(1));
+
+    // Test encoding
+    final String json =
+        new DataFileValue(700, 25, time, List.of(new Range("abc", "xyz"), new Range("123", "789")))
+            .encodeAsString();
+    final DataFileValue decoded = DataFileValue.decode(json);
+
+    assertEquals(700, decoded.getSize());
+    assertEquals(25, decoded.getNumEntries());
+    assertEquals(time, decoded.getTime());
+    assertEquals(2, decoded.getRanges().size());
+    assertEquals(2, decoded.getRanges().size());
+    assertEquals(new Range("123", "789"), decoded.getRanges().get(0));
+    assertEquals(new Range("abc", "xyz"), decoded.getRanges().get(1));
+  }
+
+  @Test
+  public void testLegacyNoTime() {
+    String legacyFormat = "500,25";
+    DataFileValue dfv = DataFileValue.decode(legacyFormat);
+
+    assertEquals(500, dfv.getSize());
+    assertEquals(25, dfv.getNumEntries());
+    assertEquals(-1, dfv.getTime());
+  }
+
+  @Test
+  public void testLegacy() {
+    long time = System.currentTimeMillis();
+    String legacyFormat = "500,25," + time;
+    DataFileValue dfv = DataFileValue.decode(legacyFormat);
+
+    assertEquals(500, dfv.getSize());
+    assertEquals(25, dfv.getNumEntries());
+    assertEquals(time, dfv.getTime());
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/util/json/RangeAdapterTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/json/RangeAdapterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+public class RangeAdapterTest {
+
+  private static final Gson gson = RangeAdapter.createRangeGson();
+
+  private static class TestRangeWrapper {
+    Range range;
+  }
+
+  @Test
+  public void testRangeNullField() {
+    // Verify null Range fields work
+    String json = gson.toJson(new TestRangeWrapper());
+    TestRangeWrapper testWrapper = gson.fromJson(json, TestRangeWrapper.class);
+    assertNull(testWrapper.range);
+  }
+
+  @Test
+  public void testRangeSerialization() {
+    String json = gson.toJson(new Range());
+    assertEquals(new Range(), gson.fromJson(json, Range.class));
+
+    // set all fields to verify serialization
+    Key key1 = new Key("row1", "cf1", "cq1", 50);
+    Key key2 = new Key("row2", "cf2", "cq2", 100);
+    key2.setDeleted(true);
+
+    json = gson.toJson(new Range(key1, false, key2, false));
+    assertEquals(new Range(key1, false, key2, false), gson.fromJson(json, Range.class));
+  }
+
+  @Test
+  public void testRangeCollectionSerialization() {
+    // Verify a collection can be serialized/deserialized
+    String json = gson.toJson(List.of(new Range("1111", "2222"), new Range("abc", "xyz")));
+    assertEquals(List.of(new Range("1111", "2222"), new Range("abc", "xyz")),
+        gson.fromJson(json, new TypeToken<List<Range>>() {}.getType()));
+  }
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/constraints/MetadataConstraints.java
@@ -203,7 +203,7 @@ public class MetadataConstraints implements Constraint {
 
       if (columnFamily.equals(DataFileColumnFamily.NAME)) {
         try {
-          DataFileValue dfv = new DataFileValue(columnUpdate.getValue());
+          DataFileValue dfv = DataFileValue.decode(columnUpdate.getValue());
 
           if (dfv.getSize() < 0 || dfv.getNumEntries() < 0) {
             violations = addViolation(violations, 1);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -156,7 +156,7 @@ public class ManagerMetadataUtil {
             if (entry.getKey().compareColumnFamily(DataFileColumnFamily.NAME) == 0) {
               StoredTabletFile stf =
                   new StoredTabletFile(entry.getKey().getColumnQualifierData().toString());
-              origDatafileSizes.put(stf, new DataFileValue(entry.getValue().get()));
+              origDatafileSizes.put(stf, DataFileValue.decode(entry.getValue().get()));
             }
           }
         }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -238,7 +238,7 @@ public class TableDiskUsage {
             // This tracks the file size for individual files for computing shared file statistics
             // later
             tdu.addFileSize(file.getFileName(),
-                new DataFileValue(entry.getValue().get()).getSize());
+                DataFileValue.decode(entry.getValue().get()).getSize());
           }
         }
 


### PR DESCRIPTION
This adds support for storing a collection of ranges associated with a data file in the Accumulo metadata table. This will allow the ability to fence off RFiles by ranges in the future so we can accomplish no-chop merges. The previous CSV format of the serialized DataFileValue has been converted to Json and the ranges are Base64 encoded. 

This is the second part of #1327 and will provide a mechanism to store ranges. Note that this PR doesn't actually update Accumulo to start storing ranges yet, it just adds support to do so. When this PR and #3246 is ready, a follow on task would be to go back and update the merge code to no longer run chop compactions but to actually start populating ranges in the metadata, etc.

The goal here is to be able to optionally store ranges for a file in metadata. If the range list is empty then that would just mean the entire file is used (infinite range) and this is nice as it allows us to be backwards compatible with previous metadata that didn't include a range and also allows us to not have to store anything unless we need to fence the file off in the future (such as when merging).

One question I had was what the size and numEntries values should be now inside of DataFileValue. Will those values stay as they currently are (size and numEntries for the entire file) or do we need to set those values based on the Ranges provided? Ie do we need to try and reduce the size somehow based on the fenced off values vs the actual values? I don't think so, I think we can leave the values alone (apply to the whole file) and just get what we need out of the ranges as those values are used for things like splits which I would still think you'd want to take into account the entire file for but maybe someone else with more background can comment on that.

A couple of other notes about this PR:

1. I made it a draft PR for now as this should really be target at a 3.1 branch and right now main is just 3.0 plus I wanted to get some initial feedback.
2. DataFileValue format is now a JSON string when serialized into the metadata table instead of a CSV. Reading of the old format is detected by checking for a Json parsing exception and falling back to the legacy format.
3. Ranges are encoded as Base64. The simplest and most compact way to store a range was to encode the entire Range into a byte array and then encode that as Base 64 as ranges are complex with keys and a lot of binary values.
4. I left the equals/hashcode methods alone for now in DataFileValue and they only compare the size and number of entries. I wasn't sure if we wanted to also add the range comparison to the equals yet, it probably depends how we intend to use it.

