### PR TITLE
fix metrics tags, tserver hostname, remove tags from thrift metrics

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsUtil.java
@@ -79,9 +79,14 @@ public class MetricsUtil {
       List<Tag> tags = new ArrayList<>();
       tags.add(Tag.of("process.name", processName));
 
-      if (address != null) {
-        tags.add(Tag.of("Address", address.toString()));
+      if (address != null && !address.getHost().isEmpty()) {
+        tags.add(Tag.of("host", address.getHost()));
       }
+
+      if (address != null && address.getPort() > 0) {
+        tags.add(Tag.of("port", Integer.toString(address.getPort())));
+      }
+
       commonTags = Collections.unmodifiableList(tags);
 
       // Configure replication metrics to display percentiles and change its expiry to 10 mins

--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsUtil.java
@@ -79,12 +79,13 @@ public class MetricsUtil {
       List<Tag> tags = new ArrayList<>();
       tags.add(Tag.of("process.name", processName));
 
-      if (address != null && !address.getHost().isEmpty()) {
-        tags.add(Tag.of("host", address.getHost()));
-      }
-
-      if (address != null && address.getPort() > 0) {
-        tags.add(Tag.of("port", Integer.toString(address.getPort())));
+      if (address != null) {
+        if (!address.getHost().isEmpty()) {
+          tags.add(Tag.of("host", address.getHost()));
+        }
+        if (address.getPort() > 0) {
+          tags.add(Tag.of("port", Integer.toString(address.getPort())));
+        }
       }
 
       commonTags = Collections.unmodifiableList(tags);

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.9.8</version>
+        <version>1.10.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -186,14 +186,14 @@
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.19.0</version>
+        <version>1.25.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom-alpha</artifactId>
-        <version>1.19.0-alpha</version>
+        <version>1.25.0-alpha</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/server/base/src/main/java/org/apache/accumulo/server/metrics/ThriftMetrics.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metrics/ThriftMetrics.java
@@ -25,15 +25,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 public class ThriftMetrics implements MetricsProducer {
 
-  private final String serverName;
-  private final String threadName;
   private DistributionSummary idle;
   private DistributionSummary execute;
 
-  public ThriftMetrics(String serverName, String threadName) {
-    this.serverName = serverName;
-    this.threadName = threadName;
-  }
+  public ThriftMetrics() {}
 
   public void addIdle(long time) {
     idle.record(time);
@@ -45,10 +40,8 @@ public class ThriftMetrics implements MetricsProducer {
 
   @Override
   public void registerMetrics(MeterRegistry registry) {
-    idle = DistributionSummary.builder(METRICS_THRIFT_IDLE).baseUnit("ms")
-        .tags("server", serverName, "thread", threadName).register(registry);
-    execute = DistributionSummary.builder(METRICS_THRIFT_EXECUTE).baseUnit("ms")
-        .tags("server", serverName, "thread", threadName).register(registry);
+    idle = DistributionSummary.builder(METRICS_THRIFT_IDLE).baseUnit("ms").register(registry);
+    execute = DistributionSummary.builder(METRICS_THRIFT_EXECUTE).baseUnit("ms").register(registry);
   }
 
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -167,7 +167,7 @@ public class TServerUtils {
     // create the TimedProcessor outside the port search loop so we don't try to
     // register the same
     // metrics mbean more than once
-    TimedProcessor timedProcessor = new TimedProcessor(config, processor, serverName, threadName);
+    TimedProcessor timedProcessor = new TimedProcessor(processor);
 
     HostAndPort[] addresses = getHostAndPorts(hostname, portHint);
     try {
@@ -557,9 +557,9 @@ public class TServerUtils {
     }
 
     try {
-      return startTServer(serverType, new TimedProcessor(conf, processor, serverName, threadName),
-          serverName, threadName, numThreads, threadTimeOut, conf, timeBetweenThreadChecks,
-          maxMessageSize, sslParams, saslParams, serverSocketTimeout, addresses);
+      return startTServer(serverType, new TimedProcessor(processor), serverName, threadName,
+          numThreads, threadTimeOut, conf, timeBetweenThreadChecks, maxMessageSize, sslParams,
+          saslParams, serverSocketTimeout, addresses);
     } catch (TTransportException e) {
       throw new IllegalStateException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.server.rpc;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.server.metrics.ThriftMetrics;
 import org.apache.thrift.TException;
@@ -34,14 +33,9 @@ public class TimedProcessor implements TProcessor {
   private final ThriftMetrics thriftMetrics;
   private long idleStart = 0;
 
-  public TimedProcessor(AccumuloConfiguration conf, TProcessor next, String serverName,
-      String threadName) {
-    this(next, serverName, threadName);
-  }
-
-  public TimedProcessor(TProcessor next, String serverName, String threadName) {
+  public TimedProcessor(TProcessor next) {
     this.other = next;
-    thriftMetrics = new ThriftMetrics(serverName, threadName);
+    thriftMetrics = new ThriftMetrics();
     MetricsUtil.initializeProducers(thriftMetrics);
     idleStart = System.currentTimeMillis();
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -752,6 +752,11 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
             + " ZooKeeper. Delegation token authentication will be unavailable.", e);
       }
     }
+    try {
+      clientAddress = startTabletClientService();
+    } catch (UnknownHostException e1) {
+      throw new RuntimeException("Failed to start the tablet client service", e1);
+    }
 
     try {
       MetricsUtil.initializeMetrics(context.getConfiguration(), this.applicationName,
@@ -774,11 +779,6 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
         getContext(), ceMetrics);
     compactionManager.start();
 
-    try {
-      clientAddress = startTabletClientService();
-    } catch (UnknownHostException e1) {
-      throw new RuntimeException("Failed to start the tablet client service", e1);
-    }
     announceExistence();
 
     try {

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -190,8 +190,10 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
             log.trace("METRICS, name: '{}' num tags: {}, tags: {}", a.getName(), t.size(), t);
             // check hostname is always set and is valid
             assertNotEquals("0.0.0.0", a.getTags().get("host"));
+
             // check the length of the tag value is sane
-            a.getTags().forEach((k, v) -> assertTrue(v.length() < 128));
+            final int MAX_EXPECTED_TAG_LEN = 128;
+            a.getTags().forEach((k, v) -> assertTrue(v.length() < MAX_EXPECTED_TAG_LEN));
           });
     }
   }

--- a/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/MetricsIT.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.test.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -27,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -43,6 +46,7 @@ import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.accumulo.test.metrics.TestStatsDSink.Metric;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -70,6 +74,7 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
 
   @Override
   protected void configure(MiniAccumuloConfigImpl cfg, Configuration hadoopCoreSite) {
+    cfg.setNumTservers(2);
     cfg.setProperty(Property.GC_CYCLE_START, "1s");
     cfg.setProperty(Property.GC_CYCLE_DELAY, "1s");
     cfg.setProperty(Property.MANAGER_FATE_METRICS_MIN_UPDATE_INTERVAL, "1s");
@@ -130,6 +135,9 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     try (AccumuloClient client = Accumulo.newClient().from(getClientProperties()).build()) {
       String tableName = this.getClass().getSimpleName();
       client.tableOperations().create(tableName);
+      SortedSet<Text> splits = new TreeSet<>(List.of(new Text("5")));
+      client.tableOperations().addSplits(tableName, splits);
+      Thread.sleep(3_000);
       BatchWriterConfig config = new BatchWriterConfig().setMaxMemory(0);
       try (BatchWriter writer = client.createBatchWriter(tableName, config)) {
         Mutation m = new Mutation("row");
@@ -141,6 +149,14 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
         Mutation m = new Mutation("row");
         m.put("cf", "cq", new Value("value"));
         writer.addMutation(m);
+      }
+      client.tableOperations().flush(tableName);
+      try (BatchWriter writer = client.createBatchWriter(tableName, config)) {
+        for (int i = 0; i < 10; i++) {
+          Mutation m = new Mutation(i + "_row");
+          m.put("cf", "cq", new Value("value"));
+          writer.addMutation(m);
+        }
       }
       client.tableOperations().compact(tableName, new CompactionConfig());
       try (Scanner scanner = client.createScanner(tableName)) {
@@ -158,4 +174,25 @@ public class MetricsIT extends ConfigurableMacBase implements MetricsProducer {
     // unused; this class only extends MetricsProducer to easily reference its methods/constants
   }
 
+  @Test
+  public void metricTags() throws Exception {
+
+    doWorkToGenerateMetrics();
+    cluster.stop();
+
+    List<String> statsDMetrics;
+
+    // loop until we run out of lines or until we see all expected metrics
+    while (!(statsDMetrics = sink.getLines()).isEmpty()) {
+      statsDMetrics.stream().filter(line -> line.startsWith("accumulo"))
+          .map(TestStatsDSink::parseStatsDMetric).forEach(a -> {
+            var t = a.getTags();
+            log.trace("METRICS, name: '{}' num tags: {}, tags: {}", a.getName(), t.size(), t);
+            // check hostname is always set and is valid
+            assertNotEquals("0.0.0.0", a.getTags().get("host"));
+            // check the length of the tag value is sane
+            a.getTags().forEach((k, v) -> assertTrue(v.length() < 128));
+          });
+    }
+  }
 }

--- a/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
+++ b/test/src/main/java/org/apache/accumulo/test/metrics/TestStatsDSink.java
@@ -83,7 +83,7 @@ public class TestStatsDSink implements Closeable {
     String[] tag = tags.split(",");
     for (String t : tag) {
       String[] p = t.split(":");
-      m.getTags().put(p[0], p[1].trim());
+      m.getTags().put(p[0], p[1]);
     }
     return m;
   }
@@ -102,7 +102,7 @@ public class TestStatsDSink implements Closeable {
         DatagramPacket packet = new DatagramPacket(buf, len);
         try {
           sock.receive(packet);
-          received.add(new String(packet.getData()));
+          received.add(new String(packet.getData(), 0, packet.getLength()));
         } catch (IOException e) {
           if (!sock.isClosed()) {
             LOG.error("Error receiving packet", e);


### PR DESCRIPTION
- Fixes tserver initialization so host name and port are reported in metrics
- remove extra tags from thrift metrics
- Update opentelemetry and micrometer versions
- update test to check tag length is sane.
- Includes fix for tag length submitted as PR #3296 

Currently, tserver metrics tags do not include the host and there are extra tags on the thrift metrics.  Currently the tags are reported as:
```
METRICS, name: 'accumulo.thrift.idle' num tags: 4, tags: {process.name=tserver, server=TabletServer, Address=0.0.0.0, thread=Thrift Client Server}
METRICS, name: 'accumulo.thrift.idle' num tags: 4, tags: {process.name=tserver, server=TabletServer, Address=0.0.0.0, thread=Thrift Client Server}
METRICS, name: 'accumulo.thrift.idle' num tags: 4, tags: {process.name=manager, server=Manager, Address=server1 thread=Manager Client Service Handler}
METRICS, name: 'accumulo.tserver.scans.files.open' num tags: 3, tags: {process.name=tserver, statistic=value, Address=0.0.0.0}
METRICS, name: 'accumulo.tserver.compactions.majc.queued' num tags: 4, tags: {process.name=tserver, statistic=value, Address=0.0.0.0, id=i.meta.huge}


```

This update changes the global tags to always include the host and the port number:

```
METRICS, name: 'accumulo.thrift.idle' num tags: 3, tags: {process.name=tserver, port=32779, host=server1}
METRICS, name: 'accumulo.thrift.idle' num tags: 3, tags: {process.name=tserver, port=39729, host=server1}
METRICS, name: 'accumulo.thrift.idle' num tags: 3, tags: {process.name=manager, port=43165, host=server1}
METRICS, name: 'accumulo.tserver.scans.files.open' num tags: 4, tags: {process.name=tserver, statistic=value, port=32779, host=server1}
METRICS, name: 'accumulo.tserver.compactions.majc.running' num tags: 5, tags: {process.name=tserver, statistic=value, port=32779, host=server1, id=i.root.huge}
```

Co-authored-by: NAME @ddanielr 