### PR TITLE
Introduce new GC trash property, move duplicate methods to new class

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -873,8 +873,13 @@ public enum Property {
       "The listening port for the garbage collector's monitor service", "1.3.5"),
   GC_DELETE_THREADS("gc.threads.delete", "16", PropertyType.COUNT,
       "The number of threads used to delete RFiles and write-ahead logs", "1.3.5"),
+  @Deprecated(since = "2.1.1", forRemoval = true)
   GC_TRASH_IGNORE("gc.trash.ignore", "false", PropertyType.BOOLEAN,
       "Do not use the Trash, even if it is configured.", "1.5.0"),
+  GC_USE_TRASH("gc.use.trash", "true", PropertyType.STRING,
+      "Moves a file to the Trash (if available). Valid values are true, false, and bulk_imports_only."
+          + " Mutually exclusive with gc.trash.ignore.",
+      "2.1.1"),
   @Deprecated(since = "2.1.0", forRemoval = true)
   GC_TRACE_PERCENT("gc.trace.percent", "0.01", PropertyType.FRACTION,
       "Percent of gc cycles to trace", "1.7.0"),

--- a/server/gc/src/main/java/org/apache/accumulo/gc/FileJanitor.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/FileJanitor.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.gc;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.server.ServerContext;
+import org.apache.accumulo.server.fs.VolumeManager;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileJanitor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileJanitor.class);
+
+  enum SendFilesToTrash {
+
+    TRUE("true"), FALSE("false"), IMPORTS_ONLY("bulk_imports_only");
+
+    final String val;
+
+    SendFilesToTrash(String val) {
+      this.val = val;
+    }
+
+    public static SendFilesToTrash fromBoolean(boolean b) {
+      if (b) {
+        return TRUE;
+      }
+      return FALSE;
+    }
+
+    public static SendFilesToTrash fromString(String val) {
+      switch (val.toLowerCase()) {
+        case "true":
+          return TRUE;
+        case "false":
+          return FALSE;
+        case "bulk_imports_only":
+          return IMPORTS_ONLY;
+        default:
+          throw new IllegalArgumentException("Unknown value: " + val);
+      }
+    }
+  }
+
+  private final ServerContext context;
+  private final SendFilesToTrash usingTrash;
+
+  @SuppressWarnings("removal")
+  public FileJanitor(ServerContext context) {
+    this.context = context;
+    final AccumuloConfiguration conf = this.context.getConfiguration();
+    if (conf.isPropertySet(Property.GC_TRASH_IGNORE) && conf.isPropertySet(Property.GC_USE_TRASH)) {
+      throw new IllegalStateException("Cannot specify both " + Property.GC_TRASH_IGNORE.getKey()
+          + " and " + Property.GC_USE_TRASH.getKey() + " properties.");
+    }
+    if (conf.isPropertySet(Property.GC_TRASH_IGNORE)) {
+      this.usingTrash = SendFilesToTrash.fromBoolean(!conf.getBoolean(Property.GC_TRASH_IGNORE));
+    } else if (conf.isPropertySet(Property.GC_USE_TRASH)) {
+      this.usingTrash = SendFilesToTrash.fromString(conf.get(Property.GC_USE_TRASH));
+    } else {
+      LOG.warn(
+          "Neither GC trash property was set ({} or {}). Defaulting to using trash for all files (if available).",
+          Property.GC_TRASH_IGNORE.getKey(), Property.GC_USE_TRASH.getKey());
+      this.usingTrash = SendFilesToTrash.TRUE;
+    }
+  }
+
+  public ServerContext getContext() {
+    return this.context;
+  }
+
+  /**
+   * Moves a file to trash. If this garbage collector is not using trash, this method returns false
+   * and leaves the file alone. If the file is missing, this method returns false as opposed to
+   * throwing an exception.
+   *
+   * @return true if the file was moved to trash
+   * @throws IOException if the volume manager encountered a problem
+   */
+  public boolean moveToTrash(Path path) throws IOException {
+    final VolumeManager fs = getContext().getVolumeManager();
+
+    if (this.isUsingTrash() == SendFilesToTrash.FALSE) {
+      return false;
+    } else if (this.isUsingTrash() == SendFilesToTrash.IMPORTS_ONLY
+        && !path.getName().startsWith("I")) {
+      return false;
+    } else {
+      try {
+        return fs.moveToTrash(path);
+      } catch (FileNotFoundException ex) {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Checks if the volume manager should move files to the trash rather than delete them.
+   *
+   * @return true if trash is used
+   */
+  public SendFilesToTrash isUsingTrash() {
+    return this.usingTrash;
+  }
+
+}

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -68,7 +68,7 @@ public class GarbageCollectWriteAheadLogs {
 
   private final ServerContext context;
   private final VolumeManager fs;
-  private final boolean useTrash;
+  private final FileJanitor janitor;
   private final LiveTServerSet liveServers;
   private final WalStateManager walMarker;
   private final Iterable<TabletLocationState> store;
@@ -81,10 +81,10 @@ public class GarbageCollectWriteAheadLogs {
    * @param useTrash true to move files to trash rather than delete them
    */
   GarbageCollectWriteAheadLogs(final ServerContext context, final VolumeManager fs,
-      final LiveTServerSet liveServers, boolean useTrash) {
+      final LiveTServerSet liveServers, FileJanitor janitor) {
     this.context = context;
     this.fs = fs;
-    this.useTrash = useTrash;
+    this.janitor = janitor;
     this.liveServers = liveServers;
     this.walMarker = new WalStateManager(context);
     this.store = () -> Iterators.concat(
@@ -102,12 +102,12 @@ public class GarbageCollectWriteAheadLogs {
    * @param liveTServerSet a started LiveTServerSet instance
    */
   @VisibleForTesting
-  GarbageCollectWriteAheadLogs(ServerContext context, VolumeManager fs, boolean useTrash,
+  GarbageCollectWriteAheadLogs(ServerContext context, VolumeManager fs, FileJanitor janitor,
       LiveTServerSet liveTServerSet, WalStateManager walMarker,
       Iterable<TabletLocationState> store) {
     this.context = context;
     this.fs = fs;
-    this.useTrash = useTrash;
+    this.janitor = janitor;
     this.liveServers = liveTServerSet;
     this.walMarker = walMarker;
     this.store = store;
@@ -253,7 +253,7 @@ public class GarbageCollectWriteAheadLogs {
 
   private long removeFile(Path path) {
     try {
-      if (!useTrash || !fs.moveToTrash(path)) {
+      if (!janitor.moveToTrash(path)) {
         fs.deleteRecursively(path);
       }
       return 1;

--- a/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogs.java
@@ -78,7 +78,7 @@ public class GarbageCollectWriteAheadLogs {
    *
    * @param context the collection server's context
    * @param fs volume manager to use
-   * @param useTrash true to move files to trash rather than delete them
+   * @param janitor FileJanitor instance
    */
   GarbageCollectWriteAheadLogs(final ServerContext context, final VolumeManager fs,
       final LiveTServerSet liveServers, FileJanitor janitor) {
@@ -98,7 +98,7 @@ public class GarbageCollectWriteAheadLogs {
    *
    * @param context the collection server's context
    * @param fs volume manager to use
-   * @param useTrash true to move files to trash rather than delete them
+   * @param janitor FileJanitor instance
    * @param liveTServerSet a started LiveTServerSet instance
    */
   @VisibleForTesting

--- a/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/GarbageCollectWriteAheadLogsTest.java
@@ -108,8 +108,10 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expect(fs.deleteRecursively(path)).andReturn(true).once();
     marker.removeWalMarker(server1, id);
     EasyMock.expectLastCall().once();
-    EasyMock.replay(context, fs, marker, tserverSet);
-    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, false,
+    FileJanitor janitor = EasyMock.createMock(FileJanitor.class);
+    EasyMock.expect(janitor.moveToTrash(EasyMock.anyObject(Path.class))).andReturn(false);
+    EasyMock.replay(context, fs, marker, tserverSet, janitor);
+    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, janitor,
         tserverSet, marker, tabletOnServer1List) {
       @Override
       @Deprecated
@@ -141,8 +143,10 @@ public class GarbageCollectWriteAheadLogsTest {
 
     EasyMock.expect(marker.getAllMarkers()).andReturn(markers).once();
     EasyMock.expect(marker.state(server1, id)).andReturn(new Pair<>(WalState.CLOSED, path));
-    EasyMock.replay(context, marker, tserverSet, fs);
-    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, false,
+    FileJanitor janitor = EasyMock.createMock(FileJanitor.class);
+    EasyMock.expect(janitor.moveToTrash(EasyMock.anyObject(Path.class))).andReturn(false);
+    EasyMock.replay(context, marker, tserverSet, fs, janitor);
+    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, janitor,
         tserverSet, marker, tabletOnServer1List) {
       @Override
       @Deprecated
@@ -195,8 +199,10 @@ public class GarbageCollectWriteAheadLogsTest {
     EasyMock.expectLastCall().once();
     marker.forget(server2);
     EasyMock.expectLastCall().once();
-    EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, false,
+    FileJanitor janitor = EasyMock.createMock(FileJanitor.class);
+    EasyMock.expect(janitor.moveToTrash(EasyMock.anyObject(Path.class))).andReturn(false);
+    EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner, janitor);
+    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, janitor,
         tserverSet, marker, tabletOnServer1List) {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {
@@ -238,8 +244,10 @@ public class GarbageCollectWriteAheadLogsTest {
     mscanner.setRange(ReplicationSection.getRange());
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(emptyKV);
-    EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, false,
+    FileJanitor janitor = EasyMock.createMock(FileJanitor.class);
+    EasyMock.expect(janitor.moveToTrash(EasyMock.anyObject(Path.class))).andReturn(false);
+    EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner, janitor);
+    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, janitor,
         tserverSet, marker, tabletOnServer2List) {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {
@@ -286,8 +294,10 @@ public class GarbageCollectWriteAheadLogsTest {
     mscanner.setRange(ReplicationSection.getRange());
     EasyMock.expectLastCall().once();
     EasyMock.expect(mscanner.iterator()).andReturn(replicationWork.entrySet().iterator());
-    EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner);
-    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, false,
+    FileJanitor janitor = EasyMock.createMock(FileJanitor.class);
+    EasyMock.expect(janitor.moveToTrash(EasyMock.anyObject(Path.class))).andReturn(false);
+    EasyMock.replay(context, fs, marker, tserverSet, rscanner, mscanner, janitor);
+    GarbageCollectWriteAheadLogs gc = new GarbageCollectWriteAheadLogs(context, fs, janitor,
         tserverSet, marker, tabletOnServer1List) {
       @Override
       protected Map<UUID,Path> getSortedWALogs() {

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorNewPropertyTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorNewPropertyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.gc;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.partialMockBuilder;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.accumulo.core.conf.ConfigurationCopy;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.gc.FileJanitor.SendFilesToTrash;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+
+public class SimpleGarbageCollectorNewPropertyTest extends SimpleGarbageCollectorTest {
+
+  @Override
+  protected ConfigurationCopy createSystemConfig() {
+    Map<String,String> conf = new HashMap<>();
+    conf.put(Property.INSTANCE_RPC_SASL_ENABLED.getKey(), "false");
+    conf.put(Property.GC_CYCLE_START.getKey(), "1");
+    conf.put(Property.GC_CYCLE_DELAY.getKey(), "20");
+    conf.put(Property.GC_DELETE_THREADS.getKey(), "2");
+    conf.put(Property.GC_USE_TRASH.getKey(), "true");
+
+    return new ConfigurationCopy(conf);
+  }
+
+  @Test
+  public void testMoveToTrash_NotUsingTrash_importsOnlyEnabled() throws Exception {
+    systemConfig.set(Property.GC_USE_TRASH.getKey(), "bulk_imports_only");
+
+    gc = partialMockBuilder(SimpleGarbageCollector.class).addMockedMethod("getContext")
+        .addMockedMethod("getFileJanitor").createMock();
+    FileJanitor janitor = new FileJanitor(context);
+    expect(gc.getContext()).andReturn(context).anyTimes();
+    expect(gc.getFileJanitor()).andReturn(janitor).anyTimes();
+    replay(gc);
+
+    assertEquals(SendFilesToTrash.IMPORTS_ONLY, gc.getFileJanitor().isUsingTrash());
+    Path iFilePath = new Path("I0000070.rf");
+    Path iFileWithFullPath =
+        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/I0000070.rf");
+    Path notIFilePath = new Path("F0000070.rf");
+    Path notIFileWithFullPath =
+        new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf");
+    expect(volMgr.moveToTrash(iFilePath)).andReturn(true).times(1);
+    expect(volMgr.moveToTrash(iFileWithFullPath)).andReturn(true).times(1);
+    replay(volMgr);
+
+    assertTrue(gc.getFileJanitor().moveToTrash(iFilePath));
+    assertTrue(gc.getFileJanitor().moveToTrash(iFileWithFullPath));
+    assertFalse(gc.getFileJanitor().moveToTrash(notIFilePath));
+    assertFalse(gc.getFileJanitor().moveToTrash(notIFileWithFullPath));
+
+    verify(volMgr);
+  }
+
+}

--- a/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
+++ b/server/gc/src/test/java/org/apache/accumulo/gc/SimpleGarbageCollectorTest.java
@@ -65,7 +65,7 @@ public class SimpleGarbageCollectorTest {
   protected Credentials credentials;
   protected SimpleGarbageCollector gc;
   protected ConfigurationCopy systemConfig;
-  protected static SiteConfiguration siteConfig = SiteConfiguration.empty().build();
+  protected static final SiteConfiguration siteConfig = SiteConfiguration.empty().build();
 
   @BeforeEach
   public void setUp() {

--- a/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/RootFilesUpgradeTest.java
+++ b/server/manager/src/test/java/org/apache/accumulo/manager/upgrade/RootFilesUpgradeTest.java
@@ -78,6 +78,7 @@ public class RootFilesUpgradeTest extends WithTestNames {
       rename(fs, tmpDatafile, newDatafile);
     }
 
+    @SuppressWarnings("removal")
     public void finishReplacement(AccumuloConfiguration acuTableConf, VolumeManager fs,
         Path location, Set<Path> oldDatafiles, String compactName) throws IOException {
       // start deleting files, if we do not finish they will be cleaned

--- a/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/ScanServerMetadataEntriesIT.java
@@ -53,6 +53,7 @@ import org.apache.accumulo.core.metadata.schema.Ample.DataLevel;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.ScanServerFileReferenceSection;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.HostAndPort;
+import org.apache.accumulo.gc.FileJanitor;
 import org.apache.accumulo.gc.GCRun;
 import org.apache.accumulo.harness.MiniClusterConfigurationCallback;
 import org.apache.accumulo.harness.SharedMiniClusterBase;
@@ -209,7 +210,7 @@ public class ScanServerMetadataEntriesIT extends SharedMiniClusterBase {
   public void testGcRunScanServerReferences() throws Exception {
 
     ServerContext ctx = getCluster().getServerContext();
-    GCRun gc = new GCRun(DataLevel.USER, ctx);
+    GCRun gc = new GCRun(DataLevel.USER, ctx, new FileJanitor(ctx));
     try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
       final String tableName = getUniqueNames(1)[0];
 


### PR DESCRIPTION
This commit deprecates GC_TRASH_IGNORE in favor of GC_USE_TRASH. The description for the deprecated property and the way that it was used is confusing as it's written and used in the negative. If you want to use the Trash, you have to set it the property to "false". The new property works in the affirmative. Set it to "true" if you want to use the Trash, "false" if you don't. A third value, "bulk_imports_only" means that you only want to send bulk import files to the Trash.