### PR TITLE
adds tests for file misnormalization

### DIFF
--- a/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
@@ -92,8 +92,7 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
       HashSet<String> paths = new HashSet<>();
 
       // uncomment verify and test will hang here because tablet server dies w/ uncaught exception
-      // in
-      // AssignmentHandler
+      // in AssignmentHandler
       //
       // VerifyIngest.verifyIngest(client, params);
 
@@ -144,7 +143,7 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
 
         assertEquals(1, filenames.size());
 
-        System.out.println(filenames);
+        VerifyIngest.verifyIngest(client, params);
       }
     }
   }
@@ -198,6 +197,8 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
 
       assertEquals(0, client.tableOperations().listSplits(table).size());
       assertEquals(filesBeforeMerge, filesAfterMerge);
+
+      VerifyIngest.verifyIngest(client, params);
     }
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.test.functional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.Accumulo;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
+import org.apache.accumulo.core.security.TablePermission;
+import org.apache.accumulo.harness.SharedMiniClusterBase;
+import org.apache.accumulo.test.TestIngest;
+import org.apache.accumulo.test.VerifyIngest;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * These test check that Accumulo handles misnormalized files in the metadata table correctly. If
+ * Accumulo code reads a misnormalized file from the metadata table, normalizes it, and then tries
+ * to update the metadata table then the key will not match. The mismatch could result in duplicate
+ * entries.
+ */
+public class FileNormalizationIT extends SharedMiniClusterBase {
+
+  private static final Logger log = LoggerFactory.getLogger(FileNormalizationIT.class);
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    SharedMiniClusterBase.startMiniCluster();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    SharedMiniClusterBase.stopMiniCluster();
+  }
+
+  @Test
+  public void testSplits() throws Exception {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+
+      client.tableOperations().create(table);
+      VerifyIngest.VerifyParams params =
+          new VerifyIngest.VerifyParams(getClientProps(), table, 100_000);
+      TestIngest.ingest(client, params);
+
+      client.tableOperations().flush(table, null, null, true);
+
+      misnormalizeFiles(client, table);
+
+      var splits = TestIngest.getSplitPoints(params.startRow, params.startRow + params.rows, 2);
+      assertEquals(1, splits.size());
+
+      client.tableOperations().addSplits(table, splits);
+
+      HashSet<String> paths = new HashSet<>();
+
+      // uncomment verify and test will hang here because tablet server dies w/ uncaught exception
+      // in
+      // AssignmentHandler
+      //
+      // VerifyIngest.verifyIngest(client, params);
+
+      try (var scanner = createMetadataFileScanner(client, table)) {
+        scanner.forEach((k, v) -> {
+          var row = k.getRowData().toString();
+          var qual = k.getColumnQualifierData().toString();
+          var path = new Path(qual).toString();
+          var rowPath = row + "+" + path;
+
+          log.debug("split test, inspecting {} {} {}", row, qual, v);
+
+          assertFalse(paths.contains(rowPath),
+              "Tablet " + row + " has duplicate normalized path " + path);
+          paths.add(rowPath);
+        });
+      }
+
+      VerifyIngest.verifyIngest(client, params);
+    }
+  }
+
+  @Test
+  public void testCompaction() throws Exception {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+
+      client.tableOperations().create(table);
+      VerifyIngest.VerifyParams params =
+          new VerifyIngest.VerifyParams(getClientProps(), table, 100_000);
+      TestIngest.ingest(client, params);
+
+      client.tableOperations().flush(table, null, null, true);
+
+      misnormalizeFiles(client, table);
+
+      client.tableOperations().compact(table, new CompactionConfig().setWait(true));
+
+      try (var scanner = createMetadataFileScanner(client, table)) {
+        Set<String> filenames = new HashSet<>();
+
+        scanner.forEach((k, v) -> {
+          var path = new Path(k.getColumnQualifierData().toString());
+          assertFalse(filenames.contains(path.getName()));
+          assertTrue(path.getName().startsWith("A"));
+          filenames.add(path.getName());
+        });
+
+        assertEquals(1, filenames.size());
+
+        System.out.println(filenames);
+      }
+    }
+  }
+
+  @Test
+  public void testMerge() throws Exception {
+    try (AccumuloClient client = Accumulo.newClient().from(getClientProps()).build()) {
+      String table = getUniqueNames(1)[0];
+
+      // disable compactions
+      Map<String,String> props = Map.of(Property.TABLE_MAJC_RATIO.getKey(), "10");
+      client.tableOperations().create(table, new NewTableConfiguration().setProperties(props));
+      VerifyIngest.VerifyParams params =
+          new VerifyIngest.VerifyParams(getClientProps(), table, 100_000);
+      TestIngest.ingest(client, params);
+
+      client.tableOperations().flush(table, null, null, true);
+
+      var splits = TestIngest.getSplitPoints(params.startRow, params.startRow + params.rows, 4);
+      assertEquals(3, splits.size());
+
+      client.tableOperations().addSplits(table, splits);
+
+      // create a unique file per tablet
+      client.tableOperations().compact(table, new CompactionConfig().setWait(true));
+
+      misnormalizeFiles(client, table);
+
+      Set<String> filesBeforeMerge = new HashSet<>();
+      try (var scanner = createMetadataFileScanner(client, table)) {
+        scanner.forEach((k, v) -> {
+          var qual = k.getColumnQualifierData().toString();
+          assertTrue(qual.contains("//tables//"));
+          filesBeforeMerge.add(qual);
+        });
+      }
+
+      // expect 4 files. one for each tablet
+      assertEquals(4, filesBeforeMerge.size());
+
+      client.tableOperations().merge(table, null, null);
+
+      Set<String> filesAfterMerge = new HashSet<>();
+      try (var scanner = createMetadataFileScanner(client, table)) {
+        scanner.forEach((k, v) -> {
+          // should only see the default tablet
+          assertTrue(k.getRow().toString().endsWith("<"));
+          filesAfterMerge.add(k.getColumnQualifierData().toString());
+        });
+      }
+
+      assertEquals(0, client.tableOperations().listSplits(table).size());
+      assertEquals(filesBeforeMerge, filesAfterMerge);
+    }
+  }
+
+  private Scanner createMetadataFileScanner(AccumuloClient client, String table) throws Exception {
+    var scanner = client.createScanner(MetadataTable.NAME);
+    var tableId = TableId.of(client.tableOperations().tableIdMap().get(table));
+    var range = new KeyExtent(tableId, null, null).toMetaRange();
+    scanner.setRange(range);
+    scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
+    return scanner;
+  }
+
+  private Set<String> misnormalizeFiles(AccumuloClient client, String table) throws Exception {
+    client.tableOperations().offline(table, true);
+
+    client.securityOperations().grantTablePermission(getPrincipal(), MetadataTable.NAME,
+        TablePermission.WRITE);
+
+    try (var scanner = createMetadataFileScanner(client, table);
+        var writer = client.createBatchWriter(MetadataTable.NAME)) {
+      scanner.forEach((k, v) -> {
+        Mutation m = new Mutation(k.getRow());
+        var qual = k.getColumnQualifierData().toString();
+        assertTrue(qual.contains("/tables/"));
+        var newQual = new Text(qual.replace("/tables/", "//tables//"));
+        m.put(k.getColumnFamily(), newQual, v);
+        m.putDelete(k.getColumnFamily(), k.getColumnQualifier());
+        try {
+          writer.addMutation(m);
+        } catch (MutationsRejectedException e) {
+          throw new RuntimeException(e);
+        }
+      });
+    } finally {
+      client.securityOperations().revokeTablePermission(getPrincipal(), MetadataTable.NAME,
+          TablePermission.WRITE);
+      client.tableOperations().online(table, true);
+    }
+
+    return Set.of();
+  }
+}

