### PR TITLE
Improve some exception handling

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/ClientSideIteratorScanner.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -259,7 +260,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
 
       skvi = IteratorConfigUtil.loadIterators(smi, ib);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
 
     final Set<ByteSequence> colfs = new TreeSet<>();
@@ -270,7 +271,7 @@ public class ClientSideIteratorScanner extends ScannerOptions implements Scanner
     try {
       skvi.seek(range, colfs, true);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
 
     return new IteratorAdapter(skvi);

--- a/core/src/main/java/org/apache/accumulo/core/client/PluginEnvironment.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/PluginEnvironment.java
@@ -163,7 +163,7 @@ public interface PluginEnvironment {
    * @param className Fully qualified name of the class.
    * @param base The expected super type of the class.
    */
-  <T> T instantiate(String className, Class<T> base) throws Exception;
+  <T> T instantiate(String className, Class<T> base) throws ReflectiveOperationException;
 
   /**
    * Instantiate a class using Accumulo's per table classloader. The class must have a no argument
@@ -172,5 +172,6 @@ public interface PluginEnvironment {
    * @param className Fully qualified name of the class.
    * @param base The expected super type of the class.
    */
-  <T> T instantiate(TableId tableId, String className, Class<T> base) throws Exception;
+  <T> T instantiate(TableId tableId, String className, Class<T> base)
+      throws ReflectiveOperationException;
 }

--- a/core/src/main/java/org/apache/accumulo/core/client/admin/FindMax.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/admin/FindMax.java
@@ -67,7 +67,7 @@ public class FindMax {
 
     if (ba.length == startOS.size()) {
       if (ba[0] != 0) {
-        throw new RuntimeException();
+        throw new IllegalStateException();
       }
 
       // big int added a zero so it would not be negative, drop it

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BigIntegerLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/BigIntegerLexicoder.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.FixedByteArrayOutputStream;
@@ -59,7 +60,7 @@ public class BigIntegerLexicoder extends AbstractLexicoder<BigInteger> {
 
       return ret;
     } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
+      throw new UncheckedIOException(ioe);
     }
 
   }
@@ -87,7 +88,7 @@ public class BigIntegerLexicoder extends AbstractLexicoder<BigInteger> {
 
       return new BigInteger(bytes);
     } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
+      throw new UncheckedIOException(ioe);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/PairLexicoder.java
@@ -80,7 +80,7 @@ public class PairLexicoder<A extends Comparable<A>,B extends Comparable<B>>
 
     byte[][] fields = split(data, offset, len);
     if (fields.length != 2) {
-      throw new RuntimeException("Data does not have 2 fields, it has " + fields.length);
+      throw new IllegalArgumentException("Data does not have 2 fields, it has " + fields.length);
     }
 
     return new ComparablePair<>(firstLexicoder.decode(unescape(fields[0])),

--- a/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UUIDLexicoder.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/lexicoder/UUIDLexicoder.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.UUID;
 
 import org.apache.accumulo.core.clientImpl.lexicoder.FixedByteArrayOutputStream;
@@ -52,7 +53,7 @@ public class UUIDLexicoder extends AbstractLexicoder<UUID> {
 
       return ret;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -69,7 +70,7 @@ public class UUIDLexicoder extends AbstractLexicoder<UUID> {
       DataInputStream in = new DataInputStream(new ByteArrayInputStream(b, offset, len));
       return new UUID(in.readLong() ^ 0x8000000000000000L, in.readLong() ^ 0x8000000000000000L);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/sample/AbstractHashSampler.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/sample/AbstractHashSampler.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.Set;
 
@@ -131,7 +132,7 @@ public abstract class AbstractHashSampler implements Sampler {
     try {
       hash(new DataoutputHasher(hasher), k);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
     return hasher.hash().asInt() % modulus == 0;
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/AuthenticationToken.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -115,7 +116,7 @@ public interface AuthenticationToken extends Writable, Destroyable, Cloneable {
         token.write(out);
         return baos.toByteArray();
       } catch (IOException e) {
-        throw new RuntimeException("Bug found in serialization code", e);
+        throw new UncheckedIOException("Bug found in serialization code", e);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/KerberosToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/KerberosToken.java
@@ -25,6 +25,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.Set;
 
@@ -107,8 +108,10 @@ public class KerberosToken implements AuthenticationToken {
       clone.principal = principal;
       clone.keytab = keytab == null ? keytab : keytab.getCanonicalFile();
       return clone;
-    } catch (CloneNotSupportedException | IOException e) {
-      throw new RuntimeException(e);
+    } catch (CloneNotSupportedException e) {
+      throw new IllegalStateException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/client/security/tokens/PasswordToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/client/security/tokens/PasswordToken.java
@@ -101,8 +101,8 @@ public class PasswordToken implements AuthenticationToken {
       AtomicBoolean calledFirstReadInt = new AtomicBoolean(false);
       DataInput wrapped = (DataInput) Proxy.newProxyInstance(DataInput.class.getClassLoader(),
           arg0.getClass().getInterfaces(), (obj, method, args) -> {
-            // wrap the original DataInput in order to return the integer that was read
-            // and then not used, because it didn't match -2
+            // wrap the original DataInput in order to simulate replacing the integer that was
+            // previously read and then not used back into the input, after it didn't match -2
             if (!calledFirstReadInt.get() && method.getName().equals("readInt")) {
               calledFirstReadInt.set(true);
               return version;
@@ -160,7 +160,7 @@ public class PasswordToken implements AuthenticationToken {
       clone.password = Arrays.copyOf(password, password.length);
       return clone;
     } catch (CloneNotSupportedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientServiceEnvironmentImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientServiceEnvironmentImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.core.clientImpl;
 
-import java.io.IOException;
-
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -62,15 +60,14 @@ public class ClientServiceEnvironmentImpl implements ServiceEnvironment {
   }
 
   @Override
-  public <T> T instantiate(String className, Class<T> base)
-      throws ReflectiveOperationException, IOException {
+  public <T> T instantiate(String className, Class<T> base) throws ReflectiveOperationException {
     return ClientServiceEnvironmentImpl.class.getClassLoader().loadClass(className).asSubclass(base)
         .getDeclaredConstructor().newInstance();
   }
 
   @Override
   public <T> T instantiate(TableId tableId, String className, Class<T> base)
-      throws ReflectiveOperationException, IOException {
+      throws ReflectiveOperationException {
     return instantiate(className, base);
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ConditionalWriterImpl.java
@@ -148,7 +148,7 @@ class ConditionalWriterImpl implements ConditionalWriter {
         count--;
         return result;
       } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/Credentials.java
@@ -86,14 +86,14 @@ public class Credentials {
    *
    * @param instanceID Accumulo instance ID
    * @return Thrift credentials
-   * @throws RuntimeException if the authentication token has been destroyed (expired)
+   * @throws IllegalStateException if the authentication token has been destroyed (expired)
    */
   public TCredentials toThrift(InstanceId instanceID) {
     TCredentials tCreds = new TCredentials(getPrincipal(), getToken().getClass().getName(),
         ByteBuffer.wrap(AuthenticationTokenSerializer.serialize(getToken())),
         instanceID.canonical());
     if (getToken().isDestroyed()) {
-      throw new RuntimeException("Token has been destroyed",
+      throw new IllegalStateException("Token has been destroyed",
           new AccumuloSecurityException(getPrincipal(), SecurityErrorCode.TOKEN_EXPIRED));
     }
     return tCreds;

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/InstanceOperationsImpl.java
@@ -361,7 +361,7 @@ public class InstanceOperationsImpl implements InstanceOperations {
           client -> client.waitForBalance(TraceUtil.traceInfo()));
     } catch (AccumuloSecurityException ex) {
       // should never happen
-      throw new RuntimeException("Unexpected exception thrown", ex);
+      throw new IllegalStateException("Unexpected exception thrown", ex);
     }
 
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/NamespaceOperationsImpl.java
@@ -338,7 +338,8 @@ public class NamespaceOperationsImpl extends NamespaceOperationsHelper {
   public Map<String,String> namespaceIdMap() {
     return Namespaces.getNameToIdMap(context).entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().canonical(), (v1, v2) -> {
-          throw new RuntimeException(String.format("Duplicate key for values %s and %s", v1, v2));
+          throw new IllegalStateException(
+              String.format("Duplicate key for values %s and %s", v1, v2));
         }, TreeMap::new));
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -25,6 +25,7 @@ import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType
 import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.PREV_ROW;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -170,11 +171,10 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
         nextTablet();
       }
 
-    } catch (Exception e) {
-      if (e instanceof RuntimeException) {
-        throw (RuntimeException) e;
-      }
-      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -197,8 +197,10 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
       }
 
       return ret;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
+      throw new IllegalStateException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ScannerIterator.java
@@ -27,11 +27,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
 import org.apache.accumulo.core.client.TableDeletedException;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.TableOfflineException;
 import org.apache.accumulo.core.clientImpl.ThriftScanner.ScanState;
+import org.apache.accumulo.core.clientImpl.ThriftScanner.ScanTimedOutException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.KeyValue;
 import org.apache.accumulo.core.data.Range;
@@ -143,7 +147,8 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
     readAheadOperation = context.submitScannerReadAheadTask(this::readBatch);
   }
 
-  private List<KeyValue> readBatch() throws Exception {
+  private List<KeyValue> readBatch() throws ScanTimedOutException, AccumuloException,
+      AccumuloSecurityException, TableNotFoundException {
 
     List<KeyValue> batch;
 
@@ -176,11 +181,10 @@ public class ScannerIterator implements Iterator<Entry<Key,Value>> {
       }
     } catch (ExecutionException ee) {
       wrapExecutionException(ee);
-      throw new RuntimeException(ee);
-    } catch (RuntimeException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(ee);
+    } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException
+        | ScanTimedOutException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
 
     if (!nextBatch.isEmpty()) {

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -530,7 +530,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
         }
       }
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } finally {
       executor.shutdown();
     }
@@ -1480,7 +1480,8 @@ public class TableOperationsImpl extends TableOperationsHelper {
   public Map<String,String> tableIdMap() {
     return context.getTableNameToIdMap().entrySet().stream()
         .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().canonical(), (v1, v2) -> {
-          throw new RuntimeException(String.format("Duplicate key for values %s and %s", v1, v2));
+          throw new IllegalStateException(
+              String.format("Duplicate key for values %s and %s", v1, v2));
         }, TreeMap::new));
   }
 
@@ -1827,7 +1828,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
           List<Range> prev =
               groupedByTablets.put(tabletId, Collections.unmodifiableList(entry2.getValue()));
           if (prev != null) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                 "Unexpected : tablet at multiple locations : " + location + " " + tabletId);
           }
         }
@@ -1899,7 +1900,7 @@ public class TableOperationsImpl extends TableOperationsHelper {
             String.format("locating tablets in table %s(%s) for %d ranges", tableName, tableId,
                 rangeList.size()));
       } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
       locator.invalidateCache();
     }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchReaderIterator.java
@@ -159,17 +159,15 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
           log.warn("Failed to add Batch Scan result", e);
         }
         fatalException = e;
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
 
       }
     };
 
     try {
       lookup(ranges, rr);
-    } catch (RuntimeException re) {
-      throw re;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to create iterator", e);
+    } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
+      throw new IllegalStateException("Failed to create iterator", e);
     }
   }
 
@@ -195,7 +193,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
           if (fatalException instanceof RuntimeException) {
             throw (RuntimeException) fatalException;
           } else {
-            throw new RuntimeException(fatalException);
+            throw new IllegalStateException(fatalException);
           }
         }
 
@@ -206,13 +204,14 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
               + " so that it can be closed when this Iterator is exhausted. Not"
               + " retaining a reference to the BatchScanner guarantees that you are"
               + " leaking threads in your client JVM.", shortMsg);
-          throw new RuntimeException(shortMsg + " Ensure proper handling of the BatchScanner.");
+          throw new IllegalStateException(
+              shortMsg + " Ensure proper handling of the BatchScanner.");
         }
 
         batchIterator = batch.iterator();
         return batch != LAST_BATCH;
       } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
   }
@@ -285,7 +284,7 @@ public class TabletServerBatchReaderIterator implements Iterator<Entry<Key,Value
         try {
           retry.waitForNextAttempt(log, "binRanges retry failures");
         } catch (InterruptedException e) {
-          throw new RuntimeException(e);
+          throw new IllegalStateException(e);
         }
 
       }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TabletServerBatchWriter.java
@@ -499,7 +499,7 @@ public class TabletServerBatchWriter implements AutoCloseable {
         wait();
       }
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftScanner.java
@@ -343,7 +343,7 @@ public class ThriftScanner {
               } else if (scanState.range.getEndKey() != null
                   && dataRange.beforeStartKey(scanState.range.getEndKey())) {
                 // should not happen
-                throw new RuntimeException("Unexpected tablet, extent : " + loc.getExtent()
+                throw new IllegalStateException("Unexpected tablet, extent : " + loc.getExtent()
                     + "  range : " + scanState.range + " startRow : " + scanState.startRow);
               }
             }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportKey.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportKey.java
@@ -54,7 +54,7 @@ public class ThriftTransportKey {
     this.saslParams = saslParams;
     if (saslParams != null && sslParams != null) {
       // TSasl and TSSL transport factories don't play nicely together
-      throw new RuntimeException("Cannot use both SSL and SASL thrift transports");
+      throw new IllegalArgumentException("Cannot use both SSL and SASL thrift transports");
     }
     this.hash = Objects.hash(server, timeout, sslParams, saslParams);
   }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ThriftTransportPool.java
