### PR TITLE
reduces metadata reads and caches hosting request in client tablet cache

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCache.java
@@ -276,34 +276,39 @@ public abstract class ClientTabletCache {
     private final String tserverLocation;
     private final String tserverSession;
     private final TabletHostingGoal goal;
+    private final boolean hostingRequested;
+
     private final Long creationTime = System.nanoTime();
 
     public CachedTablet(KeyExtent tablet_extent, String tablet_location, String session,
-        TabletHostingGoal goal) {
+        TabletHostingGoal goal, boolean hostingRequested) {
       checkArgument(tablet_extent != null, "tablet_extent is null");
       checkArgument(tablet_location != null, "tablet_location is null");
       checkArgument(session != null, "session is null");
       this.tablet_extent = tablet_extent;
       this.tserverLocation = interner.intern(tablet_location);
       this.tserverSession = interner.intern(session);
-      this.goal = goal;
+      this.goal = Objects.requireNonNull(goal);
+      this.hostingRequested = hostingRequested;
     }
 
     public CachedTablet(KeyExtent tablet_extent, Optional<String> tablet_location,
-        Optional<String> session, TabletHostingGoal goal) {
+        Optional<String> session, TabletHostingGoal goal, boolean hostingRequested) {
       checkArgument(tablet_extent != null, "tablet_extent is null");
       this.tablet_extent = tablet_extent;
       this.tserverLocation = tablet_location.map(interner::intern).orElse(null);
       this.tserverSession = session.map(interner::intern).orElse(null);
-      this.goal = goal;
+      this.goal = Objects.requireNonNull(goal);
+      this.hostingRequested = hostingRequested;
     }
 
-    public CachedTablet(KeyExtent tablet_extent, TabletHostingGoal goal) {
+    public CachedTablet(KeyExtent tablet_extent, TabletHostingGoal goal, boolean hostingRequested) {
       checkArgument(tablet_extent != null, "tablet_extent is null");
       this.tablet_extent = tablet_extent;
       this.tserverLocation = null;
       this.tserverSession = null;
-      this.goal = goal;
+      this.goal = Objects.requireNonNull(goal);
+      this.hostingRequested = hostingRequested;
     }
 
     @Override
@@ -312,14 +317,15 @@ public abstract class ClientTabletCache {
         CachedTablet otl = (CachedTablet) o;
         return getExtent().equals(otl.getExtent())
             && getTserverLocation().equals(otl.getTserverLocation())
-            && getTserverSession().equals(otl.getTserverSession()) && getGoal() == otl.getGoal();
+            && getTserverSession().equals(otl.getTserverSession()) && getGoal() == otl.getGoal()
+            && hostingRequested == otl.hostingRequested;
       }
       return false;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(getExtent(), tserverLocation, tserverSession, goal);
+      return Objects.hash(getExtent(), tserverLocation, tserverSession, goal, hostingRequested);
     }
 
     @Override
@@ -352,6 +358,10 @@ public abstract class ClientTabletCache {
 
     public Duration getAge() {
       return Duration.ofNanos(System.nanoTime() - creationTime);
+    }
+
+    public boolean wasHostingRequested() {
+      return hostingRequested;
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImpl.java
@@ -19,8 +19,6 @@
 package org.apache.accumulo.core.clientImpl;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_GOAL;
-import static org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType.HOSTING_REQUESTED;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -33,7 +31,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -59,8 +56,6 @@ import org.apache.accumulo.core.dataImpl.thrift.TKeyExtent;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.metadata.MetadataTable;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.schema.TabletMetadata;
-import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.core.rpc.clients.ThriftClientTypes;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.core.util.OpTimer;
@@ -71,8 +66,6 @@ import org.apache.hadoop.io.WritableComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -112,9 +105,6 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
   private final Lock rLock = rwLock.readLock();
   private final Lock wLock = rwLock.writeLock();
   private final AtomicLong tabletHostingRequestCount = new AtomicLong(0);
-
-  private final Cache<KeyExtent,Long> recentOndemandRequest =
-      Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(30)).build();
 
   public interface CachedTabletObtainer {
     /**
@@ -235,7 +225,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
       rLock.unlock();
     }
 
-    List<KeyExtent> locationLess = new ArrayList<>();
+    HashSet<CachedTablet> locationLess = new HashSet<>();
 
     if (!notInCache.isEmpty()) {
       notInCache.sort((o1, o2) -> WritableComparator.compareBytes(o1.getRow(), 0,
@@ -253,7 +243,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
           if (!addMutation(binnedMutations, mutation, tl, lcSession)) {
             failures.add(mutation);
             if (tl != null && tl.getTserverLocation().isEmpty()) {
-              locationLess.add(tl.getExtent());
+              locationLess.add(tl);
             }
           }
         }
@@ -323,8 +313,9 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
 
   private List<Range> findTablets(ClientContext context, List<Range> ranges,
       BiConsumer<CachedTablet,Range> rangeConsumer, boolean useCache, LockCheckerSession lcSession,
-      LocationNeed locationNeed, Consumer<KeyExtent> locationlessConsumer) throws AccumuloException,
-      AccumuloSecurityException, TableNotFoundException, InvalidTabletHostingRequestException {
+      LocationNeed locationNeed, Consumer<CachedTablet> locationlessConsumer)
+      throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
+      InvalidTabletHostingRequestException {
     List<Range> failures = new ArrayList<>();
     List<CachedTablet> cachedTablets = new ArrayList<>();
 
@@ -375,7 +366,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
 
       // pass all tablets without a location before failing range
       cachedTablets.stream().filter(tloc -> tloc.getTserverLocation().isEmpty())
-          .map(CachedTablet::getExtent).forEach(locationlessConsumer);
+          .forEach(locationlessConsumer);
 
       if (locationNeed == LocationNeed.REQUIRED
           && !cachedTablets.stream().allMatch(tloc -> tloc.getTserverLocation().isPresent())) {
@@ -443,8 +434,8 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
 
       // use a hashset because some ranges may overlap the same extent, so want to avoid duplicate
       // extents
-      HashSet<KeyExtent> locationLess = new HashSet<>();
-      Consumer<KeyExtent> locationLessConsumer;
+      HashSet<CachedTablet> locationLess = new HashSet<>();
+      Consumer<CachedTablet> locationLessConsumer;
       if (locationNeed == LocationNeed.REQUIRED) {
         locationLessConsumer = locationLess::add;
       } else {
@@ -566,7 +557,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     }
 
     if (tl != null && locationNeed == LocationNeed.REQUIRED && tl.getTserverLocation().isEmpty()) {
-      requestTabletHosting(context, List.of(tl.getExtent()));
+      requestTabletHosting(context, List.of(tl));
       return null;
     }
 
@@ -589,8 +580,10 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
     HOSTING_ENABLED.set(enabled);
   }
 
+  private static final Duration STALE_DURATION = Duration.ofMinutes(2);
+
   private void requestTabletHosting(ClientContext context,
-      Collection<KeyExtent> extentsWithNoLocation) throws AccumuloException,
+      Collection<CachedTablet> tabletsWithNoLocation) throws AccumuloException,
       AccumuloSecurityException, TableNotFoundException, InvalidTabletHostingRequestException {
 
     if (!HOSTING_ENABLED.get()) {
@@ -602,7 +595,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
       return;
     }
 
-    if (extentsWithNoLocation.isEmpty()) {
+    if (tabletsWithNoLocation.isEmpty()) {
       return;
     }
 
@@ -611,35 +604,36 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
       return;
     }
 
-    List<KeyExtent> extentsToLookup = new ArrayList<>();
-    for (var extent : extentsWithNoLocation) {
-      if (recentOndemandRequest.asMap().putIfAbsent(extent, System.currentTimeMillis()) == null) {
-        extentsToLookup.add(extent);
-        log.debug("Marking tablet as onDemand: {}", extent);
-      }
-    }
-
     List<TKeyExtent> extentsToBringOnline = new ArrayList<>();
-
-    try (TabletsMetadata tm =
-        context.getAmple().readTablets().forTablets(extentsToLookup, Optional.empty())
-            .fetch(HOSTING_REQUESTED, HOSTING_GOAL).build()) {
-
-      for (TabletMetadata tabletMetadata : tm) {
-        if (tabletMetadata.getHostingGoal() == TabletHostingGoal.ONDEMAND
-            && !tabletMetadata.getHostingRequested()) {
-          extentsToBringOnline.add(tabletMetadata.getExtent().toThrift());
-        }
-
-        if (tabletMetadata.getHostingGoal() == TabletHostingGoal.NEVER) {
-          throw new InvalidTabletHostingRequestException("Extent " + tabletMetadata.getExtent()
+    for (var cachedTablet : tabletsWithNoLocation) {
+      if (cachedTablet.getAge().compareTo(STALE_DURATION) < 0) {
+        if (cachedTablet.getGoal() == TabletHostingGoal.ONDEMAND) {
+          if (!cachedTablet.wasHostingRequested()) {
+            extentsToBringOnline.add(cachedTablet.getExtent().toThrift());
+            log.trace("requesting ondemand tablet to be hosted {}", cachedTablet.getExtent());
+          } else {
+            log.trace("ignoring ondemand tablet that already has a hosting request in place {} {}",
+                cachedTablet.getExtent(), cachedTablet.getAge());
+          }
+        } else if (cachedTablet.getGoal() == TabletHostingGoal.NEVER) {
+          throw new InvalidTabletHostingRequestException("Extent " + cachedTablet.getExtent()
               + " has a tablet hosting goal state " + TabletHostingGoal.NEVER);
         }
+      } else {
+        // When a tablet does not have a location it is reread from the metadata table before this
+        // method is called. Therefore, it's expected that entries in the cache are recent. If the
+        // entries are not recent it could have two causes. One is a bug in the Accumulo code.
+        // Another is externalities like process swapping or slow metadata table reads. Logging a
+        // warning in case there is a bug. If the warning ends up being too spammy and is caused by
+        // externalities then this code/warning will need to be improved.
+        log.warn("Unexpected stale tablet seen in cache {}", cachedTablet.getExtent());
+        invalidateCache(cachedTablet.getExtent());
       }
     }
 
     if (!extentsToBringOnline.isEmpty()) {
-      log.debug("Requesting tablets be hosted: {}", extentsToBringOnline);
+      log.debug("Requesting hosting for {} ondemand tablets for table id {}.",
+          extentsToBringOnline.size(), tableId);
       ThriftClientTypes.TABLET_MGMT.executeVoid(context,
           client -> client.requestTabletHosting(TraceUtil.traceInfo(), context.rpcCreds(),
               tableId.canonical(), extentsToBringOnline));
@@ -693,7 +687,7 @@ public class ClientTabletCacheImpl extends ClientTabletCache {
             && ke.prevEndRow().equals(lastEndRow)) {
           locToCache = new CachedTablet(new KeyExtent(ke.tableId(), ke.endRow(), lastEndRow),
               cachedTablet.getTserverLocation(), cachedTablet.getTserverSession(),
-              cachedTablet.getGoal());
+              cachedTablet.getGoal(), cachedTablet.wasHostingRequested());
         } else {
           locToCache = cachedTablet;
         }

--- a/core/src/main/java/org/apache/accumulo/core/clientImpl/RootClientTabletCache.java
+++ b/core/src/main/java/org/apache/accumulo/core/clientImpl/RootClientTabletCache.java
@@ -124,16 +124,17 @@ public class RootClientTabletCache extends ClientTabletCache {
 
     if (loc == null || loc.getType() != LocationType.CURRENT) {
       return new CachedTablet(RootTable.EXTENT, Optional.empty(), Optional.empty(),
-          TabletHostingGoal.ALWAYS);
+          TabletHostingGoal.ALWAYS, false);
     }
 
     String server = loc.getHostPort();
 
     if (lockChecker.isLockHeld(server, loc.getSession())) {
-      return new CachedTablet(RootTable.EXTENT, server, loc.getSession(), TabletHostingGoal.ALWAYS);
+      return new CachedTablet(RootTable.EXTENT, server, loc.getSession(), TabletHostingGoal.ALWAYS,
+          false);
     } else {
       return new CachedTablet(RootTable.EXTENT, Optional.empty(), Optional.empty(),
-          TabletHostingGoal.ALWAYS);
+          TabletHostingGoal.ALWAYS, false);
     }
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/MetadataCachedTabletObtainer.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/MetadataCachedTabletObtainer.java
@@ -80,6 +80,7 @@ public class MetadataCachedTabletObtainer implements CachedTabletObtainer {
     locCols.add(new Column(TextUtil.getBytes(CurrentLocationColumnFamily.NAME), null, null));
     locCols.add(TabletColumnFamily.PREV_ROW_COLUMN.toColumn());
     locCols.add(HostingColumnFamily.GOAL_COLUMN.toColumn());
+    locCols.add(HostingColumnFamily.REQUESTED_COLUMN.toColumn());
     columns = new ArrayList<>(locCols);
   }
 
@@ -222,6 +223,7 @@ public class MetadataCachedTabletObtainer implements CachedTabletObtainer {
     Text location = null;
     Text session = null;
     TabletHostingGoal goal = null;
+    boolean hostingRequested = false;
 
     List<CachedTablet> results = new ArrayList<>();
 
@@ -239,6 +241,7 @@ public class MetadataCachedTabletObtainer implements CachedTabletObtainer {
         location = null;
         session = null;
         goal = null;
+        hostingRequested = false;
         key.getRow(lastRowFromKey);
       }
 
@@ -255,18 +258,18 @@ public class MetadataCachedTabletObtainer implements CachedTabletObtainer {
         session = new Text(colq);
       } else if (HostingColumnFamily.GOAL_COLUMN.equals(colf, colq)) {
         goal = TabletHostingGoalUtil.fromValue(val);
+      } else if (HostingColumnFamily.REQUESTED_COLUMN.equals(colf, colq)) {
+        hostingRequested = true;
       } else if (TabletColumnFamily.PREV_ROW_COLUMN.equals(colf, colq)) {
         KeyExtent ke = KeyExtent.fromMetaPrevRow(entry);
         if (ke.isMeta()) {
           goal = TabletHostingGoal.ALWAYS;
-        } else if (goal == null) {
-          log.debug("TabletHostingGoal not set for extent: {}, using ONDEMAND", ke);
-          goal = TabletHostingGoal.ONDEMAND;
         }
         if (location != null) {
-          results.add(new CachedTablet(ke, location.toString(), session.toString(), goal));
+          results.add(new CachedTablet(ke, location.toString(), session.toString(), goal,
+              hostingRequested));
         } else {
-          results.add(new CachedTablet(ke, goal));
+          results.add(new CachedTablet(ke, goal, hostingRequested));
         }
         location = null;
       }

--- a/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImplTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/clientImpl/ClientTabletCacheImplTest.java
@@ -138,7 +138,7 @@ public class ClientTabletCacheImplTest {
     for (int i = 0; i < data.length; i += 2) {
       KeyExtent ke = (KeyExtent) data[i];
       String loc = (String) data[i + 1];
-      mcke.put(ke, new CachedTablet(ke, loc, "1", TabletHostingGoal.ONDEMAND));
+      mcke.put(ke, new CachedTablet(ke, loc, "1", TabletHostingGoal.ONDEMAND, false));
     }
 
     return mcke;
@@ -607,7 +607,7 @@ public class ClientTabletCacheImplTest {
     @Override
     protected CachedTablet getRootTabletLocation(ClientContext context) {
       return new CachedTablet(RootTable.EXTENT, context.getRootTabletLocation(), "1",
-          TabletHostingGoal.ALWAYS);
+          TabletHostingGoal.ALWAYS, false);
     }
 
     @Override
@@ -1231,13 +1231,13 @@ public class ClientTabletCacheImplTest {
   @Test
   public void testIsContiguous() {
     CachedTablet e1 = new CachedTablet(createNewKeyExtent("foo", "1", null), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
     CachedTablet e2 = new CachedTablet(createNewKeyExtent("foo", "2", "1"), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
     CachedTablet e3 = new CachedTablet(createNewKeyExtent("foo", "3", "2"), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
     CachedTablet e4 = new CachedTablet(createNewKeyExtent("foo", null, "3"), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
 
     assertTrue(ClientTabletCacheImpl.isContiguous(List.of(e1, e2, e3, e4)));
     assertTrue(ClientTabletCacheImpl.isContiguous(List.of(e1, e2, e3)));
@@ -1251,7 +1251,7 @@ public class ClientTabletCacheImplTest {
     assertFalse(ClientTabletCacheImpl.isContiguous(List.of(e1, e3, e4)));
 
     CachedTablet e5 = new CachedTablet(createNewKeyExtent("foo", null, null), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
     assertFalse(ClientTabletCacheImpl.isContiguous(List.of(e1, e2, e3, e4, e5)));
     assertFalse(ClientTabletCacheImpl.isContiguous(List.of(e5, e1, e2, e3, e4)));
     assertFalse(ClientTabletCacheImpl.isContiguous(List.of(e1, e2, e3, e5)));
@@ -1259,12 +1259,12 @@ public class ClientTabletCacheImplTest {
     assertTrue(ClientTabletCacheImpl.isContiguous(List.of(e5)));
 
     CachedTablet e6 = new CachedTablet(createNewKeyExtent("foo", null, "1"), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
 
     assertFalse(ClientTabletCacheImpl.isContiguous(List.of(e1, e2, e3, e6)));
 
     CachedTablet e7 = new CachedTablet(createNewKeyExtent("foo", "33", "11"), "l1", "1",
-        TabletHostingGoal.ONDEMAND);
+        TabletHostingGoal.ONDEMAND, false);
 
     assertFalse(ClientTabletCacheImpl.isContiguous(List.of(e1, e2, e7, e4)));
   }
@@ -1757,9 +1757,9 @@ public class ClientTabletCacheImplTest {
     var failures = metaCache.findTablets(context, ranges, (tl, r) -> actual.add(new Pair<>(tl, r)),
         LocationNeed.NOT_REQUIRED);
     assertEquals(List.of(), failures);
-    var tl1 = new CachedTablet(ke1, TabletHostingGoal.ONDEMAND);
-    var tl2 = new CachedTablet(ke2, TabletHostingGoal.ONDEMAND);
-    var tl3 = new CachedTablet(ke3, "L2", "I2", TabletHostingGoal.ONDEMAND);
+    var tl1 = new CachedTablet(ke1, TabletHostingGoal.ONDEMAND, false);
+    var tl2 = new CachedTablet(ke2, TabletHostingGoal.ONDEMAND, false);
+    var tl3 = new CachedTablet(ke3, "L2", "I2", TabletHostingGoal.ONDEMAND, false);
     var expected =
         Set.of(new Pair<>(tl1, r1), new Pair<>(tl1, r2), new Pair<>(tl2, r2), new Pair<>(tl3, r2));
     assertEquals(expected, actual);
@@ -1786,7 +1786,7 @@ public class ClientTabletCacheImplTest {
     failures = metaCache.findTablets(context, ranges, (tl, r) -> actual.add(new Pair<>(tl, r)),
         LocationNeed.NOT_REQUIRED);
     assertEquals(List.of(), failures);
-    tl1 = new CachedTablet(ke1, "L3", "I3", TabletHostingGoal.ONDEMAND);
+    tl1 = new CachedTablet(ke1, "L3", "I3", TabletHostingGoal.ONDEMAND, false);
     expected =
         Set.of(new Pair<>(tl1, r1), new Pair<>(tl1, r2), new Pair<>(tl2, r2), new Pair<>(tl3, r2));
     assertEquals(expected, actual);
@@ -1795,7 +1795,7 @@ public class ClientTabletCacheImplTest {
     failures = metaCache.findTablets(context, ranges, (tl, r) -> actual.add(new Pair<>(tl, r)),
         LocationNeed.REQUIRED);
     assertEquals(List.of(), failures);
-    tl2 = new CachedTablet(ke2, "L4", "I4", TabletHostingGoal.ONDEMAND);
+    tl2 = new CachedTablet(ke2, "L4", "I4", TabletHostingGoal.ONDEMAND, false);
     expected =
         Set.of(new Pair<>(tl1, r1), new Pair<>(tl1, r2), new Pair<>(tl2, r2), new Pair<>(tl3, r2));
     assertEquals(expected, actual);

--- a/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/BulkSplitOptimizationIT.java
@@ -109,7 +109,7 @@ public class BulkSplitOptimizationIT extends AccumuloClusterHarness {
       Thread.sleep(SECONDS.toMillis(2));
 
       // wait until over split threshold -- should be 78 splits
-      while (c.tableOperations().listSplits(tableName).size() < 75) {
+      while (c.tableOperations().listSplits(tableName).size() < 50) {
         Thread.sleep(500);
       }
 


### PR DESCRIPTION
The code to host a tablet was reading from the metdata table to gather a tablets hosting goal. The hosting goal was already present in the cache. Used the value from the cache instead of reading from the metadata table again.

Also added the hosting request column to the tablet cache and removed a specialized caffine cache that was related to this.  Moving it into the tablet cache will help avoid request when other client processes have already made the request, the specialized caffine cache was not enabling this case.

fixes #3304