### PR TITLE
Encapsulate file metadata inside a new object

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/gc/Reference.java
+++ b/core/src/main/java/org/apache/accumulo/core/gc/Reference.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.gc;
 
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 
 /**
  * A GC reference used for collecting files and directories into a single stream. The GC deals with
@@ -37,11 +38,11 @@ public interface Reference {
   TableId getTableId();
 
   /**
-   * Get the exact string stored in the metadata table for this file or directory. A file will be
-   * read from the Tablet "file" column family:
+   * Get the {@link TabletFileMetadataEntry} which contains the exact string stored in the metadata
+   * table for this file or directory. A file will be read from the Tablet "file" column family:
    * {@link org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily}
    * A directory will be read from the "srv:dir" column family:
    * {@link org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.ServerColumnFamily}
    */
-  String getMetadataEntry();
+  TabletFileMetadataEntry getMetadataEntry();
 }

--- a/core/src/main/java/org/apache/accumulo/core/gc/ReferenceDirectory.java
+++ b/core/src/main/java/org/apache/accumulo/core/gc/ReferenceDirectory.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.core.gc;
 
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 
 /**
  * A GC reference to a Tablet directory, like t-0003.
@@ -28,7 +29,7 @@ public class ReferenceDirectory extends ReferenceFile {
   private final String tabletDir; // t-0003
 
   public ReferenceDirectory(TableId tableId, String dirName) {
-    super(tableId, dirName);
+    super(tableId, TabletFileMetadataEntry.of(dirName));
     MetadataSchema.TabletsSection.ServerColumnFamily.validateDirCol(dirName);
     this.tabletDir = dirName;
   }
@@ -46,8 +47,8 @@ public class ReferenceDirectory extends ReferenceFile {
    * A Tablet directory should have a metadata entry equal to the dirName.
    */
   @Override
