### PR TITLE
Handle exceptions during tablet metadata task

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -24,7 +24,6 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.LOGS;
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 import static org.apache.accumulo.core.util.UtilWaitThread.sleepUninterruptibly;
-import static org.apache.accumulo.core.util.threads.ThreadPools.watchCriticalFixedDelay;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchCriticalScheduledTask;
 import static org.apache.accumulo.core.util.threads.ThreadPools.watchNonCriticalScheduledTask;
 
@@ -823,7 +822,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
 
     long tabletCheckFrequency = aconf.getTimeInMillis(Property.TSERV_HEALTH_CHECK_FREQ);
     // Periodically check that metadata of tablets matches what is held in memory
-    watchCriticalFixedDelay(aconf, tabletCheckFrequency, () -> {
+    watchNonCriticalScheduledTask(context.getScheduledExecutor().scheduleWithFixedDelay(() -> {
       final SortedMap<KeyExtent,Tablet> onlineTabletsSnapshot = onlineTablets.snapshot();
 
       Map<KeyExtent,MetadataUpdateCount> updateCounts = new HashMap<>();
@@ -859,7 +858,7 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
       } finally {
         mdScanSpan.end();
       }
-    });
+    }, tabletCheckFrequency, tabletCheckFrequency, TimeUnit.SECONDS));
 
     final long CLEANUP_BULK_LOADED_CACHE_MILLIS = TimeUnit.MINUTES.toMillis(15);
     watchCriticalScheduledTask(context.getScheduledExecutor().scheduleWithFixedDelay(

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -841,7 +841,6 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
         try (TabletsMetadata tabletsMetadata =
             getContext().getAmple().readTablets().forTablets(onlineTabletsSnapshot.keySet())
                 .fetch(FILES, LOGS, ECOMP, PREV_ROW).build()) {
-          mdScanSpan.end();
           duration = Duration.between(start, Instant.now());
           log.debug("Metadata scan took {}ms for {} tablets read.", duration.toMillis(),
               onlineTabletsSnapshot.keySet().size());
@@ -854,6 +853,11 @@ public class TabletServer extends AbstractServer implements TabletHostingServer 
             tablet.compareTabletInfo(counter, tabletMetadata);
           }
         }
+      } catch (Exception e) {
+        log.error("Unable to complete verification of tablet metadata", e);
+        TraceUtil.setException(mdScanSpan, e, true);
+      } finally {
+        mdScanSpan.end();
       }
     });
 


### PR DESCRIPTION
Make sure to catch and log any errors when the tablet metadata verification task runs to check tablet metadata so that errors do not cause the task and server to halt.

This closes #3346