### PR TITLE
update to use nanotime in TimedProcessor calculations

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TimedProcessor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.server.rpc;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import org.apache.accumulo.core.metrics.MetricsUtil;
 import org.apache.accumulo.server.metrics.ThriftMetrics;
 import org.apache.thrift.TException;
@@ -37,18 +39,19 @@ public class TimedProcessor implements TProcessor {
     this.other = next;
     thriftMetrics = new ThriftMetrics();
     MetricsUtil.initializeProducers(thriftMetrics);
-    idleStart = System.currentTimeMillis();
+    idleStart = System.nanoTime();
   }
 
   @Override
   public void process(TProtocol in, TProtocol out) throws TException {
-    long now = System.currentTimeMillis();
-    thriftMetrics.addIdle(now - idleStart);
+    long processStart = System.nanoTime();
+    thriftMetrics.addIdle(NANOSECONDS.toMillis(processStart - idleStart));
     try {
       other.process(in, out);
     } finally {
-      idleStart = System.currentTimeMillis();
-      thriftMetrics.addExecute(idleStart - now);
+      // set idle to now, calc time in process
+      idleStart = System.nanoTime();
+      thriftMetrics.addExecute(NANOSECONDS.toMillis(idleStart - processStart));
     }
   }
 }


### PR DESCRIPTION
Use nano time instead of System.currentTime in thrift metric calculation.

This also renames an variable to improve readability.  The time captured as stored locally as `now` but was also used as start time for second calculation.  Renamed and added comment,