### PR TITLE
use the most recent last column in tablet

### DIFF
--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
@@ -181,6 +181,7 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
       } else if (cf.compareTo(LastLocationColumnFamily.NAME) == 0) {
         if (lastTimestamp < entry.getKey().getTimestamp()) {
           last = Location.last(new TServerInstance(entry.getValue(), cq));
+          lastTimestamp = entry.getKey().getTimestamp();
         }
       } else if (cf.compareTo(ChoppedColumnFamily.NAME) == 0) {
         chopped = true;


### PR DESCRIPTION
While reviewing #3331 an unused variable in MetaDataTableScanner was noticed.  Seems like the purpose of this variable was to get the most recent last column when there are multiple last cols. Update the code to use the variable and hopefully get the most recent last column.