### PR TITLE
Refactor StoredTabletFile to contain a TabletFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -59,7 +59,6 @@ import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SystemIteratorUtil;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
@@ -296,7 +295,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     if (scannerSamplerConfigImpl != null && !scannerSamplerConfigImpl.equals(samplerConfImpl)) {
       throw new SampleNotPresentException();
     }
-    for (TabletFile file : absFiles) {
+    for (StoredTabletFile file : absFiles) {
       var cs = CryptoFactoryLoader.getServiceForClientWithTable(systemConf, tableConf, tableId);
       FileSystem fs = VolumeConfiguration.fileSystemForPath(file.getPathStr(), conf);
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/OfflineIterator.java
@@ -297,7 +297,7 @@ class OfflineIterator implements Iterator<Entry<Key,Value>> {
     }
     for (StoredTabletFile file : absFiles) {
       var cs = CryptoFactoryLoader.getServiceForClientWithTable(systemConf, tableConf, tableId);
-      FileSystem fs = VolumeConfiguration.fileSystemForPath(file.getPathStr(), conf);
+      FileSystem fs = VolumeConfiguration.fileSystemForPath(file.getNormalizedPathStr(), conf);
       FileSKVIterator reader = FileOperations.getInstance().newReaderBuilder()
           .forFile(file, fs, conf, cs).withTableConfiguration(tableCC).build();
       if (scannerSamplerConfigImpl != null) {

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -140,7 +140,7 @@ public class TabletLogger {
     }
   }
 
-  public static void compacted(KeyExtent extent, CompactionJob job, AbstractTabletFile<?> output) {
+  public static void compacted(KeyExtent extent, CompactionJob job, StoredTabletFile output) {
     fileLog.debug("Compacted {} for {} created {} from {}", extent, job.getKind(), output,
         asFileNames(job.getFiles()));
   }

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -28,9 +28,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
@@ -122,9 +122,9 @@ public class TabletLogger {
   }
 
   public static void selected(KeyExtent extent, CompactionKind kind,
-      Collection<? extends TabletFile> inputs) {
+      Collection<StoredTabletFile> inputs) {
     fileLog.trace("{} changed compaction selection set for {} new set {}", extent, kind,
-        Collections2.transform(inputs, TabletFile::getFileName));
+        Collections2.transform(inputs, StoredTabletFile::getFileName));
   }
 
   public static void compacting(KeyExtent extent, CompactionJob job, CompactionConfig config) {
@@ -140,7 +140,7 @@ public class TabletLogger {
     }
   }
 
-  public static void compacted(KeyExtent extent, CompactionJob job, TabletFile output) {
+  public static void compacted(KeyExtent extent, CompactionJob job, AbstractTabletFile<?> output) {
     fileLog.debug("Compacted {} for {} created {} from {}", extent, job.getKind(), output,
         asFileNames(job.getFiles()));
   }
@@ -153,7 +153,7 @@ public class TabletLogger {
     }
   }
 
-  public static void bulkImported(KeyExtent extent, TabletFile file) {
+  public static void bulkImported(KeyExtent extent, AbstractTabletFile<?> file) {
     fileLog.debug("Imported {} {}  ", extent, file);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
@@ -44,7 +44,7 @@ public class ScanServerRefTabletFile extends TabletFile {
   }
 
   public String getRowSuffix() {
-    return this.getPathStr();
+    return this.getNormalizedPathStr();
   }
 
   public Text getServerAddress() {

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -73,10 +73,12 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
     return tabletFile.getTableId();
   }
 
-  public String getPathStr() {
-    return tabletFile.getPathStr();
+  public String getNormalizedPathStr() {
+    return tabletFile.getNormalizedPathStr();
   }
 
+  // TODO: This will be deleted as soon as #3432 is merged in which
+  // removes the only call to this method
   public Text getMetaInsertText() {
     return tabletFile.getMetaInsertText();
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -18,6 +18,9 @@
  */
 package org.apache.accumulo.core.metadata;
 
+import java.util.Objects;
+
+import org.apache.accumulo.core.data.TableId;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 
@@ -32,8 +35,9 @@ import org.apache.hadoop.io.Text;
  * As of 2.1, Tablet file paths should now be only absolute URIs with the removal of relative paths
  * in Upgrader9to10.upgradeRelativePaths()
  */
-public class StoredTabletFile extends TabletFile {
+public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   private final String metadataEntry;
+  private final TabletFile tabletFile;
 
   /**
    * Construct a tablet file using the string read from the metadata. Preserve the exact string so
@@ -42,6 +46,7 @@ public class StoredTabletFile extends TabletFile {
   public StoredTabletFile(String metadataEntry) {
     super(new Path(metadataEntry));
     this.metadataEntry = metadataEntry;
+    this.tabletFile = TabletFile.of(getPath());
   }
 
   /**
@@ -60,6 +65,22 @@ public class StoredTabletFile extends TabletFile {
     return new Text(getMetaUpdateDelete());
   }
 
+  public TabletFile getTabletFile() {
+    return tabletFile;
+  }
+
+  public TableId getTableId() {
+    return tabletFile.getTableId();
+  }
+
+  public String getPathStr() {
+    return tabletFile.getPathStr();
+  }
+
+  public Text getMetaInsertText() {
+    return tabletFile.getMetaInsertText();
+  }
+
   /**
    * Validate that the provided reference matches what is in the metadata table.
    *
@@ -71,4 +92,40 @@ public class StoredTabletFile extends TabletFile {
           + " does not match what was in the metadata: " + metadataEntry);
     }
   }
+
+  @Override
+  public int compareTo(StoredTabletFile o) {
+    if (equals(o)) {
+      return 0;
+    } else {
+      return metadataEntry.compareTo(o.metadataEntry);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StoredTabletFile that = (StoredTabletFile) o;
+    return Objects.equals(metadataEntry, that.metadataEntry);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadataEntry);
+  }
+
+  @Override
+  public String toString() {
+    return metadataEntry;
+  }
+
+  public static StoredTabletFile of(final String metadataEntry) {
+    return new StoredTabletFile(metadataEntry);
+  }
+
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -77,12 +77,6 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
     return tabletFile.getNormalizedPathStr();
   }
 
-  // TODO: This will be deleted as soon as #3432 is merged in which
-  // removes the only call to this method
-  public Text getMetaInsertText() {
-    return tabletFile.getMetaInsertText();
-  }
-
   /**
    * Validate that the provided reference matches what is in the metadata table.
    *

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -90,7 +90,7 @@ public class TabletFile extends AbstractTabletFile<TabletFile> {
    * Return a string for opening and reading the tablet file. Doesn't have to be exact string in
    * metadata.
    */
-  public String getPathStr() {
+  public String getNormalizedPathStr() {
     return normalizedPath;
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -251,7 +251,7 @@ public interface Ample {
 
     TabletMutator deleteFile(StoredTabletFile path);
 
-    TabletMutator putScan(TabletFile path);
+    TabletMutator putScan(StoredTabletFile path);
 
     TabletMutator deleteScan(StoredTabletFile path);
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/TabletMetadata.java
@@ -52,7 +52,6 @@ import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.SuspendingTServer;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.TabletLocationState;
 import org.apache.accumulo.core.metadata.TabletState;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
@@ -92,7 +91,7 @@ public class TabletMetadata {
   private Location location;
   private Map<StoredTabletFile,DataFileValue> files;
   private List<StoredTabletFile> scans;
-  private Map<TabletFile,Long> loadedFiles;
+  private Map<StoredTabletFile,Long> loadedFiles;
   private EnumSet<ColumnType> fetchedCols;
   private KeyExtent extent;
   private Location last;
@@ -284,7 +283,7 @@ public class TabletMetadata {
     return location != null && location.getType() == LocationType.CURRENT;
   }
 
-  public Map<TabletFile,Long> getLoaded() {
+  public Map<StoredTabletFile,Long> getLoaded() {
     ensureFetched(ColumnType.LOADED);
     return loadedFiles;
   }
@@ -398,7 +397,7 @@ public class TabletMetadata {
     final var logsBuilder = ImmutableList.<LogEntry>builder();
     final var extCompBuilder =
         ImmutableMap.<ExternalCompactionId,ExternalCompactionMetadata>builder();
-    final var loadedFilesBuilder = ImmutableMap.<TabletFile,Long>builder();
+    final var loadedFilesBuilder = ImmutableMap.<StoredTabletFile,Long>builder();
     ByteSequence row = null;
 
     while (rowIter.hasNext()) {

--- a/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
+++ b/core/src/main/java/org/apache/accumulo/core/summary/Gatherer.java
@@ -209,9 +209,8 @@ public class Gatherer {
 
         // When no location, the approach below will consistently choose the same tserver for the
         // same file (as long as the set of tservers is stable).
-        int idx = Math
-            .abs(Hashing.murmur3_32_fixed().hashString(entry.getKey().getPathStr(), UTF_8).asInt())
-            % tservers.size();
+        int idx = Math.abs(Hashing.murmur3_32_fixed()
+            .hashString(entry.getKey().getNormalizedPathStr(), UTF_8).asInt()) % tservers.size();
         location = tservers.get(idx);
       }
 
@@ -315,8 +314,8 @@ public class Gatherer {
 
           try {
             TSummaries tSums = client.startGetSummariesFromFiles(tinfo, ctx.rpcCreds(),
-                getRequest(), files.entrySet().stream().collect(
-                    Collectors.toMap(entry -> entry.getKey().getPathStr(), Entry::getValue)));
+                getRequest(), files.entrySet().stream().collect(Collectors
+                    .toMap(entry -> entry.getKey().getNormalizedPathStr(), Entry::getValue)));
             while (!tSums.finished && !cancelFlag.get()) {
               tSums = client.contiuneGetSummaries(tinfo, tSums.sessionId);
             }
@@ -351,8 +350,8 @@ public class Gatherer {
     PartitionFuture(TInfo tinfo, ExecutorService execSrv, int modulus, int remainder) {
       Function<ProcessedFiles,CompletableFuture<ProcessedFiles>> go = previousWork -> {
         Predicate<StoredTabletFile> fileSelector = file -> Math
-            .abs(Hashing.murmur3_32_fixed().hashString(file.getPathStr(), UTF_8).asInt()) % modulus
-            == remainder;
+            .abs(Hashing.murmur3_32_fixed().hashString(file.getNormalizedPathStr(), UTF_8).asInt())
+            % modulus == remainder;
         if (previousWork != null) {
           fileSelector = fileSelector.and(previousWork.failedFiles::contains);
         }

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/TabletFileTest.java
@@ -30,10 +30,11 @@ public class TabletFileTest {
 
   private TabletFile test(String metadataEntry, String volume, String tableId, String tabletDir,
       String fileName) {
-    StoredTabletFile tabletFile = new StoredTabletFile(metadataEntry);
+    StoredTabletFile storedTabletFile = new StoredTabletFile(metadataEntry);
+    TabletFile tabletFile = storedTabletFile.getTabletFile();
 
     assertEquals(volume, tabletFile.getVolume());
-    assertEquals(metadataEntry, tabletFile.getMetaUpdateDelete());
+    assertEquals(metadataEntry, storedTabletFile.getMetaUpdateDelete());
     assertEquals(TableId.of(tableId), tabletFile.getTableId());
     assertEquals(tabletDir, tabletFile.getTabletDir());
     assertEquals(fileName, tabletFile.getFileName());
@@ -101,8 +102,9 @@ public class TabletFileTest {
     String metadataEntry = uglyVolume + "/tables/" + id + "/" + dir + "/" + filename;
     TabletFile uglyFile =
         test(metadataEntry, "hdfs://nn.somewhere.com:86753/accumulo", id, dir, filename);
-    TabletFile niceFile = new StoredTabletFile(
-        "hdfs://nn.somewhere.com:86753/accumulo/tables/" + id + "/" + dir + "/" + filename);
+    TabletFile niceFile = StoredTabletFile
+        .of("hdfs://nn.somewhere.com:86753/accumulo/tables/" + id + "/" + dir + "/" + filename)
+        .getTabletFile();
     assertEquals(niceFile, uglyFile);
     assertEquals(niceFile.hashCode(), uglyFile.hashCode());
   }

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionInfo.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/CompactionInfo.java
@@ -102,8 +102,8 @@ public class CompactionInfo {
           iterSetting.getName()));
       iterOptions.put(iterSetting.getName(), iterSetting.getOptions());
     }
-    List<String> files = compactor.getFilesToCompact().stream().map(StoredTabletFile::getPathStr)
-        .collect(Collectors.toList());
+    List<String> files = compactor.getFilesToCompact().stream()
+        .map(StoredTabletFile::getNormalizedPathStr).collect(Collectors.toList());
     return new ActiveCompaction(compactor.extent.toThrift(),
         System.currentTimeMillis() - compactor.getStartTime(), files, compactor.getOutputFile(),
         type, reason, localityGroup, entriesRead, entriesWritten, iiList, iterOptions, timesPaused);

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -192,7 +192,7 @@ public class FileCompactor implements Callable<CompactionStats> {
   }
 
   protected String getOutputFile() {
-    return outputFile.toString();
+    return outputFile.getMetaInsert();
   }
 
   protected Map<String,Set<ByteSequence>> getLocalityGroups(AccumuloConfiguration acuTableConf)

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -330,7 +330,7 @@ public class FileCompactor implements Callable<CompactionStats> {
 
     List<SortedKeyValueIterator<Key,Value>> iters = new ArrayList<>(filesToCompact.size());
 
-    for (TabletFile dataFile : filesToCompact.keySet()) {
+    for (StoredTabletFile dataFile : filesToCompact.keySet()) {
       try {
 
         FileOperations fileFactory = FileOperations.getInstance();

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -344,7 +344,7 @@ public class FileCompactor implements Callable<CompactionStats> {
         readers.add(reader);
 
         InterruptibleIterator iter = new ProblemReportingIterator(context, extent.tableId(),
-            dataFile.getPathStr(), false, reader);
+            dataFile.getNormalizedPathStr(), false, reader);
 
         iter = filesToCompact.get(dataFile).wrapFileIterator(iter);
 
@@ -352,8 +352,8 @@ public class FileCompactor implements Callable<CompactionStats> {
 
       } catch (Exception e) {
 
-        ProblemReports.getInstance(context).report(
-            new ProblemReport(extent.tableId(), ProblemType.FILE_READ, dataFile.getPathStr(), e));
+        ProblemReports.getInstance(context).report(new ProblemReport(extent.tableId(),
+            ProblemType.FILE_READ, dataFile.getNormalizedPathStr(), e));
 
         log.warn("Some problem opening data file {} {}", dataFile, e.getMessage(), e);
         // failed to open some data file... close the ones that were opened

--- a/server/base/src/main/java/org/apache/accumulo/server/iterators/TabletIteratorEnvironment.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/iterators/TabletIteratorEnvironment.java
@@ -32,7 +32,7 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
@@ -53,7 +53,7 @@ public class TabletIteratorEnvironment implements SystemIteratorEnvironment {
   private final AccumuloConfiguration tableConfig;
   private final TableId tableId;
   private final ArrayList<SortedKeyValueIterator<Key,Value>> topLevelIterators;
-  private Map<TabletFile,DataFileValue> files;
+  private Map<StoredTabletFile,DataFileValue> files;
 
   private final Authorizations authorizations; // these will only be supplied during scan scope
   private SamplerConfiguration samplerConfig;
@@ -79,7 +79,7 @@ public class TabletIteratorEnvironment implements SystemIteratorEnvironment {
 
   public TabletIteratorEnvironment(ServerContext context, IteratorScope scope,
       AccumuloConfiguration tableConfig, TableId tableId, ScanFileManager trm,
-      Map<TabletFile,DataFileValue> files, Authorizations authorizations,
+      Map<StoredTabletFile,DataFileValue> files, Authorizations authorizations,
       SamplerConfigurationImpl samplerConfig,
       ArrayList<SortedKeyValueIterator<Key,Value>> topLevelIterators) {
     if (scope == IteratorScope.majc) {

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -103,9 +103,9 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putScan(TabletFile path) {
+  public Ample.TabletMutator putScan(StoredTabletFile path) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
-    mutation.put(ScanFileColumnFamily.NAME, path.getMetaInsertText(), new Value());
+    mutation.put(ScanFileColumnFamily.NAME, path.getMetaUpdateDeleteText(), new Value());
     return this;
   }
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -571,6 +571,6 @@ public class FileUtil {
    * used will have irregular paths that don't conform to TabletFile verification.
    */
   public static Collection<String> toPathStrings(Collection<TabletFile> files) {
-    return files.stream().map(TabletFile::getPathStr).collect(Collectors.toList());
+    return files.stream().map(TabletFile::getNormalizedPathStr).collect(Collectors.toList());
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ListVolumesUsed.java
@@ -65,7 +65,8 @@ public class ListVolumesUsed {
     try (TabletsMetadata tablets = TabletsMetadata.builder(context).forLevel(level)
         .fetch(TabletMetadata.ColumnType.FILES, TabletMetadata.ColumnType.LOGS).build()) {
       for (TabletMetadata tabletMetadata : tablets) {
-        tabletMetadata.getFiles().forEach(file -> volumes.add(getTableURI(file.getPathStr())));
+        tabletMetadata.getFiles()
+            .forEach(file -> volumes.add(getTableURI(file.getNormalizedPathStr())));
         tabletMetadata.getLogs().forEach(le -> getLogURIs(volumes, le));
       }
     }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -94,7 +94,7 @@ public class ManagerMetadataUtil {
       tablet.deleteLocation(Location.future(tServerInstance));
     }
 
-    datafileSizes.forEach(tablet::putFile);
+    datafileSizes.forEach((key, value) -> tablet.putFile(key.getTabletFile(), value));
 
     for (Entry<Long,? extends Collection<TabletFile>> entry : bulkLoadedFiles.entrySet()) {
       for (TabletFile ref : entry.getValue()) {
@@ -199,10 +199,10 @@ public class ManagerMetadataUtil {
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
 
     datafilesToDelete.forEach(tablet::deleteFile);
-    scanFiles.forEach(tablet::putScan);
+    scanFiles.stream().map(StoredTabletFile::getTabletFile).forEach(tablet::putScan);
 
     if (path.isPresent()) {
-      tablet.putFile(path.orElseThrow(), size);
+      tablet.putFile(path.orElseThrow().getTabletFile(), size);
     }
 
     if (compactionId != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -202,7 +202,7 @@ public class ManagerMetadataUtil {
     scanFiles.stream().map(StoredTabletFile::getTabletFile).forEach(tablet::putScan);
 
     if (path.isPresent()) {
-      tablet.putFile(path.orElseThrow().getTabletFile(), size);
+      tablet.putFile(path.orElseThrow(), size);
     }
 
     if (compactionId != null) {

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -199,7 +199,7 @@ public class ManagerMetadataUtil {
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
 
     datafilesToDelete.forEach(tablet::deleteFile);
-    scanFiles.stream().forEach(tablet::putScan);
+    scanFiles.forEach(tablet::putScan);
 
     if (path.isPresent()) {
       tablet.putFile(path.orElseThrow(), size);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -199,7 +199,7 @@ public class ManagerMetadataUtil {
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
 
     datafilesToDelete.forEach(tablet::deleteFile);
-    scanFiles.stream().map(StoredTabletFile::getTabletFile).forEach(tablet::putScan);
+    scanFiles.stream().forEach(tablet::putScan);
 
     if (path.isPresent()) {
       tablet.putFile(path.orElseThrow(), size);

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -284,7 +284,7 @@ public class MetadataTableUtil {
   }
 
   public static void splitDatafiles(Text midRow, double splitRatio,
-      Map<TabletFile,FileUtil.FileInfo> firstAndLastRows,
+      Map<StoredTabletFile,FileUtil.FileInfo> firstAndLastRows,
       SortedMap<StoredTabletFile,DataFileValue> datafiles,
       SortedMap<StoredTabletFile,DataFileValue> lowDatafileSizes,
       SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes,
@@ -513,7 +513,7 @@ public class MetadataTableUtil {
     while (cloneIter.hasNext()) {
       TabletMetadata cloneTablet = cloneIter.next();
       Text cloneEndRow = cloneTablet.getEndRow();
-      HashSet<TabletFile> cloneFiles = new HashSet<>();
+      HashSet<StoredTabletFile> cloneFiles = new HashSet<>();
 
       boolean cloneSuccessful = cloneTablet.getCloned() != null;
 
@@ -532,7 +532,7 @@ public class MetadataTableUtil {
             "Tablets deleted from src during clone : " + cloneEndRow + " " + srcEndRow);
       }
 
-      HashSet<TabletFile> srcFiles = new HashSet<>();
+      HashSet<StoredTabletFile> srcFiles = new HashSet<>();
       if (!cloneSuccessful) {
         srcFiles.addAll(srcTablet.getFiles());
       }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/TableDiskUsage.java
@@ -45,14 +45,13 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.NumUtil;
 import org.apache.accumulo.server.cli.ServerUtilOpts;
-import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,12 +210,12 @@ public class TableDiskUsage {
         mdScanner.fetchColumnFamily(MetadataSchema.TabletsSection.DataFileColumnFamily.NAME);
         mdScanner.setRange(new KeyExtent(tableId, null, null).toMetaRange());
 
-        final Set<TabletFile> files = new HashSet<>();
+        final Set<StoredTabletFile> files = new HashSet<>();
 
         // Read each file referenced by that table
         for (Map.Entry<Key,Value> entry : mdScanner) {
-          final TabletFile file =
-              new TabletFile(new Path(entry.getKey().getColumnQualifier().toString()));
+          final StoredTabletFile file =
+              new StoredTabletFile(entry.getKey().getColumnQualifier().toString());
 
           // get the table referenced by the file which may not be the same as the current
           // table we are scanning if the file is shared between multiple tables

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GCRun.java
@@ -167,7 +167,7 @@ public class GCRun implements GarbageCollectionEnvironment {
     });
 
     var scanServerRefs = context.getAmple().getScanServerFileReferences()
-        .map(sfr -> new ReferenceFile(sfr.getTableId(), sfr.getPathStr()));
+        .map(sfr -> new ReferenceFile(sfr.getTableId(), sfr.getNormalizedPathStr()));
 
     return Stream.concat(tabletReferences, scanServerRefs);
   }

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
@@ -48,6 +49,7 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
@@ -219,7 +221,8 @@ class LoadFiles extends ManagerRepo {
           server = location.getHostAndPort();
         }
 
-        Set<TabletFile> loadedFiles = tablet.getLoaded().keySet();
+        Set<TabletFile> loadedFiles = tablet.getLoaded().keySet().stream()
+            .map(StoredTabletFile::getTabletFile).collect(Collectors.toSet());
 
         Map<String,DataFileInfo> thriftImports = new HashMap<>();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/ScanServer.java
@@ -573,7 +573,8 @@ public class ScanServer extends AbstractServer
 
       for (StoredTabletFile file : allFiles.keySet()) {
         if (!reservedFiles.containsKey(file)) {
-          refs.add(new ScanServerRefTabletFile(file.getPathStr(), serverAddress, serverLockUUID));
+          refs.add(new ScanServerRefTabletFile(file.getNormalizedPathStr(), serverAddress,
+              serverLockUUID));
           filesToReserve.add(file);
           tabletsToCheck.add(Objects.requireNonNull(allFiles.get(file)));
           LOG.trace("RFFS {} need to add scan ref for file {}", myReservationId, file);
@@ -757,8 +758,8 @@ public class ScanServer extends AbstractServer
             // then adding the file to influxFiles will make it wait until we finish
             influxFiles.add(file);
             confirmed.add(file);
-            refsToDelete
-                .add(new ScanServerRefTabletFile(file.getPathStr(), serverAddress, serverLockUUID));
+            refsToDelete.add(new ScanServerRefTabletFile(file.getNormalizedPathStr(), serverAddress,
+                serverLockUUID));
 
             // remove the entry from the map while holding the write lock ensuring no new
             // reservations are added to the map values while the metadata operation to delete is

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -182,7 +182,8 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
           path = ns.makeQualified(path);
           newFileMap.put(new TabletFile(path), mapping.getValue());
         }
-        var files = newFileMap.keySet().stream().map(TabletFile::getPathStr).collect(toList());
+        var files =
+            newFileMap.keySet().stream().map(TabletFile::getNormalizedPathStr).collect(toList());
         server.updateBulkImportState(files, BulkImportState.INITIAL);
 
         Tablet importTablet = server.getOnlineTablet(KeyExtent.fromThrift(tke));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ExternalCompactionJob.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ExternalCompactionJob.java
@@ -76,12 +76,12 @@ public class ExternalCompactionJob {
 
     List<InputFile> files = jobFiles.entrySet().stream().map(e -> {
       var dfv = e.getValue();
-      return new InputFile(e.getKey().getPathStr(), dfv.getSize(), dfv.getNumEntries(),
+      return new InputFile(e.getKey().getNormalizedPathStr(), dfv.getSize(), dfv.getNumEntries(),
           dfv.getTime());
     }).collect(Collectors.toList());
 
     return new TExternalCompactionJob(externalCompactionId.toString(), extent.toThrift(), files,
-        iteratorSettings, compactTmpName.getPathStr(), propagateDeletes,
+        iteratorSettings, compactTmpName.getNormalizedPathStr(), propagateDeletes,
         org.apache.accumulo.core.tabletserver.thrift.TCompactionKind.valueOf(kind.name()),
         userCompactionId, overrides);
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -84,7 +84,7 @@ class DatafileManager {
         new AtomicReference<>(new MetadataUpdateCount(tablet.getExtent(), 0L, 0L));
   }
 
-  private final Set<TabletFile> filesToDeleteAfterScan = new HashSet<>();
+  private final Set<StoredTabletFile> filesToDeleteAfterScan = new HashSet<>();
   private final Map<Long,Set<StoredTabletFile>> scanFileReservations = new HashMap<>();
   private final MapCounter<StoredTabletFile> fileScanReferenceCounts = new MapCounter<>();
   private long nextScanReservationId = 0;
@@ -108,7 +108,7 @@ class DatafileManager {
 
       for (StoredTabletFile path : absFilePaths) {
         fileScanReferenceCounts.increment(path, 1);
-        ret.put(path, datafileSizes.get(path));
+        ret.put(path.getTabletFile(), datafileSizes.get(path));
       }
 
       return new Pair<>(rid, ret);
@@ -495,9 +495,9 @@ class DatafileManager {
     }
   }
 
-  public Set<TabletFile> getFiles() {
+  public Set<StoredTabletFile> getFiles() {
     synchronized (tablet) {
-      HashSet<TabletFile> files = new HashSet<>(datafileSizes.keySet());
+      HashSet<StoredTabletFile> files = new HashSet<>(datafileSizes.keySet());
       return Collections.unmodifiableSet(files);
     }
   }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -95,7 +95,7 @@ class DatafileManager {
     }
   }
 
-  Pair<Long,Map<TabletFile,DataFileValue>> reserveFilesForScan() {
+  Pair<Long,Map<StoredTabletFile,DataFileValue>> reserveFilesForScan() {
     synchronized (tablet) {
 
       Set<StoredTabletFile> absFilePaths = new HashSet<>(datafileSizes.keySet());
@@ -104,11 +104,11 @@ class DatafileManager {
 
       scanFileReservations.put(rid, absFilePaths);
 
-      Map<TabletFile,DataFileValue> ret = new HashMap<>();
+      Map<StoredTabletFile,DataFileValue> ret = new HashMap<>();
 
       for (StoredTabletFile path : absFilePaths) {
         fileScanReferenceCounts.increment(path, 1);
-        ret.put(path.getTabletFile(), datafileSizes.get(path));
+        ret.put(path, datafileSizes.get(path));
       }
 
       return new Pair<>(rid, ret);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -78,7 +78,7 @@ class MinorCompactionTask implements Runnable {
             try {
               if (newFile == null) {
                 newFile = tablet.getNextDataFilename(FilePrefix.MINOR_COMPACTION);
-                tmpFile = new TabletFile(new Path(newFile.getPathStr() + "_tmp"));
+                tmpFile = new TabletFile(new Path(newFile.getNormalizedPathStr() + "_tmp"));
               }
               /*
                * the purpose of the minor compaction start event is to keep track of the filename...

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/ScanDataSource.java
@@ -40,7 +40,7 @@ import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator.DataSource;
 import org.apache.accumulo.core.iteratorsImpl.system.StatsIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SystemIteratorUtil;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.util.Pair;
@@ -124,7 +124,7 @@ class ScanDataSource implements DataSource {
 
   private SortedKeyValueIterator<Key,Value> createIterator() throws IOException {
 
-    Map<TabletFile,DataFileValue> files;
+    Map<StoredTabletFile,DataFileValue> files;
 
     SamplerConfigurationImpl samplerConfig = scanParams.getSamplerConfigurationImpl();
 
@@ -159,7 +159,7 @@ class ScanDataSource implements DataSource {
       expectedDeletionCount = tablet.getDataSourceDeletions();
 
       memIters = tablet.getMemIterators(samplerConfig);
-      Pair<Long,Map<TabletFile,DataFileValue>> reservation = tablet.reserveFilesForScan();
+      Pair<Long,Map<StoredTabletFile,DataFileValue>> reservation = tablet.reserveFilesForScan();
       fileReservationId = reservation.getFirst();
       files = reservation.getSecond();
     }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/SnapshotTablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/SnapshotTablet.java
@@ -27,7 +27,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
@@ -97,10 +96,9 @@ public class SnapshotTablet extends TabletBase {
 
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
-  public Pair<Long,Map<TabletFile,DataFileValue>> reserveFilesForScan() {
-    return new Pair(0L, getDatafiles());
+  public Pair<Long,Map<StoredTabletFile,DataFileValue>> reserveFilesForScan() {
+    return new Pair<>(0L, getDatafiles());
   }
 
   @Override

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -327,7 +327,7 @@ public class Tablet extends TabletBase {
       final CommitSession commitSession = getTabletMemory().getCommitSession();
       try {
         Set<String> absPaths = new HashSet<>();
-        for (TabletFile ref : datafiles.keySet()) {
+        for (StoredTabletFile ref : datafiles.keySet()) {
           absPaths.add(ref.getPathStr());
         }
 
@@ -1322,7 +1322,7 @@ public class Tablet extends TabletBase {
 
   // encapsulates results of computations needed to make determinations about splits
   private static class SplitComputations {
-    final Set<TabletFile> inputFiles;
+    final Set<StoredTabletFile> inputFiles;
 
     // cached result of calling FileUtil.findMidpoint
     final SortedMap<Double,Key> midPoint;
@@ -1330,7 +1330,7 @@ public class Tablet extends TabletBase {
     // the last row seen in the files, only set for the default tablet
     final Text lastRowForDefaultTablet;
 
-    private SplitComputations(Set<TabletFile> inputFiles, SortedMap<Double,Key> midPoint,
+    private SplitComputations(Set<StoredTabletFile> inputFiles, SortedMap<Double,Key> midPoint,
         Text lastRowForDefaultTablet) {
       this.inputFiles = inputFiles;
       this.midPoint = midPoint;
@@ -1356,7 +1356,7 @@ public class Tablet extends TabletBase {
       return Optional.empty();
     }
 
-    Set<TabletFile> files = getDatafileManager().getFiles();
+    Set<StoredTabletFile> files = getDatafileManager().getFiles();
     SplitComputations lastComputation = lastSplitComputation.get();
     if (lastComputation != null && lastComputation.inputFiles.equals(files)) {
       // the last computation is still relevant
@@ -1513,8 +1513,8 @@ public class Tablet extends TabletBase {
     // this info is used for optimization... it is ok if data files are missing
     // from the set... can still query and insert into the tablet while this
     // data file operation is happening
-    Map<TabletFile,FileUtil.FileInfo> firstAndLastRows = FileUtil.tryToGetFirstAndLastRows(context,
-        tableConfiguration, getDatafileManager().getFiles());
+    Map<StoredTabletFile,FileUtil.FileInfo> firstAndLastRows = FileUtil
+        .tryToGetFirstAndLastRows(context, tableConfiguration, getDatafileManager().getFiles());
 
     synchronized (this) {
       // java needs tuples ...

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -328,7 +328,7 @@ public class Tablet extends TabletBase {
       try {
         Set<String> absPaths = new HashSet<>();
         for (StoredTabletFile ref : datafiles.keySet()) {
-          absPaths.add(ref.getPathStr());
+          absPaths.add(ref.getNormalizedPathStr());
         }
 
         tabletServer.recover(this.getTabletServer().getVolumeManager(), extent, logEntries,
@@ -1664,7 +1664,7 @@ public class Tablet extends TabletBase {
 
     for (Entry<TabletFile,DataFileInfo> entry : fileMap.entrySet()) {
       entries.put(entry.getKey(), new DataFileValue(entry.getValue().estimatedSize, 0L));
-      files.add(entry.getKey().getPathStr());
+      files.add(entry.getKey().getNormalizedPathStr());
     }
 
     // Clients timeout and will think that this operation failed.

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/Tablet.java
@@ -2058,7 +2058,7 @@ public class Tablet extends TabletBase {
   }
 
   @Override
-  public Pair<Long,Map<TabletFile,DataFileValue>> reserveFilesForScan() {
+  public Pair<Long,Map<StoredTabletFile,DataFileValue>> reserveFilesForScan() {
     return getDatafileManager().reserveFilesForScan();
   }
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletBase.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletBase.java
@@ -44,7 +44,6 @@ import org.apache.accumulo.core.iterators.YieldCallback;
 import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.accumulo.core.iteratorsImpl.system.SourceSwitchingIterator;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -129,7 +128,7 @@ public abstract class TabletBase {
 
   public abstract void returnMemIterators(List<InMemoryMap.MemoryIterator> iters);
 
-  public abstract Pair<Long,Map<TabletFile,DataFileValue>> reserveFilesForScan();
+  public abstract Pair<Long,Map<StoredTabletFile,DataFileValue>> reserveFilesForScan();
 
   public abstract void returnFilesForScan(long scanId);
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -69,7 +69,7 @@ public class TabletData {
     dataFiles.putAll(meta.getFilesMap());
 
     meta.getLoaded().forEach((path, txid) -> {
-      bulkImported.computeIfAbsent(txid, k -> new ArrayList<>()).add(path);
+      bulkImported.computeIfAbsent(txid, k -> new ArrayList<>()).add(path.getTabletFile());
     });
 
     this.extCompactions = meta.getExternalCompactions();

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/CompactableImplTest.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
 import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
@@ -50,13 +49,13 @@ public class CompactableImplTest {
       Set<StoredTabletFile> nextFiles, CompactionKind kind, boolean propagateDeletes,
       boolean initiallySelectedAll, Long compactionId) {
 
-    TabletFile compactTmpName = newFile("C00000A.rf_tmp");
+    StoredTabletFile compactTmpName = newFile("C00000A.rf_tmp");
     String compactorId = "cid";
     short priority = 9;
     CompactionExecutorId ceid = CompactionExecutorIdImpl.externalId("ecs1");
 
-    return new ExternalCompactionMetadata(jobFiles, nextFiles, compactTmpName, compactorId, kind,
-        priority, ceid, propagateDeletes, initiallySelectedAll, compactionId);
+    return new ExternalCompactionMetadata(jobFiles, nextFiles, compactTmpName.getTabletFile(),
+        compactorId, kind, priority, ceid, propagateDeletes, initiallySelectedAll, compactionId);
   }
 
   ExternalCompactionId newEcid() {

--- a/test/src/main/java/org/apache/accumulo/test/functional/PerTableCryptoIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/PerTableCryptoIT.java
@@ -182,7 +182,7 @@ public class PerTableCryptoIT extends AccumuloClusterHarness {
           try (PrintStream newOut = new PrintStream(baos)) {
             System.setOut(newOut);
             List<String> args = new ArrayList<>();
-            args.add(f.getPathStr());
+            args.add(f.getNormalizedPathStr());
             args.add("--props");
             args.add(getCluster().getAccumuloPropertiesPath());
             if (getClusterType() == ClusterType.STANDALONE && saslEnabled()) {

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -191,8 +191,8 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
       KeyExtent extent) {
     Map<Long,List<TabletFile>> bulkFiles = new HashMap<>();
 
-    context.getAmple().readTablet(extent).getLoaded()
-        .forEach((path, txid) -> bulkFiles.computeIfAbsent(txid, k -> new ArrayList<>()).add(path));
+    context.getAmple().readTablet(extent).getLoaded().forEach((path, txid) -> bulkFiles
+        .computeIfAbsent(txid, k -> new ArrayList<>()).add(path.getTabletFile()));
 
     return bulkFiles;
   }


### PR DESCRIPTION
This PR fixes #2830  (not having a hashcode/equals in StoredTabletFile) by leveraging the newly added [AbstractTabletFile](https://github.com/apache/accumulo/blob/4d933f1a285fb1a5c323bf58062fb05d3110dd91/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java) class and by changing `StoredTabletFile` to extend that class and become a sibling of `TabletFile`. Also, there is now a composition relationship between StoredTabletFile and TabletFile instead of "is a" relationship. (StoredTabletFile now contains a TabletFile).

The composition relationship fixes the issues of equality using the same strategy as the [fix](https://github.com/apache/accumulo/pull/3257) for #3254. Also, by updating `StoredTabletFile` to extend `AbstractTabletFile` this has the nice side effect of being able to directly pass it to FileOperations as FileOperations now [supports](https://github.com/apache/accumulo/blob/4d933f1a285fb1a5c323bf58062fb05d3110dd91/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java#L190) AbstractTabletFile. Lastly, by using composition we can still leverage the existing [validation](https://github.com/apache/accumulo/blob/4d933f1a285fb1a5c323bf58062fb05d3110dd91/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java#L55-L74) checks done in TabletFile when that object is created in the StoredTabletFile constructor.

StoredTabletFile now implements hashcode, equals, and compareTo() and uses the metadataString (exact String in the metadata table) as the comparision. I also added a few delegation methods to TabletFile just as a shortcut to make it easier to call certain methods.

As part of these changes I updated each place in the code with the correct usage, either StoredTabletFile or TabletFile. Several places in the code used to interchangeably jump back and forth between the two (since there was an "is a" relationship) and that has now been fixed. The end result is every place in the code where we are using files loaded from metadata ends up being a StoredTabletFile and in other case just TabletFile is used.

This fixes #2830