### PR TITLE
add dependency for packaging, micrometer-core has a runtime dependency on micrometer-commons

### DIFF
--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -128,12 +128,12 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
+      <artifactId>micrometer-commons</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-commons</artifactId>
+      <artifactId>micrometer-core</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/assemble/pom.xml
+++ b/assemble/pom.xml
@@ -132,6 +132,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
With the latest version of micrometer (1.10.6), there is a runtime dependency on micrometer-commons.

@jmark99 discovered running fluo that the manager / tservers were dying with the exception

<details>
<summary>java.lang.NoClassDefFoundError: io/micrometer/common/util/internal/logging/InternalLoggerFactory</summary>

```
Exception in thread "manager" java.lang.NoClassDefFoundError:io/micrometer/common/util/internal/logging/InternalLoggerFactory
        at io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics.<clinit>(ExecutorServiceMetrics.java:58)
        at org.apache.accumulo.core.metrics.MetricsUtil.addExecutorServiceMetrics(MetricsUtil.java:117)
        at org.apache.accumulo.core.util.threads.ThreadPools.createScheduledExecutorService(ThreadPools.java:541)
        at org.apache.accumulo.core.util.threads.ThreadPools.createExecutorService(ThreadPools.java:251)
        at org.apache.accumulo.core.util.threads.ThreadPools.createGeneralScheduledExecutorService(ThreadPools.java:469)
        at org.apache.accumulo.server.ServerContext.lambda$new$7(ServerContext.java:128)
        at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:183)
        at org.apache.accumulo.server.ServerContext.getScheduledExecutor(ServerContext.java:439)
        at org.apache.accumulo.server.ServerContext.monitorSwappiness(ServerContext.java:413)
        at org.apache.accumulo.server.ServerContext.init(ServerContext.java:399)
        at org.apache.accumulo.server.AbstractServer.<init>(AbstractServer.java:55)
        at org.apache.accumulo.manager.Manager.<init>(Manager.java:421)
        at org.apache.accumulo.manager.Manager.main(Manager.java:415)
        at org.apache.accumulo.manager.ManagerExecutable.execute(ManagerExecutable.java:45)
        at org.apache.accumulo.start.Main.lambda$execKeyword$0(Main.java:81)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: io.micrometer.common.util.internal.logging.InternalLoggerFactory
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:582)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        ... 16 more (edited) 
```
</details>