### PR TITLE
WIP: Convert remove clone flag to ample

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -360,6 +360,15 @@ public interface Ample {
   }
 
   /**
+   * Removes a cloned flag from the metadata table.
+   *
+   * @param tableId - TableID for transaction removal
+   */
+  default void removeClonedFlag(TableId tableId) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Remove all the Bulk Load transaction ids from a given table's metadata
    *
    * @param tableId Table ID for transaction removals

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1525,7 +1525,7 @@ public class Tablet extends TabletBase {
       return null;
     }
 
-    // obtain this info outside of synch block since it will involve opening
+    // obtain this info outside of a synch block since it will involve opening
     // the map files... it is ok if the set of map files changes, because
     // this info is used for optimization... it is ok if map files are missing
     // from the set... can still query and insert into the tablet while this


### PR DESCRIPTION
Converted the remove clone flag to use ample for metadata actions.

Most of the clone operations in MetadataTableUtil are not using ample and will need to be converted.
Due to the amount of code changes, I'm keeping these PRs small to hopefully aid in reviewing. 