### PR TITLE
Add ProblemReport section to metadata schema

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -431,18 +431,6 @@ public class Mutation implements Writable {
    * @param columnQualifier column qualifier
    * @see #at()
    */
-  // public void putDelete(String columnFamily, String columnQualifier) {
-  // put(columnFamily, columnQualifier, EMPTY_BYTES, false, 0L, true, EMPTY_BYTES);
-  // }
-
-  /**
-   * Puts a deletion in this mutation. Matches empty column visibility; timestamp is not set. All
-   * parameters are defensively copied.
-   *
-   * @param columnFamily column family
-   * @param columnQualifier column qualifier
-   * @see #at()
-   */
   public void putDelete(Text columnFamily, Text columnQualifier) {
     put(columnFamily, columnQualifier, EMPTY_BYTES, false, 0L, true, EMPTY_BYTES);
   }

--- a/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/Mutation.java
@@ -431,6 +431,18 @@ public class Mutation implements Writable {
    * @param columnQualifier column qualifier
    * @see #at()
    */
+  // public void putDelete(String columnFamily, String columnQualifier) {
+  // put(columnFamily, columnQualifier, EMPTY_BYTES, false, 0L, true, EMPTY_BYTES);
+  // }
+
+  /**
+   * Puts a deletion in this mutation. Matches empty column visibility; timestamp is not set. All
+   * parameters are defensively copied.
+   *
+   * @param columnFamily column family
+   * @param columnQualifier column qualifier
+   * @see #at()
+   */
   public void putDelete(Text columnFamily, Text columnQualifier) {
     put(columnFamily, columnQualifier, EMPTY_BYTES, false, 0L, true, EMPTY_BYTES);
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/MetadataSchema.java
@@ -402,6 +402,23 @@ public class MetadataSchema {
   }
 
   /**
+   * Holds error message processing flags
+   */
+  public static class ProblemSection {
+    private static final Section section =
+        new Section(RESERVED_PREFIX + "err_", true, RESERVED_PREFIX + "err`", false);
+
+    public static Range getRange() {
+      return section.getRange();
+    }
+
+    public static String getRowPrefix() {
+      return section.getRowPrefix();
+    }
+
+  }
+
+  /**
    * Holds references to files that need replication
    *
    * <pre>

--- a/core/src/main/java/org/apache/accumulo/core/util/Encoding.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/Encoding.java
@@ -20,12 +20,10 @@ package org.apache.accumulo.core.util;
 
 import java.util.Base64;
 
-import org.apache.hadoop.io.Text;
-
 public class Encoding {
 
-  public static String encodeAsBase64FileName(Text data) {
-    String encodedRow = Base64.getUrlEncoder().encodeToString(TextUtil.getBytes(data));
+  public static String encodeAsBase64FileName(byte[] data) {
+    String encodedRow = Base64.getUrlEncoder().encodeToString(data);
 
     int index = encodedRow.length() - 1;
     while (index >= 0 && encodedRow.charAt(index) == '=') {

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
@@ -41,7 +41,6 @@ import org.apache.accumulo.core.metadata.schema.MetadataSchema.ProblemSection;
 import org.apache.accumulo.core.util.Encoding;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.MetadataTableUtil;
-import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.KeeperException;
 
 public class ProblemReport {
@@ -141,15 +140,14 @@ public class ProblemReport {
   }
 
   void removeFromMetadataTable(ServerContext context) throws Exception {
-
-    Mutation m = new Mutation(new Text(ProblemSection.getRowPrefix() + tableId));
-    m.putDelete(new Text(problemType.name()), new Text(resource));
+    Mutation m = new Mutation(ProblemSection.getRowPrefix() + tableId);
+    m.putDelete(problemType.name(), resource);
     MetadataTableUtil.getMetadataTable(context).update(m);
   }
 
   void saveToMetadataTable(ServerContext context) throws Exception {
-    Mutation m = new Mutation(new Text(ProblemSection.getRowPrefix() + tableId));
-    m.put(new Text(problemType.name()), new Text(resource), new Value(encode()));
+    Mutation m = new Mutation(ProblemSection.getRowPrefix() + tableId);
+    m.put(problemType.name(), resource, new Value(encode()));
     MetadataTableUtil.getMetadataTable(context).update(m);
   }
 
@@ -178,8 +176,7 @@ public class ProblemReport {
     dos.close();
     baos.close();
 
-    return zkRoot + Constants.ZPROBLEMS + "/"
-        + Encoding.encodeAsBase64FileName(new Text(baos.toByteArray()));
+    return zkRoot + Constants.ZPROBLEMS + "/" + Encoding.encodeAsBase64FileName(baos.toByteArray());
   }
 
   static ProblemReport decodeZooKeeperEntry(ServerContext context, String node)

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReport.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeExistsPolicy;
 import org.apache.accumulo.core.fate.zookeeper.ZooUtil.NodeMissingPolicy;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ProblemSection;
 import org.apache.accumulo.core.util.Encoding;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.MetadataTableUtil;
@@ -140,13 +141,14 @@ public class ProblemReport {
   }
 
   void removeFromMetadataTable(ServerContext context) throws Exception {
-    Mutation m = new Mutation(new Text("~err_" + tableId));
+
+    Mutation m = new Mutation(new Text(ProblemSection.getRowPrefix() + tableId));
     m.putDelete(new Text(problemType.name()), new Text(resource));
     MetadataTableUtil.getMetadataTable(context).update(m);
   }
 
   void saveToMetadataTable(ServerContext context) throws Exception {
-    Mutation m = new Mutation(new Text("~err_" + tableId));
+    Mutation m = new Mutation(new Text(ProblemSection.getRowPrefix() + tableId));
     m.put(new Text(problemType.name()), new Text(resource), new Value(encode()));
     MetadataTableUtil.getMetadataTable(context).update(m);
   }
@@ -199,7 +201,8 @@ public class ProblemReport {
   }
 
   public static ProblemReport decodeMetadataEntry(Entry<Key,Value> entry) throws IOException {
-    TableId tableId = TableId.of(entry.getKey().getRow().toString().substring("~err_".length()));
+    TableId tableId = TableId
+        .of(entry.getKey().getRow().toString().substring(ProblemSection.getRowPrefix().length()));
     String problemType = entry.getKey().getColumnFamily().toString();
     String resource = entry.getKey().getColumnQualifier().toString();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.iterators.SortedKeyIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.ProblemSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
@@ -161,9 +162,9 @@ public class ProblemReports implements Iterable<ProblemReport> {
     Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     scanner.addScanIterator(new IteratorSetting(1, "keys-only", SortedKeyIterator.class));
 
-    scanner.setRange(new Range(new Text("~err_" + table)));
+    scanner.setRange(new Range(new Text(ProblemSection.getRowPrefix() + table)));
 
-    Mutation delMut = new Mutation(new Text("~err_" + table));
+    Mutation delMut = new Mutation(new Text(ProblemSection.getRowPrefix() + table));
 
     boolean hasProblems = false;
     for (Entry<Key,Value> entry : scanner) {
@@ -217,9 +218,9 @@ public class ProblemReports implements Iterable<ProblemReport> {
                 scanner.setTimeout(3, TimeUnit.SECONDS);
 
                 if (table == null) {
-                  scanner.setRange(new Range(new Text("~err_"), false, new Text("~err`"), false));
+                  scanner.setRange(ProblemSection.getRange());
                 } else {
-                  scanner.setRange(new Range(new Text("~err_" + table)));
+                  scanner.setRange(new Range(new Text(ProblemSection.getRowPrefix() + table)));
                 }
 
                 iter2 = scanner.iterator();

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -50,7 +50,6 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.commons.collections4.map.LRUMap;
-import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,9 +161,9 @@ public class ProblemReports implements Iterable<ProblemReport> {
     Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
     scanner.addScanIterator(new IteratorSetting(1, "keys-only", SortedKeyIterator.class));
 
-    scanner.setRange(new Range(new Text(ProblemSection.getRowPrefix() + table)));
+    scanner.setRange(new Range(ProblemSection.getRowPrefix() + table));
 
-    Mutation delMut = new Mutation(new Text(ProblemSection.getRowPrefix() + table));
+    Mutation delMut = new Mutation(ProblemSection.getRowPrefix() + table);
 
     boolean hasProblems = false;
     for (Entry<Key,Value> entry : scanner) {
@@ -220,7 +219,7 @@ public class ProblemReports implements Iterable<ProblemReport> {
                 if (table == null) {
                   scanner.setRange(ProblemSection.getRange());
                 } else {
-                  scanner.setRange(new Range(new Text(ProblemSection.getRowPrefix() + table)));
+                  scanner.setRange(new Range(ProblemSection.getRowPrefix() + table));
                 }
 
                 iter2 = scanner.iterator();

--- a/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/problems/ProblemReportTest.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.util.Encoding;
 import org.apache.accumulo.server.MockServerContext;
 import org.apache.accumulo.server.ServerContext;
-import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -159,7 +158,7 @@ public class ProblemReportTest {
     r = new ProblemReport(TABLE_ID, ProblemType.FILE_READ, RESOURCE, SERVER, null);
     byte[] zpathFileName = makeZPathFileName(TABLE_ID, ProblemType.FILE_READ, RESOURCE);
     String path = ZooUtil.getRoot(InstanceId.of("instance")) + Constants.ZPROBLEMS + "/"
-        + Encoding.encodeAsBase64FileName(new Text(zpathFileName));
+        + Encoding.encodeAsBase64FileName(zpathFileName);
     zoorw.recursiveDelete(path, NodeMissingPolicy.SKIP);
     replay(zoorw);
 
@@ -173,7 +172,7 @@ public class ProblemReportTest {
     r = new ProblemReport(TABLE_ID, ProblemType.FILE_READ, RESOURCE, SERVER, null, now);
     byte[] zpathFileName = makeZPathFileName(TABLE_ID, ProblemType.FILE_READ, RESOURCE);
     String path = ZooUtil.getRoot(InstanceId.of("instance")) + Constants.ZPROBLEMS + "/"
-        + Encoding.encodeAsBase64FileName(new Text(zpathFileName));
+        + Encoding.encodeAsBase64FileName(zpathFileName);
     byte[] encoded = encodeReportData(now, SERVER, null);
     expect(zoorw.putPersistentData(eq(path), aryEq(encoded), eq(NodeExistsPolicy.OVERWRITE)))
         .andReturn(true);
@@ -186,7 +185,7 @@ public class ProblemReportTest {
   @Test
   public void testDecodeZooKeeperEntry() throws Exception {
     byte[] zpathFileName = makeZPathFileName(TABLE_ID, ProblemType.FILE_READ, RESOURCE);
-    String node = Encoding.encodeAsBase64FileName(new Text(zpathFileName));
+    String node = Encoding.encodeAsBase64FileName(zpathFileName);
     long now = System.currentTimeMillis();
     byte[] encoded = encodeReportData(now, SERVER, "excmsg");
 


### PR DESCRIPTION
Adds ProblemReport section to the metadata schema to consolidate metadata table prefixes.
This removes hardcoded prefix strings located in various classes.