@@ -275,7 +275,7 @@ public class ThriftTransportPool {
     try {
       checkThread.join();
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/bulk/BulkImport.java
@@ -179,7 +179,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         try {
           retry.waitForNextAttempt(log, String.format("bulk import to %s(%s)", tableName, tableId));
         } catch (InterruptedException e) {
-          throw new RuntimeException(e);
+          throw new IllegalStateException(e);
         }
         log.info(ae.getMessage() + ". Retrying bulk import to " + tableName);
       }
@@ -411,13 +411,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
     fileDestinations.values().stream().flatMap(List::stream)
         .filter(dest -> dest.getRangeType() == RangeType.FILE)
         .flatMap(dest -> Stream.of(dest.getStartRow(), dest.getEndRow())).filter(Objects::nonNull)
-        .map(Text::new).sorted().distinct().forEach(row -> {
-          try {
-            extentCache.lookup(row);
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        });
+        .map(Text::new).sorted().distinct().forEach(extentCache::lookup);
 
     SortedMap<KeyExtent,Files> mapping = new TreeMap<>();
 
@@ -581,9 +575,9 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         pathMapping.forEach((ext, fi) -> mappings.computeIfAbsent(ext, k -> new Files()).add(fi));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       } catch (ExecutionException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
 
@@ -606,7 +600,7 @@ public class BulkImport implements ImportDestinationArguments, ImportMappingOpti
         if (ke.contains(oke)) {
           mappings.get(ke).merge(mappings.remove(oke));
         } else if (!oke.contains(ke)) {
-          throw new RuntimeException("Error during bulk import: Unable to merge overlapping "
+          throw new IllegalStateException("Error during bulk import: Unable to merge overlapping "
               + "tablets where neither tablet contains the other. This may be caused by "
               + "a concurrent merge. Key extents " + oke + " and " + ke + " overlap, but "
               + "neither contains the other.");

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigCheckUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.core.conf;
 
-import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -161,7 +160,7 @@ public class ConfigCheckUtil {
       Class<?> requiredBaseClass) {
     try {
       ConfigurationTypeHelper.getClassInstance(null, className, requiredBaseClass);
-    } catch (IOException | ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException e) {
       fatal(confOption + " has an invalid class name: " + className);
     } catch (ClassCastException e) {
       fatal(confOption + " must implement " + requiredBaseClass

--- a/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/ConfigurationTypeHelper.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -173,7 +172,7 @@ public class ConfigurationTypeHelper {
 
     try {
       instance = getClassInstance(context, clazzName, base);
-    } catch (RuntimeException | IOException | ReflectiveOperationException e) {
+    } catch (RuntimeException | ReflectiveOperationException e) {
       log.warn("Failed to load class {} in classloader context {}", clazzName, context, e);
     }
 
@@ -193,7 +192,7 @@ public class ConfigurationTypeHelper {
    * @return a new instance of the class
    */
   public static <T> T getClassInstance(String context, String clazzName, Class<T> base)
-      throws IOException, ReflectiveOperationException {
+      throws ReflectiveOperationException {
     T instance;
 
     Class<? extends T> clazz = ClassLoaderUtil.loadClass(context, clazzName, base);

--- a/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/cluster/ClusterConfigParser.java
@@ -61,14 +61,12 @@ public class ClusterConfigParser {
         (parentKey == null || parentKey.equals("")) ? "" : parentKey + addTheDot(parentKey);
     if (value instanceof String) {
       results.put(parent + key, (String) value);
-      return;
     } else if (value instanceof List) {
       ((List<?>) value).forEach(l -> {
         if (l instanceof String) {
           // remove the [] at the ends of toString()
           String val = value.toString();
           results.put(parent + key, val.substring(1, val.length() - 1).replace(", ", " "));
-          return;
         } else {
           flatten(parent, key, l, results);
         }
@@ -79,9 +77,8 @@ public class ClusterConfigParser {
       map.forEach((k, v) -> flatten(parent + key, k, v, results));
     } else if (value instanceof Number) {
       results.put(parent + key, value.toString());
-      return;
     } else {
-      throw new RuntimeException("Unhandled object type: " + value.getClass());
+      throw new IllegalStateException("Unhandled object type: " + value.getClass());
     }
   }
 
@@ -92,7 +89,7 @@ public class ClusterConfigParser {
         out.printf(PROPERTY_FORMAT, section.toUpperCase() + "_HOSTS", config.get(section));
       } else {
         if (section.equals("manager") || section.equals("tserver")) {
-          throw new RuntimeException("Required configuration section is missing: " + section);
+          throw new IllegalStateException("Required configuration section is missing: " + section);
         }
         System.err.println("WARN: " + section + " is missing");
       }

--- a/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedInputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedInputStream.java
@@ -38,7 +38,7 @@ public class BlockedInputStream extends InputStream {
 
   public BlockedInputStream(InputStream in, int blockSize, int maxSize) {
     if (blockSize == 0) {
-      throw new RuntimeException("Invalid block size");
+      throw new IllegalArgumentException("Invalid block size");
     }
     if (in instanceof DataInputStream) {
       this.in = (DataInputStream) in;
@@ -67,7 +67,7 @@ public class BlockedInputStream extends InputStream {
     if (readPos == array.length) {
       readPos = 0;
     } else if (readPos > array.length) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           "Unexpected state, this should only ever increase or cycle on the boundary!");
     }
     return toRet;
@@ -121,7 +121,7 @@ public class BlockedInputStream extends InputStream {
       finished = true;
       return false;
     } else if (size == 0) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           "Empty block written, this shouldn't happen with this BlockedOutputStream.");
     }
 

--- a/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedOutputStream.java
+++ b/core/src/main/java/org/apache/accumulo/core/crypto/streams/BlockedOutputStream.java
@@ -55,7 +55,7 @@ public class BlockedOutputStream extends OutputStream {
   @Override
   public synchronized void flush() throws IOException {
     if (!bb.hasArray()) {
-      throw new RuntimeException("BlockedOutputStream has no backing array.");
+      throw new IllegalStateException("BlockedOutputStream has no backing array.");
     }
     int size = bb.position();
     if (size == 0) {

--- a/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
+++ b/core/src/main/java/org/apache/accumulo/core/data/LoadPlan.java
@@ -125,7 +125,7 @@ public class LoadPlan {
               "Start row is greater than or equal to end row : " + srs + " " + ers);
         }
       } else {
-        throw new RuntimeException();
+        throw new IllegalStateException();
       }
 
     }

--- a/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
+++ b/core/src/main/java/org/apache/accumulo/core/dataImpl/KeyExtent.java
@@ -488,7 +488,7 @@ public class KeyExtent implements Comparable<KeyExtent> {
     try {
       digester = MessageDigest.getInstance(OBSCURING_HASH_ALGORITHM);
     } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
     if (endRow() != null && endRow().getLength() > 0) {
       digester.update(endRow().getBytes(), 0, endRow().getLength());

--- a/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/Fate.java
@@ -275,7 +275,7 @@ public class Fate<T> {
             store.push(tid, repo);
           } catch (StackOverflowException e) {
             // this should not happen
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
         }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/ZooStore.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,7 +77,7 @@ public class ZooStore<T> implements TStore<T> {
 
       return baos.toByteArray();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -88,8 +89,10 @@ public class ZooStore<T> implements TStore<T> {
       ByteArrayInputStream bais = new ByteArrayInputStream(ser);
       ObjectInputStream ois = new ObjectInputStream(bais);
       return ois.readObject();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -127,8 +130,8 @@ public class ZooStore<T> implements TStore<T> {
         return tid;
       } catch (NodeExistsException nee) {
         // exist, so just try another random #
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (KeeperException | InterruptedException e) {
+        throw new IllegalStateException(e);
       }
     }
   }
@@ -191,7 +194,7 @@ public class ZooStore<T> implements TStore<T> {
           } catch (NoNodeException nne) {
             // node deleted after we got the list of children, its ok
             unreserve(tid);
-          } catch (Exception e) {
+          } catch (KeeperException | InterruptedException | RuntimeException e) {
             unreserve(tid);
             throw e;
           }
@@ -212,8 +215,8 @@ public class ZooStore<T> implements TStore<T> {
           }
         }
       }
-    } catch (InterruptedException | KeeperException e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -226,7 +229,7 @@ public class ZooStore<T> implements TStore<T> {
           try {
             this.wait(1000);
           } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
         }
 
@@ -317,7 +320,7 @@ public class ZooStore<T> implements TStore<T> {
             return null;
           }
         } catch (KeeperException.NoNodeException ex) {
-          throw new RuntimeException(ex);
+          throw new IllegalStateException(ex);
         }
 
         byte[] ser = zk.getData(txpath + "/" + top);
@@ -328,8 +331,8 @@ public class ZooStore<T> implements TStore<T> {
         log.debug("zookeeper error reading " + txpath + ": " + ex, ex);
         sleepUninterruptibly(100, MILLISECONDS);
         continue;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+      } catch (KeeperException | InterruptedException e) {
+        throw new IllegalStateException(e);
       }
     }
     return null;
@@ -369,8 +372,8 @@ public class ZooStore<T> implements TStore<T> {
       zk.putPersistentSequential(txpath + "/repo_", serialize(repo));
     } catch (StackOverflowException soe) {
       throw soe;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -385,8 +388,8 @@ public class ZooStore<T> implements TStore<T> {
         throw new IllegalStateException("Tried to pop when empty " + FateTxId.formatTid(tid));
       }
       zk.recursiveDelete(txpath + "/" + top, NodeMissingPolicy.SKIP);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -395,8 +398,8 @@ public class ZooStore<T> implements TStore<T> {
       return TStatus.valueOf(new String(zk.getData(getTXPath(tid)), UTF_8));
     } catch (NoNodeException nne) {
       return TStatus.UNKNOWN;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -425,7 +428,7 @@ public class ZooStore<T> implements TStore<T> {
           try {
             this.wait(5000);
           } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
         }
       }
@@ -439,8 +442,8 @@ public class ZooStore<T> implements TStore<T> {
     try {
       zk.putPersistentData(getTXPath(tid), status.name().getBytes(UTF_8),
           NodeExistsPolicy.OVERWRITE);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
 
     synchronized (this) {
@@ -455,8 +458,8 @@ public class ZooStore<T> implements TStore<T> {
 
     try {
       zk.recursiveDelete(getTXPath(tid), NodeMissingPolicy.SKIP);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -476,8 +479,8 @@ public class ZooStore<T> implements TStore<T> {
         data[1] = ' ';
         zk.putPersistentData(getTXPath(tid) + "/" + txInfo, data, NodeExistsPolicy.OVERWRITE);
       }
-    } catch (Exception e2) {
-      throw new RuntimeException(e2);
+    } catch (KeeperException | InterruptedException e2) {
+      throw new IllegalStateException(e2);
     }
   }
 
@@ -499,8 +502,8 @@ public class ZooStore<T> implements TStore<T> {
       }
     } catch (NoNodeException nne) {
       return null;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -513,8 +516,8 @@ public class ZooStore<T> implements TStore<T> {
         l.add(parseTid(txid));
       }
       return l;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (KeeperException | InterruptedException e) {
+      throw new IllegalStateException(e);
     }
   }
 
@@ -541,7 +544,7 @@ public class ZooStore<T> implements TStore<T> {
       } catch (KeeperException.NoNodeException e) {
         return Collections.emptyList();
       } catch (KeeperException | InterruptedException e1) {
-        throw new RuntimeException(e1);
+        throw new IllegalStateException(e1);
       }
 
       ops = new ArrayList<>(ops);
@@ -561,7 +564,7 @@ public class ZooStore<T> implements TStore<T> {
             // children changed so start over
             continue outer;
           } catch (KeeperException | InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
         }
       }

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/FateLock.java
@@ -83,8 +83,8 @@ public class FateLock implements QueueLock {
           zoo.putPersistentData(path.toString(), new byte[] {}, NodeExistsPolicy.SKIP);
         }
       }
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (KeeperException | InterruptedException ex) {
+      throw new IllegalStateException(ex);
     }
   }
 
@@ -112,8 +112,8 @@ public class FateLock implements QueueLock {
           // ignored
         }
       }
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (KeeperException | InterruptedException ex) {
+      throw new IllegalStateException(ex);
     }
     return result;
   }
@@ -128,8 +128,8 @@ public class FateLock implements QueueLock {
       } catch (NotEmptyException nee) {
         // the path had other lock nodes, no big deal
       }
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (KeeperException | InterruptedException ex) {
+      throw new IllegalStateException(ex);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
+++ b/core/src/main/java/org/apache/accumulo/core/fate/zookeeper/ZooSession.java
@@ -157,7 +157,7 @@ public class ZooSession {
       long duration = NANOSECONDS.toMillis(stopTime - startTime);
 
       if (duration > 2L * timeout) {
-        throw new RuntimeException("Failed to connect to zookeeper (" + host
+        throw new IllegalStateException("Failed to connect to zookeeper (" + host
             + ") within 2x zookeeper timeout period " + timeout);
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheManagerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/impl/BlockCacheManagerFactory.java
@@ -35,10 +35,10 @@ public class BlockCacheManagerFactory {
    *
    * @param conf accumulo configuration
    * @return block cache manager instance
-   * @throws Exception error loading block cache manager implementation class
+   * @throws ReflectiveOperationException error loading block cache manager implementation class
    */
   public static synchronized BlockCacheManager getInstance(AccumuloConfiguration conf)
-      throws Exception {
+      throws ReflectiveOperationException {
     String impl = conf.get(Property.TSERV_CACHE_MANAGER_IMPL);
     Class<? extends BlockCacheManager> clazz =
         ClassLoaderUtil.loadClass(impl, BlockCacheManager.class);
@@ -51,10 +51,10 @@ public class BlockCacheManagerFactory {
    *
    * @param conf accumulo configuration
    * @return block cache manager instance
-   * @throws Exception error loading block cache manager implementation class
+   * @throws ReflectiveOperationException error loading block cache manager implementation class
    */
   public static synchronized BlockCacheManager getClientInstance(AccumuloConfiguration conf)
-      throws Exception {
+      throws ReflectiveOperationException {
     String impl = conf.get(Property.TSERV_CACHE_MANAGER_IMPL);
     Class<? extends BlockCacheManager> clazz =
         Class.forName(impl).asSubclass(BlockCacheManager.class);

--- a/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/blockfile/cache/lru/LruBlockCache.java
@@ -154,7 +154,7 @@ public class LruBlockCache extends SynchronousLoadingBlockCache implements Block
         try {
           Thread.sleep(10);
         } catch (InterruptedException ex) {
-          throw new RuntimeException(ex);
+          throw new IllegalStateException(ex);
         }
       }
     } else {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/MultiLevelIndex.java
@@ -28,6 +28,7 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -190,7 +191,7 @@ public class MultiLevelIndex {
         sbais.seek(indexOffset + offset);
         return newValue();
       } catch (IOException ioe) {
-        throw new RuntimeException(ioe);
+        throw new UncheckedIOException(ioe);
       }
     }
 
@@ -399,7 +400,7 @@ public class MultiLevelIndex {
         offsetsArray = offsets;
         newFormat = false;
       } else {
-        throw new RuntimeException("Unexpected version " + version);
+        throw new IllegalStateException("Unexpected version " + version);
       }
 
     }
@@ -705,7 +706,7 @@ public class MultiLevelIndex {
         try {
           return node.getPreviousNode();
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new UncheckedIOException(e);
         }
       }
 
@@ -713,7 +714,7 @@ public class MultiLevelIndex {
         try {
           return node.getNextNode();
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new UncheckedIOException(e);
         }
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFile.java
@@ -1292,7 +1292,7 @@ public class RFile {
     @Override
     public void closeDeepCopies() {
       if (deepCopy) {
-        throw new RuntimeException("Calling closeDeepCopies on a deep copy is not supported");
+        throw new IllegalStateException("Calling closeDeepCopies on a deep copy is not supported");
       }
 
       for (Reader deepCopy : deepCopies) {
@@ -1305,7 +1305,7 @@ public class RFile {
     @Override
     public void close() throws IOException {
       if (deepCopy) {
-        throw new RuntimeException("Calling close on a deep copy is not supported");
+        throw new IllegalStateException("Calling close on a deep copy is not supported");
       }
 
       closeDeepCopies();
@@ -1531,11 +1531,12 @@ public class RFile {
     @Override
     public void setInterruptFlag(AtomicBoolean flag) {
       if (deepCopy) {
-        throw new RuntimeException("Calling setInterruptFlag on a deep copy is not supported");
+        throw new IllegalStateException("Calling setInterruptFlag on a deep copy is not supported");
       }
 
       if (!deepCopies.isEmpty()) {
-        throw new RuntimeException("Setting interrupt flag after calling deep copy not supported");
+        throw new IllegalStateException(
+            "Setting interrupt flag after calling deep copy not supported");
       }
 
       setInterruptFlagInternal(flag);

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/bcfile/Utils.java
@@ -142,7 +142,7 @@ public final class Utils {
         out.writeLong(n);
         return;
       default:
-        throw new RuntimeException("Internal error");
+        throw new IllegalStateException("Internal error");
     }
   }
 
@@ -157,7 +157,7 @@ public final class Utils {
   public static int readVInt(DataInput in) throws IOException {
     long ret = readVLong(in);
     if ((ret > Integer.MAX_VALUE) || (ret < Integer.MIN_VALUE)) {
-      throw new RuntimeException("Number too large to be represented as Integer");
+      throw new IllegalStateException("Number too large to be represented as Integer");
     }
     return (int) ret;
   }
@@ -218,7 +218,7 @@ public final class Utils {
             throw new IOException("Corrupted VLong encoding");
         }
       default:
-        throw new RuntimeException("Internal error");
+        throw new IllegalStateException("Internal error");
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Combiner.java
@@ -315,8 +315,8 @@ public abstract class Combiner extends WrappingIterator implements OptionDescrib
     Combiner newInstance;
     try {
       newInstance = this.getClass().getDeclaredConstructor().newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
     newInstance.setSource(getSource().deepCopy(env));
     newInstance.combiners = combiners;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/Filter.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.iterators;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -45,8 +46,8 @@ public abstract class Filter extends WrappingIterator implements OptionDescriber
     Filter newInstance;
     try {
       newInstance = this.getClass().getDeclaredConstructor().newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
     newInstance.setSource(getSource().deepCopy(env));
     newInstance.negate = negate;
@@ -79,7 +80,7 @@ public abstract class Filter extends WrappingIterator implements OptionDescriber
       try {
         source.next();
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw new UncheckedIOException(e);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowEncodingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowEncodingIterator.java
@@ -90,8 +90,8 @@ public abstract class RowEncodingIterator
     RowEncodingIterator newInstance;
     try {
       newInstance = this.getClass().getDeclaredConstructor().newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
     newInstance.sourceIter = sourceIter.deepCopy(env);
     newInstance.maxBufferSize = maxBufferSize;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/RowFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/RowFilter.java
@@ -155,8 +155,8 @@ public abstract class RowFilter extends WrappingIterator {
     RowFilter newInstance;
     try {
       newInstance = getClass().getDeclaredConstructor().newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
     newInstance.setSource(getSource().deepCopy(env));
     newInstance.decisionIterator = new RowIterator(getSource().deepCopy(env));

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/SeekingFilter.java
@@ -152,8 +152,8 @@ public abstract class SeekingFilter extends WrappingIterator {
     SeekingFilter newInstance;
     try {
       newInstance = this.getClass().getDeclaredConstructor().newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
     newInstance.setSource(getSource().deepCopy(env));
     newInstance.negate = negate;

--- a/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/iterators/user/TransformingIterator.java
@@ -176,8 +176,8 @@ public abstract class TransformingIterator extends WrappingIterator implements O
 
     try {
       copy = getClass().getDeclaredConstructor().newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
     }
 
     copy.setSource(getSource().deepCopy(env));

--- a/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/iteratorsImpl/IteratorConfigUtil.java
@@ -228,7 +228,7 @@ public class IteratorConfigUtil {
       }
     } catch (ReflectiveOperationException e) {
       log.error(e.toString());
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
     return prev;
   }

--- a/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
+++ b/core/src/main/java/org/apache/accumulo/core/lock/ServiceLock.java
@@ -118,9 +118,9 @@ public class ServiceLock implements Watcher {
       zooKeeper.exists(path.toString(), this);
       watchingParent = true;
       this.vmLockPrefix = new Prefix(ZLOCK_PREFIX + uuid.toString() + "#");
-    } catch (Exception ex) {
+    } catch (KeeperException | InterruptedException ex) {
       LOG.error("Error setting initial watch", ex);
-      throw new RuntimeException(ex);
+      throw new IllegalStateException(ex);
     }
   }
 
@@ -284,7 +284,7 @@ public class ServiceLock implements Watcher {
     if (null == children || !children.contains(createdEphemeralNode)) {
       LOG.error("Expected ephemeral node {} to be in the list of children {}", createdEphemeralNode,
           children);
-      throw new RuntimeException(
+      throw new IllegalStateException(
           "Lock attempt ephemeral node no longer exist " + createdEphemeralNode);
     }
 
@@ -413,7 +413,8 @@ public class ServiceLock implements Watcher {
           || !children.contains(createPath.substring(path.toString().length() + 1))) {
         LOG.error("Expected ephemeral node {} to be in the list of children {}", createPath,
             children);
-        throw new RuntimeException("Lock attempt ephemeral node no longer exist " + createPath);
+        throw new IllegalStateException(
+            "Lock attempt ephemeral node no longer exist " + createPath);
       }
 
       String lowestSequentialPath = null;
@@ -683,7 +684,7 @@ public class ServiceLock implements Watcher {
     String lockNode = children.get(0);
 
     if (!lockNode.startsWith(ZLOCK_PREFIX)) {
-      throw new RuntimeException("Node " + lockNode + " at " + path + " is not a lock node");
+      throw new IllegalStateException("Node " + lockNode + " at " + path + " is not a lock node");
     }
 
     byte[] data = zc.get(path + "/" + lockNode, stat);
@@ -736,7 +737,7 @@ public class ServiceLock implements Watcher {
     String lockNode = children.get(0);
 
     if (!lockNode.startsWith(ZLOCK_PREFIX)) {
-      throw new RuntimeException("Node " + lockNode + " at " + path + " is not a lock node");
+      throw new IllegalStateException("Node " + lockNode + " at " + path + " is not a lock node");
     }
 
     String pathToDelete = path + "/" + lockNode;
@@ -757,7 +758,7 @@ public class ServiceLock implements Watcher {
     String lockNode = children.get(0);
 
     if (!lockNode.startsWith(ZLOCK_PREFIX)) {
-      throw new RuntimeException("Node " + lockNode + " at " + path + " is not a lock node");
+      throw new IllegalStateException("Node " + lockNode + " at " + path + " is not a lock node");
     }
 
     byte[] data = zk.getData(path + "/" + lockNode);

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataLocationObtainer.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.core.metadata;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -180,7 +181,7 @@ public class MetadataLocationObtainer implements TabletLocationObtainer {
         try {
           results.putAll(WholeRowIterator.decodeRow(entry.getKey(), entry.getValue()));
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new UncheckedIOException(e);
         }
       }
     };

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletsMetadata.java
@@ -181,7 +181,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
             closables.add(scanner);
 
           } catch (TableNotFoundException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
 
         }
@@ -265,7 +265,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
           return new TabletsMetadata(scanner, tmi);
         }
       } catch (TableNotFoundException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
 
@@ -577,7 +577,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
           byte[] bytes = zooReader.getData(zkRoot + RootTable.ZROOT_TABLET);
           return new RootTabletMetadata(new String(bytes, UTF_8)).toTabletMetadata();
         } catch (InterruptedException | KeeperException e) {
-          throw new RuntimeException(e);
+          throw new IllegalStateException(e);
         }
       default:
         throw new IllegalArgumentException("Unknown consistency level " + readConsistency);
@@ -612,7 +612,7 @@ public class TabletsMetadata implements Iterable<TabletMetadata>, AutoCloseable 
         // avoid wrapping runtime w/ runtime
         throw e;
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/SaslConnectionParams.java
@@ -21,9 +21,11 @@ package org.apache.accumulo.core.rpc;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -166,7 +168,7 @@ public class SaslConnectionParams {
   protected void updatePrincipalFromUgi() {
     // Ensure we're using Kerberos auth for Hadoop UGI
     if (!UserGroupInformation.isSecurityEnabled()) {
-      throw new RuntimeException("Cannot use SASL if Hadoop security is not enabled");
+      throw new IllegalStateException("Cannot use SASL if Hadoop security is not enabled");
     }
 
     // Get the current user
@@ -174,13 +176,13 @@ public class SaslConnectionParams {
     try {
       currentUser = UserGroupInformation.getCurrentUser();
     } catch (IOException e) {
-      throw new RuntimeException("Failed to get current user", e);
+      throw new UncheckedIOException("Failed to get current user", e);
     }
 
     // The full name is our principal
     this.principal = currentUser.getUserName();
     if (this.principal == null) {
-      throw new RuntimeException("Got null username from " + currentUser);
+      throw new IllegalStateException("Got null username from " + currentUser);
     }
 
   }
@@ -260,11 +262,7 @@ public class SaslConnectionParams {
       if (!mechanism.equals(other.mechanism)) {
         return false;
       }
-      if (callbackHandler == null) {
-        if (other.callbackHandler != null) {
-          return false;
-        }
-      } else if (!callbackHandler.equals(other.callbackHandler)) {
+      if (!Objects.equals(callbackHandler, other.callbackHandler)) {
         return false;
       }
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/ThriftUtil.java
@@ -366,7 +366,7 @@ public class ThriftUtil {
       if (loginUser == null || !loginUser.hasKerberosCredentials()) {
         // We should have already checked that we're logged in and have credentials. A
         // precondition-like check.
-        throw new RuntimeException("Expected to find Kerberos UGI credentials, but did not");
+        throw new IllegalStateException("Expected to find Kerberos UGI credentials, but did not");
       }
       UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
       // A Proxy user is the "effective user" (in name only), riding on top of the "real user"'s Krb
@@ -398,7 +398,7 @@ public class ThriftUtil {
       // The inability to check is worrisome and deserves a RuntimeException instead of a propagated
       // IO-like Exception.
       log.warn("Failed to check (and/or perform) Kerberos client re-login", e);
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/rpc/UGIAssumingTransport.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/UGIAssumingTransport.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.rpc;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,8 +57,10 @@ public class UGIAssumingTransport extends FilterTransport {
         }
         return null;
       });
-    } catch (IOException | InterruptedException e) {
-      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (InterruptedException e) {
+      throw new IllegalStateException(e);
     }
 
     // Make sure the transport exception gets (re)thrown if it happened

--- a/core/src/main/java/org/apache/accumulo/core/rpc/UGIAssumingTransportFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/UGIAssumingTransportFactory.java
@@ -52,7 +52,7 @@ public class UGIAssumingTransportFactory extends TTransportFactory {
       try {
         return wrapped.getTransport(trans);
       } catch (TTransportException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     });
   }

--- a/core/src/main/java/org/apache/accumulo/core/rpc/clients/ManagerClient.java
+++ b/core/src/main/java/org/apache/accumulo/core/rpc/clients/ManagerClient.java
@@ -55,7 +55,7 @@ public interface ManagerClient<C extends TServiceClient> {
       Throwable cause = tte.getCause();
       if (cause != null && cause instanceof UnknownHostException) {
         // do not expect to recover from this
-        throw new RuntimeException(tte);
+        throw new IllegalStateException(tte);
       }
       log.debug("Failed to connect to manager=" + manager + ", will retry... ", tte);
       return null;

--- a/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
+++ b/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
@@ -91,7 +91,7 @@ public class ColumnVisibility {
   /**
    * The node types in a parse tree for a visibility expression.
    */
-  public static enum NodeType {
+  public enum NodeType {
     EMPTY, TERM, OR, AND,
   }
 
@@ -151,7 +151,7 @@ public class ColumnVisibility {
 
     public ByteSequence getTerm(byte[] expression) {
       if (type != NodeType.TERM) {
-        throw new RuntimeException();
+        throw new IllegalStateException();
       }
 
       if (expression[start] == '"') {

--- a/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlanner.java
@@ -210,87 +210,81 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
 
   @Override
   public CompactionPlan makePlan(PlanningParameters params) {
-    try {
+    if (params.getCandidates().isEmpty()) {
+      return params.createPlanBuilder().build();
+    }
 
-      if (params.getCandidates().isEmpty()) {
-        return params.createPlanBuilder().build();
+    Set<CompactableFile> filesCopy = new HashSet<>(params.getCandidates());
+
+    long maxSizeToCompact = getMaxSizeToCompact(params.getKind());
+
+    Collection<CompactableFile> group;
+    if (params.getRunningCompactions().isEmpty()) {
+      group =
+          findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact, maxSizeToCompact);
+
+      if (!group.isEmpty() && group.size() < params.getCandidates().size()
+          && params.getCandidates().size() <= maxFilesToCompact
+          && (params.getKind() == CompactionKind.USER
+              || params.getKind() == CompactionKind.SELECTOR)) {
+        // USER and SELECTOR compactions must eventually compact all files. When a subset of files
+        // that meets the compaction ratio is selected, look ahead and see if the next compaction
+        // would also meet the compaction ratio. If not then compact everything to avoid doing
+        // more than logarithmic work across multiple comapctions.
+
+        filesCopy.removeAll(group);
+        filesCopy.add(getExpected(group, 0));
+
+        if (findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact,
+            maxSizeToCompact).isEmpty()) {
+          // The next possible compaction does not meet the compaction ratio, so compact
+          // everything.
+          group = Set.copyOf(params.getCandidates());
+        }
+
       }
 
-      Set<CompactableFile> filesCopy = new HashSet<>(params.getCandidates());
+    } else if (params.getKind() == CompactionKind.SYSTEM) {
+      // This code determines if once the files compacting finish would they be included in a
+      // compaction with the files smaller than them? If so, then wait for the running compaction
+      // to complete.
 
-      long maxSizeToCompact = getMaxSizeToCompact(params.getKind());
+      // The set of files running compactions may produce
+      var expectedFiles = getExpected(params.getRunningCompactions());
 
-      Collection<CompactableFile> group;
-      if (params.getRunningCompactions().isEmpty()) {
-        group = findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact,
-            maxSizeToCompact);
+      if (!Collections.disjoint(filesCopy, expectedFiles)) {
+        throw new AssertionError();
+      }
 
-        if (!group.isEmpty() && group.size() < params.getCandidates().size()
-            && params.getCandidates().size() <= maxFilesToCompact
-            && (params.getKind() == CompactionKind.USER
-                || params.getKind() == CompactionKind.SELECTOR)) {
-          // USER and SELECTOR compactions must eventually compact all files. When a subset of files
-          // that meets the compaction ratio is selected, look ahead and see if the next compaction
-          // would also meet the compaction ratio. If not then compact everything to avoid doing
-          // more than logarithmic work across multiple comapctions.
+      filesCopy.addAll(expectedFiles);
 
-          filesCopy.removeAll(group);
-          filesCopy.add(getExpected(group, 0));
+      group =
+          findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact, maxSizeToCompact);
 
-          if (findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact,
-              maxSizeToCompact).isEmpty()) {
-            // The next possible compaction does not meet the compaction ratio, so compact
-            // everything.
-            group = Set.copyOf(params.getCandidates());
-          }
-
-        }
-
-      } else if (params.getKind() == CompactionKind.SYSTEM) {
-        // This code determines if once the files compacting finish would they be included in a
-        // compaction with the files smaller than them? If so, then wait for the running compaction
-        // to complete.
-
-        // The set of files running compactions may produce
-        var expectedFiles = getExpected(params.getRunningCompactions());
-
-        if (!Collections.disjoint(filesCopy, expectedFiles)) {
-          throw new AssertionError();
-        }
-
-        filesCopy.addAll(expectedFiles);
-
-        group = findDataFilesToCompact(filesCopy, params.getRatio(), maxFilesToCompact,
-            maxSizeToCompact);
-
-        if (!Collections.disjoint(group, expectedFiles)) {
-          // file produced by running compaction will eventually compact with existing files, so
-          // wait.
-          group = Set.of();
-        }
-      } else {
+      if (!Collections.disjoint(group, expectedFiles)) {
+        // file produced by running compaction will eventually compact with existing files, so
+        // wait.
         group = Set.of();
       }
+    } else {
+      group = Set.of();
+    }
 
-      if (group.isEmpty()
-          && (params.getKind() == CompactionKind.USER || params.getKind() == CompactionKind.SELECTOR
-              || params.getKind() == CompactionKind.CHOP)
-          && params.getRunningCompactions().stream()
-              .noneMatch(job -> job.getKind() == params.getKind())) {
-        group = findMaximalRequiredSetToCompact(params.getCandidates(), maxFilesToCompact);
-      }
+    if (group.isEmpty()
+        && (params.getKind() == CompactionKind.USER || params.getKind() == CompactionKind.SELECTOR
+            || params.getKind() == CompactionKind.CHOP)
+        && params.getRunningCompactions().stream()
+            .noneMatch(job -> job.getKind() == params.getKind())) {
+      group = findMaximalRequiredSetToCompact(params.getCandidates(), maxFilesToCompact);
+    }
 
-      if (group.isEmpty()) {
-        return params.createPlanBuilder().build();
-      } else {
-        // determine which executor to use based on the size of the files
-        var ceid = getExecutor(group);
+    if (group.isEmpty()) {
+      return params.createPlanBuilder().build();
+    } else {
+      // determine which executor to use based on the size of the files
+      var ceid = getExecutor(group);
 
-        return params.createPlanBuilder().addJob(createPriority(params, group), ceid, group)
-            .build();
-      }
-    } catch (RuntimeException e) {
-      throw e;
+      return params.createPlanBuilder().addJob(createPriority(params, group), ceid, group).build();
     }
   }
 
@@ -317,7 +311,7 @@ public class DefaultCompactionPlanner implements CompactionPlanner {
           new URI("hdfs://fake/accumulo/tables/adef/t-zzFAKEzz/FAKE-0000" + count + ".rf"), size,
           0);
     } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/DelegatingChooser.java
@@ -89,7 +89,7 @@ public class DelegatingChooser implements VolumeChooser {
           + Property.GENERAL_ARBITRARY_PROP_PREFIX + DEFAULT_SCOPED_VOLUME_CHOOSER
           + " must be a valid " + VolumeChooser.class.getSimpleName() + " to use the "
           + getClass().getSimpleName();
-      throw new RuntimeException(msg);
+      throw new IllegalStateException(msg);
     }
 
     return createVolumeChooser(env, clazz, TABLE_CUSTOM_SUFFIX, env.getTable().orElseThrow(),
@@ -115,7 +115,7 @@ public class DelegatingChooser implements VolumeChooser {
             + Property.GENERAL_ARBITRARY_PROP_PREFIX + DEFAULT_SCOPED_VOLUME_CHOOSER
             + " must be a valid " + VolumeChooser.class.getSimpleName() + " to use the "
             + getClass().getSimpleName();
-        throw new RuntimeException(msg);
+        throw new IllegalStateException(msg);
       }
 
       property = DEFAULT_SCOPED_VOLUME_CHOOSER;
@@ -155,10 +155,10 @@ public class DelegatingChooser implements VolumeChooser {
         } else {
           return env.getServiceEnv().instantiate(className, VolumeChooser.class);
         }
-      } catch (Exception e) {
+      } catch (ReflectiveOperationException e) {
         String msg = "Failed to create instance for " + key + " configured to use " + className
             + " via " + property;
-        throw new RuntimeException(msg, e);
+        throw new IllegalStateException(msg, e);
       }
     });
   }

--- a/core/src/main/java/org/apache/accumulo/core/spi/fs/PreferredVolumeChooser.java
+++ b/core/src/main/java/org/apache/accumulo/core/spi/fs/PreferredVolumeChooser.java
@@ -182,7 +182,7 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
     if (preferredVolumes == null || preferredVolumes.isEmpty()) {
       String msg = "Property " + TABLE_CUSTOM_SUFFIX + " or " + DEFAULT_SCOPED_PREFERRED_VOLUMES
           + " must be a subset of " + options + " to use the " + getClass().getSimpleName();
-      throw new RuntimeException(msg);
+      throw new IllegalArgumentException(msg);
     }
 
     return parsePreferred(TABLE_CUSTOM_SUFFIX, preferredVolumes, options);
@@ -208,7 +208,7 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
       if (preferredVolumes == null || preferredVolumes.isEmpty()) {
         String msg = "Property " + property + " or " + DEFAULT_SCOPED_PREFERRED_VOLUMES
             + " must be a subset of " + options + " to use the " + getClass().getSimpleName();
-        throw new RuntimeException(msg);
+        throw new IllegalArgumentException(msg);
       }
 
       property = DEFAULT_SCOPED_PREFERRED_VOLUMES;
@@ -226,13 +226,13 @@ public class PreferredVolumeChooser extends RandomVolumeChooser {
     if (preferred.isEmpty()) {
       String msg = "No volumes could be parsed from '" + property + "', which had a value of '"
           + preferredVolumes + "'";
-      throw new RuntimeException(msg);
+      throw new IllegalArgumentException(msg);
     }
     // preferred volumes should also exist in the original options (typically, from
     // instance.volumes)
     if (Collections.disjoint(preferred, options)) {
       String msg = "Some volumes in " + preferred + " are not valid volumes from " + options;
-      throw new RuntimeException(msg);
+      throw new IllegalArgumentException(msg);
     }
 
     return preferred;

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -326,7 +326,7 @@ public class Gatherer {
             pfiles.failedFiles.addAll(files.keySet());
             continue;
           } catch (TException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
 
         }
@@ -337,7 +337,7 @@ public class Gatherer {
       }
 
       if (cancelFlag.get()) {
-        throw new RuntimeException("Operation canceled");
+        throw new IllegalStateException("Operation canceled");
       }
 
       return pfiles;
@@ -481,11 +481,11 @@ public class Gatherer {
           return tsr;
         });
       } catch (AccumuloException | AccumuloSecurityException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
 
       if (cancelFlag.get()) {
-        throw new RuntimeException("Operation canceled");
+        throw new IllegalStateException("Operation canceled");
       }
 
       return new SummaryCollection(tSums);

--- a/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/SummarizerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.core.summary;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.summary.Summarizer;
@@ -55,8 +56,10 @@ public class SummarizerFactory {
   public Summarizer getSummarizer(SummarizerConfiguration conf) {
     try {
       return newSummarizer(conf.getClassName());
-    } catch (ReflectiveOperationException | IOException e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/CreateToken.java
@@ -86,34 +86,35 @@ public class CreateToken implements KeywordExecutable {
       pass = opts.securePassword;
     }
 
-    try {
-      String principal = opts.principal;
-      if (principal == null) {
-        principal = getConsoleReader().readLine("Username (aka principal): ");
-      }
-
-      AuthenticationToken token = Class.forName(opts.tokenClassName)
-          .asSubclass(AuthenticationToken.class).getDeclaredConstructor().newInstance();
-      Properties props = new Properties();
-      for (TokenProperty tp : token.getProperties()) {
-        String input;
-        if (pass != null && tp.getKey().equals("password")) {
-          input = pass;
-        } else {
-          if (tp.getMask()) {
-            input = getConsoleReader().readLine(tp.getDescription() + ": ", '*');
-          } else {
-            input = getConsoleReader().readLine(tp.getDescription() + ": ");
-          }
-        }
-        props.put(tp.getKey(), input);
-        token.init(props);
-      }
-      System.out.println("auth.type = " + opts.tokenClassName);
-      System.out.println("auth.principal = " + principal);
-      System.out.println("auth.token = " + ClientProperty.encodeToken(token));
-    } catch (ReflectiveOperationException e) {
-      throw new RuntimeException(e);
+    String principal = opts.principal;
+    if (principal == null) {
+      principal = getConsoleReader().readLine("Username (aka principal): ");
     }
+
+    AuthenticationToken token;
+    try {
+      token = Class.forName(opts.tokenClassName).asSubclass(AuthenticationToken.class)
+          .getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+    Properties props = new Properties();
+    for (TokenProperty tp : token.getProperties()) {
+      String input;
+      if (pass != null && tp.getKey().equals("password")) {
+        input = pass;
+      } else {
+        if (tp.getMask()) {
+          input = getConsoleReader().readLine(tp.getDescription() + ": ", '*');
+        } else {
+          input = getConsoleReader().readLine(tp.getDescription() + ": ");
+        }
+      }
+      props.put(tp.getKey(), input);
+      token.init(props);
+    }
+    System.out.println("auth.type = " + opts.tokenClassName);
+    System.out.println("auth.principal = " + principal);
+    System.out.println("auth.token = " + ClientProperty.encodeToken(token));
   }
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/FastFormat.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/FastFormat.java
@@ -31,8 +31,8 @@ public class FastFormat {
     String strNum = Long.toString(num, radix);
     byte[] ret = new byte[Math.max(strNum.length(), width) + prefix.length];
     if (toZeroPaddedString(ret, 0, strNum, width, prefix) != ret.length) {
-      throw new RuntimeException(" Did not format to expected width " + num + " " + width + " "
-          + radix + " " + new String(prefix, UTF_8));
+      throw new IllegalArgumentException(" Did not format to expected width " + num + " " + width
+          + " " + radix + " " + new String(prefix, UTF_8));
     }
     return ret;
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/compaction/ExternalCompactionUtil.java
@@ -110,7 +110,7 @@ public class ExternalCompactionUtil {
       }
       return Optional.ofNullable(sld.orElseThrow().getAddress(ThriftService.COORDINATOR));
     } catch (KeeperException | InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -144,10 +144,10 @@ public class ExternalCompactionUtil {
 
       return queuesAndAddresses;
     } catch (KeeperException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -248,7 +248,7 @@ public class ExternalCompactionUtil {
           results.add(new RunningCompaction(job, compactorAddress, rcf.getQueue()));
         }
       } catch (InterruptedException | ExecutionException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     });
     return results;
@@ -277,7 +277,7 @@ public class ExternalCompactionUtil {
           runningIds.add(ceid);
         }
       } catch (InterruptedException | ExecutionException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     });
 

--- a/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/threads/ThreadPools.java
@@ -241,7 +241,7 @@ public class ThreadPools {
    *        pools. Creating lots of short lived thread pools and registering them can lead to out of
    *        memory errors over long time periods.
    * @return ExecutorService impl
-   * @throws RuntimeException if property is not handled
+   * @throws IllegalArgumentException if property is not handled
    */
   public ThreadPoolExecutor createExecutorService(final AccumuloConfiguration conf,
       final Property p, boolean emitThreadPoolMetrics) {
@@ -284,7 +284,7 @@ public class ThreadPools {
       case GC_DELETE_THREADS:
         return createFixedThreadPool(conf.getCount(p), "deleting", emitThreadPoolMetrics);
       default:
-        throw new RuntimeException("Unhandled thread pool property: " + p);
+        throw new IllegalArgumentException("Unhandled thread pool property: " + p);
     }
   }
 

--- a/core/src/main/spotbugs/exclude-filter.xml
+++ b/core/src/main/spotbugs/exclude-filter.xml
@@ -22,6 +22,7 @@
   <!--
     DO NOT exclude anything other than generated files here. Other files
     can be excluded inline by adding the @SuppressFBWarnings annotation.
+    Exceptions can be made if the bug is particularly spammy or trivial.
   -->
   <Match>
     <!-- ignore thrift-generated files -->

--- a/core/src/test/java/org/apache/accumulo/core/cli/TestHelp.java
+++ b/core/src/test/java/org/apache/accumulo/core/cli/TestHelp.java
@@ -31,7 +31,7 @@ public class TestHelp {
 
     @Override
     public void exit(int status) {
-      throw new RuntimeException(Integer.toString(status));
+      throw new IllegalStateException(Integer.toString(status));
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/TabletLocatorImplTest.java
@@ -596,7 +596,7 @@ public class TabletLocatorImplTest {
         tservers.tservers.computeIfAbsent(server, k -> new HashMap<>());
     SortedMap<Key,Value> tabletData = tablets.computeIfAbsent(tablet, k -> new TreeMap<>());
     if (!tabletData.isEmpty()) {
-      throw new RuntimeException("Asked for empty tablet, but non empty tablet exists");
+      throw new IllegalStateException("Asked for empty tablet, but non empty tablet exists");
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/MultiThreadedRFileTest.java
@@ -82,7 +82,7 @@ public class MultiThreadedRFileTest {
       Key lastKey = new Key(indexIter.getTopKey());
 
       if (reader.getFirstKey().compareTo(lastKey) > 0) {
-        throw new RuntimeException(
+        throw new IllegalStateException(
             "First key out of order " + reader.getFirstKey() + " " + lastKey);
       }
 
@@ -90,7 +90,7 @@ public class MultiThreadedRFileTest {
 
       while (indexIter.hasTop()) {
         if (lastKey.compareTo(indexIter.getTopKey()) > 0) {
-          throw new RuntimeException(
+          throw new IllegalStateException(
               "Indext out of order " + lastKey + " " + indexIter.getTopKey());
         }
 
@@ -100,7 +100,8 @@ public class MultiThreadedRFileTest {
       }
 
       if (!reader.getLastKey().equals(lastKey)) {
-        throw new RuntimeException("Last key out of order " + reader.getLastKey() + " " + lastKey);
+        throw new IllegalStateException(
+            "Last key out of order " + reader.getLastKey() + " " + lastKey);
       }
     }
   }

--- a/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/file/rfile/RFileTest.java
@@ -205,7 +205,7 @@ public class RFileTest {
       Key lastKey = new Key(indexIter.getTopKey());
 
       if (reader.getFirstKey().compareTo(lastKey) > 0) {
-        throw new RuntimeException(
+        throw new IllegalStateException(
             "First key out of order " + reader.getFirstKey() + " " + lastKey);
       }
 
@@ -213,7 +213,7 @@ public class RFileTest {
 
       while (indexIter.hasTop()) {
         if (lastKey.compareTo(indexIter.getTopKey()) > 0) {
-          throw new RuntimeException(
+          throw new IllegalStateException(
               "Indext out of order " + lastKey + " " + indexIter.getTopKey());
         }
 
@@ -223,7 +223,8 @@ public class RFileTest {
       }
 
       if (!reader.getLastKey().equals(lastKey)) {
-        throw new RuntimeException("Last key out of order " + reader.getLastKey() + " " + lastKey);
+        throw new IllegalStateException(
+            "Last key out of order " + reader.getLastKey() + " " + lastKey);
       }
     }
   }
@@ -310,8 +311,8 @@ public class RFileTest {
       cc.set(Property.TSERV_CACHE_MANAGER_IMPL, LruBlockCacheManager.class.getName());
       try {
         manager = BlockCacheManagerFactory.getInstance(cc);
-      } catch (Exception e) {
-        throw new RuntimeException("Error creating BlockCacheManager", e);
+      } catch (ReflectiveOperationException e) {
+        throw new IllegalStateException("Error creating BlockCacheManager", e);
       }
       cc.set(Property.TSERV_DEFAULT_BLOCKSIZE, Long.toString(100000));
       cc.set(Property.TSERV_DATACACHE_SIZE, Long.toString(100000000));

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TestCfCqSlice.java
@@ -71,7 +71,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testAllRowsFullSlice() {
+  public void testAllRowsFullSlice() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     loadKvs(foundKvs, EMPTY_OPTS, INFINITY);
     for (int i = 0; i < LR_DIM; i++) {
@@ -85,7 +85,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testSingleRowFullSlice() {
+  public void testSingleRowFullSlice() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     int rowId = LR_DIM / 2;
     loadKvs(foundKvs, EMPTY_OPTS, Range.exact(new Text(LONG_LEX.encode((long) rowId))));
@@ -105,7 +105,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testAllRowsSlice() {
+  public void testAllRowsSlice() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCf = 20;
     long sliceMinCq = 30;
@@ -137,7 +137,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testSingleColumnSlice() {
+  public void testSingleColumnSlice() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCf = 20;
     long sliceMinCq = 20;
@@ -165,7 +165,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testSingleColumnSliceByExclude() {
+  public void testSingleColumnSliceByExclude() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCf = 20;
     long sliceMinCq = 20;
@@ -195,7 +195,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testAllCfsCqSlice() {
+  public void testAllCfsCqSlice() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCq = 10;
     long sliceMaxCq = 30;
@@ -219,7 +219,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testSliceCfsAllCqs() {
+  public void testSliceCfsAllCqs() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCf = 10;
     long sliceMaxCf = 30;
@@ -243,7 +243,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testEmptySlice() {
+  public void testEmptySlice() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCf = LR_DIM + 1;
     long sliceMinCq = LR_DIM + 1;
@@ -304,7 +304,7 @@ public abstract class TestCfCqSlice {
   }
 
   @Test
-  public void testSeekMinExclusive() {
+  public void testSeekMinExclusive() throws Exception {
     boolean[][][] foundKvs = new boolean[LR_DIM][LR_DIM][LR_DIM];
     long sliceMinCf = 20;
     long sliceMinCq = 30;
@@ -360,37 +360,33 @@ public abstract class TestCfCqSlice {
     }
   }
 
-  private void loadKvs(boolean[][][] foundKvs, Map<String,String> options, Range range) {
+  private void loadKvs(boolean[][][] foundKvs, Map<String,String> options, Range range)
+      throws Exception {
     loadKvs(new SortedMapIterator(data), foundKvs, options, range);
   }
 
   private void loadKvs(SortedKeyValueIterator<Key,Value> parent, boolean[][][] foundKvs,
-      Map<String,String> options, Range range) {
-    try {
-      SortedKeyValueIterator<Key,Value> skvi =
-          getFilterClass().getDeclaredConstructor().newInstance();
-      skvi.init(parent, options, null);
-      skvi.seek(range, EMPTY_CF_SET, false);
+      Map<String,String> options, Range range) throws Exception {
+    SortedKeyValueIterator<Key,Value> skvi =
+        getFilterClass().getDeclaredConstructor().newInstance();
+    skvi.init(parent, options, null);
+    skvi.seek(range, EMPTY_CF_SET, false);
 
-      while (skvi.hasTop()) {
-        Key k = skvi.getTopKey();
-        int row = LONG_LEX.decode(k.getRow().copyBytes()).intValue();
-        int cf = LONG_LEX.decode(k.getColumnFamily().copyBytes()).intValue();
-        int cq = LONG_LEX.decode(k.getColumnQualifier().copyBytes()).intValue();
+    while (skvi.hasTop()) {
+      Key k = skvi.getTopKey();
+      int row = LONG_LEX.decode(k.getRow().copyBytes()).intValue();
+      int cf = LONG_LEX.decode(k.getColumnFamily().copyBytes()).intValue();
+      int cq = LONG_LEX.decode(k.getColumnQualifier().copyBytes()).intValue();
 
-        assertFalse(foundKvs[row][cf][cq], "Duplicate " + row + " " + cf + " " + cq);
-        foundKvs[row][cf][cq] = true;
+      assertFalse(foundKvs[row][cf][cq], "Duplicate " + row + " " + cf + " " + cq);
+      foundKvs[row][cf][cq] = true;
 
-        if (random.nextInt(100) == 0) {
-          skvi.seek(new Range(k, false, range.getEndKey(), range.isEndKeyInclusive()), EMPTY_CF_SET,
-              false);
-        } else {
-          skvi.next();
-        }
+      if (random.nextInt(100) == 0) {
+        skvi.seek(new Range(k, false, range.getEndKey(), range.isEndKeyInclusive()), EMPTY_CF_SET,
+            false);
+      } else {
+        skvi.next();
       }
-
-    } catch (Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/iterators/user/TransformingIteratorTest.java
@@ -90,7 +90,7 @@ public class TransformingIteratorTest {
     try {
       titer = clazz.getDeclaredConstructor().newInstance();
     } catch (ReflectiveOperationException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
 
     IteratorEnvironment iterEnv = EasyMock.createMock(IteratorEnvironment.class);

--- a/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/spi/compaction/DefaultCompactionPlannerTest.java
@@ -51,7 +51,7 @@ public class DefaultCompactionPlannerTest {
   }
 
   @Test
-  public void testFindFilesToCompact() {
+  public void testFindFilesToCompact() throws Exception {
 
     testFFtC(createCFs("F4", "1M", "F5", "1M", "F6", "1M"),
         createCFs("F1", "100M", "F2", "100M", "F3", "100M", "F4", "1M", "F5", "1M", "F6", "1M"),
@@ -129,7 +129,7 @@ public class DefaultCompactionPlannerTest {
   }
 
   @Test
-  public void testRunningCompaction() {
+  public void testRunningCompaction() throws Exception {
     var planner = createPlanner(true);
     var all = createCFs("F1", "3M", "F2", "3M", "F3", "11M", "F4", "12M", "F5", "13M");
     var candidates = createCFs("F3", "11M", "F4", "12M", "F5", "13M");
@@ -156,7 +156,7 @@ public class DefaultCompactionPlannerTest {
   }
 
   @Test
-  public void testUserCompaction() {
+  public void testUserCompaction() throws Exception {
     var planner = createPlanner(true);
     var all = createCFs("F1", "3M", "F2", "3M", "F3", "11M", "F4", "12M", "F5", "13M");
     var candidates = createCFs("F3", "11M", "F4", "12M", "F5", "13M");
@@ -220,7 +220,7 @@ public class DefaultCompactionPlannerTest {
   }
 
   @Test
-  public void testMaxSize() {
+  public void testMaxSize() throws Exception {
     var planner = createPlanner(false);
     var all = createCFs("F1", "128M", "F2", "129M", "F3", "130M", "F4", "131M", "F5", "132M");
     var params = createPlanningParams(all, all, Set.of(), 2, CompactionKind.SYSTEM);
@@ -393,18 +393,15 @@ public class DefaultCompactionPlannerTest {
         .getJobs().iterator().next();
   }
 
-  private static Set<CompactableFile> createCFs(String... namesSizePairs) {
+  private static Set<CompactableFile> createCFs(String... namesSizePairs)
+      throws URISyntaxException {
     Set<CompactableFile> files = new HashSet<>();
 
     for (int i = 0; i < namesSizePairs.length; i += 2) {
       String name = namesSizePairs[i];
       long size = ConfigurationTypeHelper.getFixedMemoryAsBytes(namesSizePairs[i + 1]);
-      try {
-        files.add(CompactableFile
-            .create(new URI("hdfs://fake/accumulo/tables/1/t-0000000z/" + name + ".rf"), size, 0));
-      } catch (URISyntaxException e) {
-        throw new RuntimeException(e);
-      }
+      files.add(CompactableFile
+          .create(new URI("hdfs://fake/accumulo/tables/1/t-0000000z/" + name + ".rf"), size, 0));
     }
 
     return files;

--- a/core/src/test/java/org/apache/accumulo/core/util/ByteBufferUtilTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/util/ByteBufferUtilTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +53,7 @@ public class ByteBufferUtilTest {
       ByteBufferUtil.write(dos, bb);
       dos.close();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
 
     assertEquals(expected, new String(baos.toByteArray(), UTF_8));
@@ -63,7 +64,7 @@ public class ByteBufferUtilTest {
       bais.read(buffer);
       assertEquals(expected, new String(buffer, UTF_8));
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/hadoop-mapreduce/src/main/spotbugs/exclude-filter.xml
+++ b/hadoop-mapreduce/src/main/spotbugs/exclude-filter.xml
@@ -22,6 +22,7 @@
   <!--
     DO NOT exclude anything other than generated files here. Other files
     can be excluded inline by adding the @SuppressFBWarnings annotation.
+    Exceptions can be made if the bug is particularly spammy or trivial.
   -->
   <Match>
     <!-- More convenient to ignore these everywhere, because it's very common and unimportant -->

--- a/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/AbstractServer.java
@@ -89,7 +89,7 @@ public abstract class AbstractServer implements AutoCloseable, MetricsProducer, 
       if (thrown instanceof Exception) {
         throw (Exception) thrown;
       }
-      throw new RuntimeException("Weird throwable type thrown", thrown);
+      throw new IllegalStateException("Weird throwable type thrown", thrown);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerContext.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
@@ -195,7 +196,7 @@ public class ServerContext extends ClientContext {
       // currentUser() like KerberosToken
       loginUser = UserGroupInformation.getLoginUser();
     } catch (IOException e) {
-      throw new RuntimeException("Could not get login user", e);
+      throw new UncheckedIOException("Could not get login user", e);
     }
 
     checkArgument(loginUser.hasKerberosCredentials(), "Server does not have Kerberos credentials");

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerDirs.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerDirs.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -116,7 +117,7 @@ public class ServerDirs {
     }
 
     if (baseDirsList.isEmpty()) {
-      throw new RuntimeException("None of the configured paths are initialized.");
+      throw new IllegalStateException("None of the configured paths are initialized.");
     }
 
     return baseDirsList;
@@ -234,7 +235,7 @@ public class ServerDirs {
       }
       return dataVersion;
     } catch (IOException e) {
-      throw new RuntimeException("Unable to read accumulo version: an error occurred.", e);
+      throw new UncheckedIOException("Unable to read accumulo version: an error occurred.", e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServerInfo.java
@@ -21,6 +21,7 @@ package org.apache.accumulo.server;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Properties;
 
 import org.apache.accumulo.core.Constants;
@@ -67,21 +68,23 @@ public class ServerInfo implements ClientInfo {
     try {
       volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
     } catch (IOException e) {
-      throw new IllegalStateException(e);
+      throw new UncheckedIOException(e);
     }
     zooCache = new ZooCacheFactory().getZooCache(zooKeepers, zooKeepersSessionTimeOut);
     String instanceNamePath = Constants.ZROOT + Constants.ZINSTANCES + "/" + instanceName;
     byte[] iidb = zooCache.get(instanceNamePath);
     if (iidb == null) {
-      throw new RuntimeException("Instance name " + instanceName + " does not exist in zookeeper. "
-          + "Run \"accumulo org.apache.accumulo.server.util.ListInstances\" to see a list.");
+      throw new IllegalStateException(
+          "Instance name " + instanceName + " does not exist in zookeeper. "
+              + "Run \"accumulo org.apache.accumulo.server.util.ListInstances\" to see a list.");
     }
     instanceID = InstanceId.of(new String(iidb, UTF_8));
     if (zooCache.get(Constants.ZROOT + "/" + instanceID) == null) {
       if (instanceName == null) {
-        throw new RuntimeException("Instance id " + instanceID + " does not exist in zookeeper");
+        throw new IllegalStateException(
+            "Instance id " + instanceID + " does not exist in zookeeper");
       }
-      throw new RuntimeException("Instance id " + instanceID + " pointed to by the name "
+      throw new IllegalStateException("Instance id " + instanceID + " pointed to by the name "
           + instanceName + " does not exist in zookeeper");
     }
     serverDirs = new ServerDirs(siteConfig, hadoopConf);
@@ -95,7 +98,7 @@ public class ServerInfo implements ClientInfo {
     try {
       volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
     } catch (IOException e) {
-      throw new IllegalStateException(e);
+      throw new UncheckedIOException(e);
     }
     serverDirs = new ServerDirs(siteConfig, hadoopConf);
     Path instanceIdPath = serverDirs.getInstanceIdLocation(volumeManager.getFirst());
@@ -114,7 +117,7 @@ public class ServerInfo implements ClientInfo {
     try {
       volumeManager = VolumeManagerImpl.get(siteConfig, hadoopConf);
     } catch (IOException e) {
-      throw new IllegalStateException(e);
+      throw new UncheckedIOException(e);
     }
     this.instanceID = instanceID;
     zooKeepers = config.get(Property.INSTANCE_ZK_HOST);

--- a/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/ServiceEnvironmentImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.server;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -57,14 +56,13 @@ public class ServiceEnvironmentImpl implements ServiceEnvironment {
   }
 
   @Override
-  public <T> T instantiate(String className, Class<T> base)
-      throws ReflectiveOperationException, IOException {
+  public <T> T instantiate(String className, Class<T> base) throws ReflectiveOperationException {
     return ConfigurationTypeHelper.getClassInstance(null, className, base);
   }
 
   @Override
   public <T> T instantiate(TableId tableId, String className, Class<T> base)
-      throws ReflectiveOperationException, IOException {
+      throws ReflectiveOperationException {
     String ctx = ClassLoaderUtil.tableContext(context.getTableConfiguration(tableId));
     return ConfigurationTypeHelper.getClassInstance(ctx, className, base);
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/client/ClientServiceHandler.java
@@ -355,7 +355,7 @@ public class ClientServiceHandler implements ClientService.Iface {
       case DEFAULT:
         return conf(credentials, context.getDefaultConfiguration());
     }
-    throw new RuntimeException("Unexpected configuration type " + type);
+    throw new IllegalArgumentException("Unexpected configuration type " + type);
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/conf/ServerConfigurationFactory.java
@@ -118,7 +118,7 @@ public class ServerConfigurationFactory extends ServerConfiguration {
     try {
       namespaceId = context.getNamespaceId(tableId);
     } catch (TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
     return tableParentConfigs.computeIfAbsent(tableId,
         key -> getNamespaceConfiguration(namespaceId));

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/FileManager.java
@@ -200,7 +200,7 @@ public class FileManager {
 
       List<OpenReader> ofl = openFiles.get(or.fileName);
       if (!ofl.remove(or)) {
-        throw new RuntimeException("Failed to remove open reader that should have been there");
+        throw new IllegalStateException("Failed to remove open reader that should have been there");
       }
 
       if (ofl.isEmpty()) {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManager.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.server.fs;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Map;
@@ -218,18 +219,18 @@ public interface VolumeManager extends AutoCloseable {
       log.debug("Trying to read instance id from {}", instanceDirectory);
       if (files == null || files.length == 0) {
         log.error("unable to obtain instance id at {}", instanceDirectory);
-        throw new RuntimeException(
+        throw new IllegalStateException(
             "Accumulo not initialized, there is no instance id at " + instanceDirectory);
       } else if (files.length != 1) {
         log.error("multiple potential instances in {}", instanceDirectory);
-        throw new RuntimeException(
+        throw new IllegalStateException(
             "Accumulo found multiple possible instance ids in " + instanceDirectory);
       } else {
         return InstanceId.of(files[0].getPath().getName());
       }
     } catch (IOException e) {
       log.error("Problem reading instance id out of hdfs at " + instanceDirectory, e);
-      throw new RuntimeException(
+      throw new UncheckedIOException(
           "Can't tell if Accumulo is initialized; can't read instance id at " + instanceDirectory,
           e);
     } catch (IllegalArgumentException exception) {

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeManagerImpl.java
@@ -96,7 +96,7 @@ public class VolumeManagerImpl implements VolumeManager {
       // null chooser handled below
     }
     if (chooser1 == null) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           "Failed to load volume chooser specified by " + Property.GENERAL_VOLUME_CHOOSER);
     }
     chooser = chooser1;
@@ -220,7 +220,7 @@ public class VolumeManagerImpl implements VolumeManager {
               + " not be configured as false. " + ticketMessage;
           // ACCUMULO-3651 Changed level to error and added FATAL to message for slf4j compatibility
           log.error("FATAL {}", msg);
-          throw new RuntimeException(msg);
+          throw new IllegalStateException(msg);
         }
 
         // Warn if synconclose isn't set
@@ -476,7 +476,7 @@ public class VolumeManagerImpl implements VolumeManager {
     if (!options.contains(choice)) {
       String msg = "The configured volume chooser, '" + chooser.getClass()
           + "', or one of its delegates returned a volume not in the set of options provided";
-      throw new RuntimeException(msg);
+      throw new IllegalStateException(msg);
     }
     return choice;
   }
@@ -489,7 +489,7 @@ public class VolumeManagerImpl implements VolumeManager {
       if (!options.contains(choice)) {
         String msg = "The configured volume chooser, '" + chooser.getClass()
             + "', or one of its delegates returned a volume not in the set of options provided";
-        throw new RuntimeException(msg);
+        throw new IllegalStateException(msg);
       }
     }
     return choices;

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/MetaDataTableScanner.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.manager.state;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.ref.Cleaner.Cleanable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -137,8 +138,10 @@ public class MetaDataTableScanner implements ClosableIterator<TabletLocationStat
     try {
       Entry<Key,Value> e = iter.next();
       return createTabletLocationState(e.getKey(), e.getValue());
-    } catch (IOException | BadLocationStateException ex) {
-      throw new RuntimeException(ex);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    } catch (BadLocationStateException ex) {
+      throw new IllegalStateException(ex);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateChangeIterator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/TabletStateChangeIterator.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.manager.state;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -77,11 +78,12 @@ public class TabletStateChangeIterator extends SkippingIterator {
     merges = parseMerges(options.get(MERGES_OPTION));
     debug = options.containsKey(DEBUG_OPTION);
     migrations = parseMigrations(options.get(MIGRATIONS_OPTION));
+    String managerStateOptionName = options.get(MANAGER_STATE_OPTION);
     try {
-      managerState = ManagerState.valueOf(options.get(MANAGER_STATE_OPTION));
-    } catch (Exception ex) {
-      if (options.get(MANAGER_STATE_OPTION) != null) {
-        log.error("Unable to decode managerState {}", options.get(MANAGER_STATE_OPTION));
+      managerState = ManagerState.valueOf(managerStateOptionName);
+    } catch (RuntimeException ex) {
+      if (managerStateOptionName != null) {
+        log.error("Unable to decode managerState {}", managerStateOptionName);
       }
     }
     Set<TServerInstance> shuttingDown = parseServers(options.get(SHUTTING_DOWN_OPTION));
@@ -103,8 +105,8 @@ public class TabletStateChangeIterator extends SkippingIterator {
         result.add(KeyExtent.readFrom(buffer));
       }
       return result;
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
     }
   }
 
@@ -154,8 +156,8 @@ public class TabletStateChangeIterator extends SkippingIterator {
         result.put(mergeInfo.extent.tableId(), mergeInfo);
       }
       return result;
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
     }
   }
 
@@ -253,8 +255,8 @@ public class TabletStateChangeIterator extends SkippingIterator {
           info.write(buffer);
         }
       }
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
     }
     String encoded =
         Base64.getEncoder().encodeToString(Arrays.copyOf(buffer.getData(), buffer.getLength()));
@@ -267,8 +269,8 @@ public class TabletStateChangeIterator extends SkippingIterator {
       for (KeyExtent extent : migrations) {
         extent.writeTo(buffer);
       }
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
     }
     String encoded =
         Base64.getEncoder().encodeToString(Arrays.copyOf(buffer.getData(), buffer.getLength()));

--- a/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/manager/state/ZooTabletStateStore.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.TServerInstance;
 import org.apache.accumulo.core.metadata.TabletLocationState;
+import org.apache.accumulo.core.metadata.TabletLocationState.BadLocationStateException;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ReadConsistency;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
@@ -95,8 +96,8 @@ class ZooTabletStateStore implements TabletStateStore {
 
           return new TabletLocationState(RootTable.EXTENT, futureSession, currentSession,
               lastSession, null, logs, false);
-        } catch (Exception ex) {
-          throw new RuntimeException(ex);
+        } catch (BadLocationStateException ex) {
+          throw new IllegalStateException(ex);
         }
       }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/RootTabletMutatorImpl.java
@@ -110,7 +110,7 @@ public class RootTabletMutatorImpl extends TabletMutatorBase implements Ample.Ta
         closeAfterMutate.close();
       }
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/ServerAmpleImpl.java
@@ -113,7 +113,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         return newJson.getBytes(UTF_8);
       });
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -130,7 +130,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         writer.addMutation(createDeleteMutation(file));
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -149,7 +149,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         writer.addMutation(createDeleteMutation(fileOrDir));
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -164,7 +164,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     try (BatchWriter bw = context.createBatchWriter(MetadataTable.NAME)) {
       bw.addMutation(m);
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -179,7 +179,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     try (BatchWriter bw = context.createBatchWriter(MetadataTable.NAME)) {
       bw.addMutation(m);
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -205,7 +205,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         }
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -224,7 +224,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         writer.addMutation(m);
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -237,7 +237,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         jsonBytes =
             zooReader.getData(context.getZooKeeperRoot() + RootTable.ZROOT_TABLET_GC_CANDIDATES);
       } catch (KeeperException | InterruptedException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
       return new RootGcCandidates(new String(jsonBytes, UTF_8)).sortedStream().iterator();
     } else if (level == DataLevel.METADATA || level == DataLevel.USER) {
@@ -247,7 +247,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       try {
         scanner = context.createScanner(level.metaTable(), Authorizations.EMPTY);
       } catch (TableNotFoundException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
       scanner.setRange(range);
       return scanner.stream().filter(entry -> entry.getValue().equals(SkewedKeyValue.NAME))
@@ -283,7 +283,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
         writer.addMutation(m);
       }
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -293,7 +293,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
     try {
       scanner = context.createScanner(DataLevel.USER.metaTable(), Authorizations.EMPTY);
     } catch (TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
 
     scanner.setRange(ExternalCompactionSection.getRange());
@@ -317,7 +317,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       log.debug("Deleted external compaction final state entries for external compactions: {}",
           statusesToDelete);
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -384,7 +384,7 @@ public class ServerAmpleImpl extends AmpleImpl implements Ample {
       }
       log.debug("Deleted scan server file reference entries for files: {}", refsToDelete);
     } catch (MutationsRejectedException | TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorImpl.java
@@ -41,7 +41,7 @@ class TabletMutatorImpl extends TabletMutatorBase implements Ample.TabletMutator
         closeAfterMutate.close();
       }
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletsMutatorImpl.java
@@ -61,7 +61,7 @@ public class TabletsMutatorImpl implements TabletsMutator {
         return metaWriter;
       }
     } catch (TableNotFoundException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -85,7 +85,7 @@ public class TabletsMutatorImpl implements TabletsMutator {
         metaWriter.close();
       }
     } catch (MutationsRejectedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
 
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/problems/ProblemReports.java
@@ -18,6 +18,8 @@
  */
 package org.apache.accumulo.server.problems;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Iterator;
@@ -34,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.conf.SiteConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -50,6 +53,7 @@ import org.apache.accumulo.core.util.threads.ThreadPools;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.util.MetadataTableUtil;
 import org.apache.commons.collections4.map.LRUMap;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,97 +185,93 @@ public class ProblemReports implements Iterable<ProblemReport> {
   }
 
   public Iterator<ProblemReport> iterator(final TableId table) {
-    try {
+    return new Iterator<>() {
 
-      return new Iterator<>() {
+      ZooReaderWriter zoo = context.getZooReaderWriter();
+      private int iter1Count = 0;
+      private Iterator<String> iter1;
 
-        ZooReaderWriter zoo = context.getZooReaderWriter();
-        private int iter1Count = 0;
-        private Iterator<String> iter1;
-
-        private Iterator<String> getIter1() {
-          if (iter1 == null) {
-            try {
-              List<String> children;
-              if (table == null || isMeta(table)) {
-                children = zoo.getChildren(context.getZooKeeperRoot() + Constants.ZPROBLEMS);
-              } else {
-                children = Collections.emptyList();
-              }
-              iter1 = children.iterator();
-            } catch (Exception e) {
-              throw new RuntimeException(e);
-            }
-          }
-
-          return iter1;
-        }
-
-        private Iterator<Entry<Key,Value>> iter2;
-
-        private Iterator<Entry<Key,Value>> getIter2() {
-          if (iter2 == null) {
-            try {
-              if ((table == null || !isMeta(table)) && iter1Count == 0) {
-                Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
-                scanner.setTimeout(3, TimeUnit.SECONDS);
-
-                if (table == null) {
-                  scanner.setRange(ProblemSection.getRange());
-                } else {
-                  scanner.setRange(new Range(ProblemSection.getRowPrefix() + table));
-                }
-
-                iter2 = scanner.iterator();
-
-              } else {
-                Map<Key,Value> m = Collections.emptyMap();
-                iter2 = m.entrySet().iterator();
-              }
-            } catch (Exception e) {
-              throw new RuntimeException(e);
-            }
-          }
-
-          return iter2;
-        }
-
-        @Override
-        public boolean hasNext() {
-          if (getIter1().hasNext()) {
-            return true;
-          }
-          return getIter2().hasNext();
-        }
-
-        @Override
-        public ProblemReport next() {
+      private Iterator<String> getIter1() {
+        if (iter1 == null) {
           try {
-            if (getIter1().hasNext()) {
-              iter1Count++;
-              return ProblemReport.decodeZooKeeperEntry(context, getIter1().next());
+            List<String> children;
+            if (table == null || isMeta(table)) {
+              children = zoo.getChildren(context.getZooKeeperRoot() + Constants.ZPROBLEMS);
+            } else {
+              children = Collections.emptyList();
             }
+            iter1 = children.iterator();
+          } catch (KeeperException | InterruptedException e) {
+            throw new IllegalStateException(e);
+          }
+        }
 
-            if (getIter2().hasNext()) {
-              return ProblemReport.decodeMetadataEntry(getIter2().next());
+        return iter1;
+      }
+
+      private Iterator<Entry<Key,Value>> iter2;
+
+      private Iterator<Entry<Key,Value>> getIter2() {
+        if (iter2 == null) {
+          try {
+            if ((table == null || !isMeta(table)) && iter1Count == 0) {
+              Scanner scanner = context.createScanner(MetadataTable.NAME, Authorizations.EMPTY);
+              scanner.setTimeout(3, TimeUnit.SECONDS);
+
+              if (table == null) {
+                scanner.setRange(ProblemSection.getRange());
+              } else {
+                scanner.setRange(new Range(ProblemSection.getRowPrefix() + table));
+              }
+
+              iter2 = scanner.iterator();
+
+            } else {
+              Map<Key,Value> m = Collections.emptyMap();
+              iter2 = m.entrySet().iterator();
             }
-          } catch (Exception e) {
-            throw new RuntimeException(e);
+          } catch (TableNotFoundException e) {
+            throw new IllegalStateException(e);
+          }
+        }
+
+        return iter2;
+      }
+
+      @Override
+      public boolean hasNext() {
+        if (getIter1().hasNext()) {
+          return true;
+        }
+        return getIter2().hasNext();
+      }
+
+      @Override
+      public ProblemReport next() {
+        try {
+          if (getIter1().hasNext()) {
+            iter1Count++;
+            return ProblemReport.decodeZooKeeperEntry(context, getIter1().next());
           }
 
-          throw new NoSuchElementException();
+          if (getIter2().hasNext()) {
+            return ProblemReport.decodeMetadataEntry(getIter2().next());
+          }
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        } catch (KeeperException | InterruptedException e) {
+          throw new IllegalStateException(e);
         }
 
-        @Override
-        public void remove() {
-          throw new UnsupportedOperationException();
-        }
+        throw new NoSuchElementException();
+      }
 
-      };
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
 
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    };
   }
 
   @Override

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomNonBlockingServer.java
@@ -47,8 +47,8 @@ public class CustomNonBlockingServer extends THsHaServer {
     try {
       selectAcceptThreadField = TNonblockingServer.class.getDeclaredField("selectAcceptThread_");
       selectAcceptThreadField.setAccessible(true);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to access required field in Thrift code.", e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to access required field in Thrift code.", e);
     }
   }
 
@@ -80,7 +80,7 @@ public class CustomNonBlockingServer extends THsHaServer {
       LOGGER.error("Failed to start selector thread!", e);
       return false;
     } catch (IllegalAccessException | IllegalArgumentException e) {
-      throw new RuntimeException("Exception setting customer select thread in Thrift");
+      throw new IllegalStateException("Exception setting customer select thread in Thrift");
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomThreadedSelectorServer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/CustomThreadedSelectorServer.java
@@ -37,7 +37,7 @@ public class CustomThreadedSelectorServer extends TThreadedSelectorServer {
       fbTansportField = FrameBuffer.class.getDeclaredField("trans_");
       fbTansportField.setAccessible(true);
     } catch (SecurityException | NoSuchFieldException e) {
-      throw new RuntimeException("Failed to access required field in Thrift code.", e);
+      throw new IllegalStateException("Failed to access required field in Thrift code.", e);
     }
   }
 
@@ -45,7 +45,7 @@ public class CustomThreadedSelectorServer extends TThreadedSelectorServer {
     try {
       return (TNonblockingTransport) fbTansportField.get(frameBuffer);
     } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TCredentialsUpdatingInvocationHandler.java
@@ -60,7 +60,6 @@ public class TCredentialsUpdatingInvocationHandler<I> implements InvocationHandl
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
     updateArgs(args);
-
     return invokeMethod(method, args);
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/TServerUtils.java
@@ -405,7 +405,7 @@ public class TServerUtils {
       socketEnabledProtocols.retainAll(Arrays.asList(protocols));
       if (socketEnabledProtocols.isEmpty()) {
         // Bad configuration...
-        throw new RuntimeException(
+        throw new IllegalStateException(
             "No available protocols available for secure socket. Available protocols: "
                 + Arrays.toString(sslServerSock.getEnabledProtocols()) + ", allowed protocols: "
                 + Arrays.toString(protocols));
@@ -492,7 +492,7 @@ public class TServerUtils {
           + " the Accumulo hosts files (e.g. managers, tservers) are the FQDN for"
           + " each host when using SASL.", fqdn, hostname);
       transport.close();
-      throw new RuntimeException("SASL requires that the address the thrift"
+      throw new IllegalStateException("SASL requires that the address the thrift"
           + " server listens on is the same as the FQDN for this host");
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/rpc/UGIAssumingProcessor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/rpc/UGIAssumingProcessor.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.rpc;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import javax.security.sasl.SaslServer;
 
@@ -55,7 +56,7 @@ public class UGIAssumingProcessor implements TProcessor {
       this.loginUser = UserGroupInformation.getLoginUser();
     } catch (IOException e) {
       log.error("Failed to obtain login user", e);
-      throw new RuntimeException("Failed to obtain login user", e);
+      throw new UncheckedIOException("Failed to obtain login user", e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityOperation.java
@@ -115,7 +115,7 @@ public class SecurityOperation {
     if (!authorizor.validSecurityHandlers(authenticator, pm)
         || !authenticator.validSecurityHandlers()
         || !permHandle.validSecurityHandlers(authent, author)) {
-      throw new RuntimeException(authorizor + ", " + authenticator + ", and " + pm
+      throw new IllegalStateException(authorizor + ", " + authenticator + ", and " + pm
           + " do not play nice with each other. Please choose authentication and"
           + " authorization mechanisms that are compatible with one another.");
     }
@@ -138,7 +138,7 @@ public class SecurityOperation {
           TablePermission.ALTER_TABLE);
     } catch (TableNotFoundException e) {
       // Shouldn't happen
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/SecurityUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/SecurityUtil.java
@@ -19,6 +19,7 @@
 package org.apache.accumulo.server.security;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -71,7 +72,7 @@ public class SecurityUtil {
       }
     }
 
-    throw new RuntimeException(
+    throw new IllegalStateException(
         "Failed to perform Kerberos login for " + principal + " using  " + keyTab);
   }
 
@@ -107,7 +108,7 @@ public class SecurityUtil {
       return org.apache.hadoop.security.SecurityUtil.getServerPrincipal(configuredPrincipal,
           InetAddress.getLocalHost().getCanonicalHostName());
     } catch (IOException e) {
-      throw new RuntimeException(
+      throw new UncheckedIOException(
           "Could not convert configured server principal: " + configuredPrincipal, e);
     }
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenKeyManager.java
@@ -162,7 +162,7 @@ public class AuthenticationTokenKeyManager implements Runnable {
         keyDistributor.advertise(newKey);
       } catch (KeeperException | InterruptedException e) {
         log.error("Failed to advertise AuthenticationKey in ZooKeeper. Exiting.", e);
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
 
       lastKeyUpdate = now;

--- a/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/delegation/AuthenticationTokenSecretManager.java
@@ -94,7 +94,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
         }
         // Ensure that the user doesn't try to extend the expiration date -- they may only limit it
         if (requestedExpirationDate > identifier.getExpirationDate()) {
-          throw new RuntimeException("Requested token lifetime exceeds configured maximum");
+          throw new IllegalStateException("Requested token lifetime exceeds configured maximum");
         }
         log.trace("Overriding token expiration date from {} to {}", identifier.getExpirationDate(),
             requestedExpirationDate);
@@ -256,7 +256,7 @@ public class AuthenticationTokenSecretManager extends SecretManager<Authenticati
           keyDistributor.remove(key);
         } catch (KeeperException | InterruptedException e) {
           log.error("Failed to remove AuthenticationKey from ZooKeeper. Exiting", e);
-          throw new RuntimeException(e);
+          throw new IllegalStateException(e);
         }
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/KerberosAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/KerberosAuthenticator.java
@@ -102,7 +102,7 @@ public class KerberosAuthenticator implements Authenticator {
       }
     } catch (KeeperException | InterruptedException e) {
       log.error("Failed to initialize security", e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -158,7 +158,7 @@ public class KerberosAuthenticator implements Authenticator {
       throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("Interrupted trying to create node for user", e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthenticator.java
@@ -72,7 +72,7 @@ public final class ZKAuthenticator implements Authenticator {
       }
     } catch (KeeperException | AccumuloException | InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -110,7 +110,7 @@ public final class ZKAuthenticator implements Authenticator {
       throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } catch (AccumuloException e) {
       log.error("{}", e.getMessage(), e);
       throw new AccumuloSecurityException(principal, SecurityErrorCode.DEFAULT_SECURITY_ERROR, e);
@@ -127,7 +127,7 @@ public final class ZKAuthenticator implements Authenticator {
       }
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } catch (KeeperException e) {
       if (e.code().equals(KeeperException.Code.NONODE)) {
         throw new AccumuloSecurityException(user, SecurityErrorCode.USER_DOESNT_EXIST, e);
@@ -156,7 +156,7 @@ public final class ZKAuthenticator implements Authenticator {
         throw new AccumuloSecurityException(principal, SecurityErrorCode.CONNECTION_ERROR, e);
       } catch (InterruptedException e) {
         log.error("{}", e.getMessage(), e);
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       } catch (AccumuloException e) {
         log.error("{}", e.getMessage(), e);
         throw new AccumuloSecurityException(principal, SecurityErrorCode.DEFAULT_SECURITY_ERROR, e);

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKAuthorizor.java
@@ -84,7 +84,7 @@ public class ZKAuthorizor implements Authorizor {
           ZKSecurityTool.convertAuthorizations(Authorizations.EMPTY), NodeExistsPolicy.FAIL);
     } catch (KeeperException | InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -98,7 +98,7 @@ public class ZKAuthorizor implements Authorizor {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -112,7 +112,7 @@ public class ZKAuthorizor implements Authorizor {
       }
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } catch (KeeperException e) {
       log.error("{}", e.getMessage(), e);
       if (e.code().equals(KeeperException.Code.NONODE)) {
@@ -137,7 +137,7 @@ public class ZKAuthorizor implements Authorizor {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKPermHandler.java
@@ -198,7 +198,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -226,7 +226,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -256,7 +256,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -285,7 +285,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -316,7 +316,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -350,7 +350,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -369,7 +369,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException("unknownUser", SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -388,7 +388,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException("unknownUser", SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -428,7 +428,7 @@ public class ZKPermHandler implements PermissionHandler {
       }
     } catch (KeeperException | InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -445,7 +445,7 @@ public class ZKPermHandler implements PermissionHandler {
       throw new AccumuloSecurityException(user, SecurityErrorCode.CONNECTION_ERROR, e);
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -486,7 +486,7 @@ public class ZKPermHandler implements PermissionHandler {
       }
     } catch (InterruptedException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } catch (KeeperException e) {
       log.error("{}", e.getMessage(), e);
       if (e.code().equals(KeeperException.Code.NONODE)) {

--- a/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/security/handler/ZKSecurityTool.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.time.Duration;
@@ -111,8 +112,8 @@ class ZKSecurityTool {
       }
     } catch (IOException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e); // this is impossible with ByteArrayOutputStream; crash hard if
-                                     // this happens
+      // this is impossible with ByteArrayOutputStream; crash hard if this happens
+      throw new UncheckedIOException(e);
     }
     return bytes.toByteArray();
   }
@@ -141,8 +142,8 @@ class ZKSecurityTool {
       }
     } catch (IOException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e); // this is impossible with ByteArrayOutputStream; crash hard if
-                                     // this happens
+      // this is impossible with ByteArrayOutputStream; crash hard if this happens
+      throw new UncheckedIOException(e);
     }
     return bytes.toByteArray();
   }
@@ -164,8 +165,8 @@ class ZKSecurityTool {
       }
     } catch (IOException e) {
       log.error("{}", e.getMessage(), e);
-      throw new RuntimeException(e); // this is impossible with ByteArrayOutputStream; crash hard if
-                                     // this happens
+      // this is impossible with ByteArrayOutputStream; crash hard if this happens
+      throw new UncheckedIOException(e);
     }
     return bytes.toByteArray();
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tables/TableManager.java
@@ -176,7 +176,7 @@ public class TableManager {
       });
     } catch (Exception e) {
       log.error("FATAL Failed to transition table to state {}", newState);
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/tablets/UniqueNameAllocator.java
@@ -60,7 +60,7 @@ public class UniqueNameAllocator {
         next = maxAllocated - allocate;
 
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ChangeSecret.java
@@ -93,7 +93,7 @@ public class ChangeSecret {
         recurse(zoo, root + "/" + child, v);
       }
     } catch (Exception ex) {
-      throw new RuntimeException(ex);
+      throw new IllegalStateException(ex);
     }
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/CheckForMetadataProblems.java
@@ -186,7 +186,7 @@ public class CheckForMetadataProblems {
       System.out.println();
       checkMetadataAndRootTableEntries(MetadataTable.NAME, opts);
       if (sawProblems) {
-        throw new RuntimeException();
+        throw new IllegalStateException();
       }
     } catch (Exception e) {
       TraceUtil.setException(span, e, true);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ECAdmin.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ECAdmin.java
@@ -138,7 +138,7 @@ public class ECAdmin implements KeywordExecutable {
       coordinatorClient.cancel(TraceUtil.traceInfo(), context.rpcCreds(), ecid);
       System.out.println("Cancel sent to coordinator for " + ecid);
     } catch (Exception e) {
-      throw new RuntimeException("Exception calling cancel compaction for " + ecid, e);
+      throw new IllegalStateException("Exception calling cancel compaction for " + ecid, e);
     } finally {
       ThriftUtil.returnClient(coordinatorClient, context);
     }
@@ -189,7 +189,7 @@ public class ECAdmin implements KeywordExecutable {
         }
       });
     } catch (Exception e) {
-      throw new RuntimeException("Unable to get running compactions.", e);
+      throw new IllegalStateException("Unable to get running compactions.", e);
     } finally {
       ThriftUtil.returnClient(coordinatorClient, context);
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -262,8 +262,8 @@ public class FileUtil {
 
       if (numLte > numKeys) {
         // something went wrong
-        throw new RuntimeException("numLte > numKeys " + numLte + " " + numKeys + " " + prevEndRow
-            + " " + endRow + " " + splitRow + " " + dataFiles);
+        throw new IllegalStateException("numLte > numKeys " + numLte + " " + numKeys + " "
+            + prevEndRow + " " + endRow + " " + splitRow + " " + dataFiles);
       }
 
       // do not want to return 0% or 100%, so add 1 and 2 below

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -154,7 +154,7 @@ public class MetadataTableUtil {
       } catch (ConstraintViolationException e) {
         logUpdateFailure(m, extent, e);
         // retrying when a CVE occurs is probably futile and can cause problems, see ACCUMULO-3096
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
       sleepUninterruptibly(1, TimeUnit.SECONDS);
     }
@@ -406,7 +406,7 @@ public class MetadataTableUtil {
     TabletMetadata tablet = context.getAmple().readTablet(extent, FILES, LOGS, PREV_ROW, DIR);
 
     if (tablet == null) {
-      throw new RuntimeException("Tablet " + extent + " not found in metadata");
+      throw new IllegalStateException("Tablet " + extent + " not found in metadata");
     }
 
     result.addAll(tablet.getLogs());
@@ -478,7 +478,7 @@ public class MetadataTableUtil {
     Iterator<TabletMetadata> ti = createCloneScanner(testTableName, srcTableId, client).iterator();
 
     if (!ti.hasNext()) {
-      throw new RuntimeException(" table deleted during clone?  srcTableId = " + srcTableId);
+      throw new IllegalStateException(" table deleted during clone?  srcTableId = " + srcTableId);
     }
 
     while (ti.hasNext()) {
@@ -504,7 +504,7 @@ public class MetadataTableUtil {
         createCloneScanner(testTableName, tableId, client).iterator();
 
     if (!cloneIter.hasNext() || !srcIter.hasNext()) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           " table deleted during clone?  srcTableId = " + srcTableId + " tableId=" + tableId);
     }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/PortUtils.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/PortUtils.java
@@ -49,6 +49,6 @@ public class PortUtils {
       count++;
     }
 
-    throw new RuntimeException("Unable to find port");
+    throw new IllegalStateException("Unable to find port");
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/RestoreZookeeper.java
@@ -54,7 +54,7 @@ public class RestoreZookeeper {
       if ("node".equals(name)) {
         String child = attributes.getValue("name");
         if (child == null) {
-          throw new RuntimeException("name attribute not set");
+          throw new IllegalStateException("name attribute not set");
         }
         String encoding = attributes.getValue("encoding");
         String value = attributes.getValue("value");
@@ -94,12 +94,12 @@ public class RestoreZookeeper {
               overwrite ? NodeExistsPolicy.OVERWRITE : NodeExistsPolicy.FAIL);
         } catch (KeeperException e) {
           if (e.code().equals(KeeperException.Code.NODEEXISTS)) {
-            throw new RuntimeException(path + " exists.  Remove it first.");
+            throw new IllegalStateException(path + " exists.  Remove it first.");
           }
           throw e;
         }
       } catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
   }

--- a/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/constraints/MetadataConstraintsTest.java
@@ -49,7 +49,7 @@ public class MetadataConstraintsTest {
         @Override
         public boolean transactionAlive(String type, long tid) {
           if (tid == 9) {
-            throw new RuntimeException("txid 9 reserved for future use");
+            throw new IllegalArgumentException("txid 9 reserved for future use");
           }
           return tid == 5 || tid == 7;
         }

--- a/server/base/src/test/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilterTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/iterators/MetadataBulkLoadFilterTest.java
@@ -51,7 +51,7 @@ public class MetadataBulkLoadFilterTest {
     @Override
     public boolean transactionComplete(String type, long tid) {
       if (tid == 9) {
-        throw new RuntimeException();
+        throw new IllegalArgumentException();
       }
       return tid != 5 && tid != 7;
     }

--- a/server/base/src/test/java/org/apache/accumulo/server/rpc/TServerUtilsTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/rpc/TServerUtilsTest.java
@@ -277,7 +277,7 @@ public class TServerUtilsTest {
         // keep trying
       }
     }
-    throw new RuntimeException("Unable to find open port");
+    throw new IllegalStateException("Unable to find open port");
   }
 
   private ServerAddress startServer() throws Exception {

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionCoordinator.java
@@ -254,7 +254,7 @@ public class CompactionCoordinator extends AbstractServer
     try {
       coordinatorAddress = startCoordinatorClientService();
     } catch (UnknownHostException e1) {
-      throw new RuntimeException("Failed to start the coordinator service", e1);
+      throw new IllegalStateException("Failed to start the coordinator service", e1);
     }
     final HostAndPort clientAddress = coordinatorAddress.address;
 
@@ -727,7 +727,7 @@ public class CompactionCoordinator extends AbstractServer
       LOG.warn("Failed to clean up compactors", e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
+++ b/server/compaction-coordinator/src/main/java/org/apache/accumulo/coordinator/CompactionFinalizer.java
@@ -202,7 +202,7 @@ public class CompactionFinalizer {
 
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       } catch (RuntimeException e) {
         LOG.warn("Failed to process pending notifications", e);
       }
@@ -221,7 +221,7 @@ public class CompactionFinalizer {
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     } catch (RuntimeException e) {
       LOG.warn("Failed to notify tservers", e);
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServerResourceManager.java
@@ -258,8 +258,8 @@ public class TabletServerResourceManager {
 
     try {
       cacheManager = BlockCacheManagerFactory.getInstance(acuConf);
-    } catch (Exception e) {
-      throw new RuntimeException("Error creating BlockCacheManager", e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Error creating BlockCacheManager", e);
     }
 
     cacheManager.start(tserver.getBlockCacheConfiguration(acuConf));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/CompactionService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.accumulo.tserver.compactions;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -120,7 +119,7 @@ public class CompactionService {
           new InternalCompactionExecutor(ceid, numThreads, ceMetrics, readLimiter, writeLimiter));
     });
 
-    initParams.getRequestedExternalExecutors().forEach((ceid) -> {
+    initParams.getRequestedExternalExecutors().forEach(ceid -> {
       tmpExecutors.put(ceid, externExecutorSupplier.apply(ceid));
     });
 
@@ -141,8 +140,8 @@ public class CompactionService {
   private CompactionPlanner createPlanner(String plannerClass) {
     try {
       return ConfigurationTypeHelper.getClassInstance(null, plannerClass, CompactionPlanner.class);
-    } catch (IOException | ReflectiveOperationException e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalArgumentException(e);
     }
   }
 
@@ -290,7 +289,8 @@ public class CompactionService {
       Compactable compactable, Consumer<Compactable> completionCallback) {
     // log error if tablet is metadata and compaction is external
     var execIds = plan.getJobs().stream().map(cj -> (CompactionExecutorIdImpl) cj.getExecutor());
-    if (compactable.getExtent().isMeta() && execIds.anyMatch(ceid -> ceid.isExternalId())) {
+    if (compactable.getExtent().isMeta()
+        && execIds.anyMatch(CompactionExecutorIdImpl::isExternalId)) {
       log.error(
           "Compacting metadata tablets on external compactors is not supported, please change "
               + "config for compaction service ({}) and/or table ASAP.  {} is not compacting, "

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -198,8 +198,8 @@ public class CompactableUtils {
     String context = ClassLoaderUtil.tableContext(tableConfig);
     try {
       return ConfigurationTypeHelper.getClassInstance(context, className, baseClass);
-    } catch (IOException | ReflectiveOperationException e) {
-      throw new RuntimeException(e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalArgumentException(e);
     }
   }
 

--- a/start/src/main/java/org/apache/accumulo/start/TestMain.java
+++ b/start/src/main/java/org/apache/accumulo/start/TestMain.java
@@ -34,7 +34,7 @@ public class TestMain {
         System.exit(0);
       }
       if (args[0].equals("throw")) {
-        throw new RuntimeException("This is an exception");
+        throw new IllegalStateException("This is an exception");
       }
     }
     System.exit(-1);

--- a/start/src/main/java/org/apache/accumulo/start/util/MiniDFSUtil.java
+++ b/start/src/main/java/org/apache/accumulo/start/util/MiniDFSUtil.java
@@ -45,8 +45,8 @@ public class MiniDFSUtil {
 
         return String.format("%03o", newPermission);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Error getting umask from O/S", e);
+    } catch (IOException | InterruptedException e) {
+      throw new IllegalStateException("Error getting umask from O/S", e);
     }
   }
 

--- a/start/src/main/spotbugs/exclude-filter.xml
+++ b/start/src/main/spotbugs/exclude-filter.xml
@@ -22,6 +22,7 @@
   <!--
     DO NOT exclude anything other than generated files here. Other files
     can be excluded inline by adding the @SuppressFBWarnings annotation.
+    Exceptions can be made if the bug is particularly spammy or trivial.
   -->
   <Match>
     <!-- More convenient to ignore these everywhere, because it's very common and unimportant -->

--- a/test/src/main/spotbugs/exclude-filter.xml
+++ b/test/src/main/spotbugs/exclude-filter.xml
@@ -22,6 +22,7 @@
   <!--
     DO NOT exclude anything other than generated files here. Other files
     can be excluded inline by adding the @SuppressFBWarnings annotation.
+    Exceptions can be made if the bug is particularly spammy or trivial.
   -->
   <Match>
     <!-- ignore thrift-generated files -->


### PR DESCRIPTION
Use a more specific RuntimeException type, for a large number of appropriate situations. Clean up some unnecessary wrapping of RuntimeExceptions with a new RuntimeException.

Also, try to catch more specific checked exceptions, when appropriate, instead of catching (Exception) and do the same in non-public API methods where Exception was being thrown, forcing catch blocks to handle a wider number of exceptions than were actually thrown.

This change represents an incremental improvement, and does not try to be an exhaustive fix of all these similar issues. There may be other opportunities for similar improvements that are not included in this change and can be done in a subsequent change. Rather, this more narrowly fixes the occurrences originally included as part of abandoned PR #2762 to address spotbugs warnings that no longer occur on the latest version of spotbugs.