### PR TITLE
Fix modernizer build errors

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientContext.java
@@ -407,8 +407,8 @@ public class ClientContext implements AccumuloClient {
         ZcStat stat = new ZcStat();
         Optional<ServiceLockData> sld = ServiceLock.getLockData(getZooCache(), zLockPath, stat);
         if (sld.isPresent()) {
-          UUID uuid = sld.get().getServerUUID(ThriftService.TABLET_SCAN);
-          String group = sld.get().getGroup(ThriftService.TABLET_SCAN);
+          UUID uuid = sld.orElseThrow().getServerUUID(ThriftService.TABLET_SCAN);
+          String group = sld.orElseThrow().getGroup(ThriftService.TABLET_SCAN);
           liveScanServers.put(addr, new Pair<>(uuid, group));
         }
       } catch (IllegalArgumentException e) {
@@ -522,7 +522,7 @@ public class ClientContext implements AccumuloClient {
     Optional<ServiceLockData> sld = zooCache.getLockData(zLockManagerPath);
     String location = null;
     if (sld.isPresent()) {
-      location = sld.get().getAddressString(ThriftService.MANAGER);
+      location = sld.orElseThrow().getAddressString(ThriftService.MANAGER);
     }
 
     if (timer != null) {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -547,7 +547,7 @@ public class TabletMetadata {
 
     if (sld.isPresent()) {
       log.trace("Checking server at ZK path = " + lockPath);
-      HostAndPort client = sld.get().getAddress(ServiceLockData.ThriftService.TSERV);
+      HostAndPort client = sld.orElseThrow().getAddress(ServiceLockData.ThriftService.TSERV);
       if (client != null) {
         server = Optional.of(new TServerInstance(client, stat.getEphemeralOwner()));
       }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/TServerClient.java
@@ -70,7 +70,7 @@ public interface TServerClient<C extends TServiceClient> {
           ServiceLock.path(context.getZooKeeperRoot() + Constants.ZTSERVERS + "/" + tserver);
       Optional<ServiceLockData> sld = zc.getLockData(zLocPath);
       if (sld.isPresent()) {
-        HostAndPort address = sld.get().getAddress(ThriftService.TSERV);
+        HostAndPort address = sld.orElseThrow().getAddress(ThriftService.TSERV);
         if (address != null) {
           servers.add(new ThriftTransportKey(address, rpcTimeout, context));
         }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
@@ -108,7 +108,7 @@ public class ExternalCompactionUtil {
       if (sld.isEmpty()) {
         return Optional.empty();
       }
-      return Optional.ofNullable(sld.get().getAddress(ThriftService.COORDINATOR));
+      return Optional.ofNullable(sld.orElseThrow().getAddress(ThriftService.COORDINATOR));
     } catch (KeeperException | InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeChooserEnvironmentImpl.java
@@ -102,7 +102,7 @@ public class VolumeChooserEnvironmentImpl implements VolumeChooserEnvironment {
     }
     VolumeChooserEnvironmentImpl other = (VolumeChooserEnvironmentImpl) obj;
     return getChooserScope() == other.getChooserScope()
-        && Objects.equals(tableId.get(), other.getTable().get());
+        && Objects.equals(tableId.orElseThrow(), other.getTable().orElseThrow());
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/LiveTServerSet.java
@@ -325,7 +325,7 @@ public class LiveTServerSet implements Watcher {
       }
     } else {
       locklessServers.remove(zPath);
-      HostAndPort client = sld.get().getAddress(ServiceLockData.ThriftService.TSERV);
+      HostAndPort client = sld.orElseThrow().getAddress(ServiceLockData.ThriftService.TSERV);
       TServerInstance instance = new TServerInstance(client, stat.getEphemeralOwner());
 
       if (info == null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListInstances.java
@@ -171,7 +171,7 @@ public class ListInstances {
       if (sld.isEmpty()) {
         return null;
       }
-      return sld.get().getAddressString(ThriftService.MANAGER);
+      return sld.orElseThrow().getAddressString(ThriftService.MANAGER);
     } catch (Exception e) {
       handleException(e, printErrors);
       return null;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TabletServerLocks.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TabletServerLocks.java
@@ -49,7 +49,7 @@ public class TabletServerLocks {
         Optional<ServiceLockData> lockData = ServiceLock.getLockData(cache, zLockPath, null);
         final String holder;
         if (lockData.isPresent()) {
-          holder = lockData.get().getAddressString(ThriftService.TSERV);
+          holder = lockData.orElseThrow().getAddressString(ThriftService.TSERV);
         } else {
           holder = "<none>";
         }

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/Monitor.java
@@ -431,7 +431,7 @@ public class Monitor extends AbstractServer implements HighlyAvailableService {
         Optional<ServiceLockData> sld =
             ServiceLockData.parse(zk.getData(path + "/" + locks.get(0)));
         if (sld.isPresent()) {
-          address = sld.get().getAddress(ThriftService.GC);
+          address = sld.orElseThrow().getAddress(ThriftService.GC);
         }
         GCMonitorService.Client client =
             ThriftUtil.getClient(ThriftClientTypes.GC, address, context);

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -288,8 +288,8 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
 
           Optional<ServiceLockData> sld = ServiceLockData.parse(zk.getData(lockPath));
 
-          assertNotNull(sld.get());
-          HostAndPort hostAndPort = sld.get().getAddress(ThriftService.GC);
+          assertNotNull(sld.orElseThrow());
+          HostAndPort hostAndPort = sld.orElseThrow().getAddress(ThriftService.GC);
 
           // We shouldn't have the "bindall" address in zk
           assertNotEquals("0.0.0.0", hostAndPort.getHost());


### PR DESCRIPTION
For some reason e29b58d561b0d0ae5bc032e87f0aa5474a161f61 was causing more modernizer errors. This PR fixes those errors.

All of the errors were fixed by replacing `get()` with `orElseThrow()`