### PR TITLE
Minor POM quality updates

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metrics/MetricsProducer.java
@@ -35,7 +35,6 @@ import io.micrometer.core.instrument.MeterRegistry;
  * <a href="https://micrometer.io/">Micrometer</a>. Micrometer suggests using a particular
  * <a href="https://micrometer.io/docs/concepts#_naming_meters">naming convention</a> for the
  * metrics. The table below contains a mapping of the old to new metric names.
- * <p>
  * <table border="1">
  * <caption>Summary of Metric Changes</caption> <!-- fate -->
  * <tr>

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/GuavaRateLimiter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/GuavaRateLimiter.java
@@ -52,14 +52,14 @@ public class GuavaRateLimiter implements RateLimiter {
   }
 
   @Override
-  public void acquire(long permits) {
+  public void acquire(long numPermits) {
     if (this.currentRate > 0) {
-      while (permits > Integer.MAX_VALUE) {
+      while (numPermits > Integer.MAX_VALUE) {
         rateLimiter.acquire(Integer.MAX_VALUE);
-        permits -= Integer.MAX_VALUE;
+        numPermits -= Integer.MAX_VALUE;
       }
-      if (permits > 0) {
-        rateLimiter.acquire((int) permits);
+      if (numPermits > 0) {
+        rateLimiter.acquire((int) numPermits);
       }
     }
   }

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/NullRateLimiter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/NullRateLimiter.java
@@ -32,6 +32,6 @@ public class NullRateLimiter implements RateLimiter {
   }
 
   @Override
-  public void acquire(long permits) {}
+  public void acquire(long numPermits) {}
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/RateLimiter.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/RateLimiter.java
@@ -25,5 +25,5 @@ public interface RateLimiter {
   long getRate();
 
   /** Sleep until the specified number of queries are available. */
-  void acquire(long permits);
+  void acquire(long numPermits);
 }

--- a/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/util/ratelimit/SharedRateLimiterFactory.java
@@ -157,9 +157,9 @@ public class SharedRateLimiterFactory {
     }
 
     @Override
-    public void acquire(long permits) {
-      super.acquire(permits);
-      permitsAcquired.addAndGet(permits);
+    public void acquire(long numPermits) {
+      super.acquire(numPermits);
+      permitsAcquired.addAndGet(numPermits);
     }
 
     /** Poll the callback, updating the current rate if necessary. */

--- a/pom.xml
+++ b/pom.xml
@@ -119,22 +119,23 @@
     <!-- bouncycastle version for test dependencies -->
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
-    <curator.version>5.3.0</curator.version>
-    <errorprone.version>2.18.0</errorprone.version>
+    <curator.version>5.5.0</curator.version>
+    <errorprone.version>2.19.1</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <extraTestArgs />
     <failsafe.excludedGroups />
+    <failsafe.failIfNoSpecifiedTests>false</failsafe.failIfNoSpecifiedTests>
     <failsafe.forkCount>1</failsafe.forkCount>
     <failsafe.groups />
     <failsafe.reuseForks>false</failsafe.reuseForks>
     <hadoop.version>3.3.5</hadoop.version>
-    <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
     <!-- surefire/failsafe plugin option -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -151,7 +152,7 @@
     <surefire.forkCount>1C</surefire.forkCount>
     <surefire.groups />
     <surefire.reuseForks>true</surefire.reuseForks>
-    <surefire.version>3.0.0-M6</surefire.version>
+    <surefire.version>3.1.0</surefire.version>
     <!-- Thrift version -->
     <thrift.version>0.17.0</thrift.version>
     <unitTestMemSize>-Xmx1G</unitTestMemSize>
@@ -163,14 +164,14 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.14.2</version>
+        <version>2.15.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-bom</artifactId>
-        <version>1.10.6</version>
+        <version>1.11.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -178,21 +179,21 @@
         <!-- for dependency convergence between Micrometer and ZooKeeper -->
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.89.Final</version>
+        <version>4.1.92.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.25.0</version>
+        <version>1.26.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom-alpha</artifactId>
-        <version>1.25.0-alpha</version>
+        <version>1.26.0-alpha</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -213,14 +214,14 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
-        <version>11.0.13</version>
+        <version>11.0.15</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-bom</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -242,7 +243,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.9.2</version>
+        <version>5.10.0-M1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -259,7 +260,7 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>3.1.4</version>
+        <version>3.1.6</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
@@ -279,7 +280,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.1</version>
       </dependency>
       <dependency>
         <!-- converge transitive dependency version between guava and caffeine -->
@@ -316,7 +317,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <version>2.12.0</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -418,7 +419,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
-        <version>2.8.0</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -563,7 +564,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.26.0</version>
+        <version>3.34.0</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
@@ -588,7 +589,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>7.0.5.Final</version>
+        <version>8.0.0.Final</version>
       </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
@@ -615,7 +616,7 @@
       <dependency>
         <groupId>org.jline</groupId>
         <artifactId>jline</artifactId>
-        <version>3.22.0</version>
+        <version>3.23.0</version>
       </dependency>
       <dependency>
         <groupId>org.latencyutils</groupId>
@@ -663,12 +664,12 @@
         <!-- version specified to converge transitive dependency of hadoop and curator -->
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.8.4</version>
+        <version>1.1.9.1</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.33</version>
+        <version>2.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -747,13 +748,23 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-remote-resources-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>4.0.0-M8</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
@@ -891,7 +902,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <!-- 3.1.0 is broken https://github.com/mojohaus/exec-maven-plugin/issues/334 -->
@@ -945,7 +956,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.8.0</version>
+          <version>1.9.0</version>
           <configuration>
             <removeUnused>true</removeUnused>
             <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -1188,7 +1199,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.9.3</version>
+            <version>10.11.0</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <bouncycastle.version>1.70</bouncycastle.version>
     <!-- Curator version -->
     <curator.version>5.5.0</curator.version>
-    <errorprone.version>2.19.1</errorprone.version>
+    <errorprone.version>2.18.0</errorprone.version>
     <!-- avoid error shutting down built-in ForkJoinPool.commonPool() during exec:java tasks -->
     <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
     <extraTestArgs />


### PR DESCRIPTION
* Update our plugins with versions that we specify to the latest
* Update plugins whose versions are in the parent POM, to avoid warnings about deprecations in Maven 3.9
* Fail on javadoc doclint issues, and fix the single issue in the MetricsProducer
* Work around revelc/impsort-maven-plugin#72 by renaming the "permits" variable in rate limiter APIs
* Bump some low-risk dependencies: curator, jackson, micrometer, netty, opentelemetry, jetty, hk2, caffeine, gson, commons-io, commons-configuration2, checker-qual, hibernate-validator, jline, snappy-java, snakeyaml