### PR TITLE
executes user initiated splits in manager

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/TableOperationsImpl.java
@@ -59,10 +59,11 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -140,8 +141,6 @@ import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.summary.SummarizerConfigurationUtil;
 import org.apache.accumulo.core.summary.SummaryCollection;
-import org.apache.accumulo.core.tablet.thrift.TabletManagementClientService;
-import org.apache.accumulo.core.tabletserver.thrift.NotServingTabletException;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.core.util.LocalityGroupUtil.LocalityGroupConfigurationError;
@@ -155,7 +154,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.transport.TTransportException;
@@ -164,7 +162,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.net.HostAndPort;
 
 public class TableOperationsImpl extends TableOperationsHelper {
 
@@ -435,198 +432,143 @@ public class TableOperationsImpl extends TableOperationsHelper {
     }
   }
 
-  private static class SplitEnv {
-    private final String tableName;
-    private final TableId tableId;
-    private final ExecutorService executor;
-    private final CountDownLatch latch;
-    private final AtomicReference<Exception> exception;
-
-    SplitEnv(String tableName, TableId tableId, ExecutorService executor, CountDownLatch latch,
-        AtomicReference<Exception> exception) {
-      this.tableName = tableName;
-      this.tableId = tableId;
-      this.executor = executor;
-      this.latch = latch;
-      this.exception = exception;
-    }
-  }
-
-  private class SplitTask implements Runnable {
-
-    private List<Text> splits;
-    private SplitEnv env;
-
-    SplitTask(SplitEnv env, List<Text> splits) {
-      this.env = env;
-      this.splits = splits;
-    }
-
-    @Override
-    public void run() {
-      try {
-        if (env.exception.get() != null) {
-          return;
-        }
-
-        if (splits.size() <= 2) {
-          addSplits(env, new TreeSet<>(splits));
-          splits.forEach(s -> env.latch.countDown());
-          return;
-        }
-
-        int mid = splits.size() / 2;
-
-        // split the middle split point to ensure that child task split
-        // different tablets and can therefore run in parallel
-        addSplits(env, new TreeSet<>(splits.subList(mid, mid + 1)));
-        env.latch.countDown();
-
-        env.executor.execute(new SplitTask(env, splits.subList(0, mid)));
-        env.executor.execute(new SplitTask(env, splits.subList(mid + 1, splits.size())));
-
-      } catch (Exception t) {
-        env.exception.compareAndSet(null, t);
-      }
-    }
-
-  }
+  /**
+   * On the server side the fate operation will exit w/o an error if the tablet requested to split
+   * does not exist. When this happens it will also return an empty string. In the case where the
+   * fate operation successfully splits the tablet it will return the following string. This code
+   * uses this return value to see if it needs to retry finding the tablet.
+   */
+  public static final String SPLIT_SUCCESS_MSG = "SPLIT_SUCCEEDED";
 
   @Override
