### PR TITLE
Show manager goal state in monitor

### DIFF
--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -61,7 +61,7 @@ function refreshManagerBanners() {
       // only show the goal state if it differs from the manager's current state
       bannerMessage += '. Manager goal state: ' + managerGoalState;
     }
-    $('.manager-banner-message').text(bannerMessage);
+    $('#manager-banner-message').text(bannerMessage);
     $('#managerStateBanner').show();
   });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -46,20 +46,22 @@ function refreshManagerBanners() {
     const managerState = managerData.managerState;
     const managerGoalState = managerData.managerGoalState;
 
-    const isStateGoalDifferent = managerState !== managerGoalState;
+    const isStateGoalSame = managerState === managerGoalState;
 
-    // if the manager state is normal and the goal is the same as the state or manager is not running, return early
-    if ((managerState === 'NORMAL' && !isStateGoalDifferent) || managerState === null) {
+    // if the manager state is normal and the goal state is the same as the current state,
+    // or of the manager is not running, hide the state banner and return early
+    if ((managerState === 'NORMAL' && isStateGoalSame) || managerState === null) {
       $('#managerStateBanner').hide();
       return;
     }
 
     // update the manager state banner message and show it
     let bannerMessage = 'Manager state: ' + managerState;
-    if (isStateGoalDifferent) {
+    if (!isStateGoalSame) {
+      // only show the goal state if it differs from the manager's current state
       bannerMessage += '. Manager goal state: ' + managerGoalState;
     }
-    $('#managerStateBanner .alert.alert-warning').text(bannerMessage);
+    $('.manager-banner-message').text(bannerMessage);
     $('#managerStateBanner').show();
   });
 
@@ -105,79 +107,79 @@ $(document).ready(function () {
     "paging": false,
     "info": false,
     "columnDefs": [{
-        "targets": "big-num",
-        "render": function (data, type) {
-          if (type === 'display') {
-            data = bigNumberForQuantity(data);
-          }
-          return data;
+      "targets": "big-num",
+      "render": function (data, type) {
+        if (type === 'display') {
+          data = bigNumberForQuantity(data);
         }
-      },
-      {
-        "targets": "big-num-rounded",
-        "render": function (data, type) {
-          if (type === 'display') {
-            data = bigNumberForQuantity(Math.round(data));
-          }
-          return data;
-        }
-      },
-      {
-        "targets": "duration",
-        "render": function (data, type) {
-          if (type === 'display') {
-            data = timeDuration(parseInt(data, 10));
-          }
-          return data;
-        }
+        return data;
       }
+    },
+    {
+      "targets": "big-num-rounded",
+      "render": function (data, type) {
+        if (type === 'display') {
+          data = bigNumberForQuantity(Math.round(data));
+        }
+        return data;
+      }
+    },
+    {
+      "targets": "duration",
+      "render": function (data, type) {
+        if (type === 'display') {
+          data = timeDuration(parseInt(data, 10));
+        }
+        return data;
+      }
+    }
     ],
     "columns": [{
-        "data": "manager"
-      },
-      {
-        "data": "onlineTabletServers"
-      },
-      {
-        "data": "totalTabletServers"
-      },
-      {
-        "data": "lastGC",
-        "type": "html",
-        "render": function (data, type) {
-          if (type === 'display') {
-            if (data !== 'Waiting') {
-              data = dateFormat(parseInt(data, 10));
-            }
-            data = '<a href="/gc">' + data + '</a>';
+      "data": "manager"
+    },
+    {
+      "data": "onlineTabletServers"
+    },
+    {
+      "data": "totalTabletServers"
+    },
+    {
+      "data": "lastGC",
+      "type": "html",
+      "render": function (data, type) {
+        if (type === 'display') {
+          if (data !== 'Waiting') {
+            data = dateFormat(parseInt(data, 10));
           }
-          return data;
+          data = '<a href="/gc">' + data + '</a>';
         }
-      },
-      {
-        "data": "tablets"
-      },
-      {
-        "data": "unassignedTablets"
-      },
-      {
-        "data": "numentries"
-      },
-      {
-        "data": "ingestrate"
-      },
-      {
-        "data": "entriesRead"
-      },
-      {
-        "data": "queryrate"
-      },
-      {
-        "data": "holdTime"
-      },
-      {
-        "data": "osload"
-      },
+        return data;
+      }
+    },
+    {
+      "data": "tablets"
+    },
+    {
+      "data": "unassignedTablets"
+    },
+    {
+      "data": "numentries"
+    },
+    {
+      "data": "ingestrate"
+    },
+    {
+      "data": "entriesRead"
+    },
+    {
+      "data": "queryrate"
+    },
+    {
+      "data": "holdTime"
+    },
+    {
+      "data": "osload"
+    },
     ]
   });
 
@@ -197,37 +199,37 @@ $(document).ready(function () {
       }
     },
     "columnDefs": [{
-        "targets": "duration",
-        "render": function (data, type) {
-          if (type === 'display') {
-            data = timeDuration(parseInt(data, 10));
-          }
-          return data;
+      "targets": "duration",
+      "render": function (data, type) {
+        if (type === 'display') {
+          data = timeDuration(parseInt(data, 10));
         }
-      },
-      {
-        "targets": "percent",
-        "render": function (data, type) {
-          if (type === 'display') {
-            data = (data * 100).toFixed(2) + '%';
-          }
-          return data;
-        }
+        return data;
       }
+    },
+    {
+      "targets": "percent",
+      "render": function (data, type) {
+        if (type === 'display') {
+          data = (data * 100).toFixed(2) + '%';
+        }
+        return data;
+      }
+    }
     ],
     "stateSave": true,
     "columns": [{
-        "data": "server"
-      },
-      {
-        "data": "log"
-      },
-      {
-        "data": "time"
-      },
-      {
-        "data": "progress"
-      }
+      "data": "server"
+    },
+    {
+      "data": "log"
+    },
+    {
+      "data": "time"
+    },
+    {
+      "data": "progress"
+    }
     ]
   });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -107,79 +107,79 @@ $(document).ready(function () {
     "paging": false,
     "info": false,
     "columnDefs": [{
-      "targets": "big-num",
-      "render": function (data, type) {
-        if (type === 'display') {
-          data = bigNumberForQuantity(data);
+        "targets": "big-num",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(data);
+          }
+          return data;
         }
-        return data;
-      }
-    },
-    {
-      "targets": "big-num-rounded",
-      "render": function (data, type) {
-        if (type === 'display') {
-          data = bigNumberForQuantity(Math.round(data));
+      },
+      {
+        "targets": "big-num-rounded",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = bigNumberForQuantity(Math.round(data));
+          }
+          return data;
         }
-        return data;
-      }
-    },
-    {
-      "targets": "duration",
-      "render": function (data, type) {
-        if (type === 'display') {
-          data = timeDuration(parseInt(data, 10));
+      },
+      {
+        "targets": "duration",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = timeDuration(parseInt(data, 10));
+          }
+          return data;
         }
-        return data;
       }
-    }
     ],
     "columns": [{
-      "data": "manager"
-    },
-    {
-      "data": "onlineTabletServers"
-    },
-    {
-      "data": "totalTabletServers"
-    },
-    {
-      "data": "lastGC",
-      "type": "html",
-      "render": function (data, type) {
-        if (type === 'display') {
-          if (data !== 'Waiting') {
-            data = dateFormat(parseInt(data, 10));
+        "data": "manager"
+      },
+      {
+        "data": "onlineTabletServers"
+      },
+      {
+        "data": "totalTabletServers"
+      },
+      {
+        "data": "lastGC",
+        "type": "html",
+        "render": function (data, type) {
+          if (type === 'display') {
+            if (data !== 'Waiting') {
+              data = dateFormat(parseInt(data, 10));
+            }
+            data = '<a href="/gc">' + data + '</a>';
           }
-          data = '<a href="/gc">' + data + '</a>';
+          return data;
         }
-        return data;
-      }
-    },
-    {
-      "data": "tablets"
-    },
-    {
-      "data": "unassignedTablets"
-    },
-    {
-      "data": "numentries"
-    },
-    {
-      "data": "ingestrate"
-    },
-    {
-      "data": "entriesRead"
-    },
-    {
-      "data": "queryrate"
-    },
-    {
-      "data": "holdTime"
-    },
-    {
-      "data": "osload"
-    },
+      },
+      {
+        "data": "tablets"
+      },
+      {
+        "data": "unassignedTablets"
+      },
+      {
+        "data": "numentries"
+      },
+      {
+        "data": "ingestrate"
+      },
+      {
+        "data": "entriesRead"
+      },
+      {
+        "data": "queryrate"
+      },
+      {
+        "data": "holdTime"
+      },
+      {
+        "data": "osload"
+      },
     ]
   });
 
