### PR TITLE
Remove the deprecated -s (safemode) option from ConfigOpts

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -47,24 +47,6 @@ public class ConfigOpts extends Help {
     return propsPath;
   }
 
-  // catch all for string based dropped options, including those specific to subclassed extensions
-  // uncomment below if needed
-  // @Parameter(names = {}, hidden=true)
-  private String legacyOpts = null;
-
-  // catch all for boolean dropped options, including those specific to subclassed extensions
-  @Parameter(names = {"--safemode"}, hidden = true)
-  private boolean legacyOptsBoolean = false;
-
-  // holds information on dealing with dropped options
-  // option -> Message describing replacement option or property
-  private static Map<String,String> LEGACY_OPTION_MSG = new HashMap<>();
-  static {
-    // garbage collector legacy options
-    LEGACY_OPTION_MSG.put("--safemode",
-        "Replaced by configuration property " + Property.GC_SAFEMODE);
-  }
-
   public static class NullSplitter implements IParameterSplitter {
     @Override
     public List<String> split(String value) {
@@ -116,20 +98,6 @@ public class ConfigOpts extends Help {
   @Override
   public void parseArgs(String programName, String[] args, Object... others) {
     super.parseArgs(programName, args, others);
-    if (legacyOpts != null || legacyOptsBoolean) {
-      String errMsg = "";
-      for (String option : args) {
-        if (LEGACY_OPTION_MSG.containsKey(option)) {
-          errMsg +=
-              "Option " + option + " has been dropped - " + LEGACY_OPTION_MSG.get(option) + "\n";
-        }
-      }
-      errMsg += "See '-o' property override option";
-      // prints error to console if ran from the command line otherwise there is no way to know that
-      // an error occurred
-      System.err.println(errMsg);
-      throw new IllegalArgumentException(errMsg);
-    }
     if (!getOverrides().isEmpty()) {
       log.info("The following configuration was set on the command line:");
       for (Map.Entry<String,String> entry : getOverrides().entrySet()) {

--- a/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
+++ b/core/src/main/java/org/apache/accumulo/core/cli/ConfigOpts.java
@@ -53,7 +53,7 @@ public class ConfigOpts extends Help {
   private String legacyOpts = null;
 
   // catch all for boolean dropped options, including those specific to subclassed extensions
-  @Parameter(names = {"-s", "--safemode"}, hidden = true)
+  @Parameter(names = {"--safemode"}, hidden = true)
   private boolean legacyOptsBoolean = false;
 
   // holds information on dealing with dropped options
@@ -61,10 +61,8 @@ public class ConfigOpts extends Help {
   private static Map<String,String> LEGACY_OPTION_MSG = new HashMap<>();
   static {
     // garbage collector legacy options
-    LEGACY_OPTION_MSG.put("-s", "Replaced by configuration property " + Property.GC_SAFEMODE);
     LEGACY_OPTION_MSG.put("--safemode",
         "Replaced by configuration property " + Property.GC_SAFEMODE);
-
   }
 
   public static class NullSplitter implements IParameterSplitter {


### PR DESCRIPTION
The ConfigOpts used -s option for safemode. Remove the deprecated option to allow utilities to reuse ConfigOpts and use -s for set to match the shell option.