-  public String getMetadataEntry() {
-    if (!tabletDir.equals(metadataEntry)) {
+  public TabletFileMetadataEntry getMetadataEntry() {
+    if (!tabletDir.equals(metadataEntry.getFilePathString())) {
       throw new IllegalStateException(
           "Tablet dir " + tabletDir + " is not equal to metadataEntry: " + metadataEntry);
     }

--- a/core/src/main/java/org/apache/accumulo/core/gc/ReferenceFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/gc/ReferenceFile.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.gc;
 import java.util.Objects;
 
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 
 /**
  * A GC reference used for streaming and delete markers. This type is a file. Subclass is a
@@ -31,9 +32,9 @@ public class ReferenceFile implements Reference, Comparable<ReferenceFile> {
   public final TableId tableId; // 2a
 
   // the exact string that is stored in the metadata
-  protected final String metadataEntry;
+  protected final TabletFileMetadataEntry metadataEntry;
 
-  public ReferenceFile(TableId tableId, String metadataEntry) {
+  public ReferenceFile(TableId tableId, TabletFileMetadataEntry metadataEntry) {
     this.tableId = Objects.requireNonNull(tableId);
     this.metadataEntry = Objects.requireNonNull(metadataEntry);
   }
@@ -49,7 +50,7 @@ public class ReferenceFile implements Reference, Comparable<ReferenceFile> {
   }
 
   @Override
-  public String getMetadataEntry() {
+  public TabletFileMetadataEntry getMetadataEntry() {
     return metadataEntry;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.accumulo.core.data.Value;
-import org.apache.hadoop.fs.Path;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.hadoop.io.Text;
 
 public class ScanServerRefTabletFile extends TabletFile {
@@ -31,20 +31,21 @@ public class ScanServerRefTabletFile extends TabletFile {
   private final Text colf;
   private final Text colq;
 
-  public ScanServerRefTabletFile(String file, String serverAddress, UUID serverLockUUID) {
-    super(new Path(file));
+  public ScanServerRefTabletFile(TabletFileMetadataEntry metadataEntry, String serverAddress,
+      UUID serverLockUUID) {
+    super(Objects.requireNonNull(metadataEntry.getFilePath()));
     this.colf = new Text(serverAddress);
     this.colq = new Text(serverLockUUID.toString());
   }
 
-  public ScanServerRefTabletFile(String file, Text colf, Text colq) {
-    super(new Path(file));
+  public ScanServerRefTabletFile(TabletFileMetadataEntry metadataEntry, Text colf, Text colq) {
+    super(Objects.requireNonNull(metadataEntry.getFilePath()));
     this.colf = colf;
     this.colq = colq;
   }
 
-  public String getRowSuffix() {
-    return this.getPathStr();
+  public TabletFileMetadataEntry getRowSuffix() {
+    return this.getMetaInsert();
   }
 
   public Text getServerAddress() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -23,6 +23,7 @@ import static org.apache.accumulo.core.Constants.HDFS_TABLES_DIR;
 import java.util.Objects;
 
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class TabletFile implements Comparable<TabletFile> {
   private final TabletDirectory tabletDir; // hdfs://1.2.3.4/accumulo/tables/2a/t-0003
   private final String fileName; // C0004.rf
   protected final Path metaPath;
-  private final String normalizedPath;
+  private final TabletFileMetadataEntry normalizedPath;
 
   private static final Logger log = LoggerFactory.getLogger(TabletFile.class);
 
@@ -76,7 +77,8 @@ public class TabletFile implements Comparable<TabletFile> {
     var volume = volumePath.toString();
 
     this.tabletDir = new TabletDirectory(volume, TableId.of(id), tabletDirPath.getName());
-    this.normalizedPath = tabletDir.getNormalizedPath() + "/" + fileName;
+    this.normalizedPath =
+        TabletFileMetadataEntry.of(tabletDir.getNormalizedPath() + "/" + fileName);
   }
 
   public String getVolume() {
@@ -100,28 +102,28 @@ public class TabletFile implements Comparable<TabletFile> {
    * metadata.
    */
   public String getPathStr() {
-    return normalizedPath;
+    return normalizedPath.getFilePathString();
   }
 
   /**
-   * Return a string for inserting a new tablet file.
+   * Return a {@link TabletFileMetadataEntry} for inserting a new tablet file.
    */
-  public String getMetaInsert() {
+  public TabletFileMetadataEntry getMetaInsert() {
     return normalizedPath;
   }
 
   /**
-   * Return a new Text object of {@link #getMetaInsert()}
+   * Return a new Text object of {@link #getMetaInsert()} for inserting into a table file
    */
   public Text getMetaInsertText() {
-    return new Text(getMetaInsert());
+    return getMetaInsert().getMetaText();
   }
 
   /**
    * New file was written to metadata so return a StoredTabletFile
    */
   public StoredTabletFile insert() {
-    return new StoredTabletFile(normalizedPath);
+    return new StoredTabletFile(getMetaInsert());
   }
 
   public Path getPath() {
@@ -153,6 +155,6 @@ public class TabletFile implements Comparable<TabletFile> {
 
   @Override
   public String toString() {
-    return normalizedPath;
+    return normalizedPath.toString();
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ValidationUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ValidationUtil.java
@@ -40,7 +40,7 @@ public class ValidationUtil {
   }
 
   public static ReferenceFile validate(ReferenceFile reference) {
-    validate(new Path(reference.getMetadataEntry()));
+    validate(reference.getMetadataEntry().getFilePath());
     return reference;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
@@ -129,10 +129,11 @@ public class ExternalCompactionMetadata {
   public String toJson() {
     GSonData jData = new GSonData();
 
-    jData.inputs = jobFiles.stream().map(StoredTabletFile::getMetaUpdateDelete).collect(toList());
-    jData.nextFiles =
-        nextFiles.stream().map(StoredTabletFile::getMetaUpdateDelete).collect(toList());
-    jData.tmp = compactTmpName.getMetaInsert();
+    jData.inputs = jobFiles.stream()
+        .map(tabletFile -> tabletFile.getMetaUpdateDelete().getMetaString()).collect(toList());
+    jData.nextFiles = nextFiles.stream()
+        .map(tabletFile -> tabletFile.getMetaUpdateDelete().getMetaString()).collect(toList());
+    jData.tmp = compactTmpName.getMetaInsert().getMetaString();
     jData.compactor = compactorId;
     jData.kind = kind.name();
     jData.executorId = ((CompactionExecutorIdImpl) ceid).getExternalName();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileMetadataEntry.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileMetadataEntry.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata.schema;
+
+import java.util.Objects;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+
+/**
+ * Represents the exact string stored in the metadata table "file" column family. Currently the
+ * metadata only contains a file reference but could be expanded in the future.
+ */
+public class TabletFileMetadataEntry implements Comparable<TabletFileMetadataEntry> {
+
+  private final Path filePath;
+  private final String filePathString;
+
+  public TabletFileMetadataEntry(final Path filePath) {
+    this.filePath = Objects.requireNonNull(filePath);
+    // Cache the string value of the filePath, so we don't have to keep converting.
+    this.filePathString = filePath.toString();
+  }
+
+  /**
+   * The file path portion of the metadata
+   *
+   * @return The file path
+   */
+  public Path getFilePath() {
+    return filePath;
+  }
+
+  /**
+   * String representation of the file path
+   *
+   * @return file path string
+   */
+  public String getFilePathString() {
+    return filePathString;
+  }
+
+  /**
+   * Exact representation of what is in the Metadata table Currently this is just a file path but
+   * may expand
+   *
+   * @return The exact metadata string
+   */
+  public String getMetaString() {
+    return filePathString;
+  }
+
+  /**
+   * Exact {@link Text} representation of the metadat Generated from {@link #getMetaString()}
+   *
+   * @return The exact metadata as Text
+   */
+  public Text getMetaText() {
+    return new Text(filePathString);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TabletFileMetadataEntry that = (TabletFileMetadataEntry) o;
+    return Objects.equals(filePathString, that.filePathString);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filePathString);
+  }
+
+  @Override
+  public int compareTo(TabletFileMetadataEntry o) {
+    return filePathString.compareTo(o.filePathString);
+  }
+
+  @Override
+  public String toString() {
+    return filePathString;
+  }
+
+  /**
+   * Utility to create a new TabletFileMetadataEntry from the exact String in the Metadata table
+   *
+   * @param metadataEntry Exact string for the metadataEntry
+   * @return A TabletFileMetadataEntry created from the metadata string
+   */
+  public static TabletFileMetadataEntry of(String metadataEntry) {
+    return new TabletFileMetadataEntry(new Path(Objects.requireNonNull(metadataEntry)));
+  }
+
+}

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -33,7 +33,7 @@ public class TabletFileTest {
     StoredTabletFile tabletFile = new StoredTabletFile(metadataEntry);
 
     assertEquals(volume, tabletFile.getVolume());
-    assertEquals(metadataEntry, tabletFile.getMetaUpdateDelete());
+    assertEquals(TabletFileMetadataEntry.of(metadataEntry), tabletFile.getMetaUpdateDelete());
     assertEquals(TableId.of(tableId), tabletFile.getTableId());
     assertEquals(tabletDir, tabletFile.getTabletDir());
     assertEquals(fileName, tabletFile.getFileName());
@@ -101,8 +101,8 @@ public class TabletFileTest {
     String metadataEntry = uglyVolume + "/tables/" + id + "/" + dir + "/" + filename;
     TabletFile uglyFile =
         test(metadataEntry, "hdfs://nn.somewhere.com:86753/accumulo", id, dir, filename);
-    TabletFile niceFile = new StoredTabletFile(
-        "hdfs://nn.somewhere.com:86753/accumulo/tables/" + id + "/" + dir + "/" + filename);
+    TabletFile niceFile = new StoredTabletFile(TabletFileMetadataEntry
+        .of("hdfs://nn.somewhere.com:86753/accumulo/tables/" + id + "/" + dir + "/" + filename));
     assertEquals(niceFile, uglyFile);
     assertEquals(niceFile.hashCode(), uglyFile.hashCode());
   }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletMetadataTest.java
@@ -79,21 +79,25 @@ public class TabletMetadataTest {
     FLUSH_COLUMN.put(mutation, new Value("6"));
     TIME_COLUMN.put(mutation, new Value("M123456789"));
 
-    String bf1 = "hdfs://nn1/acc/tables/1/t-0001/bf1";
-    String bf2 = "hdfs://nn1/acc/tables/1/t-0001/bf2";
-    mutation.at().family(BulkFileColumnFamily.NAME).qualifier(bf1).put(FateTxId.formatTid(56));
-    mutation.at().family(BulkFileColumnFamily.NAME).qualifier(bf2).put(FateTxId.formatTid(59));
+    TabletFileMetadataEntry bf1 = TabletFileMetadataEntry.of("hdfs://nn1/acc/tables/1/t-0001/bf1");
+    TabletFileMetadataEntry bf2 = TabletFileMetadataEntry.of("hdfs://nn1/acc/tables/1/t-0001/bf2");
+    mutation.at().family(BulkFileColumnFamily.NAME).qualifier(bf1.getMetaString())
+        .put(FateTxId.formatTid(56));
+    mutation.at().family(BulkFileColumnFamily.NAME).qualifier(bf2.getMetaString())
+        .put(FateTxId.formatTid(59));
 
     mutation.at().family(ClonedColumnFamily.NAME).qualifier("").put("OK");
 
     DataFileValue dfv1 = new DataFileValue(555, 23);
-    StoredTabletFile tf1 = new StoredTabletFile("hdfs://nn1/acc/tables/1/t-0001/df1.rf");
-    StoredTabletFile tf2 = new StoredTabletFile("hdfs://nn1/acc/tables/1/t-0001/df2.rf");
-    mutation.at().family(DataFileColumnFamily.NAME).qualifier(tf1.getMetaUpdateDelete())
-        .put(dfv1.encode());
+    StoredTabletFile tf1 =
+        new StoredTabletFile(TabletFileMetadataEntry.of("hdfs://nn1/acc/tables/1/t-0001/df1.rf"));
+    StoredTabletFile tf2 =
+        new StoredTabletFile(TabletFileMetadataEntry.of("hdfs://nn1/acc/tables/1/t-0001/df2.rf"));
+    mutation.at().family(DataFileColumnFamily.NAME)
+        .qualifier(tf1.getMetaUpdateDelete().getMetaString()).put(dfv1.encode());
     DataFileValue dfv2 = new DataFileValue(234, 13);
-    mutation.at().family(DataFileColumnFamily.NAME).qualifier(tf2.getMetaUpdateDelete())
-        .put(dfv2.encode());
+    mutation.at().family(DataFileColumnFamily.NAME)
+        .qualifier(tf2.getMetaUpdateDelete().getMetaString()).put(dfv2.encode());
 
     mutation.at().family(CurrentLocationColumnFamily.NAME).qualifier("s001").put("server1:8555");
 
@@ -106,10 +110,14 @@ public class TabletMetadataTest {
     mutation.at().family(le2.getColumnFamily()).qualifier(le2.getColumnQualifier())
         .timestamp(le2.timestamp).put(le2.getValue());
 
-    StoredTabletFile sf1 = new StoredTabletFile("hdfs://nn1/acc/tables/1/t-0001/sf1.rf");
-    StoredTabletFile sf2 = new StoredTabletFile("hdfs://nn1/acc/tables/1/t-0001/sf2.rf");
-    mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf1.getMetaUpdateDelete()).put("");
-    mutation.at().family(ScanFileColumnFamily.NAME).qualifier(sf2.getMetaUpdateDelete()).put("");
+    StoredTabletFile sf1 =
+        new StoredTabletFile(TabletFileMetadataEntry.of("hdfs://nn1/acc/tables/1/t-0001/sf1.rf"));
+    StoredTabletFile sf2 =
+        new StoredTabletFile(TabletFileMetadataEntry.of("hdfs://nn1/acc/tables/1/t-0001/sf2.rf"));
+    mutation.at().family(ScanFileColumnFamily.NAME)
+        .qualifier(sf1.getMetaUpdateDelete().getMetaString()).put("");
+    mutation.at().family(ScanFileColumnFamily.NAME)
+        .qualifier(sf2.getMetaUpdateDelete().getMetaString()).put("");
 
     SortedMap<Key,Value> rowMap = toRowMap(mutation);
 

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -232,7 +232,7 @@ public class FileCompactor implements Callable<CompactionStats> {
               || (!isMinC && acuTableConf.getBoolean(Property.TABLE_MAJC_OUTPUT_DROP_CACHE)));
 
       WriterBuilder outBuilder = fileFactory.newWriterBuilder()
-          .forFile(outputFile.getMetaInsert(), ns, ns.getConf(), cryptoService)
+          .forFile(outputFile.getMetaInsert().getFilePathString(), ns, ns.getConf(), cryptoService)
           .withTableConfiguration(acuTableConf).withRateLimiter(env.getWriteLimiter());
       if (dropCacheBehindOutput) {
         outBuilder.dropCachesBehind();
@@ -345,7 +345,7 @@ public class FileCompactor implements Callable<CompactionStats> {
         readers.add(reader);
 
         InterruptibleIterator iter = new ProblemReportingIterator(context, extent.tableId(),
-            mapFile.getPathStr(), false, reader);
+            mapFile.getPathStr().toString(), false, reader);
 
         iter = filesToCompact.get(mapFile).wrapFileIterator(iter);
 
@@ -353,8 +353,8 @@ public class FileCompactor implements Callable<CompactionStats> {
 
       } catch (Exception e) {
 
-        ProblemReports.getInstance(context).report(
-            new ProblemReport(extent.tableId(), ProblemType.FILE_READ, mapFile.getPathStr(), e));
+        ProblemReports.getInstance(context).report(new ProblemReport(extent.tableId(),
+            ProblemType.FILE_READ, mapFile.getPathStr().toString(), e));
 
         log.warn("Some problem opening map file {} {}", mapFile, e.getMessage(), e);
         // failed to open some map file... close the ones that were opened

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.server.ServerContext;
@@ -162,8 +163,8 @@ public class VolumeUtil {
     }
 
     for (Entry<StoredTabletFile,DataFileValue> entry : tabletFiles.datafiles.entrySet()) {
-      String metaPath = entry.getKey().getMetaUpdateDelete();
-      Path switchedPath = switchVolume(metaPath, FileType.TABLE, replacements);
+      TabletFileMetadataEntry metaPath = entry.getKey().getMetaUpdateDelete();
+      Path switchedPath = switchVolume(metaPath.getFilePathString(), FileType.TABLE, replacements);
       if (switchedPath != null) {
         filesToRemove.add(entry.getKey());
         TabletFile switchedFile = new TabletFile(switchedPath);

--- a/server/base/src/main/java/org/apache/accumulo/server/gc/AllVolumesDirectory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/gc/AllVolumesDirectory.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.hadoop.fs.Path;
 
 /**
@@ -32,7 +33,7 @@ import org.apache.hadoop.fs.Path;
 public class AllVolumesDirectory extends ReferenceFile {
 
   public AllVolumesDirectory(TableId tableId, String dirName) {
-    super(tableId, getDeleteTabletOnAllVolumesUri(tableId, dirName));
+    super(tableId, TabletFileMetadataEntry.of(getDeleteTabletOnAllVolumesUri(tableId, dirName)));
   }
 
   private static String getDeleteTabletOnAllVolumesUri(TableId tableId, String dirName) {
@@ -42,7 +43,7 @@ public class AllVolumesDirectory extends ReferenceFile {
   }
 
   @Override
-  public String getMetadataEntry() {
+  public TabletFileMetadataEntry getMetadataEntry() {
     return metadataEntry;
   }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -167,7 +167,7 @@ public class GCRun implements GarbageCollectionEnvironment {
     });
 
     var scanServerRefs = context.getAmple().getScanServerFileReferences()
-        .map(sfr -> new ReferenceFile(sfr.getTableId(), sfr.getPathStr()));
+        .map(sfr -> new ReferenceFile(sfr.getTableId(), sfr.getRowSuffix()));
 
     return Stream.concat(tabletReferences, scanServerRefs);
   }

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectionAlgorithm.java
@@ -156,7 +156,7 @@ public class GarbageCollectionAlgorithm {
           log.debug("Candidate was still in use: {}", dir);
         }
       } else {
-        String reference = ref.getMetadataEntry();
+        String reference = ref.getMetadataEntry().getFilePathString();
         if (reference.startsWith("/")) {
           log.debug("Candidate {} has a relative path, prepend tableId {}", reference,
               ref.getTableId());

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectionTest.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.junit.jupiter.api.Test;
 
 public class GarbageCollectionTest {
@@ -111,7 +112,8 @@ public class GarbageCollectionTest {
 
     public void addFileReference(String tableId, String endRow, String file) {
       TableId tid = TableId.of(tableId);
-      references.put(tableId + ":" + endRow + ":" + file, new ReferenceFile(tid, file));
+      references.put(tableId + ":" + endRow + ":" + file,
+          new ReferenceFile(tid, TabletFileMetadataEntry.of(file)));
       tableIds.add(tid);
     }
 

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -172,12 +172,12 @@ public class SimpleGarbageCollectorTest {
     confirmed.put("5a/t-0001/F0002.rf", "hdfs://nn1/accumulo/tables/5a/t-0001/F0002.rf");
     confirmed.put("5a/t-0002/F0001.rf", "hdfs://nn1/accumulo/tables/5a/t-0002/F0001.rf");
     var allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0003");
-    confirmed.put("5b/t-0003", allVolumesDirectory.getMetadataEntry());
+    confirmed.put("5b/t-0003", allVolumesDirectory.getMetadataEntry().getFilePathString());
     confirmed.put("5b/t-0003/F0001.rf", "hdfs://nn1/accumulo/tables/5b/t-0003/F0001.rf");
     confirmed.put("5b/t-0003/F0002.rf", "hdfs://nn2/accumulo/tables/5b/t-0003/F0002.rf");
     confirmed.put("5b/t-0003/F0003.rf", "hdfs://nn3/accumulo/tables/5b/t-0003/F0003.rf");
     allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0004");
-    confirmed.put("5b/t-0004", allVolumesDirectory.getMetadataEntry());
+    confirmed.put("5b/t-0004", allVolumesDirectory.getMetadataEntry().getFilePathString());
     confirmed.put("5b/t-0004/F0001.rf", "hdfs://nn1/accumulo/tables/5b/t-0004/F0001.rf");
 
     List<String> processedDeletes = new ArrayList<>();
@@ -188,10 +188,10 @@ public class SimpleGarbageCollectorTest {
     expected.put("5a/t-0001", "hdfs://nn1/accumulo/tables/5a/t-0001");
     expected.put("5a/t-0002/F0001.rf", "hdfs://nn1/accumulo/tables/5a/t-0002/F0001.rf");
     allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0003");
-    expected.put("5b/t-0003", allVolumesDirectory.getMetadataEntry());
+    expected.put("5b/t-0003", allVolumesDirectory.getMetadataEntry().getFilePathString());
     expected.put("5b/t-0003/F0003.rf", "hdfs://nn3/accumulo/tables/5b/t-0003/F0003.rf");
     allVolumesDirectory = new AllVolumesDirectory(TableId.of("5b"), "t-0004");
-    expected.put("5b/t-0004", allVolumesDirectory.getMetadataEntry());
+    expected.put("5b/t-0004", allVolumesDirectory.getMetadataEntry().getFilePathString());
 
     assertEquals(expected, confirmed);
     assertEquals(Arrays.asList("hdfs://nn1/accumulo/tables/5a/t-0001/F0001.rf",

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/CleanUpBulkImport.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.schema.Ample;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.accumulo.manager.Manager;
 import org.apache.accumulo.manager.tableOps.ManagerRepo;
 import org.apache.accumulo.manager.tableOps.Utils;
@@ -56,8 +57,8 @@ public class CleanUpBulkImport extends ManagerRepo {
     Path bulkDir = new Path(info.bulkDir);
     ample.removeBulkLoadInProgressFlag(
         "/" + bulkDir.getParent().getName() + "/" + bulkDir.getName());
-    ample.putGcFileAndDirCandidates(info.tableId,
-        Collections.singleton(new ReferenceFile(info.tableId, bulkDir.toString())));
+    ample.putGcFileAndDirCandidates(info.tableId, Collections.singleton(
+        new ReferenceFile(info.tableId, TabletFileMetadataEntry.of(bulkDir.toString()))));
     if (info.tableState == TableState.ONLINE) {
       log.debug("removing the metadata table markers for loaded files");
       ample.removeBulkLoadEntries(info.tableId, tid);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -573,7 +573,8 @@ public class ScanServer extends AbstractServer
 
       for (StoredTabletFile file : allFiles.keySet()) {
         if (!reservedFiles.containsKey(file)) {
-          refs.add(new ScanServerRefTabletFile(file.getPathStr(), serverAddress, serverLockUUID));
+          refs.add(
+              new ScanServerRefTabletFile(file.getMetaInsert(), serverAddress, serverLockUUID));
           filesToReserve.add(file);
           tabletsToCheck.add(Objects.requireNonNull(allFiles.get(file)));
           LOG.trace("RFFS {} need to add scan ref for file {}", myReservationId, file);
@@ -757,8 +758,8 @@ public class ScanServer extends AbstractServer
             // then adding the file to influxFiles will make it wait until we finish
             influxFiles.add(file);
             confirmed.add(file);
-            refsToDelete
-                .add(new ScanServerRefTabletFile(file.getPathStr(), serverAddress, serverLockUUID));
+            refsToDelete.add(new ScanServerRefTabletFile(file.getMetaUpdateDelete(), serverAddress,
+                serverLockUUID));
 
             // remove the entry from the map while holding the write lock ensuring no new
             // reservations are added to the map values while the metadata operation to delete is

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -449,7 +449,7 @@ public class CompactableUtils {
   }
 
   public static TabletFile computeCompactionFileDest(TabletFile tmpFile) {
-    String newFilePath = tmpFile.getMetaInsert();
+    String newFilePath = tmpFile.getMetaInsert().getFilePathString();
     int idx = newFilePath.indexOf("_tmp");
     if (idx > 0) {
       newFilePath = newFilePath.substring(0, idx);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -89,7 +89,7 @@ class MinorCompactionTask implements Runnable {
                * for the minor compaction
                */
               tablet.getTabletServer().minorCompactionStarted(commitSession,
-                  commitSession.getWALogSeq() + 1, newFile.getMetaInsert());
+                  commitSession.getWALogSeq() + 1, newFile.getMetaInsert().getFilePathString());
               break;
             } catch (IOException e) {
               // An IOException could have occurred while creating the new file

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesCleanIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesCleanIT.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.ScanServerMetadataEntries;
@@ -57,7 +58,8 @@ public class ScanServerMetadataEntriesCleanIT extends SharedMiniClusterBase {
     UUID serverLockUUID = UUID.randomUUID();
 
     Set<ScanServerRefTabletFile> scanRefs = Stream.of("F0000070.rf", "F0000071.rf")
-        .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f)
+        .map(f -> TabletFileMetadataEntry
+            .of("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f))
         .map(f -> new ScanServerRefTabletFile(f, server.toString(), serverLockUUID))
         .collect(Collectors.toSet());
 

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -52,6 +52,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ScanServerFileReferenceSection;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.gc.GCRun;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
@@ -112,7 +113,8 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
     UUID serverLockUUID = UUID.randomUUID();
 
     Set<ScanServerRefTabletFile> scanRefs = Stream.of("F0000070.rf", "F0000071.rf")
-        .map(f -> "hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f)
+        .map(f -> TabletFileMetadataEntry
+            .of("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/" + f))
         .map(f -> new ScanServerRefTabletFile(f, server.toString(), serverLockUUID))
         .collect(Collectors.toSet());
 
@@ -241,12 +243,12 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
         assertEquals(fileCount, metadataEntries.size());
         metadataEntries.forEach(e -> log.info("{}", e.getKey()));
 
-        Set<String> metadataScanFileRefs = new HashSet<>();
+        Set<TabletFileMetadataEntry> metadataScanFileRefs = new HashSet<>();
         metadataEntries.forEach(m -> {
           String row = m.getKey().getRow().toString();
           assertTrue(row.startsWith("~sserv"));
           String file = row.substring(ScanServerFileReferenceSection.getRowPrefix().length());
-          metadataScanFileRefs.add(file);
+          metadataScanFileRefs.add(TabletFileMetadataEntry.of(file));
         });
         assertEquals(fileCount, metadataScanFileRefs.size());
 
@@ -263,7 +265,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
         // server references
         assertEquals(fileCount * 2, tableRefs.size());
 
-        Set<String> deduplicatedReferences =
+        Set<TabletFileMetadataEntry> deduplicatedReferences =
             tableRefs.stream().map(Reference::getMetadataEntry).collect(Collectors.toSet());
 
         assertEquals(fileCount, deduplicatedReferences.size());

--- a/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/VolumeIT.java
@@ -373,7 +373,7 @@ public class VolumeIT extends ConfigurableMacBase {
       int count = 0;
       for (StoredTabletFile file : ((ClientContext) client).getAmple().readTablet(RootTable.EXTENT)
           .getFiles()) {
-        assertTrue(file.getMetaUpdateDelete().startsWith(v2.toString()));
+        assertTrue(file.getMetaUpdateDelete().getFilePathString().startsWith(v2.toString()));
         count++;
       }
 
@@ -442,8 +442,8 @@ public class VolumeIT extends ConfigurableMacBase {
     int count = 0;
     for (StoredTabletFile file : ((ClientContext) client).getAmple().readTablet(RootTable.EXTENT)
         .getFiles()) {
-      assertTrue(file.getMetaUpdateDelete().startsWith(v8.toString())
-          || file.getMetaUpdateDelete().startsWith(v9.toString()));
+      assertTrue(file.getMetaUpdateDelete().getFilePathString().startsWith(v8.toString())
+          || file.getMetaUpdateDelete().getFilePathString().startsWith(v9.toString()));
       count++;
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -555,8 +555,9 @@ public class BulkNewIT extends SharedMiniClusterBase {
       for (TabletMetadata tablet : tablets) {
         assertTrue(tablet.getLoaded().isEmpty());
 
-        Set<String> fileHashes = tablet.getFiles().stream().map(f -> hash(f.getMetaUpdateDelete()))
-            .collect(Collectors.toSet());
+        Set<String> fileHashes =
+            tablet.getFiles().stream().map(f -> hash(f.getMetaUpdateDelete().getFilePathString()))
+                .collect(Collectors.toSet());
 
         String endRow = tablet.getEndRow() == null ? "null" : tablet.getEndRow().toString();
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorIT.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.DeletesSection.SkewedKeyValue;
+import org.apache.accumulo.core.metadata.schema.TabletFileMetadataEntry;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.gc.SimpleGarbageCollector;
@@ -319,7 +320,8 @@ public class GarbageCollectorIT extends ConfigurableMacBase {
         String longpath = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee"
             + "ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjjj";
         var path = String.format("file:/%020d/%s", i, longpath);
-        Mutation delFlag = ample.createDeleteMutation(new ReferenceFile(TableId.of("1"), path));
+        Mutation delFlag = ample.createDeleteMutation(
+            new ReferenceFile(TableId.of("1"), TabletFileMetadataEntry.of(path)));
         bw.addMutation(delFlag);
       }
     }


### PR DESCRIPTION
The goal of this PR is to start to move away from using a String representation everywhere for the file path reference in the metadata table in order to support easier changes in the future when adding more information besides just a path. This is to support the future changes #1327 

The current plan for supporting no chop merges is to start associating a range with a file and treating each file that is fenced off by a range as unique. This is going to lead to storing more than one metadata entry for the same file if there is multiple ranges so we will need to start handling the combination of the file reference and Range in the code.

This PR is an incremental step and introduces an object to encapsulate the file metadata instead of using a String everywhere. There is a new object that is now used as part of `TabletFile` and `StoredTabletFile` called `TabletFileMetadataEntry` which will now represent the value that is stored in the file column. Currently the only thing it has is just a file path like before but now with the addition of this class we can add a field to it (a range or other information) and it will be much easier to update since we are not using a String everywhere.

This PR doesn't go too crazy yet, it introduces the new object and updates the `StoredTabletFile` and `TabletFile` objects but many places in the code still just call the [getter](https://github.com/cshannon/accumulo/blob/991fe838c059e5f2675e4e89c2d8a33b80e58e9e/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletFileMetadataEntry.java#L55) on the new object to get the string representation. Besides a [new constructor](https://github.com/cshannon/accumulo/blob/991fe838c059e5f2675e4e89c2d8a33b80e58e9e/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java#L44) for the new object type, a string is still allowed to be passed to a [constructor](https://github.com/cshannon/accumulo/blob/991fe838c059e5f2675e4e89c2d8a33b80e58e9e/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java#L53) for StoredTabletFile and then just gets converted to the new object but we could stop doing that in the future to prevent errors. I wasn't sure how far to take this in this PR. We could go much further with more changes (at a higher risk) and push the object as far as we can and stop using Strings as much as possible. The main issue with doing that now is it would cause a lot of cascading changes to the code from everything to file handling to external compactions, basically anything using a file reference and I'm not quite sure yet how things are going to progress with the no chop merge changes.

A notable example would be changes to in `FileManager`.  Instead of [tracking](https://github.com/apache/accumulo/blob/56d49f15a05db9a46dbceb845918497760601c11/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java#L484) Strings for the files when range information is added we will need to  track the new object `TabletFileMetadataEntry`. However, I think that the changes for that may be better done in my upcoming PR for adding range information because I haven't decided yet if I plan to use `TabletFileMetadataEntry` or actually just `TabletFile` itself. It might make more sense to just track `TabletFiles` (which will now contain `TabletFileMetadataEntry`). 

Anyways, I think we could probably merge this into 3.0 but could also wait to 3.1. Either way I plan to make my other no-chop merge PRs based on this and continue.