### PR TITLE
Rename TabletFile to ReferencedTabletFile

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/BloomFilterLayer.java
@@ -49,7 +49,7 @@ import org.apache.accumulo.core.file.keyfunctor.KeyFunctor;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.util.threads.ThreadPools;
@@ -477,7 +477,7 @@ public class BloomFilterLayer {
     String suffix = FileOperations.getNewFileExtension(acuconf);
     String fname = "/tmp/test." + suffix;
     FileSKVWriter bmfw = FileOperations.getInstance().newWriterBuilder()
-        .forFile(new TabletFile(new Path(fname)), fs, conf, NoCryptoServiceFactory.NONE)
+        .forFile(new ReferencedTabletFile(new Path(fname)), fs, conf, NoCryptoServiceFactory.NONE)
         .withTableConfiguration(acuconf).build();
 
     long t1 = System.currentTimeMillis();
@@ -500,7 +500,7 @@ public class BloomFilterLayer {
 
     t1 = System.currentTimeMillis();
     FileSKVIterator bmfr = FileOperations.getInstance().newReaderBuilder()
-        .forFile(new TabletFile(new Path(fname)), fs, conf, NoCryptoServiceFactory.NONE)
+        .forFile(new ReferencedTabletFile(new Path(fname)), fs, conf, NoCryptoServiceFactory.NONE)
         .withTableConfiguration(acuconf).build();
     t2 = System.currentTimeMillis();
     out.println("Opened " + fname + " in " + (t2 - t1));

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ReferencedTabletFile.java
@@ -40,18 +40,18 @@ import com.google.common.base.Preconditions;
  * As of 2.1, Tablet file paths should now be only absolute URIs with the removal of relative paths
  * in Upgrader9to10.upgradeRelativePaths()
  */
-public class TabletFile extends AbstractTabletFile<TabletFile> {
+public class ReferencedTabletFile extends AbstractTabletFile<ReferencedTabletFile> {
   // parts of an absolute URI, like "hdfs://1.2.3.4/accumulo/tables/2a/t-0003/C0004.rf"
   private final TabletDirectory tabletDir; // hdfs://1.2.3.4/accumulo/tables/2a/t-0003
   private final String normalizedPath;
 
-  private static final Logger log = LoggerFactory.getLogger(TabletFile.class);
+  private static final Logger log = LoggerFactory.getLogger(ReferencedTabletFile.class);
 
   /**
    * Construct new tablet file using a Path. Used in the case where we had to use Path object to
    * qualify an absolute path or create a new file.
    */
-  public TabletFile(Path metaPath) {
+  public ReferencedTabletFile(Path metaPath) {
     super(Objects.requireNonNull(metaPath));
     String errorMsg = "Missing or invalid part of tablet file metadata entry: " + metaPath;
     log.trace("Parsing TabletFile from {}", metaPath);
@@ -116,7 +116,7 @@ public class TabletFile extends AbstractTabletFile<TabletFile> {
   }
 
   @Override
-  public int compareTo(TabletFile o) {
+  public int compareTo(ReferencedTabletFile o) {
     if (equals(o)) {
       return 0;
     } else {
@@ -126,8 +126,8 @@ public class TabletFile extends AbstractTabletFile<TabletFile> {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof TabletFile) {
-      TabletFile that = (TabletFile) obj;
+    if (obj instanceof ReferencedTabletFile) {
+      ReferencedTabletFile that = (ReferencedTabletFile) obj;
       return normalizedPath.equals(that.normalizedPath);
     }
     return false;
@@ -143,8 +143,8 @@ public class TabletFile extends AbstractTabletFile<TabletFile> {
     return normalizedPath;
   }
 
-  public static TabletFile of(final Path path) {
-    return new TabletFile(path);
+  public static ReferencedTabletFile of(final Path path) {
+    return new ReferencedTabletFile(path);
   }
 
 }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/ScanServerRefTabletFile.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 
-public class ScanServerRefTabletFile extends TabletFile {
+public class ScanServerRefTabletFile extends ReferencedTabletFile {
 
   private final Value NULL_VALUE = new Value(new byte[0]);
   private final Text colf;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/StoredTabletFile.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.io.Text;
  */
 public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   private final String metadataEntry;
-  private final TabletFile tabletFile;
+  private final ReferencedTabletFile referencedTabletFile;
 
   /**
    * Construct a tablet file using the string read from the metadata. Preserve the exact string so
@@ -46,7 +46,7 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
   public StoredTabletFile(String metadataEntry) {
     super(new Path(metadataEntry));
     this.metadataEntry = metadataEntry;
-    this.tabletFile = TabletFile.of(getPath());
+    this.referencedTabletFile = ReferencedTabletFile.of(getPath());
   }
 
   /**
@@ -65,16 +65,16 @@ public class StoredTabletFile extends AbstractTabletFile<StoredTabletFile> {
     return new Text(getMetaUpdateDelete());
   }
 
-  public TabletFile getTabletFile() {
-    return tabletFile;
+  public ReferencedTabletFile getTabletFile() {
+    return referencedTabletFile;
   }
 
   public TableId getTableId() {
-    return tabletFile.getTableId();
+    return referencedTabletFile.getTableId();
   }
 
   public String getNormalizedPathStr() {
-    return tabletFile.getNormalizedPathStr();
+    return referencedTabletFile.getNormalizedPathStr();
   }
 
   /**

--- a/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/UnreferencedTabletFile.java
@@ -33,8 +33,8 @@ import org.apache.hadoop.fs.Path;
  * added to a tablet later as a new file reference, but within a different scope (process, thread,
  * code block, method, etc.) that uses a different class to represent the file in that scope.
  *
- * Unlike {@link TabletFile}, this class does not perform any validation or normalization on the
- * provided path.
+ * Unlike {@link ReferencedTabletFile}, this class does not perform any validation or normalization
+ * on the provided path.
  *
  * @since 3.0.0
  */

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/Ample.java
@@ -29,11 +29,11 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.ScanServerRefTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
@@ -218,7 +218,7 @@ public interface Ample {
   /**
    * Return an encoded delete marker Mutation to delete the specified TabletFile path. A
    * ReferenceFile is used for the parameter because the Garbage Collector is optimized to store a
-   * directory for Tablet File. Otherwise, a {@link TabletFile} object could be used. The
+   * directory for Tablet File. Otherwise, a {@link ReferencedTabletFile} object could be used. The
    * tabletFilePathToRemove is validated and normalized before creating the mutation.
    *
    * @param tabletFilePathToRemove String full path of the TabletFile
@@ -245,7 +245,7 @@ public interface Ample {
   interface TabletMutator {
     TabletMutator putPrevEndRow(Text per);
 
-    TabletMutator putFile(TabletFile path, DataFileValue dfv);
+    TabletMutator putFile(ReferencedTabletFile path, DataFileValue dfv);
 
     TabletMutator putFile(StoredTabletFile path, DataFileValue dfv);
 
@@ -275,9 +275,9 @@ public interface Ample {
 
     TabletMutator putTime(MetadataTime time);
 
-    TabletMutator putBulkFile(TabletFile bulkref, long tid);
+    TabletMutator putBulkFile(ReferencedTabletFile bulkref, long tid);
 
-    TabletMutator deleteBulkFile(TabletFile bulkref);
+    TabletMutator deleteBulkFile(ReferencedTabletFile bulkref);
 
     TabletMutator putChopped();
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/schema/ExternalCompactionMetadata.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.spi.compaction.CompactionExecutorId;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.util.compaction.CompactionExecutorIdImpl;
@@ -40,7 +40,7 @@ public class ExternalCompactionMetadata {
 
   private final Set<StoredTabletFile> jobFiles;
   private final Set<StoredTabletFile> nextFiles;
-  private final TabletFile compactTmpName;
+  private final ReferencedTabletFile compactTmpName;
   private final String compactorId;
   private final CompactionKind kind;
   private final short priority;
@@ -50,7 +50,7 @@ public class ExternalCompactionMetadata {
   private final Long compactionId;
 
   public ExternalCompactionMetadata(Set<StoredTabletFile> jobFiles, Set<StoredTabletFile> nextFiles,
-      TabletFile compactTmpName, String compactorId, CompactionKind kind, short priority,
+      ReferencedTabletFile compactTmpName, String compactorId, CompactionKind kind, short priority,
       CompactionExecutorId ceid, boolean propagateDeletes, boolean initiallySelectedAll,
       Long compactionId) {
     if (!initiallySelectedAll && !propagateDeletes
@@ -79,7 +79,7 @@ public class ExternalCompactionMetadata {
     return nextFiles;
   }
 
-  public TabletFile getCompactTmpName() {
+  public ReferencedTabletFile getCompactTmpName() {
     return compactTmpName;
   }
 
@@ -149,9 +149,10 @@ public class ExternalCompactionMetadata {
     return new ExternalCompactionMetadata(
         jData.inputs.stream().map(StoredTabletFile::new).collect(toSet()),
         jData.nextFiles.stream().map(StoredTabletFile::new).collect(toSet()),
-        new TabletFile(new Path(jData.tmp)), jData.compactor, CompactionKind.valueOf(jData.kind),
-        jData.priority, CompactionExecutorIdImpl.externalId(jData.executorId), jData.propDels,
-        jData.selectedAll, jData.compactionId);
+        new ReferencedTabletFile(new Path(jData.tmp)), jData.compactor,
+        CompactionKind.valueOf(jData.kind), jData.priority,
+        CompactionExecutorIdImpl.externalId(jData.executorId), jData.propDels, jData.selectedAll,
+        jData.compactionId);
   }
 
   @Override

--- a/core/src/test/java/org/apache/accumulo/core/metadata/schema/ReferencedTabletFileTest.java
+++ b/core/src/test/java/org/apache/accumulo/core/metadata/schema/ReferencedTabletFileTest.java
@@ -22,16 +22,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.junit.jupiter.api.Test;
 
-public class TabletFileTest {
+public class ReferencedTabletFileTest {
 
-  private TabletFile test(String metadataEntry, String volume, String tableId, String tabletDir,
-      String fileName) {
+  private ReferencedTabletFile test(String metadataEntry, String volume, String tableId,
+      String tabletDir, String fileName) {
     StoredTabletFile storedTabletFile = new StoredTabletFile(metadataEntry);
-    TabletFile tabletFile = storedTabletFile.getTabletFile();
+    ReferencedTabletFile tabletFile = storedTabletFile.getTabletFile();
 
     assertEquals(volume, tabletFile.getVolume());
     assertEquals(metadataEntry, storedTabletFile.getMetaUpdateDelete());
@@ -100,9 +100,9 @@ public class TabletFileTest {
   public void testNormalizePath() {
     String uglyVolume = "hdfs://nn.somewhere.com:86753/accumulo/blah/.././/bad/bad2/../.././/////";
     String metadataEntry = uglyVolume + "/tables/" + id + "/" + dir + "/" + filename;
-    TabletFile uglyFile =
+    ReferencedTabletFile uglyFile =
         test(metadataEntry, "hdfs://nn.somewhere.com:86753/accumulo", id, dir, filename);
-    TabletFile niceFile = StoredTabletFile
+    ReferencedTabletFile niceFile = StoredTabletFile
         .of("hdfs://nn.somewhere.com:86753/accumulo/tables/" + id + "/" + dir + "/" + filename)
         .getTabletFile();
     assertEquals(niceFile, uglyFile);

--- a/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/compaction/FileCompactor.java
@@ -55,9 +55,9 @@ import org.apache.accumulo.core.iteratorsImpl.system.DeletingIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.InterruptibleIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.tabletserver.thrift.TCompactionReason;
@@ -107,7 +107,7 @@ public class FileCompactor implements Callable<CompactionStats> {
   }
 
   private final Map<StoredTabletFile,DataFileValue> filesToCompact;
-  private final TabletFile outputFile;
+  private final ReferencedTabletFile outputFile;
   private final boolean propagateDeletes;
   private final AccumuloConfiguration acuTableConf;
   private final CompactionEnv env;
@@ -165,9 +165,9 @@ public class FileCompactor implements Callable<CompactionStats> {
   }
 
   public FileCompactor(ServerContext context, KeyExtent extent,
-      Map<StoredTabletFile,DataFileValue> files, TabletFile outputFile, boolean propagateDeletes,
-      CompactionEnv env, List<IteratorSetting> iterators, AccumuloConfiguration tableConfiguation,
-      CryptoService cs, PausedCompactionMetrics metrics) {
+      Map<StoredTabletFile,DataFileValue> files, ReferencedTabletFile outputFile,
+      boolean propagateDeletes, CompactionEnv env, List<IteratorSetting> iterators,
+      AccumuloConfiguration tableConfiguation, CryptoService cs, PausedCompactionMetrics metrics) {
     this.context = context;
     this.extent = extent;
     this.fs = context.getVolumeManager();

--- a/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/fs/VolumeUtil.java
@@ -26,8 +26,8 @@ import java.util.TreeMap;
 
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.lock.ServiceLock;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
 import org.apache.accumulo.core.util.Pair;
@@ -144,7 +144,7 @@ public class VolumeUtil {
     List<LogEntry> logsToAdd = new ArrayList<>();
 
     List<StoredTabletFile> filesToRemove = new ArrayList<>();
-    SortedMap<TabletFile,DataFileValue> filesToAdd = new TreeMap<>();
+    SortedMap<ReferencedTabletFile,DataFileValue> filesToAdd = new TreeMap<>();
 
     TabletFiles ret = new TabletFiles();
 
@@ -166,7 +166,7 @@ public class VolumeUtil {
       Path switchedPath = switchVolume(metaPath, FileType.TABLE, replacements);
       if (switchedPath != null) {
         filesToRemove.add(entry.getKey());
-        TabletFile switchedFile = new TabletFile(switchedPath);
+        ReferencedTabletFile switchedFile = new ReferencedTabletFile(switchedPath);
         filesToAdd.put(switchedFile, entry.getValue());
         ret.datafiles.put(switchedFile.insert(), entry.getValue());
         log.debug("Replacing volume {} : {} -> {}", extent, metaPath, switchedPath);

--- a/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/init/FileSystemInitializer.java
@@ -41,8 +41,8 @@ import org.apache.accumulo.core.fate.zookeeper.ZooReaderWriter;
 import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.metadata.schema.MetadataTime;
@@ -165,7 +165,7 @@ class FileSystemInitializer {
     for (Tablet tablet : tablets) {
       createEntriesForTablet(sorted, tablet);
     }
-    TabletFile file = TabletFile.of(new Path(fileName));
+    ReferencedTabletFile file = ReferencedTabletFile.of(new Path(fileName));
     FileSystem fs = volmanager.getFileSystemByPath(file.getPath());
 
     CryptoService cs = CryptoFactoryLoader.getServiceForServer(conf);

--- a/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/metadata/TabletMutatorBase.java
@@ -23,10 +23,10 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.fate.FateTxId;
 import org.apache.accumulo.core.lock.ServiceLock;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.SuspendingTServer;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -81,7 +81,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putFile(TabletFile path, DataFileValue dfv) {
+  public Ample.TabletMutator putFile(ReferencedTabletFile path, DataFileValue dfv) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.put(DataFileColumnFamily.NAME, path.getMetaInsertText(), new Value(dfv.encode()));
     return this;
@@ -195,7 +195,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator putBulkFile(TabletFile bulkref, long tid) {
+  public Ample.TabletMutator putBulkFile(ReferencedTabletFile bulkref, long tid) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.put(BulkFileColumnFamily.NAME, bulkref.getMetaInsertText(),
         new Value(FateTxId.formatTid(tid)));
@@ -203,7 +203,7 @@ public abstract class TabletMutatorBase implements Ample.TabletMutator {
   }
 
   @Override
-  public Ample.TabletMutator deleteBulkFile(TabletFile bulkref) {
+  public Ample.TabletMutator deleteBulkFile(ReferencedTabletFile bulkref) {
     Preconditions.checkState(updatesEnabled, "Cannot make updates after calling mutate.");
     mutation.putDelete(BulkFileColumnFamily.NAME, bulkref.getMetaInsertText());
     return this;

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -45,7 +45,7 @@ import org.apache.accumulo.core.file.rfile.RFileOperations;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.metadata.AbstractTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
@@ -570,7 +570,8 @@ public class FileUtil {
    * Convert TabletFiles to Strings in case we need to reduce number of files. The temporary files
    * used will have irregular paths that don't conform to TabletFile verification.
    */
-  public static Collection<String> toPathStrings(Collection<TabletFile> files) {
-    return files.stream().map(TabletFile::getNormalizedPathStr).collect(Collectors.toList());
+  public static Collection<String> toPathStrings(Collection<ReferencedTabletFile> files) {
+    return files.stream().map(ReferencedTabletFile::getNormalizedPathStr)
+        .collect(Collectors.toList());
   }
 }

--- a/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/ManagerMetadataUtil.java
@@ -45,9 +45,9 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -72,7 +72,7 @@ public class ManagerMetadataUtil {
 
   public static void addNewTablet(ServerContext context, KeyExtent extent, String dirName,
       TServerInstance tServerInstance, Map<StoredTabletFile,DataFileValue> datafileSizes,
-      Map<Long,? extends Collection<TabletFile>> bulkLoadedFiles, MetadataTime time,
+      Map<Long,? extends Collection<ReferencedTabletFile>> bulkLoadedFiles, MetadataTime time,
       long lastFlushID, long lastCompactID, ServiceLock zooLock) {
 
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
@@ -96,8 +96,9 @@ public class ManagerMetadataUtil {
 
     datafileSizes.forEach((key, value) -> tablet.putFile(key.getTabletFile(), value));
 
-    for (Entry<Long,? extends Collection<TabletFile>> entry : bulkLoadedFiles.entrySet()) {
-      for (TabletFile ref : entry.getValue()) {
+    for (Entry<Long,? extends Collection<ReferencedTabletFile>> entry : bulkLoadedFiles
+        .entrySet()) {
+      for (ReferencedTabletFile ref : entry.getValue()) {
         tablet.putBulkFile(ref, entry.getKey());
       }
     }
@@ -224,7 +225,7 @@ public class ManagerMetadataUtil {
    * Update tablet file data from flush. Returns a StoredTabletFile if there are data entries.
    */
   public static Optional<StoredTabletFile> updateTabletDataFile(ServerContext context,
-      KeyExtent extent, TabletFile newDatafile, DataFileValue dfv, MetadataTime time,
+      KeyExtent extent, ReferencedTabletFile newDatafile, DataFileValue dfv, MetadataTime time,
       String address, ServiceLock zooLock, Set<String> unusedWalLogs, Location lastLocation,
       long flushId) {
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/MetadataTableUtil.java
@@ -64,9 +64,9 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.gc.ReferenceFile;
 import org.apache.accumulo.core.lock.ServiceLock;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
@@ -181,7 +181,7 @@ public class MetadataTableUtil {
   }
 
   public static Map<StoredTabletFile,DataFileValue> updateTabletDataFile(long tid, KeyExtent extent,
-      Map<TabletFile,DataFileValue> estSizes, MetadataTime time, ServerContext context,
+      Map<ReferencedTabletFile,DataFileValue> estSizes, MetadataTime time, ServerContext context,
       ServiceLock zooLock) {
     TabletMutator tablet = context.getAmple().mutateTablet(extent);
     tablet.putTime(time);
@@ -210,7 +210,8 @@ public class MetadataTableUtil {
 
   public static void updateTabletVolumes(KeyExtent extent, List<LogEntry> logsToRemove,
       List<LogEntry> logsToAdd, List<StoredTabletFile> filesToRemove,
-      SortedMap<TabletFile,DataFileValue> filesToAdd, ServiceLock zooLock, ServerContext context) {
+      SortedMap<ReferencedTabletFile,DataFileValue> filesToAdd, ServiceLock zooLock,
+      ServerContext context) {
 
     TabletMutator tabletMutator = context.getAmple().mutateTablet(extent);
     logsToRemove.forEach(tabletMutator::deleteWal);

--- a/server/base/src/test/java/org/apache/accumulo/server/util/TableDiskUsageTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/TableDiskUsageTest.java
@@ -37,8 +37,8 @@ import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema;
 import org.apache.accumulo.core.security.Authorizations;
@@ -276,20 +276,22 @@ public class TableDiskUsageTest {
     return tableIdToNameMap.get(tableId);
   }
 
-  private static void appendFileMetadata(Map<Key,Value> tableEntries, TabletFile file, long size) {
+  private static void appendFileMetadata(Map<Key,Value> tableEntries, ReferencedTabletFile file,
+      long size) {
     tableEntries.put(
         new Key(new Text(file.getTableId() + "<"),
             MetadataSchema.TabletsSection.DataFileColumnFamily.NAME, file.getMetaInsertText()),
         new DataFileValue(size, 1).encodeAsValue());
   }
 
-  private static TabletFile getTabletFile(String volume, TableId tableId, String tablet,
+  private static ReferencedTabletFile getTabletFile(String volume, TableId tableId, String tablet,
       String fileName) {
-    return new TabletFile(new Path(
+    return new ReferencedTabletFile(new Path(
         volume + Constants.HDFS_TABLES_DIR + "/" + tableId + "/" + tablet + "/" + fileName));
   }
 
-  private static TabletFile getTabletFile(TableId tableId, String tablet, String fileName) {
+  private static ReferencedTabletFile getTabletFile(TableId tableId, String tablet,
+      String fileName) {
     return getTabletFile(volume1, tableId, tablet, fileName);
   }
 

--- a/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
+++ b/server/compactor/src/main/java/org/apache/accumulo/compactor/Compactor.java
@@ -70,8 +70,8 @@ import org.apache.accumulo.core.lock.ServiceLock.LockLossReason;
 import org.apache.accumulo.core.lock.ServiceLock.LockWatcher;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -503,7 +503,8 @@ public class Compactor extends AbstractServer implements MetricsProducer, Compac
           aConfig = tConfig;
         }
 
-        final TabletFile outputFile = new TabletFile(new Path(job.getOutputFile()));
+        final ReferencedTabletFile outputFile =
+            new ReferencedTabletFile(new Path(job.getOutputFile()));
 
         final Map<StoredTabletFile,DataFileValue> files = new TreeMap<>();
         job.getFiles().forEach(f -> {

--- a/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
+++ b/server/manager/src/main/java/org/apache/accumulo/manager/tableOps/bulkVer2/LoadFiles.java
@@ -49,8 +49,8 @@ import org.apache.accumulo.core.fate.Repo;
 import org.apache.accumulo.core.manager.state.tables.TableState;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.DataFileColumnFamily;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata;
@@ -221,14 +221,14 @@ class LoadFiles extends ManagerRepo {
           server = location.getHostAndPort();
         }
 
-        Set<TabletFile> loadedFiles = tablet.getLoaded().keySet().stream()
+        Set<ReferencedTabletFile> loadedFiles = tablet.getLoaded().keySet().stream()
             .map(StoredTabletFile::getTabletFile).collect(Collectors.toSet());
 
         Map<String,DataFileInfo> thriftImports = new HashMap<>();
 
         for (final Bulk.FileInfo fileInfo : files) {
           Path fullPath = new Path(bulkDir, fileInfo.getFileName());
-          TabletFile bulkFile = new TabletFile(fullPath);
+          ReferencedTabletFile bulkFile = new ReferencedTabletFile(fullPath);
 
           if (!loadedFiles.contains(bulkFile)) {
             thriftImports.put(fileInfo.getFileName(), new DataFileInfo(fileInfo.getEstFileSize()));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletClientHandler.java
@@ -77,8 +77,8 @@ import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.thrift.BulkImportState;
 import org.apache.accumulo.core.manager.thrift.TabletServerStatus;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.RootTable;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.securityImpl.thrift.TCredentials;
@@ -174,16 +174,16 @@ public class TabletClientHandler implements TabletServerClientService.Iface,
 
     watcher.runQuietly(Constants.BULK_ARBITRATOR_TYPE, tid, () -> {
       tabletImports.forEach((tke, fileMap) -> {
-        Map<TabletFile,DataFileInfo> newFileMap = new HashMap<>();
+        Map<ReferencedTabletFile,DataFileInfo> newFileMap = new HashMap<>();
 
         for (Entry<String,DataFileInfo> mapping : fileMap.entrySet()) {
           Path path = new Path(dir, mapping.getKey());
           FileSystem ns = context.getVolumeManager().getFileSystemByPath(path);
           path = ns.makeQualified(path);
-          newFileMap.put(new TabletFile(path), mapping.getValue());
+          newFileMap.put(new ReferencedTabletFile(path), mapping.getValue());
         }
-        var files =
-            newFileMap.keySet().stream().map(TabletFile::getNormalizedPathStr).collect(toList());
+        var files = newFileMap.keySet().stream().map(ReferencedTabletFile::getNormalizedPathStr)
+            .collect(toList());
         server.updateBulkImportState(files, BulkImportState.INITIAL);
 
         Tablet importTablet = server.getOnlineTablet(KeyExtent.fromThrift(tke));

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ExternalCompactionJob.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/compactions/ExternalCompactionJob.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.iteratorsImpl.system.SystemIteratorUtil;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
@@ -41,7 +41,7 @@ public class ExternalCompactionJob {
 
   private Map<StoredTabletFile,DataFileValue> jobFiles;
   private boolean propagateDeletes;
-  private TabletFile compactTmpName;
+  private ReferencedTabletFile compactTmpName;
   private KeyExtent extent;
   private ExternalCompactionId externalCompactionId;
   private CompactionKind kind;
@@ -52,7 +52,7 @@ public class ExternalCompactionJob {
   public ExternalCompactionJob() {}
 
   public ExternalCompactionJob(Map<StoredTabletFile,DataFileValue> jobFiles,
-      boolean propagateDeletes, TabletFile compactTmpName, KeyExtent extent,
+      boolean propagateDeletes, ReferencedTabletFile compactTmpName, KeyExtent extent,
       ExternalCompactionId externalCompactionId, CompactionKind kind, List<IteratorSetting> iters,
       Long userCompactionId, Map<String,String> overrides) {
     this.jobFiles = Objects.requireNonNull(jobFiles);

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableImpl.java
@@ -52,8 +52,8 @@ import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.logging.TabletLogger;
 import org.apache.accumulo.core.manager.thrift.TabletLoadState;
 import org.apache.accumulo.core.metadata.CompactableFileImpl;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
@@ -1280,7 +1280,7 @@ public class CompactableImpl implements Compactable {
       TabletLogger.compacting(getExtent(), job, cInfo.localCompactionCfg);
       tablet.incrementStatusMajor();
       var check = new CompactionCheck(service, kind, cInfo.checkCompactionId);
-      TabletFile tmpFileName = tablet.getNextDataFilenameForMajc(cInfo.propagateDeletes);
+      ReferencedTabletFile tmpFileName = tablet.getNextDataFilenameForMajc(cInfo.propagateDeletes);
       var compactEnv = new MajCEnv(kind, check, readLimiter, writeLimiter, cInfo.propagateDeletes);
 
       SortedMap<StoredTabletFile,DataFileValue> allFiles = tablet.getDatafiles();
@@ -1323,7 +1323,8 @@ public class CompactableImpl implements Compactable {
       Map<String,String> overrides =
           CompactableUtils.getOverrides(job.getKind(), tablet, cInfo.localHelper, job.getFiles());
 
-      TabletFile compactTmpName = tablet.getNextDataFilenameForMajc(cInfo.propagateDeletes);
+      ReferencedTabletFile compactTmpName =
+          tablet.getNextDataFilenameForMajc(cInfo.propagateDeletes);
 
       ExternalCompactionInfo ecInfo = new ExternalCompactionInfo();
 

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/CompactableUtils.java
@@ -58,8 +58,8 @@ import org.apache.accumulo.core.file.FileOperations;
 import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.metadata.CompactableFileImpl;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.spi.common.ServiceEnvironment;
@@ -283,7 +283,8 @@ public class CompactableUtils {
           FileSystem ns = tablet.getTabletServer().getVolumeManager().getFileSystemByPath(path);
           var tableConf = tablet.getTableConfiguration();
           var fiter = fileFactory.newReaderBuilder()
-              .forFile(TabletFile.of(path), ns, ns.getConf(), tableConf.getCryptoService())
+              .forFile(ReferencedTabletFile.of(path), ns, ns.getConf(),
+                  tableConf.getCryptoService())
               .withTableConfiguration(tableConf).seekToBeginning().build();
           return Optional.ofNullable(fiter.getSample(new SamplerConfigurationImpl(sc)));
         } catch (IOException e) {
@@ -421,7 +422,7 @@ public class CompactableUtils {
    */
   static CompactionStats compact(Tablet tablet, CompactionJob job,
       CompactableImpl.CompactionInfo cInfo, CompactionEnv cenv,
-      Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile tmpFileName)
+      Map<StoredTabletFile,DataFileValue> compactFiles, ReferencedTabletFile tmpFileName)
       throws IOException, CompactionCanceledException {
     TableConfiguration tableConf = tablet.getTableConfiguration();
 
@@ -440,7 +441,7 @@ public class CompactableUtils {
    */
   static Optional<StoredTabletFile> bringOnline(DatafileManager datafileManager,
       CompactableImpl.CompactionInfo cInfo, CompactionStats stats,
-      Map<StoredTabletFile,DataFileValue> compactFiles, TabletFile compactTmpName)
+      Map<StoredTabletFile,DataFileValue> compactFiles, ReferencedTabletFile compactTmpName)
       throws IOException {
 
     var dfv = new DataFileValue(stats.getFileSize(), stats.getEntriesWritten());
@@ -448,7 +449,7 @@ public class CompactableUtils {
         cInfo.checkCompactionId, cInfo.selectedFiles, dfv, Optional.empty());
   }
 
-  public static TabletFile computeCompactionFileDest(TabletFile tmpFile) {
+  public static ReferencedTabletFile computeCompactionFileDest(ReferencedTabletFile tmpFile) {
     String newFilePath = tmpFile.getMetaInsert();
     int idx = newFilePath.indexOf("_tmp");
     if (idx > 0) {
@@ -457,7 +458,7 @@ public class CompactableUtils {
       throw new IllegalArgumentException(
           "Expected compaction tmp file " + tmpFile.getMetaInsert() + " to have suffix '_tmp'");
     }
-    return new TabletFile(new Path(newFilePath));
+    return new ReferencedTabletFile(new Path(newFilePath));
   }
 
 }

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/DatafileManager.java
@@ -38,8 +38,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
 import org.apache.accumulo.core.logging.TabletLogger;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.Location;
@@ -209,14 +209,14 @@ class DatafileManager {
     return inUse;
   }
 
-  public Collection<StoredTabletFile> importDataFiles(long tid, Map<TabletFile,DataFileValue> paths,
-      boolean setTime) throws IOException {
+  public Collection<StoredTabletFile> importDataFiles(long tid,
+      Map<ReferencedTabletFile,DataFileValue> paths, boolean setTime) throws IOException {
 
     String bulkDir = null;
     // once tablet files are inserted into the metadata they will become StoredTabletFiles
     Map<StoredTabletFile,DataFileValue> newFiles = new HashMap<>(paths.size());
 
-    for (TabletFile tpath : paths.keySet()) {
+    for (ReferencedTabletFile tpath : paths.keySet()) {
       boolean inTheRightDirectory = false;
       Path parent = tpath.getPath().getParent().getParent();
       for (String tablesDir : tablet.getContext().getTablesDirs()) {
@@ -293,8 +293,9 @@ class DatafileManager {
    * entries so was not inserted into the metadata. In this case empty is returned. If the file was
    * stored in the metadata table, then StoredTableFile will be returned.
    */
-  Optional<StoredTabletFile> bringMinorCompactionOnline(TabletFile tmpDatafile,
-      TabletFile newDatafile, DataFileValue dfv, CommitSession commitSession, long flushId) {
+  Optional<StoredTabletFile> bringMinorCompactionOnline(ReferencedTabletFile tmpDatafile,
+      ReferencedTabletFile newDatafile, DataFileValue dfv, CommitSession commitSession,
+      long flushId) {
     Optional<StoredTabletFile> newFile;
     // rename before putting in metadata table, so files in metadata table should
     // always exist
@@ -395,13 +396,13 @@ class DatafileManager {
   }
 
   Optional<StoredTabletFile> bringMajorCompactionOnline(Set<StoredTabletFile> oldDatafiles,
-      TabletFile tmpDatafile, Long compactionId, Set<StoredTabletFile> selectedFiles,
+      ReferencedTabletFile tmpDatafile, Long compactionId, Set<StoredTabletFile> selectedFiles,
       DataFileValue dfv, Optional<ExternalCompactionId> ecid) throws IOException {
     final KeyExtent extent = tablet.getExtent();
     VolumeManager vm = tablet.getTabletServer().getContext().getVolumeManager();
     long t1, t2;
 
-    TabletFile newDatafile = CompactableUtils.computeCompactionFileDest(tmpDatafile);
+    ReferencedTabletFile newDatafile = CompactableUtils.computeCompactionFileDest(tmpDatafile);
 
     if (vm.exists(newDatafile.getPath())) {
       log.error("Target data file already exist " + newDatafile, new Exception());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactionTask.java
@@ -21,7 +21,7 @@ package org.apache.accumulo.tserver.tablet;
 import java.io.IOException;
 
 import org.apache.accumulo.core.file.FilePrefix;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.trace.TraceUtil;
 import org.apache.accumulo.tserver.MinorCompactionReason;
@@ -70,15 +70,16 @@ class MinorCompactionTask implements Runnable {
         } finally {
           span2.end();
         }
-        TabletFile newFile = null;
-        TabletFile tmpFile = null;
+        ReferencedTabletFile newFile = null;
+        ReferencedTabletFile tmpFile = null;
         Span span3 = TraceUtil.startSpan(this.getClass(), "start");
         try (Scope scope3 = span3.makeCurrent()) {
           while (true) {
             try {
               if (newFile == null) {
                 newFile = tablet.getNextDataFilename(FilePrefix.MINOR_COMPACTION);
-                tmpFile = new TabletFile(new Path(newFile.getNormalizedPathStr() + "_tmp"));
+                tmpFile =
+                    new ReferencedTabletFile(new Path(newFile.getNormalizedPathStr() + "_tmp"));
               }
               /*
                * the purpose of the minor compaction start event is to keep track of the filename...

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/MinorCompactor.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.manager.state.tables.TableState;
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.util.LocalityGroupUtil;
 import org.apache.accumulo.server.compaction.CompactionStats;
 import org.apache.accumulo.server.compaction.FileCompactor;
@@ -54,7 +54,8 @@ public class MinorCompactor extends FileCompactor {
   private final MinorCompactionReason mincReason;
 
   public MinorCompactor(TabletServer tabletServer, Tablet tablet, InMemoryMap imm,
-      TabletFile outputFile, MinorCompactionReason mincReason, TableConfiguration tableConfig) {
+      ReferencedTabletFile outputFile, MinorCompactionReason mincReason,
+      TableConfiguration tableConfig) {
     super(tabletServer.getContext(), tablet.getExtent(), Collections.emptyMap(), outputFile, true,
         new MinCEnv(mincReason, imm.compactionIterator()), Collections.emptyList(), tableConfig,
         tableConfig.getCryptoService(), tabletServer.getPausedCompactionMetrics());

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/tablet/TabletData.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionId;
 import org.apache.accumulo.core.metadata.schema.ExternalCompactionMetadata;
@@ -47,7 +47,7 @@ public class TabletData {
   private long flushID = -1;
   private long compactID = -1;
   private Location lastLocation = null;
-  private Map<Long,List<TabletFile>> bulkImported = new HashMap<>();
+  private Map<Long,List<ReferencedTabletFile>> bulkImported = new HashMap<>();
   private long splitTime = 0;
   private String directoryName = null;
   private Map<ExternalCompactionId,ExternalCompactionMetadata> extCompactions;
@@ -78,7 +78,7 @@ public class TabletData {
   // Data pulled from an existing tablet to make a split
   public TabletData(String dirName, SortedMap<StoredTabletFile,DataFileValue> highDatafileSizes,
       MetadataTime time, long lastFlushID, long lastCompactID, Location lastLocation,
-      Map<Long,List<TabletFile>> bulkIngestedFiles) {
+      Map<Long,List<ReferencedTabletFile>> bulkIngestedFiles) {
     this.directoryName = dirName;
     this.dataFiles = highDatafileSizes;
     this.time = time;
@@ -118,7 +118,7 @@ public class TabletData {
     return lastLocation;
   }
 
-  public Map<Long,List<TabletFile>> getBulkImported() {
+  public Map<Long,List<ReferencedTabletFile>> getBulkImported() {
     return bulkImported;
   }
 

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactableUtilsTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/compaction/CompactableUtilsTest.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.tserver.compaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.accumulo.core.metadata.TabletFile;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.tserver.tablet.CompactableUtils;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
@@ -29,10 +29,11 @@ public class CompactableUtilsTest {
 
   @Test
   public void testEquivalence() {
-    TabletFile expected = new TabletFile(
+    ReferencedTabletFile expected = new ReferencedTabletFile(
         new Path("hdfs://localhost:8020/accumulo/tables/2a/default_tablet/F0000070.rf"));
-    TabletFile tmpFile = new TabletFile(new Path(expected.getMetaInsert() + "_tmp"));
-    TabletFile dest = CompactableUtils.computeCompactionFileDest(tmpFile);
+    ReferencedTabletFile tmpFile =
+        new ReferencedTabletFile(new Path(expected.getMetaInsert() + "_tmp"));
+    ReferencedTabletFile dest = CompactableUtils.computeCompactionFileDest(tmpFile);
     assertEquals(expected, dest);
   }
 

--- a/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashBase.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/GarbageCollectorTrashBase.java
@@ -29,8 +29,8 @@ import java.util.Iterator;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.TabletMetadata.ColumnType;
 import org.apache.accumulo.core.metadata.schema.TabletsMetadata;
 import org.apache.accumulo.server.ServerContext;
@@ -112,7 +112,7 @@ public class GarbageCollectorTrashBase extends ConfigurableMacBase {
         if (lfs.isDirectory()) {
           continue;
         }
-        TabletFile tf = new TabletFile(lfs.getPath());
+        ReferencedTabletFile tf = new ReferencedTabletFile(lfs.getPath());
         LOG.debug("File in trash: {}, tableId: {}", lfs.getPath(), tf.getTableId());
         if (tid.equals(tf.getTableId())) {
           count++;

--- a/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
+++ b/test/src/main/java/org/apache/accumulo/test/functional/SplitRecoveryIT.java
@@ -53,9 +53,9 @@ import org.apache.accumulo.core.lock.ServiceLock.LockWatcher;
 import org.apache.accumulo.core.lock.ServiceLockData;
 import org.apache.accumulo.core.lock.ServiceLockData.ThriftService;
 import org.apache.accumulo.core.metadata.MetadataTable;
+import org.apache.accumulo.core.metadata.ReferencedTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
-import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.schema.Ample.TabletMutator;
 import org.apache.accumulo.core.metadata.schema.DataFileValue;
 import org.apache.accumulo.core.metadata.schema.MetadataSchema.TabletsSection.BulkFileColumnFamily;
@@ -164,8 +164,8 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
       String tdir =
           context.getTablesDirs().iterator().next() + "/" + extent.tableId() + "/" + dirName;
       MetadataTableUtil.addTablet(extent, dirName, context, TimeType.LOGICAL, zl);
-      SortedMap<TabletFile,DataFileValue> dataFiles = new TreeMap<>();
-      dataFiles.put(new TabletFile(new Path(tdir + "/" + RFile.EXTENSION + "_000_000")),
+      SortedMap<ReferencedTabletFile,DataFileValue> dataFiles = new TreeMap<>();
+      dataFiles.put(new ReferencedTabletFile(new Path(tdir + "/" + RFile.EXTENSION + "_000_000")),
           new DataFileValue(1000017 + i, 10000 + i));
 
       int tid = 0;
@@ -187,9 +187,9 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
         "localhost:1234", failPoint, zl);
   }
 
-  private static Map<Long,List<TabletFile>> getBulkFilesLoaded(ServerContext context,
+  private static Map<Long,List<ReferencedTabletFile>> getBulkFilesLoaded(ServerContext context,
       KeyExtent extent) {
-    Map<Long,List<TabletFile>> bulkFiles = new HashMap<>();
+    Map<Long,List<ReferencedTabletFile>> bulkFiles = new HashMap<>();
 
     context.getAmple().readTablet(extent).getLoaded().forEach((path, txid) -> bulkFiles
         .computeIfAbsent(txid, k -> new ArrayList<>()).add(path.getTabletFile()));
@@ -217,7 +217,7 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
     tabletMutator.mutate();
 
     if (steps >= 1) {
-      Map<Long,List<TabletFile>> bulkFiles = getBulkFilesLoaded(context, high);
+      Map<Long,List<ReferencedTabletFile>> bulkFiles = getBulkFilesLoaded(context, high);
 
       ManagerMetadataUtil.addNewTablet(context, low, "lowDir", instance, lowDatafileSizes,
           bulkFiles, new MetadataTime(0, TimeType.LOGICAL), -1L, -1L, zl);
@@ -238,8 +238,10 @@ public class SplitRecoveryIT extends ConfigurableMacBase {
       ensureTabletHasNoUnexpectedMetadataEntries(context, low, lowDatafileSizes);
       ensureTabletHasNoUnexpectedMetadataEntries(context, high, highDatafileSizes);
 
-      Map<Long,? extends Collection<TabletFile>> lowBulkFiles = getBulkFilesLoaded(context, low);
-      Map<Long,? extends Collection<TabletFile>> highBulkFiles = getBulkFilesLoaded(context, high);
+      Map<Long,? extends Collection<ReferencedTabletFile>> lowBulkFiles =
+          getBulkFilesLoaded(context, low);
+      Map<Long,? extends Collection<ReferencedTabletFile>> highBulkFiles =
+          getBulkFilesLoaded(context, high);
 
       if (!lowBulkFiles.equals(highBulkFiles)) {
         throw new Exception(" " + lowBulkFiles + " != " + highBulkFiles + " " + low + " " + high);


### PR DESCRIPTION
Renaming `TabletFile` to `ReferencedTabletFile` so it matches `UnreferencedTabletFile` and will allow adding a new more generic `TabletFile` interface in a future commit.

The plan is to add a new `TabletFile` interface that can be used everywhere instead of `AbstractTabletFile` in the code but that needs to be added in a separate commit otherwise git won't detect the file rename from `TabletFile` to `ReferencedTabletFile`. Having git detect the rename is important so that things will merge cleanly. 

I figure I can add a follow on PR with the addition of the `TabletFile` interface if/when this is merged since we can't chain PRs.

The original comment I made that was the basis of this is here: https://github.com/apache/accumulo/pull/3417#issuecomment-1557160881