### PR TITLE
Set finished time for GC cycles even if Exception

### DIFF
--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -217,12 +217,12 @@ public class GarbageCollectWriteAheadLogs {
         span5.end();
       }
 
-      status.currentLog.finished = removeStop;
-      status.lastLog = status.currentLog;
-      status.currentLog = new GcCycleStats();
-
     } catch (Exception e) {
       log.error("exception occurred while garbage collecting write ahead logs", e);
+    } finally {
+      status.currentLog.finished = System.currentTimeMillis();
+      status.lastLog = status.currentLog;
+      status.currentLog = new GcCycleStats();
     }
   }
 

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -223,14 +223,14 @@ public class SimpleGarbageCollector extends AbstractServer implements Iface {
             incrementStatsForRun(userGC);
             logStats();
 
+          } catch (Exception e) {
+            TraceUtil.setException(innerSpan, e, false);
+            log.error("{}", e.getMessage(), e);
+          } finally {
             status.current.finished = System.currentTimeMillis();
             status.last = status.current;
             gcCycleMetrics.setLastCollect(status.current);
             status.current = new GcCycleStats();
-
-          } catch (Exception e) {
-            TraceUtil.setException(innerSpan, e, false);
-            log.error("{}", e.getMessage(), e);
           }
 
           final long tStop = System.nanoTime();

--- a/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/gc/GarbageCollectorStats.java
+++ b/server/monitor/src/main/java/org/apache/accumulo/monitor/rest/gc/GarbageCollectorStats.java
@@ -52,6 +52,6 @@ public class GarbageCollectorStats {
     this.inUse = thriftStats.inUse;
     this.deleted = thriftStats.deleted;
     this.errors = thriftStats.errors;
-    this.duration = this.finished - thriftStats.started;
+    this.duration = thriftStats.finished - thriftStats.started;
   }
 }


### PR DESCRIPTION
Always set the finished time for GC cycles, even if an exception occurred in the cycle. This prevents a GCStatus object containing a started time, but the finished time staying the default value of 0.

Ideally, this wouldn't be a problem if we used the setter/getter methods on Thrift objects so that we can tell the difference between a 0 that has been set and one that is 0 just because it's a primitive type that defaults to 0 when unset. Thrift tracks which fields are set using isSetFieldname methods, but since we're not consistently using those, and just grabbing the value of the field without checking if it has been set, we need to make sure that we've set it to something sensible.

I believe this fixes #3374