### PR TITLE
Fix MetricIT test metric line length

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
@@ -24,6 +24,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,7 @@ public class TestStatsDSink implements Closeable {
     String[] tag = tags.split(",");
     for (String t : tag) {
       String[] p = t.split(":");
-      m.getTags().put(p[0], p[1].trim());
+      m.getTags().put(p[0], p[1]);
     }
     return m;
   }
@@ -102,7 +103,8 @@ public class TestStatsDSink implements Closeable {
         DatagramPacket packet = new DatagramPacket(buf, len);
         try {
           sock.receive(packet);
-          received.add(new String(packet.getData()));
+          byte[] trimmedBuffer = Arrays.copyOf(packet.getData(), packet.getLength());
+          received.add(new String(trimmedBuffer));
         } catch (IOException e) {
           if (!sock.isClosed()) {
             LOG.error("Error receiving packet", e);


### PR DESCRIPTION
This issue was found during work on #3288 where metric lines with tags were showing a length of over `106000`.

This lead to the discovery that all metric lines were being stored with a string length of `106496`. 

This value comes from a Datagram Socket's expected receive buffer size.  https://github.com/apache/accumulo/blob/92238929f63e8ae075120712317e4cb5636f029f/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java#L98

Since `packet.getLength()` is updated on the `sock.receive(packet)` call, the code now uses that length to trim the buffer down to the expected data size. 

Removes the trim call from `parseStatsDMetric()` as metric lines are now the correct size.