### PR TITLE
Start using TabletFile instead of String for referencing data files

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
@@ -38,6 +38,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.crypto.CryptoFactoryLoader;
 import org.apache.accumulo.core.file.FileOperations;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.metadata.ValidationUtil;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
@@ -118,9 +119,12 @@ class RFileWriterBuilder implements RFile.OutputArguments, RFile.WriterFSOptions
               .withTableConfiguration(acuconf).withStartDisabled().build(),
           visCacheSize);
     } else {
-      return new RFileWriter(fileops.newWriterBuilder()
-          .forFile(out.path.toString(), out.getFileSystem(), out.getConf(), cs)
-          .withTableConfiguration(acuconf).withStartDisabled().build(), visCacheSize);
+      return new RFileWriter(
+          fileops.newWriterBuilder()
+              .forFile(UnassignedTabletFile.of(out.getFileSystem(), out.path), out.getFileSystem(),
+                  out.getConf(), cs)
+              .withTableConfiguration(acuconf).withStartDisabled().build(),
+          visCacheSize);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/rfile/RFileWriterBuilder.java
@@ -38,7 +38,7 @@ import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.crypto.CryptoFactoryLoader;
 import org.apache.accumulo.core.file.FileOperations;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.metadata.ValidationUtil;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
@@ -119,12 +119,10 @@ class RFileWriterBuilder implements RFile.OutputArguments, RFile.WriterFSOptions
               .withTableConfiguration(acuconf).withStartDisabled().build(),
           visCacheSize);
     } else {
-      return new RFileWriter(
-          fileops.newWriterBuilder()
-              .forFile(UnassignedTabletFile.of(out.getFileSystem(), out.path), out.getFileSystem(),
-                  out.getConf(), cs)
-              .withTableConfiguration(acuconf).withStartDisabled().build(),
-          visCacheSize);
+      return new RFileWriter(fileops.newWriterBuilder()
+          .forFile(UnreferencedTabletFile.of(out.getFileSystem(), out.path), out.getFileSystem(),
+              out.getConf(), cs)
+          .withTableConfiguration(acuconf).withStartDisabled().build(), visCacheSize);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -298,7 +298,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       var cs = CryptoFactoryLoader.getServiceForClientWithTable(systemConf, tableConf, tableId);
       FileSystem fs = VolumeConfiguration.fileSystemForPath(file.getPathStr(), conf);
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
-          .forFile(file.getPathStr(), fs, conf, cs).withTableConfiguration(tableCC).build();
+          .forFile(file, fs, conf, cs).withTableConfiguration(tableCC).build();
       if (scannerSamplerConfigImpl != null) {
         reader = reader.getSample(scannerSamplerConfigImpl);
         if (reader == null) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -74,7 +74,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.Retry;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
@@ -263,7 +263,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
   }
 
   public static Map<KeyExtent,Long> estimateSizes(AccumuloConfiguration acuConf,
-      UnassignedTabletFile dataFile, long fileSize, Collection<KeyExtent> extents, FileSystem ns,
+      UnreferencedTabletFile dataFile, long fileSize, Collection<KeyExtent> extents, FileSystem ns,
       Cache<String,Long> fileLenCache, CryptoService cs) throws IOException {
 
     if (extents.size() == 1) {
@@ -355,7 +355,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
   }
 
   public static List<KeyExtent> findOverlappingTablets(ClientContext context,
-      KeyExtentCache extentCache, UnassignedTabletFile file, FileSystem fs,
+      KeyExtentCache extentCache, UnreferencedTabletFile file, FileSystem fs,
       Cache<String,Long> fileLenCache, CryptoService cs) throws IOException {
     try (FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
         .forFile(file, fs, fs.getConf(), cs).withTableConfiguration(context.getConfiguration())
@@ -542,7 +542,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         context.instanceOperations().getSystemConfiguration(), tableProps, tableId);
 
     for (FileStatus fileStatus : files) {
-      UnassignedTabletFile file = UnassignedTabletFile.of(fs, fileStatus.getPath());
+      UnreferencedTabletFile file = UnreferencedTabletFile.of(fs, fileStatus.getPath());
       CompletableFuture<Map<KeyExtent,Bulk.FileInfo>> future = CompletableFuture.supplyAsync(() -> {
         try {
           long t1 = System.currentTimeMillis();

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -74,6 +74,7 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.Retry;
 import org.apache.accumulo.core.volume.VolumeConfiguration;
@@ -261,9 +262,9 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
     long l;
   }
 
-  public static Map<KeyExtent,Long> estimateSizes(AccumuloConfiguration acuConf, Path dataFile,
-      long fileSize, Collection<KeyExtent> extents, FileSystem ns, Cache<String,Long> fileLenCache,
-      CryptoService cs) throws IOException {
+  public static Map<KeyExtent,Long> estimateSizes(AccumuloConfiguration acuConf,
+      UnassignedTabletFile dataFile, long fileSize, Collection<KeyExtent> extents, FileSystem ns,
+      Cache<String,Long> fileLenCache, CryptoService cs) throws IOException {
 
     if (extents.size() == 1) {
       return Collections.singletonMap(extents.iterator().next(), fileSize);
@@ -277,9 +278,9 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
 
     Text row = new Text();
 
-    FileSKVIterator index = FileOperations.getInstance().newIndexReaderBuilder()
-        .forFile(dataFile.toString(), ns, ns.getConf(), cs).withTableConfiguration(acuConf)
-        .withFileLenCache(fileLenCache).build();
+    FileSKVIterator index =
+        FileOperations.getInstance().newIndexReaderBuilder().forFile(dataFile, ns, ns.getConf(), cs)
+            .withTableConfiguration(acuConf).withFileLenCache(fileLenCache).build();
 
     try {
       while (index.hasTop()) {
@@ -354,12 +355,11 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
   }
 
   public static List<KeyExtent> findOverlappingTablets(ClientContext context,
-      KeyExtentCache extentCache, Path file, FileSystem fs, Cache<String,Long> fileLenCache,
-      CryptoService cs) throws IOException {
+      KeyExtentCache extentCache, UnassignedTabletFile file, FileSystem fs,
+      Cache<String,Long> fileLenCache, CryptoService cs) throws IOException {
     try (FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
-        .forFile(file.toString(), fs, fs.getConf(), cs)
-        .withTableConfiguration(context.getConfiguration()).withFileLenCache(fileLenCache)
-        .seekToBeginning().build()) {
+        .forFile(file, fs, fs.getConf(), cs).withTableConfiguration(context.getConfiguration())
+        .withFileLenCache(fileLenCache).seekToBeginning().build()) {
       return findOverlappingTablets(extentCache, reader);
     }
   }
@@ -548,22 +548,22 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         context.instanceOperations().getSystemConfiguration(), tableProps, tableId);
 
     for (FileStatus fileStatus : files) {
-      Path filePath = fileStatus.getPath();
+      UnassignedTabletFile file = UnassignedTabletFile.of(fs, fileStatus.getPath());
       CompletableFuture<Map<KeyExtent,Bulk.FileInfo>> future = CompletableFuture.supplyAsync(() -> {
         try {
           long t1 = System.currentTimeMillis();
           List<KeyExtent> extents =
-              findOverlappingTablets(context, extentCache, filePath, fs, fileLensCache, cs);
+              findOverlappingTablets(context, extentCache, file, fs, fileLensCache, cs);
           // make sure file isn't going to too many tablets
-          checkTabletCount(maxTablets, extents.size(), filePath.toString());
-          Map<KeyExtent,Long> estSizes = estimateSizes(context.getConfiguration(), filePath,
+          checkTabletCount(maxTablets, extents.size(), file.toString());
+          Map<KeyExtent,Long> estSizes = estimateSizes(context.getConfiguration(), file,
               fileStatus.getLen(), extents, fs, fileLensCache, cs);
           Map<KeyExtent,Bulk.FileInfo> pathLocations = new HashMap<>();
           for (KeyExtent ke : extents) {
-            pathLocations.put(ke, new Bulk.FileInfo(filePath, estSizes.getOrDefault(ke, 0L)));
+            pathLocations.put(ke, new Bulk.FileInfo(file.getPath(), estSizes.getOrDefault(ke, 0L)));
           }
           long t2 = System.currentTimeMillis();
-          log.debug("Mapped {} to {} tablets in {}ms", filePath, pathLocations.size(), t2 - t1);
+          log.debug("Mapped {} to {} tablets in {}ms", file, pathLocations.size(), t2 - t1);
           return pathLocations;
         } catch (Exception e) {
           throw new CompletionException(e);

--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -49,11 +49,13 @@ import org.apache.accumulo.core.file.keyfunctor.KeyFunctor;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.util.bloom.Key;
 import org.apache.hadoop.util.hash.Hash;
@@ -475,8 +477,8 @@ public class BloomFilterLayer {
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = "/tmp/test." + suffix;
     FileSKVWriter bmfw = FileOperations.getInstance().newWriterBuilder()
-        .forFile(fname, fs, conf, NoCryptoServiceFactory.NONE).withTableConfiguration(acuconf)
-        .build();
+        .forFile(new TabletFile(new Path(fname)), fs, conf, NoCryptoServiceFactory.NONE)
+        .withTableConfiguration(acuconf).build();
 
     long t1 = System.currentTimeMillis();
 
@@ -498,8 +500,8 @@ public class BloomFilterLayer {
 
     t1 = System.currentTimeMillis();
     FileSKVIterator bmfr = FileOperations.getInstance().newReaderBuilder()
-        .forFile(fname, fs, conf, NoCryptoServiceFactory.NONE).withTableConfiguration(acuconf)
-        .build();
+        .forFile(new TabletFile(new Path(fname)), fs, conf, NoCryptoServiceFactory.NONE)
+        .withTableConfiguration(acuconf).build();
     t2 = System.currentTimeMillis();
     out.println("Opened " + fname + " in " + (t2 - t1));
 

--- a/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
@@ -23,16 +23,15 @@ import java.io.IOException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.file.rfile.RFileOperations;
+import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.summary.SummaryWriter;
-import org.apache.hadoop.fs.Path;
 
 class DispatchingFileFactory extends FileOperations {
 
   private FileOperations findFileFactory(FileOptions options) {
-    String file = options.getFilename();
+    AbstractTabletFile<?> file = options.getFile();
 
-    Path p = new Path(file);
-    String name = p.getName();
+    String name = file.getPath().getName();
 
     String[] sp = name.split("\\.");
 

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -31,11 +31,14 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.file.blockfile.impl.CacheProvider;
 import org.apache.accumulo.core.file.rfile.RFile;
+import org.apache.accumulo.core.metadata.AbstractTabletFile;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileOutputCommitter;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -162,10 +165,10 @@ public abstract class FileOperations {
     return new ReaderBuilder();
   }
 
-  public static class FileOptions {
+  protected static class FileOptions {
     // objects used by all
     public final AccumuloConfiguration tableConfiguration;
-    public final String filename;
+    public final AbstractTabletFile<?> file;
     public final FileSystem fs;
     public final Configuration fsConf;
     public final RateLimiter rateLimiter;
@@ -184,13 +187,13 @@ public abstract class FileOperations {
     public final boolean inclusive;
     public final boolean dropCacheBehind;
 
-    public FileOptions(AccumuloConfiguration tableConfiguration, String filename, FileSystem fs,
-        Configuration fsConf, RateLimiter rateLimiter, String compression,
+    protected FileOptions(AccumuloConfiguration tableConfiguration, AbstractTabletFile<?> file,
+        FileSystem fs, Configuration fsConf, RateLimiter rateLimiter, String compression,
         FSDataOutputStream outputStream, boolean enableAccumuloStart, CacheProvider cacheProvider,
         Cache<String,Long> fileLenCache, boolean seekToBeginning, CryptoService cryptoService,
         Range range, Set<ByteSequence> columnFamilies, boolean inclusive, boolean dropCacheBehind) {
       this.tableConfiguration = tableConfiguration;
-      this.filename = filename;
+      this.file = Objects.requireNonNull(file);
       this.fs = fs;
       this.fsConf = fsConf;
       this.rateLimiter = rateLimiter;
@@ -211,8 +214,8 @@ public abstract class FileOperations {
       return tableConfiguration;
     }
 
-    public String getFilename() {
-      return filename;
+    public AbstractTabletFile<?> getFile() {
+      return file;
     }
 
     public FileSystem getFileSystem() {
@@ -273,7 +276,7 @@ public abstract class FileOperations {
    */
   public static class FileHelper {
     private AccumuloConfiguration tableConfiguration;
-    private String filename;
+    private AbstractTabletFile<?> file;
     private FileSystem fs;
     private Configuration fsConf;
     private RateLimiter rateLimiter;
@@ -290,8 +293,8 @@ public abstract class FileOperations {
       return this;
     }
 
-    protected FileHelper filename(String filename) {
-      this.filename = Objects.requireNonNull(filename);
+    protected FileHelper file(AbstractTabletFile<?> file) {
+      this.file = Objects.requireNonNull(file);
       return this;
     }
 
@@ -317,28 +320,27 @@ public abstract class FileOperations {
 
     protected FileOptions toWriterBuilderOptions(String compression,
         FSDataOutputStream outputStream, boolean startEnabled) {
-      return new FileOptions(tableConfiguration, filename, fs, fsConf, rateLimiter, compression,
+      return new FileOptions(tableConfiguration, file, fs, fsConf, rateLimiter, compression,
           outputStream, startEnabled, NULL_PROVIDER, null, false, cryptoService, null, null, true,
           dropCacheBehind);
     }
 
     protected FileOptions toReaderBuilderOptions(CacheProvider cacheProvider,
         Cache<String,Long> fileLenCache, boolean seekToBeginning) {
-      return new FileOptions(tableConfiguration, filename, fs, fsConf, rateLimiter, null, null,
-          false, cacheProvider == null ? NULL_PROVIDER : cacheProvider, fileLenCache,
-          seekToBeginning, cryptoService, null, null, true, dropCacheBehind);
+      return new FileOptions(tableConfiguration, file, fs, fsConf, rateLimiter, null, null, false,
+          cacheProvider == null ? NULL_PROVIDER : cacheProvider, fileLenCache, seekToBeginning,
+          cryptoService, null, null, true, dropCacheBehind);
     }
 
     protected FileOptions toIndexReaderBuilderOptions(Cache<String,Long> fileLenCache) {
-      return new FileOptions(tableConfiguration, filename, fs, fsConf, rateLimiter, null, null,
-          false, NULL_PROVIDER, fileLenCache, false, cryptoService, null, null, true,
-          dropCacheBehind);
+      return new FileOptions(tableConfiguration, file, fs, fsConf, rateLimiter, null, null, false,
+          NULL_PROVIDER, fileLenCache, false, cryptoService, null, null, true, dropCacheBehind);
     }
 
     protected FileOptions toScanReaderBuilderOptions(Range range, Set<ByteSequence> columnFamilies,
         boolean inclusive) {
-      return new FileOptions(tableConfiguration, filename, fs, fsConf, rateLimiter, null, null,
-          false, NULL_PROVIDER, null, false, cryptoService, range, columnFamilies, inclusive,
+      return new FileOptions(tableConfiguration, file, fs, fsConf, rateLimiter, null, null, false,
+          NULL_PROVIDER, null, false, cryptoService, range, columnFamilies, inclusive,
           dropCacheBehind);
     }
 
@@ -356,15 +358,17 @@ public abstract class FileOperations {
     private boolean enableAccumuloStart = true;
 
     public WriterTableConfiguration forOutputStream(String extension,
-        FSDataOutputStream outputStream, Configuration fsConf, CryptoService cs) {
+        FSDataOutputStream outputStream, Configuration fsConf, CryptoService cs)
+        throws IOException {
       this.outputStream = outputStream;
-      filename("foo" + extension).fsConf(fsConf).cryptoService(cs);
+      file(UnassignedTabletFile.of(fsConf, new Path("foo/foo" + extension))).fsConf(fsConf)
+          .cryptoService(cs);
       return this;
     }
 
-    public WriterTableConfiguration forFile(String filename, FileSystem fs, Configuration fsConf,
-        CryptoService cs) {
-      filename(filename).fs(fs).fsConf(fsConf).cryptoService(cs);
+    public WriterTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
+        Configuration fsConf, CryptoService cs) {
+      file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
     }
 
@@ -411,9 +415,9 @@ public abstract class FileOperations {
     private Cache<String,Long> fileLenCache;
     private boolean seekToBeginning = false;
 
-    public ReaderTableConfiguration forFile(String filename, FileSystem fs, Configuration fsConf,
-        CryptoService cs) {
-      filename(filename).fs(fs).fsConf(fsConf).cryptoService(cs);
+    public ReaderTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
+        Configuration fsConf, CryptoService cs) {
+      file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
     }
 
@@ -479,9 +483,9 @@ public abstract class FileOperations {
 
     private Cache<String,Long> fileLenCache = null;
 
-    public IndexReaderTableConfiguration forFile(String filename, FileSystem fs,
+    public IndexReaderTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
         Configuration fsConf, CryptoService cs) {
-      filename(filename).fs(fs).fsConf(fsConf).cryptoService(cs);
+      file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
     }
 
@@ -511,9 +515,9 @@ public abstract class FileOperations {
     private Set<ByteSequence> columnFamilies;
     private boolean inclusive;
 
-    public ScanReaderTableConfiguration forFile(String filename, FileSystem fs,
+    public ScanReaderTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
         Configuration fsConf, CryptoService cs) {
-      filename(filename).fs(fs).fsConf(fsConf).cryptoService(cs);
+      file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.file.blockfile.impl.CacheProvider;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.metadata.AbstractTabletFile;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
 import org.apache.hadoop.conf.Configuration;
@@ -361,7 +361,7 @@ public abstract class FileOperations {
         FSDataOutputStream outputStream, Configuration fsConf, CryptoService cs)
         throws IOException {
       this.outputStream = outputStream;
-      file(UnassignedTabletFile.of(fsConf, new Path("foo/foo" + extension))).fsConf(fsConf)
+      file(UnreferencedTabletFile.of(fsConf, new Path("foo/foo" + extension))).fsConf(fsConf)
           .cryptoService(cs);
       return this;
     }

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.bcfile.Compression;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.spi.file.rfile.compression.NoCompression;
 import org.apache.accumulo.start.spi.KeywordExecutable;
@@ -100,7 +100,7 @@ public class CreateEmpty implements KeywordExecutable {
     opts.parseArgs("accumulo create-empty", args);
 
     for (String arg : opts.files) {
-      UnassignedTabletFile file = UnassignedTabletFile.of(conf, new Path(arg));
+      UnreferencedTabletFile file = UnreferencedTabletFile.of(conf, new Path(arg));
       log.info("Writing to file '{}'", file);
       FileSKVWriter writer = new RFileOperations().newWriterBuilder()
           .forFile(file, file.getPath().getFileSystem(conf), conf, NoCryptoServiceFactory.NONE)

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/CreateEmpty.java
@@ -25,6 +25,7 @@ import org.apache.accumulo.core.cli.Help;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.bcfile.Compression;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.spi.file.rfile.compression.NoCompression;
 import org.apache.accumulo.start.spi.KeywordExecutable;
@@ -99,10 +100,10 @@ public class CreateEmpty implements KeywordExecutable {
     opts.parseArgs("accumulo create-empty", args);
 
     for (String arg : opts.files) {
-      Path path = new Path(arg);
-      log.info("Writing to file '{}'", path);
+      UnassignedTabletFile file = UnassignedTabletFile.of(conf, new Path(arg));
+      log.info("Writing to file '{}'", file);
       FileSKVWriter writer = new RFileOperations().newWriterBuilder()
-          .forFile(arg, path.getFileSystem(conf), conf, NoCryptoServiceFactory.NONE)
+          .forFile(file, file.getPath().getFileSystem(conf), conf, NoCryptoServiceFactory.NONE)
           .withTableConfiguration(DefaultConfiguration.getInstance()).withCompression(opts.codec)
           .build();
       writer.close();

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -22,6 +22,12 @@ import java.util.Objects;
 
 import org.apache.hadoop.fs.Path;
 
+/**
+ * A base class used to represent file references that are handled by code that processes tablet
+ * files.
+ *
+ * @since 3.0.0
+ */
 public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>> implements Comparable<T> {
 
   private final String fileName; // C0004.rf
@@ -33,10 +39,16 @@ public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>> implem
     ValidationUtil.validateFileName(fileName);
   }
 
+  /**
+   * @return The file name of the TabletFile
+   */
   public String getFileName() {
     return fileName;
   }
 
+  /**
+   * @return The path of the TabletFile
+   */
   public Path getPath() {
     return path;
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata;
+
+import java.util.Objects;
+
+import org.apache.hadoop.fs.Path;
+
+public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>> implements Comparable<T> {
+
+  private final String fileName; // C0004.rf
+  protected final Path path;
+
+  protected AbstractTabletFile(Path path) {
+    this.path = Objects.requireNonNull(path);
+    this.fileName = path.getName();
+    ValidationUtil.validateFileName(fileName);
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/UnassignedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/UnassignedTabletFile.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.core.metadata;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+public class UnassignedTabletFile extends AbstractTabletFile<UnassignedTabletFile> {
+
+  public UnassignedTabletFile(FileSystem fs, Path path) {
+    super(Objects.requireNonNull(fs).makeQualified(Objects.requireNonNull(path)));
+  }
+
+  @Override
+  public int compareTo(UnassignedTabletFile o) {
+    if (equals(o)) {
+      return 0;
+    } else {
+      return path.compareTo(o.path);
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof UnassignedTabletFile) {
+      UnassignedTabletFile that = (UnassignedTabletFile) obj;
+      return path.equals(that.path);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return path.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return path.toString();
+  }
+
+  public static UnassignedTabletFile of(FileSystem fs, File file) {
+    return new UnassignedTabletFile(fs, new Path(Objects.requireNonNull(file).toString()));
+  }
+
+  public static UnassignedTabletFile of(FileSystem fs, Path path) {
+    return new UnassignedTabletFile(fs, path);
+  }
+
+  public static UnassignedTabletFile of(Configuration conf, Path path) throws IOException {
+    return new UnassignedTabletFile(Objects.requireNonNull(path).getFileSystem(conf), path);
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
@@ -26,14 +26,26 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-public class UnassignedTabletFile extends AbstractTabletFile<UnassignedTabletFile> {
+/**
+ * A file that is not intended to be added to a tablet as a reference, within the scope of the code
+ * using this class, but needs to be passed to code that processes tablet files. These files could
+ * be temp files or files directly created by a user for bulk import. The file may ultimately be
+ * added to a tablet later as a new file reference, but within a different scope (process, thread,
+ * code block, method, etc.) that uses a different class to represent the file in that scope.
+ *
+ * Unlike {@link TabletFile}, this class does not perform any validation or normalization on the
+ * provided path.
+ *
+ * @since 3.0.0
+ */
+public class UnreferencedTabletFile extends AbstractTabletFile<UnreferencedTabletFile> {
 
-  public UnassignedTabletFile(FileSystem fs, Path path) {
+  public UnreferencedTabletFile(FileSystem fs, Path path) {
     super(Objects.requireNonNull(fs).makeQualified(Objects.requireNonNull(path)));
   }
 
   @Override
-  public int compareTo(UnassignedTabletFile o) {
+  public int compareTo(UnreferencedTabletFile o) {
     if (equals(o)) {
       return 0;
     } else {
@@ -43,8 +55,8 @@ public class UnassignedTabletFile extends AbstractTabletFile<UnassignedTabletFil
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof UnassignedTabletFile) {
-      UnassignedTabletFile that = (UnassignedTabletFile) obj;
+    if (obj instanceof UnreferencedTabletFile) {
+      UnreferencedTabletFile that = (UnreferencedTabletFile) obj;
       return path.equals(that.path);
     }
     return false;
@@ -60,16 +72,16 @@ public class UnassignedTabletFile extends AbstractTabletFile<UnassignedTabletFil
     return path.toString();
   }
 
-  public static UnassignedTabletFile of(FileSystem fs, File file) {
-    return new UnassignedTabletFile(fs, new Path(Objects.requireNonNull(file).toString()));
+  public static UnreferencedTabletFile of(FileSystem fs, File file) {
+    return new UnreferencedTabletFile(fs, new Path(Objects.requireNonNull(file).toString()));
   }
 
-  public static UnassignedTabletFile of(FileSystem fs, Path path) {
-    return new UnassignedTabletFile(fs, path);
+  public static UnreferencedTabletFile of(FileSystem fs, Path path) {
+    return new UnreferencedTabletFile(fs, path);
   }
 
-  public static UnassignedTabletFile of(Configuration conf, Path path) throws IOException {
-    return new UnassignedTabletFile(Objects.requireNonNull(path).getFileSystem(conf), path);
+  public static UnreferencedTabletFile of(Configuration conf, Path path) throws IOException {
+    return new UnreferencedTabletFile(Objects.requireNonNull(path).getFileSystem(conf), path);
   }
 
 }

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -62,6 +62,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.rfile.RFile.Reader;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -810,9 +811,11 @@ public class RFileClientTest {
     }
   }
 
+  @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path is set by test, not user")
   private Reader getReader(LocalFileSystem localFs, String testFile) throws IOException {
     return (Reader) FileOperations.getInstance().newReaderBuilder()
-        .forFile(testFile, localFs, localFs.getConf(), NoCryptoServiceFactory.NONE)
+        .forFile(UnassignedTabletFile.of(localFs, new File(testFile)), localFs, localFs.getConf(),
+            NoCryptoServiceFactory.NONE)
         .withTableConfiguration(DefaultConfiguration.getInstance()).build();
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/client/rfile/RFileClientTest.java
@@ -62,7 +62,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.rfile.RFile.Reader;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -814,7 +814,7 @@ public class RFileClientTest {
   @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path is set by test, not user")
   private Reader getReader(LocalFileSystem localFs, String testFile) throws IOException {
     return (Reader) FileOperations.getInstance().newReaderBuilder()
-        .forFile(UnassignedTabletFile.of(localFs, new File(testFile)), localFs, localFs.getConf(),
+        .forFile(UnreferencedTabletFile.of(localFs, new File(testFile)), localFs, localFs.getConf(),
             NoCryptoServiceFactory.NONE)
         .withTableConfiguration(DefaultConfiguration.getInstance()).build();
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -37,9 +37,11 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor;
 import org.apache.accumulo.core.file.rfile.RFile;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -81,8 +83,9 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = new File(tempDir, testName() + "." + suffix).getAbsolutePath();
     FileSKVWriter bmfw = FileOperations.getInstance().newWriterBuilder()
-        .forFile(fname, fs, conf, NoCryptoServiceFactory.NONE).withTableConfiguration(acuconf)
-        .build();
+        .forFile(UnassignedTabletFile.of(fs, new Path(fname)), fs, conf,
+            NoCryptoServiceFactory.NONE)
+        .withTableConfiguration(acuconf).build();
 
     // write data to file
     long t1 = System.currentTimeMillis();
@@ -99,8 +102,9 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
 
     t1 = System.currentTimeMillis();
     FileSKVIterator bmfr = FileOperations.getInstance().newReaderBuilder()
-        .forFile(fname, fs, conf, NoCryptoServiceFactory.NONE).withTableConfiguration(acuconf)
-        .build();
+        .forFile(UnassignedTabletFile.of(fs, new Path(fname)), fs, conf,
+            NoCryptoServiceFactory.NONE)
+        .withTableConfiguration(acuconf).build();
     t2 = System.currentTimeMillis();
     log.debug("Opened {} in {}", fname, (t2 - t1));
 

--- a/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/BloomFilterLayerLookupTest.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.keyfunctor.ColumnFamilyFunctor;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -83,7 +83,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = new File(tempDir, testName() + "." + suffix).getAbsolutePath();
     FileSKVWriter bmfw = FileOperations.getInstance().newWriterBuilder()
-        .forFile(UnassignedTabletFile.of(fs, new Path(fname)), fs, conf,
+        .forFile(UnreferencedTabletFile.of(fs, new Path(fname)), fs, conf,
             NoCryptoServiceFactory.NONE)
         .withTableConfiguration(acuconf).build();
 
@@ -102,7 +102,7 @@ public class BloomFilterLayerLookupTest extends WithTestNames {
 
     t1 = System.currentTimeMillis();
     FileSKVIterator bmfr = FileOperations.getInstance().newReaderBuilder()
-        .forFile(UnassignedTabletFile.of(fs, new Path(fname)), fs, conf,
+        .forFile(UnreferencedTabletFile.of(fs, new Path(fname)), fs, conf,
             NoCryptoServiceFactory.NONE)
         .withTableConfiguration(acuconf).build();
     t2 = System.currentTimeMillis();

--- a/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -54,7 +54,7 @@ public class FileOperationsTest {
       FileSystem fs = FileSystem.getLocal(conf);
       AccumuloConfiguration acuconf = DefaultConfiguration.getInstance();
       writer = fileOperations.newWriterBuilder()
-          .forFile(UnassignedTabletFile.of(fs, testFile), fs, conf, NoCryptoServiceFactory.NONE)
+          .forFile(UnreferencedTabletFile.of(fs, testFile), fs, conf, NoCryptoServiceFactory.NONE)
           .withTableConfiguration(acuconf).build();
       writer.close();
     } catch (Exception ex) {

--- a/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/FileOperationsTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.file.rfile.RFile;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -52,9 +53,9 @@ public class FileOperationsTest {
       Configuration conf = new Configuration();
       FileSystem fs = FileSystem.getLocal(conf);
       AccumuloConfiguration acuconf = DefaultConfiguration.getInstance();
-      writer =
-          fileOperations.newWriterBuilder().forFile(filename, fs, conf, NoCryptoServiceFactory.NONE)
-              .withTableConfiguration(acuconf).build();
+      writer = fileOperations.newWriterBuilder()
+          .forFile(UnassignedTabletFile.of(fs, testFile), fs, conf, NoCryptoServiceFactory.NONE)
+          .withTableConfiguration(acuconf).build();
       writer.close();
     } catch (Exception ex) {
       caughtException = true;

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -200,7 +200,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
       FileSystem fileSystem = FileSystem.getLocal(conf);
       FileSKVIterator sample = FileOperations.getInstance().newReaderBuilder()
-          .forFile(UnassignedTabletFile.of(fileSystem, files[0]), fileSystem, conf,
+          .forFile(UnreferencedTabletFile.of(fileSystem, files[0]), fileSystem, conf,
               NoCryptoServiceFactory.NONE)
           .withTableConfiguration(acuconf).build()
           .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapred/AccumuloFileOutputFormatIT.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -197,8 +198,9 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
       Configuration conf = cluster.getServerContext().getHadoopConf();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
+      FileSystem fileSystem = FileSystem.getLocal(conf);
       FileSKVIterator sample = FileOperations.getInstance().newReaderBuilder()
-          .forFile(files[0].toString(), FileSystem.getLocal(conf), conf,
+          .forFile(UnassignedTabletFile.of(fileSystem, files[0]), fileSystem, conf,
               NoCryptoServiceFactory.NONE)
           .withTableConfiguration(acuconf).build()
           .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
@@ -37,7 +37,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.rfile.RFileOperations;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -213,9 +213,10 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
 
       Configuration conf = cluster.getServerContext().getHadoopConf();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
+      FileSystem fs = FileSystem.getLocal(conf);
       FileSKVIterator sample = RFileOperations.getInstance().newReaderBuilder()
-          .forFile(TabletFile.of(new Path(files[0].toString())), FileSystem.getLocal(conf), conf,
-              NoCryptoServiceFactory.NONE)
+          .forFile(UnreferencedTabletFile.of(fs, new Path(files[0].toString())),
+              FileSystem.getLocal(conf), conf, NoCryptoServiceFactory.NONE)
           .withTableConfiguration(acuconf).build()
           .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));
       assertNotNull(sample);

--- a/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
+++ b/hadoop-mapreduce/src/test/java/org/apache/accumulo/hadoop/its/mapreduce/AccumuloFileOutputFormatIT.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.rfile.RFileOperations;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -213,7 +214,7 @@ public class AccumuloFileOutputFormatIT extends AccumuloClusterHarness {
       Configuration conf = cluster.getServerContext().getHadoopConf();
       DefaultConfiguration acuconf = DefaultConfiguration.getInstance();
       FileSKVIterator sample = RFileOperations.getInstance().newReaderBuilder()
-          .forFile(files[0].toString(), FileSystem.getLocal(conf), conf,
+          .forFile(TabletFile.of(new Path(files[0].toString())), FileSystem.getLocal(conf), conf,
               NoCryptoServiceFactory.NONE)
           .withTableConfiguration(acuconf).build()
           .getSample(new SamplerConfigurationImpl(SAMPLER_CONFIG));

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -231,9 +231,9 @@ public class FileCompactor implements Callable<CompactionStats> {
           && ((isMinC && acuTableConf.getBoolean(Property.TABLE_MINC_OUTPUT_DROP_CACHE))
               || (!isMinC && acuTableConf.getBoolean(Property.TABLE_MAJC_OUTPUT_DROP_CACHE)));
 
-      WriterBuilder outBuilder = fileFactory.newWriterBuilder()
-          .forFile(outputFile.getMetaInsert(), ns, ns.getConf(), cryptoService)
-          .withTableConfiguration(acuTableConf).withRateLimiter(env.getWriteLimiter());
+      WriterBuilder outBuilder =
+          fileFactory.newWriterBuilder().forFile(outputFile, ns, ns.getConf(), cryptoService)
+              .withTableConfiguration(acuTableConf).withRateLimiter(env.getWriteLimiter());
       if (dropCacheBehindOutput) {
         outBuilder.dropCachesBehind();
       }
@@ -337,8 +337,7 @@ public class FileCompactor implements Callable<CompactionStats> {
         FileSystem fs = this.fs.getFileSystemByPath(dataFile.getPath());
         FileSKVIterator reader;
 
-        reader = fileFactory.newReaderBuilder()
-            .forFile(dataFile.getPathStr(), fs, fs.getConf(), cryptoService)
+        reader = fileFactory.newReaderBuilder().forFile(dataFile, fs, fs.getConf(), cryptoService)
             .withTableConfiguration(acuTableConf).withRateLimiter(env.getReadLimiter())
             .dropCachesBehind().build();
 

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -56,7 +56,6 @@ import org.apache.accumulo.server.problems.ProblemReportingIterator;
 import org.apache.accumulo.server.problems.ProblemReports;
 import org.apache.accumulo.server.problems.ProblemType;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,10 +70,10 @@ public class FileManager {
   private static class OpenReader implements Comparable<OpenReader> {
     long releaseTime;
     FileSKVIterator reader;
-    String fileName;
+    TabletFile file;
 
-    public OpenReader(String fileName, FileSKVIterator reader) {
-      this.fileName = fileName;
+    public OpenReader(TabletFile file, FileSKVIterator reader) {
+      this.file = file;
       this.reader = reader;
       this.releaseTime = System.currentTimeMillis();
     }
@@ -94,12 +93,12 @@ public class FileManager {
 
     @Override
     public int hashCode() {
-      return fileName.hashCode();
+      return file.hashCode();
     }
   }
 
-  private Map<String,List<OpenReader>> openFiles;
-  private HashMap<FileSKVIterator,String> reservedReaders;
+  private Map<TabletFile,List<OpenReader>> openFiles;
+  private HashMap<FileSKVIterator,TabletFile> reservedReaders;
 
   private Semaphore filePermits;
 
@@ -122,9 +121,9 @@ public class FileManager {
       // determine which files to close in a sync block, and then close the
       // files outside of the sync block
       synchronized (FileManager.this) {
-        Iterator<Entry<String,List<OpenReader>>> iter = openFiles.entrySet().iterator();
+        Iterator<Entry<TabletFile,List<OpenReader>>> iter = openFiles.entrySet().iterator();
         while (iter.hasNext()) {
-          Entry<String,List<OpenReader>> entry = iter.next();
+          Entry<TabletFile,List<OpenReader>> entry = iter.next();
           List<OpenReader> ofl = entry.getValue();
 
           for (Iterator<OpenReader> oflIter = ofl.iterator(); oflIter.hasNext();) {
@@ -173,7 +172,7 @@ public class FileManager {
         this.context.getConfiguration().getTimeInMillis(Property.TSERV_SLOW_FILEPERMIT_MILLIS);
   }
 
-  private static int countReaders(Map<String,List<OpenReader>> files) {
+  private static int countReaders(Map<TabletFile,List<OpenReader>> files) {
     int count = 0;
 
     for (List<OpenReader> list : files.values()) {
@@ -187,7 +186,7 @@ public class FileManager {
 
     ArrayList<OpenReader> openReaders = new ArrayList<>();
 
-    for (Entry<String,List<OpenReader>> entry : openFiles.entrySet()) {
+    for (Entry<TabletFile,List<OpenReader>> entry : openFiles.entrySet()) {
       openReaders.addAll(entry.getValue());
     }
 
@@ -198,13 +197,13 @@ public class FileManager {
     for (int i = 0; i < numToTake && i < openReaders.size(); i++) {
       OpenReader or = openReaders.get(i);
 
-      List<OpenReader> ofl = openFiles.get(or.fileName);
+      List<OpenReader> ofl = openFiles.get(or.file);
       if (!ofl.remove(or)) {
         throw new RuntimeException("Failed to remove open reader that should have been there");
       }
 
       if (ofl.isEmpty()) {
-        openFiles.remove(or.fileName);
+        openFiles.remove(or.file);
       }
 
       ret.add(or.reader);
@@ -223,10 +222,10 @@ public class FileManager {
     }
   }
 
-  private List<String> takeOpenFiles(Collection<String> files,
-      Map<FileSKVIterator,String> readersReserved) {
-    List<String> filesToOpen = Collections.emptyList();
-    for (String file : files) {
+  private List<TabletFile> takeOpenFiles(Collection<TabletFile> files,
+      Map<FileSKVIterator,TabletFile> readersReserved) {
+    List<TabletFile> filesToOpen = Collections.emptyList();
+    for (TabletFile file : files) {
       List<OpenReader> ofl = openFiles.get(file);
       if (ofl != null && !ofl.isEmpty()) {
         OpenReader openReader = ofl.remove(ofl.size() - 1);
@@ -244,8 +243,9 @@ public class FileManager {
     return filesToOpen;
   }
 
-  private Map<FileSKVIterator,String> reserveReaders(KeyExtent tablet, Collection<String> files,
-      boolean continueOnFailure, CacheProvider cacheProvider) throws IOException {
+  private Map<FileSKVIterator,TabletFile> reserveReaders(KeyExtent tablet,
+      Collection<TabletFile> files, boolean continueOnFailure, CacheProvider cacheProvider)
+      throws IOException {
 
     if (!tablet.isMeta() && files.size() >= maxOpen) {
       throw new IllegalArgumentException("requested files exceeds max open");
@@ -255,9 +255,9 @@ public class FileManager {
       return Collections.emptyMap();
     }
 
-    List<String> filesToOpen = null;
+    List<TabletFile> filesToOpen = null;
     List<FileSKVIterator> filesToClose = Collections.emptyList();
-    Map<FileSKVIterator,String> readersReserved = new HashMap<>();
+    Map<FileSKVIterator,TabletFile> readersReserved = new HashMap<>();
 
     if (!tablet.isMeta()) {
       long start = System.currentTimeMillis();
@@ -297,24 +297,20 @@ public class FileManager {
     closeReaders(filesToClose);
 
     // open any files that need to be opened
-    for (String file : filesToOpen) {
+    for (TabletFile file : filesToOpen) {
       try {
-        if (!file.contains(":")) {
-          throw new IllegalArgumentException("Expected uri, got : " + file);
-        }
-        Path path = new Path(file);
-        FileSystem ns = context.getVolumeManager().getFileSystemByPath(path);
+        FileSystem ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
         // log.debug("Opening "+file + " path " + path);
         var tableConf = context.getTableConfiguration(tablet.tableId());
         FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
-            .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
+            .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
             .withTableConfiguration(tableConf).withCacheProvider(cacheProvider)
             .withFileLenCache(fileLenCache).build();
         readersReserved.put(reader, file);
       } catch (Exception e) {
 
         ProblemReports.getInstance(context)
-            .report(new ProblemReport(tablet.tableId(), ProblemType.FILE_READ, file, e));
+            .report(new ProblemReport(tablet.tableId(), ProblemType.FILE_READ, file.toString(), e));
 
         if (continueOnFailure) {
           // release the permit for the file that failed to open
@@ -366,10 +362,9 @@ public class FileManager {
       }
 
       for (FileSKVIterator reader : readers) {
-        String fileName = reservedReaders.remove(reader);
+        TabletFile file = reservedReaders.remove(reader);
         if (!sawIOException) {
-          openFiles.computeIfAbsent(fileName, k -> new ArrayList<>())
-              .add(new OpenReader(fileName, reader));
+          openFiles.computeIfAbsent(file, k -> new ArrayList<>()).add(new OpenReader(file, reader));
         }
       }
     }
@@ -391,10 +386,10 @@ public class FileManager {
     private ArrayList<FileDataSource> deepCopies;
     private boolean current = true;
     private IteratorEnvironment env;
-    private String file;
+    private TabletFile file;
     private AtomicBoolean iflag;
 
-    FileDataSource(String file, SortedKeyValueIterator<Key,Value> iter) {
+    FileDataSource(TabletFile file, SortedKeyValueIterator<Key,Value> iter) {
       this.file = file;
       this.iter = iter;
       this.deepCopies = new ArrayList<>();
@@ -481,7 +476,7 @@ public class FileManager {
       }
     }
 
-    private Map<FileSKVIterator,String> openFiles(List<String> files)
+    private Map<FileSKVIterator,TabletFile> openFiles(List<TabletFile> files)
         throws TooManyFilesException, IOException {
       // one tablet can not open more than maxOpen files, otherwise it could get stuck
       // forever waiting on itself to release files
@@ -493,7 +488,7 @@ public class FileManager {
                 + maxOpen + " tablet = " + tablet);
       }
 
-      Map<FileSKVIterator,String> newlyReservedReaders =
+      Map<FileSKVIterator,TabletFile> newlyReservedReaders =
           reserveReaders(tablet, files, continueOnFailure, cacheProvider);
 
       tabletReservedReaders.addAll(newlyReservedReaders.keySet());
@@ -503,17 +498,17 @@ public class FileManager {
     public synchronized List<InterruptibleIterator> openFiles(Map<TabletFile,DataFileValue> files,
         boolean detachable, SamplerConfigurationImpl samplerConfig) throws IOException {
 
-      Map<FileSKVIterator,String> newlyReservedReaders = openFiles(
-          files.keySet().stream().map(TabletFile::getPathStr).collect(Collectors.toList()));
+      Map<FileSKVIterator,TabletFile> newlyReservedReaders =
+          openFiles(new ArrayList<>(files.keySet()));
 
       ArrayList<InterruptibleIterator> iters = new ArrayList<>();
 
       boolean someIteratorsWillWrap =
           files.values().stream().anyMatch(DataFileValue::willWrapIterator);
 
-      for (Entry<FileSKVIterator,String> entry : newlyReservedReaders.entrySet()) {
+      for (Entry<FileSKVIterator,TabletFile> entry : newlyReservedReaders.entrySet()) {
         FileSKVIterator source = entry.getKey();
-        String filename = entry.getValue();
+        TabletFile file = entry.getValue();
         InterruptibleIterator iter;
 
         if (samplerConfig != null) {
@@ -523,12 +518,12 @@ public class FileManager {
           }
         }
 
-        iter = new ProblemReportingIterator(context, tablet.tableId(), filename, continueOnFailure,
-            detachable ? getSsi(filename, source) : source);
+        iter = new ProblemReportingIterator(context, tablet.tableId(), file.toString(),
+            continueOnFailure, detachable ? getSsi(file, source) : source);
 
         if (someIteratorsWillWrap) {
           // constructing FileRef is expensive so avoid if not needed
-          DataFileValue value = files.get(new TabletFile(new Path(filename)));
+          DataFileValue value = files.get(file);
           iter = value.wrapFileIterator(iter);
         }
 
@@ -538,8 +533,8 @@ public class FileManager {
       return iters;
     }
 
-    private SourceSwitchingIterator getSsi(String filename, FileSKVIterator source) {
-      FileDataSource fds = new FileDataSource(filename, source);
+    private SourceSwitchingIterator getSsi(TabletFile file, FileSKVIterator source) {
+      FileDataSource fds = new FileDataSource(file, source);
       dataSources.add(fds);
       return new SourceSwitchingIterator(fds);
     }
@@ -559,11 +554,11 @@ public class FileManager {
         throw new IllegalStateException();
       }
 
-      List<String> files = dataSources.stream().map(x -> x.file).collect(Collectors.toList());
-      Map<FileSKVIterator,String> newlyReservedReaders = openFiles(files);
-      Map<String,List<FileSKVIterator>> map = new HashMap<>();
+      List<TabletFile> files = dataSources.stream().map(x -> x.file).collect(Collectors.toList());
+      Map<FileSKVIterator,TabletFile> newlyReservedReaders = openFiles(files);
+      Map<TabletFile,List<FileSKVIterator>> map = new HashMap<>();
       newlyReservedReaders.forEach(
-          (reader, fileName) -> map.computeIfAbsent(fileName, k -> new LinkedList<>()).add(reader));
+          (reader, file) -> map.computeIfAbsent(file, k -> new LinkedList<>()).add(reader));
 
       for (FileDataSource fds : dataSources) {
         FileSKVIterator source = map.get(fds.file).remove(0);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
@@ -42,6 +42,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
@@ -164,12 +165,13 @@ class FileSystemInitializer {
     for (Tablet tablet : tablets) {
       createEntriesForTablet(sorted, tablet);
     }
-    FileSystem fs = volmanager.getFileSystemByPath(new Path(fileName));
+    TabletFile file = TabletFile.of(new Path(fileName));
+    FileSystem fs = volmanager.getFileSystemByPath(file.getPath());
 
     CryptoService cs = CryptoFactoryLoader.getServiceForServer(conf);
 
     FileSKVWriter tabletWriter = FileOperations.getInstance().newWriterBuilder()
-        .forFile(fileName, fs, fs.getConf(), cs).withTableConfiguration(conf).build();
+        .forFile(file, fs, fs.getConf(), cs).withTableConfiguration(conf).build();
     tabletWriter.startDefaultLocalityGroup();
 
     for (Map.Entry<Key,Value> entry : sorted.entrySet()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -46,7 +46,7 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -140,7 +140,7 @@ public class FileUtil {
       // temporary tablet file does not conform to typical path verified in TabletFile
       Path newPath = new Path(String.format("%s/%04d.%s", newDir, count++, RFile.EXTENSION));
       FileSystem ns = context.getVolumeManager().getFileSystemByPath(newPath);
-      UnassignedTabletFile newDataFile = UnassignedTabletFile.of(ns, newPath);
+      UnreferencedTabletFile newDataFile = UnreferencedTabletFile.of(ns, newPath);
 
       outFiles.add(newDataFile);
       FileSKVWriter writer = new RFileOperations().newWriterBuilder()

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -44,7 +44,9 @@ import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.file.rfile.RFileOperations;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
+import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
 import org.apache.accumulo.server.fs.VolumeManager;
@@ -110,35 +112,37 @@ public class FileUtil {
     return result;
   }
 
-  public static Collection<String> reduceFiles(ServerContext context, TableConfiguration tableConf,
-      Text prevEndRow, Text endRow, Collection<String> dataFiles, int maxFiles, Path tmpDir,
-      int pass) throws IOException {
+  public static Collection<AbstractTabletFile<?>> reduceFiles(ServerContext context,
+      TableConfiguration tableConf, Text prevEndRow, Text endRow,
+      Collection<? extends AbstractTabletFile<?>> dataFiles, int maxFiles, Path tmpDir, int pass)
+      throws IOException {
 
-    ArrayList<String> paths = new ArrayList<>(dataFiles);
+    ArrayList<AbstractTabletFile<?>> files = new ArrayList<>(dataFiles);
 
-    if (paths.size() <= maxFiles) {
-      return paths;
+    if (files.size() <= maxFiles) {
+      return files;
     }
 
     String newDir = String.format("%s/pass_%04d", tmpDir, pass);
 
     int start = 0;
 
-    ArrayList<String> outFiles = new ArrayList<>();
+    ArrayList<AbstractTabletFile<?>> outFiles = new ArrayList<>();
 
     int count = 0;
 
-    while (start < paths.size()) {
-      int end = Math.min(maxFiles + start, paths.size());
-      List<String> inFiles = paths.subList(start, end);
+    while (start < files.size()) {
+      int end = Math.min(maxFiles + start, files.size());
+      List<AbstractTabletFile<?>> inFiles = files.subList(start, end);
 
       start = end;
 
       // temporary tablet file does not conform to typical path verified in TabletFile
-      String newDataFile = String.format("%s/%04d.%s", newDir, count++, RFile.EXTENSION);
+      Path newPath = new Path(String.format("%s/%04d.%s", newDir, count++, RFile.EXTENSION));
+      FileSystem ns = context.getVolumeManager().getFileSystemByPath(newPath);
+      UnassignedTabletFile newDataFile = UnassignedTabletFile.of(ns, newPath);
 
       outFiles.add(newDataFile);
-      FileSystem ns = context.getVolumeManager().getFileSystemByPath(new Path(newDataFile));
       FileSKVWriter writer = new RFileOperations().newWriterBuilder()
           .forFile(newDataFile, ns, ns.getConf(), tableConf.getCryptoService())
           .withTableConfiguration(tableConf).build();
@@ -147,8 +151,8 @@ public class FileUtil {
 
       FileSKVIterator reader = null;
       try {
-        for (String file : inFiles) {
-          ns = context.getVolumeManager().getFileSystemByPath(new Path(file));
+        for (AbstractTabletFile<?> file : inFiles) {
+          ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
           reader = FileOperations.getInstance().newIndexReaderBuilder()
               .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
               .withTableConfiguration(tableConf).build();
@@ -207,8 +211,8 @@ public class FileUtil {
   }
 
   public static double estimatePercentageLTE(ServerContext context, TableConfiguration tableConf,
-      String tabletDir, Text prevEndRow, Text endRow, Collection<String> dataFiles, Text splitRow)
-      throws IOException {
+      String tabletDir, Text prevEndRow, Text endRow,
+      Collection<? extends AbstractTabletFile<?>> dataFiles, Text splitRow) throws IOException {
 
     Path tmpDir = null;
 
@@ -285,9 +289,10 @@ public class FileUtil {
    */
   public static SortedMap<Double,Key> findMidPoint(ServerContext context,
       TableConfiguration tableConf, String tabletDirectory, Text prevEndRow, Text endRow,
-      Collection<String> dataFiles, double minSplit, boolean useIndex) throws IOException {
+      Collection<? extends AbstractTabletFile<?>> dataFiles, double minSplit, boolean useIndex)
+      throws IOException {
 
-    Collection<String> origDataFiles = dataFiles;
+    Collection<? extends AbstractTabletFile<?>> origDataFiles = dataFiles;
 
     Path tmpDir = null;
 
@@ -425,23 +430,22 @@ public class FileUtil {
   }
 
   private static long countIndexEntries(ServerContext context, TableConfiguration tableConf,
-      Text prevEndRow, Text endRow, Collection<String> dataFiles, boolean useIndex,
-      ArrayList<FileSKVIterator> readers) throws IOException {
+      Text prevEndRow, Text endRow, Collection<? extends AbstractTabletFile<?>> dataFiles,
+      boolean useIndex, ArrayList<FileSKVIterator> readers) throws IOException {
     long numKeys = 0;
 
     // count the total number of index entries
-    for (String file : dataFiles) {
+    for (AbstractTabletFile<?> file : dataFiles) {
       FileSKVIterator reader = null;
-      Path path = new Path(file);
-      FileSystem ns = context.getVolumeManager().getFileSystemByPath(path);
+      FileSystem ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
       try {
         if (useIndex) {
           reader = FileOperations.getInstance().newIndexReaderBuilder()
-              .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
+              .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
               .withTableConfiguration(tableConf).build();
         } else {
           reader = FileOperations.getInstance().newScanReaderBuilder()
-              .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
+              .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
               .withTableConfiguration(tableConf)
               .overRange(new Range(prevEndRow, false, null, true), Set.of(), false).build();
         }
@@ -468,11 +472,11 @@ public class FileUtil {
 
       if (useIndex) {
         readers.add(FileOperations.getInstance().newIndexReaderBuilder()
-            .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
+            .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
             .withTableConfiguration(tableConf).build());
       } else {
         readers.add(FileOperations.getInstance().newScanReaderBuilder()
-            .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
+            .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
             .withTableConfiguration(tableConf)
             .overRange(new Range(prevEndRow, false, null, true), Set.of(), false).build());
       }
@@ -494,7 +498,7 @@ public class FileUtil {
       FileSystem ns = context.getVolumeManager().getFileSystemByPath(dataFile.getPath());
       try {
         reader = FileOperations.getInstance().newReaderBuilder()
-            .forFile(dataFile.getPathStr(), ns, ns.getConf(), tableConf.getCryptoService())
+            .forFile(dataFile, ns, ns.getConf(), tableConf.getCryptoService())
             .withTableConfiguration(tableConf).build();
 
         Key firstKey = reader.getFirstKey();
@@ -532,7 +536,7 @@ public class FileUtil {
     for (TabletFile file : dataFiles) {
       FileSystem ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
-          .forFile(file.getPathStr(), ns, ns.getConf(), tableConf.getCryptoService())
+          .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
           .withTableConfiguration(tableConf).seekToBeginning().build();
 
       try {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -63,6 +63,7 @@ import org.apache.accumulo.core.iteratorsImpl.system.LocalityGroupIterator.Local
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator.DataSource;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
@@ -602,7 +603,8 @@ public class InMemoryMap {
 
         TableConfiguration tableConf = context.getTableConfiguration(tableId);
         reader = new RFileOperations().newReaderBuilder()
-            .forFile(memDumpFile, fs, conf, tableConf.getCryptoService())
+            .forFile(UnassignedTabletFile.of(fs, new Path(memDumpFile)), fs, conf,
+                tableConf.getCryptoService())
             .withTableConfiguration(tableConf).seekToBeginning().build();
         if (iflag != null) {
           reader.setInterruptFlag(iflag);
@@ -783,7 +785,8 @@ public class InMemoryMap {
 
         TableConfiguration tableConf = context.getTableConfiguration(tableId);
         FileSKVWriter out = new RFileOperations().newWriterBuilder()
-            .forFile(tmpFile, fs, newConf, tableConf.getCryptoService())
+            .forFile(UnassignedTabletFile.of(fs, new Path(tmpFile)), fs, newConf,
+                tableConf.getCryptoService())
             .withTableConfiguration(aconf).build();
 
         InterruptibleIterator iter = map.skvIterator(null);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/InMemoryMap.java
@@ -63,7 +63,7 @@ import org.apache.accumulo.core.iteratorsImpl.system.LocalityGroupIterator.Local
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator.DataSource;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
@@ -603,7 +603,7 @@ public class InMemoryMap {
 
         TableConfiguration tableConf = context.getTableConfiguration(tableId);
         reader = new RFileOperations().newReaderBuilder()
-            .forFile(UnassignedTabletFile.of(fs, new Path(memDumpFile)), fs, conf,
+            .forFile(UnreferencedTabletFile.of(fs, new Path(memDumpFile)), fs, conf,
                 tableConf.getCryptoService())
             .withTableConfiguration(tableConf).seekToBeginning().build();
         if (iflag != null) {
@@ -785,7 +785,7 @@ public class InMemoryMap {
 
         TableConfiguration tableConf = context.getTableConfiguration(tableId);
         FileSKVWriter out = new RFileOperations().newWriterBuilder()
-            .forFile(UnassignedTabletFile.of(fs, new Path(tmpFile)), fs, newConf,
+            .forFile(UnreferencedTabletFile.of(fs, new Path(tmpFile)), fs, newConf,
                 tableConf.getCryptoService())
             .withTableConfiguration(aconf).build();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.manager.thrift.RecoveryStatus;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.Pair;
@@ -278,7 +279,7 @@ public class LogSorter {
     }
 
     try (var writer = FileOperations.getInstance().newWriterBuilder()
-        .forFile(fullPath.toString(), fs, fs.getConf(), cryptoService)
+        .forFile(UnassignedTabletFile.of(fs, fullPath), fs, fs.getConf(), cryptoService)
         .withTableConfiguration(sortedLogConf).build()) {
       writer.startDefaultLocalityGroup();
       for (var entry : keyListMap.entrySet()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/LogSorter.java
@@ -39,7 +39,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.manager.thrift.RecoveryStatus;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.Pair;
@@ -279,7 +279,7 @@ public class LogSorter {
     }
 
     try (var writer = FileOperations.getInstance().newWriterBuilder()
-        .forFile(UnassignedTabletFile.of(fs, fullPath), fs, fs.getConf(), cryptoService)
+        .forFile(UnreferencedTabletFile.of(fs, fullPath), fs, fs.getConf(), cryptoService)
         .withTableConfiguration(sortedLogConf).build()) {
       writer.startDefaultLocalityGroup();
       for (var entry : keyListMap.entrySet()) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/log/RecoveryLogsIterator.java
@@ -36,6 +36,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.iterators.IteratorAdapter;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.server.ServerContext;
@@ -80,7 +81,7 @@ public class RecoveryLogsIterator
 
     for (Path logDir : recoveryLogDirs) {
       LOG.debug("Opening recovery log dir {}", logDir.getName());
-      SortedSet<Path> logFiles = getFiles(vm, logDir);
+      SortedSet<UnassignedTabletFile> logFiles = getFiles(vm, logDir);
       var fs = vm.getFileSystemByPath(logDir);
 
       // only check the first key once to prevent extra iterator creation and seeking
@@ -88,9 +89,9 @@ public class RecoveryLogsIterator
         validateFirstKey(context, cryptoService, fs, logFiles, logDir);
       }
 
-      for (Path log : logFiles) {
+      for (UnassignedTabletFile log : logFiles) {
         FileSKVIterator fileIter = FileOperations.getInstance().newReaderBuilder()
-            .forFile(log.toString(), fs, fs.getConf(), cryptoService)
+            .forFile(log, fs, fs.getConf(), cryptoService)
             .withTableConfiguration(context.getConfiguration()).seekToBeginning().build();
         if (range != null) {
           fileIter.seek(range, Collections.emptySet(), false);
@@ -98,11 +99,13 @@ public class RecoveryLogsIterator
         Iterator<Entry<Key,Value>> scanIter = new IteratorAdapter(fileIter);
 
         if (scanIter.hasNext()) {
-          LOG.debug("Write ahead log {} has data in range {} {}", log.getName(), start, end);
+          LOG.debug("Write ahead log {} has data in range {} {}", log.getPath().getName(), start,
+              end);
           iterators.add(scanIter);
           fileIters.add(fileIter);
         } else {
-          LOG.debug("Write ahead log {} has no data in range {} {}", log.getName(), start, end);
+          LOG.debug("Write ahead log {} has no data in range {} {}", log.getPath().getName(), start,
+              end);
           fileIter.close();
         }
       }
@@ -137,12 +140,14 @@ public class RecoveryLogsIterator
   /**
    * Check for sorting signal files (finished/failed) and get the logs in the provided directory.
    */
-  private SortedSet<Path> getFiles(VolumeManager fs, Path directory) throws IOException {
+  private SortedSet<UnassignedTabletFile> getFiles(VolumeManager fs, Path directory)
+      throws IOException {
     boolean foundFinish = false;
     // Path::getName compares the last component of each Path value. In this case, the last
     // component should
     // always have the format 'part-r-XXXXX.rf', where XXXXX are one-up values.
-    SortedSet<Path> logFiles = new TreeSet<>(Comparator.comparing(Path::getName));
+    SortedSet<UnassignedTabletFile> logFiles =
+        new TreeSet<>(Comparator.comparing(tf -> tf.getPath().getName()));
     for (FileStatus child : fs.listStatus(directory)) {
       if (child.getPath().getName().startsWith("_")) {
         continue;
@@ -155,7 +160,8 @@ public class RecoveryLogsIterator
         continue;
       }
       FileSystem ns = fs.getFileSystemByPath(child.getPath());
-      Path fullLogPath = ns.makeQualified(child.getPath());
+      UnassignedTabletFile fullLogPath =
+          UnassignedTabletFile.of(ns, ns.makeQualified(child.getPath()));
       logFiles.add(fullLogPath);
     }
     if (!foundFinish) {
@@ -169,9 +175,9 @@ public class RecoveryLogsIterator
    * Check that the first entry in the WAL is OPEN. Only need to do this once.
    */
   private void validateFirstKey(ServerContext context, CryptoService cs, FileSystem fs,
-      SortedSet<Path> logFiles, Path fullLogPath) throws IOException {
+      SortedSet<UnassignedTabletFile> logFiles, Path fullLogPath) throws IOException {
     try (FileSKVIterator fileIter = FileOperations.getInstance().newReaderBuilder()
-        .forFile(logFiles.first().toString(), fs, fs.getConf(), cs)
+        .forFile(logFiles.first(), fs, fs.getConf(), cs)
         .withTableConfiguration(context.getConfiguration()).seekToBeginning().build()) {
       Iterator<Entry<Key,Value>> iterator = new IteratorAdapter(fileIter);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -98,7 +98,7 @@ public class CompactableUtils {
     for (StoredTabletFile file : allFiles) {
       FileSystem ns = fs.getFileSystemByPath(file.getPath());
       try (FileSKVIterator openReader =
-          fileFactory.newReaderBuilder().forFile(file.getPathStr(), ns, ns.getConf(), cs)
+          fileFactory.newReaderBuilder().forFile(file, ns, ns.getConf(), cs)
               .withTableConfiguration(tableConf).seekToBeginning().build()) {
         Key first = openReader.getFirstKey();
         Key last = openReader.getLastKey();
@@ -283,7 +283,7 @@ public class CompactableUtils {
           FileSystem ns = tablet.getTabletServer().getVolumeManager().getFileSystemByPath(path);
           var tableConf = tablet.getTableConfiguration();
           var fiter = fileFactory.newReaderBuilder()
-              .forFile(path.toString(), ns, ns.getConf(), tableConf.getCryptoService())
+              .forFile(TabletFile.of(path), ns, ns.getConf(), tableConf.getCryptoService())
               .withTableConfiguration(tableConf).seekToBeginning().build();
           return Optional.ofNullable(fiter.getSample(new SamplerConfigurationImpl(sc)));
         } catch (IOException e) {

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -1376,9 +1376,8 @@ public class Tablet extends TabletBase {
     // Only want one thread doing this computation at time for a tablet.
     if (splitComputationLock.tryLock()) {
       try {
-        SortedMap<Double,Key> midpoint =
-            FileUtil.findMidPoint(context, tableConfiguration, chooseTabletDir(),
-                extent.prevEndRow(), extent.endRow(), FileUtil.toPathStrings(files), .25, true);
+        SortedMap<Double,Key> midpoint = FileUtil.findMidPoint(context, tableConfiguration,
+            chooseTabletDir(), extent.prevEndRow(), extent.endRow(), files, .25, true);
 
         Text lastRow = null;
 
@@ -1528,9 +1527,8 @@ public class Tablet extends TabletBase {
         splitPoint = findSplitRow(splitComputations);
       } else {
         Text tsp = new Text(sp);
-        var fileStrings = FileUtil.toPathStrings(getDatafileManager().getFiles());
         var ratio = FileUtil.estimatePercentageLTE(context, tableConfiguration, chooseTabletDir(),
-            extent.prevEndRow(), extent.endRow(), fileStrings, tsp);
+            extent.prevEndRow(), extent.endRow(), getDatafileManager().getFiles(), tsp);
         splitPoint = new SplitRowSpec(ratio, tsp);
       }
 

--- a/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
@@ -44,7 +44,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -134,7 +134,7 @@ public class CountNameNodeOpsBulkIT extends ConfigurableMacBase {
           for (int i1 = 0; i1 < 100; i1++) {
             FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
                 .forFile(
-                    UnassignedTabletFile.of(fs,
+                    UnreferencedTabletFile.of(fs,
                         new Path(files + "/bulk_" + i1 + "." + RFile.EXTENSION)),
                     fs, fs.getConf(), NoCryptoServiceFactory.NONE)
                 .withTableConfiguration(DefaultConfiguration.getInstance()).build();

--- a/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/CountNameNodeOpsBulkIT.java
@@ -44,6 +44,7 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.manager.thrift.ManagerMonitorInfo;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.minicluster.ServerType;
 import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
@@ -132,8 +133,10 @@ public class CountNameNodeOpsBulkIT extends ConfigurableMacBase {
           fs.mkdirs(files);
           for (int i1 = 0; i1 < 100; i1++) {
             FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
-                .forFile(files + "/bulk_" + i1 + "." + RFile.EXTENSION, fs, fs.getConf(),
-                    NoCryptoServiceFactory.NONE)
+                .forFile(
+                    UnassignedTabletFile.of(fs,
+                        new Path(files + "/bulk_" + i1 + "." + RFile.EXTENSION)),
+                    fs, fs.getConf(), NoCryptoServiceFactory.NONE)
                 .withTableConfiguration(DefaultConfiguration.getInstance()).build();
             writer.startDefaultLocalityGroup();
             for (int j = 0x100; j < 0xfff; j += 3) {

--- a/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
@@ -24,7 +24,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -59,8 +59,8 @@ public class GenerateSequentialRFile implements Runnable {
   public void run() {
     try {
       final Configuration conf = new Configuration();
-      TabletFile file = TabletFile.of(new Path(opts.filePath));
-      final FileSystem fs = file.getPath().getFileSystem(conf);
+      final FileSystem fs = FileSystem.get(conf);
+      UnreferencedTabletFile file = UnreferencedTabletFile.of(fs, new Path(opts.filePath));
       FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
           .forFile(file, fs, conf, NoCryptoServiceFactory.NONE)
           .withTableConfiguration(DefaultConfiguration.getInstance()).build();

--- a/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
+++ b/test/src/main/java/org/apache/accumulo/test/GenerateSequentialRFile.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -58,10 +59,10 @@ public class GenerateSequentialRFile implements Runnable {
   public void run() {
     try {
       final Configuration conf = new Configuration();
-      Path p = new Path(opts.filePath);
-      final FileSystem fs = p.getFileSystem(conf);
+      TabletFile file = TabletFile.of(new Path(opts.filePath));
+      final FileSystem fs = file.getPath().getFileSystem(conf);
       FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
-          .forFile(opts.filePath, fs, conf, NoCryptoServiceFactory.NONE)
+          .forFile(file, fs, conf, NoCryptoServiceFactory.NONE)
           .withTableConfiguration(DefaultConfiguration.getInstance()).build();
 
       writer.startDefaultLocalityGroup();

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -49,11 +49,13 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.util.FastFormat;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
@@ -269,8 +271,8 @@ public class TestIngest {
     if (params.outputFile != null) {
       ClientContext cc = (ClientContext) accumuloClient;
       writer = FileOperations.getInstance().newWriterBuilder()
-          .forFile(params.outputFile + "." + RFile.EXTENSION, fs, cc.getHadoopConf(),
-              NoCryptoServiceFactory.NONE)
+          .forFile(UnassignedTabletFile.of(fs, new Path(params.outputFile + "." + RFile.EXTENSION)),
+              fs, cc.getHadoopConf(), NoCryptoServiceFactory.NONE)
           .withTableConfiguration(DefaultConfiguration.getInstance()).build();
       writer.startDefaultLocalityGroup();
     } else {

--- a/test/src/main/java/org/apache/accumulo/test/TestIngest.java
+++ b/test/src/main/java/org/apache/accumulo/test/TestIngest.java
@@ -49,7 +49,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -271,7 +271,8 @@ public class TestIngest {
     if (params.outputFile != null) {
       ClientContext cc = (ClientContext) accumuloClient;
       writer = FileOperations.getInstance().newWriterBuilder()
-          .forFile(UnassignedTabletFile.of(fs, new Path(params.outputFile + "." + RFile.EXTENSION)),
+          .forFile(
+              UnreferencedTabletFile.of(fs, new Path(params.outputFile + "." + RFile.EXTENSION)),
               fs, cc.getHadoopConf(), NoCryptoServiceFactory.NONE)
           .withTableConfiguration(DefaultConfiguration.getInstance()).build();
       writer.startDefaultLocalityGroup();

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -61,6 +61,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
@@ -590,7 +591,8 @@ public class BulkNewIT extends SharedMiniClusterBase {
     FileSystem fs = getCluster().getFileSystem();
     String filename = file + RFile.EXTENSION;
     try (FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
-        .forFile(filename, fs, fs.getConf(), NoCryptoServiceFactory.NONE)
+        .forFile(UnassignedTabletFile.of(fs, new Path(filename)), fs, fs.getConf(),
+            NoCryptoServiceFactory.NONE)
         .withTableConfiguration(aconf).build()) {
       writer.startDefaultLocalityGroup();
       for (int i = s; i <= e; i++) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkNewIT.java
@@ -61,7 +61,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.security.Authorizations;
@@ -591,7 +591,7 @@ public class BulkNewIT extends SharedMiniClusterBase {
     FileSystem fs = getCluster().getFileSystem();
     String filename = file + RFile.EXTENSION;
     try (FileSKVWriter writer = FileOperations.getInstance().newWriterBuilder()
-        .forFile(UnassignedTabletFile.of(fs, new Path(filename)), fs, fs.getConf(),
+        .forFile(UnreferencedTabletFile.of(fs, new Path(filename)), fs, fs.getConf(),
             NoCryptoServiceFactory.NONE)
         .withTableConfiguration(aconf).build()) {
       writer.startDefaultLocalityGroup();

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -464,7 +464,7 @@ public class CollectTabletStats {
     for (TabletFile file : files) {
       FileSystem ns = fs.getFileSystemByPath(file.getPath());
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
-          .forFile(file.getPathStr(), ns, ns.getConf(), NoCryptoServiceFactory.NONE)
+          .forFile(file, ns, ns.getConf(), NoCryptoServiceFactory.NONE)
           .withTableConfiguration(aconf).build();
       Range range = new Range(ke.prevEndRow(), false, ke.endRow(), true);
       reader.seek(range, columnSet, !columnSet.isEmpty());
@@ -497,7 +497,7 @@ public class CollectTabletStats {
     for (TabletFile file : files) {
       FileSystem ns = fs.getFileSystemByPath(file.getPath());
       readers.add(FileOperations.getInstance().newReaderBuilder()
-          .forFile(file.getPathStr(), ns, ns.getConf(), NoCryptoServiceFactory.NONE)
+          .forFile(file, ns, ns.getConf(), NoCryptoServiceFactory.NONE)
           .withTableConfiguration(context.getConfiguration()).build());
     }
 

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -68,7 +68,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.metadata.MetadataTable;
-import org.apache.accumulo.core.metadata.UnassignedTabletFile;
+import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -1314,11 +1314,13 @@ public class ShellServerIT extends SharedMiniClusterBase {
     String odd = new File(importDir, "odd.rf").toString();
     AccumuloConfiguration aconf = DefaultConfiguration.getInstance();
     FileSKVWriter evenWriter = FileOperations.getInstance().newWriterBuilder()
-        .forFile(UnassignedTabletFile.of(fs, new Path(even)), fs, conf, NoCryptoServiceFactory.NONE)
+        .forFile(UnreferencedTabletFile.of(fs, new Path(even)), fs, conf,
+            NoCryptoServiceFactory.NONE)
         .withTableConfiguration(aconf).build();
     evenWriter.startDefaultLocalityGroup();
     FileSKVWriter oddWriter = FileOperations.getInstance().newWriterBuilder()
-        .forFile(UnassignedTabletFile.of(fs, new Path(odd)), fs, conf, NoCryptoServiceFactory.NONE)
+        .forFile(UnreferencedTabletFile.of(fs, new Path(odd)), fs, conf,
+            NoCryptoServiceFactory.NONE)
         .withTableConfiguration(aconf).build();
     oddWriter.startDefaultLocalityGroup();
     long timestamp = System.currentTimeMillis();

--- a/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/shell/ShellServerIT.java
@@ -68,6 +68,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.UnassignedTabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.NamespacePermission;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
@@ -1313,10 +1314,12 @@ public class ShellServerIT extends SharedMiniClusterBase {
     String odd = new File(importDir, "odd.rf").toString();
     AccumuloConfiguration aconf = DefaultConfiguration.getInstance();
     FileSKVWriter evenWriter = FileOperations.getInstance().newWriterBuilder()
-        .forFile(even, fs, conf, NoCryptoServiceFactory.NONE).withTableConfiguration(aconf).build();
+        .forFile(UnassignedTabletFile.of(fs, new Path(even)), fs, conf, NoCryptoServiceFactory.NONE)
+        .withTableConfiguration(aconf).build();
     evenWriter.startDefaultLocalityGroup();
     FileSKVWriter oddWriter = FileOperations.getInstance().newWriterBuilder()
-        .forFile(odd, fs, conf, NoCryptoServiceFactory.NONE).withTableConfiguration(aconf).build();
+        .forFile(UnassignedTabletFile.of(fs, new Path(odd)), fs, conf, NoCryptoServiceFactory.NONE)
+        .withTableConfiguration(aconf).build();
     oddWriter.startDefaultLocalityGroup();
     long timestamp = System.currentTimeMillis();
     Text cf = new Text("cf");


### PR DESCRIPTION
This PR replaces the now closed #3385. The goal of this PR is to start to move away from using a String/Path representation everywhere for the file path reference when referring to data files in order to support easier changes in the future when adding more information besides just a path. This is to support the future changes #1327. I am making this a draft PR for now because before this is merged I need to write new Javadocs for the new classes in the API and document changes better but before I did that I wanted to get feedback first.

The current plan for supporting no chop merges is to start associating a range with a file and treating each file that is fenced off by a range as unique. This is going to lead to storing more than one metadata entry for the same file if there is multiple ranges so we will need to start handling the combination of the path and Range in the code when reading a file and not just the path like today.

This PR is an incremental step by using TabletFile/StoredTabletFile and the new `AbstractTabletFile` and `UnassignedTabletFile` classes instead of String in places like `FileManager` and `FileOperations`. The idea here is that by always using those TabletFile classes instead of a Path/String it will be easier to read/write a fenced file as we can add a Range in the future to AbstractTabletFile and a getRange() method.

I originally tried to just use TabletFile but ended up creating two new classes called AbstractTabletFile and UnassignedTabletFile because TabletFile does a lot of [validation](https://github.com/apache/accumulo/blob/2f27dbd188ea5cee32f486599b97181b136fa787/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java#L61) that caused several places to break in the code. There are a lot of areas where we write to RFiles or read from RFiles but the file wouldn't pass the validation checks inside TabletFile as TabletFile requires the path to contain the right structure so it can be [parsed](https://github.com/apache/accumulo/blob/2f27dbd188ea5cee32f486599b97181b136fa787/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java#L78) into a TabletDirectory object. This is problematic in several spots: Writing files, Tests, WAL, Bulk import, etc. Essentially any place we would be doing operations on files that are not part of a Tablet/Tablet yet.

I used the name `UnassignedTabletFile` but a different name can be picked of course. I chose that name as that seemed to be the best name for it is in all cases as it's essentially a data file that hasn't actually been assigned to a Tablet or Tablet which is why we can't parse the TabletDirectory. When we add a Range to the API we could still fence off the new unassigned file if we wanted to (if there's a use case), there wouldn't be anything stopping us from assigning a range but I am going to assume the majority of cases (if not all) there wouldn't be an actual range, it would just be infinite.

Also note that even with tracking a TabletFile we will still always need to get the metadata string representation for serialization when dealing with the metadata table. This is unavoidable of course and the format will change in the future (likely to Json instead of just a file path as it will have a serialized range) so we will need to handle that. A good example of this is ExternalCompactionMetadata. This class already tracks a StoredTabletFile but when data is serialized it calls to getMetaUpdateDelete() and that will be a new format. The format won't change in this first PR but it will later so just noting that we will need to be aware of that and make sure we can handle the change when the Range is added.