--- a/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
@@ -91,10 +91,7 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
 
       HashSet<String> paths = new HashSet<>();
 
-      // uncomment verify and test will hang here because tablet server dies w/ uncaught exception
-      // in AssignmentHandler
-      //
-      // VerifyIngest.verifyIngest(client, params);
+      VerifyIngest.verifyIngest(client, params);
 
       try (var scanner = createMetadataFileScanner(client, table)) {
         scanner.forEach((k, v) -> {

--- a/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/FileNormalizationIT.java
@@ -211,7 +211,7 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
     return scanner;
   }
 
-  private Set<String> misnormalizeFiles(AccumuloClient client, String table) throws Exception {
+  private void misnormalizeFiles(AccumuloClient client, String table) throws Exception {
     client.tableOperations().offline(table, true);
 
     client.securityOperations().grantTablePermission(getPrincipal(), MetadataTable.NAME,
@@ -237,7 +237,5 @@ public class FileNormalizationIT extends SharedMiniClusterBase {
           TablePermission.WRITE);
       client.tableOperations().online(table, true);
     }
-
-    return Set.of();
   }
 }


### PR DESCRIPTION
Adds a test for misnormalized files in the metadata table.  The test currently does not run because splits do not handle misnormalized files.  The split code will duplicate files in the existing tablet when it tries to update the estimated size.  Surprisingly the duplicated files causes the tserver to crash on tablet assignment.

Seeing the following error when the tserver tries to load a tablet with duplicated files entries (multiple entries that normalize to the same path).

```
2023-05-26T17:56:22,089 [tserver.AssignmentHandler] WARN : Failed to verify tablet 1<;row_0000050000
java.lang.IllegalArgumentException: Multiple entries with same key: file:/home/ubuntu/git/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.FileNormalizationIT_SharedMiniClusterBase/accumulo/tables/1/defa
ult_tablet/F000003x.rf=24146 4802 and file:/home/ubuntu/git/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.FileNormalizationIT_SharedMiniClusterBase/accumulo/tables/1/default_tablet/F000003x.rf=24146 4
802
        at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:377) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:371) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:241) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.RegularImmutableMap.fromEntryArrayCheckingBucketOverflow(RegularImmutableMap.java:132) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:94) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:573) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:601) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:588) ~[guava-31.1-jre.jar:?]
        at org.apache.accumulo.core.metadata.schema.TabletMetadata.convertRow(TabletMetadata.java:500) ~[classes/:?]
        at org.apache.accumulo.core.metadata.schema.TabletsMetadata$Builder.lambda$buildNonRoot$8(TabletsMetadata.java:217) ~[classes/:?]
        at com.google.common.collect.Iterators$6.transform(Iterators.java:829) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.Iterators$5.computeNext(Iterators.java:672) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:146) ~[guava-31.1-jre.jar:?]
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:141) ~[guava-31.1-jre.jar:?]
        at java.util.Iterator.forEachRemaining(Iterator.java:132) ~[?:?]
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
        at org.apache.accumulo.core.metadata.schema.AmpleImpl.readTablet(AmpleImpl.java:48) ~[classes/:?]
        at org.apache.accumulo.core.metadata.schema.Ample.readTablet(Ample.java:144) ~[classes/:?]
        at org.apache.accumulo.tserver.AssignmentHandler.run(AssignmentHandler.java:110) [classes/:?]
        at org.apache.accumulo.tserver.ActiveAssignmentRunnable.run(ActiveAssignmentRunnable.java:63) [classes/:?]
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52) [classes/:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52) [classes/:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
2023-05-26T17:56:22,090 [threads.AccumuloUncaughtExceptionHandler] ERROR: Caught an Exception in Thread[tablet assignment-Worker-4,5,main]. Thread is dead.
java.lang.RuntimeException: java.lang.IllegalArgumentException: Multiple entries with same key: file:/home/ubuntu/git/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.FileNormalizationIT_SharedMiniCluste
rBase/accumulo/tables/1/default_tablet/F000003x.rf=24146 4802 and file:/home/ubuntu/git/accumulo/test/target/mini-tests/org.apache.accumulo.test.functional.FileNormalizationIT_SharedMiniClusterBase/accumulo/tables/1/defaul
t_tablet/F000003x.rf=24146 4802
        at org.apache.accumulo.tserver.AssignmentHandler.run(AssignmentHandler.java:142) ~[classes/:?]
        at org.apache.accumulo.tserver.ActiveAssignmentRunnable.run(ActiveAssignmentRunnable.java:63) ~[classes/:?]
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52) ~[classes/:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at org.apache.accumulo.core.trace.TraceWrappedRunnable.run(TraceWrappedRunnable.java:52) ~[classes/:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
``` 

The above needs investigation of its own, should an exception in the assignment handler kill the tserver?