### PR TITLE
More build updates to reduce warnings

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -34,7 +34,6 @@ Commands:
   start-here          Starts all services on this node
   stop-here           Stops all services on this node
 EOF
-  exit 1
 }
 
 function invalid_args {

--- a/assemble/bin/accumulo-service
+++ b/assemble/bin/accumulo-service
@@ -37,7 +37,6 @@ Commands:
   kill        Kills service
 
 EOF
-  exit 1
 }
 
 function invalid_args {

--- a/assemble/bin/accumulo-util
+++ b/assemble/bin/accumulo-util
@@ -28,7 +28,6 @@ Commands:
   gen-monitor-cert    Generates Accumulo monitor certificate
   
 EOF
-  exit 1
 }
 
 function build_native() {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -334,9 +334,8 @@
             </goals>
             <phase>prepare-package</phase>
             <configuration>
-              <executable>mkdir</executable>
+              <executable>${basedir}/src/main/scripts/mkdirs.sh</executable>
               <arguments>
-                <argument>-p</argument>
                 <argument>${project.build.directory}/generated-docs</argument>
               </arguments>
             </configuration>

--- a/core/src/main/scripts/generate-thrift.sh
+++ b/core/src/main/scripts/generate-thrift.sh
@@ -78,7 +78,7 @@ done
 # add dummy method to suppress "unnecessary suppress warnings" for classes which don't have any unused variables
 # this only affects classes, enums aren't affected
 #shellcheck disable=SC1004
-find $BUILD_DIR/gen-java -name '*.java' -exec grep -Zl '^public class ' {} + | xargs -0 sed -i -e 's/^[}]$/  private static void unusedMethod() {}\
+find "$BUILD_DIR/gen-java" -name '*.java' -exec grep -Zl '^public class ' {} + | xargs -0 sed -i -e 's/^[}]$/  private static void unusedMethod() {}\
 }/'
 
 for lang in "${LANGUAGES_TO_GENERATE[@]}"; do

--- a/core/src/main/scripts/mkdirs.sh
+++ b/core/src/main/scripts/mkdirs.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This script is a workaround for exec-maven-plugin's perpetual breakage
+# due to the `-p` flag being misinterpreted.
+# The latest iteration of this breakage is in 3.1.0
+# See:
+#   https://github.com/mojohaus/exec-maven-plugin/issues/334
+#   https://github.com/apache/accumulo/issues/3033
+mkdir -p "$@"

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -101,6 +101,10 @@
       <artifactId>zookeeper</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper-jute</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-remote-resources-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
@@ -809,6 +814,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
           <configuration>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
@@ -905,16 +911,14 @@
           <version>3.4.0</version>
         </plugin>
         <plugin>
-          <!-- 3.1.0 is broken https://github.com/mojohaus/exec-maven-plugin/issues/334 -->
-          <!-- problem tracked in https://github.com/apache/accumulo/issues/3033 -->
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>apilyzer-maven-plugin</artifactId>
-          <version>1.2.0</version>
+          <version>1.3.0</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
@@ -964,6 +968,16 @@
               <exclude>**/thrift/*.java</exclude>
             </excludes>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/server/monitor/pom.xml
+++ b/server/monitor/pom.xml
@@ -97,6 +97,10 @@
       <artifactId>log4j-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
     </dependency>


### PR DESCRIPTION
Reduce warnings at the end of the build from using Maven 3.9.2 by updating several plugins whose versions are specified in the parent POM to the latest, which resolves the warnings from Maven. Specifically, update maven-resources-plugin, maven-compiler-plugin, exec-maven-plugin, apilyzer-maven-plugin, maven-dependency-plugin, and maven-enforcer-plugin.

Update some dependency declarations, based on new detections from latest version of maven-dependency-plugin (specifically, zookeeper-jute in minicluster and libthrift in the monitor).

Updating exec-maven-plugin required addressing #3033 with a workaround, and testing the script added for that workaround caught some additional shellcheck issues in the assembly module's cluster management scripts (unreachable redundant exit command) and generate-thrift.sh (unquoted path variable). So those fixes are included here as well.

This fixes #3033.