### PR TITLE
Disable MapFile in 1.10 and 2.1 patch releases

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -690,7 +690,7 @@ public enum Property {
   TABLE_SCAN_MAXMEM("table.scan.max.memory", "512K", PropertyType.MEMORY,
       "The maximum amount of memory that will be used to cache results of a client query/scan. "
           + "Once this limit is reached, the buffered data is sent to the client."),
-  TABLE_FILE_TYPE("table.file.type", RFile.EXTENSION, PropertyType.STRING,
+  TABLE_FILE_TYPE("table.file.type", RFile.EXTENSION, PropertyType.FILENAME_EXT,
       "Change the type of file a table writes"),
   TABLE_LOAD_BALANCER("table.balancer",
       "org.apache.accumulo.server.master.balancer.DefaultLoadBalancer", PropertyType.STRING,

--- a/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/PropertyType.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.accumulo.core.Constants;
+import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.lang.math.IntRange;
 import org.apache.hadoop.fs.Path;
@@ -119,7 +120,11 @@ public enum PropertyType {
   BOOLEAN("boolean", in(false, null, "true", "false"),
       "Has a value of either 'true' or 'false' (case-insensitive)"),
 
-  URI("uri", x -> true, "A valid URI");
+  URI("uri", x -> true, "A valid URI"),
+
+  FILENAME_EXT("file name extension", in(true, RFile.EXTENSION),
+      "One of the currently supported filename extensions for storing table data files. "
+          + "Currently, only " + RFile.EXTENSION + " is supported.");
 
   private String shortname, format;
   // Field is transient because enums are Serializable, but Predicates aren't necessarily,

--- a/core/src/main/java/org/apache/accumulo/core/iterators/system/MapFileIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/system/MapFileIterator.java
@@ -17,7 +17,6 @@
 package org.apache.accumulo.core.iterators.system;
 
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,139 +27,89 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileSKVIterator;
-import org.apache.accumulo.core.file.NoSuchMetaStoreException;
-import org.apache.accumulo.core.file.map.MapFileUtil;
-import org.apache.accumulo.core.iterators.IterationInterruptedException;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.MapFile.Reader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MapFileIterator implements FileSKVIterator {
-  private static final Logger log = LoggerFactory.getLogger(MapFileIterator.class);
 
-  private Reader reader;
-  private Value topValue;
-  private Key topKey;
-  private AtomicBoolean interruptFlag;
-  private int interruptCheckCount = 0;
-  private FileSystem fs;
-  private String dirName;
+  private static final String MSG = "Map files are not supported";
 
   public MapFileIterator(AccumuloConfiguration acuconf, FileSystem fs, String dir,
-      Configuration conf) throws IOException {
-    this.reader = MapFileUtil.openMapFile(acuconf, fs, dir, conf);
-    this.fs = fs;
-    this.dirName = dir;
+      Configuration conf) {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public void setInterruptFlag(AtomicBoolean flag) {
-    this.interruptFlag = flag;
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options,
-      IteratorEnvironment env) throws IOException {
-    throw new UnsupportedOperationException();
+      IteratorEnvironment env) {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public boolean hasTop() {
-    return topKey != null;
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public void next() throws IOException {
-    if (interruptFlag != null && interruptCheckCount++ % 100 == 0 && interruptFlag.get())
-      throw new IterationInterruptedException();
-
-    reader.next(topKey, topValue);
+  public void next() {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
-      throws IOException {
-    if (columnFamilies.size() != 0 || inclusive) {
-      throw new IllegalArgumentException("I do not know how to filter column families");
-    }
-
-    if (range == null)
-      throw new IllegalArgumentException("Cannot seek to null range");
-
-    if (interruptFlag != null && interruptFlag.get())
-      throw new IterationInterruptedException();
-
-    Key key = range.getStartKey();
-    if (key == null) {
-      key = new Key();
-    }
-
-    reader.seek(key);
-
-    while (hasTop() && range.beforeStartKey(getTopKey())) {
-      next();
-    }
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public Key getTopKey() {
-    return topKey;
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public Value getTopValue() {
-    return topValue;
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
-    try {
-      SortedKeyValueIterator<Key,Value> other = env.reserveMapFileReader(dirName);
-      ((InterruptibleIterator) other).setInterruptFlag(interruptFlag);
-      log.debug("deep copying MapFile: " + this + " -> " + other);
-      return other;
-    } catch (IOException e) {
-      log.error("failed to clone map file reader", e);
-      throw new RuntimeException(e);
-    }
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public Key getFirstKey() throws IOException {
-    throw new UnsupportedOperationException();
+  public Key getFirstKey() {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public Key getLastKey() throws IOException {
-    throw new UnsupportedOperationException();
+  public Key getLastKey() {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public DataInputStream getMetaStore(String name) throws IOException {
-    Path path = new Path(this.dirName, name);
-    if (!fs.exists(path))
-      throw new NoSuchMetaStoreException("name = " + name);
-    return fs.open(path);
+  public DataInputStream getMetaStore(String name) {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public void closeDeepCopies() throws IOException {
-    // nothing to do, deep copies are externally managed/closed
+  public void closeDeepCopies() {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
-  public void close() throws IOException {
-    reader.close();
+  public void close() {
+    throw new UnsupportedOperationException(MSG);
   }
 
   @Override
   public FileSKVIterator getSample(SamplerConfigurationImpl sampleConfig) {
-    return null;
+    throw new UnsupportedOperationException(MSG);
   }
 }

--- a/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/conf/PropertyTypeTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.accumulo.core.file.rfile.RFile;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -198,6 +199,12 @@ public class PropertyTypeTest {
   @Test
   public void testTypeURI() {
     valid(null, "", "hdfs://hostname", "file:///path/", "hdfs://example.com:port/path");
+  }
+
+  @Test
+  public void testTypeFILENAME_EXT() {
+    valid(RFile.EXTENSION, "rf");
+    invalid(null, "RF", "map", "", "MAP", "rF", "Rf", " rf ");
   }
 
 }


### PR DESCRIPTION
Drop MapFile support (#3359) by partially backporting PR #3378, and making minimally disruptive changes to avoid use of MapFiles for 1.10.4 and 2.1.1.

As noted in #3378, MapFile support is already broken and has been for a long time. This change will cause an explicit and detectable failure, rather than a silent one, if a MapFile is attempted to be used.