@@ -199,37 +199,37 @@ $(document).ready(function () {
       }
     },
     "columnDefs": [{
-      "targets": "duration",
-      "render": function (data, type) {
-        if (type === 'display') {
-          data = timeDuration(parseInt(data, 10));
+        "targets": "duration",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = timeDuration(parseInt(data, 10));
+          }
+          return data;
         }
-        return data;
-      }
-    },
-    {
-      "targets": "percent",
-      "render": function (data, type) {
-        if (type === 'display') {
-          data = (data * 100).toFixed(2) + '%';
+      },
+      {
+        "targets": "percent",
+        "render": function (data, type) {
+          if (type === 'display') {
+            data = (data * 100).toFixed(2) + '%';
+          }
+          return data;
         }
-        return data;
       }
-    }
     ],
     "stateSave": true,
     "columns": [{
-      "data": "server"
-    },
-    {
-      "data": "log"
-    },
-    {
-      "data": "time"
-    },
-    {
-      "data": "progress"
-    }
+        "data": "server"
+      },
+      {
+        "data": "log"
+      },
+      {
+        "data": "time"
+      },
+      {
+        "data": "progress"
+      }
     ]
   });
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/resources/js/manager.js
@@ -25,21 +25,44 @@
 
 var managerStatusTable, recoveryListTable;
 