-  public void addSplits(String tableName, SortedSet<Text> partitionKeys)
-      throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
+  public void addSplits(String tableName, SortedSet<Text> splits)
+      throws AccumuloException, TableNotFoundException, AccumuloSecurityException {
+
     EXISTING_TABLE_NAME.validate(tableName);
 
     TableId tableId = context.getTableId(tableName);
-    List<Text> splits = new ArrayList<>(partitionKeys);
 
-    // should be sorted because we copied from a sorted set, but that makes
-    // assumptions about how the copy was done so resort to be sure.
-    Collections.sort(splits);
-    CountDownLatch latch = new CountDownLatch(splits.size());
-    AtomicReference<Exception> exception = new AtomicReference<>(null);
+    // TODO should there be a server side check for this?
+    context.requireNotOffline(tableId, tableName);
 
+    ClientTabletCache tabLocator = ClientTabletCache.getInstance(context, tableId);
+
+    SortedSet<Text> splitsTodo = new TreeSet<>(splits);
     ExecutorService executor = context.threadPools().createFixedThreadPool(16, "addSplits", false);
     try {
-      executor.execute(
-          new SplitTask(new SplitEnv(tableName, tableId, executor, latch, exception), splits));
+      while (!splitsTodo.isEmpty()) {
 
-      while (!latch.await(100, MILLISECONDS)) {
-        if (exception.get() != null) {
-          executor.shutdownNow();
-          Throwable excep = exception.get();
-          // Below all exceptions are wrapped and rethrown. This is done so that the user knows what
-          // code path got them here. If the wrapping was not done, the
-          // user would only have the stack trace for the background thread.
-          if (excep instanceof TableNotFoundException) {
-            TableNotFoundException tnfe = (TableNotFoundException) excep;
-            throw new TableNotFoundException(tableId.canonical(), tableName,
-                "Table not found by background thread", tnfe);
-          } else if (excep instanceof TableOfflineException) {
-            log.debug("TableOfflineException occurred in background thread. Throwing new exception",
-                excep);
-            throw new TableOfflineException(tableId, tableName);
-          } else if (excep instanceof AccumuloSecurityException) {
-            // base == background accumulo security exception
-            AccumuloSecurityException base = (AccumuloSecurityException) excep;
-            throw new AccumuloSecurityException(base.getUser(), base.asThriftException().getCode(),
-                base.getTableInfo(), excep);
-          } else if (excep instanceof AccumuloServerException) {
-            throw new AccumuloServerException((AccumuloServerException) excep);
-          } else if (excep instanceof Error) {
-            throw new Error(excep);
-          } else {
-            throw new AccumuloException(excep);
+        tabLocator.invalidateCache();
+
+        Map<KeyExtent,List<Text>> tabletSplits =
+            mapSplitsToTablets(tableName, tableId, tabLocator, splitsTodo);
+
+        List<Future<List<Text>>> splitTasks = new ArrayList<>();
+
+        for (Entry<KeyExtent,List<Text>> splitsForTablet : tabletSplits.entrySet()) {
+          Callable<List<Text>> splitTask = createSplitTask(tableName, splitsForTablet);
+          splitTasks.add(executor.submit(splitTask));
+        }
+
+        for (var future : splitTasks) {
+          try {
+            var completedSplits = future.get();
+            completedSplits.forEach(splitsTodo::remove);
+          } catch (ExecutionException ee) {
+            Throwable excep = ee.getCause();
+            // Below all exceptions are wrapped and rethrown. This is done so that the user knows
+            // what
+            // code path got them here. If the wrapping was not done, the user would only have the
+            // stack trace for the background thread.
+            if (excep instanceof TableNotFoundException) {
+              TableNotFoundException tnfe = (TableNotFoundException) excep;
+              throw new TableNotFoundException(tableId.canonical(), tableName,
+                  "Table not found by background thread", tnfe);
+            } else if (excep instanceof TableOfflineException) {
+              log.debug(
+                  "TableOfflineException occurred in background thread. Throwing new exception",
+                  excep);
+              throw new TableOfflineException(tableId, tableName);
+            } else if (excep instanceof AccumuloSecurityException) {
+              // base == background accumulo security exception
+              AccumuloSecurityException base = (AccumuloSecurityException) excep;
+              throw new AccumuloSecurityException(base.getUser(),
+                  base.asThriftException().getCode(), base.getTableInfo(), excep);
+            } else if (excep instanceof AccumuloServerException) {
+              throw new AccumuloServerException((AccumuloServerException) excep);
+            } else {
+              throw new AccumuloException(excep);
+            }
+          } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
           }
         }
       }
-    } catch (InterruptedException e) {
-      throw new IllegalStateException(e);
     } finally {
-      executor.shutdown();
+      executor.shutdownNow();
     }
   }
 
-  private void addSplits(SplitEnv env, SortedSet<Text> partitionKeys)
-      throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
-      AccumuloServerException, InvalidTabletHostingRequestException {
+  private Map<KeyExtent,List<Text>> mapSplitsToTablets(String tableName, TableId tableId,
+      ClientTabletCache tabLocator, SortedSet<Text> splitsTodo)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
+    Map<KeyExtent,List<Text>> tabletSplits = new HashMap<>();
 
-    ClientTabletCache tabLocator = ClientTabletCache.getInstance(context, env.tableId);
-    for (Text split : partitionKeys) {
-      boolean successful = false;
-      int attempt = 0;
-      long locationFailures = 0;
+    var iterator = splitsTodo.iterator();
+    while (iterator.hasNext()) {
+      var split = iterator.next();
 
-      while (!successful) {
-
-        if (attempt > 0) {
-          sleepUninterruptibly(100, MILLISECONDS);
-        }
-
-        attempt++;
-
-        CachedTablet tl = tabLocator.findTablet(context, split, false, LocationNeed.REQUIRED);
-
-        if (tl == null) {
-          context.requireTableExists(env.tableId, env.tableName);
-          context.requireNotOffline(env.tableId, env.tableName);
+      try {
+        var tablet = tabLocator.findTablet(context, split, false, LocationNeed.NOT_REQUIRED);
+        if (tablet == null) {
+          context.requireTableExists(tableId, tableName);
+          // TODO sleep... what else could cause this?
           continue;
         }
 
-        HostAndPort address = HostAndPort.fromString(tl.getTserverLocation().orElseThrow());
-
-        try {
-          TabletManagementClientService.Client client =
-              ThriftUtil.getClient(ThriftClientTypes.TABLET_MGMT, address, context);
-          try {
-
-            OpTimer timer = null;
-
-            if (log.isTraceEnabled()) {
-              log.trace("tid={} Splitting tablet {} on {} at {}", Thread.currentThread().getId(),
-                  tl.getExtent(), address, split);
-              timer = new OpTimer().start();
-            }
-
-            client.splitTablet(TraceUtil.traceInfo(), context.rpcCreds(), tl.getExtent().toThrift(),
-                TextUtil.getByteBuffer(split));
-
-            // just split it, might as well invalidate it in the cache
-            tabLocator.invalidateCache(tl.getExtent());
-
-            if (timer != null) {
-              timer.stop();
-              log.trace("Split tablet in {}", String.format("%.3f secs", timer.scale(SECONDS)));
-            }
-
-          } finally {
-            ThriftUtil.returnClient(client, context);
-          }
-
-        } catch (TApplicationException tae) {
-          throw new AccumuloServerException(address.toString(), tae);
-        } catch (ThriftSecurityException e) {
-          context.clearTableListCache();
-          context.requireTableExists(env.tableId, env.tableName);
-          throw new AccumuloSecurityException(e.user, e.code, e);
-        } catch (NotServingTabletException e) {
-          // Do not silently spin when we repeatedly fail to get the location for a tablet
-          locationFailures++;
-          if (locationFailures == 5 || locationFailures % 50 == 0) {
-            log.warn("Having difficulty locating hosting tabletserver for split {} on table {}."
-                + " Seen {} failures.", split, env.tableName, locationFailures);
-          }
-
-          tabLocator.invalidateCache(tl.getExtent());
-          continue;
-        } catch (TException e) {
-          tabLocator.invalidateCache(context, tl.getTserverLocation().orElseThrow());
+        if (split.equals(tablet.getExtent().endRow())) {
+          // split already exists, so remove it
+          iterator.remove();
           continue;
         }
 
-        successful = true;
+        tabletSplits.computeIfAbsent(tablet.getExtent(), k -> new ArrayList<>()).add(split);
+
+      } catch (InvalidTabletHostingRequestException e) {
+        // not expected
+        throw new AccumuloException(e);
       }
     }
+    return tabletSplits;
+  }
+
+  private Callable<List<Text>> createSplitTask(String tableName,
+      Entry<KeyExtent,List<Text>> splitsForTablet) {
+    Callable<List<Text>> splitTask = () -> {
+      var extent = splitsForTablet.getKey();
+
+      ByteBuffer EMPTY = ByteBuffer.allocate(0);
+
+      List<ByteBuffer> args = new ArrayList<>();
+      args.add(ByteBuffer.wrap(extent.tableId().canonical().getBytes(UTF_8)));
+      args.add(extent.endRow() == null ? EMPTY : TextUtil.getByteBuffer(extent.endRow()));
+      args.add(extent.prevEndRow() == null ? EMPTY : TextUtil.getByteBuffer(extent.prevEndRow()));
+      splitsForTablet.getValue().forEach(split -> args.add(TextUtil.getByteBuffer(split)));
+
+      try {
+        String status = doFateOperation(FateOperation.TABLE_SPLIT, args, Map.of(), tableName);
+        if (SPLIT_SUCCESS_MSG.equals(status)) {
+          // the fate operation successfully created the splits, so these splits are done
+          return splitsForTablet.getValue();
+        } else {
+          // splits did not succeed
+          return List.of();
+        }
+      } catch (TableExistsException | NamespaceExistsException | NamespaceNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+    };
+    return splitTask;
   }
 
   @Override

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TableOperation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/clientImpl/thrift/TableOperation.java
@@ -43,7 +43,8 @@ public enum TableOperation implements org.apache.thrift.TEnum {
   IMPORT(14),
   EXPORT(15),
   COMPACT_CANCEL(16),
-  SET_HOSTING_GOAL(17);
+  SET_HOSTING_GOAL(17),
+  SPLIT(18);
 
   private final int value;
 
@@ -102,6 +103,8 @@ public enum TableOperation implements org.apache.thrift.TEnum {
         return COMPACT_CANCEL;
       case 17:
         return SET_HOSTING_GOAL;
+      case 18:
+        return SPLIT;
       default:
         return null;
     }

--- a/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateOperation.java
+++ b/core/src/main/thrift-gen-java/org/apache/accumulo/core/manager/thrift/FateOperation.java
@@ -43,7 +43,8 @@ public enum FateOperation implements org.apache.thrift.TEnum {
   NAMESPACE_DELETE(14),
   NAMESPACE_RENAME(15),
   TABLE_BULK_IMPORT2(16),
-  TABLE_HOSTING_GOAL(17);
+  TABLE_HOSTING_GOAL(17),
+  TABLE_SPLIT(18);
 
   private final int value;
 
@@ -102,6 +103,8 @@ public enum FateOperation implements org.apache.thrift.TEnum {
         return TABLE_BULK_IMPORT2;
       case 17:
         return TABLE_HOSTING_GOAL;
+      case 18:
+        return TABLE_SPLIT;
       default:
         return null;
     }

--- a/core/src/main/thrift/client.thrift
+++ b/core/src/main/thrift/client.thrift
@@ -40,6 +40,7 @@ enum TableOperation {
   EXPORT
   COMPACT_CANCEL
   SET_HOSTING_GOAL
+  SPLIT
 }
 
 enum TableOperationExceptionType {

--- a/core/src/main/thrift/manager.thrift
+++ b/core/src/main/thrift/manager.thrift
@@ -68,6 +68,7 @@ enum FateOperation {
   NAMESPACE_RENAME
   TABLE_BULK_IMPORT2
   TABLE_HOSTING_GOAL
+  TABLE_SPLIT
 }
 
 enum ManagerState {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/DeleteOperationIds.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/split/DeleteOperationIds.java
@@ -20,6 +20,7 @@ package org.apache.accumulo.manager.tableOps.split;
 
 import java.util.stream.Collectors;
 
+import org.apache.accumulo.core.clientImpl.TableOperationsImpl;
 import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.ConditionalResult.Status;
@@ -67,5 +68,10 @@ public class DeleteOperationIds extends ManagerRepo {
     }
 
     return null;
+  }
+
+  @Override
+  public String getReturn() {
+    return TableOperationsImpl.SPLIT_SUCCESS_MSG;
   }
 }


### PR DESCRIPTION
Modifies the user API for adding splits to execute a fate operation instead of calling the tablet server.  Now user initiated splits can happen without having having to host a tablet.