### PR TITLE
Bump plugins and build-related deps

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/tinylfu/TinyLfuBlockCache.java
@@ -71,7 +71,7 @@ public final class TinyLfuBlockCache implements BlockCache {
           int keyWeight = ClassSize.align(blockName.length()) + ClassSize.STRING;
           return keyWeight + block.weight();
         }).maximumWeight(conf.getMaxSize(type)).recordStats().build();
-    policy = cache.policy().eviction().get();
+    policy = cache.policy().eviction().orElseThrow();
     maxSize = (int) Math.min(Integer.MAX_VALUE, policy.getMaximum());
     ScheduledFuture<?> future = statsExecutor.scheduleAtFixedRate(this::logStats, STATS_PERIOD_SEC,
         STATS_PERIOD_SEC, SECONDS);

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -147,7 +147,7 @@ public class TabletLogger {
 
   public static void flushed(KeyExtent extent, Optional<StoredTabletFile> newDatafile) {
     if (newDatafile.isPresent()) {
-      fileLog.debug("Flushed {} created {} from [memory]", extent, newDatafile.get());
+      fileLog.debug("Flushed {} created {} from [memory]", extent, newDatafile.orElseThrow());
     } else {
       fileLog.debug("Flushed {} from [memory] but no file was written.", extent);
     }

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/AESCryptoService.java
@@ -169,11 +169,11 @@ public class AESCryptoService implements CryptoService {
     ensureInit();
     CryptoModule cm;
     var decryptionParams = environment.getDecryptionParams();
-    if (decryptionParams.isEmpty() || checkNoCrypto(decryptionParams.get())) {
+    if (decryptionParams.isEmpty() || checkNoCrypto(decryptionParams.orElseThrow())) {
       return new NoFileDecrypter();
     }
 
-    ParsedCryptoParameters parsed = parseCryptoParameters(decryptionParams.get());
+    ParsedCryptoParameters parsed = parseCryptoParameters(decryptionParams.orElseThrow());
     Key kek = loadDecryptionKek(parsed);
     Key fek = unwrapKey(parsed.getEncFek(), kek);
     switch (parsed.getCryptoServiceVersion()) {

--- a/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/crypto/PerTableCryptoServiceFactory.java
@@ -57,7 +57,7 @@ public class PerTableCryptoServiceFactory implements CryptoServiceFactory {
         log.debug("No tableId present in crypto env: " + environment);
         return NoCryptoServiceFactory.NONE;
       }
-      TableId tableId = environment.getTableId().get();
+      TableId tableId = environment.getTableId().orElseThrow();
       if (props == null || props.isEmpty() || props.get(TABLE_SERVICE_NAME_PROP) == null) {
         return NoCryptoServiceFactory.NONE;
       }

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
@@ -75,7 +75,7 @@ public class DelegatingChooser implements VolumeChooser {
   private VolumeChooser getVolumeChooserForTable(VolumeChooserEnvironment env) {
     log.trace("Looking up property {} for table id: {}", TABLE_CUSTOM_SUFFIX, env.getTable());
 
-    String clazz = env.getServiceEnv().getConfiguration(env.getTable().get())
+    String clazz = env.getServiceEnv().getConfiguration(env.getTable().orElseThrow())
         .getTableCustom(TABLE_CUSTOM_SUFFIX);
 
     // fall back to global default scope, so setting only one default is necessary, rather than a
@@ -92,7 +92,7 @@ public class DelegatingChooser implements VolumeChooser {
       throw new RuntimeException(msg);
     }
 
-    return createVolumeChooser(env, clazz, TABLE_CUSTOM_SUFFIX, env.getTable().get(),
+    return createVolumeChooser(env, clazz, TABLE_CUSTOM_SUFFIX, env.getTable().orElseThrow(),
         tableSpecificChooserCache);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/PreferredVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/PreferredVolumeChooser.java
@@ -168,7 +168,7 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
       Set<String> options) {
     log.trace("Looking up property {} + for Table id: {}", TABLE_CUSTOM_SUFFIX, env.getTable());
 
-    String preferredVolumes = env.getServiceEnv().getConfiguration(env.getTable().get())
+    String preferredVolumes = env.getServiceEnv().getConfiguration(env.getTable().orElseThrow())
         .getTableCustom(TABLE_CUSTOM_SUFFIX);
 
     // fall back to global default scope, so setting only one default is necessary, rather than a

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/CompactionJobImpl.java
@@ -93,7 +93,7 @@ public class CompactionJobImpl implements CompactionJob {
   }
 
   public boolean selectedAll() {
-    return jobSelectedAll.get();
+    return jobSelectedAll.orElseThrow();
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/WithTestNames.java
+++ b/core/src/test/java/org/apache/accumulo/core/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   protected String testName() {

--- a/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/AccumuloConfigurationTest.java
@@ -306,11 +306,11 @@ public class AccumuloConfigurationTest {
     assertEquals(2, executors.size());
 
     ScanExecutorConfig sec =
-        executors.stream().filter(c -> c.name.equals(defName)).findFirst().get();
+        executors.stream().filter(c -> c.name.equals(defName)).findFirst().orElseThrow();
     assertEquals(Integer.parseInt(Property.TSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getDefaultValue()),
         sec.maxThreads);
     assertFalse(sec.priority.isPresent());
-    assertTrue(sec.prioritizerClass.get().isEmpty());
+    assertTrue(sec.prioritizerClass.orElseThrow().isEmpty());
     assertTrue(sec.prioritizerOpts.isEmpty());
 
     // ensure deprecated props is read if nothing else is set
@@ -318,8 +318,8 @@ public class AccumuloConfigurationTest {
     assertEquals(6, sec.getCurrentMaxThreads());
     assertEquals(Integer.parseInt(Property.TSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getDefaultValue()),
         sec.maxThreads);
-    ScanExecutorConfig sec2 =
-        tc.getScanExecutors(false).stream().filter(c -> c.name.equals(defName)).findFirst().get();
+    ScanExecutorConfig sec2 = tc.getScanExecutors(false).stream()
+        .filter(c -> c.name.equals(defName)).findFirst().orElseThrow();
     assertEquals(6, sec2.maxThreads);
 
     // ensure new prop overrides deprecated prop
@@ -327,12 +327,12 @@ public class AccumuloConfigurationTest {
     assertEquals(9, sec.getCurrentMaxThreads());
     assertEquals(Integer.parseInt(Property.TSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getDefaultValue()),
         sec.maxThreads);
-    ScanExecutorConfig sec3 =
-        tc.getScanExecutors(false).stream().filter(c -> c.name.equals(defName)).findFirst().get();
+    ScanExecutorConfig sec3 = tc.getScanExecutors(false).stream()
+        .filter(c -> c.name.equals(defName)).findFirst().orElseThrow();
     assertEquals(9, sec3.maxThreads);
 
     ScanExecutorConfig sec4 =
-        executors.stream().filter(c -> c.name.equals("meta")).findFirst().get();
+        executors.stream().filter(c -> c.name.equals("meta")).findFirst().orElseThrow();
     assertEquals(Integer.parseInt(Property.TSERV_SCAN_EXECUTORS_META_THREADS.getDefaultValue()),
         sec4.maxThreads);
     assertFalse(sec4.priority.isPresent());
@@ -341,14 +341,14 @@ public class AccumuloConfigurationTest {
 
     tc.set("tserver.metadata.readahead.concurrent.max", "2");
     assertEquals(2, sec4.getCurrentMaxThreads());
-    ScanExecutorConfig sec5 =
-        tc.getScanExecutors(false).stream().filter(c -> c.name.equals("meta")).findFirst().get();
+    ScanExecutorConfig sec5 = tc.getScanExecutors(false).stream().filter(c -> c.name.equals("meta"))
+        .findFirst().orElseThrow();
     assertEquals(2, sec5.maxThreads);
 
     tc.set(Property.TSERV_SCAN_EXECUTORS_META_THREADS.getKey(), "3");
     assertEquals(3, sec4.getCurrentMaxThreads());
-    ScanExecutorConfig sec6 =
-        tc.getScanExecutors(false).stream().filter(c -> c.name.equals("meta")).findFirst().get();
+    ScanExecutorConfig sec6 = tc.getScanExecutors(false).stream().filter(c -> c.name.equals("meta"))
+        .findFirst().orElseThrow();
     assertEquals(3, sec6.maxThreads);
 
     String prefix = Property.TSERV_SCAN_EXECUTORS_PREFIX.getKey();
@@ -361,10 +361,10 @@ public class AccumuloConfigurationTest {
     executors = tc.getScanExecutors(false);
     assertEquals(3, executors.size());
     ScanExecutorConfig sec7 =
-        executors.stream().filter(c -> c.name.equals("hulksmash")).findFirst().get();
+        executors.stream().filter(c -> c.name.equals("hulksmash")).findFirst().orElseThrow();
     assertEquals(66, sec7.maxThreads);
     assertEquals(3, sec7.priority.getAsInt());
-    assertEquals("com.foo.ScanPrioritizer", sec7.prioritizerClass.get());
+    assertEquals("com.foo.ScanPrioritizer", sec7.prioritizerClass.orElseThrow());
     assertEquals(Map.of("k1", "v1", "k2", "v3"), sec7.prioritizerOpts);
 
     tc.set(prefix + "hulksmash.threads", "44");
@@ -372,23 +372,23 @@ public class AccumuloConfigurationTest {
     assertEquals(44, sec7.getCurrentMaxThreads());
 
     ScanExecutorConfig sec8 = tc.getScanExecutors(false).stream()
-        .filter(c -> c.name.equals("hulksmash")).findFirst().get();
+        .filter(c -> c.name.equals("hulksmash")).findFirst().orElseThrow();
     assertEquals(44, sec8.maxThreads);
 
     // test scan server props
     Collection<ScanExecutorConfig> scanServExecutors = tc.getScanExecutors(true);
     assertEquals(2, scanServExecutors.size());
     ScanExecutorConfig sec9 =
-        scanServExecutors.stream().filter(c -> c.name.equals(defName)).findFirst().get();
+        scanServExecutors.stream().filter(c -> c.name.equals(defName)).findFirst().orElseThrow();
     // earlier in the test tserver.readahead.concurrent.max was set to 6
     assertEquals(6, sec9.maxThreads);
     assertFalse(sec9.priority.isPresent());
-    assertTrue(sec9.prioritizerClass.get().isEmpty());
+    assertTrue(sec9.prioritizerClass.orElseThrow().isEmpty());
     assertTrue(sec9.prioritizerOpts.isEmpty());
 
     tc.set(Property.SSERV_SCAN_EXECUTORS_DEFAULT_THREADS.getKey(), "17");
-    ScanExecutorConfig sec10 =
-        tc.getScanExecutors(true).stream().filter(c -> c.name.equals(defName)).findFirst().get();
+    ScanExecutorConfig sec10 = tc.getScanExecutors(true).stream()
+        .filter(c -> c.name.equals(defName)).findFirst().orElseThrow();
     assertEquals(17, sec10.maxThreads);
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/system/SourceSwitchingIteratorTest.java
@@ -359,7 +359,7 @@ public class SourceSwitchingIteratorTest {
 
     @Override
     public boolean hasTop() {
-      return (!(yield.isPresent() && yield.get().hasYielded()) && super.hasTop());
+      return (!(yield.isPresent() && yield.orElseThrow().hasYielded()) && super.hasTop());
     }
 
     @Override
@@ -372,7 +372,8 @@ public class SourceSwitchingIteratorTest {
         yielded = true;
         // since we are not actually skipping keys underneath, simply use the key following the top
         // key as the yield key
-        yield.get().yield(getTopKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
+        yield.orElseThrow()
+            .yield(getTopKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
       }
 
       // if not yielding, then simply pass on the next call
@@ -393,7 +394,7 @@ public class SourceSwitchingIteratorTest {
           yielded = true;
           // since we are not actually skipping keys underneath, simply use the key following the
           // range start key
-          yield.get()
+          yield.orElseThrow()
               .yield(range.getStartKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
         }
       }

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/FileOutputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/FileOutputFormatBuilderImpl.java
@@ -116,22 +116,22 @@ public class FileOutputFormatBuilderImpl<T> implements FileOutputFormatBuilder,
 
   private void _store(Configuration conf) {
     if (comp.isPresent()) {
-      FileOutputConfigurator.setCompressionType(callingClass, conf, comp.get());
+      FileOutputConfigurator.setCompressionType(callingClass, conf, comp.orElseThrow());
     }
     if (dataBlockSize.isPresent()) {
-      FileOutputConfigurator.setDataBlockSize(callingClass, conf, dataBlockSize.get());
+      FileOutputConfigurator.setDataBlockSize(callingClass, conf, dataBlockSize.orElseThrow());
     }
     if (fileBlockSize.isPresent()) {
-      FileOutputConfigurator.setFileBlockSize(callingClass, conf, fileBlockSize.get());
+      FileOutputConfigurator.setFileBlockSize(callingClass, conf, fileBlockSize.orElseThrow());
     }
     if (indexBlockSize.isPresent()) {
-      FileOutputConfigurator.setIndexBlockSize(callingClass, conf, indexBlockSize.get());
+      FileOutputConfigurator.setIndexBlockSize(callingClass, conf, indexBlockSize.orElseThrow());
     }
     if (replication.isPresent()) {
-      FileOutputConfigurator.setReplication(callingClass, conf, replication.get());
+      FileOutputConfigurator.setReplication(callingClass, conf, replication.orElseThrow());
     }
     if (sampler.isPresent()) {
-      FileOutputConfigurator.setSampler(callingClass, conf, sampler.get());
+      FileOutputConfigurator.setSampler(callingClass, conf, sampler.orElseThrow());
     }
     if (!summarizers.isEmpty()) {
       FileOutputConfigurator.setSummarizers(callingClass, conf,

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderImpl.java
@@ -216,10 +216,12 @@ public class InputFormatBuilderImpl<T>
           config.setScanAuths(c.securityOperations().getUserAuthorizations(principal));
         }
       }
-      InputConfigurator.setScanAuthorizations(callingClass, conf, config.getScanAuths().get());
+      InputConfigurator.setScanAuthorizations(callingClass, conf,
+          config.getScanAuths().orElseThrow());
       // all optional values
       if (config.getContext().isPresent()) {
-        InputConfigurator.setClassLoaderContext(callingClass, conf, config.getContext().get());
+        InputConfigurator.setClassLoaderContext(callingClass, conf,
+            config.getContext().orElseThrow());
       }
       if (!config.getRanges().isEmpty()) {
         InputConfigurator.setRanges(callingClass, conf, config.getRanges());

--- a/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/OutputFormatBuilderImpl.java
+++ b/hadoop-mapreduce/src/main/java/org/apache/accumulo/hadoopImpl/mapreduce/OutputFormatBuilderImpl.java
@@ -87,7 +87,7 @@ public class OutputFormatBuilderImpl<T>
   private void _store(Configuration conf) {
     OutputConfigurator.setClientProperties(callingClass, conf, clientProps, clientPropsPath);
     if (defaultTableName.isPresent()) {
-      OutputConfigurator.setDefaultTableName(callingClass, conf, defaultTableName.get());
+      OutputConfigurator.setDefaultTableName(callingClass, conf, defaultTableName.orElseThrow());
     }
     OutputConfigurator.setCreateTables(callingClass, conf, createTables);
     OutputConfigurator.setSimulationMode(callingClass, conf, simulationMode);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/WithTestNames.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   public String testName() {

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderTest.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoopImpl/mapreduce/InputFormatBuilderTest.java
@@ -115,7 +115,7 @@ public class InputFormatBuilderTest {
     formatBuilderTest.classLoaderContext(context);
 
     Optional<String> classLoaderContextStr = formatBuilderTest.getClassLoaderContext();
-    assertEquals(context, classLoaderContextStr.get());
+    assertEquals(context, classLoaderContextStr.orElseThrow());
   }
 
   @Test

--- a/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
+++ b/minicluster/src/main/java/org/apache/accumulo/miniclusterImpl/MiniAccumuloClusterControl.java
@@ -138,7 +138,7 @@ public class MiniAccumuloClusterControl implements ClusterControl {
       throw new TTransportException("Unable to get CompactionCoordinator address from ZooKeeper");
     }
     CompactionCoordinatorService.Client client =
-        ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.get(), context);
+        ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.orElseThrow(), context);
     try {
       return client.getRunningCompactions(TraceUtil.traceInfo(), context.rpcCreds());
     } finally {

--- a/minicluster/src/test/java/org/apache/accumulo/minicluster/WithTestNames.java
+++ b/minicluster/src/test/java/org/apache/accumulo/minicluster/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   protected String testName() {

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
     <curator.version>5.3.0</curator.version>
-    <errorprone.version>2.15.0</errorprone.version>
+    <errorprone.version>2.18.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <extraTestArgs />
@@ -145,7 +145,7 @@
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2023-04-07T20:15:28Z</project.build.outputTimestamp>
     <rat.consoleOutput>true</rat.consoleOutput>
-    <slf4j.version>2.0.6</slf4j.version>
+    <slf4j.version>2.0.7</slf4j.version>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.excludedGroups />
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
@@ -585,7 +585,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>4.3</version>
+        <version>5.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.freemarker</groupId>
@@ -703,12 +703,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.12.0</version>
+          <version>2.15.0</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.1</version>
+          <version>4.2</version>
           <configuration>
             <licenseSets>
               <licenseSet>
@@ -738,7 +738,7 @@
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>2.5.0</version>
+          <version>2.6.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
@@ -746,7 +746,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.7.2.0</version>
+          <version>4.7.3.4</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>
@@ -766,7 +766,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -776,7 +776,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.2.1</version>
           <configuration>
             <createBackupFile>false</createBackupFile>
             <expandEmptyElements>false</expandEmptyElements>
@@ -793,7 +793,7 @@
         <plugin>
           <groupId>com.github.koraktor</groupId>
           <artifactId>mavanagaiata</artifactId>
-          <version>1.0.0</version>
+          <version>1.0.1</version>
           <configuration>
             <skipNoGit>true</skipNoGit>
           </configuration>
@@ -912,6 +912,8 @@
           <version>3.3.0</version>
         </plugin>
         <plugin>
+          <!-- 3.1.0 is broken https://github.com/mojohaus/exec-maven-plugin/issues/334 -->
+          <!-- problem tracked in https://github.com/apache/accumulo/issues/3033 -->
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>3.0.0</version>
@@ -924,7 +926,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.21.0</version>
+          <version>2.22.0</version>
           <configuration>
             <configFile>${rootlocation}/contrib/Eclipse-Accumulo-Codestyle.xml</configFile>
             <excludes>
@@ -1201,7 +1203,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.8.0</version>
+            <version>10.9.3</version>
           </dependency>
         </dependencies>
         <executions>
@@ -1377,6 +1379,20 @@
                         <versionRange>[0,)</versionRange>
                         <goals>
                           <goal>commit</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <versionRange>[0,)</versionRange>
+                        <goals>
+                          <goal>check</goal>
+                          <goal>format</goal>
                         </goals>
                       </pluginExecutionFilter>
                       <action>

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -372,7 +372,8 @@ public class ClientServiceHandler implements ClientService.Iface {
       throws ThriftSecurityException {
     checkSystemPermission(credentials);
     return Optional.of(context.getPropStore().get(SystemPropKey.of(context)))
-        .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap())).get();
+        .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap()))
+        .orElseThrow();
   }
 
   @Override
@@ -399,7 +400,8 @@ public class ClientServiceHandler implements ClientService.Iface {
     final TableId tableId = checkTableId(context, tableName, null);
     checkTablePermission(credentials, tableId, TablePermission.ALTER_TABLE);
     return Optional.of(context.getPropStore().get(TablePropKey.of(context, tableId)))
-        .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap())).get();
+        .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap()))
+        .orElseThrow();
   }
 
   @Override
@@ -570,7 +572,8 @@ public class ClientServiceHandler implements ClientService.Iface {
       namespaceId = Namespaces.getNamespaceId(context, ns);
       checkNamespacePermission(credentials, namespaceId, NamespacePermission.ALTER_NAMESPACE);
       return Optional.of(context.getPropStore().get(NamespacePropKey.of(context, namespaceId)))
-          .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap())).get();
+          .map(vProps -> new TVersionedProperties(vProps.getDataVersion(), vProps.asMap()))
+          .orElseThrow();
     } catch (NamespaceNotFoundException e) {
       String why = "Could not find namespace while getting configuration.";
       throw new ThriftTableOperationException(null, ns, null,

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
@@ -95,7 +95,7 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
 
   @Override
   public TableId getTableId() {
-    return tableId.get();
+    return tableId.orElseThrow();
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ECAdmin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ECAdmin.java
@@ -200,7 +200,7 @@ public class ECAdmin implements KeywordExecutable {
     if (coordinatorHost.isEmpty()) {
       throw new IllegalStateException("Unable to find coordinator. Check that it is running.");
     }
-    HostAndPort address = coordinatorHost.get();
+    HostAndPort address = coordinatorHost.orElseThrow();
     CompactionCoordinatorService.Client coordinatorClient;
     try {
       coordinatorClient = ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, address, context);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -200,7 +200,7 @@ public class ManagerMetadataUtil {
     scanFiles.forEach(tablet::putScan);
 
     if (path.isPresent()) {
-      tablet.putFile(path.get(), size);
+      tablet.putFile(path.orElseThrow(), size);
     }
 
     if (compactionId != null) {
@@ -210,7 +210,7 @@ public class ManagerMetadataUtil {
     updateLastForCompactionMode(context, tablet, lastLocation, address, zooLock);
 
     if (ecid.isPresent()) {
-      tablet.deleteExternalCompaction(ecid.get());
+      tablet.deleteExternalCompaction(ecid.orElseThrow());
     }
 
     tablet.putZooLock(zooLock);

--- a/server/base/src/test/java/org/apache/accumulo/server/WithTestNames.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   protected String testName() {

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TableDiskUsageTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TableDiskUsageTest.java
@@ -91,7 +91,8 @@ public class TableDiskUsageTest {
 
     assertEquals(4096, getTotalUsage(result, tableId1));
     assertEquals(1, result.size());
-    Map.Entry<SortedSet<String>,Long> firstResult = result.entrySet().stream().findFirst().get();
+    Map.Entry<SortedSet<String>,Long> firstResult =
+        result.entrySet().stream().findFirst().orElseThrow();
     assertEquals(1, firstResult.getKey().size());
     assertTrue(firstResult.getKey().contains(getTableName(tableId1)));
     assertEquals(4096, firstResult.getValue());
@@ -120,7 +121,8 @@ public class TableDiskUsageTest {
 
     assertEquals(14096, getTotalUsage(result, tableId1));
     assertEquals(1, result.size());
-    Map.Entry<SortedSet<String>,Long> firstResult = result.entrySet().stream().findFirst().get();
+    Map.Entry<SortedSet<String>,Long> firstResult =
+        result.entrySet().stream().findFirst().orElseThrow();
     assertEquals(1, firstResult.getKey().size());
     assertEquals(14096, firstResult.getValue());
 
@@ -148,7 +150,8 @@ public class TableDiskUsageTest {
 
     assertEquals(1024, getTotalUsage(result, MetadataTable.ID));
     assertEquals(1, result.size());
-    Map.Entry<SortedSet<String>,Long> firstResult = result.entrySet().stream().findFirst().get();
+    Map.Entry<SortedSet<String>,Long> firstResult =
+        result.entrySet().stream().findFirst().orElseThrow();
     assertEquals(1024, firstResult.getValue());
 
     EasyMock.verify(client, scanner);
@@ -171,7 +174,8 @@ public class TableDiskUsageTest {
 
     assertEquals(1024, getTotalUsage(result, tableId1));
     assertEquals(1, result.size());
-    Map.Entry<SortedSet<String>,Long> firstResult = result.entrySet().stream().findFirst().get();
+    Map.Entry<SortedSet<String>,Long> firstResult =
+        result.entrySet().stream().findFirst().orElseThrow();
     assertEquals(1, firstResult.getKey().size());
     assertTrue(firstResult.getKey().contains(getTableName(tableId1)));
     assertEquals(1024, firstResult.getValue());
@@ -194,7 +198,8 @@ public class TableDiskUsageTest {
 
     assertEquals(0, getTotalUsage(result, tableId1));
     assertEquals(1, result.size());
-    Map.Entry<SortedSet<String>,Long> firstResult = result.entrySet().stream().findFirst().get();
+    Map.Entry<SortedSet<String>,Long> firstResult =
+        result.entrySet().stream().findFirst().orElseThrow();
     assertEquals(1, firstResult.getKey().size());
     assertEquals(0, firstResult.getValue());
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -479,8 +479,9 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
     if (coordinatorHost.isEmpty()) {
       throw new TTransportException("Unable to get CompactionCoordinator address from ZooKeeper");
     }
-    LOG.trace("CompactionCoordinator address is: {}", coordinatorHost.get());
-    return ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.get(), getContext());
+    LOG.trace("CompactionCoordinator address is: {}", coordinatorHost.orElseThrow());
+    return ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.orElseThrow(),
+        getContext());
   }
 
   /**

--- a/server/manager/src/test/java/org/apache/accumulo/manager/WithTestNames.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   protected String testName() {

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -389,7 +389,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
         coordinatorHost = ExternalCompactionUtil.findCompactionCoordinator(context);
         coordinatorCheckNanos = System.nanoTime();
         if (previousHost.isEmpty() && coordinatorHost.isPresent()) {
-          log.info("External Compaction Coordinator found at {}", coordinatorHost.get());
+          log.info("External Compaction Coordinator found at {}", coordinatorHost.orElseThrow());
         }
       }
 
@@ -665,7 +665,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
     if (coordinatorHost.isEmpty()) {
       throw new IllegalStateException(coordinatorMissingMsg);
     }
-    var ccHost = coordinatorHost.get();
+    var ccHost = coordinatorHost.orElseThrow();
     log.info("User initiated fetch of running External Compactions from " + ccHost);
     var client = getCoordinator(ccHost);
     TExternalCompactionList running;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -147,7 +147,7 @@ public class TabletServerResourceManager {
     } else {
       ScanPrioritizer factory = null;
       try {
-        factory = ConfigurationTypeHelper.getClassInstance(null, sec.prioritizerClass.get(),
+        factory = ConfigurationTypeHelper.getClassInstance(null, sec.prioritizerClass.orElseThrow(),
             ScanPrioritizer.class);
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -187,11 +187,11 @@ public class CompactionService {
         planningExecutor.execute(() -> {
           try {
             Optional<Compactable.Files> files = compactable.getFiles(myId, kind);
-            if (files.isEmpty() || files.get().candidates.isEmpty()) {
+            if (files.isEmpty() || files.orElseThrow().candidates.isEmpty()) {
               log.trace("Compactable returned no files {} {}", compactable.getExtent(), kind);
             } else {
-              CompactionPlan plan = getCompactionPlan(kind, files.get(), compactable);
-              submitCompactionJob(plan, files.get(), compactable, completionCallback);
+              CompactionPlan plan = getCompactionPlan(kind, files.orElseThrow(), compactable);
+              submitCompactionJob(plan, files.orElseThrow(), compactable, completionCallback);
             }
           } finally {
             queuedForPlanning.get(kind).remove(compactable.getExtent());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/DfsLogger.java
@@ -172,7 +172,7 @@ public class DfsLogger implements Comparable<DfsLogger> {
         long start = System.currentTimeMillis();
         try {
           if (shouldHSync.isPresent()) {
-            if (shouldHSync.get()) {
+            if (shouldHSync.orElseThrow()) {
               logFile.hsync();
               syncCounter.incrementAndGet();
             } else {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -212,9 +212,9 @@ public class CompactableImpl implements Compactable {
       this.selectionExpirationDeriver = selectionExpirationDeriver;
       allCompactingFiles.addAll(extCompactingFiles);
       if (extSelInfo.isPresent()) {
-        this.selectedFiles.addAll(extSelInfo.get().selectedFiles);
-        this.selectKind = extSelInfo.get().selectKind;
-        this.initiallySelectedAll = extSelInfo.get().initiallySelectedAll;
+        this.selectedFiles.addAll(extSelInfo.orElseThrow().selectedFiles);
+        this.selectKind = extSelInfo.orElseThrow().selectKind;
+        this.initiallySelectedAll = extSelInfo.orElseThrow().initiallySelectedAll;
         this.selectStatus = FileSelectionStatus.RESERVED;
 
         log.debug("Selected compaction status initialized from external compactions {} {} {} {}",
@@ -583,7 +583,7 @@ public class CompactableImpl implements Compactable {
       Preconditions.checkArgument(!jobFiles.isEmpty());
       Preconditions.checkState(allCompactingFiles.removeAll(jobFiles));
       if (newFile.isPresent()) {
-        choppedFiles.add(newFile.get());
+        choppedFiles.add(newFile.orElseThrow());
       }
 
       if ((job.getKind() == CompactionKind.USER || job.getKind() == CompactionKind.SELECTOR)) {
@@ -607,7 +607,7 @@ public class CompactableImpl implements Compactable {
         log.trace("Selected compaction status changed {} {}", getExtent(), selectStatus);
       } else if (selectStatus == FileSelectionStatus.RESERVED) {
         if (newFile.isPresent()) {
-          selectedFiles.add(newFile.get());
+          selectedFiles.add(newFile.orElseThrow());
         }
         log.trace("Compacted subset of selected files {} {} -> {}", getExtent(),
             asFileNames(jobFiles), newFile.orElse(null));
@@ -645,13 +645,15 @@ public class CompactableImpl implements Compactable {
             dataFileSizes.keySet(), extCompactionsToRemove);
 
     if (extSelInfo.isPresent()) {
-      if (extSelInfo.get().selectKind == CompactionKind.USER) {
-        this.chelper = CompactableUtils.getHelper(extSelInfo.get().selectKind, tablet,
-            tabletCompactionId.get().get().getFirst(), tabletCompactionId.get().get().getSecond());
-        this.compactionConfig = tabletCompactionId.get().get().getSecond();
-        this.compactionId = tabletCompactionId.get().get().getFirst();
-      } else if (extSelInfo.get().selectKind == CompactionKind.SELECTOR) {
-        this.chelper = CompactableUtils.getHelper(extSelInfo.get().selectKind, tablet, null, null);
+      if (extSelInfo.orElseThrow().selectKind == CompactionKind.USER) {
+        this.chelper = CompactableUtils.getHelper(extSelInfo.orElseThrow().selectKind, tablet,
+            tabletCompactionId.get().orElseThrow().getFirst(),
+            tabletCompactionId.get().orElseThrow().getSecond());
+        this.compactionConfig = tabletCompactionId.get().orElseThrow().getSecond();
+        this.compactionId = tabletCompactionId.get().orElseThrow().getFirst();
+      } else if (extSelInfo.orElseThrow().selectKind == CompactionKind.SELECTOR) {
+        this.chelper =
+            CompactableUtils.getHelper(extSelInfo.orElseThrow().selectKind, tablet, null, null);
       }
     }
 
@@ -980,7 +982,7 @@ public class CompactableImpl implements Compactable {
       if (compactionId.isEmpty()) {
         unexpectedExternal = true;
         reasons.add("No compaction id in zookeeper");
-      } else if (!compactionId.get().equals(cid)) {
+      } else if (!compactionId.orElseThrow().equals(cid)) {
         unexpectedExternal = true;
         reasons.add("Compaction id mismatch with zookeeper");
       }
@@ -1278,7 +1280,7 @@ public class CompactableImpl implements Compactable {
       return;
     }
 
-    var cInfo = ocInfo.get();
+    var cInfo = ocInfo.orElseThrow();
     Optional<StoredTabletFile> newFile = Optional.empty();
     long startTime = System.currentTimeMillis();
     CompactionKind kind = job.getKind();
@@ -1328,7 +1330,7 @@ public class CompactableImpl implements Compactable {
       return null;
     }
 
-    var cInfo = ocInfo.get();
+    var cInfo = ocInfo.orElseThrow();
 
     try {
       Map<String,String> overrides =

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -404,7 +404,7 @@ class DatafileManager {
         t1 = System.currentTimeMillis();
 
         if (dfv.getNumEntries() > 0 && newFile.isPresent()) {
-          StoredTabletFile newFileStored = newFile.get();
+          StoredTabletFile newFileStored = newFile.orElseThrow();
           if (datafileSizes.containsKey(newFileStored)) {
             log.error("Adding file that is already in set {}", newFileStored);
           }
@@ -480,7 +480,7 @@ class DatafileManager {
             "Compacted files %s are not a subset of tablet files %s", oldDatafiles,
             datafileSizes.keySet());
         if (newFile.isPresent()) {
-          Preconditions.checkState(!datafileSizes.containsKey(newFile.get()),
+          Preconditions.checkState(!datafileSizes.containsKey(newFile.orElseThrow()),
               "New compaction file %s already exist in tablet files %s", newFile,
               datafileSizes.keySet());
         }
@@ -490,7 +490,7 @@ class DatafileManager {
         datafileSizes.keySet().removeAll(oldDatafiles);
 
         if (newFile.isPresent()) {
-          datafileSizes.put(newFile.get(), dfv);
+          datafileSizes.put(newFile.orElseThrow(), dfv);
           // could be used by a follow on compaction in a multipass compaction
         }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1221,7 +1221,7 @@ public class Tablet extends TabletBase {
       return null;
     }
 
-    SortedMap<Double,Key> keys = splitComputations.get().midPoint;
+    SortedMap<Double,Key> keys = splitComputations.orElseThrow().midPoint;
 
     if (keys.isEmpty()) {
       log.info("Cannot split tablet " + extent + ", files contain no data for tablet.");
@@ -1232,7 +1232,7 @@ public class Tablet extends TabletBase {
     // check to see if one row takes up most of the tablet, in which case we can not split
     Text lastRow;
     if (extent.endRow() == null) {
-      lastRow = splitComputations.get().lastRowForDefaultTablet;
+      lastRow = splitComputations.orElseThrow().lastRowForDefaultTablet;
     } else {
       lastRow = extent.endRow();
     }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/WithTestNames.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   protected String testName() {

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplTest.java
@@ -370,7 +370,7 @@ public class CompactableImplTest {
         newFiles("F00001", "F00002", "F00003", "F00004", "F00005", "F00006"), toRemove);
     assertEquals(Set.of(), toRemove.keySet());
     assertTrue(selInfoOpt.isPresent());
-    var selInfo = selInfoOpt.get();
+    var selInfo = selInfoOpt.orElseThrow();
 
     assertTrue(selInfo.initiallySelectedAll);
     assertEquals(CompactionKind.USER, selInfo.selectKind);

--- a/start/src/test/java/org/apache/accumulo/start/classloader/vfs/WithTestNames.java
+++ b/start/src/test/java/org/apache/accumulo/start/classloader/vfs/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   protected String testName() {

--- a/test/src/main/java/org/apache/accumulo/harness/WithTestNames.java
+++ b/test/src/main/java/org/apache/accumulo/harness/WithTestNames.java
@@ -32,7 +32,7 @@ public class WithTestNames {
 
   @BeforeEach
   public void setTestName(TestInfo info) {
-    testName = info.getTestMethod().get().getName();
+    testName = info.getTestMethod().orElseThrow().getName();
   }
 
   public String testName() {

--- a/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
+++ b/test/src/main/java/org/apache/accumulo/test/compaction/ExternalCompactionTestUtils.java
@@ -248,7 +248,7 @@ public class ExternalCompactionTestUtils {
       throw new TTransportException("Unable to get CompactionCoordinator address from ZooKeeper");
     }
     CompactionCoordinatorService.Client client =
-        ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.get(), context);
+        ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.orElseThrow(), context);
     try {
       TExternalCompactionList running =
           client.getRunningCompactions(TraceUtil.traceInfo(), context.rpcCreds());
@@ -266,7 +266,7 @@ public class ExternalCompactionTestUtils {
       throw new TTransportException("Unable to get CompactionCoordinator address from ZooKeeper");
     }
     CompactionCoordinatorService.Client client =
-        ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.get(), context);
+        ThriftUtil.getClient(ThriftClientTypes.COORDINATOR, coordinatorHost.orElseThrow(), context);
     try {
       TExternalCompactionList completed =
           client.getCompletedCompactions(TraceUtil.traceInfo(), context.rpcCreds());

--- a/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/MetadataIT.java
@@ -180,8 +180,8 @@ public class MetadataIT extends AccumuloClusterHarness {
       TabletsMetadata tablets = cc.getAmple().readTablets().forTable(TableId.of("1"))
           .overlapping(startRow, endRow).fetch(FILES, LOCATION, LAST, PREV_ROW).build();
 
-      TabletMetadata tabletMetadata0 = tablets.stream().findFirst().get();
-      TabletMetadata tabletMetadata1 = tablets.stream().skip(1).findFirst().get();
+      TabletMetadata tabletMetadata0 = tablets.stream().findFirst().orElseThrow();
+      TabletMetadata tabletMetadata1 = tablets.stream().skip(1).findFirst().orElseThrow();
 
       String infoTabletId0 = tabletMetadata0.getTableId().toString();
       String infoExtent0 = tabletMetadata0.getExtent().toString();

--- a/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/YieldingIterator.java
@@ -60,7 +60,7 @@ public class YieldingIterator extends WrappingIterator {
 
   @Override
   public boolean hasTop() {
-    return (!(yield.isPresent() && yield.get().hasYielded()) && super.hasTop());
+    return (!(yield.isPresent() && yield.orElseThrow().hasYielded()) && super.hasTop());
   }
 
   @Override
@@ -75,7 +75,8 @@ public class YieldingIterator extends WrappingIterator {
       yieldNexts.incrementAndGet();
       // since we are not actually skipping keys underneath, simply use the key following the top
       // key as the yield key
-      yield.get().yield(getTopKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
+      yield.orElseThrow()
+          .yield(getTopKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
       log.info("end YieldingIterator.next: yielded at " + getTopKey());
     }
 
@@ -122,9 +123,9 @@ public class YieldingIterator extends WrappingIterator {
         // since we are not actually skipping keys underneath, simply use the key following the
         // range start key
         if (range.isStartKeyInclusive()) {
-          yield.get().yield(range.getStartKey());
+          yield.orElseThrow().yield(range.getStartKey());
         } else {
-          yield.get()
+          yield.orElseThrow()
               .yield(range.getStartKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME));
         }
         log.info("end YieldingIterator.next: yielded at " + range.getStartKey());

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellIT.java
@@ -668,7 +668,7 @@ public class ShellIT extends SharedMiniClusterBase {
 
   private String getTableNameFromId(Map<String,String> map, String value) {
     return map.entrySet().stream().filter(entry -> value.equals(entry.getValue()))
-        .map(Map.Entry::getKey).findFirst().get();
+        .map(Map.Entry::getKey).findFirst().orElseThrow();
   }
 
   private void createTables(final int limit, final int modifier) throws IOException {


### PR DESCRIPTION
* Bump plugin versions to latest
* Bump build related deps and plugin deps to latest (errorprone, easymock, checkstyle, slf4j)
* Ignore license-maven-plugin execution when using Eclipse M2E (broken by https://github.com/eclipse-m2e/m2e-core/issues/1332)
* Update source with modernizer recommendations to use Optional.orElseThrow instead of Optional.get (this is also recommended in the Optional javadoc)
* Add comment for why exec-maven-plugin can't be updated (they broke `-p` again)