### PR TITLE
Add a new TabletFile interface

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
@@ -23,13 +23,13 @@ import java.io.IOException;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.file.rfile.RFileOperations;
-import org.apache.accumulo.core.metadata.AbstractTabletFile;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.summary.SummaryWriter;
 
 class DispatchingFileFactory extends FileOperations {
 
   private FileOperations findFileFactory(FileOptions options) {
-    AbstractTabletFile<?> file = options.getFile();
+    TabletFile<?> file = options.getFile();
 
     String name = file.getPath().getName();
 

--- a/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/DispatchingFileFactory.java
@@ -29,7 +29,7 @@ import org.apache.accumulo.core.summary.SummaryWriter;
 class DispatchingFileFactory extends FileOperations {
 
   private FileOperations findFileFactory(FileOptions options) {
-    TabletFile<?> file = options.getFile();
+    TabletFile file = options.getFile();
 
     String name = file.getPath().getName();
 

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -31,7 +31,7 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.file.blockfile.impl.CacheProvider;
 import org.apache.accumulo.core.file.rfile.RFile;
-import org.apache.accumulo.core.metadata.AbstractTabletFile;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.accumulo.core.util.ratelimit.RateLimiter;
@@ -168,7 +168,7 @@ public abstract class FileOperations {
   protected static class FileOptions {
     // objects used by all
     public final AccumuloConfiguration tableConfiguration;
-    public final AbstractTabletFile<?> file;
+    public final TabletFile<?> file;
     public final FileSystem fs;
     public final Configuration fsConf;
     public final RateLimiter rateLimiter;
@@ -187,7 +187,7 @@ public abstract class FileOperations {
     public final boolean inclusive;
     public final boolean dropCacheBehind;
 
-    protected FileOptions(AccumuloConfiguration tableConfiguration, AbstractTabletFile<?> file,
+    protected FileOptions(AccumuloConfiguration tableConfiguration, TabletFile<?> file,
         FileSystem fs, Configuration fsConf, RateLimiter rateLimiter, String compression,
         FSDataOutputStream outputStream, boolean enableAccumuloStart, CacheProvider cacheProvider,
         Cache<String,Long> fileLenCache, boolean seekToBeginning, CryptoService cryptoService,
@@ -214,7 +214,7 @@ public abstract class FileOperations {
       return tableConfiguration;
     }
 
-    public AbstractTabletFile<?> getFile() {
+    public TabletFile<?> getFile() {
       return file;
     }
 
@@ -276,7 +276,7 @@ public abstract class FileOperations {
    */
   public static class FileHelper {
     private AccumuloConfiguration tableConfiguration;
-    private AbstractTabletFile<?> file;
+    private TabletFile<?> file;
     private FileSystem fs;
     private Configuration fsConf;
     private RateLimiter rateLimiter;
@@ -293,7 +293,7 @@ public abstract class FileOperations {
       return this;
     }
 
-    protected FileHelper file(AbstractTabletFile<?> file) {
+    protected FileHelper file(TabletFile<?> file) {
       this.file = Objects.requireNonNull(file);
       return this;
     }
@@ -366,8 +366,8 @@ public abstract class FileOperations {
       return this;
     }
 
-    public WriterTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
-        Configuration fsConf, CryptoService cs) {
+    public WriterTableConfiguration forFile(TabletFile<?> file, FileSystem fs, Configuration fsConf,
+        CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
     }
@@ -415,8 +415,8 @@ public abstract class FileOperations {
     private Cache<String,Long> fileLenCache;
     private boolean seekToBeginning = false;
 
-    public ReaderTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
-        Configuration fsConf, CryptoService cs) {
+    public ReaderTableConfiguration forFile(TabletFile<?> file, FileSystem fs, Configuration fsConf,
+        CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
     }
@@ -483,7 +483,7 @@ public abstract class FileOperations {
 
     private Cache<String,Long> fileLenCache = null;
 
-    public IndexReaderTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
+    public IndexReaderTableConfiguration forFile(TabletFile<?> file, FileSystem fs,
         Configuration fsConf, CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
@@ -515,7 +515,7 @@ public abstract class FileOperations {
     private Set<ByteSequence> columnFamilies;
     private boolean inclusive;
 
-    public ScanReaderTableConfiguration forFile(AbstractTabletFile<?> file, FileSystem fs,
+    public ScanReaderTableConfiguration forFile(TabletFile<?> file, FileSystem fs,
         Configuration fsConf, CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;

--- a/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/FileOperations.java
@@ -168,7 +168,7 @@ public abstract class FileOperations {
   protected static class FileOptions {
     // objects used by all
     public final AccumuloConfiguration tableConfiguration;
-    public final TabletFile<?> file;
+    public final TabletFile file;
     public final FileSystem fs;
     public final Configuration fsConf;
     public final RateLimiter rateLimiter;
@@ -187,8 +187,8 @@ public abstract class FileOperations {
     public final boolean inclusive;
     public final boolean dropCacheBehind;
 
-    protected FileOptions(AccumuloConfiguration tableConfiguration, TabletFile<?> file,
-        FileSystem fs, Configuration fsConf, RateLimiter rateLimiter, String compression,
+    protected FileOptions(AccumuloConfiguration tableConfiguration, TabletFile file, FileSystem fs,
+        Configuration fsConf, RateLimiter rateLimiter, String compression,
         FSDataOutputStream outputStream, boolean enableAccumuloStart, CacheProvider cacheProvider,
         Cache<String,Long> fileLenCache, boolean seekToBeginning, CryptoService cryptoService,
         Range range, Set<ByteSequence> columnFamilies, boolean inclusive, boolean dropCacheBehind) {
@@ -214,7 +214,7 @@ public abstract class FileOperations {
       return tableConfiguration;
     }
 
-    public TabletFile<?> getFile() {
+    public TabletFile getFile() {
       return file;
     }
 
@@ -276,7 +276,7 @@ public abstract class FileOperations {
    */
   public static class FileHelper {
     private AccumuloConfiguration tableConfiguration;
-    private TabletFile<?> file;
+    private TabletFile file;
     private FileSystem fs;
     private Configuration fsConf;
     private RateLimiter rateLimiter;
@@ -293,7 +293,7 @@ public abstract class FileOperations {
       return this;
     }
 
-    protected FileHelper file(TabletFile<?> file) {
+    protected FileHelper file(TabletFile file) {
       this.file = Objects.requireNonNull(file);
       return this;
     }
@@ -366,7 +366,7 @@ public abstract class FileOperations {
       return this;
     }
 
-    public WriterTableConfiguration forFile(TabletFile<?> file, FileSystem fs, Configuration fsConf,
+    public WriterTableConfiguration forFile(TabletFile file, FileSystem fs, Configuration fsConf,
         CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
@@ -415,7 +415,7 @@ public abstract class FileOperations {
     private Cache<String,Long> fileLenCache;
     private boolean seekToBeginning = false;
 
-    public ReaderTableConfiguration forFile(TabletFile<?> file, FileSystem fs, Configuration fsConf,
+    public ReaderTableConfiguration forFile(TabletFile file, FileSystem fs, Configuration fsConf,
         CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
@@ -483,7 +483,7 @@ public abstract class FileOperations {
 
     private Cache<String,Long> fileLenCache = null;
 
-    public IndexReaderTableConfiguration forFile(TabletFile<?> file, FileSystem fs,
+    public IndexReaderTableConfiguration forFile(TabletFile file, FileSystem fs,
         Configuration fsConf, CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;
@@ -515,7 +515,7 @@ public abstract class FileOperations {
     private Set<ByteSequence> columnFamilies;
     private boolean inclusive;
 
-    public ScanReaderTableConfiguration forFile(TabletFile<?> file, FileSystem fs,
+    public ScanReaderTableConfiguration forFile(TabletFile file, FileSystem fs,
         Configuration fsConf, CryptoService cs) {
       file(file).fs(fs).fsConf(fsConf).cryptoService(cs);
       return this;

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
@@ -133,7 +133,7 @@ public class RFileOperations extends FileOperations {
       }
       int bufferSize = conf.getInt("io.file.buffer.size", 4096);
 
-      TabletFile<?> file = options.getFile();
+      TabletFile file = options.getFile();
       FileSystem fs = options.getFileSystem();
 
       if (options.dropCacheBehind) {

--- a/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
+++ b/core/src/main/java/org/apache/accumulo/core/file/rfile/RFileOperations.java
@@ -34,7 +34,7 @@ import org.apache.accumulo.core.file.FileSKVIterator;
 import org.apache.accumulo.core.file.FileSKVWriter;
 import org.apache.accumulo.core.file.blockfile.impl.CachableBlockFile.CachableBuilder;
 import org.apache.accumulo.core.file.rfile.bcfile.BCFile;
-import org.apache.accumulo.core.metadata.AbstractTabletFile;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.sample.impl.SamplerConfigurationImpl;
 import org.apache.accumulo.core.sample.impl.SamplerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -133,7 +133,7 @@ public class RFileOperations extends FileOperations {
       }
       int bufferSize = conf.getInt("io.file.buffer.size", 4096);
 
-      AbstractTabletFile<?> file = options.getFile();
+      TabletFile<?> file = options.getFile();
       FileSystem fs = options.getFileSystem();
 
       if (options.dropCacheBehind) {

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -153,7 +153,7 @@ public class TabletLogger {
     }
   }
 
-  public static void bulkImported(KeyExtent extent, TabletFile<?> file) {
+  public static void bulkImported(KeyExtent extent, TabletFile file) {
     fileLog.debug("Imported {} {}  ", extent, file);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
+++ b/core/src/main/java/org/apache/accumulo/core/logging/TabletLogger.java
@@ -28,9 +28,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.compaction.CompactableFile;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
-import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
 import org.apache.accumulo.core.metadata.TServerInstance;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.spi.compaction.CompactionJob;
 import org.apache.accumulo.core.spi.compaction.CompactionKind;
 import org.apache.accumulo.core.tabletserver.log.LogEntry;
@@ -153,7 +153,7 @@ public class TabletLogger {
     }
   }
 
-  public static void bulkImported(KeyExtent extent, AbstractTabletFile<?> file) {
+  public static void bulkImported(KeyExtent extent, TabletFile<?> file) {
     fileLog.debug("Imported {} {}  ", extent, file);
   }
 

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.Path;
  * @since 3.0.0
  */
 public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>>
-    implements TabletFile<T>, Comparable<T> {
+    implements TabletFile, Comparable<T> {
 
   private final String fileName; // C0004.rf
   protected final Path path;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/AbstractTabletFile.java
@@ -28,7 +28,8 @@ import org.apache.hadoop.fs.Path;
  *
  * @since 3.0.0
  */
-public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>> implements Comparable<T> {
+public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>>
+    implements TabletFile<T>, Comparable<T> {
 
   private final String fileName; // C0004.rf
   protected final Path path;
@@ -39,16 +40,12 @@ public abstract class AbstractTabletFile<T extends AbstractTabletFile<T>> implem
     ValidationUtil.validateFileName(fileName);
   }
 
-  /**
-   * @return The file name of the TabletFile
-   */
+  @Override
   public String getFileName() {
     return fileName;
   }
 
-  /**
-   * @return The path of the TabletFile
-   */
+  @Override
   public Path getPath() {
     return path;
   }

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -20,7 +20,7 @@ package org.apache.accumulo.core.metadata;
 
 import org.apache.hadoop.fs.Path;
 
-public interface TabletFile<T extends TabletFile<T>> {
+public interface TabletFile {
 
   /**
    * @return The file name of the TabletFile

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.accumulo.core.metadata;
 
 import org.apache.hadoop.fs.Path;

--- a/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
+++ b/core/src/main/java/org/apache/accumulo/core/metadata/TabletFile.java
@@ -1,0 +1,16 @@
+package org.apache.accumulo.core.metadata;
+
+import org.apache.hadoop.fs.Path;
+
+public interface TabletFile<T extends TabletFile<T>> {
+
+  /**
+   * @return The file name of the TabletFile
+   */
+  String getFileName();
+
+  /**
+   * @return The path of the TabletFile
+   */
+  Path getPath();
+}

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -44,8 +44,8 @@ import org.apache.accumulo.core.file.rfile.RFile;
 import org.apache.accumulo.core.file.rfile.RFileOperations;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
-import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.ReferencedTabletFile;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.metadata.UnreferencedTabletFile;
 import org.apache.accumulo.server.ServerContext;
 import org.apache.accumulo.server.conf.TableConfiguration;
@@ -112,12 +112,12 @@ public class FileUtil {
     return result;
   }
 
-  public static Collection<? extends AbstractTabletFile<?>> reduceFiles(ServerContext context,
+  public static Collection<? extends TabletFile<?>> reduceFiles(ServerContext context,
       TableConfiguration tableConf, Text prevEndRow, Text endRow,
-      Collection<? extends AbstractTabletFile<?>> dataFiles, int maxFiles, Path tmpDir, int pass)
+      Collection<? extends TabletFile<?>> dataFiles, int maxFiles, Path tmpDir, int pass)
       throws IOException {
 
-    ArrayList<? extends AbstractTabletFile<?>> files = new ArrayList<>(dataFiles);
+    ArrayList<? extends TabletFile<?>> files = new ArrayList<>(dataFiles);
 
     if (files.size() <= maxFiles) {
       return files;
@@ -133,7 +133,7 @@ public class FileUtil {
 
     while (start < files.size()) {
       int end = Math.min(maxFiles + start, files.size());
-      List<? extends AbstractTabletFile<?>> inFiles = files.subList(start, end);
+      List<? extends TabletFile<?>> inFiles = files.subList(start, end);
 
       start = end;
 
@@ -151,7 +151,7 @@ public class FileUtil {
 
       FileSKVIterator reader = null;
       try {
-        for (AbstractTabletFile<?> file : inFiles) {
+        for (TabletFile<?> file : inFiles) {
           ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
           reader = FileOperations.getInstance().newIndexReaderBuilder()
               .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
@@ -211,8 +211,8 @@ public class FileUtil {
   }
 
   public static double estimatePercentageLTE(ServerContext context, TableConfiguration tableConf,
-      String tabletDir, Text prevEndRow, Text endRow,
-      Collection<? extends AbstractTabletFile<?>> dataFiles, Text splitRow) throws IOException {
+      String tabletDir, Text prevEndRow, Text endRow, Collection<? extends TabletFile<?>> dataFiles,
+      Text splitRow) throws IOException {
 
     Path tmpDir = null;
 
@@ -289,10 +289,10 @@ public class FileUtil {
    */
   public static SortedMap<Double,Key> findMidPoint(ServerContext context,
       TableConfiguration tableConf, String tabletDirectory, Text prevEndRow, Text endRow,
-      Collection<? extends AbstractTabletFile<?>> dataFiles, double minSplit, boolean useIndex)
+      Collection<? extends TabletFile<?>> dataFiles, double minSplit, boolean useIndex)
       throws IOException {
 
-    Collection<? extends AbstractTabletFile<?>> origDataFiles = dataFiles;
+    Collection<? extends TabletFile<?>> origDataFiles = dataFiles;
 
     Path tmpDir = null;
 
@@ -430,12 +430,12 @@ public class FileUtil {
   }
 
   private static long countIndexEntries(ServerContext context, TableConfiguration tableConf,
-      Text prevEndRow, Text endRow, Collection<? extends AbstractTabletFile<?>> dataFiles,
-      boolean useIndex, ArrayList<FileSKVIterator> readers) throws IOException {
+      Text prevEndRow, Text endRow, Collection<? extends TabletFile<?>> dataFiles, boolean useIndex,
+      ArrayList<FileSKVIterator> readers) throws IOException {
     long numKeys = 0;
 
     // count the total number of index entries
-    for (AbstractTabletFile<?> file : dataFiles) {
+    for (TabletFile<?> file : dataFiles) {
       FileSKVIterator reader = null;
       FileSystem ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
       try {
@@ -485,7 +485,7 @@ public class FileUtil {
     return numKeys;
   }
 
-  public static <T extends AbstractTabletFile<T>> Map<T,FileInfo> tryToGetFirstAndLastRows(
+  public static <T extends TabletFile<T>> Map<T,FileInfo> tryToGetFirstAndLastRows(
       ServerContext context, TableConfiguration tableConf, Set<T> dataFiles) {
 
     HashMap<T,FileInfo> dataFilesInfo = new HashMap<>();
@@ -528,9 +528,8 @@ public class FileUtil {
     return dataFilesInfo;
   }
 
-  public static <T extends AbstractTabletFile<T>> WritableComparable<Key>
-      findLastKey(ServerContext context, TableConfiguration tableConf, Collection<T> dataFiles)
-          throws IOException {
+  public static <T extends TabletFile<T>> WritableComparable<Key> findLastKey(ServerContext context,
+      TableConfiguration tableConf, Collection<T> dataFiles) throws IOException {
 
     Key lastKey = null;
 

--- a/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
+++ b/server/base/src/main/java/org/apache/accumulo/server/util/FileUtil.java
@@ -112,12 +112,12 @@ public class FileUtil {
     return result;
   }
 
-  public static Collection<? extends TabletFile<?>> reduceFiles(ServerContext context,
+  public static Collection<? extends TabletFile> reduceFiles(ServerContext context,
       TableConfiguration tableConf, Text prevEndRow, Text endRow,
-      Collection<? extends TabletFile<?>> dataFiles, int maxFiles, Path tmpDir, int pass)
+      Collection<? extends TabletFile> dataFiles, int maxFiles, Path tmpDir, int pass)
       throws IOException {
 
-    ArrayList<? extends TabletFile<?>> files = new ArrayList<>(dataFiles);
+    ArrayList<? extends TabletFile> files = new ArrayList<>(dataFiles);
 
     if (files.size() <= maxFiles) {
       return files;
@@ -133,7 +133,7 @@ public class FileUtil {
 
     while (start < files.size()) {
       int end = Math.min(maxFiles + start, files.size());
-      List<? extends TabletFile<?>> inFiles = files.subList(start, end);
+      List<? extends TabletFile> inFiles = files.subList(start, end);
 
       start = end;
 
@@ -151,7 +151,7 @@ public class FileUtil {
 
       FileSKVIterator reader = null;
       try {
-        for (TabletFile<?> file : inFiles) {
+        for (TabletFile file : inFiles) {
           ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
           reader = FileOperations.getInstance().newIndexReaderBuilder()
               .forFile(file, ns, ns.getConf(), tableConf.getCryptoService())
@@ -211,7 +211,7 @@ public class FileUtil {
   }
 
   public static double estimatePercentageLTE(ServerContext context, TableConfiguration tableConf,
-      String tabletDir, Text prevEndRow, Text endRow, Collection<? extends TabletFile<?>> dataFiles,
+      String tabletDir, Text prevEndRow, Text endRow, Collection<? extends TabletFile> dataFiles,
       Text splitRow) throws IOException {
 
     Path tmpDir = null;
@@ -289,10 +289,10 @@ public class FileUtil {
    */
   public static SortedMap<Double,Key> findMidPoint(ServerContext context,
       TableConfiguration tableConf, String tabletDirectory, Text prevEndRow, Text endRow,
-      Collection<? extends TabletFile<?>> dataFiles, double minSplit, boolean useIndex)
+      Collection<? extends TabletFile> dataFiles, double minSplit, boolean useIndex)
       throws IOException {
 
-    Collection<? extends TabletFile<?>> origDataFiles = dataFiles;
+    Collection<? extends TabletFile> origDataFiles = dataFiles;
 
     Path tmpDir = null;
 
@@ -430,12 +430,12 @@ public class FileUtil {
   }
 
   private static long countIndexEntries(ServerContext context, TableConfiguration tableConf,
-      Text prevEndRow, Text endRow, Collection<? extends TabletFile<?>> dataFiles, boolean useIndex,
+      Text prevEndRow, Text endRow, Collection<? extends TabletFile> dataFiles, boolean useIndex,
       ArrayList<FileSKVIterator> readers) throws IOException {
     long numKeys = 0;
 
     // count the total number of index entries
-    for (TabletFile<?> file : dataFiles) {
+    for (TabletFile file : dataFiles) {
       FileSKVIterator reader = null;
       FileSystem ns = context.getVolumeManager().getFileSystemByPath(file.getPath());
       try {
@@ -485,7 +485,7 @@ public class FileUtil {
     return numKeys;
   }
 
-  public static <T extends TabletFile<T>> Map<T,FileInfo> tryToGetFirstAndLastRows(
+  public static <T extends TabletFile> Map<T,FileInfo> tryToGetFirstAndLastRows(
       ServerContext context, TableConfiguration tableConf, Set<T> dataFiles) {
 
     HashMap<T,FileInfo> dataFilesInfo = new HashMap<>();
@@ -528,7 +528,7 @@ public class FileUtil {
     return dataFilesInfo;
   }
 
-  public static <T extends TabletFile<T>> WritableComparable<Key> findLastKey(ServerContext context,
+  public static <T extends TabletFile> WritableComparable<Key> findLastKey(ServerContext context,
       TableConfiguration tableConf, Collection<T> dataFiles) throws IOException {
 
     Key lastKey = null;

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -397,11 +397,11 @@ public class CollectTabletStats {
   }
 
   private static void reportHdfsBlockLocations(ServerContext context,
-      List<? extends TabletFile<?>> files) throws Exception {
+      List<? extends TabletFile> files) throws Exception {
     VolumeManager fs = context.getVolumeManager();
 
     System.out.println("\t\tFile block report : ");
-    for (TabletFile<?> file : files) {
+    for (TabletFile file : files) {
       FileStatus status = fs.getFileStatus(file.getPath());
 
       if (status.isDirectory()) {

--- a/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
+++ b/test/src/main/java/org/apache/accumulo/test/performance/scan/CollectTabletStats.java
@@ -63,9 +63,9 @@ import org.apache.accumulo.core.iteratorsImpl.system.DeletingIterator.Behavior;
 import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.VisibilityFilter;
-import org.apache.accumulo.core.metadata.AbstractTabletFile;
 import org.apache.accumulo.core.metadata.MetadataServicer;
 import org.apache.accumulo.core.metadata.StoredTabletFile;
+import org.apache.accumulo.core.metadata.TabletFile;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.spi.crypto.NoCryptoServiceFactory;
 import org.apache.accumulo.core.util.Stat;
@@ -397,11 +397,11 @@ public class CollectTabletStats {
   }
 
   private static void reportHdfsBlockLocations(ServerContext context,
-      List<? extends AbstractTabletFile<?>> files) throws Exception {
+      List<? extends TabletFile<?>> files) throws Exception {
     VolumeManager fs = context.getVolumeManager();
 
     System.out.println("\t\tFile block report : ");
-    for (AbstractTabletFile<?> file : files) {
+    for (TabletFile<?> file : files) {
       FileStatus status = fs.getFileStatus(file.getPath());
 
       if (status.isDirectory()) {


### PR DESCRIPTION
This is a follow on to #3449 and adds a new `TabletFile` interface that can be used instead of having to use the abstract class `AbstractTabletFile` everywhere.