### PR TITLE
Make sure existing file path is used for metadata updates

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -247,6 +247,8 @@ public interface Ample {
 
     TabletMutator putFile(TabletFile path, DataFileValue dfv);
 
+    TabletMutator putFile(StoredTabletFile path, DataFileValue dfv);
+
     TabletMutator deleteFile(StoredTabletFile path);
 
     TabletMutator putScan(TabletFile path);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -88,6 +88,14 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
+  public Ample.TabletMutator putFile(StoredTabletFile path, DataFileValue dfv) {
+    Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
+    mutation.put(DataFileColumnFamily.NAME, path.getMetaUpdateDeleteText(),
+        new Value(dfv.encode()));
+    return this;
+  }
+
+  @Override
   public Ample.TabletMutator deleteFile(StoredTabletFile path) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.putDelete(DataFileColumnFamily.NAME, path.getMetaUpdateDeleteText());

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -258,7 +258,7 @@ public class MetadataTableUtil {
     ChoppedColumnFamily.CHOPPED_COLUMN.putDelete(m);
 
     for (Entry<StoredTabletFile,DataFileValue> entry : datafileSizes.entrySet()) {
-      m.put(DataFileColumnFamily.NAME, entry.getKey().getMetaInsertText(),
+      m.put(DataFileColumnFamily.NAME, entry.getKey().getMetaUpdateDeleteText(),
           new Value(entry.getValue().encode()));
     }
 


### PR DESCRIPTION
This fixes instances identified in #3417 where updates to existing files in the metadata table were using the normalized path by mistake and not the existing path.