### PR TITLE
Include missing stack trace when logging error

### DIFF
--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -984,7 +984,7 @@ public class Tablet extends TabletBase {
             activeScans.size());
         this.wait(50);
       } catch (InterruptedException e) {
-        log.error("{}", e, e);
+        log.error("Interrupted waiting to completeClose for extent {}, {}", extent, e, e);
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -984,7 +984,8 @@ public class Tablet extends TabletBase {
             activeScans.size());
         this.wait(50);
       } catch (InterruptedException e) {
-        log.error(e.toString());
+        log.error("{}", e, e);
+        ;
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -985,7 +985,6 @@ public class Tablet extends TabletBase {
         this.wait(50);
       } catch (InterruptedException e) {
         log.error("{}", e, e);
-        ;
       }
     }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -984,7 +984,7 @@ public class Tablet extends TabletBase {
             activeScans.size());
         this.wait(50);
       } catch (InterruptedException e) {
-        log.error("Interrupted waiting to completeClose for extent {}, {}", extent, e, e);
+        log.error("Interrupted waiting to completeClose for extent {}", extent, e);
       }
     }
 


### PR DESCRIPTION
Update the log message for InterruptedException inside the Tablet class to include the full stack trace as it is logged at the error level.