### PR TITLE
Add trim command to parse metrics

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
@@ -83,7 +83,7 @@ public class TestStatsDSink implements Closeable {
     String[] tag = tags.split(",");
     for (String t : tag) {
       String[] p = t.split(":");
-      m.getTags().put(p[0], p[1]);
+      m.getTags().put(p[0], p[1].trim());
     }
     return m;
   }


### PR DESCRIPTION
Currently the line length being returned in statsd is exceedingly long. 
Adding a trim line to the parseStatsDMetric test sink for better testing validation.

NOTE: this does not solve any possible issues with metric data size, just testing output. 