-function refreshManagerBanner() {
+function refreshManagerBanners() {
   getStatus().then(function () {
-    var managerStatus = JSON.parse(sessionStorage.status).managerStatus;
+    const managerStatus = JSON.parse(sessionStorage.status).managerStatus;
 
     // If manager status is error
     if (managerStatus === 'ERROR') {
-      // show banner and hide table
-      $('#managerBanner').show();
+      // show the manager error banner and hide table
+      $('#managerRunningBanner').show();
       $('#managerStatus_wrapper').hide();
     } else {
-      // otherwise, hide banner and show table
-      $('#managerBanner').hide();
+      // otherwise, hide the error banner and show manager table
+      $('#managerRunningBanner').hide();
       $('#managerStatus_wrapper').show();
     }
   });
+
+  getManager().then(function () {
+    const managerData = JSON.parse(sessionStorage.manager);
+    const managerState = managerData.managerState;
+    const managerGoalState = managerData.managerGoalState;
+
+    const isStateGoalDifferent = managerState !== managerGoalState;
+
+    // if the manager state is normal and the goal is the same as the state or manager is not running, return early
+    if ((managerState === 'NORMAL' && !isStateGoalDifferent) || managerState === null) {
+      $('#managerStateBanner').hide();
+      return;
+    }
+
+    // update the manager state banner message and show it
+    let bannerMessage = 'Manager state: ' + managerState;
+    if (isStateGoalDifferent) {
+      bannerMessage += '. Manager goal state: ' + managerGoalState;
+    }
+    $('#managerStateBanner .alert.alert-warning').text(bannerMessage);
+    $('#managerStateBanner').show();
+  });
+
 }
 
 /**
@@ -47,7 +70,7 @@ function refreshManagerBanner() {
  */
 function refreshManagerTables() {
   ajaxReloadTable(managerStatusTable);
-  refreshManagerBanner();
+  refreshManagerBanners();
   ajaxReloadTable(recoveryListTable);
 }
 

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
@@ -23,8 +23,11 @@
           <h3>Manager Server Overview</h3>
        </div>
     </div>
-    <div id="managerBanner" style="display: none;">
+    <div id="managerRunningBanner" style="display: none;">
         <div class="alert alert-danger" role="alert">Manager Server Not Running</div>
+    </div>
+    <div id="managerStateBanner" style="display: none;">
+        <div class="alert alert-warning" role="alert"></div>
     </div>
     <table id="managerStatus" class="table caption-top table-bordered table-striped table-condensed">
         <caption><span class="table-caption">${title}</span><br /></caption>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
@@ -27,7 +27,7 @@
         <div class="alert alert-danger" role="alert">Manager Server Not Running</div>
     </div>
     <div id="managerStateBanner" style="display: none;">
-        <div class="alert alert-warning" role="alert"></div>
+        <div class="alert alert-warning manager-banner-message" role="alert"></div>
     </div>
     <table id="managerStatus" class="table caption-top table-bordered table-striped table-condensed">
         <caption><span class="table-caption">${title}</span><br /></caption>

--- a/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
+++ b/server/monitor/src/main/resources/org/apache/accumulo/monitor/templates/manager.ftl
@@ -27,7 +27,7 @@
         <div class="alert alert-danger" role="alert">Manager Server Not Running</div>
     </div>
     <div id="managerStateBanner" style="display: none;">
-        <div class="alert alert-warning manager-banner-message" role="alert"></div>
+        <div id="manager-banner-message" class="alert alert-warning" role="alert"></div>
     </div>
     <table id="managerStatus" class="table caption-top table-bordered table-striped table-condensed">
         <caption><span class="table-caption">${title}</span><br /></caption>


### PR DESCRIPTION
Fixes #3373 

This PR adds a banner to the Manager page in 2.1 that will be displayed when the Managers state is not normal or when the state and the goal state differ. The new manager state banner will not be displayed if the manager is down.

Here are some screenshots from the updated Manager page:

When state and goal state differ:
![Screenshot from 2023-05-09 15-19-43](https://github.com/apache/accumulo/assets/47725857/d470c9c1-a739-46fa-905d-8550c4cf9e69)

After state and goal state converge (and the state is not 'NORMAL'):
![Screenshot from 2023-05-09 15-19-49](https://github.com/apache/accumulo/assets/47725857/ea55b0a5-fafe-4c13-a50f-13db758f8600)

When the manager is not running:
![Screenshot from 2023-05-09 15-20-25](https://github.com/apache/accumulo/assets/47725857/fed8a46a-aca1-42e4-920d-7c8579cc41fc)

